### PR TITLE
Add expanded suppliers with full CRUD pages and purchase order tracking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -975,8 +975,28 @@ Template detail page hides: status dropdown, documents button, cancel/archive/de
 - **Settings**: `/settings/assets` no longer embeds CategoryManager — links to `/assets/categories` instead
 
 ### Suppliers
-- Unique per org by name
-- Referenced by: assets (purchase supplier), line items (subhire supplier)
+- **Routes**: `/suppliers` (list), `/suppliers/[id]` (detail), `/suppliers/[id]/edit`, `/suppliers/new`, `/suppliers/[id]/orders/new`
+- **Fields**: name (required), contactName, email, phone, website, address, notes, accountNumber, paymentTerms, defaultLeadTime, tags, isActive
+- **Server actions**: `src/server/suppliers.ts` — `getSuppliers()`, `getSuppliersPaginated()`, `getSupplierById()`, `getSupplierAssets()`, `getSupplierSubhires()`, `createSupplier()`, `updateSupplier()`, `deleteSupplier()`
+- **Permissions**: `"supplier"` resource with full CRUD. Owner/admin: all, manager: create/read/update, member/viewer: read
+- **Sidebar**: Between Clients and Locations with `Truck` icon, `resource: "supplier"`
+- **Search**: Global search matches name, contactName, accountNumber, email, tags. Added to PAGE_COMMANDS with `searchType: "supplier"`
+- **Detail page**: Info cards (Contact, Account Details, Summary), tags display, notes section, 3 tabs (Orders, Assets, Subhires)
+- **Delete guards**: Cannot delete supplier with linked assets, line items, or orders
+- **Tags**: Normalized to lowercase on save. `TagInput` on form
+- **Settings migration**: `/settings/assets` now links to `/suppliers` instead of inline SupplierManager
+
+### Supplier Orders (Purchase Orders)
+- **Models**: `SupplierOrder` and `SupplierOrderItem` for tracking purchases and subhire POs
+- **Enums**: `SupplierOrderType` (PURCHASE, SUBHIRE, REPAIR, OTHER), `SupplierOrderStatus` (DRAFT, SUBMITTED, CONFIRMED, PARTIAL, RECEIVED, CANCELLED)
+- **Server actions**: `src/server/supplier-orders.ts` — full CRUD for orders and items
+- **Order fields**: orderNumber (unique per org), type, status, dates (orderDate, expectedDate, receivedDate), financials (subtotal, taxAmount, total as Decimal), supplierId, projectId, createdById, notes
+- **Order items**: description, quantity, unitPrice, lineTotal (auto-calculated), modelId (optional), assetId (optional), notes, sortOrder
+- **Auto-calculations**: `recalculateOrderTotals()` sums item lineTotals, applies 10% GST
+- **Status shortcuts**: `updateSupplierOrderStatus()` — setting to RECEIVED auto-sets receivedDate
+- **Asset integration**: `purchaseOrderNumber` field on Asset, `supplierOrderId` FK linking asset to order
+- **Line item integration**: `subhireOrderNumber` field on ProjectLineItem, `supplierOrderId` FK linking line item to order
+- **Org export/import**: Both `supplierOrders` and `supplierOrderItems` included in manifest. Import order: after Projects (due to projectId FK)
 
 ---
 
@@ -1236,7 +1256,53 @@ const date = input.scheduledDate ? new Date(input.scheduledDate) : null;
 
 ---
 
-## 36. Integration Checklist for New Features
+## 36. Accessories & Auto-Pulls
+
+### Data Model
+- **`ModelAccessory`**: Join table linking a parent model to an accessory model. Fields: `parentModelId`, `accessoryModelId`, `quantity` (per parent unit), `level` (`AccessoryLevel` enum), `notes`, `sortOrder`. Unique constraint on `(parentModelId, accessoryModelId)`.
+- **`AccessoryLevel` enum**: `MANDATORY` (always auto-added, cannot remove without removing parent), `OPTIONAL` (auto-added but user can remove), `RECOMMENDED` (not auto-added, shown as suggestion).
+- **`ProjectLineItem` fields**: `isAccessory` (Boolean, default false), `accessoryLevel` (AccessoryLevel?), `manualOverride` (Boolean, default false — set when user manually changes qty, prevents auto-scaling).
+
+### Server Actions
+- `src/server/model-accessories.ts`: `getModelAccessories(modelId)`, `addModelAccessory(parentModelId, data)`, `updateModelAccessory(id, data)`, `removeModelAccessory(id)`, `reorderModelAccessories(parentModelId, orderedIds)`.
+- Circular reference detection: BFS walk up to 3 levels deep from the proposed accessory model to check if the parent model appears as a descendant.
+- **Live propagation**: Changes to `ModelAccessory` definitions automatically propagate to all active (non-finished, non-template) projects:
+  - `addModelAccessory`: Creates accessory child line items on all projects that have the parent model.
+  - `updateModelAccessory`: Scales quantity and updates level on existing non-manually-overridden accessory line items.
+  - `removeModelAccessory`: Deletes non-manually-overridden accessory line items (and their grandchildren) from active projects.
+  - All propagation functions recalculate project totals after changes.
+
+### Auto-Pull Logic (`src/server/line-items.ts`)
+- **`addLineItem`**: After creating a line item for an equipment model, queries `ModelAccessory` for that model. Creates child line items for MANDATORY and OPTIONAL accessories with `isAccessory: true`, `parentLineItemId` set. Cascades up to 3 levels. Returns `recommendedAccessories` array for RECOMMENDED items (UI can show toast).
+- **`addKitLineItem`**: After creating kit parent + kit children, queries each kit child's model for accessories and calls `autoAddAccessories` for each. Kit child accessories become grandchildren of the kit parent.
+- **`updateLineItem`**: When parent quantity changes, scales non-`manualOverride` accessory children proportionally using the base ratio from `ModelAccessory.quantity`.
+- **`removeLineItem`**: Cascade deletes all accessory children (`isAccessory: true`) when parent is removed.
+- **Duplicate merging**: If an accessory model already exists on the project as a standalone line item, increments its quantity instead of creating a new row.
+
+### Unified Tree Rendering
+- **Children are children**: Accessories use the same `parentLineItemId`/`childLineItems` relation as kit children. All rendering code uses a single unified `allChildren = item.childLineItems || []` array.
+- **Three levels**: Parent item -> children (kit items or accessories) -> grandchildren (accessories of kit children).
+- **All 5 PDFs**: Use unified `allChildren` rendering with `isAccessory` badge where applicable. Grandchildren rendered at deeper indent.
+- **Quote/Invoice special case**: For KIT_PRICE kits, `allChildren` is filtered to only accessories (kit children without individual prices are hidden).
+- **Warehouse page**: Recursive `renderChildren()` function handles all child types uniformly.
+- **Pull sheet**: Single `allChildren` array for both kit items and accessories.
+- **Line items panel**: Unified rendering with teal background for accessories, standard background for kit children. Grandchildren rendered at deeper indent.
+
+### Overbooking
+- `computeOverbookedStatus()` propagates overbooking from grandchildren (kit child accessories) up to kit children (as inherited), then from kit children up to kit parents.
+- Accessories consume stock like any other line item and are checked for overbooking.
+
+### UI
+- **Model detail page**: "Accessories" tab (`ModelAccessoriesTab` component) showing table of accessory relationships with inline editing for quantity and level. "Add Accessory" dialog with model picker (excludes self and already-added models).
+- **Line items panel**: All children rendered uniformly under parent. Accessories get teal background tint and "Required"/"Acc." badge. Mandatory accessories cannot be individually deleted.
+- **Validation schema**: `src/lib/validations/model-accessory.ts`.
+
+### Org Export/Import
+- `ModelAccessory` added to export manifest and import (after Models, before Kits). Import remaps `parentModelId` and `accessoryModelId` via model ID map.
+
+---
+
+## 37. Integration Checklist for New Features
 
 When implementing a new feature, ensure it integrates with ALL existing systems.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,14 @@ No test framework is configured.
 - Pricing modes: `KIT_PRICE` (single price on parent) or `ITEMIZED` (individual prices on children).
 - Warehouse: kits check out/in via `checkOutKit`/`checkInKit` (not `checkOutItems`). Kit items in the checkout selection must be routed to `kitCheckOutMutation` separately from regular items.
 
+### Accessories & Auto-Pulls
+- `ModelAccessory` links parent model → accessory model with quantity ratio and `AccessoryLevel` (MANDATORY/OPTIONAL/RECOMMENDED).
+- `addLineItem` auto-adds MANDATORY and OPTIONAL accessories as child line items (`isAccessory: true`, `parentLineItemId` set). Cascades up to 3 levels. RECOMMENDED returned for UI toast.
+- `updateLineItem` scales non-`manualOverride` accessory children when parent qty changes.
+- `removeLineItem` cascade deletes all accessory children.
+- Circular reference detection via BFS up to 3 levels in `addModelAccessory`.
+- Server actions in `src/server/model-accessories.ts`. Validation in `src/lib/validations/model-accessory.ts`.
+
 ### Auto-Incrementing Asset Tags
 - Org settings (`Organization.metadata` JSON) store `assetTagPrefix`, `assetTagDigits`, `assetTagCounter`.
 - `peekNextAssetTags(count)` — read-only preview, no counter increment. Used by forms for suggested tags.

--- a/prisma/migrations/20260313122352_add_supplier_orders/migration.sql
+++ b/prisma/migrations/20260313122352_add_supplier_orders/migration.sql
@@ -1,0 +1,103 @@
+-- CreateEnum
+CREATE TYPE "SupplierOrderType" AS ENUM ('PURCHASE', 'SUBHIRE', 'REPAIR', 'LABOUR', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "SupplierOrderStatus" AS ENUM ('DRAFT', 'ORDERED', 'PARTIAL', 'RECEIVED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "asset" ADD COLUMN     "purchaseOrderNumber" TEXT,
+ADD COLUMN     "supplierOrderId" TEXT;
+
+-- AlterTable
+ALTER TABLE "project_line_item" ADD COLUMN     "subhireOrderNumber" TEXT,
+ADD COLUMN     "supplierOrderId" TEXT;
+
+-- AlterTable
+ALTER TABLE "supplier" ADD COLUMN     "accountNumber" TEXT,
+ADD COLUMN     "defaultLeadTime" TEXT,
+ADD COLUMN     "paymentTerms" TEXT,
+ADD COLUMN     "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "supplier_order" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "supplierId" TEXT NOT NULL,
+    "orderNumber" TEXT NOT NULL,
+    "type" "SupplierOrderType" NOT NULL,
+    "status" "SupplierOrderStatus" NOT NULL DEFAULT 'DRAFT',
+    "orderDate" TIMESTAMP(3),
+    "expectedDate" TIMESTAMP(3),
+    "receivedDate" TIMESTAMP(3),
+    "subtotal" DECIMAL(10,2),
+    "taxAmount" DECIMAL(10,2),
+    "total" DECIMAL(10,2),
+    "projectId" TEXT,
+    "notes" TEXT,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "supplier_order_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "supplier_order_item" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unitPrice" DECIMAL(10,2),
+    "lineTotal" DECIMAL(10,2),
+    "modelId" TEXT,
+    "assetId" TEXT,
+    "notes" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "supplier_order_item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "supplier_order_organizationId_idx" ON "supplier_order"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "supplier_order_organizationId_supplierId_idx" ON "supplier_order"("organizationId", "supplierId");
+
+-- CreateIndex
+CREATE INDEX "supplier_order_organizationId_orderNumber_idx" ON "supplier_order"("organizationId", "orderNumber");
+
+-- CreateIndex
+CREATE INDEX "supplier_order_item_orderId_idx" ON "supplier_order_item"("orderId");
+
+-- CreateIndex
+CREATE INDEX "asset_supplierOrderId_idx" ON "asset"("supplierOrderId");
+
+-- CreateIndex
+CREATE INDEX "project_line_item_supplierOrderId_idx" ON "project_line_item"("supplierOrderId");
+
+-- AddForeignKey
+ALTER TABLE "supplier_order" ADD CONSTRAINT "supplier_order_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order" ADD CONSTRAINT "supplier_order_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "supplier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order" ADD CONSTRAINT "supplier_order_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order" ADD CONSTRAINT "supplier_order_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order_item" ADD CONSTRAINT "supplier_order_item_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "supplier_order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order_item" ADD CONSTRAINT "supplier_order_item_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "model"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "supplier_order_item" ADD CONSTRAINT "supplier_order_item_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "asset"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "asset" ADD CONSTRAINT "asset_supplierOrderId_fkey" FOREIGN KEY ("supplierOrderId") REFERENCES "supplier_order"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_line_item" ADD CONSTRAINT "project_line_item_supplierOrderId_fkey" FOREIGN KEY ("supplierOrderId") REFERENCES "supplier_order"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model User {
   backupCodes             BackupCode[]
   activityLogs            ActivityLog[]
   passkeys                Passkey[]
+  supplierOrders          SupplierOrder[]
 
   @@map("user")
 }
@@ -120,6 +121,7 @@ model Organization {
   projectLineItems   ProjectLineItem[]
   scanLogs           AssetScanLog[]
   suppliers          Supplier[]
+  supplierOrders     SupplierOrder[]
   kits               Kit[]
   kitSerializedItems KitSerializedItem[]
   kitBulkItems       KitBulkItem[]
@@ -133,6 +135,7 @@ model Organization {
   testTagAssets      TestTagAsset[]
   testTagRecords     TestTagRecord[]
   activityLogs       ActivityLog[]
+  modelAccessories   ModelAccessory[]
 
   @@map("organization")
 }
@@ -382,6 +385,28 @@ enum FailureAction {
   REFERRED_TO_ELECTRICIAN
 }
 
+enum AccessoryLevel {
+  MANDATORY
+  OPTIONAL
+  RECOMMENDED
+}
+
+enum SupplierOrderType {
+  PURCHASE
+  SUBHIRE
+  REPAIR
+  LABOUR
+  OTHER
+}
+
+enum SupplierOrderStatus {
+  DRAFT
+  ORDERED
+  PARTIAL
+  RECEIVED
+  CANCELLED
+}
+
 enum ProjectMediaType {
   FLOOR_PLAN
   QUOTE
@@ -459,35 +484,121 @@ model Model {
   lineItems  ProjectLineItem[]
   media      ModelMedia[]
 
+  parentAccessories   ModelAccessory[] @relation("ParentAccessories")
+  accessoryOf         ModelAccessory[] @relation("AccessoryOf")
+  supplierOrderItems  SupplierOrderItem[]
+
   @@index([organizationId])
   @@index([categoryId])
   @@index([isActive])
   @@map("model")
 }
 
+// ─── Model Accessory ──────────────────────────────────────────────────────────
+
+model ModelAccessory {
+  id              String         @id @default(cuid())
+  organizationId  String
+  organization    Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  parentModelId   String
+  parentModel     Model          @relation("ParentAccessories", fields: [parentModelId], references: [id], onDelete: Cascade)
+
+  accessoryModelId String
+  accessoryModel  Model          @relation("AccessoryOf", fields: [accessoryModelId], references: [id], onDelete: Cascade)
+
+  quantity        Int            @default(1)
+  level           AccessoryLevel
+  notes           String?
+  sortOrder       Int            @default(0)
+
+  @@unique([parentModelId, accessoryModelId])
+  @@index([organizationId])
+  @@index([parentModelId])
+  @@map("model_accessory")
+}
+
 // ─── Supplier ───────────────────────────────────────────────────────────────
 
 model Supplier {
-  id             String       @id @default(cuid())
-  organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  name           String
-  contactName    String?
-  email          String?
-  phone          String?
-  website        String?
-  address        String?
-  notes          String?
-  isActive       Boolean      @default(true)
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  id              String       @id @default(cuid())
+  organizationId  String
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  name            String
+  contactName     String?
+  email           String?
+  phone           String?
+  website         String?
+  address         String?
+  notes           String?
+  accountNumber   String?
+  paymentTerms    String?
+  defaultLeadTime String?
+  tags            String[]     @default([])
+  isActive        Boolean      @default(true)
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
 
   assets    Asset[]
   lineItems ProjectLineItem[]
+  orders    SupplierOrder[]
 
   @@unique([organizationId, name])
   @@index([organizationId])
   @@map("supplier")
+}
+
+// ─── Supplier Orders ────────────────────────────────────────────────────────
+
+model SupplierOrder {
+  id              String              @id @default(cuid())
+  organizationId  String
+  organization    Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  supplierId      String
+  supplier        Supplier            @relation(fields: [supplierId], references: [id], onDelete: Cascade)
+  orderNumber     String
+  type            SupplierOrderType
+  status          SupplierOrderStatus @default(DRAFT)
+  orderDate       DateTime?
+  expectedDate    DateTime?
+  receivedDate    DateTime?
+  subtotal        Decimal?            @db.Decimal(10, 2)
+  taxAmount       Decimal?            @db.Decimal(10, 2)
+  total           Decimal?            @db.Decimal(10, 2)
+  projectId       String?
+  project         Project?            @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  notes           String?
+  createdById     String?
+  createdBy       User?               @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  items           SupplierOrderItem[]
+  assets          Asset[]
+  lineItems       ProjectLineItem[]
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+
+  @@index([organizationId])
+  @@index([organizationId, supplierId])
+  @@index([organizationId, orderNumber])
+  @@map("supplier_order")
+}
+
+model SupplierOrderItem {
+  id          String         @id @default(cuid())
+  orderId     String
+  order       SupplierOrder  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  description String
+  quantity    Int            @default(1)
+  unitPrice   Decimal?       @db.Decimal(10, 2)
+  lineTotal   Decimal?       @db.Decimal(10, 2)
+  modelId     String?
+  model       Model?         @relation(fields: [modelId], references: [id], onDelete: SetNull)
+  assetId     String?
+  asset       Asset?         @relation(fields: [assetId], references: [id], onDelete: SetNull)
+  notes       String?
+  sortOrder   Int            @default(0)
+
+  @@index([orderId])
+  @@map("supplier_order_item")
 }
 
 // ─── Kit (Physical Container) ────────────────────────────────────────────────
@@ -597,6 +708,9 @@ model Asset {
   purchaseSupplier    String?
   supplierId          String?
   supplier            Supplier?      @relation(fields: [supplierId], references: [id])
+  purchaseOrderNumber String?
+  supplierOrderId     String?
+  supplierOrder       SupplierOrder? @relation(fields: [supplierOrderId], references: [id], onDelete: SetNull)
   warrantyExpiry      DateTime?
   notes               String?
   locationId          String?
@@ -616,11 +730,12 @@ model Asset {
   kit                Kit?           @relation(fields: [kitId], references: [id])
   kitItem            KitSerializedItem?
 
-  maintenanceLinks   MaintenanceRecordAsset[]
-  lineItems          ProjectLineItem[]
-  scanLogs           AssetScanLog[]
-  media              AssetMedia[]
-  testTagAsset       TestTagAsset?
+  maintenanceLinks    MaintenanceRecordAsset[]
+  lineItems           ProjectLineItem[]
+  scanLogs            AssetScanLog[]
+  media               AssetMedia[]
+  testTagAsset        TestTagAsset?
+  supplierOrderItems  SupplierOrderItem[]
 
   @@unique([organizationId, assetTag])
   @@index([organizationId])
@@ -628,6 +743,7 @@ model Asset {
   @@index([modelId])
   @@index([locationId])
   @@index([supplierId])
+  @@index([supplierOrderId])
   @@index([kitId])
   @@index([isActive])
   @@map("asset")
@@ -820,9 +936,10 @@ model Project {
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
 
-  lineItems ProjectLineItem[]
-  scanLogs  AssetScanLog[]
-  media     ProjectMedia[]
+  lineItems      ProjectLineItem[]
+  scanLogs       AssetScanLog[]
+  media          ProjectMedia[]
+  supplierOrders SupplierOrder[]
 
   @@unique([organizationId, projectNumber])
   @@index([organizationId])
@@ -878,12 +995,18 @@ model ProjectLineItem {
   returnedBy      User?          @relation("ReturnedBy", fields: [returnedById], references: [id])
   returnCondition ReturnCondition?
   returnNotes     String?
-  isSubhire       Boolean        @default(false)
-  showSubhireOnDocs Boolean      @default(false)
-  supplierId      String?
-  supplier        Supplier?      @relation(fields: [supplierId], references: [id])
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  isAccessory       Boolean        @default(false)
+  accessoryLevel    AccessoryLevel?
+  manualOverride    Boolean        @default(false)
+  isSubhire         Boolean        @default(false)
+  showSubhireOnDocs Boolean        @default(false)
+  supplierId        String?
+  supplier          Supplier?      @relation(fields: [supplierId], references: [id])
+  subhireOrderNumber String?
+  supplierOrderId   String?
+  supplierOrder     SupplierOrder? @relation(fields: [supplierOrderId], references: [id], onDelete: SetNull)
+  createdAt         DateTime       @default(now())
+  updatedAt         DateTime       @updatedAt
 
   @@index([organizationId])
   @@index([projectId])
@@ -893,6 +1016,7 @@ model ProjectLineItem {
   @@index([kitId])
   @@index([parentLineItemId])
   @@index([supplierId])
+  @@index([supplierOrderId])
   @@map("project_line_item")
 }
 

--- a/src/app/(app)/settings/assets/page.tsx
+++ b/src/app/(app)/settings/assets/page.tsx
@@ -10,7 +10,6 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { SupplierManager } from "@/components/settings/supplier-manager";
 import {
   getOrganization,
   updateOrganization,
@@ -141,7 +140,9 @@ export default function AssetsSettingsPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <SupplierManager />
+            <Button variant="outline" render={<Link href="/suppliers" />}>
+              Manage Suppliers
+            </Button>
           </CardContent>
         </Card>
       )}

--- a/src/app/(app)/suppliers/[id]/edit/page.tsx
+++ b/src/app/(app)/suppliers/[id]/edit/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { use } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { getSupplierById } from "@/server/suppliers";
+import { SupplierForm } from "@/components/suppliers/supplier-form";
+
+export default function EditSupplierPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data: supplier, isLoading } = useQuery({
+    queryKey: ["supplier", orgId, id],
+    queryFn: () => getSupplierById(id),
+  });
+
+  if (isLoading) return <div className="text-muted-foreground">Loading...</div>;
+  if (!supplier) return <div className="text-muted-foreground">Supplier not found.</div>;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Edit Supplier</h1>
+        <p className="text-muted-foreground">
+          Update supplier details.
+        </p>
+      </div>
+      <SupplierForm initialData={{
+        id,
+        name: supplier.name,
+        contactName: supplier.contactName || "",
+        email: supplier.email || "",
+        phone: supplier.phone || "",
+        website: supplier.website || "",
+        address: supplier.address || "",
+        notes: supplier.notes || "",
+        accountNumber: supplier.accountNumber || "",
+        paymentTerms: supplier.paymentTerms || "",
+        defaultLeadTime: supplier.defaultLeadTime || "",
+        tags: supplier.tags || [],
+        isActive: supplier.isActive,
+      }} />
+    </div>
+  );
+}

--- a/src/app/(app)/suppliers/[id]/orders/new/page.tsx
+++ b/src/app/(app)/suppliers/[id]/orders/new/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { use } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { supplierOrderSchema, type SupplierOrderFormValues } from "@/lib/validations/supplier-order";
+import { createSupplierOrder } from "@/server/supplier-orders";
+import { getSupplierById } from "@/server/suppliers";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function NewSupplierOrderPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: supplierId } = use(params);
+  const router = useRouter();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data: supplier } = useQuery({
+    queryKey: ["supplier", orgId, supplierId],
+    queryFn: () => getSupplierById(supplierId),
+  });
+
+  const form = useForm<SupplierOrderFormValues>({
+    resolver: zodResolver(supplierOrderSchema),
+    defaultValues: {
+      supplierId,
+      orderNumber: "",
+      type: "PURCHASE",
+      status: "DRAFT",
+      orderDate: "",
+      expectedDate: "",
+      notes: "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: SupplierOrderFormValues) => createSupplierOrder(data),
+    onSuccess: () => {
+      toast.success("Order created");
+      router.push(`/suppliers/${supplierId}`);
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">New Order</h1>
+        <p className="text-muted-foreground">
+          Create a purchase order for {supplier?.name || "..."}
+        </p>
+      </div>
+
+      <form onSubmit={form.handleSubmit((d) => mutation.mutate(d))} className="space-y-6">
+        <input type="hidden" {...form.register("supplierId")} />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Order Details</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="orderNumber">Order / PO Number *</Label>
+              <Input id="orderNumber" {...form.register("orderNumber")} placeholder="e.g. PO-2024-001" />
+              {form.formState.errors.orderNumber && (
+                <p className="text-xs text-destructive">{form.formState.errors.orderNumber.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <select
+                id="type"
+                {...form.register("type")}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="PURCHASE">Purchase</option>
+                <option value="SUBHIRE">Subhire</option>
+                <option value="REPAIR">Repair</option>
+                <option value="LABOUR">Labour</option>
+                <option value="OTHER">Other</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="status">Status</Label>
+              <select
+                id="status"
+                {...form.register("status")}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="DRAFT">Draft</option>
+                <option value="ORDERED">Ordered</option>
+                <option value="PARTIAL">Partial</option>
+                <option value="RECEIVED">Received</option>
+                <option value="CANCELLED">Cancelled</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="orderDate">Order Date</Label>
+              <Input id="orderDate" type="date" {...form.register("orderDate")} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="expectedDate">Expected Date</Label>
+              <Input id="expectedDate" type="date" {...form.register("expectedDate")} />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Notes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Textarea {...form.register("notes")} placeholder="Order notes..." rows={3} />
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-3">
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create Order
+          </Button>
+          <Button type="button" variant="outline" onClick={() => router.back()}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(app)/suppliers/[id]/page.tsx
+++ b/src/app/(app)/suppliers/[id]/page.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { PageMeta } from "@/components/layout/page-meta";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Pencil, Mail, Phone, Globe, MapPin, Trash2, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { getSupplierById, getSupplierAssets, getSupplierSubhires, deleteSupplier } from "@/server/suppliers";
+import { getSupplierOrders } from "@/server/supplier-orders";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { CanDo } from "@/components/auth/permission-gate";
+import { RequirePermission } from "@/components/auth/require-permission";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const orderStatusColors: Record<string, string> = {
+  DRAFT: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+  ORDERED: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+  PARTIAL: "bg-amber-500/10 text-amber-500 border-amber-500/20",
+  RECEIVED: "bg-green-500/10 text-green-500 border-green-500/20",
+  CANCELLED: "bg-red-500/10 text-red-500 border-red-500/20",
+};
+
+const orderTypeLabels: Record<string, string> = {
+  PURCHASE: "Purchase",
+  SUBHIRE: "Subhire",
+  REPAIR: "Repair",
+  LABOUR: "Labour",
+  OTHER: "Other",
+};
+
+const projectStatusColors: Record<string, string> = {
+  ENQUIRY: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+  QUOTED: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+  CONFIRMED: "bg-green-500/10 text-green-500 border-green-500/20",
+  PREPPING: "bg-cyan-500/10 text-cyan-500 border-cyan-500/20",
+  CHECKED_OUT: "bg-orange-500/10 text-orange-500 border-orange-500/20",
+  ON_SITE: "bg-amber-500/10 text-amber-500 border-amber-500/20",
+  RETURNED: "bg-teal-500/10 text-teal-500 border-teal-500/20",
+  COMPLETED: "bg-green-500/10 text-green-500 border-green-500/20",
+  CANCELLED: "bg-red-500/10 text-red-500 border-red-500/20",
+  INVOICED: "bg-purple-500/10 text-purple-500 border-purple-500/20",
+};
+
+export default function SupplierDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data: supplier, isLoading } = useQuery({
+    queryKey: ["supplier", orgId, id],
+    queryFn: () => getSupplierById(id),
+  });
+
+  const { data: ordersData } = useQuery({
+    queryKey: ["supplier-orders", orgId, id],
+    queryFn: () => getSupplierOrders({ supplierId: id, pageSize: 50 }),
+    enabled: !!supplier,
+  });
+
+  const { data: assetsData } = useQuery({
+    queryKey: ["supplier-assets", orgId, id],
+    queryFn: () => getSupplierAssets(id, { pageSize: 50 }),
+    enabled: !!supplier,
+  });
+
+  const { data: subhiresData } = useQuery({
+    queryKey: ["supplier-subhires", orgId, id],
+    queryFn: () => getSupplierSubhires(id, { pageSize: 50 }),
+    enabled: !!supplier,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteSupplier(id),
+    onSuccess: () => {
+      toast.success("Supplier deleted");
+      queryClient.invalidateQueries({ queryKey: ["suppliers"] });
+      router.push("/suppliers");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  if (isLoading) return <div className="text-muted-foreground">Loading...</div>;
+  if (!supplier) return <div className="text-muted-foreground">Supplier not found.</div>;
+
+  const orders = ordersData?.orders || [];
+  const assets = assetsData?.assets || [];
+  const subhires = subhiresData?.lineItems || [];
+
+  return (
+    <RequirePermission resource="supplier" action="read">
+      <PageMeta title={supplier.name} />
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight">{supplier.name}</h1>
+              {!supplier.isActive && <Badge variant="destructive">Archived</Badge>}
+            </div>
+            <p className="text-muted-foreground">
+              {supplier.contactName || "No primary contact"}
+              {supplier.accountNumber && <> &middot; Acct: {supplier.accountNumber}</>}
+            </p>
+          </div>
+          <CanDo resource="supplier" action="update">
+            <div className="flex gap-2">
+              <Button variant="outline" render={<Link href={`/suppliers/${id}/edit`} />}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+              <CanDo resource="supplier" action="delete">
+                <Button
+                  variant="outline"
+                  className="text-destructive"
+                  onClick={() => { if (confirm("Delete this supplier? This cannot be undone.")) deleteMutation.mutate(); }}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </Button>
+              </CanDo>
+            </div>
+          </CanDo>
+        </div>
+
+        {/* Info Cards */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Contact</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {supplier.contactName && <p className="font-medium">{supplier.contactName}</p>}
+              {supplier.email && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Mail className="h-3.5 w-3.5" />
+                  <a href={`mailto:${supplier.email}`} className="hover:underline">{supplier.email}</a>
+                </div>
+              )}
+              {supplier.phone && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Phone className="h-3.5 w-3.5" />
+                  <a href={`tel:${supplier.phone}`} className="hover:underline">{supplier.phone}</a>
+                </div>
+              )}
+              {supplier.website && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Globe className="h-3.5 w-3.5" />
+                  <a href={supplier.website} target="_blank" rel="noopener noreferrer" className="hover:underline truncate">{supplier.website}</a>
+                </div>
+              )}
+              {supplier.address && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <MapPin className="h-3.5 w-3.5 shrink-0" />
+                  <span className="whitespace-pre-wrap">{supplier.address}</span>
+                </div>
+              )}
+              {!supplier.contactName && !supplier.email && !supplier.phone && (
+                <p className="text-muted-foreground">No contact info</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Account Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1 text-sm">
+              <div className="flex justify-between">
+                <span>Account #</span>
+                <span className="font-medium">{supplier.accountNumber || "\u2014"}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Payment Terms</span>
+                <span className="font-medium">{supplier.paymentTerms || "\u2014"}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Lead Time</span>
+                <span className="font-medium">{supplier.defaultLeadTime || "\u2014"}</span>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1 text-sm">
+              <div className="flex justify-between">
+                <span>Orders</span>
+                <span className="font-medium">{supplier._count?.orders ?? 0}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Assets</span>
+                <span className="font-medium">{supplier._count?.assets ?? 0}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Subhire Items</span>
+                <span className="font-medium">{supplier._count?.lineItems ?? 0}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Tags */}
+        {supplier.tags?.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {supplier.tags.map((tag: string) => (
+              <Badge key={tag} variant="secondary">{tag}</Badge>
+            ))}
+          </div>
+        )}
+
+        {/* Notes */}
+        {supplier.notes && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Notes</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm whitespace-pre-wrap">{supplier.notes}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Tabs */}
+        <Tabs defaultValue="orders">
+          <TabsList>
+            <TabsTrigger value="orders">Orders ({orders.length})</TabsTrigger>
+            <TabsTrigger value="assets">Assets ({assets.length})</TabsTrigger>
+            <TabsTrigger value="subhires">Subhires ({subhires.length})</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="orders" className="mt-4">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">Purchase Orders</CardTitle>
+                  <CanDo resource="supplier" action="create">
+                    <Button size="sm" render={<Link href={`/suppliers/${id}/orders/new`} />}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      New Order
+                    </Button>
+                  </CanDo>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {orders.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-4">No orders yet.</p>
+                ) : (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Order #</TableHead>
+                          <TableHead>Type</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="hidden md:table-cell">Project</TableHead>
+                          <TableHead className="hidden md:table-cell">Items</TableHead>
+                          <TableHead className="text-right hidden sm:table-cell">Total</TableHead>
+                          <TableHead className="hidden md:table-cell">Date</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {orders.map((order) => (
+                          <TableRow key={order.id}>
+                            <TableCell>
+                              <span className="font-mono text-sm font-medium">{order.orderNumber}</span>
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline">{orderTypeLabels[order.type] || order.type}</Badge>
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline" className={orderStatusColors[order.status] || ""}>
+                                {order.status}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="hidden md:table-cell">
+                              {order.project ? (
+                                <Link href={`/projects/${order.project.id}`} className="hover:underline text-sm">
+                                  {order.project.projectNumber}
+                                </Link>
+                              ) : "\u2014"}
+                            </TableCell>
+                            <TableCell className="hidden md:table-cell text-muted-foreground">
+                              {order._count?.items ?? 0}
+                            </TableCell>
+                            <TableCell className="text-right hidden sm:table-cell">
+                              {order.total != null ? `$${Number(order.total).toFixed(2)}` : "\u2014"}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground hidden md:table-cell">
+                              {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : "\u2014"}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="assets" className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Purchased Assets</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {assets.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-4">No assets from this supplier.</p>
+                ) : (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Asset Tag</TableHead>
+                          <TableHead>Model</TableHead>
+                          <TableHead className="hidden md:table-cell">Manufacturer</TableHead>
+                          <TableHead className="hidden md:table-cell">PO #</TableHead>
+                          <TableHead>Status</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {assets.map((asset) => (
+                          <TableRow key={asset.id}>
+                            <TableCell>
+                              <Link href={`/assets/registry/${asset.id}`} className="font-mono text-sm font-medium hover:underline">
+                                {asset.assetTag}
+                              </Link>
+                            </TableCell>
+                            <TableCell>{asset.model?.name}</TableCell>
+                            <TableCell className="text-muted-foreground hidden md:table-cell">
+                              {asset.model?.manufacturer || "\u2014"}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground hidden md:table-cell font-mono text-sm">
+                              {asset.purchaseOrderNumber || "\u2014"}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline">{asset.status}</Badge>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="subhires" className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Subhire Line Items</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {subhires.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-4">No subhire items from this supplier.</p>
+                ) : (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Project</TableHead>
+                          <TableHead>Model</TableHead>
+                          <TableHead className="text-right">Qty</TableHead>
+                          <TableHead className="hidden md:table-cell">Order #</TableHead>
+                          <TableHead>Status</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {subhires.map((item) => (
+                          <TableRow key={item.id}>
+                            <TableCell>
+                              <Link href={`/projects/${item.project?.id}`} className="hover:underline text-sm">
+                                {item.project?.projectNumber} - {item.project?.name}
+                              </Link>
+                            </TableCell>
+                            <TableCell>{item.model?.name || item.description}</TableCell>
+                            <TableCell className="text-right">{item.quantity}</TableCell>
+                            <TableCell className="text-muted-foreground hidden md:table-cell font-mono text-sm">
+                              {item.subhireOrderNumber || "\u2014"}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline" className={projectStatusColors[item.project?.status] || ""}>
+                                {item.project?.status?.replace("_", " ")}
+                              </Badge>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </RequirePermission>
+  );
+}

--- a/src/app/(app)/suppliers/new/page.tsx
+++ b/src/app/(app)/suppliers/new/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { SupplierForm } from "@/components/suppliers/supplier-form";
+
+export default function NewSupplierPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">New Supplier</h1>
+        <p className="text-muted-foreground">
+          Add a new supplier to your directory.
+        </p>
+      </div>
+      <SupplierForm />
+    </div>
+  );
+}

--- a/src/app/(app)/suppliers/page.tsx
+++ b/src/app/(app)/suppliers/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { SupplierTable } from "@/components/suppliers/supplier-table";
+import { RequirePermission } from "@/components/auth/require-permission";
+
+export default function SuppliersPage() {
+  return (
+    <RequirePermission resource="supplier" action="read">
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Suppliers</h1>
+          <p className="text-muted-foreground">
+            Manage your suppliers and vendors.
+          </p>
+        </div>
+        <SupplierTable />
+      </div>
+    </RequirePermission>
+  );
+}

--- a/src/components/assets/asset-form.tsx
+++ b/src/components/assets/asset-form.tsx
@@ -294,6 +294,12 @@ export function AssetForm({ initialData, preselectedModelId }: AssetFormProps) {
               allowClear
             />
           </div>
+          {form.watch("supplierId") && (
+            <div className="space-y-2">
+              <Label htmlFor="purchaseOrderNumber">Purchase Order #</Label>
+              <Input id="purchaseOrderNumber" {...form.register("purchaseOrderNumber")} placeholder="e.g. PO-2024-001" />
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="warrantyExpiry">Warranty Expiry</Label>
             <Input id="warrantyExpiry" type="date" {...form.register("warrantyExpiry")} />

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   BookTemplate,
   ChevronRight,
   Tags,
+  Truck,
   type LucideIcon,
 } from "lucide-react";
 import { usePlatformBranding } from "@/lib/use-platform-name";
@@ -98,6 +99,12 @@ const navItems: NavItem[] = [
     url: "/clients",
     icon: Users,
     resource: "client",
+  },
+  {
+    title: "Suppliers",
+    url: "/suppliers",
+    icon: Truck,
+    resource: "supplier",
   },
   {
     title: "Locations",

--- a/src/components/layout/command-search.tsx
+++ b/src/components/layout/command-search.tsx
@@ -32,6 +32,7 @@ import {
   PackageX,
   CreditCard,
   Palette,
+  Truck,
 } from "lucide-react";
 import {
   Dialog,
@@ -53,6 +54,7 @@ const typeIcons: Record<SearchResultType, React.ComponentType<{ className?: stri
   client: Users,
   location: MapPin,
   category: Layers,
+  supplier: Truck,
   maintenance: Wrench,
 };
 
@@ -63,6 +65,7 @@ const typeLabels: Record<SearchResultType, string> = {
   "bulk-asset": "Bulk Asset",
   project: "Project",
   client: "Client",
+  supplier: "Supplier",
   location: "Location",
   category: "Category",
   maintenance: "Maintenance",
@@ -72,7 +75,7 @@ const pageIcons: Record<string, React.ComponentType<{ className?: string }>> = {
   LayoutDashboard, Package, Boxes, Box, CalendarRange, Container,
   FolderOpen, BookTemplate, Warehouse, Users, MapPin, Wrench,
   ShieldCheck, BarChart3, Settings, UserCircle, PackageCheck, PackageX,
-  CreditCard, Palette,
+  CreditCard, Palette, Truck,
 };
 
 function normalize(s: string): string {
@@ -191,6 +194,7 @@ export function CommandSearch() {
       client: ["client"],
       location: ["location"],
       maintenance: ["maintenance"],
+      supplier: ["supplier"],
     };
     const allowedTypes = typeMap[atSearchType] || [];
     const statusFilter = atSearchStatusFilter;
@@ -432,6 +436,7 @@ export function CommandSearch() {
       client: ["client"],
       location: ["location"],
       maintenance: ["maintenance"],
+      supplier: ["supplier"],
     };
     const allowedTypes = typeMap[atEntitySearchType] || [];
     const statusFilter = atEntityStatusFilter;

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -28,6 +28,8 @@ const segmentLabels: Record<string, string> = {
   templates: "Templates",
   warehouse: "Warehouse",
   clients: "Clients",
+  suppliers: "Suppliers",
+  orders: "Orders",
   locations: "Locations",
   maintenance: "Maintenance",
   "test-and-tag": "Test & Tag",

--- a/src/components/projects/add-subhire-dialog.tsx
+++ b/src/components/projects/add-subhire-dialog.tsx
@@ -118,6 +118,17 @@ export function AddSubhireDialog({
               />
             </div>
 
+            {form.watch("supplierId") && (
+              <div className="space-y-2">
+                <Label htmlFor="sub-orderNumber">Subhire Order #</Label>
+                <Input
+                  id="sub-orderNumber"
+                  {...form.register("subhireOrderNumber")}
+                  placeholder="e.g. PO-2024-001"
+                />
+              </div>
+            )}
+
             <div className="space-y-2">
               <Label htmlFor="sub-description">Description *</Label>
               <Input

--- a/src/components/suppliers/supplier-form.tsx
+++ b/src/components/suppliers/supplier-form.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { supplierSchema, type SupplierFormValues } from "@/lib/validations/supplier";
+import { createSupplier, updateSupplier } from "@/server/suppliers";
+import { getOrgTags } from "@/server/tags";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { TagInput } from "@/components/ui/tag-input";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface SupplierFormProps {
+  initialData?: SupplierFormValues & { id: string };
+}
+
+export function SupplierForm({ initialData }: SupplierFormProps) {
+  const router = useRouter();
+  const isEditing = !!initialData;
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data: orgTags } = useQuery({
+    queryKey: ["org-tags", orgId],
+    queryFn: () => getOrgTags(),
+  });
+
+  const form = useForm<SupplierFormValues>({
+    resolver: zodResolver(supplierSchema),
+    defaultValues: initialData || {
+      name: "",
+      contactName: "",
+      email: "",
+      phone: "",
+      website: "",
+      address: "",
+      notes: "",
+      accountNumber: "",
+      paymentTerms: "",
+      defaultLeadTime: "",
+      tags: [],
+      isActive: true,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: SupplierFormValues) =>
+      isEditing ? updateSupplier(initialData.id, data) : createSupplier(data),
+    onSuccess: (result) => {
+      toast.success(isEditing ? "Supplier updated" : "Supplier created");
+      router.push(`/suppliers/${result.id}`);
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit((d) => mutation.mutate(d))} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Supplier Details</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name *</Label>
+            <Input id="name" {...form.register("name")} placeholder="e.g. Sennheiser Australia" />
+            {form.formState.errors.name && (
+              <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="accountNumber">Account Number</Label>
+            <Input id="accountNumber" {...form.register("accountNumber")} placeholder="Your account # with this supplier" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Contact Information</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="contactName">Contact Name</Label>
+            <Input id="contactName" {...form.register("contactName")} placeholder="Primary contact person" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" {...form.register("email")} placeholder="email@example.com" />
+            {form.formState.errors.email && (
+              <p className="text-xs text-destructive">{form.formState.errors.email.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone">Phone</Label>
+            <Input id="phone" {...form.register("phone")} placeholder="+61 400 000 000" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="website">Website</Label>
+            <Input id="website" {...form.register("website")} placeholder="https://example.com" />
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="address">Address</Label>
+            <Textarea id="address" {...form.register("address")} placeholder="Supplier address" rows={2} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Terms & Lead Time</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="paymentTerms">Payment Terms</Label>
+            <Input id="paymentTerms" {...form.register("paymentTerms")} placeholder="e.g. Net 30, COD, Prepay" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="defaultLeadTime">Default Lead Time</Label>
+            <Input id="defaultLeadTime" {...form.register("defaultLeadTime")} placeholder="e.g. 3-5 business days" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Additional</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea id="notes" {...form.register("notes")} placeholder="Any additional notes" rows={3} />
+          </div>
+          <div className="space-y-2">
+            <Label>Tags</Label>
+            <Controller
+              name="tags"
+              control={form.control}
+              render={({ field }) => (
+                <TagInput
+                  value={field.value ?? []}
+                  onChange={field.onChange}
+                  suggestions={orgTags}
+                  placeholder="Add tags..."
+                />
+              )}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex gap-3">
+        <Button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {isEditing ? "Update Supplier" : "Create Supplier"}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => router.back()}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/suppliers/supplier-table.tsx
+++ b/src/components/suppliers/supplier-table.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+
+import { getSuppliersPaginated } from "@/server/suppliers";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useTablePreferences } from "@/lib/use-table-preferences";
+import { Button } from "@/components/ui/button";
+import { CanDo } from "@/components/auth/permission-gate";
+import { Badge } from "@/components/ui/badge";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySupplier = Record<string, any>;
+
+const columns: ColumnDef<AnySupplier>[] = [
+  {
+    id: "name",
+    header: "Name",
+    accessorKey: "name",
+    alwaysVisible: true,
+    sortKey: "name",
+    cell: (row) => (
+      <Link href={`/suppliers/${row.id}`} className="font-medium hover:underline" onClick={(e) => e.stopPropagation()}>
+        {row.name}
+      </Link>
+    ),
+  },
+  {
+    id: "contactName",
+    header: "Contact",
+    accessorKey: "contactName",
+    sortKey: "contactName",
+    responsiveHide: "md",
+    cell: (row) => (
+      <span className="text-muted-foreground">{row.contactName || "\u2014"}</span>
+    ),
+  },
+  {
+    id: "email",
+    header: "Email",
+    accessorKey: "email",
+    sortKey: "email",
+    responsiveHide: "md",
+    cell: (row) => (
+      <span className="text-muted-foreground">{row.email || "\u2014"}</span>
+    ),
+  },
+  {
+    id: "phone",
+    header: "Phone",
+    accessorKey: "phone",
+    responsiveHide: "lg",
+    cell: (row) => (
+      <span className="text-muted-foreground">{row.phone || "\u2014"}</span>
+    ),
+  },
+  {
+    id: "accountNumber",
+    header: "Account #",
+    accessorKey: "accountNumber",
+    responsiveHide: "lg",
+    cell: (row) => (
+      <span className="font-mono text-sm text-muted-foreground">{row.accountNumber || "\u2014"}</span>
+    ),
+  },
+  {
+    id: "orders",
+    header: "Orders",
+    align: "right",
+    responsiveHide: "md",
+    cell: (row) => row._count?.orders ?? 0,
+  },
+  {
+    id: "assets",
+    header: "Assets",
+    align: "right",
+    responsiveHide: "md",
+    cell: (row) => row._count?.assets ?? 0,
+  },
+  {
+    id: "isActive",
+    header: "Status",
+    sortKey: "isActive",
+    filterable: true,
+    filterType: "enum",
+    filterOptions: [
+      { value: "true", label: "Active" },
+      { value: "false", label: "Archived" },
+    ],
+    cell: (row) => (
+      <Badge variant={row.isActive ? "default" : "destructive"}>
+        {row.isActive ? "Active" : "Archived"}
+      </Badge>
+    ),
+  },
+  {
+    id: "tags",
+    header: "Tags",
+    sortable: false,
+    defaultVisible: true,
+    responsiveHide: "lg",
+    cell: (row) => (
+      <div className="flex flex-wrap gap-1">
+        {row.tags?.map((tag: string) => (
+          <Badge key={tag} variant="secondary" className="text-xs">
+            {tag}
+          </Badge>
+        ))}
+      </div>
+    ),
+  },
+];
+
+export function SupplierTable() {
+  const {
+    sortBy, sortOrder, pageSize, page,
+    setPage, setPageSize, handleSort,
+    columnVisibility, toggleColumnVisibility, resetPreferences,
+    filters, setFilter,
+  } = useTablePreferences("suppliers", { sortBy: "name", sortOrder: "asc" });
+
+  const [search, setSearch] = useState("");
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["suppliers", orgId, { search, filters, page, pageSize, sortBy, sortOrder }],
+    queryFn: () => getSuppliersPaginated({
+      search: search || undefined,
+      filters,
+      page,
+      pageSize,
+      sortBy,
+      sortOrder,
+    }),
+  });
+
+  const suppliers = data?.suppliers || [];
+  const total = data?.total || 0;
+
+  const toolbarActions = (
+    <CanDo resource="supplier" action="create">
+      <Button render={<Link href="/suppliers/new" />}>
+        <Plus className="mr-2 h-4 w-4" />
+        New Supplier
+      </Button>
+    </CanDo>
+  );
+
+  return (
+    <DataTable
+      data={suppliers}
+      columns={columns}
+      totalRows={total}
+      page={page}
+      pageSize={pageSize}
+      onPageChange={setPage}
+      onPageSizeChange={setPageSize}
+      sortField={sortBy}
+      sortDirection={sortOrder}
+      onSortChange={handleSort}
+      filters={filters}
+      onFilterChange={setFilter}
+      searchValue={search}
+      onSearchChange={(v) => { setSearch(v); setPage(1); }}
+      searchPlaceholder="Search by name, contact, account #..."
+      columnVisibility={columnVisibility}
+      onToggleColumnVisibility={toggleColumnVisibility}
+      onResetPreferences={resetPreferences}
+      isLoading={isLoading}
+      emptyTitle="No suppliers found"
+      toolbarActions={toolbarActions}
+    />
+  );
+}

--- a/src/lib/org-export.ts
+++ b/src/lib/org-export.ts
@@ -43,6 +43,9 @@ export async function exportOrganization(orgId: string) {
     maintenanceRecordAssets,
     testTagAssets,
     testTagRecords,
+    modelAccessories,
+    supplierOrders,
+    supplierOrderItems,
     activityLogs,
     fileUploads,
     modelMedia,
@@ -73,6 +76,11 @@ export async function exportOrganization(orgId: string) {
     }),
     prisma.testTagAsset.findMany({ where: { organizationId: orgId } }),
     prisma.testTagRecord.findMany({ where: { organizationId: orgId } }),
+    prisma.modelAccessory.findMany({ where: { organizationId: orgId } }),
+    prisma.supplierOrder.findMany({ where: { organizationId: orgId } }),
+    prisma.supplierOrderItem.findMany({
+      where: { order: { organizationId: orgId } },
+    }),
     prisma.activityLog.findMany({ where: { organizationId: orgId } }),
     prisma.fileUpload.findMany({ where: { organizationId: orgId } }),
     prisma.modelMedia.findMany({ where: { organizationId: orgId } }),
@@ -107,6 +115,7 @@ export async function exportOrganization(orgId: string) {
   collectUserIds(testTagRecords as unknown as Record<string, unknown>[], ["testedById"]);
   collectUserIds(kitSerializedItems as unknown as Record<string, unknown>[], ["addedById"]);
   collectUserIds(kitBulkItems as unknown as Record<string, unknown>[], ["addedById"]);
+  collectUserIds(supplierOrders as unknown as Record<string, unknown>[], ["createdById"]);
   collectUserIds(activityLogs as unknown as Record<string, unknown>[], ["userId"]);
   collectUserIds(fileUploads as unknown as Record<string, unknown>[], ["uploadedById"]);
 
@@ -143,6 +152,9 @@ export async function exportOrganization(orgId: string) {
     maintenanceRecordAssets: clean(maintenanceRecordAssets) as Record<string, unknown>[],
     testTagAssets: clean(testTagAssets) as Record<string, unknown>[],
     testTagRecords: clean(testTagRecords) as Record<string, unknown>[],
+    modelAccessories: clean(modelAccessories) as Record<string, unknown>[],
+    supplierOrders: clean(supplierOrders) as Record<string, unknown>[],
+    supplierOrderItems: clean(supplierOrderItems) as Record<string, unknown>[],
     activityLogs: clean(activityLogs) as Record<string, unknown>[],
     fileUploads: clean(fileUploads) as Record<string, unknown>[],
     modelMedia: clean(modelMedia) as Record<string, unknown>[],

--- a/src/lib/org-import.ts
+++ b/src/lib/org-import.ts
@@ -262,6 +262,23 @@ export async function importOrganization(
     });
   }
 
+  // ── 5b. Model Accessories ───────────────────────────────────────
+  for (const r of (manifest.modelAccessories || []) as Rec[]) {
+    const id = newId("modelAccessory", r.id);
+    await prisma.modelAccessory.create({
+      data: {
+        id,
+        organizationId: newOrgId,
+        parentModelId: remap("model", r.parentModelId)!,
+        accessoryModelId: remap("model", r.accessoryModelId)!,
+        quantity: r.quantity ?? 1,
+        level: r.level,
+        notes: r.notes ?? null,
+        sortOrder: r.sortOrder ?? 0,
+      } as any,
+    });
+  }
+
   // ── 6. Kits ──────────────────────────────────────────────────────
   for (const r of manifest.kits as Rec[]) {
     const id = newId("kit", r.id);
@@ -288,6 +305,7 @@ export async function importOrganization(
         organizationId: newOrgId,
         modelId: remap("model", r.modelId)!,
         supplierId: remap("supplier", r.supplierId),
+        supplierOrderId: remap("supplierOrder", r.supplierOrderId),
         locationId: remap("location", r.locationId),
         kitId: remap("kit", r.kitId),
         purchaseDate: safeDateOpt(r.purchaseDate),
@@ -390,6 +408,47 @@ export async function importOrganization(
     });
   }
 
+  // ── 12b. Supplier Orders ────────────────────────────────────────────
+  for (const r of (manifest.supplierOrders ?? []) as Rec[]) {
+    const id = newId("supplierOrder", r.id);
+    await prisma.supplierOrder.create({
+      data: {
+        ...stripRelations(r),
+        id,
+        organizationId: newOrgId,
+        supplierId: remap("supplier", r.supplierId)!,
+        projectId: remap("project", r.projectId),
+        createdById: remapUser(r.createdById),
+        orderDate: safeDateOpt(r.orderDate),
+        expectedDate: safeDateOpt(r.expectedDate),
+        receivedDate: safeDateOpt(r.receivedDate),
+        createdAt: safeDate(r.createdAt),
+        updatedAt: safeDate(r.updatedAt),
+      } as any,
+    });
+  }
+
+  // ── 12c. Supplier Order Items ──────────────────────────────────────
+  for (const r of (manifest.supplierOrderItems ?? []) as Rec[]) {
+    const id = newId("supplierOrderItem", r.id);
+    const orderId = remap("supplierOrder", r.orderId);
+    if (!orderId) continue;
+    await prisma.supplierOrderItem.create({
+      data: {
+        id,
+        orderId,
+        description: r.description as string,
+        quantity: r.quantity ?? 1,
+        unitPrice: r.unitPrice ?? null,
+        lineTotal: r.lineTotal ?? null,
+        modelId: remap("model", r.modelId),
+        assetId: remap("asset", r.assetId),
+        notes: r.notes ?? null,
+        sortOrder: r.sortOrder ?? 0,
+      } as any,
+    });
+  }
+
   // ── 13. Project Line Items (with parent hierarchy for kit children) ──
   await insertWithHierarchy("projectLineItem", manifest.projectLineItems as Rec[], async (r, id) => {
     await prisma.projectLineItem.create({
@@ -403,6 +462,7 @@ export async function importOrganization(
         bulkAssetId: remap("bulkAsset", r.bulkAssetId),
         kitId: remap("kit", r.kitId),
         parentLineItemId: remap("projectLineItem", r.parentLineItemId),
+        supplierOrderId: remap("supplierOrder", r.supplierOrderId),
         checkedOutById: remapUser(r.checkedOutById),
         returnedById: remapUser(r.returnedById),
         checkedOutAt: safeDateOpt(r.checkedOutAt),

--- a/src/lib/org-transfer-types.ts
+++ b/src/lib/org-transfer-types.ts
@@ -26,6 +26,9 @@ export interface OrgExportManifest {
   maintenanceRecordAssets: Record<string, unknown>[];
   testTagAssets: Record<string, unknown>[];
   testTagRecords: Record<string, unknown>[];
+  modelAccessories: Record<string, unknown>[];
+  supplierOrders: Record<string, unknown>[];
+  supplierOrderItems: Record<string, unknown>[];
   activityLogs: Record<string, unknown>[];
   fileUploads: Record<string, unknown>[];
   modelMedia: Record<string, unknown>[];

--- a/src/lib/page-commands.ts
+++ b/src/lib/page-commands.ts
@@ -148,6 +148,15 @@ export const PAGE_COMMANDS: PageCommand[] = [
     searchType: "client",
   },
   {
+    label: "Suppliers",
+    href: "/suppliers",
+    aliases: ["suppliers", "supplier", "vendors", "vendor", "purchase", "purchaseorders"],
+    icon: "Truck",
+    description: "Supplier management and purchase orders",
+    searchable: true,
+    searchType: "supplier",
+  },
+  {
     label: "Locations",
     href: "/locations",
     aliases: ["locations", "location", "venues", "sites", "places", "venue"],
@@ -226,9 +235,9 @@ export const PAGE_COMMANDS: PageCommand[] = [
       {
         label: "Assets",
         href: "/settings/assets",
-        aliases: ["assetsettings", "assettags", "tags", "suppliers"],
+        aliases: ["assetsettings", "assettags", "tags"],
         icon: "Package",
-        description: "Asset tags and suppliers",
+        description: "Asset tags configuration",
       },
       {
         label: "Test & Tag Settings",

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -25,6 +25,7 @@ export const RESOURCES = [
   "document",
   "orgSettings",
   "orgMembers",
+  "supplier",
   "reports",
 ] as const;
 
@@ -161,6 +162,15 @@ export const PERMISSION_REGISTRY: Record<
       { key: "remove", label: "Remove" },
     ],
   },
+  supplier: {
+    label: "Suppliers",
+    actions: [
+      { key: "read", label: "View" },
+      { key: "create", label: "Create" },
+      { key: "update", label: "Edit" },
+      { key: "delete", label: "Delete" },
+    ],
+  },
   reports: {
     label: "Reports",
     actions: [
@@ -191,6 +201,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: ["generate", "send"],
     orgSettings: ["read", "update"],
     orgMembers: ["read", "invite", "update_role", "remove"],
+    supplier: ALL_CRUD,
     reports: ["view", "export"],
   },
   admin: {
@@ -207,6 +218,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: ["generate", "send"],
     orgSettings: ["read", "update"],
     orgMembers: ["read", "invite", "update_role", "remove"],
+    supplier: ALL_CRUD,
     reports: ["view", "export"],
   },
   manager: {
@@ -223,6 +235,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: ["generate", "send"],
     orgSettings: ["read"],
     orgMembers: ["read"],
+    supplier: ["create", "read", "update"],
     reports: ["view", "export"],
   },
   member: {
@@ -239,6 +252,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: ["generate"],
     orgSettings: [],
     orgMembers: [],
+    supplier: ["read"],
     reports: ["view"],
   },
   staff: {
@@ -255,6 +269,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: ["generate"],
     orgSettings: [],
     orgMembers: [],
+    supplier: ["read"],
     reports: ["view"],
   },
   warehouse: {
@@ -271,6 +286,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: [],
     orgSettings: [],
     orgMembers: [],
+    supplier: ["read"],
     reports: ["view"],
   },
   viewer: {
@@ -287,6 +303,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     document: [],
     orgSettings: [],
     orgMembers: [],
+    supplier: ["read"],
     reports: ["view"],
   },
 };

--- a/src/lib/validations/asset.ts
+++ b/src/lib/validations/asset.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+// Re-export supplier schema from its dedicated file for backward compatibility
+export { supplierSchema, type SupplierFormValues } from "./supplier";
+
 export const assetSchema = z.object({
   modelId: z.string().min(1, "Model is required"),
   assetTag: z.string().min(1, "Asset tag is required").max(50),
@@ -11,6 +14,7 @@ export const assetSchema = z.object({
   purchasePrice: z.union([z.literal(""), z.coerce.number().min(0)]).optional().transform(v => v === "" ? undefined : v),
   purchaseSupplier: z.string().max(200).optional(),
   supplierId: z.string().optional(),
+  purchaseOrderNumber: z.string().max(100).optional(),
   warrantyExpiry: z.union([z.literal(""), z.coerce.date()]).optional().transform(v => v === "" ? undefined : v),
   notes: z.string().max(2000).optional(),
   locationId: z.string().optional(),
@@ -50,14 +54,3 @@ export const locationSchema = z.object({
 
 export type LocationFormValues = z.input<typeof locationSchema>;
 
-export const supplierSchema = z.object({
-  name: z.string().min(1, "Name is required").max(200),
-  contactName: z.string().max(200).optional(),
-  email: z.string().email().max(200).optional().or(z.literal("")),
-  phone: z.string().max(50).optional(),
-  website: z.string().max(500).optional(),
-  address: z.string().max(500).optional(),
-  notes: z.string().max(2000).optional(),
-});
-
-export type SupplierFormValues = z.input<typeof supplierSchema>;

--- a/src/lib/validations/line-item.ts
+++ b/src/lib/validations/line-item.ts
@@ -19,6 +19,7 @@ export const lineItemSchema = z.object({
   isSubhire: z.boolean().default(false),
   showSubhireOnDocs: z.boolean().default(false),
   supplierId: z.string().optional(),
+  subhireOrderNumber: z.string().max(100).optional(),
 });
 
 export type LineItemFormValues = z.input<typeof lineItemSchema>;

--- a/src/lib/validations/supplier-order.ts
+++ b/src/lib/validations/supplier-order.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const supplierOrderSchema = z.object({
+  supplierId: z.string().min(1, "Supplier is required"),
+  orderNumber: z.string().min(1, "Order number is required").max(100),
+  type: z.enum(["PURCHASE", "SUBHIRE", "REPAIR", "LABOUR", "OTHER"]),
+  status: z.enum(["DRAFT", "ORDERED", "PARTIAL", "RECEIVED", "CANCELLED"]).default("DRAFT"),
+  orderDate: z.union([z.literal(""), z.coerce.date()]).optional().transform(v => v === "" ? undefined : v),
+  expectedDate: z.union([z.literal(""), z.coerce.date()]).optional().transform(v => v === "" ? undefined : v),
+  receivedDate: z.union([z.literal(""), z.coerce.date()]).optional().transform(v => v === "" ? undefined : v),
+  projectId: z.string().optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export type SupplierOrderFormValues = z.input<typeof supplierOrderSchema>;
+
+export const supplierOrderItemSchema = z.object({
+  description: z.string().min(1, "Description is required").max(500),
+  quantity: z.coerce.number().int().min(1).default(1),
+  unitPrice: z.union([z.literal(""), z.coerce.number().min(0)]).optional().transform(v => v === "" ? undefined : v),
+  modelId: z.string().optional(),
+  assetId: z.string().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export type SupplierOrderItemFormValues = z.input<typeof supplierOrderItemSchema>;

--- a/src/lib/validations/supplier.ts
+++ b/src/lib/validations/supplier.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const supplierSchema = z.object({
+  name: z.string().min(1, "Name is required").max(200),
+  contactName: z.string().max(200).optional(),
+  email: z.string().email().max(200).optional().or(z.literal("")),
+  phone: z.string().max(50).optional(),
+  website: z.string().max(500).optional(),
+  address: z.string().max(500).optional(),
+  notes: z.string().max(2000).optional(),
+  accountNumber: z.string().max(100).optional(),
+  paymentTerms: z.string().max(100).optional(),
+  defaultLeadTime: z.string().max(100).optional(),
+  tags: z.array(z.string()).default([]),
+  isActive: z.boolean().default(true),
+});
+
+export type SupplierFormValues = z.input<typeof supplierSchema>;

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -180,6 +180,7 @@ export async function createAsset(data: AssetFormValues) {
         purchasePrice: parsed.purchasePrice,
         purchaseSupplier: parsed.purchaseSupplier,
         supplierId: parsed.supplierId || null,
+        purchaseOrderNumber: parsed.purchaseOrderNumber || null,
         warrantyExpiry: parsed.warrantyExpiry,
         notes: parsed.notes,
         locationId: parsed.locationId || null,

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -104,6 +104,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
     });
 
     if (existing) {
+      const oldQuantity = existing.quantity;
       const newQuantity = existing.quantity + parsed.quantity;
       const newLineTotal = calculateLineTotal(
         parsed.unitPrice ?? (existing.unitPrice ? Number(existing.unitPrice) : undefined),
@@ -131,6 +132,39 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         include: { model: true, asset: true, bulkAsset: true },
       });
 
+      // Scale accessory children proportionally
+      const accChildren = await prisma.projectLineItem.findMany({
+        where: { parentLineItemId: existing.id, organizationId, isAccessory: true, manualOverride: false },
+      });
+      for (const child of accChildren) {
+        if (oldQuantity > 0) {
+          const baseRatio = child.quantity / oldQuantity;
+          const newQty = Math.round(baseRatio * newQuantity);
+          const childTotal = calculateLineTotal(
+            child.unitPrice ? Number(child.unitPrice) : undefined,
+            newQty,
+            child.duration,
+            child.discount ? Number(child.discount) : undefined,
+          );
+          await prisma.projectLineItem.update({
+            where: { id: child.id },
+            data: { quantity: newQty, lineTotal: childTotal },
+          });
+        }
+      }
+
+      // If no accessories exist yet (e.g. accessory relationship added later), auto-add them
+      if (accChildren.length === 0 && parsed.modelId) {
+        const maxSort = await prisma.projectLineItem.aggregate({
+          where: { projectId, organizationId },
+          _max: { sortOrder: true },
+        });
+        await autoAddAccessories(
+          organizationId, projectId, existing.id,
+          parsed.modelId, newQuantity, (maxSort._max.sortOrder ?? -1) + 1,
+        );
+      }
+
       await recalculateProjectTotals(projectId);
 
       await logActivity({
@@ -141,7 +175,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         entityType: "lineItem",
         entityId: result.id,
         entityName: result.description || `Line item`,
-        summary: `Merged line item into existing on project (qty ${existing.quantity} -> ${newQuantity})`,
+        summary: `Merged line item into existing on project (qty ${oldQuantity} -> ${newQuantity})`,
         projectId,
       });
 
@@ -184,6 +218,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
       isSubhire: parsed.isSubhire,
       showSubhireOnDocs: parsed.showSubhireOnDocs,
       supplierId: parsed.supplierId || null,
+      subhireOrderNumber: parsed.subhireOrderNumber || null,
     },
     include: {
       model: true,
@@ -192,6 +227,20 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
       supplier: true,
     },
   });
+
+  // Auto-pull accessories for equipment line items
+  let recommendedAccessories: Array<{ modelName: string; modelId: string }> = [];
+  if (parsed.type === "EQUIPMENT" && parsed.modelId) {
+    const pullResult = await autoAddAccessories(
+      organizationId,
+      projectId,
+      result.id,
+      parsed.modelId,
+      parsed.quantity,
+      nextSort + 1,
+    );
+    recommendedAccessories = pullResult.recommended;
+  }
 
   await recalculateProjectTotals(projectId);
 
@@ -207,7 +256,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
     projectId,
   });
 
-  return serialize(result);
+  return serialize({ ...result, recommendedAccessories });
 }
 
 export async function updateLineItem(id: string, data: LineItemFormValues, allowOverbook = false) {
@@ -241,6 +290,7 @@ export async function updateLineItem(id: string, data: LineItemFormValues, allow
       isSubhire: parsed.isSubhire,
       showSubhireOnDocs: parsed.showSubhireOnDocs,
       supplierId: parsed.supplierId || null,
+      subhireOrderNumber: parsed.subhireOrderNumber || null,
     },
     include: {
       model: true,
@@ -249,6 +299,54 @@ export async function updateLineItem(id: string, data: LineItemFormValues, allow
       supplier: true,
     },
   });
+
+  // Scale accessory quantities when parent quantity changes
+  if (parsed.quantity) {
+    const oldItem = await prisma.projectLineItem.findUnique({
+      where: { id },
+      select: { quantity: true },
+    });
+    // oldItem may be null since we already updated, so use a pre-fetch approach
+    // Actually, result has the new quantity. We need the old quantity.
+    // Let's fetch accessory children and scale them
+    const accessoryChildren = await prisma.projectLineItem.findMany({
+      where: {
+        parentLineItemId: id,
+        organizationId,
+        isAccessory: true,
+        manualOverride: false,
+      },
+    });
+
+    if (accessoryChildren.length > 0 && result.quantity) {
+      // We need to look up the accessory definitions to find the base ratio
+      for (const child of accessoryChildren) {
+        if (!child.modelId || !result.modelId) continue;
+        const accDef = await prisma.modelAccessory.findFirst({
+          where: {
+            organizationId,
+            parentModelId: result.modelId,
+            accessoryModelId: child.modelId,
+          },
+        });
+        if (accDef) {
+          const newQty = result.quantity * accDef.quantity;
+          if (newQty !== child.quantity) {
+            const childTotal = calculateLineTotal(
+              child.unitPrice ? Number(child.unitPrice) : undefined,
+              newQty,
+              child.duration,
+              child.discount ? Number(child.discount) : undefined,
+            );
+            await prisma.projectLineItem.update({
+              where: { id: child.id },
+              data: { quantity: newQty, lineTotal: childTotal },
+            });
+          }
+        }
+      }
+    }
+  }
 
   await recalculateProjectTotals(result.projectId);
 
@@ -347,11 +445,28 @@ export async function addKitLineItem(
       });
     }
 
-    return parentItem;
+    return { parentItem, nextSort };
   });
 
+  // Auto-add accessories for kit children (outside transaction so autoAddAccessories can query committed data)
+  const kitChildren = await prisma.projectLineItem.findMany({
+    where: { parentLineItemId: result.parentItem.id, organizationId, isKitChild: true },
+    select: { id: true, modelId: true, quantity: true },
+  });
+
+  let accSort = result.nextSort;
+  for (const child of kitChildren) {
+    if (child.modelId) {
+      const accResult = await autoAddAccessories(
+        organizationId, projectId, child.id,
+        child.modelId, child.quantity, accSort,
+      );
+      accSort = accResult.nextSort;
+    }
+  }
+
   await recalculateProjectTotals(projectId);
-  return serialize(result);
+  return serialize(result.parentItem);
 }
 
 export async function removeLineItem(id: string) {
@@ -367,10 +482,16 @@ export async function removeLineItem(id: string) {
     throw new Error("This item is part of a Kit. Remove the Kit instead.");
   }
 
-  // If this is a kit parent, cascade delete children
-  if (item.kitId && !item.isKitChild) {
+  // If this is a kit parent or has accessory children, cascade delete children
+  const hasChildren = item.kitId && !item.isKitChild;
+  if (hasChildren) {
     await prisma.projectLineItem.deleteMany({
       where: { parentLineItemId: item.id, organizationId },
+    });
+  } else {
+    // Delete mandatory accessory children (optional ones are also cleaned up)
+    await prisma.projectLineItem.deleteMany({
+      where: { parentLineItemId: item.id, organizationId, isAccessory: true },
     });
   }
 
@@ -629,6 +750,115 @@ export async function checkKitAvailability(
 /** Round to 2 decimal places to avoid floating-point drift in financial calculations */
 function roundCurrency(n: number): number {
   return Math.round(n * 100) / 100;
+}
+
+/**
+ * Auto-add MANDATORY and OPTIONAL accessories as child line items.
+ * Cascades up to 3 levels deep. Returns recommended accessories for UI toast.
+ */
+async function autoAddAccessories(
+  organizationId: string,
+  projectId: string,
+  parentLineItemId: string,
+  modelId: string,
+  parentQuantity: number,
+  startSortOrder: number,
+  depth = 0,
+): Promise<{ recommended: Array<{ modelName: string; modelId: string }>; nextSort: number }> {
+  if (depth >= 3) return { recommended: [], nextSort: startSortOrder };
+
+  const accessories = await prisma.modelAccessory.findMany({
+    where: { parentModelId: modelId, organizationId },
+    include: {
+      accessoryModel: {
+        select: { id: true, name: true, defaultRentalPrice: true },
+      },
+    },
+    orderBy: { sortOrder: "asc" },
+  });
+
+  if (accessories.length === 0) return { recommended: [], nextSort: startSortOrder };
+
+  let nextSort = startSortOrder;
+  const recommended: Array<{ modelName: string; modelId: string }> = [];
+
+  for (const acc of accessories) {
+    if (acc.level === "RECOMMENDED") {
+      recommended.push({
+        modelName: acc.accessoryModel.name,
+        modelId: acc.accessoryModel.id,
+      });
+      continue;
+    }
+
+    const qty = parentQuantity * acc.quantity;
+    const unitPrice = acc.accessoryModel.defaultRentalPrice
+      ? Number(acc.accessoryModel.defaultRentalPrice)
+      : null;
+    const lineTotal = unitPrice != null ? roundCurrency(unitPrice * qty) : null;
+
+    // Check if this accessory model already exists on the project (not as a child)
+    const existingOnProject = await prisma.projectLineItem.findFirst({
+      where: {
+        projectId,
+        organizationId,
+        modelId: acc.accessoryModel.id,
+        assetId: null,
+        isKitChild: false,
+        isAccessory: false,
+        status: { not: "CANCELLED" },
+      },
+    });
+
+    if (existingOnProject) {
+      // Merge: increment quantity on the existing line item
+      const newQty = existingOnProject.quantity + qty;
+      const existingPrice = existingOnProject.unitPrice ? Number(existingOnProject.unitPrice) : unitPrice;
+      const mergedTotal = existingPrice != null
+        ? roundCurrency(existingPrice * newQty * existingOnProject.duration)
+        : null;
+
+      await prisma.projectLineItem.update({
+        where: { id: existingOnProject.id },
+        data: { quantity: newQty, lineTotal: mergedTotal },
+      });
+    } else {
+      // Create new accessory child line item
+      const childItem = await prisma.projectLineItem.create({
+        data: {
+          organizationId,
+          projectId,
+          type: "EQUIPMENT",
+          modelId: acc.accessoryModel.id,
+          description: acc.accessoryModel.name,
+          quantity: qty,
+          unitPrice,
+          pricingType: "PER_DAY",
+          duration: 1,
+          lineTotal,
+          sortOrder: nextSort++,
+          parentLineItemId,
+          isAccessory: true,
+          accessoryLevel: acc.level,
+        },
+      });
+
+      // Cascade: check if this accessory model itself has accessories
+      const cascadeResult = await autoAddAccessories(
+        organizationId,
+        projectId,
+        childItem.id,
+        acc.accessoryModel.id,
+        qty,
+        nextSort,
+        depth + 1,
+      );
+      nextSort = cascadeResult.nextSort;
+      recommended.push(...cascadeResult.recommended);
+    }
+  }
+
+  return { recommended, nextSort };
 }
 
 function calculateLineTotal(

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -11,6 +11,7 @@ export type SearchResultType =
   | "bulk-asset"
   | "project"
   | "client"
+  | "supplier"
   | "location"
   | "category"
   | "maintenance";
@@ -41,6 +42,7 @@ type ProjectRow = { id: string; projectNumber: string; name: string; status: str
 type ClientRow = { id: string; name: string; contactName: string | null; contactEmail: string | null; match_quality: number };
 type LocationRow = { id: string; name: string; address: string | null; match_quality: number };
 type CategoryRow = { id: string; name: string; description: string | null; modelCount: number; match_quality: number };
+type SupplierRow = { id: string; name: string; contactName: string | null; accountNumber: string | null; match_quality: number };
 type MaintenanceRow = { id: string; title: string; status: string; match_quality: number };
 
 // Child row types
@@ -68,7 +70,7 @@ export async function globalSearch(query: string) {
 
   if (nq.length < 1) return { results: [] };
 
-  const [models, kits, assets, bulkAssets, projects, clients, locations, categories, maintenance] =
+  const [models, kits, assets, bulkAssets, projects, clients, suppliers, locations, categories, maintenance] =
     await Promise.all([
       prisma.$queryRaw<ModelRow[]>`
         SELECT m.id, m.name, m.manufacturer, m."modelNumber",
@@ -183,6 +185,22 @@ export async function globalSearch(query: string) {
           AND (
             name ILIKE ${ilikePattern} OR COALESCE("contactName", '') ILIKE ${ilikePattern}
             OR COALESCE("contactEmail", '') ILIKE ${ilikePattern}
+            OR lower(regexp_replace(name, '[^a-zA-Z0-9]', '', 'g')) LIKE ${nqPattern}
+            OR similarity(name, ${q}) > ${trigramThreshold} OR similarity(COALESCE("contactName", ''), ${q}) > ${trigramThreshold}
+            OR EXISTS(SELECT 1 FROM unnest(tags) t WHERE t ILIKE ${ilikePattern})
+          )
+        ORDER BY match_quality DESC, name ASC LIMIT 10
+      `,
+
+      prisma.$queryRaw<SupplierRow[]>`
+        SELECT id, name, "contactName", "accountNumber",
+               GREATEST(similarity(lower(name), ${ql}), similarity(lower(COALESCE("contactName", '')), ${ql})) AS match_quality
+        FROM "public"."supplier"
+        WHERE "organizationId" = ${organizationId} AND "isActive" = true
+          AND (
+            name ILIKE ${ilikePattern} OR COALESCE("contactName", '') ILIKE ${ilikePattern}
+            OR COALESCE("accountNumber", '') ILIKE ${ilikePattern}
+            OR COALESCE(email, '') ILIKE ${ilikePattern}
             OR lower(regexp_replace(name, '[^a-zA-Z0-9]', '', 'g')) LIKE ${nqPattern}
             OR similarity(name, ${q}) > ${trigramThreshold} OR similarity(COALESCE("contactName", ''), ${q}) > ${trigramThreshold}
             OR EXISTS(SELECT 1 FROM unnest(tags) t WHERE t ILIKE ${ilikePattern})
@@ -461,6 +479,15 @@ export async function globalSearch(query: string) {
       title: `${p.projectNumber} — ${p.name}`, subtitle: p.clientName || p.status,
       href: `/projects/${p.id}`, relevance: Number(p.match_quality) || 0,
       status: p.status,
+    });
+  }
+
+  // Suppliers
+  for (const s of suppliers) {
+    results.push({
+      id: s.id, type: "supplier",
+      title: s.name, subtitle: [s.contactName, s.accountNumber ? `Acct: ${s.accountNumber}` : null].filter(Boolean).join(" · ") || null,
+      href: `/suppliers/${s.id}`, relevance: Number(s.match_quality) || 0,
     });
   }
 

--- a/src/server/supplier-orders.ts
+++ b/src/server/supplier-orders.ts
@@ -1,0 +1,329 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { serialize } from "@/lib/serialize";
+import { supplierOrderSchema, type SupplierOrderFormValues, supplierOrderItemSchema, type SupplierOrderItemFormValues } from "@/lib/validations/supplier-order";
+import { logActivity, buildChanges } from "@/lib/activity-log";
+import type { FilterValue } from "@/lib/table-utils";
+
+export async function getSupplierOrders(params: {
+  supplierId?: string;
+  type?: string;
+  status?: string;
+  search?: string;
+  filters?: Record<string, FilterValue>;
+  page?: number;
+  pageSize?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}) {
+  const { organizationId } = await getOrgContext();
+  const { supplierId, type, status, search, page = 1, pageSize = 25, sortBy = "createdAt", sortOrder = "desc" } = params;
+
+  const where: Record<string, unknown> = { organizationId };
+  if (supplierId) where.supplierId = supplierId;
+  if (type) where.type = type;
+  if (status) where.status = status;
+  if (search) {
+    where.OR = [
+      { orderNumber: { contains: search, mode: "insensitive" } },
+      { notes: { contains: search, mode: "insensitive" } },
+      { supplier: { name: { contains: search, mode: "insensitive" } } },
+    ];
+  }
+
+  const [orders, total] = await Promise.all([
+    prisma.supplierOrder.findMany({
+      where,
+      include: {
+        supplier: { select: { id: true, name: true } },
+        project: { select: { id: true, name: true, projectNumber: true } },
+        _count: { select: { items: true } },
+      },
+      orderBy: { [sortBy]: sortOrder },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.supplierOrder.count({ where }),
+  ]);
+
+  return serialize({ orders, total });
+}
+
+export async function getSupplierOrderById(id: string) {
+  const { organizationId } = await getOrgContext();
+  const order = await prisma.supplierOrder.findUnique({
+    where: { id, organizationId },
+    include: {
+      supplier: { select: { id: true, name: true } },
+      project: { select: { id: true, name: true, projectNumber: true } },
+      createdBy: { select: { id: true, name: true } },
+      items: {
+        orderBy: { sortOrder: "asc" },
+        include: {
+          model: { select: { id: true, name: true } },
+          asset: { select: { id: true, assetTag: true } },
+        },
+      },
+    },
+  });
+  if (!order) throw new Error("Order not found");
+  return serialize(order);
+}
+
+export async function createSupplierOrder(data: SupplierOrderFormValues) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "create");
+  const parsed = supplierOrderSchema.parse(data);
+
+  const order = await prisma.supplierOrder.create({
+    data: {
+      organizationId,
+      supplierId: parsed.supplierId,
+      orderNumber: parsed.orderNumber,
+      type: parsed.type,
+      status: parsed.status,
+      orderDate: parsed.orderDate ? new Date(parsed.orderDate as unknown as string) : null,
+      expectedDate: parsed.expectedDate ? new Date(parsed.expectedDate as unknown as string) : null,
+      receivedDate: parsed.receivedDate ? new Date(parsed.receivedDate as unknown as string) : null,
+      projectId: parsed.projectId || null,
+      notes: parsed.notes || null,
+      createdById: userId,
+    },
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "CREATE",
+    entityType: "supplierOrder",
+    entityId: order.id,
+    entityName: order.orderNumber,
+    summary: `Created order ${order.orderNumber}`,
+  });
+
+  return serialize(order);
+}
+
+export async function updateSupplierOrder(id: string, data: Partial<SupplierOrderFormValues>) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
+
+  const before = await prisma.supplierOrder.findUnique({ where: { id, organizationId } });
+  if (!before) throw new Error("Order not found");
+
+  const updateData: Record<string, unknown> = {};
+  if (data.orderNumber !== undefined) updateData.orderNumber = data.orderNumber;
+  if (data.type !== undefined) updateData.type = data.type;
+  if (data.status !== undefined) updateData.status = data.status;
+  if (data.orderDate !== undefined) updateData.orderDate = data.orderDate ? new Date(data.orderDate as unknown as string) : null;
+  if (data.expectedDate !== undefined) updateData.expectedDate = data.expectedDate ? new Date(data.expectedDate as unknown as string) : null;
+  if (data.receivedDate !== undefined) updateData.receivedDate = data.receivedDate ? new Date(data.receivedDate as unknown as string) : null;
+  if (data.projectId !== undefined) updateData.projectId = data.projectId || null;
+  if (data.notes !== undefined) updateData.notes = data.notes || null;
+
+  const updated = await prisma.supplierOrder.update({
+    where: { id, organizationId },
+    data: updateData,
+  });
+
+  const changes = buildChanges(before, updated, [
+    "orderNumber", "type", "status", "notes",
+  ]);
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "supplierOrder",
+    entityId: updated.id,
+    entityName: updated.orderNumber,
+    summary: `Updated order ${updated.orderNumber}`,
+    details: changes.length > 0 ? { changes } : undefined,
+  });
+
+  return serialize(updated);
+}
+
+export async function updateSupplierOrderStatus(id: string, status: string) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
+
+  const before = await prisma.supplierOrder.findUnique({ where: { id, organizationId } });
+  if (!before) throw new Error("Order not found");
+
+  const updateData: Record<string, unknown> = { status };
+  if (status === "RECEIVED" && !before.receivedDate) {
+    updateData.receivedDate = new Date();
+  }
+
+  const updated = await prisma.supplierOrder.update({
+    where: { id, organizationId },
+    data: updateData,
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "supplierOrder",
+    entityId: updated.id,
+    entityName: updated.orderNumber,
+    summary: `Changed order ${updated.orderNumber} status to ${status}`,
+    details: { changes: [{ field: "status", from: before.status, to: status }] },
+  });
+
+  return serialize(updated);
+}
+
+export async function deleteSupplierOrder(id: string) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "delete");
+
+  const order = await prisma.supplierOrder.findUnique({ where: { id, organizationId } });
+  if (!order) throw new Error("Order not found");
+
+  await prisma.supplierOrder.delete({ where: { id, organizationId } });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "DELETE",
+    entityType: "supplierOrder",
+    entityId: id,
+    entityName: order.orderNumber,
+    summary: `Deleted order ${order.orderNumber}`,
+  });
+
+  return { success: true };
+}
+
+export async function addOrderItem(orderId: string, data: SupplierOrderItemFormValues) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
+
+  const order = await prisma.supplierOrder.findUnique({ where: { id: orderId, organizationId } });
+  if (!order) throw new Error("Order not found");
+
+  const parsed = supplierOrderItemSchema.parse(data);
+  const lineTotal = parsed.unitPrice != null ? parsed.unitPrice * parsed.quantity : null;
+
+  const maxSort = await prisma.supplierOrderItem.aggregate({
+    where: { orderId },
+    _max: { sortOrder: true },
+  });
+
+  const item = await prisma.supplierOrderItem.create({
+    data: {
+      orderId,
+      description: parsed.description,
+      quantity: parsed.quantity,
+      unitPrice: parsed.unitPrice ?? null,
+      lineTotal,
+      modelId: parsed.modelId || null,
+      assetId: parsed.assetId || null,
+      notes: parsed.notes || null,
+      sortOrder: (maxSort._max.sortOrder ?? -1) + 1,
+    },
+  });
+
+  await recalculateOrderTotals(orderId);
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "CREATE",
+    entityType: "supplierOrderItem",
+    entityId: item.id,
+    entityName: parsed.description,
+    summary: `Added item "${parsed.description}" to order ${order.orderNumber}`,
+  });
+
+  return serialize(item);
+}
+
+export async function updateOrderItem(itemId: string, data: Partial<SupplierOrderItemFormValues>) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
+
+  const item = await prisma.supplierOrderItem.findUnique({
+    where: { id: itemId },
+    include: { order: { select: { organizationId: true, orderNumber: true } } },
+  });
+  if (!item || item.order.organizationId !== organizationId) throw new Error("Item not found");
+
+  const updateData: Record<string, unknown> = {};
+  if (data.description !== undefined) updateData.description = data.description;
+  if (data.quantity !== undefined) updateData.quantity = data.quantity;
+  if (data.unitPrice !== undefined) updateData.unitPrice = data.unitPrice ?? null;
+  if (data.modelId !== undefined) updateData.modelId = data.modelId || null;
+  if (data.assetId !== undefined) updateData.assetId = data.assetId || null;
+  if (data.notes !== undefined) updateData.notes = data.notes || null;
+
+  // Recalculate line total
+  const qty = Number(data.quantity ?? item.quantity);
+  const price = data.unitPrice !== undefined ? (data.unitPrice ?? null) : (item.unitPrice != null ? Number(item.unitPrice) : null);
+  updateData.lineTotal = price != null ? Number(price) * qty : null;
+
+  const updated = await prisma.supplierOrderItem.update({
+    where: { id: itemId },
+    data: updateData,
+  });
+
+  await recalculateOrderTotals(item.orderId);
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "supplierOrderItem",
+    entityId: updated.id,
+    entityName: updated.description,
+    summary: `Updated item "${updated.description}" on order ${item.order.orderNumber}`,
+  });
+
+  return serialize(updated);
+}
+
+export async function removeOrderItem(itemId: string) {
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
+
+  const item = await prisma.supplierOrderItem.findUnique({
+    where: { id: itemId },
+    include: { order: { select: { organizationId: true, orderNumber: true } } },
+  });
+  if (!item || item.order.organizationId !== organizationId) throw new Error("Item not found");
+
+  await prisma.supplierOrderItem.delete({ where: { id: itemId } });
+  await recalculateOrderTotals(item.orderId);
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "DELETE",
+    entityType: "supplierOrderItem",
+    entityId: itemId,
+    entityName: item.description,
+    summary: `Removed item "${item.description}" from order ${item.order.orderNumber}`,
+  });
+
+  return { success: true };
+}
+
+async function recalculateOrderTotals(orderId: string) {
+  const agg = await prisma.supplierOrderItem.aggregate({
+    where: { orderId },
+    _sum: { lineTotal: true },
+  });
+
+  const subtotal = agg._sum.lineTotal ? Number(agg._sum.lineTotal) : 0;
+  const taxAmount = Math.round(subtotal * 0.1 * 100) / 100; // 10% GST
+  const total = Math.round((subtotal + taxAmount) * 100) / 100;
+
+  await prisma.supplierOrder.update({
+    where: { id: orderId },
+    data: { subtotal, taxAmount, total },
+  });
+}

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -3,24 +3,146 @@
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
-import { supplierSchema, type SupplierFormValues } from "@/lib/validations/asset";
-import { logActivity } from "@/lib/activity-log";
+import { supplierSchema, type SupplierFormValues } from "@/lib/validations/supplier";
+import { logActivity, buildChanges } from "@/lib/activity-log";
+import { buildFilterWhere, type FilterValue } from "@/lib/table-utils";
+import type { ColumnDef } from "@/components/ui/data-table";
+
+// Column defs for server-side filter building
+const filterColumnDefs: ColumnDef<unknown>[] = [
+  { id: "isActive", header: "Status", accessorKey: "isActive", filterable: true, filterType: "enum" },
+];
 
 export async function getSuppliers() {
   const { organizationId } = await getOrgContext();
   return serialize(
     await prisma.supplier.findMany({
       where: { organizationId, isActive: true },
-      include: { _count: { select: { assets: true } } },
+      include: { _count: { select: { assets: true, orders: true } } },
       orderBy: { name: "asc" },
     })
   );
 }
 
+export async function getSuppliersPaginated(params: {
+  search?: string;
+  filters?: Record<string, FilterValue>;
+  page?: number;
+  pageSize?: number;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}) {
+  const { organizationId } = await getOrgContext();
+  const { search, filters, page = 1, pageSize = 25, sortBy = "name", sortOrder = "asc" } = params;
+
+  const filterWhere = filters ? buildFilterWhere(filters, filterColumnDefs) : {};
+
+  const where = {
+    organizationId,
+    ...filterWhere,
+    ...(search
+      ? {
+          OR: [
+            { name: { contains: search, mode: "insensitive" as const } },
+            { contactName: { contains: search, mode: "insensitive" as const } },
+            { email: { contains: search, mode: "insensitive" as const } },
+            { accountNumber: { contains: search, mode: "insensitive" as const } },
+            { tags: { hasSome: [search.toLowerCase()] } },
+          ],
+        }
+      : {}),
+  };
+
+  const [suppliers, total] = await Promise.all([
+    prisma.supplier.findMany({
+      where,
+      include: {
+        _count: { select: { assets: true, orders: true, lineItems: true } },
+      },
+      orderBy: { [sortBy]: sortOrder },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.supplier.count({ where }),
+  ]);
+
+  return serialize({ suppliers, total });
+}
+
+export async function getSupplierById(id: string) {
+  const { organizationId } = await getOrgContext();
+  const supplier = await prisma.supplier.findUnique({
+    where: { id, organizationId },
+    include: {
+      _count: { select: { assets: true, orders: true, lineItems: true } },
+      orders: {
+        orderBy: { createdAt: "desc" },
+        take: 10,
+        include: {
+          _count: { select: { items: true } },
+          project: { select: { id: true, name: true, projectNumber: true } },
+        },
+      },
+    },
+  });
+  if (!supplier) throw new Error("Supplier not found");
+  return serialize(supplier);
+}
+
+export async function getSupplierAssets(supplierId: string, params: {
+  page?: number;
+  pageSize?: number;
+}) {
+  const { organizationId } = await getOrgContext();
+  const { page = 1, pageSize = 25 } = params;
+
+  const where = { organizationId, supplierId, isActive: true };
+
+  const [assets, total] = await Promise.all([
+    prisma.asset.findMany({
+      where,
+      include: {
+        model: { select: { id: true, name: true, manufacturer: true } },
+      },
+      orderBy: { assetTag: "asc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.asset.count({ where }),
+  ]);
+
+  return serialize({ assets, total });
+}
+
+export async function getSupplierSubhires(supplierId: string, params: {
+  page?: number;
+  pageSize?: number;
+}) {
+  const { organizationId } = await getOrgContext();
+  const { page = 1, pageSize = 25 } = params;
+
+  const where = { organizationId, supplierId, isSubhire: true };
+
+  const [lineItems, total] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where,
+      include: {
+        project: { select: { id: true, name: true, projectNumber: true, status: true } },
+        model: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.projectLineItem.count({ where }),
+  ]);
+
+  return serialize({ lineItems, total });
+}
+
 export async function createSupplier(data: SupplierFormValues) {
-  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+  const { organizationId, userId, userName } = await requirePermission("supplier", "create");
   const parsed = supplierSchema.parse(data);
-  // Clean empty strings to null
   const cleaned = {
     ...parsed,
     email: parsed.email || null,
@@ -29,6 +151,10 @@ export async function createSupplier(data: SupplierFormValues) {
     website: parsed.website || null,
     address: parsed.address || null,
     notes: parsed.notes || null,
+    accountNumber: parsed.accountNumber || null,
+    paymentTerms: parsed.paymentTerms || null,
+    defaultLeadTime: parsed.defaultLeadTime || null,
+    tags: (parsed.tags || []).map((t: string) => t.toLowerCase()),
   };
   const result = await prisma.supplier.create({
     data: { ...cleaned, organizationId },
@@ -49,8 +175,12 @@ export async function createSupplier(data: SupplierFormValues) {
 }
 
 export async function updateSupplier(id: string, data: SupplierFormValues) {
-  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+  const { organizationId, userId, userName } = await requirePermission("supplier", "update");
   const parsed = supplierSchema.parse(data);
+
+  const before = await prisma.supplier.findUnique({ where: { id, organizationId } });
+  if (!before) throw new Error("Supplier not found");
+
   const cleaned = {
     ...parsed,
     email: parsed.email || null,
@@ -59,11 +189,20 @@ export async function updateSupplier(id: string, data: SupplierFormValues) {
     website: parsed.website || null,
     address: parsed.address || null,
     notes: parsed.notes || null,
+    accountNumber: parsed.accountNumber || null,
+    paymentTerms: parsed.paymentTerms || null,
+    defaultLeadTime: parsed.defaultLeadTime || null,
+    tags: (parsed.tags || []).map((t: string) => t.toLowerCase()),
   };
   const updated = await prisma.supplier.update({
     where: { id, organizationId },
     data: cleaned,
   });
+
+  const changes = buildChanges(before, updated, [
+    "name", "contactName", "email", "phone", "website", "address",
+    "notes", "accountNumber", "paymentTerms", "defaultLeadTime", "isActive",
+  ]);
 
   await logActivity({
     organizationId,
@@ -74,20 +213,27 @@ export async function updateSupplier(id: string, data: SupplierFormValues) {
     entityId: updated.id,
     entityName: updated.name,
     summary: `Updated supplier ${updated.name}`,
+    details: changes.length > 0 ? { changes } : undefined,
   });
 
   return serialize(updated);
 }
 
 export async function deleteSupplier(id: string) {
-  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+  const { organizationId, userId, userName } = await requirePermission("supplier", "delete");
   const supplier = await prisma.supplier.findUnique({
     where: { id, organizationId },
-    include: { _count: { select: { assets: true } } },
+    include: { _count: { select: { assets: true, lineItems: true, orders: true } } },
   });
   if (!supplier) throw new Error("Supplier not found");
   if (supplier._count.assets > 0) {
-    throw new Error("Cannot delete supplier with assets linked to it");
+    throw new Error("Cannot delete supplier with linked assets");
+  }
+  if (supplier._count.lineItems > 0) {
+    throw new Error("Cannot delete supplier with linked line items");
+  }
+  if (supplier._count.orders > 0) {
+    throw new Error("Cannot delete supplier with existing orders. Archive it instead.");
   }
   await prisma.supplier.delete({ where: { id, organizationId } });
 


### PR DESCRIPTION
Promote suppliers from inline settings manager to dedicated routes at /suppliers with list, detail, new, and edit pages. Add SupplierOrder and SupplierOrderItem models for purchase/subhire PO tracking. Integrate into sidebar, global search, command palette, permissions, org export/import, and ARCHITECTURE.md.