### PR TITLE
Add reporting system with ~30 pre-built reports, custom builder, CSV …

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,7 @@ Detailed docs for each system are in the [`FEATUREDOCS/`](./FEATUREDOCS/) folder
 | 31 | [Crew Management](./FEATUREDOCS/31-crew-management.md) | Crew members, roles, skills, certifications |
 | 32 | [Preps](./FEATUREDOCS/32-preps.md) | Prep-kits (temporary kits), case assets, project staging |
 | 33 | [Enterprise SSO](./FEATUREDOCS/33-enterprise-sso.md) | SAML 2.0/OIDC SSO, provisioning modes, group mapping, enforcement |
+| 34 | [Reporting System](./FEATUREDOCS/34-reporting-system.md) | Report engine, ~30 pre-built reports, custom report builder, CSV export |
 
 **When making changes**: Read the relevant feature doc(s) first, follow documented patterns, and update the relevant doc(s) after. If no doc exists for the feature you're working on, create a new numbered file in `FEATUREDOCS/` and add it to the table above.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,20 @@ npx prisma migrate dev   # Apply all migrations + generate client
 - **When adding new providers or scripts to the root layout**: place them inside `<GlobalErrorBoundary>` to ensure coverage
 - **Never remove** `DomPatch` or `GlobalErrorBoundary` from `layout.tsx` — they are critical for navigation stability
 
+### Select — ALWAYS pass explicit label children to `SelectValue`
+`SelectValue` in shadcn/ui v4 **cannot** resolve labels from portal-rendered `SelectItem` children. Without explicit children, it shows the raw `value` (e.g. an ID or enum key) instead of the human-readable label. **Every `<SelectValue>` must have explicit children**:
+```tsx
+// BAD — shows raw value like "createdAt" or "CHECKED_OUT"
+<SelectValue />
+<SelectValue placeholder="Select..." />
+
+// GOOD — shows resolved label
+<SelectValue>{items.find(i => i.value === selected)?.label ?? selected}</SelectValue>
+<SelectValue placeholder="Select...">{selected ? labelMap[selected] : "Select..."}</SelectValue>
+```
+
 ### Key Gotchas
 - No `AlertDialog` — use `Dialog` with confirm/cancel buttons
-- `SelectValue` can't resolve portal-rendered items — pass explicit label children
 - `DropdownMenuLabel` must be inside `DropdownMenuGroup`
 - `@react-pdf/renderer` — Helvetica only, no Unicode symbols
 - Server action dates arrive as strings — wrap with `new Date()`

--- a/FEATUREDOCS/05-server-actions-api.md
+++ b/FEATUREDOCS/05-server-actions-api.md
@@ -46,6 +46,7 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `scan-lookup.ts` | `scanLookup(value)` — resolves barcode to `{ url, label }` by checking Asset → Kit → BulkAsset → TestTagAsset |
 | `notifications.ts` | `getNotifications()` — 5 types: overdue_maintenance, overdue_return, upcoming_project, low_stock, pending_invitation |
 | `dashboard.ts` | `getDashboardStats`, `getRecentActivity`, `getUpcomingProjects` |
+| `reports.ts` | `getReportsSummary`, `runReport`, `runReportCSV`, `getSavedReports`, `getSavedReportById`, `saveReport`, `updateSavedReport`, `deleteSavedReport`, `togglePinReport`, `updateReportLastRun` |
 | `csv.ts` | `exportModelsCSV`, `exportAssetsCSV`, `exportBulkAssetsCSV`, `importModelsCSV`, `importAssetsCSV` |
 | `settings.ts` | `getOrgSettings`, `updateOrgSettings`, `getBrandingSettings`, `updateBrandingSettings` |
 | `site-admin.ts` | `getOrganizations`, `getUsers`, `promoteToSiteAdmin`, `banUser`, `getSiteSettings`, `updateSiteSettings` |
@@ -68,6 +69,7 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `/api/documents/[projectId]` | GET | PDF generation via pdfme (query: `type=quote\|invoice\|pull-slip\|return-sheet\|delivery-docket`, `templateId` optional) |
 | `/api/documents/call-sheet/[projectId]` | GET | Call sheet PDF via pdfme (query: `date` optional, `templateId` optional) |
 | `/api/documents/template-preview` | POST | Template preview PDF (body: `{ docType, settings }`, returns binary PDF) |
+| `/api/reports/pdf` | POST | Report PDF generation via pdfme (body: `{ config, title, subtitle }`) |
 | `/api/test-tag-reports/[reportType]` | GET | T&T report PDF/CSV via pdfme (10 types, query: `format=pdf\|csv`) |
 | `/api/platform-name` | GET | Public site settings (name, icon, logo, policies) |
 | `/api/registration-policy` | GET | Public registration policy only |

--- a/FEATUREDOCS/27-settings-admin.md
+++ b/FEATUREDOCS/27-settings-admin.md
@@ -57,5 +57,5 @@
 
 ## Dashboard & Reporting
 - **Dashboard** (`/dashboard`): Stats cards (Total Assets, Checked Out, Active Projects, Maintenance Due), recent activity feed, upcoming projects
-- **Reports** (`/reports`): Project stats by status, revenue calculations, asset utilization
+- **Reports** (`/reports`): Full reporting system with quick stats, pre-built report library (~30 reports), saved reports with pin/share, and custom report builder. See `FEATUREDOCS/30-reporting-system.md` for full details.
 - Notification-driven alerts surface the same data as the notification system

--- a/FEATUREDOCS/34-reporting-system.md
+++ b/FEATUREDOCS/34-reporting-system.md
@@ -1,0 +1,82 @@
+# Detailed Reporting System
+
+## Overview
+Two-tier reporting: ~30 pre-built reports + custom report builder with save/share/pin. All reports exportable as CSV and PDF. Uses a JSON-based `ReportConfig` translated to Prisma queries by a server-side report engine.
+
+## Data Model
+- **`SavedReport`** — `id, organizationId, name, description, dataSource, config (JSON), createdById, isShared, isPinned, lastRunAt, createdAt, updatedAt`
+- Indexed on `[organizationId]` and `[organizationId, createdById]`
+
+## Report Engine (`src/lib/report-engine.ts`)
+Translates `ReportConfig` → Prisma queries:
+- Maps 11 data sources (assets, models, projects, kits, lineItems, clients, locations, maintenance, activityLog, crew, crewAssignments)
+- Filter translation (equals, contains, gt, in, between, etc.) with nested relation support
+- Date range presets (last7days, thisMonth, thisQuarter, thisYear, etc.)
+- GroupBy with aggregations (count, sum, avg, min, max)
+- Computed fields (_totalRevenue, _availableCount, _totalProjects, etc.) via post-processing
+- Flattens nested relation data for display
+- CSV export via `generateCSV()`
+
+## Type Definitions (`src/lib/report-types.ts`)
+- `ReportConfig` — columns, filters, groupBy, sortBy, dateRange, limit
+- `FIELD_DEFINITIONS` — per-data-source field metadata (type, section, enum values)
+- `PRE_BUILT_REPORTS` — ~30 pre-defined report configs
+- `getReportsByCategory()` — groups pre-built reports by category
+
+## Pre-Built Reports (~30)
+| Category | Reports |
+|----------|---------|
+| Assets | Inventory, Utilisation, Model Popularity, Asset Value by Category, Warranty Expiry |
+| Projects | Summary, Revenue by Client, Overdue Returns, By Location, Subhire Summary, Profitability |
+| Kits | Inventory, Utilisation |
+| Clients | Revenue, Top Clients |
+| Maintenance | Costs by Type, Open Maintenance |
+| Crew | Roster, Utilisation, Labour Cost by Project, Freelancer Spend |
+| Operations | Activity Log, Location Summary |
+
+## Routes
+| Route | Description |
+|-------|-------------|
+| `/reports` | Dashboard with quick stats + report library + saved reports |
+| `/reports/builder` | Custom report builder (data source → columns → filters → grouping → sort → preview → save) |
+| `/reports/builder/[id]` | Edit existing saved report |
+| `/reports/[id]` | View/run a saved report |
+
+## Permissions
+- `reports: view` — run reports (all roles)
+- `reports: export` — CSV export (owner, admin, manager)
+- `reports: create` — save custom reports (owner, admin, manager)
+- `reports: delete` — delete saved reports (owner, admin, manager)
+
+## Server Actions (`src/server/reports.ts`)
+- `getReportsSummary()` — dashboard quick stats
+- `runReport(config, page, pageSize)` — execute report, returns paginated results
+- `runReportCSV(config)` — execute and return CSV string
+- CRUD: `saveReport`, `updateSavedReport`, `deleteSavedReport`, `getSavedReports`, `getSavedReportById`
+- `togglePinReport(id)` — pin/unpin
+- `updateReportLastRun(id)` — track last execution
+
+## Components
+- `ReportViewer` — table display with pagination, aggregation summary, CSV + PDF export; opens in wide-screen dialog with auto-run
+- `ReportBuilder` — step-by-step builder (data source → columns → filters → grouping → sort → preview → save)
+
+## Validation (`src/lib/validations/report.ts`)
+- `reportConfigSchema` — validates ReportConfig JSON
+- `saveReportSchema` — name, description, dataSource, config, isShared, isPinned
+
+## PDF Export
+- **API Route**: `POST /api/reports/pdf` — accepts `{ config, title, subtitle }`, returns PDF
+- **Template**: `src/lib/pdfme/templates/report.ts` — landscape A4, multi-page with row chunking
+- **Generator**: `generateReportPdf()` in `src/lib/pdfme/generate-pdf.ts`
+- Uses `gearflowPageHeader`, `gearflowSummaryBox`, `gearflowDataTable`, `gearflowPageFooter` plugins
+- Org branding (logo, colors) applied automatically
+- **Multi-page**: pdfme renders all schema pages per input object, so unique field names per page (`header_0`, `dataTable_0`, `header_1`, `dataTable_1`, etc.) with a single input object containing all page data
+- **Summary box**: auto-wraps to multiple rows (max 5 items per row), labels resolved from `FIELD_DEFINITIONS`
+- **Header title**: auto-scales font size to fit within 55% of header width
+- Page 1 layout adapts dynamically to summary box height (more aggregations = taller summary = fewer data rows)
+
+## Integration
+- **Org Export/Import**: SavedReport included in transfer types, export, and import
+- **Activity Log**: Create/update/delete of saved reports logged
+- **Page Commands**: Reports + Custom Report Builder entries
+- **Top Bar**: Segment labels for reports and builder

--- a/prisma/migrations/20260318000000_add_saved_report/migration.sql
+++ b/prisma/migrations/20260318000000_add_saved_report/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "saved_report" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "dataSource" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+    "createdById" TEXT,
+    "isShared" BOOLEAN NOT NULL DEFAULT false,
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "lastRunAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "saved_report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "saved_report_organizationId_idx" ON "saved_report"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "saved_report_organizationId_createdById_idx" ON "saved_report"("organizationId", "createdById");
+
+-- AddForeignKey
+ALTER TABLE "saved_report" ADD CONSTRAINT "saved_report_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "saved_report" ADD CONSTRAINT "saved_report_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model User {
   pendingSSOApprovals     PendingSSOApproval[]
   reviewedSSOApprovals    PendingSSOApproval[] @relation("SSOReviewer")
   warehouseDashboardTokens WarehouseDashboardToken[]
+  savedReports             SavedReport[]
 
   @@map("user")
 }
@@ -153,6 +154,7 @@ model Organization {
   ssoProviders               SsoProvider[]
   pendingSSOApprovals        PendingSSOApproval[]
   warehouseDashboardTokens   WarehouseDashboardToken[]
+  savedReports               SavedReport[]
   @@map("organization")
 }
 
@@ -1942,6 +1944,31 @@ model WarehouseDashboardToken {
 
   @@index([organizationId])
   @@map("warehouse_dashboard_token")
+}
+
+// ─── Saved Reports ──────────────────────────────────────────────────────────
+
+model SavedReport {
+  id              String   @id @default(cuid())
+  organizationId  String
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  name            String
+  description     String?
+  dataSource      String           // "assets", "models", "projects", "kits", "lineItems", "clients", "locations", "maintenance", "activityLog", "crew", "crewAssignments"
+  config          Json             // Full ReportConfig JSON
+  createdById     String?
+  createdBy       User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  isShared        Boolean  @default(false)
+  isPinned        Boolean  @default(false)
+
+  lastRunAt       DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([organizationId])
+  @@index([organizationId, createdById])
+  @@map("saved_report")
 }
 
 // ─── Prep System (Pre-Packing / Staging) ─────────────────────────────────────

--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Edit, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RequirePermission } from "@/components/auth/require-permission";
+import { ReportViewer } from "@/components/reports/report-viewer";
+import { getSavedReportById } from "@/server/reports";
+import { DATA_SOURCE_LABELS, type ReportConfig, type DataSource } from "@/lib/report-types";
+
+export default function SavedReportPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+
+  const { data: report, isLoading } = useQuery({
+    queryKey: ["saved-report", id],
+    queryFn: () => getSavedReportById(id),
+  });
+
+  if (isLoading) return <div className="text-muted-foreground">Loading...</div>;
+  if (!report) return <div className="text-destructive">Report not found</div>;
+
+  const r = report as unknown as {
+    id: string;
+    name: string;
+    description?: string;
+    dataSource: DataSource;
+    config: ReportConfig;
+    isShared: boolean;
+    createdBy: { name: string } | null;
+  };
+
+  return (
+    <RequirePermission resource="reports" action="view">
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Button variant="ghost" size="sm" render={<Link href="/reports" />}>
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+              <h1 className="text-2xl font-bold tracking-tight">{r.name}</h1>
+            </div>
+            {r.description && (
+              <p className="text-muted-foreground">{r.description}</p>
+            )}
+            <div className="flex items-center gap-2 mt-1">
+              <Badge variant="outline">{DATA_SOURCE_LABELS[r.dataSource]}</Badge>
+              {r.isShared && <Badge variant="secondary">Shared</Badge>}
+              {r.createdBy && (
+                <span className="text-xs text-muted-foreground">by {r.createdBy.name}</span>
+              )}
+            </div>
+          </div>
+          <Button variant="outline" size="sm" render={<Link href={`/reports/builder/${r.id}`} />}>
+            <Edit className="mr-1.5 h-3.5 w-3.5" /> Edit
+          </Button>
+        </div>
+
+        <ReportViewer config={r.config} title={r.name} />
+      </div>
+    </RequirePermission>
+  );
+}

--- a/src/app/(app)/reports/builder/[id]/page.tsx
+++ b/src/app/(app)/reports/builder/[id]/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { use } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { RequirePermission } from "@/components/auth/require-permission";
+import { ReportBuilder } from "@/components/reports/report-builder";
+import { getSavedReportById } from "@/server/reports";
+import type { ReportConfig } from "@/lib/report-types";
+
+export default function EditReportPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+
+  const { data: report, isLoading } = useQuery({
+    queryKey: ["saved-report", id],
+    queryFn: () => getSavedReportById(id),
+  });
+
+  if (isLoading) return <div className="text-muted-foreground">Loading...</div>;
+  if (!report) return <div className="text-destructive">Report not found</div>;
+
+  const r = report as unknown as { id: string; name: string; description?: string; config: ReportConfig };
+
+  return (
+    <RequirePermission resource="reports" action="view">
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Edit Report</h1>
+          <p className="text-muted-foreground">Editing &quot;{r.name}&quot;</p>
+        </div>
+        <ReportBuilder
+          initialConfig={r.config}
+          savedReportId={r.id}
+          savedReportName={r.name}
+        />
+      </div>
+    </RequirePermission>
+  );
+}

--- a/src/app/(app)/reports/builder/page.tsx
+++ b/src/app/(app)/reports/builder/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { RequirePermission } from "@/components/auth/require-permission";
+import { ReportBuilder } from "@/components/reports/report-builder";
+import type { ReportConfig } from "@/lib/report-types";
+
+function BuilderContent() {
+  const searchParams = useSearchParams();
+  const configParam = searchParams.get("config");
+
+  let initialConfig: ReportConfig | undefined;
+  if (configParam) {
+    try {
+      initialConfig = JSON.parse(configParam);
+    } catch {
+      // ignore parse error
+    }
+  }
+
+  return (
+    <RequirePermission resource="reports" action="view">
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Custom Report Builder</h1>
+          <p className="text-muted-foreground">
+            Build a custom report by selecting a data source, columns, filters, and grouping.
+          </p>
+        </div>
+        <ReportBuilder initialConfig={initialConfig} />
+      </div>
+    </RequirePermission>
+  );
+}
+
+export default function BuilderPage() {
+  return (
+    <Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
+      <BuilderContent />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -1,166 +1,428 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import {
   Package,
-  FolderOpen,
-  Users,
-  DollarSign,
-  Wrench,
   Boxes,
+  FolderOpen,
+  Box,
+  Users,
+  MapPin,
+  Wrench,
+  DollarSign,
+  BarChart3,
+  Plus,
+  Star,
+  TrendingUp,
+  AlertTriangle,
+  HardHat,
+  UserCheck,
+  ScrollText,
+  Clock,
+  Truck,
+  ShieldAlert,
+  Trophy,
+  Calculator,
+  Wallet,
+  Pin,
+  PinOff,
+  Trash2,
+  Play,
+  Edit,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { getReportsSummary } from "@/server/reports";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogClose } from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
 import { RequirePermission } from "@/components/auth/require-permission";
 import { useActiveOrganization } from "@/lib/auth-client";
+import {
+  getReportsSummary,
+  getSavedReports,
+  deleteSavedReport,
+  togglePinReport,
+} from "@/server/reports";
+import { ReportViewer } from "@/components/reports/report-viewer";
+import {
+  PRE_BUILT_REPORTS,
+  getReportsByCategory,
+  type PreBuiltReport,
+  type ReportConfig,
+} from "@/lib/report-types";
 import { assetStatusLabels, projectStatusLabels, maintenanceStatusLabels, formatLabel } from "@/lib/status-labels";
+
+const ICON_MAP: Record<string, React.ReactNode> = {
+  Package: <Package className="h-4 w-4" />,
+  Boxes: <Boxes className="h-4 w-4" />,
+  FolderOpen: <FolderOpen className="h-4 w-4" />,
+  Box: <Box className="h-4 w-4" />,
+  Users: <Users className="h-4 w-4" />,
+  MapPin: <MapPin className="h-4 w-4" />,
+  Wrench: <Wrench className="h-4 w-4" />,
+  DollarSign: <DollarSign className="h-4 w-4" />,
+  BarChart3: <BarChart3 className="h-4 w-4" />,
+  Star: <Star className="h-4 w-4" />,
+  TrendingUp: <TrendingUp className="h-4 w-4" />,
+  AlertTriangle: <AlertTriangle className="h-4 w-4" />,
+  HardHat: <HardHat className="h-4 w-4" />,
+  UserCheck: <UserCheck className="h-4 w-4" />,
+  ScrollText: <ScrollText className="h-4 w-4" />,
+  Clock: <Clock className="h-4 w-4" />,
+  Truck: <Truck className="h-4 w-4" />,
+  ShieldAlert: <ShieldAlert className="h-4 w-4" />,
+  Trophy: <Trophy className="h-4 w-4" />,
+  Calculator: <Calculator className="h-4 w-4" />,
+  Wallet: <Wallet className="h-4 w-4" />,
+};
 
 export default function ReportsPage() {
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const queryClient = useQueryClient();
 
-  const { data, isLoading } = useQuery({
+  const [activeReport, setActiveReport] = useState<{
+    config: ReportConfig;
+    title: string;
+  } | null>(null);
+
+  const { data: summary, isLoading: summaryLoading } = useQuery({
     queryKey: ["reports-summary", orgId],
     queryFn: getReportsSummary,
   });
 
-  if (isLoading) return <div className="text-muted-foreground">Loading...</div>;
-  if (!data) return null;
+  const { data: savedReports } = useQuery({
+    queryKey: ["saved-reports", orgId],
+    queryFn: getSavedReports,
+  });
 
-  const d = data as Record<string, unknown>;
-  const assetsByStatus = d.assetsByStatus as Array<{ status: string; count: number }>;
-  const projectsByStatus = d.projectsByStatus as Array<{ status: string; count: number }>;
-  const maintenanceSummary = d.maintenanceSummary as Array<{ status: string; count: number }>;
+  const deleteMutation = useMutation({
+    mutationFn: deleteSavedReport,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["saved-reports"] }),
+  });
+
+  const pinMutation = useMutation({
+    mutationFn: togglePinReport,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["saved-reports"] }),
+  });
+
+  const reportsByCategory = getReportsByCategory();
+  const d = summary as Record<string, unknown> | undefined;
+  const assetsByStatus = (d?.assetsByStatus as Array<{ status: string; count: number }>) ?? [];
+  const projectsByStatus = (d?.projectsByStatus as Array<{ status: string; count: number }>) ?? [];
+  const maintenanceSummary = (d?.maintenanceSummary as Array<{ status: string; count: number }>) ?? [];
+
+  type SavedReportRow = {
+    id: string;
+    name: string;
+    description: string | null;
+    dataSource: string;
+    config: ReportConfig;
+    isPinned: boolean;
+    isShared: boolean;
+    createdBy: { id: string; name: string } | null;
+  };
+
+  const pinnedReports = ((savedReports as unknown as SavedReportRow[]) ?? []).filter((r) => r.isPinned);
+  const myReports = ((savedReports as unknown as SavedReportRow[]) ?? []);
+
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   return (
     <RequirePermission resource="reports" action="view">
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
-        <p className="text-muted-foreground">Business overview and metrics.</p>
-      </div>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
+            <p className="text-muted-foreground">Business reports and analytics</p>
+          </div>
+          <Button render={<Link href="/reports/builder" />}>
+            <Plus className="mr-1.5 h-4 w-4" /> Custom Report
+          </Button>
+        </div>
 
-      {/* Top-level stats */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Serialized Assets</CardTitle>
-            <Package className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{d.totalSerializedAssets as number}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Bulk Assets</CardTitle>
-            <Boxes className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{d.totalBulkAssets as number}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Clients</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{d.totalClients as number}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              ${((d.totalRevenue as number) || 0).toLocaleString("en-AU", {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
+        {/* Quick Stats */}
+        {!summaryLoading && d && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Serialized Assets</CardTitle>
+                <Package className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{d.totalSerializedAssets as number}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Bulk Assets</CardTitle>
+                <Boxes className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{d.totalBulkAssets as number}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Clients</CardTitle>
+                <Users className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{d.totalClients as number}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  ${((d.totalRevenue as number) || 0).toLocaleString("en-AU", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">Completed &amp; invoiced projects</p>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Status Breakdowns */}
+        {!summaryLoading && d && (
+          <div className="grid gap-4 lg:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Package className="h-4 w-4" /> Assets by Status
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {assetsByStatus.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No assets yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {assetsByStatus.map((g) => (
+                      <div key={g.status} className="flex items-center justify-between">
+                        <span className="text-sm">{assetStatusLabels[g.status] || formatLabel(g.status)}</span>
+                        <Badge variant="secondary">{g.count}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <FolderOpen className="h-4 w-4" /> Projects by Status
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {projectsByStatus.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No projects yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {projectsByStatus.map((g) => (
+                      <div key={g.status} className="flex items-center justify-between">
+                        <span className="text-sm">{projectStatusLabels[g.status] || formatLabel(g.status)}</span>
+                        <Badge variant="secondary">{g.count}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Wrench className="h-4 w-4" /> Maintenance
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {maintenanceSummary.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No records yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {maintenanceSummary.map((g) => (
+                      <div key={g.status} className="flex items-center justify-between">
+                        <span className="text-sm">{maintenanceStatusLabels[g.status] || formatLabel(g.status)}</span>
+                        <Badge variant="secondary">{g.count}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Pinned Reports */}
+        {pinnedReports.length > 0 && (
+          <>
+            <Separator />
+            <div>
+              <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                <Pin className="h-4 w-4" /> Pinned Reports
+              </h2>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {pinnedReports.map((report) => (
+                  <Card
+                    key={report.id}
+                    className="cursor-pointer transition-colors hover:border-primary"
+                    onClick={() => setActiveReport({ config: report.config, title: report.name })}
+                  >
+                    <CardContent className="p-4">
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <p className="font-medium">{report.name}</p>
+                          {report.description && (
+                            <p className="text-sm text-muted-foreground mt-0.5">{report.description}</p>
+                          )}
+                        </div>
+                        <Badge variant="outline">{report.dataSource}</Badge>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             </div>
-            <p className="text-xs text-muted-foreground">Completed &amp; invoiced projects</p>
-          </CardContent>
-        </Card>
+          </>
+        )}
+
+        {/* Pre-built Reports */}
+        <Separator />
+        <div>
+          <h2 className="text-lg font-semibold mb-3">Report Library</h2>
+          {Object.entries(reportsByCategory).map(([category, reports]) => (
+            <div key={category} className="mb-6">
+              <h3 className="text-sm font-medium text-muted-foreground uppercase mb-2">{category}</h3>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {reports.map((report) => (
+                  <Card
+                    key={report.id}
+                    className="cursor-pointer transition-colors hover:border-primary"
+                    onClick={() => setActiveReport({ config: report.config, title: report.name })}
+                  >
+                    <CardContent className="flex items-start gap-3 p-4">
+                      <div className="text-muted-foreground mt-0.5">
+                        {ICON_MAP[report.icon] || <BarChart3 className="h-4 w-4" />}
+                      </div>
+                      <div>
+                        <p className="font-medium text-sm">{report.name}</p>
+                        <p className="text-xs text-muted-foreground">{report.description}</p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* My Reports / Saved Reports */}
+        {myReports.length > 0 && (
+          <>
+            <Separator />
+            <div>
+              <h2 className="text-lg font-semibold mb-3">My Reports</h2>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {myReports.map((report) => (
+                  <Card key={report.id}>
+                    <CardContent className="p-4">
+                      <div className="flex items-start justify-between mb-2">
+                        <div>
+                          <p className="font-medium text-sm">{report.name}</p>
+                          {report.description && (
+                            <p className="text-xs text-muted-foreground">{report.description}</p>
+                          )}
+                        </div>
+                        <div className="flex gap-1">
+                          {report.isShared && <Badge variant="outline">Shared</Badge>}
+                        </div>
+                      </div>
+                      <div className="flex gap-1 mt-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setActiveReport({ config: report.config, title: report.name })}
+                        >
+                          <Play className="mr-1 h-3 w-3" /> Run
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          render={<Link href={`/reports/builder/${report.id}`} />}
+                        >
+                          <Edit className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => pinMutation.mutate(report.id)}
+                        >
+                          {report.isPinned ? <PinOff className="h-3 w-3" /> : <Pin className="h-3 w-3" />}
+                        </Button>
+                        <Dialog open={deleteTarget === report.id} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+                          <DialogTrigger render={<Button variant="ghost" size="sm" onClick={() => setDeleteTarget(report.id)} />}>
+                            <Trash2 className="h-3 w-3" />
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>Delete Report</DialogTitle>
+                            </DialogHeader>
+                            <p className="text-sm text-muted-foreground">
+                              Are you sure you want to delete &quot;{report.name}&quot;?
+                            </p>
+                            <div className="flex justify-end gap-2 mt-4">
+                              <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+                              <Button
+                                variant="destructive"
+                                onClick={() => {
+                                  deleteMutation.mutate(report.id);
+                                  setDeleteTarget(null);
+                                }}
+                              >
+                                Delete
+                              </Button>
+                            </div>
+                          </DialogContent>
+                        </Dialog>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Active Report Dialog */}
+        <Dialog open={!!activeReport} onOpenChange={(open) => !open && setActiveReport(null)}>
+          <DialogContent className="max-w-[95vw] w-full max-h-[90vh] overflow-y-auto">
+            {activeReport && (
+              <>
+                <DialogHeader>
+                  <DialogTitle>{activeReport.title}</DialogTitle>
+                </DialogHeader>
+                <div className="flex gap-2 -mt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    render={<Link href={`/reports/builder?config=${encodeURIComponent(JSON.stringify(activeReport.config))}`} />}
+                  >
+                    <Edit className="mr-1.5 h-3.5 w-3.5" /> Customise
+                  </Button>
+                </div>
+                <ReportViewer key={activeReport.title} config={activeReport.config} title={activeReport.title} autoRun />
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
-
-      {/* Breakdowns */}
-      <div className="grid gap-4 lg:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Package className="h-4 w-4" />
-              Assets by Status
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {assetsByStatus.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No assets yet.</p>
-            ) : (
-              <div className="space-y-2">
-                {assetsByStatus.map((g) => (
-                  <div key={g.status} className="flex items-center justify-between">
-                    <span className="text-sm">{assetStatusLabels[g.status] || formatLabel(g.status)}</span>
-                    <Badge variant="secondary">{g.count}</Badge>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <FolderOpen className="h-4 w-4" />
-              Projects by Status
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {projectsByStatus.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No projects yet.</p>
-            ) : (
-              <div className="space-y-2">
-                {projectsByStatus.map((g) => (
-                  <div key={g.status} className="flex items-center justify-between">
-                    <span className="text-sm">{projectStatusLabels[g.status] || formatLabel(g.status)}</span>
-                    <Badge variant="secondary">{g.count}</Badge>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Wrench className="h-4 w-4" />
-              Maintenance
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {maintenanceSummary.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No records yet.</p>
-            ) : (
-              <div className="space-y-2">
-                {maintenanceSummary.map((g) => (
-                  <div key={g.status} className="flex items-center justify-between">
-                    <span className="text-sm">
-                      {maintenanceStatusLabels[g.status] || formatLabel(g.status)}
-                    </span>
-                    <Badge variant="secondary">{g.count}</Badge>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-    </div>
     </RequirePermission>
   );
 }

--- a/src/app/api/reports/pdf/route.tsx
+++ b/src/app/api/reports/pdf/route.tsx
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrganization } from "@/lib/auth-server";
+import { getFileAsDataUri } from "@/lib/storage";
+import { executeReport } from "@/lib/report-engine";
+import { generateReportPdf } from "@/lib/pdfme/generate-pdf";
+import type { ReportConfig } from "@/lib/report-types";
+
+async function getOrgData(organizationId: string) {
+  const org = await prisma.organization.findUnique({ where: { id: organizationId } });
+  let orgSettings: Record<string, unknown> = {};
+  if (org?.metadata) {
+    try { orgSettings = JSON.parse(org.metadata); } catch { /* ignore */ }
+  }
+  const branding = orgSettings.branding as {
+    primaryColor?: string; accentColor?: string; documentColor?: string;
+    logoUrl?: string; iconUrl?: string; documentLogoMode?: "logo" | "icon" | "none";
+    showOrgNameOnDocuments?: boolean;
+  } | undefined;
+
+  const [logoData, iconData] = await Promise.all([
+    branding?.logoUrl ? getFileAsDataUri(branding.logoUrl) : null,
+    branding?.iconUrl ? getFileAsDataUri(branding.iconUrl) : null,
+  ]);
+
+  return {
+    name: org?.name || "",
+    email: (orgSettings.email as string) || undefined,
+    phone: (orgSettings.phone as string) || undefined,
+    address: (orgSettings.address as string) || undefined,
+    branding,
+    logoData,
+    iconData,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  let session;
+  try {
+    session = await requireOrganization();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId } = session;
+
+  try {
+    const body = await request.json();
+    const { config, title, subtitle } = body as {
+      config: ReportConfig;
+      title?: string;
+      subtitle?: string;
+    };
+
+    if (!config || !config.dataSource) {
+      return NextResponse.json({ error: "config is required" }, { status: 400 });
+    }
+
+    // Execute the report (up to 10,000 rows for PDF)
+    const result = await executeReport(config, organizationId, 1, 10000);
+
+    // Load org branding
+    const orgData = await getOrgData(organizationId);
+
+    // Generate PDF
+    const reportTitle = title || "Report";
+    const pdf = await generateReportPdf(reportTitle, result, orgData, subtitle, config.dataSource);
+
+    const filename = `${reportTitle.replace(/[^a-zA-Z0-9-_ ]/g, "").replace(/\s+/g, "-")}.pdf`;
+
+    return new NextResponse(Buffer.from(pdf), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="${filename}"`,
+      },
+    });
+  } catch (e) {
+    console.error("Report PDF generation error:", e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Report PDF generation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -36,6 +36,7 @@ const segmentLabels: Record<string, string> = {
   "quick-test": "Quick Test",
   categories: "Categories",
   reports: "Reports",
+  builder: "Report Builder",
   settings: "Settings",
   billing: "Billing",
   services: "Services",

--- a/src/components/reports/report-builder.tsx
+++ b/src/components/reports/report-builder.tsx
@@ -1,0 +1,722 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import {
+  Package, Boxes, FolderOpen, Box, List, Users, MapPin,
+  Wrench, ScrollText, HardHat, UserCheck, Plus, X, Save,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { ReportViewer } from "./report-viewer";
+import { saveReport, updateSavedReport } from "@/server/reports";
+import {
+  DATA_SOURCES,
+  DATA_SOURCE_LABELS,
+  DATA_SOURCE_DESCRIPTIONS,
+  FIELD_DEFINITIONS,
+  type DataSource,
+  type ReportConfig,
+  type ColumnConfig,
+  type FilterConfig,
+  type SortConfig,
+  type GroupByConfig,
+  type FilterOperator,
+} from "@/lib/report-types";
+
+const ICON_MAP: Record<string, React.ReactNode> = {
+  Package: <Package className="h-5 w-5" />,
+  Boxes: <Boxes className="h-5 w-5" />,
+  FolderOpen: <FolderOpen className="h-5 w-5" />,
+  Box: <Box className="h-5 w-5" />,
+  List: <List className="h-5 w-5" />,
+  Users: <Users className="h-5 w-5" />,
+  MapPin: <MapPin className="h-5 w-5" />,
+  Wrench: <Wrench className="h-5 w-5" />,
+  ScrollText: <ScrollText className="h-5 w-5" />,
+  HardHat: <HardHat className="h-5 w-5" />,
+  UserCheck: <UserCheck className="h-5 w-5" />,
+};
+
+const DATA_SOURCE_ICON_MAP: Record<DataSource, string> = {
+  assets: "Package",
+  models: "Boxes",
+  projects: "FolderOpen",
+  kits: "Box",
+  lineItems: "List",
+  clients: "Users",
+  locations: "MapPin",
+  maintenance: "Wrench",
+  activityLog: "ScrollText",
+  crew: "HardHat",
+  crewAssignments: "UserCheck",
+};
+
+const FILTER_OPERATORS: { value: FilterOperator; label: string }[] = [
+  { value: "equals", label: "Equals" },
+  { value: "not_equals", label: "Not equals" },
+  { value: "contains", label: "Contains" },
+  { value: "gt", label: "Greater than" },
+  { value: "gte", label: "Greater or equal" },
+  { value: "lt", label: "Less than" },
+  { value: "lte", label: "Less or equal" },
+  { value: "in", label: "In list" },
+  { value: "is_empty", label: "Is empty" },
+  { value: "is_not_empty", label: "Is not empty" },
+];
+
+const DATE_PRESETS = [
+  { value: "last7days", label: "Last 7 days" },
+  { value: "last30days", label: "Last 30 days" },
+  { value: "thisMonth", label: "This month" },
+  { value: "lastMonth", label: "Last month" },
+  { value: "thisQuarter", label: "This quarter" },
+  { value: "thisYear", label: "This year" },
+  { value: "lastYear", label: "Last year" },
+];
+
+interface ReportBuilderProps {
+  initialConfig?: ReportConfig;
+  savedReportId?: string;
+  savedReportName?: string;
+}
+
+export function ReportBuilder({ initialConfig, savedReportId, savedReportName }: ReportBuilderProps) {
+  const router = useRouter();
+  const [step, setStep] = useState<number>(initialConfig ? 2 : 1);
+  const [dataSource, setDataSource] = useState<DataSource | null>(initialConfig?.dataSource ?? null);
+  const [columns, setColumns] = useState<ColumnConfig[]>(initialConfig?.columns ?? []);
+  const [filters, setFilters] = useState<FilterConfig[]>(initialConfig?.filters ?? []);
+  const [sortBy, setSortBy] = useState<SortConfig[]>(initialConfig?.sortBy ?? []);
+  const [groupBy, setGroupBy] = useState<GroupByConfig | undefined>(initialConfig?.groupBy);
+  const [enableGrouping, setEnableGrouping] = useState(!!initialConfig?.groupBy);
+  const [dateRange, setDateRange] = useState(initialConfig?.dateRange);
+  const [limit, setLimit] = useState<number | undefined>(initialConfig?.limit);
+  const [includeInactive, setIncludeInactive] = useState(initialConfig?.includeInactive ?? false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [reportName, setReportName] = useState(savedReportName ?? "");
+  const [reportDescription, setReportDescription] = useState("");
+  const [isShared, setIsShared] = useState(false);
+
+  const fields = dataSource ? FIELD_DEFINITIONS[dataSource] : [];
+
+  const buildConfig = useCallback((): ReportConfig => ({
+    dataSource: dataSource!,
+    columns,
+    filters,
+    sortBy: sortBy.length > 0 ? sortBy : undefined,
+    groupBy: enableGrouping ? groupBy : undefined,
+    dateRange,
+    limit,
+    includeInactive,
+  }), [dataSource, columns, filters, sortBy, groupBy, enableGrouping, dateRange, limit, includeInactive]);
+
+  // Select data source
+  const handleSelectDataSource = (ds: DataSource) => {
+    setDataSource(ds);
+    // Pre-select all core fields
+    const defs = FIELD_DEFINITIONS[ds];
+    setColumns(defs.map((f) => ({
+      field: f.field,
+      label: f.label,
+      visible: f.section === "core",
+    })));
+    setFilters([]);
+    setSortBy([]);
+    setGroupBy(undefined);
+    setStep(2);
+  };
+
+  // Toggle column visibility
+  const toggleColumn = (field: string) => {
+    setColumns((prev) =>
+      prev.map((c) => (c.field === field ? { ...c, visible: !c.visible } : c))
+    );
+  };
+
+  // Add filter
+  const addFilter = () => {
+    if (fields.length === 0) return;
+    setFilters((prev) => [
+      ...prev,
+      { field: fields[0].field, operator: "equals" as FilterOperator, value: "" },
+    ]);
+  };
+
+  const updateFilter = (index: number, updates: Partial<FilterConfig>) => {
+    setFilters((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, ...updates } : f))
+    );
+  };
+
+  const removeFilter = (index: number) => {
+    setFilters((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  // Save mutation
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const config = buildConfig();
+      if (savedReportId) {
+        return updateSavedReport(savedReportId, {
+          name: reportName,
+          description: reportDescription || undefined,
+          config,
+          isShared,
+        });
+      } else {
+        return saveReport({
+          name: reportName,
+          description: reportDescription || undefined,
+          dataSource: dataSource!,
+          config,
+          isShared,
+        });
+      }
+    },
+    onSuccess: () => {
+      setSaveDialogOpen(false);
+      router.push("/reports");
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Step 1: Data Source */}
+      {step === 1 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Choose Data Source</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {DATA_SOURCES.map((ds) => (
+              <Card
+                key={ds}
+                className="cursor-pointer transition-colors hover:border-primary"
+                onClick={() => handleSelectDataSource(ds)}
+              >
+                <CardContent className="flex items-start gap-3 p-4">
+                  <div className="text-muted-foreground mt-0.5">
+                    {ICON_MAP[DATA_SOURCE_ICON_MAP[ds]]}
+                  </div>
+                  <div>
+                    <p className="font-medium">{DATA_SOURCE_LABELS[ds]}</p>
+                    <p className="text-sm text-muted-foreground">{DATA_SOURCE_DESCRIPTIONS[ds]}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {FIELD_DEFINITIONS[ds].length} fields
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Step 2: Configure */}
+      {step >= 2 && dataSource && (
+        <div className="space-y-6">
+          {/* Source indicator */}
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className="gap-1.5">
+              {ICON_MAP[DATA_SOURCE_ICON_MAP[dataSource]]}
+              {DATA_SOURCE_LABELS[dataSource]}
+            </Badge>
+            <Button variant="ghost" size="sm" onClick={() => setStep(1)}>
+              Change
+            </Button>
+          </div>
+
+          {/* Columns */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Columns</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {["core", "related", "computed"].map((section) => {
+                  const sectionFields = fields.filter((f) => f.section === section);
+                  if (sectionFields.length === 0) return null;
+                  return (
+                    <div key={section}>
+                      <p className="text-xs font-medium text-muted-foreground uppercase mb-2">
+                        {section === "core" ? "Core Fields" : section === "related" ? "Related Data" : "Computed Fields"}
+                      </p>
+                      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                        {sectionFields.map((f) => {
+                          const col = columns.find((c) => c.field === f.field);
+                          return (
+                            <label key={f.field} className="flex items-center gap-2 text-sm cursor-pointer">
+                              <Checkbox
+                                checked={col?.visible ?? false}
+                                onCheckedChange={() => toggleColumn(f.field)}
+                              />
+                              {f.label}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Filters */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">Filters</CardTitle>
+                <Button variant="outline" size="sm" onClick={addFilter}>
+                  <Plus className="mr-1.5 h-3.5 w-3.5" /> Add Filter
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {filters.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No filters applied. All records will be included.</p>
+              ) : (
+                <div className="space-y-3">
+                  {filters.map((filter, i) => {
+                    const fieldDef = fields.find((f) => f.field === filter.field);
+                    return (
+                      <div key={i} className="flex flex-wrap items-end gap-2">
+                        <div className="min-w-[160px]">
+                          <Label className="text-xs">Field</Label>
+                          <Select
+                            value={filter.field}
+                            onValueChange={(val) => val && updateFilter(i, { field: val })}
+                          >
+                            <SelectTrigger>
+                              <SelectValue>{fields.find((f) => f.field === filter.field)?.label ?? filter.field}</SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                              {fields.map((f) => (
+                                <SelectItem key={f.field} value={f.field}>
+                                  {f.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="min-w-[140px]">
+                          <Label className="text-xs">Operator</Label>
+                          <Select
+                            value={filter.operator}
+                            onValueChange={(val) => val && updateFilter(i, { operator: val as FilterOperator })}
+                          >
+                            <SelectTrigger>
+                              <SelectValue>{FILTER_OPERATORS.find((op) => op.value === filter.operator)?.label ?? filter.operator}</SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                              {FILTER_OPERATORS.map((op) => (
+                                <SelectItem key={op.value} value={op.value}>
+                                  {op.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        {filter.operator !== "is_empty" && filter.operator !== "is_not_empty" && (
+                          <div className="min-w-[160px] flex-1">
+                            <Label className="text-xs">Value</Label>
+                            {fieldDef?.enumValues ? (
+                              <Select
+                                value={String(filter.value)}
+                                onValueChange={(val) => val && updateFilter(i, { value: val })}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue>{fieldDef.enumLabels?.[String(filter.value)] || String(filter.value)}</SelectValue>
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {fieldDef.enumValues.map((v) => (
+                                    <SelectItem key={v} value={v}>
+                                      {fieldDef.enumLabels?.[v] || v}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            ) : (
+                              <Input
+                                value={String(filter.value ?? "")}
+                                onChange={(e) => {
+                                  const v = fieldDef?.type === "number" ? Number(e.target.value) || 0 : e.target.value;
+                                  updateFilter(i, { value: v });
+                                }}
+                                type={fieldDef?.type === "number" ? "number" : fieldDef?.type === "date" ? "date" : "text"}
+                              />
+                            )}
+                          </div>
+                        )}
+                        <Button variant="ghost" size="sm" onClick={() => removeFilter(i)}>
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Date Range */}
+              <Separator className="my-4" />
+              <div>
+                <Label className="text-sm font-medium">Date Range (optional)</Label>
+                <div className="flex flex-wrap items-end gap-2 mt-2">
+                  <div className="min-w-[160px]">
+                    <Label className="text-xs">Date Field</Label>
+                    <Select
+                      value={dateRange?.field ?? "__none__"}
+                      onValueChange={(val) => setDateRange(val && val !== "__none__" ? { field: val, preset: dateRange?.preset } : undefined)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select...">{dateRange?.field ? (fields.find((f) => f.field === dateRange.field)?.label ?? dateRange.field) : "None"}</SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none__">None</SelectItem>
+                        {fields
+                          .filter((f) => f.type === "date")
+                          .map((f) => (
+                            <SelectItem key={f.field} value={f.field}>
+                              {f.label}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {dateRange?.field && (
+                    <div className="min-w-[160px]">
+                      <Label className="text-xs">Preset</Label>
+                      <Select
+                        value={dateRange.preset ?? "__custom__"}
+                        onValueChange={(val) => setDateRange({ ...dateRange!, preset: val && val !== "__custom__" ? val : undefined })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Custom...">{dateRange?.preset ? (DATE_PRESETS.find((p) => p.value === dateRange.preset)?.label ?? dateRange.preset) : "Custom range"}</SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__custom__">Custom range</SelectItem>
+                          {DATE_PRESETS.map((p) => (
+                            <SelectItem key={p.value} value={p.value}>
+                              {p.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                  {dateRange?.field && !dateRange.preset && (
+                    <>
+                      <div>
+                        <Label className="text-xs">Start</Label>
+                        <Input
+                          type="date"
+                          value={dateRange.start ?? ""}
+                          onChange={(e) => setDateRange({ ...dateRange, start: e.target.value || undefined })}
+                        />
+                      </div>
+                      <div>
+                        <Label className="text-xs">End</Label>
+                        <Input
+                          type="date"
+                          value={dateRange.end ?? ""}
+                          onChange={(e) => setDateRange({ ...dateRange, end: e.target.value || undefined })}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Grouping */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-3">
+                <CardTitle className="text-base">Group & Aggregate</CardTitle>
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <Checkbox
+                    checked={enableGrouping}
+                    onCheckedChange={(checked) => {
+                      setEnableGrouping(!!checked);
+                      if (!checked) setGroupBy(undefined);
+                    }}
+                  />
+                  Enable grouping
+                </label>
+              </div>
+            </CardHeader>
+            {enableGrouping && (
+              <CardContent>
+                <div className="flex flex-wrap items-end gap-2">
+                  <div className="min-w-[200px]">
+                    <Label className="text-xs">Group By Field</Label>
+                    <Select
+                      value={groupBy?.field ?? "__none__"}
+                      onValueChange={(val) => {
+                        if (!val || val === "__none__") return;
+                        setGroupBy({
+                          field: val,
+                          aggregateColumns: groupBy?.aggregateColumns ?? [
+                            { field: "*", function: "count", label: "Count" },
+                          ],
+                        });
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select field...">{groupBy?.field ? (fields.find((f) => f.field === groupBy.field)?.label ?? groupBy.field) : "Select field..."}</SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {fields
+                          .filter((f) => f.type === "string" || f.type === "enum")
+                          .map((f) => (
+                            <SelectItem key={f.field} value={f.field}>
+                              {f.label}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                {groupBy?.field && (
+                  <div className="mt-3">
+                    <Label className="text-xs">Aggregations</Label>
+                    <div className="space-y-2 mt-1">
+                      {(groupBy.aggregateColumns || []).map((agg, i) => (
+                        <div key={i} className="flex items-end gap-2">
+                          <div className="min-w-[120px]">
+                            <Select
+                              value={agg.function}
+                              onValueChange={(val) => {
+                                if (!val) return;
+                                const updated = [...(groupBy.aggregateColumns || [])];
+                                updated[i] = { ...updated[i], function: val as "count" | "sum" | "avg" | "min" | "max" };
+                                setGroupBy({ ...groupBy, aggregateColumns: updated });
+                              }}
+                            >
+                              <SelectTrigger>
+                                <SelectValue>{{ count: "Count", sum: "Sum", avg: "Average", min: "Min", max: "Max" }[agg.function] ?? agg.function}</SelectValue>
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="count">Count</SelectItem>
+                                <SelectItem value="sum">Sum</SelectItem>
+                                <SelectItem value="avg">Average</SelectItem>
+                                <SelectItem value="min">Min</SelectItem>
+                                <SelectItem value="max">Max</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="min-w-[160px]">
+                            <Select
+                              value={agg.field}
+                              onValueChange={(val) => {
+                                if (!val) return;
+                                const updated = [...(groupBy.aggregateColumns || [])];
+                                updated[i] = { ...updated[i], field: val };
+                                setGroupBy({ ...groupBy, aggregateColumns: updated });
+                              }}
+                            >
+                              <SelectTrigger>
+                                <SelectValue>{agg.field === "*" ? "All (count)" : (fields.find((f) => f.field === agg.field)?.label ?? agg.field)}</SelectValue>
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="*">All (count)</SelectItem>
+                                {fields
+                                  .filter((f) => f.type === "number")
+                                  .map((f) => (
+                                    <SelectItem key={f.field} value={f.field}>
+                                      {f.label}
+                                    </SelectItem>
+                                  ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="flex-1">
+                            <Input
+                              placeholder="Label"
+                              value={agg.label ?? ""}
+                              onChange={(e) => {
+                                const updated = [...(groupBy.aggregateColumns || [])];
+                                updated[i] = { ...updated[i], label: e.target.value || undefined };
+                                setGroupBy({ ...groupBy, aggregateColumns: updated });
+                              }}
+                            />
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              const updated = (groupBy.aggregateColumns || []).filter((_, j) => j !== i);
+                              setGroupBy({ ...groupBy, aggregateColumns: updated });
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setGroupBy({
+                            ...groupBy,
+                            aggregateColumns: [
+                              ...(groupBy.aggregateColumns || []),
+                              { field: "*", function: "count", label: "Count" },
+                            ],
+                          });
+                        }}
+                      >
+                        <Plus className="mr-1.5 h-3.5 w-3.5" /> Add Aggregation
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            )}
+          </Card>
+
+          {/* Sort & Limit */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Sort & Limit</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap items-end gap-2">
+                <div className="min-w-[200px]">
+                  <Label className="text-xs">Sort By</Label>
+                  <Select
+                    value={sortBy[0]?.field ?? "__default__"}
+                    onValueChange={(val) => setSortBy(val && val !== "__default__" ? [{ field: val, direction: sortBy[0]?.direction ?? "asc" }] : [])}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Default order">{sortBy[0]?.field ? (fields.find((f) => f.field === sortBy[0].field)?.label ?? sortBy[0].field) : "Default"}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__default__">Default</SelectItem>
+                      {fields.map((f) => (
+                        <SelectItem key={f.field} value={f.field}>
+                          {f.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {sortBy.length > 0 && (
+                  <div className="min-w-[120px]">
+                    <Label className="text-xs">Direction</Label>
+                    <Select
+                      value={sortBy[0]?.direction ?? "asc"}
+                      onValueChange={(val) => val && setSortBy([{ ...sortBy[0], direction: val as "asc" | "desc" }])}
+                    >
+                      <SelectTrigger>
+                        <SelectValue>{sortBy[0]?.direction === "desc" ? "Descending" : "Ascending"}</SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="asc">Ascending</SelectItem>
+                        <SelectItem value="desc">Descending</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <div className="w-[120px]">
+                  <Label className="text-xs">Row Limit</Label>
+                  <Input
+                    type="number"
+                    value={limit ?? ""}
+                    onChange={(e) => setLimit(e.target.value ? Number(e.target.value) : undefined)}
+                    placeholder="No limit"
+                  />
+                </div>
+                <label className="flex items-center gap-2 text-sm cursor-pointer pb-2">
+                  <Checkbox
+                    checked={includeInactive}
+                    onCheckedChange={(checked) => setIncludeInactive(!!checked)}
+                  />
+                  Include inactive
+                </label>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Actions */}
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={() => setShowPreview(true)}>
+              Run Preview
+            </Button>
+            <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+              <DialogTrigger render={<Button variant="outline" />}>
+                <Save className="mr-1.5 h-4 w-4" />
+                Save Report
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{savedReportId ? "Update Report" : "Save Report"}</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <Label>Name</Label>
+                    <Input
+                      value={reportName}
+                      onChange={(e) => setReportName(e.target.value)}
+                      placeholder="My Custom Report"
+                    />
+                  </div>
+                  <div>
+                    <Label>Description (optional)</Label>
+                    <Input
+                      value={reportDescription}
+                      onChange={(e) => setReportDescription(e.target.value)}
+                      placeholder="Brief description..."
+                    />
+                  </div>
+                  <label className="flex items-center gap-2 text-sm cursor-pointer">
+                    <Checkbox
+                      checked={isShared}
+                      onCheckedChange={(checked) => setIsShared(!!checked)}
+                    />
+                    Share with all org members
+                  </label>
+                  <div className="flex justify-end gap-2">
+                    <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={() => saveMutation.mutate()}
+                      disabled={!reportName || saveMutation.isPending}
+                    >
+                      {saveMutation.isPending ? "Saving..." : "Save"}
+                    </Button>
+                  </div>
+                  {saveMutation.isError && (
+                    <p className="text-sm text-destructive">
+                      {(saveMutation.error as Error).message || "Failed to save"}
+                    </p>
+                  )}
+                </div>
+              </DialogContent>
+            </Dialog>
+          </div>
+
+          {/* Preview */}
+          {showPreview && (
+            <div className="mt-4">
+              <Separator className="mb-4" />
+              <h3 className="text-base font-semibold mb-3">Preview</h3>
+              <ReportViewer config={buildConfig()} title={reportName || "preview"} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/reports/report-viewer.tsx
+++ b/src/components/reports/report-viewer.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { FileSpreadsheet, FileText, ChevronLeft, ChevronRight } from "lucide-react";
+import type { ReportResult, ReportConfig, FieldDefinition } from "@/lib/report-types";
+import { FIELD_DEFINITIONS } from "@/lib/report-types";
+import { useMutation } from "@tanstack/react-query";
+import { runReport, runReportCSV } from "@/server/reports";
+
+interface ReportViewerProps {
+  config: ReportConfig;
+  initialResult?: ReportResult;
+  title?: string;
+  autoRun?: boolean;
+  onSave?: () => void;
+}
+
+export function ReportViewer({ config, initialResult, title, autoRun }: ReportViewerProps) {
+  const [page, setPage] = useState(1);
+  const [result, setResult] = useState<ReportResult | null>(initialResult ?? null);
+  const pageSize = config.limit || 100;
+  const hasAutoRun = useRef(false);
+
+  const runMutation = useMutation({
+    mutationFn: async (p: number) => {
+      const res = await runReport(config, p, pageSize);
+      return res as ReportResult;
+    },
+    onSuccess: (data) => setResult(data),
+  });
+
+  const csvMutation = useMutation({
+    mutationFn: () => runReportCSV(config),
+    onSuccess: (csv) => {
+      const blob = new Blob([csv], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${title || "report"}-${new Date().toISOString().split("T")[0]}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+  });
+
+  const pdfMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/reports/pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config, title: title || "Report" }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "PDF generation failed" }));
+        throw new Error(err.error || "PDF generation failed");
+      }
+      return res.blob();
+    },
+    onSuccess: (blob) => {
+      const url = URL.createObjectURL(blob);
+      window.open(url, "_blank");
+      setTimeout(() => URL.revokeObjectURL(url), 60000);
+    },
+  });
+
+  // Auto-run on mount if requested
+  useEffect(() => {
+    if (autoRun && !hasAutoRun.current && !initialResult) {
+      hasAutoRun.current = true;
+      runMutation.mutate(1);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoRun]);
+
+  const handleRun = () => {
+    setPage(1);
+    runMutation.mutate(1);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    runMutation.mutate(newPage);
+  };
+
+  // Get field definitions for formatting
+  const fieldDefs = FIELD_DEFINITIONS[config.dataSource] || [];
+
+  const formatValue = (value: unknown, field: string): React.ReactNode => {
+    if (value == null) return <span className="text-muted-foreground">-</span>;
+
+    const fieldDef = fieldDefs.find((f) => f.field === field);
+
+    if (fieldDef?.type === "enum" && fieldDef.enumLabels) {
+      const label = fieldDef.enumLabels[String(value)] || String(value);
+      return <Badge variant="secondary">{label}</Badge>;
+    }
+
+    if (fieldDef?.type === "date" || field.toLowerCase().includes("date") || field.toLowerCase().includes("at")) {
+      const d = new Date(value as string);
+      if (!isNaN(d.getTime())) {
+        return d.toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
+      }
+    }
+
+    if (fieldDef?.type === "number" || typeof value === "number") {
+      const num = Number(value);
+      // Check if it looks like currency
+      if (field.toLowerCase().includes("price") || field.toLowerCase().includes("cost") ||
+          field.toLowerCase().includes("total") || field.toLowerCase().includes("revenue") ||
+          field.toLowerCase().includes("value") || field.toLowerCase().includes("amount") ||
+          field.toLowerCase().includes("paid") || field.toLowerCase().includes("spend")) {
+        return `$${num.toLocaleString("en-AU", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+      }
+      return num.toLocaleString("en-AU");
+    }
+
+    if (typeof value === "boolean") {
+      return value ? "Yes" : "No";
+    }
+
+    return String(value);
+  };
+
+  const totalPages = result ? Math.ceil(result.totalRows / pageSize) : 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button onClick={handleRun} disabled={runMutation.isPending}>
+          {runMutation.isPending ? "Running..." : result ? "Refresh" : "Run Report"}
+        </Button>
+
+        {result && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => csvMutation.mutate()}
+              disabled={csvMutation.isPending}
+            >
+              <FileSpreadsheet className="mr-1.5 h-4 w-4" />
+              {csvMutation.isPending ? "Exporting..." : "Export CSV"}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => pdfMutation.mutate()}
+              disabled={pdfMutation.isPending}
+            >
+              <FileText className="mr-1.5 h-4 w-4" />
+              {pdfMutation.isPending ? "Generating..." : "Export PDF"}
+            </Button>
+
+            <span className="ml-auto text-sm text-muted-foreground">
+              {result.totalRows.toLocaleString()} row{result.totalRows !== 1 ? "s" : ""}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Error */}
+      {runMutation.isError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {(runMutation.error as Error).message || "Failed to run report"}
+        </div>
+      )}
+
+      {/* Results */}
+      {result && (
+        <>
+          <div className="rounded-md border overflow-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {result.columns.map((col) => (
+                    <TableHead key={col.field} className="whitespace-nowrap">
+                      {col.label || fieldDefs.find((f) => f.field === col.field)?.label || col.field}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {result.rows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={result.columns.length} className="text-center text-muted-foreground py-8">
+                      No data found
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  result.rows.map((row, i) => (
+                    <TableRow key={i}>
+                      {result.columns.map((col) => (
+                        <TableCell key={col.field} className="whitespace-nowrap">
+                          {formatValue(row[col.field], col.field)}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Aggregation summary */}
+          {result.aggregations && Object.keys(result.aggregations).length > 1 && (
+            <div className="flex flex-wrap gap-4 rounded-md border bg-muted/50 p-3">
+              {Object.entries(result.aggregations)
+                .filter(([key]) => key.startsWith("sum:"))
+                .map(([key, value]) => {
+                  const field = key.replace("sum:", "");
+                  const label = fieldDefs.find((f) => f.field === field)?.label || field;
+                  return (
+                    <div key={key} className="text-sm">
+                      <span className="text-muted-foreground">Total {label}:</span>{" "}
+                      <span className="font-medium">{formatValue(value, field)}</span>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </p>
+              <div className="flex gap-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(page - 1)}
+                  disabled={page <= 1 || runMutation.isPending}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(page + 1)}
+                  disabled={page >= totalPages || runMutation.isPending}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/org-export.ts
+++ b/src/lib/org-export.ts
@@ -53,6 +53,7 @@ export async function exportOrganization(orgId: string) {
     projectMedia,
     clientMedia,
     locationMedia,
+    savedReports,
     members,
   ] = await Promise.all([
     prisma.customRole.findMany({ where: { organizationId: orgId } }),
@@ -87,6 +88,7 @@ export async function exportOrganization(orgId: string) {
     prisma.projectMedia.findMany({ where: { organizationId: orgId } }),
     prisma.clientMedia.findMany({ where: { organizationId: orgId } }),
     prisma.locationMedia.findMany({ where: { organizationId: orgId } }),
+    prisma.savedReport.findMany({ where: { organizationId: orgId } }),
     prisma.member.findMany({
       where: { organizationId: orgId },
       include: { user: { select: { id: true, email: true, name: true } } },
@@ -116,6 +118,7 @@ export async function exportOrganization(orgId: string) {
   collectUserIds(supplierOrders as unknown as Record<string, unknown>[], ["createdById"]);
   collectUserIds(activityLogs as unknown as Record<string, unknown>[], ["userId"]);
   collectUserIds(fileUploads as unknown as Record<string, unknown>[], ["uploadedById"]);
+  collectUserIds(savedReports as unknown as Record<string, unknown>[], ["createdById"]);
 
   const users = await prisma.user.findMany({
     where: { id: { in: [...userIds] } },
@@ -160,6 +163,7 @@ export async function exportOrganization(orgId: string) {
     projectMedia: clean(projectMedia) as Record<string, unknown>[],
     clientMedia: clean(clientMedia) as Record<string, unknown>[],
     locationMedia: clean(locationMedia) as Record<string, unknown>[],
+    savedReports: clean(savedReports) as Record<string, unknown>[],
 
     members: members.map((m) => ({
       role: m.role,

--- a/src/lib/org-import.ts
+++ b/src/lib/org-import.ts
@@ -566,6 +566,21 @@ export async function importOrganization(
     });
   }
 
+  // ── 19c. Saved Reports ──────────────────────────────────────────
+  for (const r of (manifest.savedReports ?? []) as Rec[]) {
+    const id = newId("savedReport", r.id);
+    await prisma.savedReport.create({
+      data: {
+        ...stripRelations(r),
+        id,
+        organizationId: newOrgId,
+        createdById: remapUser(r.createdById),
+        createdAt: safeDate(r.createdAt),
+        updatedAt: safeDate(r.updatedAt),
+      } as any,
+    });
+  }
+
   // ── 20. File Uploads (re-upload to S3) ───────────────────────────
   const urlMap = new Map<string, string>(); // old URL -> new URL
   if (files.size > 0) {
@@ -733,6 +748,7 @@ export async function importOrganization(
       clients: manifest.clients.length,
       files: manifest.fileUploads.length,
       members: manifest.members.length,
+      savedReports: (manifest.savedReports ?? []).length,
     },
   };
 }

--- a/src/lib/org-transfer-types.ts
+++ b/src/lib/org-transfer-types.ts
@@ -37,6 +37,8 @@ export interface OrgExportManifest {
   clientMedia: Record<string, unknown>[];
   locationMedia: Record<string, unknown>[];
 
+  savedReports: Record<string, unknown>[];
+
   /** Members with user email for matching on import */
   members: Array<{
     role: string;

--- a/src/lib/page-commands.ts
+++ b/src/lib/page-commands.ts
@@ -242,6 +242,15 @@ export const PAGE_COMMANDS: PageCommand[] = [
     aliases: ["reports", "report", "analytics", "stats", "metrics"],
     icon: "BarChart3",
     description: "Business reports and analytics",
+    children: [
+      {
+        label: "Custom Report Builder",
+        href: "/reports/builder",
+        aliases: ["builder", "customreport", "newreport", "createreport", "buildreport"],
+        icon: "BarChart3",
+        description: "Build a custom report",
+      },
+    ],
   },
   {
     label: "Activity Log",

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -11,7 +11,9 @@ import { gearflowPlugins } from "./plugins";
 import { getPdfmeFonts } from "./fonts";
 import { buildDocumentData } from "./build-document-data";
 import { getTemplateBuilder, getTtReportBuilder } from "./templates";
+import { buildReportTemplate, buildReportInputs, calculatePageCount, countSummaryItems } from "./templates/report";
 import type { DocumentType, DocumentData, TestTagReportType } from "./types";
+import type { ReportResult } from "@/lib/report-types";
 import type { TemplateSettings } from "./template-settings";
 
 /**
@@ -186,6 +188,38 @@ export async function generateTestTagReport(
   const pdf = await generate({
     template,
     inputs: [inputs],
+    plugins: gearflowPlugins,
+    options: { font: getPdfmeFonts() },
+  });
+
+  return pdf;
+}
+
+/**
+ * Generate a PDF from a report result (custom or pre-built report).
+ *
+ * @param title - Report title
+ * @param result - The executed report result
+ * @param orgData - Organization data (name, branding, logos)
+ * @param subtitle - Optional subtitle (e.g. data source label)
+ * @returns PDF as Uint8Array
+ */
+export async function generateReportPdf(
+  title: string,
+  result: ReportResult,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  orgData: any,
+  subtitle?: string,
+  dataSource?: string,
+): Promise<Uint8Array> {
+  const summaryItemCount = countSummaryItems(result);
+  const pageCount = calculatePageCount(result.rows.length, summaryItemCount);
+  const template = buildReportTemplate(pageCount, summaryItemCount);
+  const inputs = buildReportInputs({ title, subtitle, result, dataSource }, orgData);
+
+  const pdf = await generate({
+    template,
+    inputs,
     plugins: gearflowPlugins,
     options: { font: getPdfmeFonts() },
   });

--- a/src/lib/pdfme/plugins/gearflow-page-header.ts
+++ b/src/lib/pdfme/plugins/gearflow-page-header.ts
@@ -91,7 +91,12 @@ async function pdfRender(arg: PDFRenderProps<PageHeaderSchema>) {
     }
 
     // Right side: doc title + meta (aligned to the same row as org name)
-    const titleSize = 22;
+    // Auto-scale title to fit within right half of header
+    const maxTitleWidth = width * 0.55;
+    let titleSize = 22;
+    while (titleSize > 10 && fonts.bold.widthOfTextAtSize(config.docTitle, titleSize) > maxTitleWidth) {
+      titleSize -= 1;
+    }
     const titleWidth = fonts.bold.widthOfTextAtSize(config.docTitle, titleSize);
     page.drawText(config.docTitle, {
       x: x + width - titleWidth,
@@ -180,7 +185,12 @@ async function pdfRender(arg: PDFRenderProps<PageHeaderSchema>) {
   }
 
   // Right side: doc title + meta
-  const titleSize = 22;
+  // Auto-scale title to fit within right half of header
+  const maxTitleWidth = width * 0.55;
+  let titleSize = 22;
+  while (titleSize > 10 && fonts.bold.widthOfTextAtSize(config.docTitle, titleSize) > maxTitleWidth) {
+    titleSize -= 1;
+  }
   const titleWidth = fonts.bold.widthOfTextAtSize(config.docTitle, titleSize);
   page.drawText(config.docTitle, {
     x: x + width - titleWidth,

--- a/src/lib/pdfme/plugins/gearflow-summary-box.ts
+++ b/src/lib/pdfme/plugins/gearflow-summary-box.ts
@@ -1,6 +1,6 @@
 /**
- * gearflowSummaryBox plugin — horizontal metrics summary row.
- * Renders a row of metric boxes (e.g., "Total: 42", "Compliance: 95%").
+ * gearflowSummaryBox plugin — horizontal metrics summary with auto-wrapping rows.
+ * Renders metric boxes in rows of up to 5, wrapping to additional rows if needed.
  */
 import type { Plugin, Schema, PDFRenderProps } from "@pdfme/common";
 import {
@@ -17,54 +17,81 @@ export interface SummaryBoxConfig {
   documentColor?: string;
 }
 
+const MAX_COLS = 5;
+const ROW_HEIGHT = 38; // pt per row of items
+const ROW_GAP = 4; // pt gap between rows
+
 export const gearflowSummaryBox: Plugin<SummaryBoxSchema> = {
   pdf: (arg: PDFRenderProps<SummaryBoxSchema>) => {
     const { value, schema, pdfDoc, pdfLib, page, _cache } = arg;
     if (!value) return;
 
     const config: SummaryBoxConfig = JSON.parse(value);
-    const { x, y, width, height } = getLayoutProps(schema, page.getHeight());
+    const pageHeight = page.getHeight();
+    const { x, y, width, height } = getLayoutProps(schema, pageHeight);
 
     return (async () => {
       const fonts = await getHelveticaFonts(pdfDoc, pdfLib, _cache);
       const { regular, bold } = fonts;
 
+      const itemCount = config.items.length;
+      const rowCount = Math.ceil(itemCount / MAX_COLS);
+      const totalHeight = rowCount * ROW_HEIGHT + (rowCount - 1) * ROW_GAP + 8; // 4pt padding top+bottom
+
+      // Use the top of the allocated area (getLayoutProps y is bottom)
+      const topY = y + height;
+
       // Background box
       page.drawRectangle({
         x,
-        y: y,
+        y: topY - totalHeight,
         width,
-        height,
+        height: totalHeight,
         color: hexToRgb("#f9fafb", pdfLib),
         borderColor: hexToRgb("#e5e7eb", pdfLib),
         borderWidth: 0.5,
       });
 
-      const itemCount = config.items.length;
-      const itemWidth = width / itemCount;
-
       for (let i = 0; i < itemCount; i++) {
         const item = config.items[i];
-        const centerX = x + itemWidth * i + itemWidth / 2;
+        const row = Math.floor(i / MAX_COLS);
+        const col = i % MAX_COLS;
+        const colsInThisRow = Math.min(MAX_COLS, itemCount - row * MAX_COLS);
+        const itemWidth = width / colsInThisRow;
+
+        const centerX = x + itemWidth * col + itemWidth / 2;
+        const rowTopY = topY - 4 - row * (ROW_HEIGHT + ROW_GAP);
 
         // Value (large, bold)
         const valStr = String(item.value);
-        const valWidth = bold.widthOfTextAtSize(valStr, 13);
+        const valSize = 13;
+        const valWidth = bold.widthOfTextAtSize(valStr, valSize);
         page.drawText(valStr, {
           x: centerX - valWidth / 2,
-          y: y + height / 2 - 2,
-          size: 13,
+          y: rowTopY - 18,
+          size: valSize,
           font: bold,
           color: hexToRgb("#1a1a1a", pdfLib),
         });
 
-        // Label (small, uppercase)
-        const label = item.label.toUpperCase();
-        const labelWidth = regular.widthOfTextAtSize(label, 6);
+        // Label (small, uppercase) — truncate if too wide
+        let label = item.label.toUpperCase();
+        let labelSize = 6;
+        let labelWidth = regular.widthOfTextAtSize(label, labelSize);
+        const maxLabelWidth = itemWidth - 8; // 4pt padding each side
+
+        if (labelWidth > maxLabelWidth) {
+          // Truncate with ellipsis
+          while (labelWidth > maxLabelWidth && label.length > 4) {
+            label = label.slice(0, -2) + "…";
+            labelWidth = regular.widthOfTextAtSize(label, labelSize);
+          }
+        }
+
         page.drawText(label, {
           x: centerX - labelWidth / 2,
-          y: y + 4,
-          size: 6,
+          y: rowTopY - ROW_HEIGHT + 6,
+          size: labelSize,
           font: regular,
           color: hexToRgb("#666666", pdfLib),
         });

--- a/src/lib/pdfme/templates/report.ts
+++ b/src/lib/pdfme/templates/report.ts
@@ -1,0 +1,373 @@
+/**
+ * Generic report PDF template — landscape A4 with multi-page table support.
+ * Used by the custom report builder and pre-built reports.
+ *
+ * pdfme multi-page: `schemas` is Schema[][] (one inner array per page).
+ * Each input object renders ALL pages, so we use unique field names per page
+ * (e.g. dataTable_1, dataTable_2) and a SINGLE input object with all keys.
+ */
+import type { Template } from "@pdfme/common";
+import type { PageHeaderConfig, FooterConfig } from "../types";
+import type { DataTableConfig, DataTableColumn } from "../plugins/gearflow-data-table";
+import type { SummaryBoxConfig } from "../plugins/gearflow-summary-box";
+import { formatDate } from "../plugins/helpers";
+import type { ReportResult, ColumnConfig } from "@/lib/report-types";
+import { FIELD_DEFINITIONS } from "@/lib/report-types";
+
+const PAGE_WIDTH = 297; // landscape A4 mm
+const PAGE_HEIGHT = 210;
+const MARGIN = 14;
+const CONTENT_W = PAGE_WIDTH - MARGIN * 2;
+
+// Data table row/header heights in points (must match gearflow-data-table plugin)
+const ROW_HEIGHT_PT = 14;
+const HEADER_HEIGHT_PT = 16;
+const PT_PER_MM = 72 / 25.4; // ~2.835
+
+// Page 2+: smaller header (18mm), table starts at y=36mm
+const CONTINUATION_HEADER_H = 18;
+const PAGEN_TABLE_Y = MARGIN + CONTINUATION_HEADER_H + 4; // 36mm
+const PAGEN_TABLE_AVAIL_MM = PAGE_HEIGHT - MARGIN - 10 - PAGEN_TABLE_Y; // 150mm
+const PAGEN_ROWS = Math.floor(
+  (PAGEN_TABLE_AVAIL_MM * PT_PER_MM - HEADER_HEIGHT_PT) / ROW_HEIGHT_PT
+);
+
+interface OrgData {
+  name: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  branding?: {
+    primaryColor?: string;
+    documentColor?: string;
+    logoUrl?: string;
+    iconUrl?: string;
+    documentLogoMode?: "logo" | "icon" | "none";
+    showOrgNameOnDocuments?: boolean;
+  };
+  logoData?: string | null;
+  iconData?: string | null;
+}
+
+interface ReportPdfData {
+  title: string;
+  subtitle?: string;
+  result: ReportResult;
+  dataSource?: string;
+}
+
+/**
+ * Build a multi-page template with unique field names per page.
+ * Field names are suffixed with page index: header_0, dataTable_0, footer_0, etc.
+ * @param summaryItemCount - number of summary items (affects page 1 layout)
+ */
+export function buildReportTemplate(pageCount: number, summaryItemCount: number = 1): Template {
+  // Calculate summary box height in mm based on item count
+  const summaryRows = Math.ceil(summaryItemCount / 5);
+  const SUMMARY_ROW_HEIGHT_PT = 38;
+  const SUMMARY_ROW_GAP_PT = 4;
+  const summaryHeightPt = summaryRows * SUMMARY_ROW_HEIGHT_PT + (summaryRows - 1) * SUMMARY_ROW_GAP_PT + 8;
+  const summaryHeightMm = summaryHeightPt / PT_PER_MM;
+  const summaryBoxY = 52; // mm, below header (logo + org details + title need ~35mm)
+  const page1TableY = summaryBoxY + summaryHeightMm + 2; // 2mm gap after summary
+  const schemas: Template["schemas"] = [];
+
+  // Page 1: header + summary + table + footer
+  schemas.push([
+    {
+      name: "header_0",
+      type: "gearflowPageHeader",
+      content: "",
+      position: { x: MARGIN, y: MARGIN },
+      width: CONTENT_W,
+      height: 35,
+    },
+    {
+      name: "summaryBox_0",
+      type: "gearflowSummaryBox",
+      content: "",
+      position: { x: MARGIN, y: summaryBoxY },
+      width: CONTENT_W,
+      height: summaryHeightMm,
+    },
+    {
+      name: "dataTable_0",
+      type: "gearflowDataTable",
+      content: "",
+      position: { x: MARGIN, y: page1TableY },
+      width: CONTENT_W,
+      height: 1, // minimal — plugin draws downward from y, ignores height
+    },
+    {
+      name: "footer_0",
+      type: "gearflowPageFooter",
+      content: "",
+      position: { x: MARGIN, y: PAGE_HEIGHT - MARGIN - 10 },
+      width: CONTENT_W,
+      height: 10,
+    },
+  ]);
+
+  // Pages 2+: continuation header + table + footer
+  for (let i = 1; i < pageCount; i++) {
+    schemas.push([
+      {
+        name: `header_${i}`,
+        type: "gearflowPageHeader",
+        content: "",
+        position: { x: MARGIN, y: MARGIN },
+        width: CONTENT_W,
+        height: CONTINUATION_HEADER_H,
+      },
+      {
+        name: `dataTable_${i}`,
+        type: "gearflowDataTable",
+        content: "",
+        position: { x: MARGIN, y: PAGEN_TABLE_Y },
+        width: CONTENT_W,
+        height: 1,
+      },
+      {
+        name: `footer_${i}`,
+        type: "gearflowPageFooter",
+        content: "",
+        position: { x: MARGIN, y: PAGE_HEIGHT - MARGIN - 10 },
+        width: CONTENT_W,
+        height: 10,
+      },
+    ]);
+  }
+
+  return {
+    basePdf: {
+      width: PAGE_WIDTH,
+      height: PAGE_HEIGHT,
+      padding: [MARGIN, MARGIN, MARGIN, MARGIN],
+    },
+    schemas,
+  };
+}
+
+/**
+ * Format a cell value for PDF display.
+ */
+function formatCellValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (value instanceof Date) return formatDate(value);
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    return formatDate(new Date(value));
+  }
+  if (typeof value === "number") {
+    if (Number.isInteger(value)) return value.toLocaleString();
+    return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+  return String(value);
+}
+
+/**
+ * Resolve a human-readable label for a column field.
+ */
+function resolveColumnLabel(col: ColumnConfig, dataSource: string): string {
+  if (col.label) return col.label;
+
+  const fieldDefs = FIELD_DEFINITIONS[dataSource as keyof typeof FIELD_DEFINITIONS];
+  if (fieldDefs) {
+    const def = fieldDefs.find((f) => f.field === col.field);
+    if (def?.label) return def.label;
+  }
+
+  // camelCase/dot-path → Title Case
+  const lastPart = col.field.split(".").pop() || col.field;
+  return lastPart
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (s) => s.toUpperCase())
+    .trim();
+}
+
+/**
+ * Build a SINGLE input object with unique keys per page.
+ * pdfme renders all schema pages for each input, so we need exactly one input
+ * with keys like header_0, dataTable_0, footer_0, header_1, dataTable_1, etc.
+ */
+export function buildReportInputs(
+  data: ReportPdfData,
+  orgData: OrgData
+): Record<string, string>[] {
+  const docColor = orgData.branding?.documentColor || "#0d9488";
+  const { result } = data;
+  const dataSource = data.dataSource || "";
+
+  // ── Shared configs ──
+
+  const footerConfig: FooterConfig = {
+    text: [orgData.name, orgData.email, orgData.phone].filter(Boolean).join(" | "),
+    secondLine: `${data.title} | Generated ${formatDate(new Date())}`,
+  };
+
+  // Build column definitions once
+  const visibleColumns = result.columns.filter((c: ColumnConfig) => c.visible);
+  const columns: DataTableColumn[] = visibleColumns.map((col: ColumnConfig) => ({
+    key: col.field,
+    label: resolveColumnLabel(col, dataSource),
+    width: col.width || 1,
+  }));
+
+  // Format all rows
+  const allRows = result.rows.map((row: Record<string, unknown>) => {
+    const mapped: Record<string, string | number | null> = {};
+    for (const col of visibleColumns) {
+      const val = formatCellValue(row[col.field]);
+      mapped[col.field] = val !== "" ? val : null;
+    }
+    return mapped;
+  });
+
+  // ── Build summary items first (needed for page 1 row count) ──
+
+  const summaryItems: { label: string; value: string | number }[] = [];
+  if (result.aggregations && Object.keys(result.aggregations).length > 0) {
+    const fieldDefs = dataSource ? FIELD_DEFINITIONS[dataSource as keyof typeof FIELD_DEFINITIONS] : undefined;
+    const aggFnLabels: Record<string, string> = { sum: "Sum", avg: "Avg", count: "Count" };
+
+    for (const [key, val] of Object.entries(result.aggregations)) {
+      if (key === "totalRows") continue;
+
+      // Keys are like "sum:_count.assets" or "avg:defaultRentalPrice"
+      const colonIdx = key.indexOf(":");
+      const aggFn = colonIdx > -1 ? key.slice(0, colonIdx) : "";
+      const fieldKey = colonIdx > -1 ? key.slice(colonIdx + 1) : key;
+
+      // Look up field label from FIELD_DEFINITIONS
+      const fieldDef = fieldDefs?.find((f) => f.field === fieldKey);
+      const fieldLabel = fieldDef?.label || fieldKey
+        .replace(/^_/, "")
+        .replace(/\./g, " ")
+        .replace(/([A-Z])/g, " $1")
+        .replace(/^./, (s) => s.toUpperCase())
+        .trim();
+
+      const fnLabel = aggFnLabels[aggFn] || aggFn.charAt(0).toUpperCase() + aggFn.slice(1);
+      const label = `${fieldLabel} (${fnLabel})`;
+
+      summaryItems.push({
+        label,
+        value: typeof val === "number" && !Number.isInteger(val)
+          ? val.toFixed(2)
+          : val,
+      });
+    }
+  }
+  summaryItems.push({ label: "Total Rows", value: result.totalRows });
+
+  // ── Split rows across pages (page 1 has fewer rows due to summary box) ──
+
+  const p1Rows = getPage1Rows(summaryItems.length);
+  const rowChunks: Record<string, string | number | null>[][] = [];
+  if (allRows.length <= p1Rows) {
+    rowChunks.push(allRows);
+  } else {
+    rowChunks.push(allRows.slice(0, p1Rows));
+    let offset = p1Rows;
+    while (offset < allRows.length) {
+      rowChunks.push(allRows.slice(offset, offset + PAGEN_ROWS));
+      offset += PAGEN_ROWS;
+    }
+  }
+
+  const totalPages = rowChunks.length;
+
+  // ── Build single input object with unique keys per page ──
+
+  const input: Record<string, string> = {};
+
+  // Page 1
+  const headerConfig: PageHeaderConfig = {
+    orgName: orgData.name,
+    orgDetails: [orgData.address, orgData.phone, orgData.email].filter(Boolean).join("\n"),
+    docTitle: data.title.toUpperCase(),
+    docMeta: data.subtitle
+      ? `${data.subtitle} | Generated ${formatDate(new Date())}`
+      : `Generated ${formatDate(new Date())}`,
+    logoData: orgData.logoData ?? null,
+    iconData: orgData.iconData ?? null,
+    documentLogoMode: orgData.branding?.documentLogoMode || "icon",
+    showOrgNameOnDocuments: orgData.branding?.showOrgNameOnDocuments !== false,
+    documentColor: docColor,
+  };
+
+  const page1Table: DataTableConfig = {
+    columns,
+    rows: rowChunks[0] || [],
+    documentColor: docColor,
+  };
+
+  input["header_0"] = JSON.stringify(headerConfig);
+  input["summaryBox_0"] = JSON.stringify({ items: summaryItems, documentColor: docColor } as SummaryBoxConfig);
+  input["dataTable_0"] = JSON.stringify(page1Table);
+  input["footer_0"] = JSON.stringify(footerConfig);
+
+  // Pages 2+
+  for (let p = 1; p < totalPages; p++) {
+    const contHeader: PageHeaderConfig = {
+      orgName: orgData.name,
+      orgDetails: "",
+      docTitle: data.title.toUpperCase(),
+      docMeta: `Page ${p + 1} of ${totalPages}`,
+      logoData: null,
+      iconData: orgData.iconData ?? null,
+      documentLogoMode: "icon",
+      showOrgNameOnDocuments: false,
+      documentColor: docColor,
+    };
+
+    const pageTable: DataTableConfig = {
+      columns,
+      rows: rowChunks[p],
+      documentColor: docColor,
+    };
+
+    input[`header_${p}`] = JSON.stringify(contHeader);
+    input[`dataTable_${p}`] = JSON.stringify(pageTable);
+    input[`footer_${p}`] = JSON.stringify(footerConfig);
+  }
+
+  // Return as single-element array — one input renders all schema pages
+  return [input];
+}
+
+/**
+ * Count how many summary items a report result will produce.
+ */
+export function countSummaryItems(result: ReportResult): number {
+  let count = 0;
+  if (result.aggregations) {
+    for (const key of Object.keys(result.aggregations)) {
+      if (key !== "totalRows") count++;
+    }
+  }
+  return count + 1; // +1 for "Total Rows"
+}
+
+/**
+ * Calculate how many rows fit on page 1 given the summary item count.
+ */
+function getPage1Rows(summaryItemCount: number): number {
+  const summaryRows = Math.ceil(summaryItemCount / 5);
+  const SUMMARY_ROW_HEIGHT_PT = 38;
+  const SUMMARY_ROW_GAP_PT = 4;
+  const summaryHeightPt = summaryRows * SUMMARY_ROW_HEIGHT_PT + (summaryRows - 1) * SUMMARY_ROW_GAP_PT + 8;
+  const summaryHeightMm = summaryHeightPt / PT_PER_MM;
+  const page1TableY = 52 + summaryHeightMm + 2;
+  const page1AvailMm = PAGE_HEIGHT - MARGIN - 10 - page1TableY;
+  return Math.floor((page1AvailMm * PT_PER_MM - HEADER_HEIGHT_PT) / ROW_HEIGHT_PT);
+}
+
+/**
+ * Calculate how many pages are needed for the given row count.
+ */
+export function calculatePageCount(rowCount: number, summaryItemCount: number = 1): number {
+  const p1Rows = getPage1Rows(summaryItemCount);
+  if (rowCount <= p1Rows) return 1;
+  return 1 + Math.ceil((rowCount - p1Rows) / PAGEN_ROWS);
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -187,6 +187,8 @@ export const PERMISSION_REGISTRY: Record<
     actions: [
       { key: "view", label: "View" },
       { key: "export", label: "Export" },
+      { key: "create", label: "Create Saved Reports" },
+      { key: "delete", label: "Delete Saved Reports" },
     ],
   },
 };
@@ -214,7 +216,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     orgMembers: ["read", "invite", "update_role", "remove"],
     supplier: ALL_CRUD,
     crew: ALL_CRUD,
-    reports: ["view", "export"],
+    reports: ["view", "export", "create", "delete"],
   },
   admin: {
     asset: ALL_ASSET,
@@ -232,7 +234,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     orgMembers: ["read", "invite", "update_role", "remove"],
     supplier: ALL_CRUD,
     crew: ALL_CRUD,
-    reports: ["view", "export"],
+    reports: ["view", "export", "create", "delete"],
   },
   manager: {
     asset: ["create", "read", "update", "import", "export"],
@@ -250,7 +252,7 @@ export const rolePermissions: Record<string, PermissionMap> = {
     orgMembers: ["read"],
     supplier: ["create", "read", "update"],
     crew: ["create", "read", "update"],
-    reports: ["view", "export"],
+    reports: ["view", "export", "create", "delete"],
   },
   member: {
     asset: ["create", "read", "update"],

--- a/src/lib/report-engine.ts
+++ b/src/lib/report-engine.ts
@@ -1,0 +1,702 @@
+/**
+ * Report query engine — translates ReportConfig into Prisma queries.
+ * Runs server-side only.
+ */
+
+import { prisma } from "@/lib/prisma";
+import type {
+  ReportConfig,
+  ReportResult,
+  FilterConfig,
+  DataSource,
+  ColumnConfig,
+  FieldDefinition,
+} from "./report-types";
+import { FIELD_DEFINITIONS } from "./report-types";
+
+// ─── Prisma model name mapping ───────────────────────────────────────────────
+
+const MODEL_MAP: Record<DataSource, string> = {
+  assets: "asset",
+  models: "model",
+  projects: "project",
+  kits: "kit",
+  lineItems: "projectLineItem",
+  clients: "client",
+  locations: "location",
+  maintenance: "maintenanceRecord",
+  activityLog: "activityLog",
+  crew: "crewMember",
+  crewAssignments: "crewAssignment",
+};
+
+// ─── Filter translation ──────────────────────────────────────────────────────
+
+function buildFilterCondition(filter: FilterConfig): Record<string, unknown> {
+  const { field, operator, value } = filter;
+  const parts = field.split(".");
+
+  // Build nested condition for relation fields
+  const buildNested = (parts: string[], condition: unknown): Record<string, unknown> => {
+    if (parts.length === 1) return { [parts[0]]: condition };
+    return { [parts[0]]: buildNested(parts.slice(1), condition) };
+  };
+
+  let condition: unknown;
+  switch (operator) {
+    case "equals":
+      condition = value;
+      break;
+    case "not_equals":
+      condition = { not: value };
+      break;
+    case "contains":
+      condition = { contains: value, mode: "insensitive" };
+      break;
+    case "not_contains":
+      condition = { not: { contains: value, mode: "insensitive" } };
+      break;
+    case "gt":
+      condition = { gt: value };
+      break;
+    case "gte":
+      condition = { gte: value };
+      break;
+    case "lt":
+      condition = { lt: value };
+      break;
+    case "lte":
+      condition = { lte: value };
+      break;
+    case "in":
+      condition = { in: Array.isArray(value) ? value : [value] };
+      break;
+    case "not_in":
+      condition = { notIn: Array.isArray(value) ? value : [value] };
+      break;
+    case "is_empty":
+      condition = null;
+      break;
+    case "is_not_empty":
+      condition = { not: null };
+      break;
+    case "between":
+      if (Array.isArray(value) && value.length === 2) {
+        condition = { gte: value[0], lte: value[1] };
+      }
+      break;
+    default:
+      condition = value;
+  }
+
+  return buildNested(parts, condition);
+}
+
+// ─── Select/Include builder ──────────────────────────────────────────────────
+
+function buildSelectAndInclude(
+  columns: ColumnConfig[],
+  dataSource: DataSource,
+): { select?: Record<string, unknown>; include?: Record<string, unknown> } {
+  const fields = FIELD_DEFINITIONS[dataSource];
+  const visibleFields = columns.filter((c) => c.visible);
+
+  // If no columns selected, use include-based approach
+  if (visibleFields.length === 0) {
+    return {};
+  }
+
+  const include: Record<string, unknown> = {};
+  const needsRelations = new Set<string>();
+
+  for (const col of visibleFields) {
+    const parts = col.field.split(".");
+    if (parts.length > 1 && !parts[0].startsWith("_")) {
+      needsRelations.add(parts[0]);
+    }
+  }
+
+  // Build include for data sources that need computed fields or relations
+  for (const rel of needsRelations) {
+    if (rel === "model") {
+      include.model = { include: { category: true } };
+    } else if (rel === "project") {
+      include.project = { include: { client: true, location: true } };
+    } else if (rel === "crewMember") {
+      include.crewMember = true;
+    } else if (rel === "crewRole") {
+      include.crewRole = true;
+    } else {
+      include[rel] = true;
+    }
+  }
+
+  // Add _count for computed fields
+  const hasCountField = visibleFields.some((c) => c.field.startsWith("_count."));
+  if (hasCountField) {
+    include._count = { select: { assets: true } };
+  }
+
+  return Object.keys(include).length > 0 ? { include } : {};
+}
+
+// ─── Date range resolution ───────────────────────────────────────────────────
+
+function resolveDateRange(config: ReportConfig): FilterConfig | null {
+  if (!config.dateRange) return null;
+
+  const { field, start, end, preset } = config.dateRange;
+  const now = new Date();
+
+  let rangeStart: string | undefined = start;
+  let rangeEnd: string | undefined = end;
+
+  if (preset) {
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    switch (preset) {
+      case "last7days":
+        rangeStart = new Date(today.getTime() - 7 * 86400000).toISOString();
+        rangeEnd = now.toISOString();
+        break;
+      case "last30days":
+        rangeStart = new Date(today.getTime() - 30 * 86400000).toISOString();
+        rangeEnd = now.toISOString();
+        break;
+      case "thisMonth":
+        rangeStart = new Date(today.getFullYear(), today.getMonth(), 1).toISOString();
+        rangeEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0, 23, 59, 59).toISOString();
+        break;
+      case "lastMonth": {
+        const lm = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+        rangeStart = lm.toISOString();
+        rangeEnd = new Date(today.getFullYear(), today.getMonth(), 0, 23, 59, 59).toISOString();
+        break;
+      }
+      case "thisQuarter": {
+        const q = Math.floor(today.getMonth() / 3);
+        rangeStart = new Date(today.getFullYear(), q * 3, 1).toISOString();
+        rangeEnd = new Date(today.getFullYear(), q * 3 + 3, 0, 23, 59, 59).toISOString();
+        break;
+      }
+      case "thisYear":
+        rangeStart = new Date(today.getFullYear(), 0, 1).toISOString();
+        rangeEnd = new Date(today.getFullYear(), 11, 31, 23, 59, 59).toISOString();
+        break;
+      case "lastYear":
+        rangeStart = new Date(today.getFullYear() - 1, 0, 1).toISOString();
+        rangeEnd = new Date(today.getFullYear() - 1, 11, 31, 23, 59, 59).toISOString();
+        break;
+      case "next90days":
+        rangeStart = now.toISOString();
+        rangeEnd = new Date(today.getTime() + 90 * 86400000).toISOString();
+        break;
+    }
+  }
+
+  if (rangeStart && rangeEnd) {
+    return { field, operator: "between", value: [rangeStart, rangeEnd] };
+  } else if (rangeStart) {
+    return { field, operator: "gte", value: rangeStart };
+  } else if (rangeEnd) {
+    return { field, operator: "lte", value: rangeEnd };
+  }
+  return null;
+}
+
+// ─── Sort builder ────────────────────────────────────────────────────────────
+
+function buildOrderBy(config: ReportConfig): Record<string, unknown>[] {
+  if (!config.sortBy?.length) return [{ createdAt: "desc" }];
+
+  return config.sortBy.map((sort) => {
+    const parts = sort.field.split(".");
+    if (parts.length === 1) return { [parts[0]]: sort.direction };
+    // Nested sort
+    let obj: Record<string, unknown> = { [parts[parts.length - 1]]: sort.direction };
+    for (let i = parts.length - 2; i >= 0; i--) {
+      obj = { [parts[i]]: obj };
+    }
+    return obj;
+  }).filter((o) => {
+    // Skip computed field sorts - handle in post-processing
+    const key = Object.keys(o)[0];
+    return !key.startsWith("_");
+  });
+}
+
+// ─── Flatten nested row data ─────────────────────────────────────────────────
+
+function flattenRow(row: Record<string, unknown>, columns: ColumnConfig[]): Record<string, unknown> {
+  const flat: Record<string, unknown> = {};
+
+  for (const col of columns) {
+    if (!col.visible) continue;
+    const parts = col.field.split(".");
+    let value: unknown = row;
+    for (const part of parts) {
+      if (value == null) break;
+      value = (value as Record<string, unknown>)[part];
+    }
+    // Convert Decimal-like values
+    if (value != null && typeof value === "object" && "toNumber" in (value as object)) {
+      value = (value as { toNumber(): number }).toNumber();
+    }
+    flat[col.field] = value ?? null;
+  }
+
+  return flat;
+}
+
+// ─── Compute aggregations ────────────────────────────────────────────────────
+
+function computeAggregations(
+  rows: Record<string, unknown>[],
+  columns: ColumnConfig[],
+  fields: FieldDefinition[],
+): Record<string, number> {
+  const aggs: Record<string, number> = {};
+  const numericFields = fields.filter((f) => f.type === "number");
+
+  for (const col of columns) {
+    if (!col.visible) continue;
+    const fieldDef = numericFields.find((f) => f.field === col.field);
+    if (!fieldDef) continue;
+
+    let sum = 0;
+    let count = 0;
+    for (const row of rows) {
+      const val = row[col.field];
+      if (val != null && typeof val === "number") {
+        sum += val;
+        count++;
+      }
+    }
+    if (count > 0) {
+      aggs[`sum:${col.field}`] = sum;
+      aggs[`avg:${col.field}`] = sum / count;
+      aggs[`count:${col.field}`] = count;
+    }
+  }
+
+  aggs["totalRows"] = rows.length;
+  return aggs;
+}
+
+// ─── Group By execution ──────────────────────────────────────────────────────
+
+async function executeGroupedReport(
+  config: ReportConfig,
+  organizationId: string,
+): Promise<ReportResult> {
+  if (!config.groupBy) throw new Error("No groupBy config");
+
+  const modelName = MODEL_MAP[config.dataSource];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const model = (prisma as any)[modelName] as {
+    findMany: (args: Record<string, unknown>) => Promise<unknown[]>;
+  };
+
+  // Build where clause
+  const where: Record<string, unknown> = { organizationId };
+
+  // Apply isTemplate filter for projects
+  if (config.dataSource === "projects") {
+    where.isTemplate = false;
+  }
+
+  // Apply isActive filter unless includeInactive
+  if (!config.includeInactive) {
+    const hasIsActive = FIELD_DEFINITIONS[config.dataSource].some(
+      (f) => f.field === "isActive"
+    );
+    if (hasIsActive && !config.filters.some((f) => f.field === "isActive")) {
+      where.isActive = true;
+    }
+  }
+
+  // Apply filters
+  for (const filter of config.filters) {
+    if (filter.field === "isTemplate") {
+      where.isTemplate = filter.value;
+      continue;
+    }
+    const cond = buildFilterCondition(filter);
+    Object.assign(where, cond);
+  }
+
+  // Apply date range
+  const dateFilter = resolveDateRange(config);
+  if (dateFilter) {
+    Object.assign(where, buildFilterCondition(dateFilter));
+  }
+
+  // Fetch all matching rows with relations
+  const { include } = buildSelectAndInclude(config.columns, config.dataSource);
+  const allRows = await model.findMany({
+    where,
+    ...(include ? { include } : {}),
+  }) as Record<string, unknown>[];
+
+  // Flatten all rows
+  const flatRows = allRows.map((row) => flattenRow(row, config.columns));
+
+  // Group by the specified field
+  const groupField = config.groupBy.field;
+  const groups = new Map<string, Record<string, unknown>[]>();
+
+  for (const row of flatRows) {
+    const key = String(row[groupField] ?? "(No value)");
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(row);
+  }
+
+  // Build aggregated rows
+  const resultRows: Record<string, unknown>[] = [];
+  for (const [groupKey, groupRows] of groups) {
+    const aggregatedRow: Record<string, unknown> = { [groupField]: groupKey };
+
+    const aggColumns: Array<{ field: string; function: string; label?: string }> = config.groupBy!.aggregateColumns;
+    for (let ai = 0; ai < aggColumns.length; ai++) {
+      const aggField = aggColumns[ai].field;
+      const aggFunc = aggColumns[ai].function;
+      const label: string = aggColumns[ai].label || `${aggFunc}(${aggField})`;
+      if (aggField === "*" && aggFunc === "count") {
+        aggregatedRow[label] = groupRows.length;
+      } else {
+        const values = groupRows
+          .map((r) => r[aggField])
+          .filter((v): v is number => typeof v === "number");
+
+        switch (aggFunc) {
+          case "count":
+            aggregatedRow[label] = values.length;
+            break;
+          case "sum":
+            aggregatedRow[label] = values.reduce((a, b) => a + b, 0);
+            break;
+          case "avg":
+            aggregatedRow[label] = values.length > 0
+              ? values.reduce((a, b) => a + b, 0) / values.length
+              : 0;
+            break;
+          case "min":
+            aggregatedRow[label] = values.length > 0 ? Math.min(...values) : 0;
+            break;
+          case "max":
+            aggregatedRow[label] = values.length > 0 ? Math.max(...values) : 0;
+            break;
+        }
+      }
+    }
+
+    resultRows.push(aggregatedRow);
+  }
+
+  // Build columns for grouped result
+  const groupedColumns: ColumnConfig[] = [
+    { field: groupField, visible: true, label: config.columns.find((c) => c.field === groupField)?.label },
+    ...config.groupBy.aggregateColumns.map((agg) => ({
+      field: agg.label || `${agg.function}(${agg.field})`,
+      visible: true,
+      label: agg.label || `${agg.function}(${agg.field})`,
+    })),
+  ];
+
+  // Sort grouped results
+  if (config.sortBy?.length) {
+    const sort = config.sortBy[0];
+    resultRows.sort((a, b) => {
+      const aVal = a[sort.field] ?? a[Object.keys(a)[0]];
+      const bVal = b[sort.field] ?? b[Object.keys(b)[0]];
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sort.direction === "asc" ? aVal - bVal : bVal - aVal;
+      }
+      return sort.direction === "asc"
+        ? String(aVal).localeCompare(String(bVal))
+        : String(bVal).localeCompare(String(aVal));
+    });
+  }
+
+  return {
+    rows: resultRows,
+    totalRows: resultRows.length,
+    columns: groupedColumns,
+    executedAt: new Date().toISOString(),
+  };
+}
+
+// ─── Computed field post-processing ──────────────────────────────────────────
+
+async function addComputedFields(
+  rows: Record<string, unknown>[],
+  config: ReportConfig,
+  organizationId: string,
+): Promise<void> {
+  const computedCols = config.columns.filter((c) => c.visible && c.field.startsWith("_"));
+
+  if (computedCols.length === 0) return;
+
+  if (config.dataSource === "models") {
+    for (const row of rows) {
+      const modelId = (row as Record<string, unknown>)["id"] as string;
+      if (!modelId) continue;
+
+      const needsAvailable = computedCols.some((c) => c.field === "_availableCount");
+      const needsCheckedOut = computedCols.some((c) => c.field === "_checkedOutCount");
+      const needsRevenue = computedCols.some((c) => c.field === "_totalRevenue");
+
+      if (needsAvailable || needsCheckedOut) {
+        const statusCounts = await prisma.asset.groupBy({
+          by: ["status"],
+          where: { organizationId, modelId, isActive: true },
+          _count: { status: true },
+        });
+        if (needsAvailable) {
+          row["_availableCount"] = statusCounts.find((s) => s.status === "AVAILABLE")?._count.status ?? 0;
+        }
+        if (needsCheckedOut) {
+          row["_checkedOutCount"] = statusCounts.find((s) => s.status === "CHECKED_OUT")?._count.status ?? 0;
+        }
+      }
+
+      if (needsRevenue) {
+        const result = await prisma.projectLineItem.aggregate({
+          where: { organizationId, modelId },
+          _sum: { lineTotal: true },
+        });
+        row["_totalRevenue"] = result._sum.lineTotal ? Number(result._sum.lineTotal) : 0;
+      }
+    }
+  }
+
+  if (config.dataSource === "clients") {
+    for (const row of rows) {
+      const clientId = (row as Record<string, unknown>)["id"] as string;
+      if (!clientId) continue;
+
+      const needsProjects = computedCols.some((c) => c.field === "_totalProjects");
+      const needsRevenue = computedCols.some((c) => c.field === "_totalRevenue");
+
+      if (needsProjects || needsRevenue) {
+        const projects = await prisma.project.findMany({
+          where: { organizationId, clientId, isTemplate: false },
+          select: { total: true },
+        });
+        if (needsProjects) {
+          row["_totalProjects"] = projects.length;
+        }
+        if (needsRevenue) {
+          row["_totalRevenue"] = projects.reduce((sum, p) => sum + (p.total ? Number(p.total) : 0), 0);
+        }
+      }
+    }
+  }
+
+  if (config.dataSource === "locations") {
+    for (const row of rows) {
+      const locationId = (row as Record<string, unknown>)["id"] as string;
+      if (!locationId) continue;
+
+      const needsAssets = computedCols.some((c) => c.field === "_assetCount");
+      const needsKits = computedCols.some((c) => c.field === "_kitCount");
+
+      if (needsAssets) {
+        row["_assetCount"] = await prisma.asset.count({
+          where: { organizationId, locationId, isActive: true },
+        });
+      }
+      if (needsKits) {
+        row["_kitCount"] = await prisma.kit.count({
+          where: { organizationId, locationId, isActive: true },
+        });
+      }
+    }
+  }
+
+  if (config.dataSource === "kits") {
+    for (const row of rows) {
+      const kitId = (row as Record<string, unknown>)["id"] as string;
+      if (!kitId) continue;
+
+      const needsSerialized = computedCols.some((c) => c.field === "_serializedItemCount");
+      const needsBulk = computedCols.some((c) => c.field === "_bulkItemCount");
+
+      if (needsSerialized) {
+        row["_serializedItemCount"] = await prisma.kitSerializedItem.count({
+          where: { kitId },
+        });
+      }
+      if (needsBulk) {
+        row["_bulkItemCount"] = await prisma.kitBulkItem.count({
+          where: { kitId },
+        });
+      }
+    }
+  }
+
+  if (config.dataSource === "projects") {
+    for (const row of rows) {
+      const projectId = (row as Record<string, unknown>)["id"] as string;
+      if (!projectId) continue;
+
+      const needsLineItems = computedCols.some((c) => c.field === "_lineItemCount");
+      if (needsLineItems) {
+        row["_lineItemCount"] = await prisma.projectLineItem.count({
+          where: { organizationId, projectId },
+        });
+      }
+    }
+  }
+
+  if (config.dataSource === "crew") {
+    for (const row of rows) {
+      const crewId = (row as Record<string, unknown>)["id"] as string;
+      if (!crewId) continue;
+
+      const needsAssignments = computedCols.some((c) => c.field === "_totalAssignments");
+      if (needsAssignments) {
+        row["_totalAssignments"] = await prisma.crewAssignment.count({
+          where: { organizationId, crewMemberId: crewId },
+        });
+      }
+    }
+  }
+}
+
+// ─── Main execution function ─────────────────────────────────────────────────
+
+export async function executeReport(
+  config: ReportConfig,
+  organizationId: string,
+  page = 1,
+  pageSize = 100,
+): Promise<ReportResult> {
+  // Grouped reports use a different path
+  if (config.groupBy) {
+    return executeGroupedReport(config, organizationId);
+  }
+
+  const modelName = MODEL_MAP[config.dataSource];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const model = (prisma as any)[modelName] as {
+    findMany: (args: Record<string, unknown>) => Promise<unknown[]>;
+    count: (args: Record<string, unknown>) => Promise<number>;
+  };
+
+  // Build where clause
+  const where: Record<string, unknown> = { organizationId };
+
+  // Apply isTemplate filter for projects
+  if (config.dataSource === "projects") {
+    where.isTemplate = false;
+  }
+
+  // Apply isActive filter unless includeInactive
+  if (!config.includeInactive) {
+    const hasIsActive = FIELD_DEFINITIONS[config.dataSource].some(
+      (f) => f.field === "isActive"
+    );
+    if (hasIsActive && !config.filters.some((f) => f.field === "isActive")) {
+      where.isActive = true;
+    }
+  }
+
+  // Apply filters
+  for (const filter of config.filters) {
+    if (filter.field === "isTemplate") {
+      where.isTemplate = filter.value;
+      continue;
+    }
+    const cond = buildFilterCondition(filter);
+    // Merge nested conditions carefully
+    for (const [key, val] of Object.entries(cond)) {
+      if (typeof val === "object" && val !== null && !Array.isArray(val) && where[key] && typeof where[key] === "object") {
+        where[key] = { ...(where[key] as Record<string, unknown>), ...(val as Record<string, unknown>) };
+      } else {
+        where[key] = val;
+      }
+    }
+  }
+
+  // Apply date range
+  const dateFilter = resolveDateRange(config);
+  if (dateFilter) {
+    const cond = buildFilterCondition(dateFilter);
+    for (const [key, val] of Object.entries(cond)) {
+      if (typeof val === "object" && val !== null && !Array.isArray(val) && where[key] && typeof where[key] === "object") {
+        where[key] = { ...(where[key] as Record<string, unknown>), ...(val as Record<string, unknown>) };
+      } else {
+        where[key] = val;
+      }
+    }
+  }
+
+  // Build query components
+  const { include } = buildSelectAndInclude(config.columns, config.dataSource);
+  const orderBy = buildOrderBy(config);
+  const take = config.limit || pageSize;
+  const skip = (page - 1) * take;
+
+  // Execute query
+  const [rawRows, totalRows] = await Promise.all([
+    model.findMany({
+      where,
+      ...(include ? { include } : {}),
+      orderBy: orderBy.length > 0 ? orderBy : undefined,
+      take,
+      skip,
+    }),
+    model.count({ where }),
+  ]);
+
+  const rows = rawRows as Record<string, unknown>[];
+
+  // Add computed fields
+  await addComputedFields(rows, config, organizationId);
+
+  // Flatten rows to include only visible columns
+  const flatRows = rows.map((row) => flattenRow(row, config.columns));
+
+  // Compute aggregations
+  const fields = FIELD_DEFINITIONS[config.dataSource];
+  const aggregations = computeAggregations(flatRows, config.columns, fields);
+
+  return {
+    rows: flatRows,
+    totalRows,
+    columns: config.columns.filter((c) => c.visible),
+    aggregations,
+    executedAt: new Date().toISOString(),
+  };
+}
+
+// ─── CSV generation ──────────────────────────────────────────────────────────
+
+export function generateCSV(result: ReportResult): string {
+  const cols = result.columns.filter((c) => c.visible);
+  const fields = FIELD_DEFINITIONS;
+
+  // Header row
+  const headers = cols.map((c) => {
+    const label = c.label || c.field;
+    // Escape quotes in CSV
+    return `"${label.replace(/"/g, '""')}"`;
+  });
+
+  // Data rows
+  const dataRows = result.rows.map((row) => {
+    return cols.map((c) => {
+      let val = row[c.field];
+      if (val == null) return '""';
+      if (val instanceof Date) {
+        val = (val as Date).toISOString().split("T")[0];
+      }
+      if (typeof val === "number") {
+        return String(val);
+      }
+      return `"${String(val).replace(/"/g, '""')}"`;
+    });
+  });
+
+  return [headers.join(","), ...dataRows.map((r) => r.join(","))].join("\n");
+}

--- a/src/lib/report-types.ts
+++ b/src/lib/report-types.ts
@@ -1,0 +1,903 @@
+/**
+ * Report system type definitions.
+ * Shared between client and server.
+ */
+
+export const DATA_SOURCES = [
+  "assets",
+  "models",
+  "projects",
+  "kits",
+  "lineItems",
+  "clients",
+  "locations",
+  "maintenance",
+  "activityLog",
+  "crew",
+  "crewAssignments",
+] as const;
+
+export type DataSource = (typeof DATA_SOURCES)[number];
+
+export const DATA_SOURCE_LABELS: Record<DataSource, string> = {
+  assets: "Assets",
+  models: "Models",
+  projects: "Projects",
+  kits: "Kits",
+  lineItems: "Line Items",
+  clients: "Clients",
+  locations: "Locations",
+  maintenance: "Maintenance",
+  activityLog: "Activity Log",
+  crew: "Crew Members",
+  crewAssignments: "Crew Assignments",
+};
+
+export const DATA_SOURCE_ICONS: Record<DataSource, string> = {
+  assets: "Package",
+  models: "Boxes",
+  projects: "FolderOpen",
+  kits: "Box",
+  lineItems: "List",
+  clients: "Users",
+  locations: "MapPin",
+  maintenance: "Wrench",
+  activityLog: "ScrollText",
+  crew: "HardHat",
+  crewAssignments: "UserCheck",
+};
+
+export const DATA_SOURCE_DESCRIPTIONS: Record<DataSource, string> = {
+  assets: "Serialized asset inventory, status, and history",
+  models: "Equipment models with utilisation and popularity",
+  projects: "Projects with financials, status, and dates",
+  kits: "Kit containers and their contents",
+  lineItems: "Individual rental line items across projects",
+  clients: "Client information and revenue metrics",
+  locations: "Warehouses, venues, and site locations",
+  maintenance: "Maintenance records and costs",
+  activityLog: "Audit trail of all user actions",
+  crew: "Crew members, skills, and availability",
+  crewAssignments: "Crew assignments, hours, and costs",
+};
+
+export type FilterOperator =
+  | "equals"
+  | "not_equals"
+  | "contains"
+  | "not_contains"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "in"
+  | "not_in"
+  | "is_empty"
+  | "is_not_empty"
+  | "between";
+
+export type AggregateFunction = "count" | "sum" | "avg" | "min" | "max";
+
+export interface ColumnConfig {
+  field: string;
+  label?: string;
+  visible: boolean;
+  width?: number;
+}
+
+export interface FilterConfig {
+  field: string;
+  operator: FilterOperator;
+  value: string | number | boolean | string[] | [string, string];
+}
+
+export interface GroupByConfig {
+  field: string;
+  aggregateColumns: {
+    field: string;
+    function: AggregateFunction;
+    label?: string;
+  }[];
+}
+
+export interface SortConfig {
+  field: string;
+  direction: "asc" | "desc";
+}
+
+export interface DateRangeConfig {
+  field: string;
+  start?: string;
+  end?: string;
+  preset?: string;
+}
+
+export interface ReportConfig {
+  dataSource: DataSource;
+  columns: ColumnConfig[];
+  filters: FilterConfig[];
+  groupBy?: GroupByConfig;
+  sortBy?: SortConfig[];
+  dateRange?: DateRangeConfig;
+  limit?: number;
+  includeInactive?: boolean;
+}
+
+export interface ReportResult {
+  rows: Record<string, unknown>[];
+  totalRows: number;
+  columns: ColumnConfig[];
+  aggregations?: Record<string, number>;
+  executedAt: string;
+}
+
+// ─── Field Definitions ────────────────────────────────────────────────────────
+
+export type FieldType = "string" | "number" | "date" | "boolean" | "enum";
+
+export interface FieldDefinition {
+  field: string;
+  label: string;
+  type: FieldType;
+  section: "core" | "related" | "computed";
+  enumValues?: string[];
+  enumLabels?: Record<string, string>;
+}
+
+// ─── Data Source Field Definitions ────────────────────────────────────────────
+
+export const FIELD_DEFINITIONS: Record<DataSource, FieldDefinition[]> = {
+  assets: [
+    { field: "assetTag", label: "Asset Tag", type: "string", section: "core" },
+    { field: "customName", label: "Custom Name", type: "string", section: "core" },
+    { field: "serialNumber", label: "Serial Number", type: "string", section: "core" },
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["AVAILABLE", "CHECKED_OUT", "IN_MAINTENANCE", "RETIRED", "LOST", "RESERVED"], enumLabels: { AVAILABLE: "Available", CHECKED_OUT: "Deployed", IN_MAINTENANCE: "In Maintenance", RETIRED: "Retired", LOST: "Lost", RESERVED: "Reserved" } },
+    { field: "condition", label: "Condition", type: "enum", section: "core", enumValues: ["NEW", "GOOD", "FAIR", "POOR", "DAMAGED"], enumLabels: { NEW: "New", GOOD: "Good", FAIR: "Fair", POOR: "Poor", DAMAGED: "Damaged" } },
+    { field: "purchaseDate", label: "Purchase Date", type: "date", section: "core" },
+    { field: "purchasePrice", label: "Purchase Price", type: "number", section: "core" },
+    { field: "warrantyExpiry", label: "Warranty Expiry", type: "date", section: "core" },
+    { field: "notes", label: "Notes", type: "string", section: "core" },
+    { field: "isActive", label: "Active", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "model.name", label: "Model Name", type: "string", section: "related" },
+    { field: "model.manufacturer", label: "Manufacturer", type: "string", section: "related" },
+    { field: "model.modelNumber", label: "Model Number", type: "string", section: "related" },
+    { field: "model.category.name", label: "Category", type: "string", section: "related" },
+    { field: "model.defaultRentalPrice", label: "Rental Price", type: "number", section: "related" },
+    { field: "model.replacementCost", label: "Replacement Cost", type: "number", section: "related" },
+    { field: "model.weight", label: "Weight", type: "number", section: "related" },
+    { field: "location.name", label: "Location", type: "string", section: "related" },
+    { field: "supplier.name", label: "Supplier", type: "string", section: "related" },
+    { field: "kit.name", label: "Kit", type: "string", section: "related" },
+  ],
+
+  models: [
+    { field: "name", label: "Name", type: "string", section: "core" },
+    { field: "manufacturer", label: "Manufacturer", type: "string", section: "core" },
+    { field: "modelNumber", label: "Model Number", type: "string", section: "core" },
+    { field: "defaultRentalPrice", label: "Rental Price", type: "number", section: "core" },
+    { field: "defaultPurchasePrice", label: "Purchase Price", type: "number", section: "core" },
+    { field: "replacementCost", label: "Replacement Cost", type: "number", section: "core" },
+    { field: "weight", label: "Weight (kg)", type: "number", section: "core" },
+    { field: "powerDraw", label: "Power Draw (W)", type: "number", section: "core" },
+    { field: "assetType", label: "Asset Type", type: "enum", section: "core", enumValues: ["SERIALIZED", "BULK"], enumLabels: { SERIALIZED: "Serialized", BULK: "Bulk" } },
+    { field: "isActive", label: "Active", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "category.name", label: "Category", type: "string", section: "related" },
+    { field: "_count.assets", label: "Total Assets", type: "number", section: "computed" },
+    { field: "_availableCount", label: "Available Count", type: "number", section: "computed" },
+    { field: "_checkedOutCount", label: "Deployed Count", type: "number", section: "computed" },
+    { field: "_totalRevenue", label: "Total Revenue", type: "number", section: "computed" },
+  ],
+
+  projects: [
+    { field: "projectNumber", label: "Project Number", type: "string", section: "core" },
+    { field: "name", label: "Name", type: "string", section: "core" },
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["ENQUIRY", "QUOTING", "QUOTED", "CONFIRMED", "PREPPING", "CHECKED_OUT", "ON_SITE", "RETURNED", "COMPLETED", "INVOICED", "CANCELLED"], enumLabels: { ENQUIRY: "Enquiry", QUOTING: "Quoting", QUOTED: "Quoted", CONFIRMED: "Confirmed", PREPPING: "Prepping", CHECKED_OUT: "Deployed", ON_SITE: "On Site", RETURNED: "Returned", COMPLETED: "Completed", INVOICED: "Invoiced", CANCELLED: "Cancelled" } },
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["DRY_HIRE", "WET_HIRE", "INSTALLATION", "TOUR", "CORPORATE", "THEATRE", "FESTIVAL", "CONFERENCE", "OTHER"] },
+    { field: "loadInDate", label: "Load In Date", type: "date", section: "core" },
+    { field: "eventStartDate", label: "Event Start", type: "date", section: "core" },
+    { field: "eventEndDate", label: "Event End", type: "date", section: "core" },
+    { field: "loadOutDate", label: "Load Out Date", type: "date", section: "core" },
+    { field: "rentalStartDate", label: "Rental Start", type: "date", section: "core" },
+    { field: "rentalEndDate", label: "Rental End", type: "date", section: "core" },
+    { field: "subtotal", label: "Subtotal", type: "number", section: "core" },
+    { field: "discountPercent", label: "Discount %", type: "number", section: "core" },
+    { field: "taxAmount", label: "Tax Amount", type: "number", section: "core" },
+    { field: "total", label: "Total", type: "number", section: "core" },
+    { field: "depositPaid", label: "Deposit Paid", type: "number", section: "core" },
+    { field: "invoicedTotal", label: "Invoiced Total", type: "number", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "client.name", label: "Client", type: "string", section: "related" },
+    { field: "client.type", label: "Client Type", type: "string", section: "related" },
+    { field: "location.name", label: "Location", type: "string", section: "related" },
+    { field: "projectManager.name", label: "Project Manager", type: "string", section: "related" },
+    { field: "_lineItemCount", label: "Line Items", type: "number", section: "computed" },
+  ],
+
+  kits: [
+    { field: "assetTag", label: "Asset Tag", type: "string", section: "core" },
+    { field: "name", label: "Name", type: "string", section: "core" },
+    { field: "description", label: "Description", type: "string", section: "core" },
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["AVAILABLE", "CHECKED_OUT", "IN_MAINTENANCE", "RETIRED", "INCOMPLETE"], enumLabels: { AVAILABLE: "Available", CHECKED_OUT: "Deployed", IN_MAINTENANCE: "In Maintenance", RETIRED: "Retired", INCOMPLETE: "Incomplete" } },
+    { field: "condition", label: "Condition", type: "enum", section: "core", enumValues: ["NEW", "GOOD", "FAIR", "POOR", "DAMAGED"] },
+    { field: "weight", label: "Weight", type: "number", section: "core" },
+    { field: "caseType", label: "Case Type", type: "string", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "category.name", label: "Category", type: "string", section: "related" },
+    { field: "location.name", label: "Location", type: "string", section: "related" },
+    { field: "_serializedItemCount", label: "Serialized Items", type: "number", section: "computed" },
+    { field: "_bulkItemCount", label: "Bulk Items", type: "number", section: "computed" },
+  ],
+
+  lineItems: [
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["EQUIPMENT", "SERVICE", "LABOUR", "TRANSPORT", "MISC"] },
+    { field: "description", label: "Description", type: "string", section: "core" },
+    { field: "quantity", label: "Quantity", type: "number", section: "core" },
+    { field: "unitPrice", label: "Unit Price", type: "number", section: "core" },
+    { field: "pricingType", label: "Pricing Type", type: "enum", section: "core", enumValues: ["PER_DAY", "PER_WEEK", "FLAT", "PER_HOUR"] },
+    { field: "duration", label: "Duration", type: "number", section: "core" },
+    { field: "discount", label: "Discount", type: "number", section: "core" },
+    { field: "lineTotal", label: "Line Total", type: "number", section: "core" },
+    { field: "groupName", label: "Group", type: "string", section: "core" },
+    { field: "isOptional", label: "Optional", type: "boolean", section: "core" },
+    { field: "isSubhire", label: "Subhire", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "project.projectNumber", label: "Project #", type: "string", section: "related" },
+    { field: "project.name", label: "Project Name", type: "string", section: "related" },
+    { field: "project.status", label: "Project Status", type: "string", section: "related" },
+    { field: "project.client.name", label: "Client", type: "string", section: "related" },
+    { field: "model.name", label: "Model", type: "string", section: "related" },
+    { field: "model.category.name", label: "Category", type: "string", section: "related" },
+    { field: "asset.assetTag", label: "Asset Tag", type: "string", section: "related" },
+    { field: "kit.name", label: "Kit", type: "string", section: "related" },
+    { field: "supplier.name", label: "Supplier", type: "string", section: "related" },
+  ],
+
+  clients: [
+    { field: "name", label: "Name", type: "string", section: "core" },
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["COMPANY", "INDIVIDUAL", "VENUE", "PRODUCTION_COMPANY"], enumLabels: { COMPANY: "Company", INDIVIDUAL: "Individual", VENUE: "Venue", PRODUCTION_COMPANY: "Production Company" } },
+    { field: "contactName", label: "Contact Name", type: "string", section: "core" },
+    { field: "contactEmail", label: "Contact Email", type: "string", section: "core" },
+    { field: "contactPhone", label: "Contact Phone", type: "string", section: "core" },
+    { field: "paymentTerms", label: "Payment Terms", type: "string", section: "core" },
+    { field: "defaultDiscount", label: "Default Discount", type: "number", section: "core" },
+    { field: "isActive", label: "Active", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "_totalProjects", label: "Total Projects", type: "number", section: "computed" },
+    { field: "_totalRevenue", label: "Total Revenue", type: "number", section: "computed" },
+  ],
+
+  locations: [
+    { field: "name", label: "Name", type: "string", section: "core" },
+    { field: "address", label: "Address", type: "string", section: "core" },
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["WAREHOUSE", "VENUE", "VEHICLE", "OFFSITE"], enumLabels: { WAREHOUSE: "Warehouse", VENUE: "Venue", VEHICLE: "Vehicle", OFFSITE: "Offsite" } },
+    { field: "isDefault", label: "Default", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "parent.name", label: "Parent Location", type: "string", section: "related" },
+    { field: "_assetCount", label: "Asset Count", type: "number", section: "computed" },
+    { field: "_kitCount", label: "Kit Count", type: "number", section: "computed" },
+  ],
+
+  maintenance: [
+    { field: "title", label: "Title", type: "string", section: "core" },
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["REPAIR", "PREVENTATIVE", "TEST_AND_TAG", "INSPECTION", "CLEANING", "FIRMWARE_UPDATE"], enumLabels: { REPAIR: "Repair", PREVENTATIVE: "Preventative", TEST_AND_TAG: "Test & Tag", INSPECTION: "Inspection", CLEANING: "Cleaning", FIRMWARE_UPDATE: "Firmware Update" } },
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["SCHEDULED", "IN_PROGRESS", "COMPLETED", "CANCELLED"], enumLabels: { SCHEDULED: "Scheduled", IN_PROGRESS: "In Progress", COMPLETED: "Completed", CANCELLED: "Cancelled" } },
+    { field: "description", label: "Description", type: "string", section: "core" },
+    { field: "scheduledDate", label: "Scheduled Date", type: "date", section: "core" },
+    { field: "completedDate", label: "Completed Date", type: "date", section: "core" },
+    { field: "cost", label: "Cost", type: "number", section: "core" },
+    { field: "result", label: "Result", type: "enum", section: "core", enumValues: ["PASS", "FAIL", "CONDITIONAL"] },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "reportedBy.name", label: "Reported By", type: "string", section: "related" },
+    { field: "assignedTo.name", label: "Assigned To", type: "string", section: "related" },
+  ],
+
+  activityLog: [
+    { field: "action", label: "Action", type: "string", section: "core" },
+    { field: "entityType", label: "Entity Type", type: "string", section: "core" },
+    { field: "entityName", label: "Entity Name", type: "string", section: "core" },
+    { field: "summary", label: "Summary", type: "string", section: "core" },
+    { field: "userName", label: "User", type: "string", section: "core" },
+    { field: "createdAt", label: "Date", type: "date", section: "core" },
+  ],
+
+  crew: [
+    { field: "firstName", label: "First Name", type: "string", section: "core" },
+    { field: "lastName", label: "Last Name", type: "string", section: "core" },
+    { field: "email", label: "Email", type: "string", section: "core" },
+    { field: "phone", label: "Phone", type: "string", section: "core" },
+    { field: "type", label: "Type", type: "enum", section: "core", enumValues: ["EMPLOYEE", "FREELANCER", "CONTRACTOR", "VOLUNTEER"], enumLabels: { EMPLOYEE: "Employee", FREELANCER: "Freelancer", CONTRACTOR: "Contractor", VOLUNTEER: "Volunteer" } },
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["ACTIVE", "INACTIVE", "ON_LEAVE", "ARCHIVED"], enumLabels: { ACTIVE: "Active", INACTIVE: "Inactive", ON_LEAVE: "On Leave", ARCHIVED: "Archived" } },
+    { field: "department", label: "Department", type: "string", section: "core" },
+    { field: "defaultDayRate", label: "Day Rate", type: "number", section: "core" },
+    { field: "defaultHourlyRate", label: "Hourly Rate", type: "number", section: "core" },
+    { field: "isActive", label: "Active", type: "boolean", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "crewRole.name", label: "Role", type: "string", section: "related" },
+    { field: "_totalAssignments", label: "Total Assignments", type: "number", section: "computed" },
+  ],
+
+  crewAssignments: [
+    { field: "status", label: "Status", type: "enum", section: "core", enumValues: ["PENDING", "OFFERED", "ACCEPTED", "DECLINED", "CONFIRMED", "CANCELLED", "COMPLETED"], enumLabels: { PENDING: "Pending", OFFERED: "Offered", ACCEPTED: "Accepted", DECLINED: "Declined", CONFIRMED: "Confirmed", CANCELLED: "Cancelled", COMPLETED: "Completed" } },
+    { field: "phase", label: "Phase", type: "enum", section: "core", enumValues: ["BUMP_IN", "EVENT", "BUMP_OUT", "DELIVERY", "PICKUP", "SETUP", "REHEARSAL", "FULL_DURATION"] },
+    { field: "isProjectManager", label: "Project Manager", type: "boolean", section: "core" },
+    { field: "startDate", label: "Start Date", type: "date", section: "core" },
+    { field: "endDate", label: "End Date", type: "date", section: "core" },
+    { field: "rateOverride", label: "Rate Override", type: "number", section: "core" },
+    { field: "estimatedHours", label: "Estimated Hours", type: "number", section: "core" },
+    { field: "estimatedCost", label: "Estimated Cost", type: "number", section: "core" },
+    { field: "createdAt", label: "Created", type: "date", section: "core" },
+    { field: "crewMember.firstName", label: "First Name", type: "string", section: "related" },
+    { field: "crewMember.lastName", label: "Last Name", type: "string", section: "related" },
+    { field: "crewMember.type", label: "Crew Type", type: "string", section: "related" },
+    { field: "crewRole.name", label: "Role", type: "string", section: "related" },
+    { field: "project.projectNumber", label: "Project #", type: "string", section: "related" },
+    { field: "project.name", label: "Project Name", type: "string", section: "related" },
+    { field: "project.client.name", label: "Client", type: "string", section: "related" },
+  ],
+};
+
+// ─── Pre-Built Report Templates ──────────────────────────────────────────────
+
+export interface PreBuiltReport {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  icon: string;
+  config: ReportConfig;
+}
+
+export const PRE_BUILT_REPORTS: PreBuiltReport[] = [
+  // ─── Asset Reports ──────────────────────────────────────────────────
+  {
+    id: "asset-inventory",
+    name: "Asset Inventory",
+    description: "Complete list of all assets with status and location",
+    category: "Assets",
+    icon: "Package",
+    config: {
+      dataSource: "assets",
+      columns: [
+        { field: "assetTag", visible: true },
+        { field: "customName", visible: true },
+        { field: "model.name", visible: true },
+        { field: "model.manufacturer", visible: true },
+        { field: "model.category.name", visible: true },
+        { field: "status", visible: true },
+        { field: "condition", visible: true },
+        { field: "location.name", visible: true },
+        { field: "serialNumber", visible: true },
+      ],
+      filters: [],
+      sortBy: [{ field: "assetTag", direction: "asc" }],
+    },
+  },
+  {
+    id: "asset-utilisation",
+    name: "Asset Utilisation",
+    description: "How often each equipment model is rented out",
+    category: "Assets",
+    icon: "TrendingUp",
+    config: {
+      dataSource: "models",
+      columns: [
+        { field: "name", visible: true },
+        { field: "manufacturer", visible: true },
+        { field: "category.name", visible: true },
+        { field: "_count.assets", visible: true },
+        { field: "_availableCount", visible: true },
+        { field: "_checkedOutCount", visible: true },
+        { field: "defaultRentalPrice", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "_checkedOutCount", direction: "desc" }],
+    },
+  },
+  {
+    id: "model-popularity",
+    name: "Model Popularity",
+    description: "Most frequently booked equipment models",
+    category: "Assets",
+    icon: "Star",
+    config: {
+      dataSource: "models",
+      columns: [
+        { field: "name", visible: true },
+        { field: "manufacturer", visible: true },
+        { field: "category.name", visible: true },
+        { field: "_count.assets", visible: true },
+        { field: "_totalRevenue", visible: true },
+        { field: "defaultRentalPrice", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "_totalRevenue", direction: "desc" }],
+    },
+  },
+  {
+    id: "asset-value",
+    name: "Asset Value by Category",
+    description: "Total value of inventory grouped by category",
+    category: "Assets",
+    icon: "DollarSign",
+    config: {
+      dataSource: "assets",
+      columns: [
+        { field: "model.category.name", visible: true },
+        { field: "purchasePrice", visible: true },
+        { field: "model.replacementCost", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      groupBy: {
+        field: "model.category.name",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Asset Count" },
+          { field: "purchasePrice", function: "sum", label: "Total Purchase Value" },
+          { field: "model.replacementCost", function: "sum", label: "Total Replacement Value" },
+        ],
+      },
+      sortBy: [{ field: "model.category.name", direction: "asc" }],
+    },
+  },
+  {
+    id: "warranty-expiry",
+    name: "Warranty Expiry",
+    description: "Assets with warranties expiring in the next 90 days",
+    category: "Assets",
+    icon: "ShieldAlert",
+    config: {
+      dataSource: "assets",
+      columns: [
+        { field: "assetTag", visible: true },
+        { field: "model.name", visible: true },
+        { field: "model.manufacturer", visible: true },
+        { field: "warrantyExpiry", visible: true },
+        { field: "purchaseDate", visible: true },
+        { field: "supplier.name", visible: true },
+      ],
+      filters: [
+        { field: "warrantyExpiry", operator: "gte", value: new Date().toISOString().split("T")[0] },
+        { field: "isActive", operator: "equals", value: true },
+      ],
+      dateRange: { field: "warrantyExpiry", preset: "next90days" },
+      sortBy: [{ field: "warrantyExpiry", direction: "asc" }],
+    },
+  },
+
+  // ─── Project Reports ────────────────────────────────────────────────
+  {
+    id: "project-summary",
+    name: "Project Summary",
+    description: "All projects by status with financial totals",
+    category: "Projects",
+    icon: "FolderOpen",
+    config: {
+      dataSource: "projects",
+      columns: [
+        { field: "status", visible: true },
+        { field: "total", visible: true },
+      ],
+      filters: [{ field: "isTemplate", operator: "equals", value: false }],
+      groupBy: {
+        field: "status",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Project Count" },
+          { field: "total", function: "sum", label: "Total Value" },
+        ],
+      },
+      sortBy: [{ field: "status", direction: "asc" }],
+    },
+  },
+  {
+    id: "revenue-by-client",
+    name: "Revenue by Client",
+    description: "Total revenue grouped by client",
+    category: "Projects",
+    icon: "DollarSign",
+    config: {
+      dataSource: "projects",
+      columns: [
+        { field: "client.name", visible: true },
+        { field: "total", visible: true },
+      ],
+      filters: [
+        { field: "status", operator: "in", value: ["COMPLETED", "INVOICED"] },
+        { field: "isTemplate", operator: "equals", value: false },
+      ],
+      groupBy: {
+        field: "client.name",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Project Count" },
+          { field: "total", function: "sum", label: "Total Revenue" },
+          { field: "total", function: "avg", label: "Avg Project Value" },
+        ],
+      },
+      sortBy: [{ field: "total", direction: "desc" }],
+    },
+  },
+  {
+    id: "overdue-returns",
+    name: "Overdue Returns",
+    description: "Projects past their rental end date that are still active",
+    category: "Projects",
+    icon: "AlertTriangle",
+    config: {
+      dataSource: "projects",
+      columns: [
+        { field: "projectNumber", visible: true },
+        { field: "name", visible: true },
+        { field: "client.name", visible: true },
+        { field: "status", visible: true },
+        { field: "rentalEndDate", visible: true },
+        { field: "total", visible: true },
+        { field: "location.name", visible: true },
+      ],
+      filters: [
+        { field: "rentalEndDate", operator: "lt", value: new Date().toISOString().split("T")[0] },
+        { field: "status", operator: "in", value: ["CONFIRMED", "PREPPING", "CHECKED_OUT", "ON_SITE"] },
+        { field: "isTemplate", operator: "equals", value: false },
+      ],
+      sortBy: [{ field: "rentalEndDate", direction: "asc" }],
+    },
+  },
+  {
+    id: "projects-by-location",
+    name: "Projects by Location",
+    description: "All projects grouped by venue/location",
+    category: "Projects",
+    icon: "MapPin",
+    config: {
+      dataSource: "projects",
+      columns: [
+        { field: "location.name", visible: true },
+        { field: "total", visible: true },
+      ],
+      filters: [{ field: "isTemplate", operator: "equals", value: false }],
+      groupBy: {
+        field: "location.name",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Project Count" },
+          { field: "total", function: "sum", label: "Total Value" },
+        ],
+      },
+      sortBy: [{ field: "location.name", direction: "asc" }],
+    },
+  },
+  {
+    id: "subhire-summary",
+    name: "Subhire Summary",
+    description: "All subhired items across projects, grouped by supplier",
+    category: "Projects",
+    icon: "Truck",
+    config: {
+      dataSource: "lineItems",
+      columns: [
+        { field: "supplier.name", visible: true },
+        { field: "lineTotal", visible: true },
+      ],
+      filters: [{ field: "isSubhire", operator: "equals", value: true }],
+      groupBy: {
+        field: "supplier.name",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Item Count" },
+          { field: "lineTotal", function: "sum", label: "Total Cost" },
+        ],
+      },
+      sortBy: [{ field: "lineTotal", direction: "desc" }],
+    },
+  },
+  {
+    id: "project-profitability",
+    name: "Project Profitability",
+    description: "Revenue vs costs per project",
+    category: "Projects",
+    icon: "TrendingUp",
+    config: {
+      dataSource: "projects",
+      columns: [
+        { field: "projectNumber", visible: true },
+        { field: "name", visible: true },
+        { field: "client.name", visible: true },
+        { field: "status", visible: true },
+        { field: "total", visible: true },
+        { field: "eventStartDate", visible: true },
+        { field: "eventEndDate", visible: true },
+      ],
+      filters: [
+        { field: "status", operator: "in", value: ["COMPLETED", "INVOICED"] },
+        { field: "isTemplate", operator: "equals", value: false },
+      ],
+      sortBy: [{ field: "total", direction: "desc" }],
+    },
+  },
+
+  // ─── Kit Reports ────────────────────────────────────────────────────
+  {
+    id: "kit-inventory",
+    name: "Kit Inventory",
+    description: "All kits with contents summary",
+    category: "Kits",
+    icon: "Box",
+    config: {
+      dataSource: "kits",
+      columns: [
+        { field: "assetTag", visible: true },
+        { field: "name", visible: true },
+        { field: "status", visible: true },
+        { field: "condition", visible: true },
+        { field: "category.name", visible: true },
+        { field: "location.name", visible: true },
+        { field: "_serializedItemCount", visible: true },
+        { field: "_bulkItemCount", visible: true },
+      ],
+      filters: [],
+      sortBy: [{ field: "name", direction: "asc" }],
+    },
+  },
+  {
+    id: "kit-utilisation",
+    name: "Kit Utilisation",
+    description: "Kit checkout frequency and status",
+    category: "Kits",
+    icon: "BarChart3",
+    config: {
+      dataSource: "kits",
+      columns: [
+        { field: "assetTag", visible: true },
+        { field: "name", visible: true },
+        { field: "status", visible: true },
+        { field: "category.name", visible: true },
+        { field: "_serializedItemCount", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "name", direction: "asc" }],
+    },
+  },
+
+  // ─── Client Reports ─────────────────────────────────────────────────
+  {
+    id: "client-revenue",
+    name: "Client Revenue",
+    description: "Revenue per client with project count",
+    category: "Clients",
+    icon: "Users",
+    config: {
+      dataSource: "clients",
+      columns: [
+        { field: "name", visible: true },
+        { field: "type", visible: true },
+        { field: "contactName", visible: true },
+        { field: "contactEmail", visible: true },
+        { field: "_totalProjects", visible: true },
+        { field: "_totalRevenue", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "_totalRevenue", direction: "desc" }],
+    },
+  },
+  {
+    id: "top-clients",
+    name: "Top Clients",
+    description: "Highest revenue clients (top 20)",
+    category: "Clients",
+    icon: "Trophy",
+    config: {
+      dataSource: "clients",
+      columns: [
+        { field: "name", visible: true },
+        { field: "type", visible: true },
+        { field: "_totalProjects", visible: true },
+        { field: "_totalRevenue", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "_totalRevenue", direction: "desc" }],
+      limit: 20,
+    },
+  },
+
+  // ─── Maintenance Reports ────────────────────────────────────────────
+  {
+    id: "maintenance-costs",
+    name: "Maintenance Costs",
+    description: "Total maintenance spend by type",
+    category: "Maintenance",
+    icon: "Wrench",
+    config: {
+      dataSource: "maintenance",
+      columns: [
+        { field: "type", visible: true },
+        { field: "cost", visible: true },
+      ],
+      filters: [],
+      groupBy: {
+        field: "type",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Record Count" },
+          { field: "cost", function: "sum", label: "Total Cost" },
+          { field: "cost", function: "avg", label: "Avg Cost" },
+        ],
+      },
+      sortBy: [{ field: "type", direction: "asc" }],
+    },
+  },
+  {
+    id: "open-maintenance",
+    name: "Open Maintenance",
+    description: "All incomplete maintenance records",
+    category: "Maintenance",
+    icon: "Clock",
+    config: {
+      dataSource: "maintenance",
+      columns: [
+        { field: "title", visible: true },
+        { field: "type", visible: true },
+        { field: "status", visible: true },
+        { field: "scheduledDate", visible: true },
+        { field: "cost", visible: true },
+        { field: "assignedTo.name", visible: true },
+        { field: "reportedBy.name", visible: true },
+      ],
+      filters: [
+        { field: "status", operator: "in", value: ["SCHEDULED", "IN_PROGRESS"] },
+      ],
+      sortBy: [{ field: "scheduledDate", direction: "asc" }],
+    },
+  },
+
+  // ─── Crew Reports ───────────────────────────────────────────────────
+  {
+    id: "crew-roster",
+    name: "Crew Roster",
+    description: "Full crew list with roles, department, and rates",
+    category: "Crew",
+    icon: "HardHat",
+    config: {
+      dataSource: "crew",
+      columns: [
+        { field: "firstName", visible: true },
+        { field: "lastName", visible: true },
+        { field: "email", visible: true },
+        { field: "phone", visible: true },
+        { field: "type", visible: true },
+        { field: "status", visible: true },
+        { field: "department", visible: true },
+        { field: "crewRole.name", visible: true },
+        { field: "defaultDayRate", visible: true },
+        { field: "defaultHourlyRate", visible: true },
+      ],
+      filters: [{ field: "isActive", operator: "equals", value: true }],
+      sortBy: [{ field: "lastName", direction: "asc" }],
+    },
+  },
+  {
+    id: "crew-utilisation",
+    name: "Crew Utilisation",
+    description: "How many projects/hours each crew member has worked",
+    category: "Crew",
+    icon: "UserCheck",
+    config: {
+      dataSource: "crewAssignments",
+      columns: [
+        { field: "crewMember.firstName", visible: true },
+        { field: "crewMember.lastName", visible: true },
+        { field: "crewRole.name", visible: true },
+        { field: "project.name", visible: true },
+        { field: "status", visible: true },
+        { field: "phase", visible: true },
+        { field: "estimatedHours", visible: true },
+        { field: "estimatedCost", visible: true },
+      ],
+      filters: [
+        { field: "status", operator: "in", value: ["CONFIRMED", "COMPLETED"] },
+      ],
+      sortBy: [{ field: "crewMember.lastName", direction: "asc" }],
+    },
+  },
+  {
+    id: "labour-cost-by-project",
+    name: "Labour Cost by Project",
+    description: "Total labour cost per project",
+    category: "Crew",
+    icon: "Calculator",
+    config: {
+      dataSource: "crewAssignments",
+      columns: [
+        { field: "project.name", visible: true },
+        { field: "estimatedCost", visible: true },
+      ],
+      filters: [
+        { field: "status", operator: "in", value: ["CONFIRMED", "COMPLETED"] },
+      ],
+      groupBy: {
+        field: "project.name",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Crew Count" },
+          { field: "estimatedHours", function: "sum", label: "Total Hours" },
+          { field: "estimatedCost", function: "sum", label: "Total Cost" },
+        ],
+      },
+      sortBy: [{ field: "estimatedCost", direction: "desc" }],
+    },
+  },
+  {
+    id: "freelancer-spend",
+    name: "Freelancer Spend",
+    description: "Total spend on freelancers grouped by crew member",
+    category: "Crew",
+    icon: "Wallet",
+    config: {
+      dataSource: "crewAssignments",
+      columns: [
+        { field: "crewMember.firstName", visible: true },
+        { field: "crewMember.lastName", visible: true },
+        { field: "estimatedCost", visible: true },
+      ],
+      filters: [
+        { field: "crewMember.type", operator: "equals", value: "FREELANCER" },
+        { field: "status", operator: "in", value: ["CONFIRMED", "COMPLETED"] },
+      ],
+      groupBy: {
+        field: "crewMember.lastName",
+        aggregateColumns: [
+          { field: "*", function: "count", label: "Assignments" },
+          { field: "estimatedHours", function: "sum", label: "Total Hours" },
+          { field: "estimatedCost", function: "sum", label: "Total Cost" },
+        ],
+      },
+      sortBy: [{ field: "estimatedCost", direction: "desc" }],
+    },
+  },
+
+  // ─── Warehouse / Activity Reports ───────────────────────────────────
+  {
+    id: "activity-log",
+    name: "Activity Log",
+    description: "Complete audit trail of all actions",
+    category: "Operations",
+    icon: "ScrollText",
+    config: {
+      dataSource: "activityLog",
+      columns: [
+        { field: "createdAt", visible: true },
+        { field: "userName", visible: true },
+        { field: "action", visible: true },
+        { field: "entityType", visible: true },
+        { field: "entityName", visible: true },
+        { field: "summary", visible: true },
+      ],
+      filters: [],
+      sortBy: [{ field: "createdAt", direction: "desc" }],
+      limit: 500,
+    },
+  },
+  {
+    id: "location-summary",
+    name: "Location Summary",
+    description: "Locations with asset and kit counts",
+    category: "Operations",
+    icon: "MapPin",
+    config: {
+      dataSource: "locations",
+      columns: [
+        { field: "name", visible: true },
+        { field: "type", visible: true },
+        { field: "address", visible: true },
+        { field: "_assetCount", visible: true },
+        { field: "_kitCount", visible: true },
+      ],
+      filters: [],
+      sortBy: [{ field: "name", direction: "asc" }],
+    },
+  },
+];
+
+/** Group pre-built reports by category */
+export function getReportsByCategory(): Record<string, PreBuiltReport[]> {
+  const groups: Record<string, PreBuiltReport[]> = {};
+  for (const report of PRE_BUILT_REPORTS) {
+    if (!groups[report.category]) groups[report.category] = [];
+    groups[report.category].push(report);
+  }
+  return groups;
+}

--- a/src/lib/validations/report.ts
+++ b/src/lib/validations/report.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { DATA_SOURCES } from "@/lib/report-types";
+
+export const filterOperators = [
+  "equals", "not_equals", "contains", "not_contains",
+  "gt", "gte", "lt", "lte",
+  "in", "not_in", "is_empty", "is_not_empty", "between",
+] as const;
+
+export const aggregateFunctions = ["count", "sum", "avg", "min", "max"] as const;
+
+const columnConfigSchema = z.object({
+  field: z.string().min(1),
+  label: z.string().optional(),
+  visible: z.boolean(),
+  width: z.number().optional(),
+});
+
+const filterConfigSchema = z.object({
+  field: z.string().min(1),
+  operator: z.enum(filterOperators),
+  value: z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.string()),
+    z.tuple([z.string(), z.string()]),
+  ]),
+});
+
+const groupByConfigSchema = z.object({
+  field: z.string().min(1),
+  aggregateColumns: z.array(z.object({
+    field: z.string().min(1),
+    function: z.enum(aggregateFunctions),
+    label: z.string().optional(),
+  })),
+});
+
+const sortConfigSchema = z.object({
+  field: z.string().min(1),
+  direction: z.enum(["asc", "desc"]),
+});
+
+const dateRangeConfigSchema = z.object({
+  field: z.string().min(1),
+  start: z.string().optional(),
+  end: z.string().optional(),
+  preset: z.string().optional(),
+});
+
+export const reportConfigSchema = z.object({
+  dataSource: z.enum(DATA_SOURCES),
+  columns: z.array(columnConfigSchema),
+  filters: z.array(filterConfigSchema),
+  groupBy: groupByConfigSchema.optional(),
+  sortBy: z.array(sortConfigSchema).optional(),
+  dateRange: dateRangeConfigSchema.optional(),
+  limit: z.number().int().positive().max(10000).optional(),
+  includeInactive: z.boolean().optional(),
+});
+
+export const saveReportSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100),
+  description: z.string().max(500).optional(),
+  dataSource: z.enum(DATA_SOURCES),
+  config: reportConfigSchema,
+  isShared: z.boolean().default(false),
+  isPinned: z.boolean().default(false),
+});
+
+export const updateReportSchema = saveReportSchema.partial();
+
+export type SaveReportInput = z.input<typeof saveReportSchema>;
+export type UpdateReportInput = z.input<typeof updateReportSchema>;

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -1,8 +1,14 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
+import { executeReport, generateCSV } from "@/lib/report-engine";
+import { logActivity } from "@/lib/activity-log";
+import type { ReportConfig } from "@/lib/report-types";
+import type { Prisma } from "@/generated/prisma/client";
+
+// ─── Dashboard summary (preserved from original) ────────────────────────────
 
 export async function getReportsSummary() {
   const { organizationId } = await getOrgContext();
@@ -70,5 +76,200 @@ export async function getReportsSummary() {
       status: g.status,
       count: g._count.status,
     })),
+  });
+}
+
+// ─── Report execution ────────────────────────────────────────────────────────
+
+export async function runReport(config: ReportConfig, page = 1, pageSize = 100) {
+  const { organizationId } = await requirePermission("reports", "view");
+  const result = await executeReport(config, organizationId, page, pageSize);
+  return serialize(result);
+}
+
+export async function runReportCSV(config: ReportConfig) {
+  const { organizationId } = await requirePermission("reports", "export");
+  // Fetch all rows for export (up to 10,000)
+  const result = await executeReport(config, organizationId, 1, 10000);
+  return generateCSV(result);
+}
+
+// ─── Saved Report CRUD ───────────────────────────────────────────────────────
+
+export async function getSavedReports() {
+  const { organizationId, userId } = await requirePermission("reports", "view");
+
+  const reports = await prisma.savedReport.findMany({
+    where: {
+      organizationId,
+      OR: [
+        { createdById: userId },
+        { isShared: true },
+      ],
+    },
+    include: {
+      createdBy: { select: { id: true, name: true } },
+    },
+    orderBy: [
+      { isPinned: "desc" },
+      { updatedAt: "desc" },
+    ],
+  });
+
+  return serialize(reports);
+}
+
+export async function getSavedReportById(id: string) {
+  const { organizationId, userId } = await requirePermission("reports", "view");
+
+  const report = await prisma.savedReport.findFirst({
+    where: {
+      id,
+      organizationId,
+      OR: [
+        { createdById: userId },
+        { isShared: true },
+      ],
+    },
+    include: {
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+
+  if (!report) throw new Error("Report not found");
+
+  return serialize(report);
+}
+
+export async function saveReport(data: {
+  name: string;
+  description?: string;
+  dataSource: string;
+  config: ReportConfig;
+  isShared?: boolean;
+  isPinned?: boolean;
+}) {
+  const { organizationId, userId, userName } = await requirePermission("reports", "view");
+
+  const report = await prisma.savedReport.create({
+    data: {
+      organizationId,
+      name: data.name,
+      description: data.description,
+      dataSource: data.dataSource,
+      config: data.config as unknown as Prisma.InputJsonValue,
+      createdById: userId,
+      isShared: data.isShared ?? false,
+      isPinned: data.isPinned ?? false,
+    },
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "created",
+    entityType: "SavedReport",
+    entityId: report.id,
+    entityName: report.name,
+    summary: `Created saved report "${report.name}"`,
+  });
+
+  return serialize(report);
+}
+
+export async function updateSavedReport(
+  id: string,
+  data: {
+    name?: string;
+    description?: string;
+    config?: ReportConfig;
+    isShared?: boolean;
+    isPinned?: boolean;
+  },
+) {
+  const { organizationId, userId, userName } = await requirePermission("reports", "view");
+
+  const existing = await prisma.savedReport.findFirst({
+    where: { id, organizationId, createdById: userId },
+  });
+
+  if (!existing) throw new Error("Report not found or you don't have permission to edit it");
+
+  const report = await prisma.savedReport.update({
+    where: { id },
+    data: {
+      ...(data.name !== undefined ? { name: data.name } : {}),
+      ...(data.description !== undefined ? { description: data.description } : {}),
+      ...(data.config !== undefined ? { config: data.config as unknown as Prisma.InputJsonValue } : {}),
+      ...(data.isShared !== undefined ? { isShared: data.isShared } : {}),
+      ...(data.isPinned !== undefined ? { isPinned: data.isPinned } : {}),
+    },
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "updated",
+    entityType: "SavedReport",
+    entityId: report.id,
+    entityName: report.name,
+    summary: `Updated saved report "${report.name}"`,
+  });
+
+  return serialize(report);
+}
+
+export async function deleteSavedReport(id: string) {
+  const { organizationId, userId, userName } = await requirePermission("reports", "view");
+
+  const existing = await prisma.savedReport.findFirst({
+    where: { id, organizationId, createdById: userId },
+  });
+
+  if (!existing) throw new Error("Report not found or you don't have permission to delete it");
+
+  await prisma.savedReport.delete({ where: { id } });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "deleted",
+    entityType: "SavedReport",
+    entityId: existing.id,
+    entityName: existing.name,
+    summary: `Deleted saved report "${existing.name}"`,
+  });
+}
+
+export async function togglePinReport(id: string) {
+  const { organizationId, userId } = await requirePermission("reports", "view");
+
+  const existing = await prisma.savedReport.findFirst({
+    where: {
+      id,
+      organizationId,
+      OR: [{ createdById: userId }, { isShared: true }],
+    },
+  });
+
+  if (!existing) throw new Error("Report not found");
+
+  const report = await prisma.savedReport.update({
+    where: { id },
+    data: { isPinned: !existing.isPinned },
+  });
+
+  return serialize(report);
+}
+
+export async function updateReportLastRun(id: string) {
+  const { organizationId } = await getOrgContext();
+
+  await prisma.savedReport.updateMany({
+    where: { id, organizationId },
+    data: { lastRunAt: new Date() },
   });
 }


### PR DESCRIPTION
…+ multi-page PDF export

Full reporting system with report engine translating JSON configs to Prisma queries, pre-built reports across 7 categories (assets, projects, kits, clients, maintenance, crew, operations), custom report builder with save/share/pin, and export to CSV and multi-page landscape PDF with org branding. Report cards open in wide-screen dialog with auto-run. PDF uses pdfme with unique field names per page and dynamic layout that adapts to summary box size.