### PR TITLE
Add crew profile pictures, user account linking, and self-access

### DIFF
--- a/FEATUREDOCS/31-crew-management.md
+++ b/FEATUREDOCS/31-crew-management.md
@@ -84,6 +84,9 @@ Crew management tracks people (employees, freelancers, contractors, volunteers) 
 | `getCrewRoleOptions()` | crew.read | Dropdown options |
 | `getCrewSkillOptions()` | crew.read | Multi-select options |
 | `getCrewDepartments()` | crew.read | Distinct departments |
+| `getOrgUsersForCrewLink()` | crew.read | Org users available for linking |
+| `updateCrewMemberImage(id, image)` | crew.update | Update profile picture URL |
+| `linkCrewMemberToUser(id, userId)` | crew.update | Link/unlink crew to platform user |
 
 ### `src/server/crew-assignments.ts` (Phase 2)
 | Function | Permission | Description |
@@ -126,11 +129,36 @@ Assignment rate is resolved in this order:
 |------|-----------|-------------|
 | `/crew` | CrewDashboard / CrewTable | Manager+ sees dashboard with stats, timesheets, assignments, offers; others see crew list |
 | `/crew/new` | CrewMemberForm | Create crew member |
-| `/crew/[id]` | Detail page | Contact, rates, skills, assignments (with status management), availability, certifications, time entries, calendar |
-| `/crew/[id]/edit` | CrewMemberForm | Edit crew member |
+| `/crew/[id]` | Detail page | Profile picture (upload/remove), contact, rates, skills, assignments (with status management), availability, certifications, time entries, calendar, linked user display |
+| `/crew/[id]/edit` | CrewMemberForm | Edit crew member (includes user account linking) |
 | `/crew/planner` | CrewPlannerPage | 14-day Gantt-style timeline of all crew |
 | `/crew/timesheets` | TimesheetsPage | All time entries with DataTable, filtering, search, edit/delete, export |
 | `/crew/settings` | CrewSettingsPage | Manage roles and skills |
+
+## Profile Pictures
+- Upload/remove via hover overlay on avatar in crew detail page header (only for unlinked crew members)
+- API route: `POST/DELETE /api/crew/avatar` — validates org ownership, resizes to 256x256 JPEG via sharp
+- Stored in S3 under `{orgId}/crew/{crewMemberId}/avatar.jpg`
+- Avatars shown in: crew table (inline with name), crew detail page header
+- Falls back to initials (first + last name) when no image
+- **Linked crew members** inherit their profile picture from the linked user account — no separate upload
+
+## User Account Linking
+- Crew members can be linked to platform users via `userId` field
+- **"Platform Account" is the first card** in the crew member form — selecting a user auto-fills first name, last name, and email
+- Linked crew members inherit **name, email, and profile picture** from the user account for display
+- Users already linked to another crew member are filtered out of the picker
+- Linked user shown in crew detail page header with link icon (hidden on own profile)
+- Server-side validation: user must be an org member, can't double-link
+- `getOrgUsersForCrewLink()` returns org members with `alreadyLinked` flag
+- `getMyCrewMemberId()` returns current user's linked crew member ID (if any)
+- `linkCrewMemberToUser(id, userId)` for programmatic linking/unlinking
+
+## Self-Access
+- Users with a linked crew profile can **always view their own crew page**, even without `crew.read` permission
+- "My Crew Profile" link appears in the user dropdown menu (next to Account Settings)
+- Own profile page shows a banner: "You are viewing your own crew profile"
+- `getCrewMemberById` returns `isOwnProfile: true` when the logged-in user matches the crew member's `userId`
 
 ## Project Detail Integration
 - **Crew tab** on project detail page (`/projects/[id]`) via `CrewPanel` component

--- a/src/app/(app)/crew/[id]/edit/page.tsx
+++ b/src/app/(app)/crew/[id]/edit/page.tsx
@@ -51,6 +51,7 @@ export default function EditCrewMemberPage({ params }: { params: Promise<{ id: s
         notes: member.notes || "",
         tags: member.tags || [],
         skillIds: member.skills?.map((s: { id: string }) => s.id) || [],
+        userId: member.userId || "",
         isActive: member.isActive,
       }} />
     </div>

--- a/src/app/(app)/crew/[id]/page.tsx
+++ b/src/app/(app)/crew/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import { PageMeta } from "@/components/layout/page-meta";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -24,6 +24,9 @@ import {
   CheckCircle,
   AlertTriangle,
   Download,
+  Camera,
+  X,
+  LinkIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -77,9 +80,9 @@ import {
   crewTimeEntrySchema,
   type CrewTimeEntryFormValues,
 } from "@/lib/validations/crew";
-import { useActiveOrganization } from "@/lib/auth-client";
+import { useActiveOrganization, useSession } from "@/lib/auth-client";
 import { CanDo } from "@/components/auth/permission-gate";
-import { RequirePermission } from "@/components/auth/require-permission";
+import { useCanDo } from "@/lib/use-permissions";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -117,6 +120,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
 const statusColors: Record<string, string> = {
   ACTIVE: "bg-green-500/10 text-green-500 border-green-500/20",
@@ -203,12 +207,15 @@ export default function CrewMemberDetailPage({
   const queryClient = useQueryClient();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const { data: session } = useSession();
+  const canReadCrew = useCanDo("crew", "read");
 
   const [tabValue, setTabValue] = useState("assignments");
   const [addCertOpen, setAddCertOpen] = useState(false);
   const [addAvailOpen, setAddAvailOpen] = useState(false);
   const [addTimeOpen, setAddTimeOpen] = useState(false);
   const [editingTimeEntry, setEditingTimeEntry] = useState<string | null>(null);
+  const avatarInputRef = useRef<HTMLInputElement>(null);
 
   // Slash command listener
   useEffect(() => {
@@ -383,41 +390,163 @@ export default function CrewMemberDetailPage({
     onError: (e) => toast.error(e.message),
   });
 
+  const uploadAvatarMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("crewMemberId", id);
+      const res = await fetch("/api/crew/avatar", { method: "POST", body: formData });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Upload failed");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["crew-member", orgId, id] });
+      toast.success("Profile picture updated");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const removeAvatarMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/crew/avatar", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ crewMemberId: id }),
+      });
+      if (!res.ok) throw new Error("Failed to remove image");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["crew-member", orgId, id] });
+      toast.success("Profile picture removed");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
   if (isLoading)
     return <div className="text-muted-foreground">Loading...</div>;
   if (!member)
     return <div className="text-muted-foreground">Crew member not found.</div>;
 
-  const fullName = `${member.firstName} ${member.lastName}`;
+  const isOwnProfile = !!(member as { isOwnProfile?: boolean }).isOwnProfile;
+
+  // Allow access if user has crew.read permission OR is viewing their own profile
+  if (!canReadCrew && !isOwnProfile) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <h2 className="text-xl font-semibold">Access Denied</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You don&apos;t have permission to access this page.
+        </p>
+      </div>
+    );
+  }
+
+  // Resolve display values — linked users inherit name/email/image from their user account
+  const displayImage = member.user?.image || member.image;
+  const displayName = member.user
+    ? member.user.name || `${member.firstName} ${member.lastName}`
+    : `${member.firstName} ${member.lastName}`;
+  const displayEmail = member.user?.email || member.email;
+
+  const fullName = displayName;
   const certifications = member.certifications || [];
   const skills = member.skills || [];
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const assignments = (member as any).assignments || [];
 
   return (
-    <RequirePermission resource="crew" action="read">
+    <>
       <PageMeta title={fullName} />
       <div className="space-y-6">
+        {/* Own profile banner */}
+        {isOwnProfile && (
+          <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-primary flex items-center gap-2">
+            <CheckCircle className="h-4 w-4 shrink-0" />
+            You are viewing your own crew profile.
+          </div>
+        )}
+
         {/* Header */}
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold tracking-tight">{fullName}</h1>
-              <Badge
-                variant="outline"
-                className={statusColors[member.status] || ""}
-              >
-                {crewMemberStatusLabels[member.status] ||
-                  formatLabel(member.status)}
-              </Badge>
-              <Badge variant="outline">
-                {crewMemberTypeLabels[member.type] || formatLabel(member.type)}
-              </Badge>
+          <div className="flex items-start gap-4">
+            {/* Profile Picture */}
+            <div className="relative group shrink-0">
+              <Avatar className="size-16 text-lg">
+                {displayImage ? (
+                  <AvatarImage src={displayImage} alt={fullName} />
+                ) : null}
+                <AvatarFallback className="bg-primary/10 text-primary text-lg font-semibold">
+                  {member.firstName[0]}{member.lastName[0]}
+                </AvatarFallback>
+              </Avatar>
+              {/* Only show upload controls for crew without a linked user (linked users sync from account) */}
+              {!member.user && (
+                <CanDo resource="crew" action="update">
+                  <button
+                    type="button"
+                    className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                    onClick={() => avatarInputRef.current?.click()}
+                  >
+                    <Camera className="h-5 w-5 text-white" />
+                  </button>
+                  <input
+                    ref={avatarInputRef}
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) uploadAvatarMutation.mutate(file);
+                      e.target.value = "";
+                    }}
+                  />
+                  {member.image && (
+                    <button
+                      type="button"
+                      className="absolute -top-1 -right-1 rounded-full bg-destructive text-destructive-foreground p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => removeAvatarMutation.mutate()}
+                      title="Remove photo"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </CanDo>
+              )}
+              {uploadAvatarMutation.isPending && (
+                <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
+                  <Loader2 className="h-5 w-5 text-white animate-spin" />
+                </div>
+              )}
             </div>
-            <p className="text-muted-foreground">
-              {member.crewRole?.name || "No role assigned"}
-              {member.department && <> &middot; {member.department}</>}
-            </p>
+
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold tracking-tight">{fullName}</h1>
+                <Badge
+                  variant="outline"
+                  className={statusColors[member.status] || ""}
+                >
+                  {crewMemberStatusLabels[member.status] ||
+                    formatLabel(member.status)}
+                </Badge>
+                <Badge variant="outline">
+                  {crewMemberTypeLabels[member.type] || formatLabel(member.type)}
+                </Badge>
+              </div>
+              <p className="text-muted-foreground">
+                {member.crewRole?.name || "No role assigned"}
+                {member.department && <> &middot; {member.department}</>}
+              </p>
+              {member.user && !isOwnProfile && (
+                <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+                  <LinkIcon className="h-3 w-3" />
+                  Linked to {member.user.name || member.user.email}
+                </p>
+              )}
+            </div>
           </div>
           <CanDo resource="crew" action="update">
             <div className="flex gap-2">
@@ -458,14 +587,14 @@ export default function CrewMemberDetailPage({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-2 text-sm">
-              {member.email && (
+              {displayEmail && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <Mail className="h-3.5 w-3.5" />
                   <a
-                    href={`mailto:${member.email}`}
+                    href={`mailto:${displayEmail}`}
                     className="hover:underline"
                   >
-                    {member.email}
+                    {displayEmail}
                   </a>
                 </div>
               )}
@@ -482,7 +611,7 @@ export default function CrewMemberDetailPage({
                   {member.address}
                 </p>
               )}
-              {!member.email && !member.phone && !member.address && (
+              {!displayEmail && !member.phone && !member.address && (
                 <p className="text-muted-foreground">No contact info</p>
               )}
             </CardContent>
@@ -1424,7 +1553,7 @@ export default function CrewMemberDetailPage({
             : null
         }
       />
-    </RequirePermission>
+    </>
   );
 }
 

--- a/src/app/api/crew/avatar/route.ts
+++ b/src/app/api/crew/avatar/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/auth-server";
+import { validateCsrfOrigin } from "@/lib/csrf";
+import { prisma } from "@/lib/prisma";
+import { uploadToS3, deleteFromS3, ensureBucket, storageKeyFromUrl } from "@/lib/storage";
+import { getOrgContext } from "@/lib/org-context";
+import sharp from "sharp";
+import { fileTypeFromBuffer } from "file-type";
+
+export const runtime = "nodejs";
+
+const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const AVATAR_SIZE = 256;
+
+export async function POST(request: NextRequest) {
+  const csrfError = validateCsrfOrigin(request);
+  if (csrfError) return csrfError;
+
+  try {
+    await requireSession();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId } = await getOrgContext();
+
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const crewMemberId = formData.get("crewMemberId") as string | null;
+
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (!crewMemberId) {
+      return NextResponse.json({ error: "No crew member ID provided" }, { status: 400 });
+    }
+
+    // Verify crew member belongs to this org
+    const member = await prisma.crewMember.findUnique({
+      where: { id: crewMemberId, organizationId },
+      select: { id: true, image: true },
+    });
+    if (!member) {
+      return NextResponse.json({ error: "Crew member not found" }, { status: 404 });
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json({ error: "File too large. Maximum 5MB." }, { status: 400 });
+    }
+
+    if (!ALLOWED_TYPES.has(file.type)) {
+      return NextResponse.json({ error: "Only JPEG, PNG, and WebP images allowed." }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    // Validate magic bytes
+    const detected = await fileTypeFromBuffer(buffer);
+    if (detected && !ALLOWED_TYPES.has(detected.mime)) {
+      return NextResponse.json({ error: `Detected type "${detected.mime}" not allowed.` }, { status: 400 });
+    }
+
+    // Resize to 256x256 square
+    const resized = await sharp(buffer)
+      .resize(AVATAR_SIZE, AVATAR_SIZE, { fit: "cover", position: "centre" })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+
+    await ensureBucket();
+
+    // Delete old image if exists
+    if (member.image) {
+      const oldKey = storageKeyFromUrl(member.image);
+      if (oldKey) {
+        try { await deleteFromS3(oldKey); } catch { /* ignore */ }
+      }
+    }
+
+    const { url } = await uploadToS3(resized, {
+      organizationId,
+      folder: "crew",
+      entityId: crewMemberId,
+      fileName: "avatar.jpg",
+      mimeType: "image/jpeg",
+    });
+
+    await prisma.crewMember.update({
+      where: { id: crewMemberId, organizationId },
+      data: { image: url },
+    });
+
+    return NextResponse.json({ url });
+  } catch (error) {
+    console.error("Crew avatar upload error:", error);
+    return NextResponse.json({ error: "Upload failed." }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const csrfError = validateCsrfOrigin(request);
+  if (csrfError) return csrfError;
+
+  try {
+    await requireSession();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId } = await getOrgContext();
+
+  try {
+    const { crewMemberId } = await request.json();
+
+    if (!crewMemberId) {
+      return NextResponse.json({ error: "No crew member ID provided" }, { status: 400 });
+    }
+
+    const member = await prisma.crewMember.findUnique({
+      where: { id: crewMemberId, organizationId },
+      select: { id: true, image: true },
+    });
+    if (!member) {
+      return NextResponse.json({ error: "Crew member not found" }, { status: 404 });
+    }
+
+    if (member.image) {
+      const key = storageKeyFromUrl(member.image);
+      if (key) {
+        try { await deleteFromS3(key); } catch { /* ignore */ }
+      }
+    }
+
+    await prisma.crewMember.update({
+      where: { id: crewMemberId, organizationId },
+      data: { image: null },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Crew avatar delete error:", error);
+    return NextResponse.json({ error: "Failed to remove image." }, { status: 500 });
+  }
+}

--- a/src/components/crew/crew-member-form.tsx
+++ b/src/components/crew/crew-member-form.tsx
@@ -5,12 +5,13 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, LinkIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { crewMemberSchema, type CrewMemberFormValues } from "@/lib/validations/crew";
-import { createCrewMember, updateCrewMember, getCrewRoleOptions, getCrewSkillOptions, createCrewSkill } from "@/server/crew";
+import { createCrewMember, updateCrewMember, getCrewRoleOptions, getCrewSkillOptions, createCrewSkill, getOrgUsersForCrewLink } from "@/server/crew";
 import { getOrgTags } from "@/server/tags";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useOrgCountry } from "@/lib/use-org-country";
 import { TagInput } from "@/components/ui/tag-input";
@@ -58,6 +59,11 @@ export function CrewMemberForm({ initialData }: CrewMemberFormProps) {
     queryFn: () => getCrewSkillOptions(),
   });
 
+  const { data: linkableUsers } = useQuery({
+    queryKey: ["crew-linkable-users", orgId],
+    queryFn: () => getOrgUsersForCrewLink(),
+  });
+
   const form = useForm<CrewMemberFormValues>({
     resolver: zodResolver(crewMemberSchema),
     defaultValues: initialData || {
@@ -83,6 +89,7 @@ export function CrewMemberForm({ initialData }: CrewMemberFormProps) {
       notes: "",
       tags: [],
       skillIds: [],
+      userId: "",
       isActive: true,
     },
   });
@@ -98,9 +105,77 @@ export function CrewMemberForm({ initialData }: CrewMemberFormProps) {
   });
 
   const selectedSkillIds = form.watch("skillIds") || [];
+  const watchedUserId = form.watch("userId");
+  const linkedUser = (linkableUsers || []).find(
+    (u: { id: string }) => u.id === watchedUserId
+  );
+
+  // Auto-fill name and email when a user is selected
+  function handleUserChange(newUserId: string) {
+    form.setValue("userId", newUserId);
+    if (newUserId) {
+      const user = (linkableUsers || []).find((u: { id: string }) => u.id === newUserId);
+      if (user) {
+        // Auto-fill name from user account
+        if (user.name) {
+          const parts = user.name.split(" ");
+          form.setValue("firstName", parts[0] || "");
+          form.setValue("lastName", parts.slice(1).join(" ") || "");
+        }
+        if (user.email) {
+          form.setValue("email", user.email);
+        }
+      }
+    }
+  }
 
   return (
     <form onSubmit={form.handleSubmit((d) => mutation.mutate(d))} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <LinkIcon className="h-4 w-4" />
+            Platform Account
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Link this crew member to a platform user to sync their name, email, and profile picture.
+          </p>
+          <Controller
+            name="userId"
+            control={form.control}
+            render={({ field }) => (
+              <div className="space-y-2">
+                <ComboboxPicker
+                  value={field.value || ""}
+                  onChange={(v) => handleUserChange(v)}
+                  options={(linkableUsers || [])
+                    .filter((u: { id: string; alreadyLinked: boolean }) => !u.alreadyLinked || u.id === field.value)
+                    .map((u: { id: string; name: string | null; email: string }) => ({
+                      value: u.id,
+                      label: u.name || u.email,
+                      description: u.name ? u.email : undefined,
+                    }))}
+                  placeholder="Select user account..."
+                  allowClear
+                />
+                {linkedUser && (
+                  <div className="flex items-center gap-2 rounded-md border border-primary/20 bg-primary/5 p-2.5">
+                    <UserAvatar user={{ name: linkedUser.name, image: linkedUser.image }} size="md" />
+                    <div className="text-sm">
+                      <p className="font-medium">{linkedUser.name}</p>
+                      <p className="text-muted-foreground text-xs">{linkedUser.email}</p>
+                    </div>
+                    <p className="ml-auto text-xs text-muted-foreground">Name, email &amp; photo synced from account</p>
+                  </div>
+                )}
+              </div>
+            )}
+          />
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Personal Details</CardTitle>

--- a/src/components/crew/crew-table.tsx
+++ b/src/components/crew/crew-table.tsx
@@ -12,6 +12,7 @@ import { crewMemberStatusLabels, crewMemberTypeLabels, formatLabel } from "@/lib
 import { Button } from "@/components/ui/button";
 import { CanDo } from "@/components/auth/permission-gate";
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,11 +32,21 @@ const columns: ColumnDef<AnyCrewMember>[] = [
     accessorKey: "lastName",
     alwaysVisible: true,
     sortKey: "lastName",
-    cell: (row) => (
-      <Link href={`/crew/${row.id}`} className="font-medium hover:underline" onClick={(e) => e.stopPropagation()}>
-        {row.firstName} {row.lastName}
-      </Link>
-    ),
+    cell: (row) => {
+      const avatarSrc = row.user?.image || row.image;
+      const displayName = row.user?.name || `${row.firstName} ${row.lastName}`;
+      return (
+        <Link href={`/crew/${row.id}`} className="flex items-center gap-2 font-medium hover:underline" onClick={(e) => e.stopPropagation()}>
+          <Avatar className="size-7">
+            {avatarSrc ? <AvatarImage src={avatarSrc} alt={displayName} /> : null}
+            <AvatarFallback className="text-[10px] bg-primary/10 text-primary">
+              {row.firstName?.[0]}{row.lastName?.[0]}
+            </AvatarFallback>
+          </Avatar>
+          {displayName}
+        </Link>
+      );
+    },
   },
   {
     id: "role",

--- a/src/components/layout/user-nav.tsx
+++ b/src/components/layout/user-nav.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { LogOut, User, ChevronsUpDown, Shield } from "lucide-react";
-import { useSession, signOut } from "@/lib/auth-client";
+import { LogOut, User, ChevronsUpDown, Shield, HardHat } from "lucide-react";
+import { useSession, signOut, useActiveOrganization } from "@/lib/auth-client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { getProfile } from "@/server/user-profile";
+import { getMyCrewMemberId } from "@/server/crew";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,6 +25,8 @@ export function UserNav() {
 
   const user = session?.user;
   const isSiteAdmin = (user as Record<string, unknown>)?.role === "admin";
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
 
   // Fetch profile for up-to-date avatar (session cookie cache may be stale)
   const { data: profile } = useQuery({
@@ -32,6 +35,14 @@ export function UserNav() {
     staleTime: 60_000,
   });
   const userImage = profile?.image || user?.image;
+
+  // Check if user has a linked crew profile
+  const { data: myCrewId } = useQuery({
+    queryKey: ["my-crew-id", orgId],
+    queryFn: () => getMyCrewMemberId(),
+    staleTime: 120_000,
+    enabled: !!orgId,
+  });
 
   return (
     <DropdownMenu>
@@ -76,6 +87,12 @@ export function UserNav() {
             <User className="mr-2 h-4 w-4" />
             Account Settings
           </DropdownMenuItem>
+          {myCrewId && (
+            <DropdownMenuItem onClick={() => router.push(`/crew/${myCrewId}`)}>
+              <HardHat className="mr-2 h-4 w-4" />
+              My Crew Profile
+            </DropdownMenuItem>
+          )}
           {isSiteAdmin && (
             <DropdownMenuItem onClick={() => router.push("/admin")}>
               <Shield className="mr-2 h-4 w-4" />

--- a/src/lib/validations/crew.ts
+++ b/src/lib/validations/crew.ts
@@ -27,6 +27,7 @@ export const crewMemberSchema = z.object({
   notes: z.string().max(2000).optional(),
   tags: z.array(z.string()).default([]),
   skillIds: z.array(z.string()).default([]),
+  userId: z.string().optional().or(z.literal("")),
   isActive: z.boolean().default(true),
 }).refine(
   (data) => (data.addressLatitude != null) === (data.addressLongitude != null),

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -63,6 +63,7 @@ export async function getCrewMembers(params: {
       include: {
         crewRole: { select: { id: true, name: true, color: true } },
         skills: { select: { id: true, name: true, category: true } },
+        user: { select: { id: true, name: true, image: true } },
         _count: { select: { certifications: true } },
       },
       orderBy: { [sortBy]: sortOrder },
@@ -76,7 +77,7 @@ export async function getCrewMembers(params: {
 }
 
 export async function getCrewMemberById(id: string) {
-  const { organizationId } = await getOrgContext();
+  const { organizationId, userId } = await getOrgContext();
   const crewMember = await prisma.crewMember.findUnique({
     where: { id, organizationId },
     include: {
@@ -96,14 +97,25 @@ export async function getCrewMemberById(id: string) {
     },
   });
   if (!crewMember) throw new Error("Crew member not found");
-  return serialize(crewMember);
+  // Include whether this is the current user's own crew profile
+  return serialize({ ...crewMember, isOwnProfile: crewMember.userId === userId });
+}
+
+/** Get the current user's crew member ID (if they have a linked crew profile) */
+export async function getMyCrewMemberId() {
+  const { organizationId, userId } = await getOrgContext();
+  const crewMember = await prisma.crewMember.findFirst({
+    where: { organizationId, userId },
+    select: { id: true },
+  });
+  return crewMember?.id ?? null;
 }
 
 export async function createCrewMember(data: CrewMemberFormValues) {
   const { organizationId, userId, userName } = await requirePermission("crew", "create");
   const parsed = crewMemberSchema.parse(data);
 
-  const { skillIds, ...rest } = parsed;
+  const { skillIds, userId: linkUserId, ...rest } = parsed;
 
   const cleaned = {
     firstName: rest.firstName,
@@ -127,6 +139,7 @@ export async function createCrewMember(data: CrewMemberFormValues) {
     abnOrGst: rest.abnOrGst || null,
     notes: rest.notes || null,
     tags: (rest.tags || []).map((t: string) => t.toLowerCase()),
+    userId: linkUserId || null,
   };
 
   const result = await prisma.crewMember.create({
@@ -163,7 +176,7 @@ export async function updateCrewMember(id: string, data: CrewMemberFormValues) {
   });
   if (!before) throw new Error("Crew member not found");
 
-  const { skillIds, ...rest } = parsed;
+  const { skillIds, userId: linkUserId, ...rest } = parsed;
 
   const cleaned = {
     firstName: rest.firstName,
@@ -187,6 +200,7 @@ export async function updateCrewMember(id: string, data: CrewMemberFormValues) {
     abnOrGst: rest.abnOrGst || null,
     notes: rest.notes || null,
     tags: (rest.tags || []).map((t: string) => t.toLowerCase()),
+    userId: linkUserId || null,
   };
 
   const updated = await prisma.crewMember.update({
@@ -445,6 +459,98 @@ export async function getCrewSkillOptions() {
       orderBy: { name: "asc" },
     })
   );
+}
+
+/** Get org users that can be linked to crew members */
+export async function getOrgUsersForCrewLink() {
+  const { organizationId } = await getOrgContext();
+
+  // Get all org members with user info
+  const members = await prisma.member.findMany({
+    where: { organizationId },
+    include: {
+      user: {
+        select: { id: true, name: true, email: true, image: true },
+      },
+    },
+  });
+
+  // Get already-linked user IDs in this org
+  const linked = await prisma.crewMember.findMany({
+    where: { organizationId, userId: { not: null } },
+    select: { userId: true },
+  });
+  const linkedIds = new Set(linked.map((c) => c.userId));
+
+  return serialize(
+    members.map((m) => ({
+      id: m.user.id,
+      name: m.user.name,
+      email: m.user.email,
+      image: m.user.image,
+      alreadyLinked: linkedIds.has(m.user.id),
+    }))
+  );
+}
+
+/** Update crew member profile image */
+export async function updateCrewMemberImage(id: string, image: string | null) {
+  const { organizationId } = await requirePermission("crew", "update");
+  const member = await prisma.crewMember.findUnique({
+    where: { id, organizationId },
+  });
+  if (!member) throw new Error("Crew member not found");
+
+  await prisma.crewMember.update({
+    where: { id, organizationId },
+    data: { image },
+  });
+
+  return serialize({ success: true, image });
+}
+
+/** Link/unlink a crew member to a platform user */
+export async function linkCrewMemberToUser(id: string, userId: string | null) {
+  const { organizationId, userId: actorId, userName } = await requirePermission("crew", "update");
+
+  const member = await prisma.crewMember.findUnique({
+    where: { id, organizationId },
+  });
+  if (!member) throw new Error("Crew member not found");
+
+  // If linking, verify the user is a member of this org
+  if (userId) {
+    const orgMember = await prisma.member.findFirst({
+      where: { organizationId, userId },
+    });
+    if (!orgMember) throw new Error("User is not a member of this organization");
+
+    // Check not already linked to another crew member
+    const existing = await prisma.crewMember.findFirst({
+      where: { organizationId, userId, id: { not: id } },
+    });
+    if (existing) throw new Error("This user is already linked to another crew member");
+  }
+
+  const updated = await prisma.crewMember.update({
+    where: { id, organizationId },
+    data: { userId: userId || null },
+  });
+
+  await logActivity({
+    organizationId,
+    userId: actorId,
+    userName,
+    action: "UPDATE",
+    entityType: "crew_member",
+    entityId: id,
+    entityName: `${member.firstName} ${member.lastName}`,
+    summary: userId
+      ? `Linked crew member ${member.firstName} ${member.lastName} to a platform user`
+      : `Unlinked crew member ${member.firstName} ${member.lastName} from platform user`,
+  });
+
+  return serialize(updated);
 }
 
 /** Get distinct departments for filter options */


### PR DESCRIPTION
- Profile pictures: upload/remove via crew detail page header, S3 storage
- User linking: crew members can be linked to platform users, inheriting name, email, and profile picture from the user account
- Platform Account is first card in form, auto-fills name/email on select
- Self-access: users can view their own crew profile without crew.read permission, with "You are viewing your own crew profile" banner
- "My Crew Profile" link in user dropdown menu for linked users
- Crew table shows linked user avatars and display names