### PR TITLE
Enforce role-based permissions on all server action write operations

### DIFF
--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -32,6 +32,7 @@ const segmentLabels: Record<string, string> = {
   maintenance: "Maintenance",
   "test-and-tag": "Test & Tag",
   "quick-test": "Quick Test",
+  categories: "Categories",
   reports: "Reports",
   settings: "Settings",
   billing: "Billing",

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { assetSchema, type AssetFormValues } from "@/lib/validations/asset";
 import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
@@ -136,7 +136,7 @@ export async function getAsset(id: string) {
 }
 
 export async function createAsset(data: AssetFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "create");
   const parsed = assetSchema.parse(data);
 
   // Fetch the model to check T&T requirements
@@ -205,7 +205,7 @@ export async function createAssets(
   data: AssetFormValues,
   assets: { tag: string; serialNumber?: string }[],
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "create");
   const parsed = assetSchema.parse(data);
 
   const model = await prisma.model.findUnique({ where: { id: parsed.modelId } });
@@ -272,7 +272,7 @@ export async function createAssets(
 }
 
 export async function updateAsset(id: string, data: AssetFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "update");
   const parsed = assetSchema.parse(data);
 
   const updated = await prisma.asset.update({
@@ -315,7 +315,7 @@ export async function bulkUpdateAssets(
     locationId?: string | null;
   },
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "update");
   if (ids.length === 0) throw new Error("No assets selected");
 
   const updateData: Record<string, unknown> = {};
@@ -334,7 +334,7 @@ export async function bulkUpdateAssets(
 }
 
 export async function deleteAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "delete");
 
   const asset = await prisma.asset.findUnique({
     where: { id, organizationId },
@@ -368,7 +368,7 @@ export async function deleteAsset(id: string) {
 }
 
 export async function updateAssetNotes(id: string, notes: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "update");
   return serialize(await prisma.asset.update({
     where: { id, organizationId },
     data: { notes: notes || null },
@@ -376,7 +376,7 @@ export async function updateAssetNotes(id: string, notes: string) {
 }
 
 export async function archiveAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "update");
 
   // Retire linked T&T entry if one exists
   await prisma.testTagAsset.updateMany({

--- a/src/server/bulk-assets.ts
+++ b/src/server/bulk-assets.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { bulkAssetSchema, type BulkAssetFormValues } from "@/lib/validations/asset";
 import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
@@ -99,7 +99,7 @@ export async function getBulkAsset(id: string) {
 }
 
 export async function createBulkAsset(data: BulkAssetFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("bulkAsset", "create");
   const parsed = bulkAssetSchema.parse(data);
   try {
     const result = await prisma.bulkAsset.create({
@@ -128,7 +128,7 @@ export async function createBulkAsset(data: BulkAssetFormValues) {
 }
 
 export async function updateBulkAsset(id: string, data: BulkAssetFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("bulkAsset", "update");
   const parsed = bulkAssetSchema.parse(data);
 
   const existing = await prisma.bulkAsset.findUnique({ where: { id, organizationId } });
@@ -156,7 +156,7 @@ export async function updateBulkAsset(id: string, data: BulkAssetFormValues) {
 }
 
 export async function deleteBulkAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("bulkAsset", "delete");
 
   const asset = await prisma.bulkAsset.findUnique({
     where: { id, organizationId },
@@ -178,7 +178,7 @@ export async function deleteBulkAsset(id: string) {
 }
 
 export async function updateBulkAssetNotes(id: string, notes: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("bulkAsset", "update");
   return serialize(await prisma.bulkAsset.update({
     where: { id, organizationId },
     data: { notes: notes || null },
@@ -186,7 +186,7 @@ export async function updateBulkAssetNotes(id: string, notes: string) {
 }
 
 export async function archiveBulkAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("bulkAsset", "update");
   return serialize(await prisma.bulkAsset.update({
     where: { id, organizationId },
     data: { isActive: false, status: "RETIRED" },

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
 
 export async function getCategories() {
@@ -40,7 +40,7 @@ export async function getCategoryTree() {
 }
 
 export async function createCategory(data: CategoryFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "create");
   const parsed = categorySchema.parse(data);
   return prisma.category.create({
     data: {
@@ -52,7 +52,7 @@ export async function createCategory(data: CategoryFormValues) {
 }
 
 export async function updateCategory(id: string, data: CategoryFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "update");
   const parsed = categorySchema.parse(data);
   return prisma.category.update({
     where: { id, organizationId },
@@ -64,7 +64,7 @@ export async function updateCategory(id: string, data: CategoryFormValues) {
 }
 
 export async function deleteCategory(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "delete");
   // Check for children or models first
   const category = await prisma.category.findUnique({
     where: { id, organizationId },

--- a/src/server/clients.ts
+++ b/src/server/clients.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { clientSchema, type ClientFormValues } from "@/lib/validations/client";
 import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
@@ -71,7 +71,7 @@ export async function getClient(id: string) {
 }
 
 export async function createClient(data: ClientFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("client", "create");
   const parsed = clientSchema.parse(data);
 
   return serialize(await prisma.client.create({
@@ -95,7 +95,7 @@ export async function createClient(data: ClientFormValues) {
 }
 
 export async function updateClient(id: string, data: ClientFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("client", "update");
   const parsed = clientSchema.parse(data);
 
   return serialize(await prisma.client.update({
@@ -119,7 +119,7 @@ export async function updateClient(id: string, data: ClientFormValues) {
 }
 
 export async function updateClientNotes(id: string, notes: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("client", "update");
   return serialize(await prisma.client.update({
     where: { id, organizationId },
     data: { notes: notes || null },
@@ -127,7 +127,7 @@ export async function updateClientNotes(id: string, notes: string) {
 }
 
 export async function archiveClient(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("client", "update");
   return serialize(await prisma.client.update({
     where: { id, organizationId },
     data: { isActive: false },

--- a/src/server/csv.ts
+++ b/src/server/csv.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 
 // ─── EXPORT ─────────────────────────────────────────────────────────────────
@@ -154,7 +154,7 @@ interface ImportResult {
 }
 
 export async function importModelsCSV(csvContent: string): Promise<ImportResult> {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "import");
   const rows = parseCSV(csvContent);
   if (rows.length === 0) throw new Error("CSV is empty");
 
@@ -253,7 +253,7 @@ export async function importModelsCSV(csvContent: string): Promise<ImportResult>
 }
 
 export async function importAssetsCSV(csvContent: string): Promise<ImportResult> {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("asset", "import");
   const rows = parseCSV(csvContent);
   if (rows.length === 0) throw new Error("CSV is empty");
 

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import {
   kitSchema,
   kitSerializedItemSchema,
@@ -132,7 +132,7 @@ export async function getKit(id: string) {
 // createKit
 // ---------------------------------------------------------------------------
 export async function createKit(data: KitFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "create");
   const parsed = kitSchema.parse(data);
 
   try {
@@ -173,7 +173,7 @@ export async function createKit(data: KitFormValues) {
 // updateKit
 // ---------------------------------------------------------------------------
 export async function updateKit(id: string, data: KitFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "update");
   const parsed = kitSchema.parse(data);
 
   return serialize(
@@ -202,7 +202,7 @@ export async function updateKit(id: string, data: KitFormValues) {
 }
 
 export async function updateKitNotes(id: string, notes: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "update");
   return serialize(await prisma.kit.update({
     where: { id, organizationId },
     data: { notes: notes || null },
@@ -213,7 +213,7 @@ export async function updateKitNotes(id: string, notes: string) {
 // archiveKit – soft delete: remove all contents, then deactivate
 // ---------------------------------------------------------------------------
 export async function archiveKit(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "delete");
 
   const kit = await prisma.kit.findUnique({
     where: { id, organizationId },
@@ -266,7 +266,7 @@ export async function addSerializedItemToKit(
   kitId: string,
   data: KitSerializedItemFormValues,
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("kit", "update");
   const parsed = kitSerializedItemSchema.parse(data);
 
   const kit = await prisma.kit.findUnique({
@@ -319,7 +319,7 @@ export async function addSerializedItemsToKit(
   kitId: string,
   items: Array<{ assetId: string; position?: string }>,
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("kit", "update");
 
   if (items.length === 0) throw new Error("No items to add");
 
@@ -381,7 +381,7 @@ export async function removeSerializedItemFromKit(
   kitId: string,
   assetId: string,
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "update");
 
   const kit = await prisma.kit.findUnique({
     where: { id: kitId, organizationId },
@@ -414,7 +414,7 @@ export async function addBulkItemToKit(
   kitId: string,
   data: KitBulkItemFormValues,
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("kit", "update");
   const parsed = kitBulkItemSchema.parse(data);
 
   const kit = await prisma.kit.findUnique({
@@ -467,7 +467,7 @@ export async function removeBulkItemFromKit(
   kitId: string,
   bulkItemId: string,
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("kit", "update");
 
   const kit = await prisma.kit.findUnique({
     where: { id: kitId, organizationId },

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import {
   lineItemSchema,
   type LineItemFormValues,
@@ -9,7 +9,7 @@ import {
 import { serialize } from "@/lib/serialize";
 
 export async function addLineItem(projectId: string, data: LineItemFormValues, allowOverbook = false) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "manage_line_items");
   const parsed = lineItemSchema.parse(data);
 
   // Server-side availability enforcement for equipment
@@ -185,7 +185,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
 }
 
 export async function updateLineItem(id: string, data: LineItemFormValues, allowOverbook = false) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "manage_line_items");
   const parsed = lineItemSchema.parse(data);
 
   const lineTotal = calculateLineTotal(
@@ -236,7 +236,7 @@ export async function addKitLineItem(
   unitPrice?: number,
   groupName?: string,
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "manage_line_items");
 
   const kit = await prisma.kit.findUnique({
     where: { id: kitId, organizationId },
@@ -317,7 +317,7 @@ export async function addKitLineItem(
 }
 
 export async function removeLineItem(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "manage_line_items");
 
   const item = await prisma.projectLineItem.findFirst({
     where: { id, organizationId },
@@ -347,7 +347,7 @@ export async function reorderLineItems(
   itemIds: string[],
   groupUpdates?: { id: string; groupName: string | null }[],
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "manage_line_items");
 
   const updates = itemIds.map((id, index) =>
     prisma.projectLineItem.update({

--- a/src/server/locations.ts
+++ b/src/server/locations.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { locationSchema, type LocationFormValues } from "@/lib/validations/asset";
 import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
@@ -101,7 +101,7 @@ export async function getLocation(id: string) {
 }
 
 export async function createLocation(data: LocationFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("location", "create");
   const parsed = locationSchema.parse(data);
 
   // If this is set as default, unset other defaults
@@ -122,7 +122,7 @@ export async function createLocation(data: LocationFormValues) {
 }
 
 export async function updateLocation(id: string, data: LocationFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("location", "update");
   const parsed = locationSchema.parse(data);
 
   if (parsed.isDefault) {
@@ -142,7 +142,7 @@ export async function updateLocation(id: string, data: LocationFormValues) {
 }
 
 export async function deleteLocation(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("location", "delete");
   const location = await prisma.location.findUnique({
     where: { id, organizationId },
     include: { _count: { select: { assets: true, bulkAssets: true, children: true } } },
@@ -156,7 +156,7 @@ export async function deleteLocation(id: string) {
 }
 
 export async function updateLocationNotes(id: string, notes: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("location", "update");
   return serialize(await prisma.location.update({
     where: { id, organizationId },
     data: { notes: notes || null },

--- a/src/server/maintenance.ts
+++ b/src/server/maintenance.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import {
   maintenanceSchema,
   type MaintenanceFormValues,
@@ -86,7 +86,7 @@ export async function getMaintenanceRecord(id: string) {
 }
 
 export async function createMaintenanceRecord(data: MaintenanceFormValues) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("maintenance", "create");
   const parsed = maintenanceSchema.parse(data);
 
   const assetIds = parsed.assetIds?.length
@@ -145,7 +145,7 @@ export async function updateMaintenanceRecord(
   id: string,
   data: MaintenanceFormValues
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("maintenance", "update");
   const parsed = maintenanceSchema.parse(data);
 
   const existing = await prisma.maintenanceRecord.findUnique({
@@ -222,7 +222,7 @@ export async function updateMaintenanceRecord(
 }
 
 export async function deleteMaintenanceRecord(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("maintenance", "delete");
 
   const record = await prisma.maintenanceRecord.findUnique({
     where: { id, organizationId },

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -2,7 +2,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { serialize } from "@/lib/serialize";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { modelSchema, type ModelFormValues } from "@/lib/validations/model";
 import type { Prisma } from "@/generated/prisma/client";
 import { backfillTestTagAssets } from "@/server/test-tag-assets";
@@ -91,7 +91,7 @@ export async function getModel(id: string) {
 }
 
 export async function createModel(data: ModelFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "create");
   const parsed = modelSchema.parse(data);
   const model = await prisma.model.create({
     data: {
@@ -130,7 +130,7 @@ export async function createModel(data: ModelFormValues) {
 }
 
 export async function updateModel(id: string, data: ModelFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "update");
   const parsed = modelSchema.parse(data);
   const model = await prisma.model.update({
     where: { id, organizationId },
@@ -197,7 +197,7 @@ export async function updateModel(id: string, data: ModelFormValues) {
 }
 
 export async function archiveModel(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("model", "delete");
 
   // Delete all assets and bulk assets under this model
   await Promise.all([

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import {
   projectSchema,
   type ProjectFormValues,
@@ -224,7 +224,7 @@ export async function getProject(id: string) {
 }
 
 export async function createProject(data: ProjectFormValues & { isTemplate?: boolean }) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "create");
   const parsed = projectSchema.parse(data);
 
   const isTemplate = data.isTemplate ?? false;
@@ -283,7 +283,7 @@ export async function createProject(data: ProjectFormValues & { isTemplate?: boo
 }
 
 export async function updateProject(id: string, data: ProjectFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "update");
   const parsed = projectSchema.parse(data);
 
   return serialize(
@@ -327,7 +327,7 @@ export async function updateProjectStatus(
   id: string,
   status: ProjectFormValues["status"]
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "update");
   const project = await prisma.project.findUnique({ where: { id, organizationId } });
   if (!project) throw new Error("Project not found");
   if (project.isTemplate) throw new Error("Cannot change status of a template");
@@ -344,7 +344,7 @@ export async function updateProjectNotes(
   field: "crewNotes" | "internalNotes" | "clientNotes",
   notes: string,
 ) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "update");
   return serialize(await prisma.project.update({
     where: { id, organizationId },
     data: { [field]: notes || null },
@@ -352,7 +352,7 @@ export async function updateProjectNotes(
 }
 
 export async function archiveProject(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "update");
   return serialize(
     await prisma.project.update({
       where: { id, organizationId },
@@ -362,7 +362,7 @@ export async function archiveProject(id: string) {
 }
 
 export async function duplicateProject(sourceId: string, newProjectNumber: string, newName: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "create");
 
   const source = await prisma.project.findUnique({
     where: { id: sourceId, organizationId },
@@ -479,7 +479,7 @@ export async function duplicateProject(sourceId: string, newProjectNumber: strin
 }
 
 export async function saveAsTemplate(projectId: string, templateName: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "create");
 
   const source = await prisma.project.findUnique({
     where: { id: projectId, organizationId },
@@ -610,7 +610,7 @@ export async function getTemplates() {
 }
 
 export async function deleteTemplate(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "delete");
 
   const template = await prisma.project.findUnique({
     where: { id, organizationId },
@@ -623,7 +623,7 @@ export async function deleteTemplate(id: string) {
 }
 
 export async function deleteProject(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("project", "delete");
 
   // Only allow deleting cancelled projects
   const project = await prisma.project.findUnique({

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { sendEmail } from "@/lib/email";
 import { getPlatformName } from "@/lib/platform";
@@ -72,7 +72,7 @@ export async function updateOrganization(data: {
   name: string;
   settings: OrgSettings;
 }) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("orgSettings", "update");
 
   const updated = await prisma.organization.update({
     where: { id: organizationId },

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { supplierSchema, type SupplierFormValues } from "@/lib/validations/asset";
 
@@ -17,7 +17,7 @@ export async function getSuppliers() {
 }
 
 export async function createSupplier(data: SupplierFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("orgSettings", "update");
   const parsed = supplierSchema.parse(data);
   // Clean empty strings to null
   const cleaned = {
@@ -37,7 +37,7 @@ export async function createSupplier(data: SupplierFormValues) {
 }
 
 export async function updateSupplier(id: string, data: SupplierFormValues) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("orgSettings", "update");
   const parsed = supplierSchema.parse(data);
   const cleaned = {
     ...parsed,
@@ -57,7 +57,7 @@ export async function updateSupplier(id: string, data: SupplierFormValues) {
 }
 
 export async function deleteSupplier(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("orgSettings", "update");
   const supplier = await prisma.supplier.findUnique({
     where: { id, organizationId },
     include: { _count: { select: { assets: true } } },

--- a/src/server/test-tag-assets.ts
+++ b/src/server/test-tag-assets.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { reserveTestTagIds, peekNextTestTagIds, getOrgTestTagSettings } from "@/server/settings";
 import type { Prisma, TestTagStatus } from "@/generated/prisma/client";
@@ -137,7 +137,7 @@ export async function createTestTagAsset(data: {
   assetId?: string;
   bulkAssetId?: string;
 }) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId } = await requirePermission("testTag", "create");
 
   // If linking to a serialized asset, use the asset's tag as the test tag ID
   let testTagId = data.testTagId;
@@ -194,7 +194,7 @@ export async function createTestTagAssetsFromBulk(data: {
   modelName?: string;
   location?: string;
 }) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("testTag", "create");
 
   // Verify bulk asset exists
   const bulkAsset = await prisma.bulkAsset.findFirst({
@@ -240,7 +240,7 @@ export async function updateTestTagAsset(id: string, data: {
   assetId?: string | null;
   bulkAssetId?: string | null;
 }) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("testTag", "update");
 
   const existing = await prisma.testTagAsset.findFirst({
     where: { id, organizationId },
@@ -268,7 +268,7 @@ export async function updateTestTagAsset(id: string, data: {
 }
 
 export async function retireTestTagAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("testTag", "update");
 
   const existing = await prisma.testTagAsset.findFirst({
     where: { id, organizationId },
@@ -284,7 +284,7 @@ export async function retireTestTagAsset(id: string) {
 }
 
 export async function deleteTestTagAsset(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId } = await requirePermission("testTag", "delete");
 
   const existing = await prisma.testTagAsset.findFirst({
     where: { id, organizationId },

--- a/src/server/test-tag-records.ts
+++ b/src/server/test-tag-records.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import type { OrgSettings } from "@/server/settings";
 
@@ -108,7 +108,7 @@ export async function createTestTagRecord(data: {
   failureNotes?: string;
   nextDueDate: Date | string;
 }) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("testTag", "create");
 
   // Verify asset exists and belongs to org
   const testTagAsset = await prisma.testTagAsset.findFirst({

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { computeOverbookedStatus } from "@/lib/availability";
 import type { Prisma } from "@/generated/prisma/client";
@@ -240,7 +240,7 @@ export async function checkOutItems(
     notes?: string;
   }>
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
 
   const results = await prisma.$transaction(async (tx) => {
     const updated: unknown[] = [];
@@ -387,7 +387,7 @@ export async function checkInItems(
     notes?: string;
   }>
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("warehouse", "check_in");
 
   const results = await prisma.$transaction(async (tx) => {
     const updated: unknown[] = [];
@@ -518,7 +518,7 @@ export async function checkInItems(
 // ---------------------------------------------------------------------------
 
 export async function checkOutKit(projectId: string, kitId: string) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
 
   return serialize(await prisma.$transaction(async (tx) => {
     // Find the kit parent line item on this project
@@ -585,7 +585,7 @@ export async function checkInKit(
   kitId: string,
   returnCondition: "GOOD" | "DAMAGED" | "MISSING" = "GOOD"
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("warehouse", "check_in");
 
   return serialize(await prisma.$transaction(async (tx) => {
     const kitLineItem = await tx.projectLineItem.findFirst({
@@ -701,7 +701,7 @@ export async function quickAddAndCheckOut(
     quantity?: number;
   }
 ) {
-  const { organizationId, userId } = await getOrgContext();
+  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
 
   const result = await prisma.$transaction(async (tx) => {
     // Get next sort order


### PR DESCRIPTION
Add requirePermission() checks to 70+ write operations across 16 server action files. Previously only org-members.ts had permission enforcement; all other create/update/delete operations were unprotected. Also adds missing "categories" breadcrumb label to top bar.