### PR TITLE
Add site admin org creation control and create org from admin panel

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "next-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/prisma/migrations/20260316000000_add_allow_org_creation/migration.sql
+++ b/prisma/migrations/20260316000000_add_allow_org_creation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "site_settings" ADD COLUMN "allowOrgCreation" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1342,6 +1342,7 @@ model SiteSettings {
   twoFactorGlobalPolicy  String   @default("OFF")  // OFF, RECOMMENDED, REQUIRED_SITE_ADMINS, REQUIRED_ALL
   defaultCurrency        String   @default("AUD")
   defaultTaxRate         Float    @default(10)
+  allowOrgCreation       Boolean  @default(true)
   socialLoginGoogle      Boolean  @default(false)
   socialLoginMicrosoft   Boolean  @default(false)
   createdAt              DateTime @default(now())

--- a/src/app/(admin)/admin/organizations/page.tsx
+++ b/src/app/(admin)/admin/organizations/page.tsx
@@ -16,11 +16,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
-import { Search, Trash2, Building2, Eye, Upload, Download } from "lucide-react";
+import { Search, Trash2, Building2, Eye, Upload, Download, Plus } from "lucide-react";
 import Link from "next/link";
+import { Label } from "@/components/ui/label";
 import {
   getAllOrganizations,
   adminDeleteOrganization,
+  adminCreateOrganization,
 } from "@/server/site-admin";
 
 export default function AdminOrganizationsPage() {
@@ -32,6 +34,9 @@ export default function AdminOrganizationsPage() {
     name: string;
   } | null>(null);
   const [confirmName, setConfirmName] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createSlug, setCreateSlug] = useState("");
   const [importOpen, setImportOpen] = useState(false);
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importName, setImportName] = useState("");
@@ -83,6 +88,22 @@ export default function AdminOrganizationsPage() {
     onError: (e) => toast.error(e.message),
   });
 
+  const createMutation = useMutation({
+    mutationFn: () => adminCreateOrganization({ name: createName.trim(), slug: createSlug.trim() }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-organizations"] });
+      toast.success("Organization created");
+      setCreateOpen(false);
+      setCreateName("");
+      setCreateSlug("");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  function slugify(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+  }
+
   return (
     <AdminShell>
       <div className="space-y-6">
@@ -107,7 +128,11 @@ export default function AdminOrganizationsPage() {
               className="pl-9"
             />
           </div>
-          <Button size="sm" onClick={() => setImportOpen(true)}>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => setImportOpen(true)}>
             <Upload className="mr-2 h-4 w-4" />
             Import
           </Button>
@@ -298,6 +323,64 @@ export default function AdminOrganizationsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      {/* Create Organization Dialog */}
+      <Dialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCreateOpen(false);
+            setCreateName("");
+            setCreateSlug("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Organization</DialogTitle>
+            <DialogDescription>
+              Create a new organization. You will be assigned as the owner.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="create-org-name">Organization Name</Label>
+              <Input
+                id="create-org-name"
+                placeholder="Two Toned Productions"
+                value={createName}
+                onChange={(e) => {
+                  setCreateName(e.target.value);
+                  setCreateSlug(slugify(e.target.value));
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="create-org-slug">URL Slug</Label>
+              <Input
+                id="create-org-slug"
+                placeholder="two-toned-productions"
+                value={createSlug}
+                onChange={(e) => setCreateSlug(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Lowercase letters, numbers, and hyphens only.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!createName.trim() || !createSlug.trim() || createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              {createMutation.isPending ? "Creating..." : "Create Organization"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Import Organization Dialog */}
       <Dialog
         open={importOpen}

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -29,6 +29,7 @@ export default function AdminSettingsPage() {
     twoFactorGlobalPolicy: "OFF",
     defaultCurrency: "AUD",
     defaultTaxRate: 10,
+    allowOrgCreation: true,
     socialLoginGoogle: false,
     socialLoginMicrosoft: false,
   });
@@ -42,6 +43,7 @@ export default function AdminSettingsPage() {
         twoFactorGlobalPolicy: settings.twoFactorGlobalPolicy || "OFF",
         defaultCurrency: settings.defaultCurrency || "AUD",
         defaultTaxRate: settings.defaultTaxRate ?? 10,
+        allowOrgCreation: settings.allowOrgCreation ?? true,
         socialLoginGoogle: settings.socialLoginGoogle ?? false,
         socialLoginMicrosoft: settings.socialLoginMicrosoft ?? false,
       });
@@ -147,6 +149,24 @@ export default function AdminSettingsPage() {
                 <option value="INVITE_ONLY">Invite Only</option>
                 <option value="DISABLED">Disabled</option>
               </select>
+            </div>
+            <Separator />
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div>
+                <span className="text-sm font-medium">Allow Organization Creation</span>
+                <p className="text-xs text-muted-foreground">
+                  When disabled, only site admins can create new organizations.
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={form.allowOrgCreation}
+                  onChange={(e) => setForm((f) => ({ ...f, allowOrgCreation: e.target.checked }))}
+                />
+                <div className="w-9 h-5 bg-muted rounded-full peer peer-checked:bg-primary transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-background after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4" />
+              </label>
             </div>
             <Separator />
             <div className="flex items-center gap-2">

--- a/src/app/(auth)/no-organization/page.tsx
+++ b/src/app/(auth)/no-organization/page.tsx
@@ -14,9 +14,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Building2, LogOut, Loader2, Shield } from "lucide-react";
+import { Building2, LogOut, Loader2, Shield, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { getMyPendingInvitations, checkIsSiteAdmin } from "@/server/invitations";
+import { checkOrgCreationAllowed } from "@/server/site-admin";
 
 export default function NoOrganizationPage() {
   const router = useRouter();
@@ -32,6 +33,11 @@ export default function NoOrganizationPage() {
   const { data: isSiteAdmin } = useQuery({
     queryKey: ["is-site-admin"],
     queryFn: checkIsSiteAdmin,
+  });
+
+  const { data: orgPolicy } = useQuery({
+    queryKey: ["org-creation-allowed"],
+    queryFn: checkOrgCreationAllowed,
   });
 
   const acceptMutation = useMutation({
@@ -113,6 +119,15 @@ export default function NoOrganizationPage() {
         )}
       </CardContent>
       <CardFooter className="flex flex-col gap-2">
+        {orgPolicy?.allowed && (
+          <Button
+            className="w-full"
+            onClick={() => router.push("/onboarding")}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Create Organization
+          </Button>
+        )}
         {isSiteAdmin && (
           <Button
             variant="outline"

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import { organization } from "@/lib/auth-client";
+import { checkOrgCreationAllowed } from "@/server/site-admin";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,7 +16,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, ShieldAlert } from "lucide-react";
 
 function slugify(text: string): string {
   return text
@@ -28,6 +30,11 @@ export default function OnboardingPage() {
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const { data: orgPolicy, isLoading: policyLoading } = useQuery({
+    queryKey: ["org-creation-allowed"],
+    queryFn: checkOrgCreationAllowed,
+  });
 
   const handleNameChange = (value: string) => {
     setName(value);
@@ -59,6 +66,37 @@ export default function OnboardingPage() {
       setLoading(false);
     }
   };
+
+  if (policyLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (orgPolicy && !orgPolicy.allowed) {
+    return (
+      <Card>
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <ShieldAlert className="h-5 w-5" />
+          </div>
+          <CardTitle className="text-xl">Organization Creation Disabled</CardTitle>
+          <CardDescription>
+            Organization creation is currently disabled. Contact a site administrator to have an organization created for you.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button variant="outline" onClick={() => router.push("/no-organization")}>
+            Go Back
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>

--- a/src/components/layout/org-switcher.tsx
+++ b/src/components/layout/org-switcher.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Building2, Check, ChevronsUpDown } from "lucide-react";
+import { Building2, Check, ChevronsUpDown, Plus } from "lucide-react";
 import {
   useActiveOrganization,
   useListOrganizations,
   organization,
 } from "@/lib/auth-client";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { checkOrgCreationAllowed } from "@/server/site-admin";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -24,6 +25,10 @@ export function OrgSwitcher() {
   const queryClient = useQueryClient();
   const { data: activeOrg } = useActiveOrganization();
   const { data: orgs } = useListOrganizations();
+  const { data: orgPolicy } = useQuery({
+    queryKey: ["org-creation-allowed"],
+    queryFn: checkOrgCreationAllowed,
+  });
 
   const handleSwitch = async (orgId: string) => {
     await organization.setActive({ organizationId: orgId });
@@ -62,6 +67,20 @@ export function OrgSwitcher() {
             </DropdownMenuItem>
           ))}
         </DropdownMenuGroup>
+        {orgPolicy?.allowed && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                onClick={() => router.push("/onboarding")}
+                className="gap-2"
+              >
+                <Plus className="h-4 w-4" />
+                <span>New Organization</span>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -52,6 +52,7 @@ export async function updateSiteSettings(data: {
   twoFactorGlobalPolicy?: string;
   defaultCurrency?: string;
   defaultTaxRate?: number;
+  allowOrgCreation?: boolean;
   socialLoginGoogle?: boolean;
   socialLoginMicrosoft?: boolean;
 }) {
@@ -73,7 +74,65 @@ export async function updateSiteSettings(data: {
   return serialize(updated);
 }
 
+// ─── Org Creation Policy ──────────────────────────────────────────────────
+
+/** Check whether the current user is allowed to create organizations. */
+export async function checkOrgCreationAllowed(): Promise<{ allowed: boolean; isSiteAdmin: boolean }> {
+  try {
+    const session = await requireSession();
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+    const admin = user?.role === "admin";
+    if (admin) return { allowed: true, isSiteAdmin: true };
+
+    const settings = await prisma.siteSettings.findFirst();
+    return { allowed: settings?.allowOrgCreation ?? true, isSiteAdmin: false };
+  } catch {
+    return { allowed: false, isSiteAdmin: false };
+  }
+}
+
 // ─── Organization Management ───────────────────────────────────────────────
+
+export async function adminCreateOrganization(data: {
+  name: string;
+  slug: string;
+  ownerUserId?: string;
+}) {
+  const session = await requireSiteAdmin();
+  const { name, slug, ownerUserId } = data;
+
+  if (!name.trim() || !slug.trim()) {
+    throw new Error("Name and slug are required.");
+  }
+
+  // Validate slug format
+  const normalizedSlug = slug.toLowerCase().replace(/[^a-z0-9-]/g, "").replace(/(^-|-$)/g, "");
+  if (!normalizedSlug) throw new Error("Invalid slug.");
+
+  // Check slug uniqueness
+  const existing = await prisma.organization.findUnique({ where: { slug: normalizedSlug } });
+  if (existing) throw new Error("An organization with this slug already exists.");
+
+  // Determine owner — defaults to the admin performing the action
+  const ownerId = ownerUserId || session.user.id;
+  const ownerUser = await prisma.user.findUnique({ where: { id: ownerId }, select: { id: true } });
+  if (!ownerUser) throw new Error("Owner user not found.");
+
+  const org = await prisma.$transaction(async (tx) => {
+    const newOrg = await tx.organization.create({
+      data: { name: name.trim(), slug: normalizedSlug },
+    });
+    await tx.member.create({
+      data: { organizationId: newOrg.id, userId: ownerId, role: "owner" },
+    });
+    return newOrg;
+  });
+
+  return serialize(org);
+}
 
 export async function getAllOrganizations(params?: {
   page?: number;


### PR DESCRIPTION
- Add allowOrgCreation boolean to SiteSettings (default true)
- Site admin toggle in Platform Settings to enable/disable org creation
- Admin organizations page gets "Create" button with name/slug dialog
- Onboarding page gates non-admins when org creation is disabled
- No-organization page shows "Create Organization" button when allowed
- Org switcher shows "New Organization" option when allowed
- Site admins always bypass the restriction