### PR TITLE
Update docs for pdfme migration and template editor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Multi-tenant asset and rental management platform for AV/theatre production comp
 | Database | PostgreSQL + Prisma v6 (client at `src/generated/prisma/`) |
 | Auth | Better Auth (Organization, TwoFactor, Admin, Passkey plugins) |
 | State | React Query (60s stale), React Hook Form + Zod |
-| PDF | @react-pdf/renderer (Helvetica only, no Unicode) |
+| PDF | pdfme (@pdfme/generator + custom plugins, Helvetica only, no Unicode) |
 | Storage | S3/MinIO, org-prefixed paths |
 
 ## Commands

--- a/FEATUREDOCS/01-tech-stack.md
+++ b/FEATUREDOCS/01-tech-stack.md
@@ -11,7 +11,7 @@
 | Auth | Better Auth | Organization, TwoFactor, Admin plugins |
 | State Management | React Query | 60s stale time, no refetchOnWindowFocus |
 | Forms | React Hook Form + Zod | `zodResolver()`, `z.input<>` for types |
-| PDF | @react-pdf/renderer | Helvetica only, no Unicode |
+| PDF | pdfme (@pdfme/generator + custom plugins) | Helvetica only, no Unicode. pdf.js for client-side preview |
 | Storage | AWS SDK (S3/MinIO) | Org-prefixed file paths |
 | Email | Resend SDK | Invitations, password reset, notifications |
 | Icons | lucide-react | 180+ icons, dynamic icon component |

--- a/FEATUREDOCS/02-project-structure.md
+++ b/FEATUREDOCS/02-project-structure.md
@@ -5,6 +5,7 @@ src/
 ├── app/
 │   ├── (auth)/           # Public pages: login, register, onboarding, invite, no-org
 │   ├── (app)/            # Protected pages: dashboard, assets, projects, warehouse, etc.
+│   ├── (designer)/       # Full-screen template designer (no sidebar layout)
 │   ├── (admin)/admin/    # Site admin panel
 │   ├── api/              # API routes: auth, files, uploads, documents, reports, admin
 │   ├── layout.tsx        # Root layout: fonts, theme, query provider, toaster
@@ -22,7 +23,7 @@ src/
 │   ├── media/            # MediaUploader, MediaThumbnail, MediaLightbox
 │   ├── projects/         # ProjectForm, LineItemsPanel, AddEquipmentDialog, documents
 │   ├── providers/        # ThemeProvider, QueryProvider, BrandingProvider
-│   ├── settings/         # InviteMember, MemberList, RoleManager, PermissionMatrix
+│   ├── settings/         # InviteMember, MemberList, RoleManager, PermissionMatrix, template-editor/, document-template-manager
 │   ├── suppliers/        # Supplier forms, tables
 │   ├── test-tag/         # TestTagTable, BatchCreateDialog
 │   ├── ui/               # Base components: Button, Card, Dialog, Sheet, Table, BarcodeScanner, ComboboxPicker, etc.
@@ -48,7 +49,7 @@ src/
 │   ├── use-platform-name.ts  # Client-side usePlatformName, usePlatformBranding
 │   ├── use-table-preferences.ts  # localStorage per-table sort/page/view
 │   ├── validations/      # Zod schemas: asset, model, kit, project, client, etc.
-│   ├── pdf/              # PDF document templates and shared styles
+│   ├── pdfme/            # pdfme PDF generation: plugins, templates, fonts, types, sample data, template settings
 │   ├── org-export.ts     # Organization ZIP export
 │   ├── org-import.ts     # Organization ZIP import
 │   └── org-transfer-types.ts  # Export manifest types
@@ -80,6 +81,7 @@ src/
 │   ├── custom-roles.ts   # Custom role CRUD
 │   ├── user-profile.ts   # User account operations
 │   ├── invitations.ts    # Invitation helpers
+│   ├── document-templates.ts # Document template CRUD, publish, set default
 │   ├── test-tag-assets.ts    # T&T asset CRUD
 │   ├── test-tag-records.ts   # T&T test record CRUD
 │   └── test-tag-reports.ts   # T&T report data + CSV

--- a/FEATUREDOCS/03-database-schema.md
+++ b/FEATUREDOCS/03-database-schema.md
@@ -67,6 +67,9 @@
 - **Prep** — `id, organizationId, projectId, name, containerAssetId? (unique), status (PACKING|PACKED|CHECKED_OUT|RETURNED|UNPACKED|CANCELLED), notes?, preparedById?, preparedAt?, checkedOutAt?, returnedAt?, unpackedAt?`. Container links to Asset via `"PrepContainer"` relation.
 - **PrepItem** — `id, prepId, assetId?, bulkAssetId?, kitId?, quantity, lineItemId?, addedAt, addedById?, sortOrder`. Unique: `[prepId, assetId]`. Links prep contents to assets, kits, and project line items.
 
+## Document Templates
+- **DocumentTemplate** — `id, organizationId, name, type (quote|invoice|packing-list|return-sheet|delivery-docket|call-sheet), basePdf (Text/JSON), schemas (Text/JSON), settings (Text/JSON, nullable), isDefault, isDraft, version, thumbnailUrl?, publishedAt?, createdAt, updatedAt`. Index: `[organizationId, type]`. Cascade delete with Organization.
+
 ## Activity & Scan Logs
 - **ActivityLog** — `id, organizationId, action, entityType, entityId, entityName, userId, userName, summary, details (JSON), metadata (JSON), projectId, assetId, kitId, createdAt`
 - **AssetScanLog** — `id, organizationId, assetId, bulkAssetId, kitId, projectId, action (CHECK_OUT|CHECK_IN|SCAN_VERIFY|TRANSFER), scannedById, scannedAt, notes, location`

--- a/FEATUREDOCS/05-server-actions-api.md
+++ b/FEATUREDOCS/05-server-actions-api.md
@@ -67,6 +67,7 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `/api/avatar` | POST/DELETE | Upload/remove profile picture |
 | `/api/documents/[projectId]` | GET | PDF generation via pdfme (query: `type=quote\|invoice\|pull-slip\|return-sheet\|delivery-docket`, `templateId` optional) |
 | `/api/documents/call-sheet/[projectId]` | GET | Call sheet PDF via pdfme (query: `date` optional, `templateId` optional) |
+| `/api/documents/template-preview` | POST | Template preview PDF (body: `{ docType, settings }`, returns binary PDF) |
 | `/api/test-tag-reports/[reportType]` | GET | T&T report PDF/CSV via pdfme (10 types, query: `format=pdf\|csv`) |
 | `/api/platform-name` | GET | Public site settings (name, icon, logo, policies) |
 | `/api/registration-policy` | GET | Public registration policy only |

--- a/FEATUREDOCS/06-pages-layouts.md
+++ b/FEATUREDOCS/06-pages-layouts.md
@@ -93,7 +93,7 @@ div.app-shell (fixed inset-0 on mobile, relative on desktop)
 | `/settings/test-and-tag` | T&T ID format, defaults |
 | `/settings/billing` | Currency & tax |
 | `/settings/documents` | Document template management — cards grouped by doc type |
-| `/template-designer/[id]` | Full-screen pdfme template designer |
+| `/template-designer/[id]` | Full-screen template editor (Zoho Books-style, `(designer)` route group with own layout — no sidebar) |
 | `/settings/branding` | Logo & colors |
 | `/settings/team` | Members, invites, roles, permission matrix |
 | `/account` | Profile, password, 2FA, sessions, organizations |

--- a/FEATUREDOCS/27-settings-admin.md
+++ b/FEATUREDOCS/27-settings-admin.md
@@ -42,6 +42,19 @@
 - `/admin/settings` — Platform name, icon, logo, registration policy, 2FA global policy, default currency/tax
 - **Mobile**: `AdminShell` component with hamburger menu replacing desktop sidebar
 
+## Document Templates (`/settings/documents`)
+- Template cards grouped by document type (Quote, Invoice, Packing List, etc.)
+- System defaults shown as virtual cards — "Customise" duplicates into org-owned `DocumentTemplate`
+- Each template has version history, draft/published state, and default flag
+- **Template Editor** (`/template-designer/[id]`): Full-screen Zoho Books-style editor
+  - Left icon nav: General, Header, Details, Table, Totals, Other
+  - Middle: form controls for each section (toggles, inputs, dropdowns)
+  - Right: live PDF preview with real org branding + sample data (pdf.js canvas)
+  - Debounced preview regeneration (600ms) via POST `/api/documents/template-preview`
+- **Permissions**: `document.manage_templates` — owner, admin, manager roles
+- **DB model**: `DocumentTemplate` — `basePdf`, `schemas`, `settings` (all JSON), `isDefault`, `isDraft`, `version`
+- **Template selection priority** (at PDF generation time): specific `templateId` → org's published default → system default
+
 ## Dashboard & Reporting
 - **Dashboard** (`/dashboard`): Stats cards (Total Assets, Checked Out, Active Projects, Maintenance Due), recent activity feed, upcoming projects
 - **Reports** (`/reports`): Project stats by status, revenue calculations, asset utilization


### PR DESCRIPTION
- ARCHITECTURE.md: PDF stack now pdfme (not @react-pdf)
- 01-tech-stack: Update PDF dependency
- 02-project-structure: Add (designer) route group, template-editor components, pdfme dir, document-templates server action
- 03-database-schema: Add DocumentTemplate model
- 05-server-actions-api: Add template-preview API route
- 06-pages-layouts: Clarify template designer uses own layout
- 27-settings-admin: Add Document Templates section