### PR TITLE
Add document_template migration and graceful fallback

### DIFF
--- a/prisma/migrations/20260316100000_add_document_template/migration.sql
+++ b/prisma/migrations/20260316100000_add_document_template/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "document_template" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "basePdf" TEXT NOT NULL,
+    "schemas" TEXT NOT NULL,
+    "settings" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "isDraft" BOOLEAN NOT NULL DEFAULT true,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "thumbnailUrl" TEXT,
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "document_template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "document_template_organizationId_type_idx" ON "document_template"("organizationId", "type");
+
+-- AddForeignKey
+ALTER TABLE "document_template" ADD CONSTRAINT "document_template_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -24,45 +24,50 @@ async function getCustomTemplate(
   docType: DocumentType,
   templateId?: string,
 ): Promise<{ template: Template; settings: TemplateSettings | null } | null> {
-  // If a specific templateId is provided, load that
-  if (templateId) {
-    const specific = await prisma.documentTemplate.findFirst({
+  try {
+    // If a specific templateId is provided, load that
+    if (templateId) {
+      const specific = await prisma.documentTemplate.findFirst({
+        where: {
+          id: templateId,
+          organizationId,
+          isDraft: false,
+        },
+      });
+      if (specific) {
+        return {
+          template: {
+            basePdf: JSON.parse(specific.basePdf),
+            schemas: JSON.parse(specific.schemas),
+          },
+          settings: specific.settings ? JSON.parse(specific.settings) : null,
+        };
+      }
+    }
+
+    // Otherwise, look for org's default template for this doc type
+    const custom = await prisma.documentTemplate.findFirst({
       where: {
-        id: templateId,
         organizationId,
+        type: docType,
+        isDefault: true,
         isDraft: false,
       },
     });
-    if (specific) {
-      return {
-        template: {
-          basePdf: JSON.parse(specific.basePdf),
-          schemas: JSON.parse(specific.schemas),
-        },
-        settings: specific.settings ? JSON.parse(specific.settings) : null,
-      };
-    }
+
+    if (!custom) return null;
+
+    return {
+      template: {
+        basePdf: JSON.parse(custom.basePdf),
+        schemas: JSON.parse(custom.schemas),
+      },
+      settings: custom.settings ? JSON.parse(custom.settings) : null,
+    };
+  } catch {
+    // Table may not exist yet (migration not run) — fall back to system default
+    return null;
   }
-
-  // Otherwise, look for org's default template for this doc type
-  const custom = await prisma.documentTemplate.findFirst({
-    where: {
-      organizationId,
-      type: docType,
-      isDefault: true,
-      isDraft: false,
-    },
-  });
-
-  if (!custom) return null;
-
-  return {
-    template: {
-      basePdf: JSON.parse(custom.basePdf),
-      schemas: JSON.parse(custom.schemas),
-    },
-    settings: custom.settings ? JSON.parse(custom.settings) : null,
-  };
 }
 
 /**


### PR DESCRIPTION
- Add Prisma migration to create document_template table
- Wrap template lookup in try/catch so PDF generation falls back to system defaults when the table doesn't exist yet