### PR TITLE
Move categories from settings to dedicated pages under Assets

### DIFF
--- a/src/app/(app)/assets/categories/[id]/page.tsx
+++ b/src/app/(app)/assets/categories/[id]/page.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import {
+  ChevronRight,
+  Boxes,
+  Container,
+  FolderOpen,
+  ArrowLeft,
+} from "lucide-react";
+
+import { getCategory } from "@/server/categories";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MediaThumbnail } from "@/components/media/media-thumbnail";
+import { resolveModelPhotoUrl } from "@/lib/media-utils";
+
+const kitStatusColors: Record<string, string> = {
+  AVAILABLE: "bg-green-500/10 text-green-500 border-green-500/20",
+  CHECKED_OUT: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+  IN_MAINTENANCE: "bg-amber-500/10 text-amber-500 border-amber-500/20",
+  RETIRED: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+};
+
+export default function CategoryDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+
+  const { data: category, isLoading } = useQuery({
+    queryKey: ["category", id],
+    queryFn: () => getCategory(id),
+  });
+
+  if (isLoading) {
+    return <div className="p-6 text-muted-foreground">Loading...</div>;
+  }
+
+  if (!category) {
+    return <div className="p-6 text-muted-foreground">Category not found.</div>;
+  }
+
+  const parentHref = category.parent
+    ? `/assets/categories/${category.parent.id}`
+    : "/assets/categories";
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.push(parentHref)}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+            <Link href="/assets/categories" className="hover:text-foreground transition-colors">
+              Categories
+            </Link>
+            {category.parent && (
+              <>
+                <ChevronRight className="h-3 w-3" />
+                <Link
+                  href={`/assets/categories/${category.parent.id}`}
+                  className="hover:text-foreground transition-colors"
+                >
+                  {category.parent.name}
+                </Link>
+              </>
+            )}
+            <ChevronRight className="h-3 w-3" />
+            <span className="text-foreground">{category.name}</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">{category.icon || "📁"}</span>
+            <h1 className="text-2xl font-bold tracking-tight">{category.name}</h1>
+          </div>
+          {category.description && (
+            <p className="text-muted-foreground mt-1">{category.description}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {category._count.models > 0 && (
+            <Badge variant="secondary" className="gap-1">
+              <Boxes className="h-3 w-3" />
+              {category._count.models} model{category._count.models !== 1 ? "s" : ""}
+            </Badge>
+          )}
+          {category._count.kits > 0 && (
+            <Badge variant="secondary" className="gap-1">
+              <Container className="h-3 w-3" />
+              {category._count.kits} kit{category._count.kits !== 1 ? "s" : ""}
+            </Badge>
+          )}
+          {category._count.children > 0 && (
+            <Badge variant="outline" className="gap-1">
+              <FolderOpen className="h-3 w-3" />
+              {category._count.children} subcategori{category._count.children !== 1 ? "es" : "y"}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Subcategories */}
+      {category.children && category.children.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Subcategories</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {category.children.map((child: any) => (
+                <Link
+                  key={child.id}
+                  href={`/assets/categories/${child.id}`}
+                  className="flex items-center gap-3 rounded-lg border p-3 hover:bg-accent/50 transition-colors group"
+                >
+                  <span className="text-lg">{child.icon || "📂"}</span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium group-hover:text-primary transition-colors">
+                      {child.name}
+                    </span>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      {child._count.models > 0 && (
+                        <span className="text-xs text-muted-foreground">{child._count.models} models</span>
+                      )}
+                      {child._count.kits > 0 && (
+                        <span className="text-xs text-muted-foreground">{child._count.kits} kits</span>
+                      )}
+                    </div>
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                </Link>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Models & Kits tabs */}
+      <Tabs defaultValue="models">
+        <TabsList>
+          <TabsTrigger value="models">
+            Models ({category._count.models})
+          </TabsTrigger>
+          <TabsTrigger value="kits">
+            Kits ({category._count.kits})
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="models">
+          {category.models && category.models.length > 0 ? (
+            <Card>
+              <CardContent className="p-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-12"></TableHead>
+                      <TableHead>Model</TableHead>
+                      <TableHead className="hidden sm:table-cell">Manufacturer</TableHead>
+                      <TableHead className="hidden md:table-cell">Model Number</TableHead>
+                      <TableHead className="text-right">Assets</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                    {category.models.map((model: any) => {
+                      const photoUrl = resolveModelPhotoUrl(model, true);
+                      return (
+                        <TableRow key={model.id}>
+                          <TableCell>
+                            <MediaThumbnail
+                              url={photoUrl}
+                              alt={model.name}
+                              size={32}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Link
+                              href={`/assets/models/${model.id}`}
+                              className="font-medium hover:text-primary transition-colors"
+                            >
+                              {model.name}
+                            </Link>
+                          </TableCell>
+                          <TableCell className="hidden sm:table-cell text-muted-foreground">
+                            {model.manufacturer || "\u2014"}
+                          </TableCell>
+                          <TableCell className="hidden md:table-cell text-muted-foreground">
+                            {model.modelNumber || "\u2014"}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Badge variant="secondary">{model._count.assets}</Badge>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+                <Boxes className="h-10 w-10 text-muted-foreground/50 mb-3" />
+                <p className="text-sm text-muted-foreground">No models in this category.</p>
+                <Button variant="outline" size="sm" className="mt-3" render={<Link href="/assets/models/new" />}>
+                  Add Model
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+
+        <TabsContent value="kits">
+          {category.kits && category.kits.length > 0 ? (
+            <Card>
+              <CardContent className="p-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Kit</TableHead>
+                      <TableHead className="hidden sm:table-cell">Asset Tag</TableHead>
+                      <TableHead className="hidden md:table-cell">Status</TableHead>
+                      <TableHead className="text-right">Items</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                    {category.kits.map((kit: any) => {
+                      const itemCount = (kit._count?.serializedItems || 0) + (kit._count?.bulkItems || 0);
+                      return (
+                        <TableRow key={kit.id}>
+                          <TableCell>
+                            <Link
+                              href={`/kits/${kit.id}`}
+                              className="font-medium hover:text-primary transition-colors"
+                            >
+                              {kit.name}
+                            </Link>
+                          </TableCell>
+                          <TableCell className="hidden sm:table-cell text-muted-foreground">
+                            {kit.assetTag || "\u2014"}
+                          </TableCell>
+                          <TableCell className="hidden md:table-cell">
+                            {kit.status && (
+                              <Badge className={kitStatusColors[kit.status] || ""}>
+                                {kit.status.replace(/_/g, " ")}
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Badge variant="secondary">{itemCount}</Badge>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+                <Container className="h-10 w-10 text-muted-foreground/50 mb-3" />
+                <p className="text-sm text-muted-foreground">No kits in this category.</p>
+                <Button variant="outline" size="sm" className="mt-3" render={<Link href="/kits/new" />}>
+                  Add Kit
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/(app)/assets/categories/page.tsx
+++ b/src/app/(app)/assets/categories/page.tsx
@@ -1,17 +1,329 @@
 "use client";
 
-import { CategoryManager } from "@/components/assets/category-manager";
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, Pencil, Trash2, Boxes, Container, FolderOpen, Search } from "lucide-react";
+import { toast } from "sonner";
+
+import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
+import { getCategories, createCategory, updateCategory, deleteCategory } from "@/server/categories";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useCanDo } from "@/lib/use-permissions";
 
 export default function CategoriesPage() {
+  const queryClient = useQueryClient();
+  const canCreate = useCanDo("model", "create");
+  const canUpdate = useCanDo("model", "update");
+  const canDelete = useCanDo("model", "delete");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [parentId, setParentId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  const { data: categories = [], isLoading } = useQuery({
+    queryKey: ["categories"],
+    queryFn: () => getCategories(),
+  });
+
+  const form = useForm<CategoryFormValues>({
+    resolver: zodResolver(categorySchema),
+    defaultValues: { name: "", description: "", icon: "", sortOrder: 0 },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createCategory,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+      toast.success("Category created");
+      resetForm();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CategoryFormValues }) => updateCategory(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+      toast.success("Category updated");
+      resetForm();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteCategory,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+      toast.success("Category deleted");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  function resetForm() {
+    form.reset({ name: "", description: "", icon: "", sortOrder: 0 });
+    setEditingId(null);
+    setParentId(null);
+    setDialogOpen(false);
+  }
+
+  function openCreate(parentCategoryId?: string) {
+    resetForm();
+    if (parentCategoryId) {
+      setParentId(parentCategoryId);
+    }
+    setDialogOpen(true);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function openEdit(cat: any) {
+    setEditingId(cat.id);
+    setParentId(cat.parentId);
+    form.reset({
+      name: cat.name,
+      description: cat.description || "",
+      icon: cat.icon || "",
+      sortOrder: cat.sortOrder,
+    });
+    setDialogOpen(true);
+  }
+
+  function onSubmit(data: CategoryFormValues) {
+    const payload = { ...data, parentId };
+    if (editingId) {
+      updateMutation.mutate({ id: editingId, data: payload });
+    } else {
+      createMutation.mutate(payload);
+    }
+  }
+
+  // Build flat list with parents followed by their children (indented)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const topLevel = (categories as any[]).filter((c) => !c.parentId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const childrenOf = (id: string) => (categories as any[]).filter((c) => c.parentId === id);
+
+  // Build ordered rows: parent, then children, then next parent...
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows: { category: any; depth: number }[] = [];
+  for (const parent of topLevel) {
+    rows.push({ category: parent, depth: 0 });
+    for (const child of childrenOf(parent.id)) {
+      rows.push({ category: child, depth: 1 });
+    }
+  }
+
+  // Filter by search
+  const filteredRows = search
+    ? rows.filter((r) => r.category.name.toLowerCase().includes(search.toLowerCase()))
+    : rows;
+
   return (
-    <div className="mx-auto max-w-2xl space-y-4">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Categories</h1>
-        <p className="text-muted-foreground">
-          Organize your equipment into categories and subcategories.
-        </p>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Categories</h1>
+          <p className="text-muted-foreground">
+            Organize your equipment into categories and subcategories.
+          </p>
+        </div>
+        {canCreate && (
+          <Button onClick={() => openCreate()}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Category
+          </Button>
+        )}
       </div>
-      <CategoryManager />
+
+      {/* Search */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search categories..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Category</TableHead>
+              <TableHead className="hidden sm:table-cell">Description</TableHead>
+              <TableHead className="text-right">Models</TableHead>
+              <TableHead className="text-right hidden sm:table-cell">Kits</TableHead>
+              <TableHead className="text-right hidden md:table-cell">Subcategories</TableHead>
+              {(canUpdate || canDelete || canCreate) && (
+                <TableHead className="w-[100px]"></TableHead>
+              )}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground">Loading...</TableCell>
+              </TableRow>
+            ) : filteredRows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-12">
+                  <div className="flex flex-col items-center gap-2">
+                    <FolderOpen className="h-10 w-10 text-muted-foreground/50" />
+                    <p>{search ? "No matching categories." : "No categories yet."}</p>
+                    {!search && canCreate && (
+                      <Button size="sm" className="mt-2" onClick={() => openCreate()}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Create First Category
+                      </Button>
+                    )}
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredRows.map(({ category: cat, depth }) => (
+                <TableRow key={cat.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-2" style={{ paddingLeft: depth * 24 }}>
+                      <span className="text-base">{cat.icon || (depth === 0 ? "📁" : "📂")}</span>
+                      <Link
+                        href={`/assets/categories/${cat.id}`}
+                        className="font-medium hover:text-primary transition-colors"
+                      >
+                        {cat.name}
+                      </Link>
+                    </div>
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell text-muted-foreground max-w-[200px] truncate">
+                    {cat.description || "\u2014"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {cat._count.models > 0 ? (
+                      <Badge variant="secondary" className="gap-1">
+                        <Boxes className="h-3 w-3" />
+                        {cat._count.models}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right hidden sm:table-cell">
+                    {cat._count.kits > 0 ? (
+                      <Badge variant="secondary" className="gap-1">
+                        <Container className="h-3 w-3" />
+                        {cat._count.kits}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right hidden md:table-cell">
+                    {cat._count.children > 0 ? cat._count.children : "\u2014"}
+                  </TableCell>
+                  {(canUpdate || canDelete || canCreate) && (
+                    <TableCell>
+                      <div className="flex items-center justify-end gap-1">
+                        {canCreate && depth === 0 && (
+                          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openCreate(cat.id)} title="Add subcategory">
+                            <Plus className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                        {canUpdate && (
+                          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openEdit(cat)} title="Edit">
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                        {canDelete && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive"
+                            title="Delete"
+                            onClick={() => {
+                              if (confirm("Delete this category?")) deleteMutation.mutate(cat.id);
+                            }}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Create/Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingId ? "Edit Category" : "New Category"}</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="cat-name">Name</Label>
+              <Input id="cat-name" {...form.register("name")} placeholder="e.g. Audio" />
+              {form.formState.errors.name && (
+                <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cat-icon">Icon (emoji)</Label>
+              <Input id="cat-icon" {...form.register("icon")} placeholder="e.g. 🎤" className="w-20" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cat-desc">Description</Label>
+              <Textarea id="cat-desc" {...form.register("description")} placeholder="Optional description" rows={2} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cat-sort">Sort Order</Label>
+              <Input id="cat-sort" type="number" {...form.register("sortOrder")} className="w-24" />
+            </div>
+            {parentId && (
+              <p className="text-xs text-muted-foreground">
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                Subcategory of: {(categories as any[]).find((c) => c.id === parentId)?.name}
+              </p>
+            )}
+            <DialogFooter>
+              <DialogClose render={<Button variant="outline" type="button" onClick={resetForm} />}>
+                Cancel
+              </DialogClose>
+              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+                {editingId ? "Update" : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(app)/settings/assets/page.tsx
+++ b/src/app/(app)/settings/assets/page.tsx
@@ -10,7 +10,6 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { CategoryManager } from "@/components/assets/category-manager";
 import { SupplierManager } from "@/components/settings/supplier-manager";
 import {
   getOrganization,
@@ -116,8 +115,16 @@ export default function AssetsSettingsPage() {
 
       {canEdit && (
         <Card>
-          <CardContent className="pt-6">
-            <CategoryManager />
+          <CardHeader>
+            <CardTitle>Categories</CardTitle>
+            <CardDescription>
+              Organize your equipment into categories and subcategories.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="outline" render={<Link href="/assets/categories" />}>
+              Manage Categories
+            </Button>
           </CardContent>
         </Card>
       )}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   ShieldCheck,
   BookTemplate,
   ChevronRight,
+  Tags,
   type LucideIcon,
 } from "lucide-react";
 import { usePlatformBranding } from "@/lib/use-platform-name";
@@ -66,6 +67,7 @@ const navItems: NavItem[] = [
     resource: "asset",
     items: [
       { title: "Models", url: "/assets/models", icon: Boxes, resource: "model" },
+      { title: "Categories", url: "/assets/categories", icon: Tags, resource: "model" },
       { title: "Kits", url: "/kits", icon: Container, resource: "kit" },
       { title: "Availability", url: "/assets/availability", icon: CalendarRange, resource: "asset" },
     ],

--- a/src/components/locations/location-table.tsx
+++ b/src/components/locations/location-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { Search, Plus, Star } from "lucide-react";
@@ -33,6 +33,46 @@ const typeLabels: Record<string, string> = {
   OFFSITE: "Offsite",
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildTreeRows(locations: any[]): { location: any; depth: number }[] {
+  const childrenMap = new Map<string | null, typeof locations>();
+  for (const loc of locations) {
+    const pid = loc.parentId || null;
+    if (!childrenMap.has(pid)) childrenMap.set(pid, []);
+    childrenMap.get(pid)!.push(loc);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows: { location: any; depth: number }[] = [];
+
+  function addChildren(parentId: string | null, depth: number) {
+    const children = childrenMap.get(parentId) || [];
+    for (const child of children) {
+      rows.push({ location: child, depth });
+      addChildren(child.id, depth + 1);
+    }
+  }
+
+  // Start with root locations (no parentId, or parent not in current result set)
+  const locationIds = new Set(locations.map((l) => l.id));
+  const roots = locations.filter((l) => !l.parentId || !locationIds.has(l.parentId));
+
+  for (const root of roots) {
+    rows.push({ location: root, depth: 0 });
+    addChildren(root.id, 1);
+  }
+
+  // If tree-building produced fewer rows than input (shouldn't happen), add missing ones
+  const addedIds = new Set(rows.map((r) => r.location.id));
+  for (const loc of locations) {
+    if (!addedIds.has(loc.id)) {
+      rows.push({ location: loc, depth: 0 });
+    }
+  }
+
+  return rows;
+}
+
 export function LocationTable() {
   const { sortBy, sortOrder, pageSize, page, setPage, setPageSize, handleSort } =
     useTablePreferences("locations", { sortBy: "name", sortOrder: "asc" });
@@ -51,9 +91,10 @@ export function LocationTable() {
     }),
   });
 
-  const locations = data?.locations || [];
   const totalPages = data?.totalPages || 1;
   const total = data?.total || 0;
+
+  const treeRows = useMemo(() => buildTreeRows(data?.locations || []), [data?.locations]);
 
   return (
     <div className="space-y-4">
@@ -91,30 +132,29 @@ export function LocationTable() {
           <TableHeader>
             <TableRow>
               <SortableTableHead sortKey="name" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort}>Name</SortableTableHead>
-              <SortableTableHead sortKey="type" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort}>Type</SortableTableHead>
-              <SortableTableHead sortKey="address" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort}>Address</SortableTableHead>
+              <SortableTableHead sortKey="type" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} className="hidden sm:table-cell">Type</SortableTableHead>
+              <SortableTableHead sortKey="address" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} className="hidden md:table-cell">Address</SortableTableHead>
               <SortableTableHead sortKey="name" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} className="text-right">Assets</SortableTableHead>
-              <SortableTableHead sortKey="name" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort}>Parent</SortableTableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground">Loading...</TableCell>
+                <TableCell colSpan={4} className="text-center text-muted-foreground">Loading...</TableCell>
               </TableRow>
-            ) : locations.length === 0 ? (
+            ) : treeRows.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground">
+                <TableCell colSpan={4} className="text-center text-muted-foreground">
                   No locations found.
                 </TableCell>
               </TableRow>
             ) : (
-              locations.map((location) => {
+              treeRows.map(({ location, depth }) => {
                 const assetCount = (location._count?.assets || 0) + (location._count?.bulkAssets || 0) + (location._count?.kits || 0);
                 return (
                   <TableRow key={location.id}>
                     <TableCell>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2" style={{ paddingLeft: depth * 24 }}>
                         <Link href={`/locations/${location.id}`} className="font-medium hover:underline">
                           {location.name}
                         </Link>
@@ -123,19 +163,16 @@ export function LocationTable() {
                         )}
                       </div>
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       <Badge variant="outline" className={typeColors[location.type] || ""}>
                         {typeLabels[location.type] || location.type}
                       </Badge>
                     </TableCell>
-                    <TableCell className="text-muted-foreground">
+                    <TableCell className="hidden md:table-cell text-muted-foreground">
                       {location.address || "\u2014"}
                     </TableCell>
                     <TableCell className="text-right">
                       {assetCount}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {location.parent?.name || "\u2014"}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/lib/page-commands.ts
+++ b/src/lib/page-commands.ts
@@ -57,6 +57,15 @@ export const PAGE_COMMANDS: PageCommand[] = [
         searchType: "model",
       },
       {
+        label: "Categories",
+        href: "/assets/categories",
+        aliases: ["categories", "category", "organize", "groups"],
+        icon: "Tags",
+        description: "Equipment categories and subcategories",
+        searchable: true,
+        searchType: "category",
+      },
+      {
         label: "Kits",
         href: "/kits",
         aliases: ["kits", "kitlist", "cases", "containers"],
@@ -210,9 +219,9 @@ export const PAGE_COMMANDS: PageCommand[] = [
       {
         label: "Assets",
         href: "/settings/assets",
-        aliases: ["assetsettings", "assettags", "tags", "categories", "suppliers"],
+        aliases: ["assetsettings", "assettags", "tags", "suppliers"],
         icon: "Package",
-        description: "Asset tags, categories, and suppliers",
+        description: "Asset tags and suppliers",
       },
       {
         label: "Test & Tag Settings",

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -2,15 +2,54 @@
 
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { serialize } from "@/lib/serialize";
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
 
 export async function getCategories() {
   const { organizationId } = await getOrgContext();
-  return prisma.category.findMany({
-    where: { organizationId },
-    include: { parent: true, _count: { select: { models: true, children: true } } },
-    orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+  return serialize(
+    await prisma.category.findMany({
+      where: { organizationId },
+      include: { parent: true, _count: { select: { models: true, kits: true, children: true } } },
+      orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+    })
+  );
+}
+
+export async function getCategory(id: string) {
+  const { organizationId } = await getOrgContext();
+
+  const category = await prisma.category.findFirst({
+    where: { id, organizationId },
+    include: {
+      parent: true,
+      children: {
+        include: { _count: { select: { models: true, kits: true, children: true } } },
+        orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+      },
+      models: {
+        include: {
+          _count: { select: { assets: true } },
+          media: {
+            include: { file: true },
+            orderBy: { sortOrder: "asc" },
+            take: 1,
+          },
+        },
+        orderBy: { name: "asc" },
+      },
+      kits: {
+        include: {
+          _count: { select: { serializedItems: true, bulkItems: true } },
+        },
+        orderBy: { name: "asc" },
+      },
+      _count: { select: { models: true, kits: true, children: true } },
+    },
   });
+
+  if (!category) throw new Error("Category not found");
+  return serialize(category);
 }
 
 export async function getCategoryTree() {
@@ -36,31 +75,35 @@ export async function getCategoryTree() {
       roots.push(node);
     }
   }
-  return roots;
+  return serialize(roots);
 }
 
 export async function createCategory(data: CategoryFormValues) {
   const { organizationId } = await requirePermission("model", "create");
   const parsed = categorySchema.parse(data);
-  return prisma.category.create({
-    data: {
-      ...parsed,
-      parentId: parsed.parentId || null,
-      organizationId,
-    },
-  });
+  return serialize(
+    await prisma.category.create({
+      data: {
+        ...parsed,
+        parentId: parsed.parentId || null,
+        organizationId,
+      },
+    })
+  );
 }
 
 export async function updateCategory(id: string, data: CategoryFormValues) {
   const { organizationId } = await requirePermission("model", "update");
   const parsed = categorySchema.parse(data);
-  return prisma.category.update({
-    where: { id, organizationId },
-    data: {
-      ...parsed,
-      parentId: parsed.parentId || null,
-    },
-  });
+  return serialize(
+    await prisma.category.update({
+      where: { id, organizationId },
+      data: {
+        ...parsed,
+        parentId: parsed.parentId || null,
+      },
+    })
+  );
 }
 
 export async function deleteCategory(id: string) {
@@ -74,5 +117,7 @@ export async function deleteCategory(id: string) {
   if (category._count.children > 0) throw new Error("Cannot delete category with subcategories");
   if (category._count.models > 0) throw new Error("Cannot delete category with models");
 
-  return prisma.category.delete({ where: { id, organizationId } });
+  return serialize(
+    await prisma.category.delete({ where: { id, organizationId } })
+  );
 }

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -496,14 +496,14 @@ export async function globalSearch(query: string) {
     results.push({
       id: cat.id, type: "category",
       title: cat.name, subtitle: `${cat.modelCount} model${cat.modelCount !== 1 ? "s" : ""}`,
-      href: `/assets/models?category=${cat.id}`, relevance: Number(cat.match_quality) || 0,
+      href: `/assets/categories/${cat.id}`, relevance: Number(cat.match_quality) || 0,
     });
     // Sub-categories
     for (const sub of (subCategoriesByParent.get(cat.id) || [])) {
       results.push({
         id: sub.id, type: "category", isChild: true,
         title: sub.name, subtitle: null,
-        href: `/assets/models?category=${sub.id}`, relevance: 0,
+        href: `/assets/categories/${sub.id}`, relevance: 0,
       });
     }
     // Models in this category


### PR DESCRIPTION
- Add getCategory() server action with full model/kit/children includes
- Wrap all category server action returns with serialize()
- Rewrite /assets/categories as table view with indented child rows
- Create /assets/categories/[id] detail page with subcategories, models & kits tabs
- Add Categories to sidebar under Assets with Tags icon
- Update search result hrefs to link to /assets/categories/[id]
- Add Categories to PAGE_COMMANDS, remove from Settings aliases
- Replace inline CategoryManager in settings with "Manage Categories" link
- Update location table to indent children under parents, remove Parent column