### PR TITLE
Add slash command system for context-aware page actions

### DIFF
--- a/FEATUREDOCS/16-search.md
+++ b/FEATUREDOCS/16-search.md
@@ -21,9 +21,43 @@ Uses PostgreSQL ILIKE and trigram similarity for fuzzy matching. Tags matched vi
   - Each page has: `label, href, aliases[], icon, description, searchable?, searchType?, children?`
   - Tab drills into children, space after page name searches entities
   - Example: `@warehouse drum` → searches projects containing "drum" and links to warehouse view
+- **/ mode**: Slash commands via `SLASH_COMMANDS` (`src/lib/slash-commands.ts`)
+  - Context-aware actions filtered by current pathname and user permissions
+  - Page-specific commands shown first, then global commands
+  - Commands execute actions: navigate, scroll to section, open dialog, generate PDF, or dispatch events
+  - Commands define `pages` (route patterns) and optional `requiredPermission` ([resource, action])
+  - Page components listen for `slash-command` CustomEvents for `open_dialog` and `trigger` action types
 - **Date shortcuts**: Typing DD/MM/YYYY navigates to availability calendar
 - **Keyboard**: `Shift+↑/↓` skip children, `Tab` drill, `Esc` back, `Cmd+L` toggle children
-- **Mobile**: Full-screen dialog with safe area padding
+- **Mobile**: Full-screen dialog with safe area padding, `/` and `@` quick-access buttons
+
+## Slash Command Registry (`src/lib/slash-commands.ts`)
+- `SlashCommand` interface: `id, label, command, aliases[], description, icon, pages[], action, requiredPermission?`
+- `SlashCommandAction` types: `navigate`, `navigate_section`, `open_dialog`, `generate_document`, `trigger`
+- Route matching: `[id]` for dynamic segments, `*` for global, `/path/*` for wildcard suffix
+- `extractEntityId(pathname)` — pulls entity ID from URL for `:id` substitution in actions
+- `matchSlashCommands(query, pathname, permissions)` — filters and scores commands
+- `logout` trigger is handled directly in command-search via `signOut()`, not dispatched as event
+
+### Document generation
+- `generate_document` action opens `/api/documents/{entityId}?type={docType}` in a new tab
+- Valid `docType` values: `quote`, `invoice`, `pull-slip`, `delivery-docket`, `return-sheet`
+- Available on both project detail (`/projects/[id]`) and warehouse (`/warehouse/[projectId]`) pages
+
+### Tab switching vs section scrolling
+- Pages using `<Tabs>` (projects, assets, models, clients) use `trigger` with `event: "switch-tab:{tabValue}"`
+- Pages with scrollable sections (kits) use `navigate_section` with `hash` matching an element `id`
+- Page components must add event listeners for `slash-command` CustomEvents to handle `switch-tab:*` and other triggers
+
+### Adding a new slash command
+1. Add entry to `SLASH_COMMANDS` array in `src/lib/slash-commands.ts`
+2. Set `pages` to the route patterns where the command is available
+3. Set `action` to what happens on execution
+4. Set `requiredPermission` if the action needs permission gating
+5. Add the icon name to `pageIcons` map in `command-search.tsx` if it's a new icon
+6. For `open_dialog`/`trigger` actions, add a `slash-command` event listener in the target page component
+7. For `navigate_section`, ensure the target element has a matching `id` attribute
+8. Add new path segments to `knownSegments` in `extractEntityId()` if they could be mistaken for IDs (> 5 chars)
 
 ## Adding New Entities to Search
 1. Add search case to `globalSearch()` in `src/server/search.ts`

--- a/src/app/(app)/kits/[id]/page.tsx
+++ b/src/app/(app)/kits/[id]/page.tsx
@@ -313,7 +313,7 @@ export default function KitDetailPage({ params }: { params: Promise<{ id: string
       <BookingCalendar entityType="kit" entityId={id} initialDate={initialDate} />
 
       {/* Contents Card */}
-      <Card>
+      <Card id="kit-contents">
         <CardHeader>
           <CardTitle className="text-base">Contents</CardTitle>
         </CardHeader>

--- a/src/components/layout/command-search.tsx
+++ b/src/components/layout/command-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import {
   Package,
   FolderOpen,
@@ -33,6 +33,23 @@ import {
   CreditCard,
   Palette,
   Truck,
+  Slash,
+  FileText,
+  ClipboardList,
+  Pencil,
+  Copy,
+  Upload,
+  Download,
+  QrCode,
+  ScrollText,
+  ScanBarcode,
+  PackagePlus,
+  LogOut,
+  CheckCircle,
+  CircleCheck,
+  CircleX,
+  StickyNote,
+  Share2,
 } from "lucide-react";
 import {
   Dialog,
@@ -41,6 +58,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { globalSearch, type SearchResult, type SearchResultType } from "@/server/search";
 import { matchPageCommands, PAGE_COMMANDS, type PageCommand } from "@/lib/page-commands";
+import { matchSlashCommands, extractEntityId, type SlashCommand } from "@/lib/slash-commands";
+import { signOut } from "@/lib/auth-client";
+import { useCurrentRole } from "@/lib/use-permissions";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 // ─── Icon maps ─────────────────────────────────────────────────────
@@ -75,7 +95,9 @@ const pageIcons: Record<string, React.ComponentType<{ className?: string }>> = {
   LayoutDashboard, Package, Boxes, Box, CalendarRange, Container,
   FolderOpen, BookTemplate, Warehouse, Users, MapPin, Wrench,
   ShieldCheck, BarChart3, Settings, UserCircle, PackageCheck, PackageX,
-  CreditCard, Palette, Truck,
+  CreditCard, Palette, Truck, FileText, ClipboardList, Pencil, Copy,
+  Upload, Download, QrCode, ScrollText, ScanBarcode, PackagePlus,
+  LogOut, CheckCircle, CircleCheck, CircleX, StickyNote, Share2,
 };
 
 function normalize(s: string): string {
@@ -146,13 +168,95 @@ export function CommandSearch() {
   const [atEntityLoading, setAtEntityLoading] = useState(false);
 
   const router = useRouter();
+  const pathname = usePathname();
+  const { permissions } = useCurrentRole();
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
   const isDrilling = drillParent !== null;
   const isAtMode = query.startsWith("@");
+  const isSlashMode = query.startsWith("/") && !isDrilling;
   const isAtEntityMode = atEntityPage !== null;
+
+  // ─── / mode: slash commands ───────────────────────────────────
+
+  const slashQuery = isSlashMode ? query.slice(1) : "";
+  const slashMatches = useMemo(() => {
+    if (!isSlashMode || isDrilling || isAtEntityMode) return [];
+    return matchSlashCommands(slashQuery, pathname, permissions);
+  }, [isSlashMode, slashQuery, pathname, permissions, isDrilling, isAtEntityMode]);
+
+  const slashDisplayItems = useMemo((): DisplayItem[] => {
+    if (!isSlashMode || isDrilling || isAtEntityMode) return [];
+
+    // Group: page-specific commands first, then global
+    const pageSpecific: DisplayItem[] = [];
+    const global: DisplayItem[] = [];
+
+    for (const match of slashMatches) {
+      const cmd = match.command;
+      const IconComp = pageIcons[cmd.icon] || Package;
+      const item: DisplayItem = {
+        id: `slash-${cmd.id}`,
+        title: cmd.label,
+        subtitle: cmd.description,
+        href: "", // Slash commands use action execution, not direct navigation
+        icon: IconComp,
+        typeLabel: match.isPageSpecific ? undefined : "Global",
+      };
+      if (match.isPageSpecific) {
+        pageSpecific.push(item);
+      } else {
+        global.push(item);
+      }
+    }
+
+    return [...pageSpecific, ...global];
+  }, [isSlashMode, slashMatches, isDrilling, isAtEntityMode]);
+
+  const executeSlashCommand = useCallback((cmd: SlashCommand) => {
+    const entityId = extractEntityId(pathname);
+    setOpen(false);
+
+    switch (cmd.action.type) {
+      case "navigate": {
+        const path = cmd.action.path.replace(":id", entityId || "");
+        router.push(path);
+        break;
+      }
+      case "navigate_section": {
+        const el = document.getElementById(cmd.action.hash);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth" });
+        }
+        break;
+      }
+      case "open_dialog": {
+        window.dispatchEvent(
+          new CustomEvent("slash-command", { detail: { dialog: cmd.action.dialog } })
+        );
+        break;
+      }
+      case "generate_document": {
+        if (entityId) {
+          window.open(`/api/documents/${entityId}?type=${cmd.action.docType}`, "_blank");
+        }
+        break;
+      }
+      case "trigger": {
+        // Handle logout specially — no need to dispatch an event
+        if (cmd.action.event === "logout") {
+          signOut();
+          return;
+        }
+        window.dispatchEvent(
+          new CustomEvent("slash-command", { detail: { event: cmd.action.event } })
+        );
+        break;
+      }
+    }
+  }, [pathname, router]);
 
   // ─── @ mode: build page command results ──────────────────────
 
@@ -575,6 +679,11 @@ export function CommandSearch() {
   // ─── Build visible items based on current mode ───────────────
 
   const visibleItems = useMemo((): DisplayItem[] => {
+    // / slash command mode
+    if (isSlashMode && !isDrilling && !isAtEntityMode) {
+      return slashDisplayItems;
+    }
+
     // @ entity drill mode (Tab on a page)
     if (isAtEntityMode) {
       return atEntityDrillItems;
@@ -631,7 +740,7 @@ export function CommandSearch() {
     }
 
     return items;
-  }, [isAtEntityMode, atEntityDrillItems, isDrilling, filteredDrillChildren,
+  }, [isSlashMode, slashDisplayItems, isAtEntityMode, atEntityDrillItems, isDrilling, filteredDrillChildren,
       isAtMode, atDisplayItems, expanded, results, dateItem, dateEntityItems]);
 
   // ─── Lifecycle ───────────────────────────────────────────────
@@ -697,8 +806,8 @@ export function CommandSearch() {
     }
     setQuery(value);
     setSelectedIndex(0);
-    // Only do server search for non-@ queries that aren't dates
-    if (!value.startsWith("@") && !tryParseDate(value.trim())) {
+    // Only do server search for non-@ non-/ queries that aren't dates
+    if (!value.startsWith("@") && !value.startsWith("/") && !tryParseDate(value.trim())) {
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => doSearch(value), 250);
     }
@@ -873,6 +982,12 @@ export function CommandSearch() {
     } else if (e.key === "Enter" && visibleItems[selectedIndex]) {
       e.preventDefault();
       const item = visibleItems[selectedIndex];
+      // Slash command mode: execute the command action
+      if (isSlashMode && item.id.startsWith("slash-")) {
+        const match = slashMatches.find((m) => `slash-${m.command.id}` === item.id);
+        if (match) executeSlashCommand(match.command);
+        return;
+      }
       // On mobile, Enter drills into items with children instead of navigating
       if (isMobile && item.hasChildren && !isDrilling && !isAtEntityMode) {
         enterDrill(selectedIndex);
@@ -886,6 +1001,17 @@ export function CommandSearch() {
 
   const getSectionLabel = (idx: number): string | null => {
     if (isDrilling || isAtEntityMode || isAtMode) return null;
+
+    // Slash mode: show "Page Actions" / "Global" section headers
+    if (isSlashMode) {
+      const item = visibleItems[idx];
+      const label = item.typeLabel === "Global" ? "Global" : "Page Actions";
+      if (idx === 0) return label;
+      const prev = visibleItems[idx - 1];
+      const prevLabel = prev.typeLabel === "Global" ? "Global" : "Page Actions";
+      return prevLabel !== label ? label : null;
+    }
+
     const item = visibleItems[idx];
     if (item.isChild || !item.typeLabel) return null;
     for (let i = idx - 1; i >= 0; i--) {
@@ -909,9 +1035,10 @@ export function CommandSearch() {
       : null;
 
   const isLoading = loading || atEntityLoading || dateSearchLoading;
-  const showEmptySearch = !isAtMode && !isDrilling && !isAtEntityMode && query.length >= 2 && visibleItems.length === 0 && !isLoading;
-  const showTyping = !isAtMode && !isDrilling && !isAtEntityMode && query.length < 2;
+  const showEmptySearch = !isAtMode && !isSlashMode && !isDrilling && !isAtEntityMode && query.length >= 2 && visibleItems.length === 0 && !isLoading;
+  const showTyping = !isAtMode && !isSlashMode && !isDrilling && !isAtEntityMode && query.length < 2;
   const showAtHint = isAtMode && !isDrilling && !isAtEntityMode && atQuery === "" && visibleItems.length > 0;
+  const showSlashHint = isSlashMode && slashQuery === "" && visibleItems.length > 0;
 
   return (
     <>
@@ -938,7 +1065,9 @@ export function CommandSearch() {
         <DialogContent showCloseButton={false} className={`p-0 gap-0 overflow-hidden ${isMobile ? "h-[100dvh] max-h-[100dvh] w-full max-w-full rounded-none border-0" : "sm:max-w-lg"}`} style={isMobile ? { paddingTop: "env(safe-area-inset-top, 0px)", paddingBottom: "env(safe-area-inset-bottom, 0px)" } : undefined}>
           {/* Search input bar */}
           <div className="flex items-center border-b px-3 gap-1">
-            {isAtMode && !breadcrumb ? (
+            {isSlashMode ? (
+              <Slash className="h-4 w-4 shrink-0 text-primary" />
+            ) : isAtMode && !breadcrumb ? (
               <AtSign className="h-4 w-4 shrink-0 text-primary" />
             ) : (
               <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -964,20 +1093,29 @@ export function CommandSearch() {
                   ? `Search ${atEntityPage?.label}...`
                   : isDrilling
                     ? `Filter ${drillParent?.title}...`
-                    : "Search... (@ for pages)"
+                    : "Search... (@ pages, / actions)"
               }
               className="h-11 border-0 shadow-none focus-visible:ring-0 px-2"
             />
             {isLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
-            {/* @ button — especially useful on mobile where @ is hard to type */}
-            {!isAtMode && !isDrilling && !isAtEntityMode && (
-              <button
-                onClick={() => { setQuery("@"); inputRef.current?.focus(); }}
-                className="shrink-0 h-8 w-8 flex items-center justify-center rounded-md hover:bg-accent text-muted-foreground hover:text-primary transition-colors font-semibold text-sm"
-                title="Navigate to page (@)"
-              >
-                @
-              </button>
+            {/* @ and / buttons — especially useful on mobile where these are hard to type */}
+            {!isAtMode && !isSlashMode && !isDrilling && !isAtEntityMode && (
+              <>
+                <button
+                  onClick={() => { setQuery("/"); inputRef.current?.focus(); }}
+                  className="shrink-0 h-8 w-8 flex items-center justify-center rounded-md hover:bg-accent text-muted-foreground hover:text-primary transition-colors font-semibold text-sm"
+                  title="Page actions (/)"
+                >
+                  /
+                </button>
+                <button
+                  onClick={() => { setQuery("@"); inputRef.current?.focus(); }}
+                  className="shrink-0 h-8 w-8 flex items-center justify-center rounded-md hover:bg-accent text-muted-foreground hover:text-primary transition-colors font-semibold text-sm"
+                  title="Navigate to page (@)"
+                >
+                  @
+                </button>
+              </>
             )}
             {showExpandToggle && (
               <button
@@ -1017,6 +1155,11 @@ export function CommandSearch() {
                     Type a page name to navigate · Add a space to search entities (e.g. <span className="font-medium text-primary">@project drum hire</span>)
                   </div>
                 )}
+                {showSlashHint && (
+                  <div className="px-3 pt-1 pb-2 text-xs text-muted-foreground">
+                    Type a command name to filter (e.g. <span className="font-medium text-primary">/quote</span>)
+                  </div>
+                )}
                 {visibleItems.map((item, idx) => {
                   const sectionLabel = getSectionLabel(idx);
                   const isChild = item.isChild && !isDrilling && !isAtEntityMode;
@@ -1034,6 +1177,12 @@ export function CommandSearch() {
                           else itemRefs.current.delete(idx);
                         }}
                         onClick={() => {
+                          // Slash command: execute the action
+                          if (isSlashMode && item.id.startsWith("slash-")) {
+                            const match = slashMatches.find((m) => `slash-${m.command.id}` === item.id);
+                            if (match) executeSlashCommand(match.command);
+                            return;
+                          }
                           // On mobile, tapping a result with children drills in instead of navigating
                           if (isMobile && item.hasChildren && !isDrilling && !isAtEntityMode) {
                             setSelectedIndex(idx);
@@ -1066,7 +1215,12 @@ export function CommandSearch() {
                             </div>
                           )}
                         </div>
-                        {!isChild && item.typeLabel && !isAtMode && (
+                        {isSlashMode && item.id.startsWith("slash-") && (
+                          <span className="shrink-0 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                            /{slashMatches.find((m) => `slash-${m.command.id}` === item.id)?.command.command}
+                          </span>
+                        )}
+                        {!isChild && item.typeLabel && !isAtMode && !isSlashMode && (
                           <span className="shrink-0 text-xs text-muted-foreground/60">
                             {item.typeLabel}
                           </span>
@@ -1087,7 +1241,7 @@ export function CommandSearch() {
             )}
             {showTyping && (
               <div className="py-6 text-center text-sm text-muted-foreground">
-                Type to search... or <span className="font-medium text-primary">@</span> to navigate
+                Type to search... <span className="font-medium text-primary">@</span> pages · <span className="font-medium text-primary">/</span> actions
               </div>
             )}
             {isAtEntityMode && drillQuery.length < 2 && (

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -1,0 +1,899 @@
+/**
+ * Slash command registry for context-aware page actions.
+ *
+ * Commands are scoped to specific pages via route patterns.
+ * The current pathname is matched against these patterns to determine
+ * which commands are available.
+ */
+
+import type { Resource } from "./permissions";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type SlashCommandAction =
+  | { type: "navigate"; path: string }
+  | { type: "navigate_section"; hash: string }
+  | { type: "open_dialog"; dialog: string }
+  | { type: "generate_document"; docType: string }
+  | { type: "trigger"; event: string };
+
+export interface SlashCommand {
+  /** Unique identifier */
+  id: string;
+  /** Display name: "Generate Pick List" */
+  label: string;
+  /** What the user types after /: "picklist" */
+  command: string;
+  /** Alternative triggers */
+  aliases: string[];
+  /** Shown in command list */
+  description: string;
+  /** Lucide icon name (maps to pageIcons in command-search) */
+  icon: string;
+  /** Route patterns where this command is available. "*" = global. */
+  pages: string[];
+  /** What happens when the command is executed */
+  action: SlashCommandAction;
+  /** Optional permission check: [resource, action] */
+  requiredPermission?: [Resource, string];
+}
+
+// ─── Command Registry ───────────────────────────────────────────────
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  // ── Global Commands (available on all pages) ──────────────────────
+  {
+    id: "global-new-project",
+    label: "New Project",
+    command: "new-project",
+    aliases: ["newproject", "create-project"],
+    description: "Create a new project",
+    icon: "FolderOpen",
+    pages: ["*"],
+    action: { type: "navigate", path: "/projects/new" },
+    requiredPermission: ["project", "create"],
+  },
+  {
+    id: "global-new-asset",
+    label: "New Asset",
+    command: "new-asset",
+    aliases: ["newasset", "create-asset"],
+    description: "Create a new asset",
+    icon: "Package",
+    pages: ["*"],
+    action: { type: "navigate", path: "/assets/registry/new" },
+    requiredPermission: ["asset", "create"],
+  },
+  {
+    id: "global-new-kit",
+    label: "New Kit",
+    command: "new-kit",
+    aliases: ["newkit", "create-kit"],
+    description: "Create a new kit",
+    icon: "Box",
+    pages: ["*"],
+    action: { type: "navigate", path: "/kits/new" },
+    requiredPermission: ["kit", "create"],
+  },
+  {
+    id: "global-new-model",
+    label: "New Model",
+    command: "new-model",
+    aliases: ["newmodel"],
+    description: "Create a new model",
+    icon: "Boxes",
+    pages: ["*"],
+    action: { type: "navigate", path: "/assets/models/new" },
+    requiredPermission: ["model", "create"],
+  },
+  {
+    id: "global-new-client",
+    label: "New Client",
+    command: "new-client",
+    aliases: ["newclient"],
+    description: "Create a new client",
+    icon: "Users",
+    pages: ["*"],
+    action: { type: "navigate", path: "/clients/new" },
+    requiredPermission: ["client", "create"],
+  },
+  {
+    id: "global-settings",
+    label: "Settings",
+    command: "settings",
+    aliases: ["preferences", "config"],
+    description: "Open settings",
+    icon: "Settings",
+    pages: ["*"],
+    action: { type: "navigate", path: "/settings" },
+  },
+  {
+    id: "global-dashboard",
+    label: "Dashboard",
+    command: "dashboard",
+    aliases: ["home", "overview"],
+    description: "Go to dashboard",
+    icon: "LayoutDashboard",
+    pages: ["*"],
+    action: { type: "navigate", path: "/dashboard" },
+  },
+  {
+    id: "global-scan",
+    label: "Scan",
+    command: "scan",
+    aliases: ["scanner", "barcode", "camera"],
+    description: "Open warehouse scanner",
+    icon: "ScanBarcode",
+    pages: ["*"],
+    action: { type: "navigate", path: "/warehouse" },
+    requiredPermission: ["warehouse", "read"],
+  },
+  {
+    id: "global-availability",
+    label: "Availability",
+    command: "availability",
+    aliases: ["calendar", "avail", "schedule"],
+    description: "View asset availability calendar",
+    icon: "CalendarRange",
+    pages: ["*"],
+    action: { type: "navigate", path: "/availability" },
+  },
+  {
+    id: "global-reports",
+    label: "Reports",
+    command: "reports",
+    aliases: ["analytics", "stats"],
+    description: "View reports and analytics",
+    icon: "BarChart3",
+    pages: ["*"],
+    action: { type: "navigate", path: "/reports" },
+    requiredPermission: ["reports", "read"],
+  },
+  {
+    id: "global-activity",
+    label: "Activity Log",
+    command: "activity",
+    aliases: ["audit", "log", "history"],
+    description: "View activity log",
+    icon: "ScrollText",
+    pages: ["*"],
+    action: { type: "navigate", path: "/activity" },
+  },
+  {
+    id: "global-account",
+    label: "Account",
+    command: "account",
+    aliases: ["profile", "myaccount", "me"],
+    description: "Your account and profile settings",
+    icon: "UserCircle",
+    pages: ["*"],
+    action: { type: "navigate", path: "/account" },
+  },
+  {
+    id: "global-logout",
+    label: "Log Out",
+    command: "logout",
+    aliases: ["signout", "sign-out", "log-out"],
+    description: "Sign out of your account",
+    icon: "LogOut",
+    pages: ["*"],
+    action: { type: "trigger", event: "logout" },
+  },
+
+  // ── Project Detail Page (/projects/[id]) ──────────────────────────
+  {
+    id: "project-picklist",
+    label: "Generate Pull Slip",
+    command: "picklist",
+    aliases: ["pullsheet", "pull-sheet", "pick-list", "picking", "pull-slip", "pullslip"],
+    description: "Generate and open pull slip / pick list PDF",
+    icon: "ClipboardList",
+    pages: ["/projects/[id]"],
+    action: { type: "generate_document", docType: "pull-slip" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "project-quote",
+    label: "Generate Quote",
+    command: "quote",
+    aliases: ["quotation"],
+    description: "Generate and open quote document",
+    icon: "FileText",
+    pages: ["/projects/[id]"],
+    action: { type: "generate_document", docType: "quote" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "project-invoice",
+    label: "Generate Invoice",
+    command: "invoice",
+    aliases: ["inv"],
+    description: "Generate and open invoice",
+    icon: "FileText",
+    pages: ["/projects/[id]"],
+    action: { type: "generate_document", docType: "invoice" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "project-return-sheet",
+    label: "Generate Return Sheet",
+    command: "return-sheet",
+    aliases: ["returnsheet", "returns"],
+    description: "Generate and open return sheet",
+    icon: "FileText",
+    pages: ["/projects/[id]"],
+    action: { type: "generate_document", docType: "return-sheet" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "project-delivery-docket",
+    label: "Generate Delivery Docket",
+    command: "delivery-docket",
+    aliases: ["delivery", "docket"],
+    description: "Generate and open delivery docket",
+    icon: "FileText",
+    pages: ["/projects/[id]"],
+    action: { type: "generate_document", docType: "delivery-docket" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "project-equipment",
+    label: "Equipment",
+    command: "equipment",
+    aliases: ["line-items", "items", "gear"],
+    description: "Switch to equipment tab",
+    icon: "Package",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "switch-tab:equipment" },
+  },
+  {
+    id: "project-add-equipment",
+    label: "Add Equipment",
+    command: "add-equipment",
+    aliases: ["add-item", "add-gear"],
+    description: "Open the add equipment dialog",
+    icon: "PackagePlus",
+    pages: ["/projects/[id]"],
+    action: { type: "open_dialog", dialog: "add-equipment" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-warehouse",
+    label: "Warehouse",
+    command: "warehouse",
+    aliases: ["checkout", "checkin"],
+    description: "Open warehouse view for this project",
+    icon: "Warehouse",
+    pages: ["/projects/[id]"],
+    action: { type: "navigate", path: "/warehouse/:id" },
+    requiredPermission: ["warehouse", "read"],
+  },
+  {
+    id: "project-duplicate",
+    label: "Duplicate Project",
+    command: "duplicate",
+    aliases: ["copy", "clone"],
+    description: "Duplicate this project",
+    icon: "Copy",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "duplicate" },
+    requiredPermission: ["project", "create"],
+  },
+  {
+    id: "project-edit",
+    label: "Edit Project",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this project",
+    icon: "Pencil",
+    pages: ["/projects/[id]"],
+    action: { type: "navigate", path: "/projects/:id/edit" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-status-confirmed",
+    label: "Confirm Project",
+    command: "confirm",
+    aliases: ["confirmed", "approve"],
+    description: "Set project status to Confirmed",
+    icon: "CheckCircle",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "set-status:CONFIRMED" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-status-prepping",
+    label: "Start Prepping",
+    command: "prep",
+    aliases: ["prepping", "start-prep"],
+    description: "Set project status to Prepping",
+    icon: "PackageCheck",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "set-status:PREPPING" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-status-completed",
+    label: "Complete Project",
+    command: "complete",
+    aliases: ["completed", "done", "finish"],
+    description: "Set project status to Completed",
+    icon: "CircleCheck",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "set-status:COMPLETED" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-status-cancelled",
+    label: "Cancel Project",
+    command: "cancel",
+    aliases: ["cancelled"],
+    description: "Set project status to Cancelled",
+    icon: "CircleX",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "set-status:CANCELLED" },
+    requiredPermission: ["project", "update"],
+  },
+  {
+    id: "project-notes",
+    label: "Notes",
+    command: "notes",
+    aliases: ["note", "comments"],
+    description: "Switch to notes tab",
+    icon: "StickyNote",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "switch-tab:notes" },
+  },
+  {
+    id: "project-client",
+    label: "View Client",
+    command: "client",
+    aliases: ["customer"],
+    description: "Go to this project's client page",
+    icon: "Users",
+    pages: ["/projects/[id]"],
+    action: { type: "trigger", event: "navigate-client" },
+  },
+  {
+    id: "project-share",
+    label: "Share Project",
+    command: "share",
+    aliases: ["send", "invite"],
+    description: "Share this project",
+    icon: "Share2",
+    pages: ["/projects/[id]"],
+    action: { type: "open_dialog", dialog: "share" },
+    requiredPermission: ["project", "update"],
+  },
+
+  // ── Project List Page (/projects) ─────────────────────────────────
+  {
+    id: "projects-new",
+    label: "New Project",
+    command: "new",
+    aliases: ["create", "add"],
+    description: "Create new project",
+    icon: "FolderOpen",
+    pages: ["/projects"],
+    action: { type: "navigate", path: "/projects/new" },
+    requiredPermission: ["project", "create"],
+  },
+  {
+    id: "projects-templates",
+    label: "Templates",
+    command: "templates",
+    aliases: ["template"],
+    description: "View project templates",
+    icon: "BookTemplate",
+    pages: ["/projects"],
+    action: { type: "navigate", path: "/projects/templates" },
+  },
+
+  // ── Asset Detail Page (/assets/registry/[id]) ─────────────────────
+  {
+    id: "asset-edit",
+    label: "Edit Asset",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this asset",
+    icon: "Pencil",
+    pages: ["/assets/registry/[id]"],
+    action: { type: "navigate", path: "/assets/registry/:id/edit" },
+    requiredPermission: ["asset", "update"],
+  },
+  {
+    id: "asset-maintenance",
+    label: "Create Maintenance",
+    command: "maintenance",
+    aliases: ["repair", "service"],
+    description: "Create maintenance record for this asset",
+    icon: "Wrench",
+    pages: ["/assets/registry/[id]"],
+    action: { type: "open_dialog", dialog: "create-maintenance" },
+    requiredPermission: ["maintenance", "create"],
+  },
+  {
+    id: "asset-qr",
+    label: "QR Code",
+    command: "qr",
+    aliases: ["qrcode", "barcode", "label"],
+    description: "Generate / print QR code",
+    icon: "QrCode",
+    pages: ["/assets/registry/[id]"],
+    action: { type: "trigger", event: "generate-qr" },
+  },
+  {
+    id: "asset-history",
+    label: "History",
+    command: "history",
+    aliases: ["log", "activity"],
+    description: "View asset checkout history",
+    icon: "ScrollText",
+    pages: ["/assets/registry/[id]"],
+    action: { type: "trigger", event: "switch-tab:history" },
+  },
+
+  // ── Model Detail Page (/assets/models/[id]) ───────────────────────
+  {
+    id: "model-edit",
+    label: "Edit Model",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this model",
+    icon: "Pencil",
+    pages: ["/assets/models/[id]"],
+    action: { type: "navigate", path: "/assets/models/:id/edit" },
+    requiredPermission: ["model", "update"],
+  },
+  {
+    id: "model-new-asset",
+    label: "New Asset",
+    command: "new-asset",
+    aliases: ["add-asset", "create-asset"],
+    description: "Create asset of this model",
+    icon: "Package",
+    pages: ["/assets/models/[id]"],
+    action: { type: "navigate", path: "/assets/registry/new?modelId=:id" },
+    requiredPermission: ["asset", "create"],
+  },
+  {
+    id: "model-assets",
+    label: "Assets",
+    command: "assets",
+    aliases: ["inventory", "stock"],
+    description: "View all assets of this model",
+    icon: "Package",
+    pages: ["/assets/models/[id]"],
+    action: { type: "trigger", event: "switch-tab:assets" },
+  },
+
+  // ── Kit Detail Page (/kits/[id]) ──────────────────────────────────
+  {
+    id: "kit-edit",
+    label: "Edit Kit",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this kit",
+    icon: "Pencil",
+    pages: ["/kits/[id]"],
+    action: { type: "navigate", path: "/kits/:id/edit" },
+    requiredPermission: ["kit", "update"],
+  },
+  {
+    id: "kit-contents",
+    label: "Contents",
+    command: "contents",
+    aliases: ["items", "assets"],
+    description: "View kit contents",
+    icon: "Package",
+    pages: ["/kits/[id]"],
+    action: { type: "navigate_section", hash: "kit-contents" },
+  },
+  {
+    id: "kit-add-item",
+    label: "Add Item",
+    command: "add-item",
+    aliases: ["add-asset"],
+    description: "Add asset to kit",
+    icon: "PackagePlus",
+    pages: ["/kits/[id]"],
+    action: { type: "open_dialog", dialog: "add-kit-item" },
+    requiredPermission: ["kit", "update"],
+  },
+
+  // ── Warehouse Page (/warehouse/[projectId]) ───────────────────────
+  {
+    id: "warehouse-picklist",
+    label: "Generate Pull Slip",
+    command: "picklist",
+    aliases: ["pullsheet", "pull-sheet", "pick-list", "picking", "pull-slip", "pullslip"],
+    description: "Generate pull slip / pick list PDF",
+    icon: "ClipboardList",
+    pages: ["/warehouse/[id]"],
+    action: { type: "generate_document", docType: "pull-slip" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "warehouse-scan",
+    label: "Scanner",
+    command: "scan",
+    aliases: ["camera"],
+    description: "Open barcode scanner",
+    icon: "ScanBarcode",
+    pages: ["/warehouse/[id]"],
+    action: { type: "trigger", event: "open-scanner" },
+    requiredPermission: ["warehouse", "read"],
+  },
+  {
+    id: "warehouse-project",
+    label: "Project Details",
+    command: "project",
+    aliases: ["details"],
+    description: "Go to project detail",
+    icon: "FolderOpen",
+    pages: ["/warehouse/[id]"],
+    action: { type: "navigate", path: "/projects/:id" },
+  },
+  {
+    id: "warehouse-quote",
+    label: "Generate Quote",
+    command: "quote",
+    aliases: ["quotation"],
+    description: "Generate quote PDF for this project",
+    icon: "FileText",
+    pages: ["/warehouse/[id]"],
+    action: { type: "generate_document", docType: "quote" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "warehouse-invoice",
+    label: "Generate Invoice",
+    command: "invoice",
+    aliases: ["inv"],
+    description: "Generate invoice PDF for this project",
+    icon: "FileText",
+    pages: ["/warehouse/[id]"],
+    action: { type: "generate_document", docType: "invoice" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "warehouse-delivery-docket",
+    label: "Generate Delivery Docket",
+    command: "delivery-docket",
+    aliases: ["delivery", "docket"],
+    description: "Generate delivery docket for this project",
+    icon: "FileText",
+    pages: ["/warehouse/[id]"],
+    action: { type: "generate_document", docType: "delivery-docket" },
+    requiredPermission: ["document", "create"],
+  },
+  {
+    id: "warehouse-return-sheet",
+    label: "Generate Return Sheet",
+    command: "return-sheet",
+    aliases: ["returnsheet", "returns"],
+    description: "Generate return sheet for this project",
+    icon: "FileText",
+    pages: ["/warehouse/[id]"],
+    action: { type: "generate_document", docType: "return-sheet" },
+    requiredPermission: ["document", "create"],
+  },
+
+  // ── Client Detail Page (/clients/[id]) ────────────────────────────
+  {
+    id: "client-edit",
+    label: "Edit Client",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this client",
+    icon: "Pencil",
+    pages: ["/clients/[id]"],
+    action: { type: "navigate", path: "/clients/:id/edit" },
+    requiredPermission: ["client", "update"],
+  },
+  {
+    id: "client-projects",
+    label: "Projects",
+    command: "projects",
+    aliases: ["rentals", "bookings"],
+    description: "View client's projects",
+    icon: "FolderOpen",
+    pages: ["/clients/[id]"],
+    action: { type: "trigger", event: "switch-tab:projects" },
+  },
+  {
+    id: "client-new-project",
+    label: "New Project",
+    command: "new-project",
+    aliases: ["create-project"],
+    description: "Create project for this client",
+    icon: "FolderOpen",
+    pages: ["/clients/[id]"],
+    action: { type: "navigate", path: "/projects/new?clientId=:id" },
+    requiredPermission: ["project", "create"],
+  },
+
+  // ── Supplier Detail Page (/suppliers/[id]) ──────────────────────────
+  {
+    id: "supplier-edit",
+    label: "Edit Supplier",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this supplier",
+    icon: "Pencil",
+    pages: ["/suppliers/[id]"],
+    action: { type: "navigate", path: "/suppliers/:id/edit" },
+    requiredPermission: ["supplier", "update"],
+  },
+
+  // ── Location Detail Page (/locations/[id]) ─────────────────────────
+  {
+    id: "location-edit",
+    label: "Edit Location",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this location",
+    icon: "Pencil",
+    pages: ["/locations/[id]"],
+    action: { type: "navigate", path: "/locations/:id/edit" },
+    requiredPermission: ["location", "update"],
+  },
+
+  // ── Maintenance Detail Page (/maintenance/[id]) ────────────────────
+  {
+    id: "maintenance-edit",
+    label: "Edit Record",
+    command: "edit",
+    aliases: ["modify"],
+    description: "Edit this maintenance record",
+    icon: "Pencil",
+    pages: ["/maintenance/[id]"],
+    action: { type: "trigger", event: "focus-edit" },
+    requiredPermission: ["maintenance", "update"],
+  },
+  {
+    id: "maintenance-complete",
+    label: "Mark Complete",
+    command: "complete",
+    aliases: ["done", "finish", "resolve"],
+    description: "Mark this maintenance as complete",
+    icon: "CircleCheck",
+    pages: ["/maintenance/[id]"],
+    action: { type: "trigger", event: "complete-maintenance" },
+    requiredPermission: ["maintenance", "update"],
+  },
+
+  // ── Maintenance List Page (/maintenance) ───────────────────────────
+  {
+    id: "maintenance-new",
+    label: "New Maintenance",
+    command: "new",
+    aliases: ["create", "add"],
+    description: "Create new maintenance record",
+    icon: "Wrench",
+    pages: ["/maintenance"],
+    action: { type: "navigate", path: "/maintenance/new" },
+    requiredPermission: ["maintenance", "create"],
+  },
+
+  // ── Asset List Page (/assets/registry) ────────────────────────────
+  {
+    id: "assets-new",
+    label: "New Asset",
+    command: "new",
+    aliases: ["create", "add"],
+    description: "Create new asset",
+    icon: "Package",
+    pages: ["/assets/registry"],
+    action: { type: "navigate", path: "/assets/registry/new" },
+    requiredPermission: ["asset", "create"],
+  },
+  {
+    id: "assets-import",
+    label: "Import",
+    command: "import",
+    aliases: ["csv"],
+    description: "Import assets from CSV",
+    icon: "Upload",
+    pages: ["/assets/registry"],
+    action: { type: "open_dialog", dialog: "import-csv" },
+    requiredPermission: ["asset", "import"],
+  },
+  {
+    id: "assets-export",
+    label: "Export",
+    command: "export",
+    aliases: ["download"],
+    description: "Export assets to CSV",
+    icon: "Download",
+    pages: ["/assets/registry"],
+    action: { type: "open_dialog", dialog: "export-csv" },
+    requiredPermission: ["asset", "export"],
+  },
+
+  // ── Settings Pages (/settings/*) ──────────────────────────────────
+  {
+    id: "settings-team",
+    label: "Team",
+    command: "team",
+    aliases: ["members", "users"],
+    description: "Team settings",
+    icon: "Users",
+    pages: ["/settings", "/settings/*"],
+    action: { type: "navigate", path: "/settings/team" },
+    requiredPermission: ["orgMembers", "read"],
+  },
+  {
+    id: "settings-branding",
+    label: "Branding",
+    command: "branding",
+    aliases: ["logo", "colors"],
+    description: "Branding settings",
+    icon: "Palette",
+    pages: ["/settings", "/settings/*"],
+    action: { type: "navigate", path: "/settings/branding" },
+    requiredPermission: ["orgSettings", "update"],
+  },
+  {
+    id: "settings-billing",
+    label: "Billing",
+    command: "billing",
+    aliases: ["tax", "currency"],
+    description: "Billing settings",
+    icon: "CreditCard",
+    pages: ["/settings", "/settings/*"],
+    action: { type: "navigate", path: "/settings/billing" },
+    requiredPermission: ["orgSettings", "update"],
+  },
+  {
+    id: "settings-assets",
+    label: "Asset Settings",
+    command: "assets",
+    aliases: ["tags", "categories"],
+    description: "Asset settings",
+    icon: "Package",
+    pages: ["/settings", "/settings/*"],
+    action: { type: "navigate", path: "/settings/assets" },
+    requiredPermission: ["orgSettings", "update"],
+  },
+];
+
+// ─── Route Matching ─────────────────────────────────────────────────
+
+/**
+ * Convert a route pattern like "/projects/[id]" to a regex.
+ * Supports: exact match, [id] dynamic segments, * wildcard, /path/* wildcard suffix.
+ */
+function patternToRegex(pattern: string): RegExp {
+  if (pattern === "*") return /^.*$/;
+
+  const escaped = pattern
+    // Replace [param] with a segment match
+    .replace(/\[([^\]]+)\]/g, "([^/]+)")
+    // Replace trailing /* with optional wildcard
+    .replace(/\/\*$/, "(?:/.*)?");
+
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Check if a pathname matches a route pattern.
+ */
+function matchesPattern(pathname: string, pattern: string): boolean {
+  return patternToRegex(pattern).test(pathname);
+}
+
+/**
+ * Extract the entity ID from a pathname based on common patterns.
+ * Looks for UUIDs or cuid-like IDs in the path segments.
+ */
+export function extractEntityId(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  // Walk from the end to find the first segment that looks like an ID
+  // (UUID, cuid, or any alphanumeric string that's not a known page segment)
+  const knownSegments = new Set([
+    "dashboard", "assets", "registry", "models", "categories", "kits",
+    "projects", "templates", "warehouse", "clients", "suppliers",
+    "locations", "maintenance", "test-and-tag", "reports", "settings",
+    "team", "billing", "branding", "account", "availability", "new", "edit",
+    "activity", "crew", "planner", "roles", "skills", "quick-test",
+    "pull-sheet",
+  ]);
+
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const seg = segments[i];
+    if (!knownSegments.has(seg) && seg.length > 5) {
+      return seg;
+    }
+  }
+  return null;
+}
+
+// ─── Filtering & Matching ───────────────────────────────────────────
+
+function normalizeSlash(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+/**
+ * Score a slash command against a query string.
+ */
+function scoreSlashCommand(cmd: SlashCommand, query: string): number {
+  const nq = normalizeSlash(query);
+  if (!nq) return 1; // Empty query matches all
+
+  const nCmd = normalizeSlash(cmd.command);
+  if (nCmd === nq) return 100;
+  if (nCmd.startsWith(nq)) return 80;
+  if (nCmd.includes(nq)) return 60;
+
+  for (const alias of cmd.aliases) {
+    const na = normalizeSlash(alias);
+    if (na === nq) return 95;
+    if (na.startsWith(nq)) return 75;
+    if (na.includes(nq)) return 55;
+  }
+
+  const nLabel = normalizeSlash(cmd.label);
+  if (nLabel.includes(nq)) return 50;
+
+  const nDesc = normalizeSlash(cmd.description);
+  if (nDesc.includes(nq)) return 25;
+
+  // Subsequence match on command name
+  let ci = 0;
+  for (let qi = 0; qi < nq.length && ci < nCmd.length; ci++) {
+    if (nCmd[ci] === nq[qi]) qi++;
+    if (qi === nq.length) return 15;
+  }
+
+  return 0;
+}
+
+export interface MatchedSlashCommand {
+  command: SlashCommand;
+  score: number;
+  /** Whether this is a page-specific command (vs global) */
+  isPageSpecific: boolean;
+}
+
+/**
+ * Get all slash commands available for the given pathname,
+ * filtered by query and optionally by permissions.
+ */
+export function matchSlashCommands(
+  query: string,
+  pathname: string,
+  permissions?: Partial<Record<Resource, readonly string[]>> | null,
+): MatchedSlashCommand[] {
+  const results: MatchedSlashCommand[] = [];
+
+  for (const cmd of SLASH_COMMANDS) {
+    // Check if command is available on this page
+    const matchesPage = cmd.pages.some((p) => matchesPattern(pathname, p));
+    if (!matchesPage) continue;
+
+    // Check permissions
+    if (cmd.requiredPermission && permissions) {
+      const [resource, action] = cmd.requiredPermission;
+      const allowed = permissions[resource];
+      if (!allowed?.includes(action)) continue;
+    }
+
+    // Score against query
+    const score = scoreSlashCommand(cmd, query);
+    if (score > 0) {
+      const isPageSpecific = !cmd.pages.includes("*");
+      results.push({ command: cmd, score, isPageSpecific });
+    }
+  }
+
+  // Sort: page-specific first at equal scores, then by score
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.isPageSpecific !== b.isPageSpecific) return a.isPageSpecific ? -1 : 1;
+    return 0;
+  });
+
+  return results;
+}


### PR DESCRIPTION
Introduces / prefix mode in the command palette alongside existing @ mode. Typing / shows filterable actions scoped to the current page and user permissions — document generation, navigation, tab switching, status changes, dialogs, and logout.

- New registry at src/lib/slash-commands.ts with route pattern matching
- 60+ commands across global, project, asset, kit, warehouse, client, supplier, location, maintenance, and settings pages
- All 5 document types (quote, invoice, pull-slip, delivery-docket, return-sheet) available on both project detail and warehouse pages
- Permission-gated via useCurrentRole() and requiredPermission field
- Page-specific commands grouped above global commands with section headers
- Trigger events for tab switching, status changes, and dialog opening
- Added id="kit-contents" anchor for scroll-to-section on kit detail page