### PR TITLE
Add WooCommerce integration and model SKUs

### DIFF
--- a/FEATUREDOCS/05-server-actions-api.md
+++ b/FEATUREDOCS/05-server-actions-api.md
@@ -56,6 +56,7 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `test-tag-records.ts` | `createTestTagRecord`, `recalculateTestTagStatus` |
 | `test-tag-reports.ts` | 10 report functions + CSV exports |
 | `document-templates.ts` | `getDocumentTemplates`, `getDocumentTemplate`, `createDocumentTemplate`, `updateDocumentTemplate`, `publishDocumentTemplate`, `setDefaultTemplate`, `unsetDefaultTemplate`, `deleteDocumentTemplate`, `duplicateSystemDefault`, `getPublishedTemplatesForDropdown` |
+| `woocommerce.ts` | `getWooCommerceIntegration`, `updateWooCommerceIntegration`, `regenerateWebhookSecret`, `getWooCommerceOrderLogs`, `retryFailedOrder`, `getLastPayloadMetaKeys`, `processWooCommerceOrder`, `verifyWebhookSignature`, `flexibleDateParse` |
 
 ## API Routes
 | Route | Method | Purpose |
@@ -75,3 +76,4 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `/api/admin/org-import` | POST | Import org from ZIP (site admin only, FormData) |
 | `/api/admin-register/verify` | GET | Verify admin registration token |
 | `/api/admin-register/promote` | POST | Promote user to site admin (token-gated) |
+| `/api/integrations/woocommerce/webhook` | POST | WooCommerce order webhook (public, HMAC-SHA256 verified) |

--- a/prisma/migrations/20260318000000_add_sku_to_model/migration.sql
+++ b/prisma/migrations/20260318000000_add_sku_to_model/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "model" ADD COLUMN "sku" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "model_organizationId_sku_key" ON "model"("organizationId", "sku");

--- a/prisma/migrations/20260318000001_add_woocommerce_integration/migration.sql
+++ b/prisma/migrations/20260318000001_add_woocommerce_integration/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "WooOrderLogStatus" AS ENUM ('RECEIVED', 'PROCESSING', 'COMPLETED', 'FAILED', 'DUPLICATE');
+
+-- CreateTable
+CREATE TABLE "woocommerce_integration" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "webhookSecret" TEXT NOT NULL,
+    "storeUrl" TEXT,
+    "productMatchField" TEXT NOT NULL DEFAULT 'sku',
+    "customFieldKey" TEXT,
+    "rentalStartKey" TEXT,
+    "rentalEndKey" TEXT,
+    "eventStartKey" TEXT,
+    "deliveryAddressKey" TEXT,
+    "notesKey" TEXT,
+    "dateFormat" TEXT NOT NULL DEFAULT 'auto',
+    "defaultProjectType" TEXT NOT NULL DEFAULT 'DRY_HIRE',
+    "autoConfirmEnquiry" BOOLEAN NOT NULL DEFAULT false,
+    "notifyUserIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "lastPayload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "woocommerce_integration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "woocommerce_order_log" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "wooOrderId" INTEGER NOT NULL,
+    "wooOrderNumber" TEXT,
+    "status" "WooOrderLogStatus" NOT NULL,
+    "projectId" TEXT,
+    "clientId" TEXT,
+    "payload" JSONB NOT NULL,
+    "errorMessage" TEXT,
+    "matchResults" JSONB,
+    "dateExtraction" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "woocommerce_order_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "woocommerce_integration_organizationId_key" ON "woocommerce_integration"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "woocommerce_order_log_organizationId_idx" ON "woocommerce_order_log"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "woocommerce_order_log_wooOrderId_idx" ON "woocommerce_order_log"("wooOrderId");
+
+-- AddForeignKey
+ALTER TABLE "woocommerce_integration" ADD CONSTRAINT "woocommerce_integration_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "woocommerce_order_log" ADD CONSTRAINT "woocommerce_order_log_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "woocommerce_order_log" ADD CONSTRAINT "woocommerce_order_log_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -519,6 +519,7 @@ model Model {
   name                    String
   manufacturer            String?
   modelNumber             String?
+  sku                     String?
   categoryId              String?
   category                Category?    @relation(fields: [categoryId], references: [id])
   description             String?
@@ -551,6 +552,7 @@ model Model {
 
   supplierOrderItems  SupplierOrderItem[]
 
+  @@unique([organizationId, sku])
   @@index([organizationId])
   @@index([categoryId])
   @@index([isActive])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,8 @@ model Organization {
   ssoProviders               SsoProvider[]
   pendingSSOApprovals        PendingSSOApproval[]
   warehouseDashboardTokens   WarehouseDashboardToken[]
+  wooCommerceIntegration     WooCommerceIntegration?
+  wooCommerceOrderLogs       WooCommerceOrderLog[]
   @@map("organization")
 }
 
@@ -993,6 +995,7 @@ model Project {
   supplierOrders   SupplierOrder[]
   crewAssignments  CrewAssignment[]
   services         ProjectService[]
+  wooCommerceOrderLogs WooCommerceOrderLog[]
 
   @@unique([organizationId, projectNumber])
   @@index([organizationId])
@@ -1944,6 +1947,82 @@ model WarehouseDashboardToken {
 
   @@index([organizationId])
   @@map("warehouse_dashboard_token")
+}
+
+// ─── WooCommerce Integration ─────────────────────────────────────────────────
+
+model WooCommerceIntegration {
+  id              String       @id @default(cuid())
+  organizationId  String       @unique
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  isEnabled       Boolean  @default(false)
+  webhookSecret   String                     // Shared secret for HMAC verification
+  storeUrl        String?                    // WooCommerce store URL (for reference/display)
+
+  // Matching strategy
+  productMatchField String  @default("sku")  // "sku", "custom_field", "name"
+  customFieldKey    String?                   // If productMatchField = "custom_field", which meta key
+
+  // Date field mapping (WooCommerce meta_data keys → project fields)
+  rentalStartKey    String?                   // e.g. "rental_start_date"
+  rentalEndKey      String?                   // e.g. "rental_end_date"
+  eventStartKey     String?                   // e.g. "event_date"
+  deliveryAddressKey String?                  // e.g. "delivery_address"
+  notesKey          String?                   // e.g. "order_notes" or "customer_note"
+
+  // Date format preference
+  dateFormat        String  @default("auto")  // "auto", "DD/MM/YYYY", "MM/DD/YYYY", "ISO"
+
+  // Defaults for created projects
+  defaultProjectType String @default("DRY_HIRE")
+  autoConfirmEnquiry Boolean @default(false)  // If true, set status to QUOTING instead of ENQUIRY
+
+  // Notification
+  notifyUserIds     String[] @default([])     // User IDs to notify on new website orders
+
+  // Last webhook payload (for "Test & Detect" feature)
+  lastPayload       Json?
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@map("woocommerce_integration")
+}
+
+model WooCommerceOrderLog {
+  id              String   @id @default(cuid())
+  organizationId  String
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  wooOrderId      Int                        // WooCommerce order ID
+  wooOrderNumber  String?                    // WooCommerce order number (may differ from ID)
+  status          WooOrderLogStatus          // RECEIVED, PROCESSING, COMPLETED, FAILED, DUPLICATE
+
+  // What was created
+  projectId       String?
+  project         Project? @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  clientId        String?
+
+  // Debugging
+  payload         Json                       // Full webhook payload (for debugging)
+  errorMessage    String?                    // If FAILED
+  matchResults    Json?                      // Which products matched which models
+  dateExtraction  Json?                      // Date parsing results for display
+
+  createdAt       DateTime @default(now())
+
+  @@index([organizationId])
+  @@index([wooOrderId])
+  @@map("woocommerce_order_log")
+}
+
+enum WooOrderLogStatus {
+  RECEIVED
+  PROCESSING
+  COMPLETED
+  FAILED
+  DUPLICATE
 }
 
 // ─── Prep System (Pre-Packing / Staging) ─────────────────────────────────────

--- a/src/app/(app)/assets/models/[id]/edit/page.tsx
+++ b/src/app/(app)/assets/models/[id]/edit/page.tsx
@@ -25,6 +25,7 @@ export default function EditModelPage({ params }: { params: Promise<{ id: string
     name: model.name,
     manufacturer: model.manufacturer || "",
     modelNumber: model.modelNumber || "",
+    sku: model.sku || "",
     categoryId: model.categoryId || "",
     description: model.description || "",
     image: model.image || "",

--- a/src/app/(app)/assets/models/[id]/page.tsx
+++ b/src/app/(app)/assets/models/[id]/page.tsx
@@ -149,7 +149,7 @@ export default function ModelDetailPage({ params }: { params: Promise<{ id: stri
             {!model.isActive && <Badge variant="destructive">Archived</Badge>}
           </div>
           <p className="text-muted-foreground">
-            {[model.manufacturer, model.modelNumber].filter(Boolean).join(" — ") || "No manufacturer info"}
+            {[model.manufacturer, model.modelNumber, model.sku && `SKU: ${model.sku}`].filter(Boolean).join(" — ") || "No manufacturer info"}
             {model.category && <> &middot; {model.category.name}</>}
           </p>
           </div>

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -14,6 +14,7 @@ import {
   CalendarSync,
   MonitorPlay,
   Shield,
+  ShoppingCart,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCanDo } from "@/lib/use-permissions";
@@ -29,6 +30,7 @@ const settingsNav = [
   { title: "Calendars", href: "/settings/calendars", icon: CalendarSync, permission: "orgSettings" as const },
   { title: "Displays", href: "/settings/displays", icon: MonitorPlay, permission: "orgSettings" as const },
   { title: "Team", href: "/settings/team", icon: Users, permission: "orgMembers" as const },
+  { title: "WooCommerce", href: "/settings/woocommerce", icon: ShoppingCart, permission: "orgSettings" as const },
   { title: "Single Sign-On", href: "/settings/sso", icon: Shield, permission: "orgSettings" as const },
 ];
 

--- a/src/app/(app)/settings/woocommerce/page.tsx
+++ b/src/app/(app)/settings/woocommerce/page.tsx
@@ -1,0 +1,693 @@
+"use client";
+
+import { useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Copy,
+  Eye,
+  EyeOff,
+  Loader2,
+  RefreshCw,
+  ExternalLink,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  SkipForward,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
+
+import {
+  wooCommerceIntegrationSchema,
+  type WooCommerceIntegrationFormValues,
+} from "@/lib/validations/woocommerce";
+import {
+  getWooCommerceIntegration,
+  updateWooCommerceIntegration,
+  regenerateWebhookSecret,
+  getWooCommerceOrderLogs,
+  getLastPayloadMetaKeys,
+  retryFailedOrder,
+} from "@/server/woocommerce";
+import { useActiveOrganization } from "@/lib/auth-client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+
+const projectTypeOptions = [
+  { value: "DRY_HIRE", label: "Dry Hire" },
+  { value: "WET_HIRE", label: "Wet Hire" },
+  { value: "INSTALLATION", label: "Installation" },
+  { value: "TOUR", label: "Tour" },
+  { value: "CORPORATE", label: "Corporate" },
+  { value: "THEATRE", label: "Theatre" },
+  { value: "FESTIVAL", label: "Festival" },
+  { value: "CONFERENCE", label: "Conference" },
+  { value: "OTHER", label: "Other" },
+];
+
+const dateFormatOptions = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "DD/MM/YYYY", label: "DD/MM/YYYY (Australian)" },
+  { value: "MM/DD/YYYY", label: "MM/DD/YYYY (US)" },
+  { value: "ISO", label: "ISO 8601 (YYYY-MM-DD)" },
+];
+
+export default function WooCommerceSettingsPage() {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const queryClient = useQueryClient();
+  const [showSecret, setShowSecret] = useState(false);
+  const [showSetupGuide, setShowSetupGuide] = useState(false);
+  const [showMetaDetect, setShowMetaDetect] = useState(false);
+
+  const { data: integration, isLoading } = useQuery({
+    queryKey: ["woocommerce-integration", orgId],
+    queryFn: () => getWooCommerceIntegration(),
+    enabled: !!orgId,
+  });
+
+  const { data: orderLogs } = useQuery({
+    queryKey: ["woocommerce-logs", orgId],
+    queryFn: () => getWooCommerceOrderLogs({ pageSize: 10 }),
+    enabled: !!orgId,
+  });
+
+  const { data: metaKeys } = useQuery({
+    queryKey: ["woocommerce-meta-keys", orgId],
+    queryFn: () => getLastPayloadMetaKeys(),
+    enabled: !!orgId && showMetaDetect,
+  });
+
+  const form = useForm<WooCommerceIntegrationFormValues>({
+    resolver: zodResolver(wooCommerceIntegrationSchema),
+    defaultValues: {
+      isEnabled: false,
+      storeUrl: "",
+      productMatchField: "sku",
+      customFieldKey: "",
+      rentalStartKey: "",
+      rentalEndKey: "",
+      eventStartKey: "",
+      deliveryAddressKey: "",
+      notesKey: "",
+      dateFormat: "auto",
+      defaultProjectType: "DRY_HIRE",
+      autoConfirmEnquiry: false,
+      notifyUserIds: [],
+    },
+    values: integration
+      ? {
+          isEnabled: integration.isEnabled,
+          storeUrl: integration.storeUrl || "",
+          productMatchField: integration.productMatchField as "sku" | "custom_field" | "name",
+          customFieldKey: integration.customFieldKey || "",
+          rentalStartKey: integration.rentalStartKey || "",
+          rentalEndKey: integration.rentalEndKey || "",
+          eventStartKey: integration.eventStartKey || "",
+          deliveryAddressKey: integration.deliveryAddressKey || "",
+          notesKey: integration.notesKey || "",
+          dateFormat: (integration.dateFormat || "auto") as "auto" | "DD/MM/YYYY" | "MM/DD/YYYY" | "ISO",
+          defaultProjectType: integration.defaultProjectType as WooCommerceIntegrationFormValues["defaultProjectType"],
+          autoConfirmEnquiry: integration.autoConfirmEnquiry,
+          notifyUserIds: integration.notifyUserIds || [],
+        }
+      : undefined,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (data: WooCommerceIntegrationFormValues) => updateWooCommerceIntegration(data),
+    onSuccess: () => {
+      toast.success("WooCommerce settings saved");
+      queryClient.invalidateQueries({ queryKey: ["woocommerce-integration"] });
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const regenMutation = useMutation({
+    mutationFn: () => regenerateWebhookSecret(),
+    onSuccess: () => {
+      toast.success("Webhook secret regenerated");
+      queryClient.invalidateQueries({ queryKey: ["woocommerce-integration"] });
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: (logId: string) => retryFailedOrder(logId),
+    onSuccess: () => {
+      toast.success("Order retry initiated");
+      queryClient.invalidateQueries({ queryKey: ["woocommerce-logs"] });
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const webhookUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/api/integrations/woocommerce/webhook`
+    : "";
+
+  if (isLoading) {
+    return <div className="text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">WooCommerce Integration</h2>
+        <p className="text-sm text-muted-foreground">
+          Automatically create projects from WooCommerce orders.
+        </p>
+      </div>
+
+      <form onSubmit={form.handleSubmit((d) => saveMutation.mutate(d))} className="space-y-6">
+        {/* Enable/Disable */}
+        <Card>
+          <CardContent className="flex items-center justify-between pt-6">
+            <div>
+              <Label>Enable Integration</Label>
+              <p className="text-xs text-muted-foreground">
+                When enabled, incoming WooCommerce webhooks will create projects automatically.
+              </p>
+            </div>
+            <Controller
+              name="isEnabled"
+              control={form.control}
+              render={({ field }) => (
+                <Switch checked={field.value} onCheckedChange={field.onChange} />
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Connection */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Connection</CardTitle>
+            <CardDescription>Configure the webhook connection between WooCommerce and GearFlow.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="storeUrl">Store URL</Label>
+              <Input
+                id="storeUrl"
+                {...form.register("storeUrl")}
+                placeholder="https://www.yourstore.com"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Webhook URL (copy to WooCommerce)</Label>
+              <div className="flex gap-2">
+                <Input value={webhookUrl} readOnly className="font-mono text-xs" />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => {
+                    navigator.clipboard.writeText(webhookUrl);
+                    toast.success("Copied to clipboard");
+                  }}
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Webhook Secret</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={integration?.webhookSecret || "Not yet generated"}
+                  readOnly
+                  type={showSecret ? "text" : "password"}
+                  className="font-mono text-xs"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setShowSecret(!showSecret)}
+                >
+                  {showSecret ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => {
+                    if (integration?.webhookSecret) {
+                      navigator.clipboard.writeText(integration.webhookSecret);
+                      toast.success("Secret copied to clipboard");
+                    }
+                  }}
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => regenMutation.mutate()}
+                  disabled={regenMutation.isPending}
+                >
+                  <RefreshCw className={`h-4 w-4 ${regenMutation.isPending ? "animate-spin" : ""}`} />
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Paste this secret into WooCommerce webhook settings. Regenerating will invalidate the old secret.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Product Matching */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Product Matching</CardTitle>
+            <CardDescription>How to match WooCommerce products to GearFlow models.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Match Strategy</Label>
+              <Controller
+                name="productMatchField"
+                control={form.control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {field.value === "sku" ? "SKU → Model SKU / Model Number"
+                          : field.value === "custom_field" ? "Custom meta field → Model ID"
+                          : "Product name → Model name (fuzzy)"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="sku">SKU → Model SKU / Model Number</SelectItem>
+                      <SelectItem value="custom_field">Custom meta field → Model ID</SelectItem>
+                      <SelectItem value="name">Product name → Model name (fuzzy)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            {form.watch("productMatchField") === "custom_field" && (
+              <div className="space-y-2">
+                <Label htmlFor="customFieldKey">Custom Field Key</Label>
+                <Input
+                  id="customFieldKey"
+                  {...form.register("customFieldKey")}
+                  placeholder="e.g. gearflow_model_id"
+                />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Date Field Mapping */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Date Field Mapping</CardTitle>
+            <CardDescription>
+              Map WooCommerce order meta fields to project dates.
+              {" "}
+              <button
+                type="button"
+                className="text-primary underline"
+                onClick={() => setShowMetaDetect(!showMetaDetect)}
+              >
+                {showMetaDetect ? "Hide" : "Test & Detect"}
+              </button>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {showMetaDetect && (
+              <MetaDetectPanel
+                metaKeys={metaKeys}
+                onSelectKey={(key) => {
+                  // Auto-fill the first empty date field
+                  if (!form.getValues("rentalStartKey")) {
+                    form.setValue("rentalStartKey", key);
+                  } else if (!form.getValues("rentalEndKey")) {
+                    form.setValue("rentalEndKey", key);
+                  } else if (!form.getValues("eventStartKey")) {
+                    form.setValue("eventStartKey", key);
+                  }
+                  toast.success(`Mapped "${key}"`);
+                }}
+              />
+            )}
+
+            <div className="space-y-2">
+              <Label>Date Format</Label>
+              <Controller
+                name="dateFormat"
+                control={form.control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {dateFormatOptions.find((o) => o.value === field.value)?.label}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {dateFormatOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="rentalStartKey">Rental Start Key</Label>
+                <Input
+                  id="rentalStartKey"
+                  {...form.register("rentalStartKey")}
+                  placeholder="e.g. rental_start_date"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="rentalEndKey">Rental End Key</Label>
+                <Input
+                  id="rentalEndKey"
+                  {...form.register("rentalEndKey")}
+                  placeholder="e.g. rental_end_date"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="eventStartKey">Event Date Key</Label>
+                <Input
+                  id="eventStartKey"
+                  {...form.register("eventStartKey")}
+                  placeholder="e.g. event_date"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="deliveryAddressKey">Delivery Address Key</Label>
+                <Input
+                  id="deliveryAddressKey"
+                  {...form.register("deliveryAddressKey")}
+                  placeholder="e.g. delivery_address"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notesKey">Notes Key</Label>
+              <Input
+                id="notesKey"
+                {...form.register("notesKey")}
+                placeholder="e.g. order_notes"
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Project Defaults */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Project Defaults</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Default Project Type</Label>
+              <Controller
+                name="defaultProjectType"
+                control={form.control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {projectTypeOptions.find((o) => o.value === field.value)?.label}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {projectTypeOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Auto-advance to Quoting</Label>
+                <p className="text-xs text-muted-foreground">
+                  Set new projects to Quoting instead of Enquiry.
+                </p>
+              </div>
+              <Controller
+                name="autoConfirmEnquiry"
+                control={form.control}
+                render={({ field }) => (
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                )}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* WordPress Setup Guide */}
+        <Card>
+          <CardHeader>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between"
+              onClick={() => setShowSetupGuide(!showSetupGuide)}
+            >
+              <div className="text-left">
+                <CardTitle className="text-base">WordPress Setup Guide</CardTitle>
+                <CardDescription>How to configure WooCommerce to send orders to GearFlow.</CardDescription>
+              </div>
+              {showSetupGuide ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </button>
+          </CardHeader>
+          {showSetupGuide && (
+            <CardContent className="space-y-4 text-sm">
+              <div className="space-y-2">
+                <h4 className="font-medium">1. Create a Webhook</h4>
+                <p className="text-muted-foreground">
+                  In WordPress admin: WooCommerce &rarr; Settings &rarr; Advanced &rarr; Webhooks &rarr; Add Webhook
+                </p>
+                <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
+                  <li><strong>Name:</strong> GearFlow Project Creation</li>
+                  <li><strong>Status:</strong> Active</li>
+                  <li><strong>Topic:</strong> Order created</li>
+                  <li><strong>Delivery URL:</strong> Copy the Webhook URL above</li>
+                  <li><strong>Secret:</strong> Copy the Webhook Secret above</li>
+                  <li><strong>API Version:</strong> WP REST API Integration v3</li>
+                </ul>
+              </div>
+
+              <div className="space-y-2">
+                <h4 className="font-medium">2. Save Custom Checkout Fields to Order Meta</h4>
+                <p className="text-muted-foreground">
+                  If your checkout has custom date fields (e.g. from a booking plugin), ensure they are saved
+                  as order meta. Add this PHP snippet to your theme&apos;s <code className="text-xs bg-muted px-1 py-0.5 rounded">functions.php</code>:
+                </p>
+                <pre className="bg-muted p-3 rounded text-xs overflow-x-auto">{`add_action('woocommerce_checkout_update_order_meta', function($order_id) {
+  $fields = ['rental_start_date', 'rental_end_date', 'event_date', 'delivery_address'];
+  foreach ($fields as $field) {
+    if (!empty($_POST[$field])) {
+      update_post_meta($order_id, $field, sanitize_text_field($_POST[$field]));
+    }
+  }
+});`}</pre>
+                <p className="text-muted-foreground">
+                  Adjust the field names to match your checkout form. Then set the same keys in the Date Field Mapping above.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <h4 className="font-medium">3. Set Product SKUs</h4>
+                <p className="text-muted-foreground">
+                  For SKU matching: set each WooCommerce product&apos;s SKU to match the corresponding GearFlow model&apos;s SKU or Model Number.
+                  Go to Products &rarr; Edit &rarr; Inventory &rarr; SKU.
+                </p>
+              </div>
+            </CardContent>
+          )}
+        </Card>
+
+        {/* Save */}
+        <Button type="submit" disabled={saveMutation.isPending}>
+          {saveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Save Settings
+        </Button>
+      </form>
+
+      {/* Order Logs */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent Orders</CardTitle>
+          <CardDescription>Webhook deliveries and processing results.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!orderLogs?.items?.length ? (
+            <p className="text-sm text-muted-foreground">No orders received yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {orderLogs.items.map((log) => (
+                <div
+                  key={log.id}
+                  className="flex items-start justify-between gap-4 rounded-md border p-3 text-sm"
+                >
+                  <div className="space-y-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <StatusIcon status={log.status} />
+                      <span className="font-mono font-medium">
+                        #{log.wooOrderNumber || log.wooOrderId}
+                      </span>
+                      <StatusBadge status={log.status} />
+                    </div>
+                    {log.project && (
+                      <p className="text-muted-foreground">
+                        &rarr; {log.project.projectNumber} — {log.project.name}
+                      </p>
+                    )}
+                    {log.errorMessage && (
+                      <p className="text-destructive text-xs">{log.errorMessage}</p>
+                    )}
+                    {log.matchResults && (
+                      <MatchSummary results={log.matchResults as unknown as MatchResult[]} />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-xs text-muted-foreground">
+                      {formatDistanceToNow(new Date(log.createdAt), { addSuffix: true })}
+                    </span>
+                    {log.status === "FAILED" && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => retryMutation.mutate(log.id)}
+                        disabled={retryMutation.isPending}
+                      >
+                        Retry
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+interface MatchResult {
+  wooProductName: string;
+  wooSku?: string;
+  matched: boolean;
+  modelName?: string;
+}
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "COMPLETED":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    case "FAILED":
+      return <XCircle className="h-4 w-4 text-destructive" />;
+    case "DUPLICATE":
+      return <SkipForward className="h-4 w-4 text-muted-foreground" />;
+    default:
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+  }
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant = status === "COMPLETED" ? "default"
+    : status === "FAILED" ? "destructive"
+    : "secondary";
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+function MatchSummary({ results }: { results: MatchResult[] }) {
+  const matched = results.filter((r) => r.matched).length;
+  const total = results.length;
+  if (matched === total) {
+    return <p className="text-xs text-green-600">{total} product{total !== 1 ? "s" : ""} matched</p>;
+  }
+  return (
+    <p className="text-xs text-yellow-600">
+      {matched}/{total} products matched
+      {results.filter((r) => !r.matched).map((r) => (
+        <span key={r.wooProductName} className="block text-muted-foreground">
+          No match: {r.wooProductName}{r.wooSku ? ` (${r.wooSku})` : ""}
+        </span>
+      ))}
+    </p>
+  );
+}
+
+function MetaDetectPanel({
+  metaKeys,
+  onSelectKey,
+}: {
+  metaKeys: { orderMeta: { key: string; value: string }[]; lineItemMeta: string[] } | null | undefined;
+  onSelectKey: (key: string) => void;
+}) {
+  if (!metaKeys) {
+    return (
+      <div className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+        <p>No webhook payload stored yet.</p>
+        <p>Send a test order from WooCommerce to detect available meta fields.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border p-4 space-y-3">
+      <p className="text-sm font-medium">Detected Meta Fields</p>
+      <p className="text-xs text-muted-foreground">
+        Click a key to map it to the next empty date field.
+      </p>
+      {metaKeys.orderMeta.length > 0 ? (
+        <div className="space-y-1">
+          {metaKeys.orderMeta.map((m) => (
+            <button
+              key={m.key}
+              type="button"
+              className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs hover:bg-accent"
+              onClick={() => onSelectKey(m.key)}
+            >
+              <code className="font-mono">{m.key}</code>
+              <span className="text-muted-foreground truncate ml-4 max-w-[200px]">
+                {m.value}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">No order-level meta fields found.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/integrations/woocommerce/webhook/route.ts
+++ b/src/app/api/integrations/woocommerce/webhook/route.ts
@@ -1,0 +1,111 @@
+import { prisma } from "@/lib/prisma";
+import { getTheOrg } from "@/lib/single-org";
+import { verifyWebhookSignature } from "@/lib/woocommerce-utils";
+import {
+  processWooCommerceOrder,
+  type WooOrder,
+} from "@/server/woocommerce";
+
+const MAX_PAYLOAD_SIZE = 1_000_000; // 1MB
+
+export async function POST(request: Request) {
+  // 1. Payload size check
+  const contentLength = request.headers.get("content-length");
+  if (contentLength && parseInt(contentLength) > MAX_PAYLOAD_SIZE) {
+    return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  // 2. Read the raw body (needed for HMAC verification)
+  const rawBody = await request.text();
+  if (rawBody.length > MAX_PAYLOAD_SIZE) {
+    return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  // 3. Get headers
+  const signature = request.headers.get("X-WC-Webhook-Signature");
+  const topic = request.headers.get("X-WC-Webhook-Topic");
+
+  // 4. Determine org — single-org mode uses the only org, or fallback to ?org= param
+  let orgId = new URL(request.url).searchParams.get("org");
+  if (!orgId) {
+    const org = await getTheOrg();
+    if (!org) {
+      return Response.json({ error: "No organization configured" }, { status: 404 });
+    }
+    orgId = org.id;
+  }
+
+  // 5. Load the org's WooCommerce integration config
+  const integration = await prisma.wooCommerceIntegration.findUnique({
+    where: { organizationId: orgId },
+  });
+  if (!integration?.isEnabled) {
+    return Response.json({ error: "Integration not enabled" }, { status: 404 });
+  }
+
+  // 6. Verify HMAC-SHA256 signature
+  if (!signature) {
+    return Response.json({ error: "Missing signature" }, { status: 401 });
+  }
+  try {
+    if (!verifyWebhookSignature(rawBody, signature, integration.webhookSecret)) {
+      return Response.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  } catch {
+    return Response.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  // 7. Parse the order payload
+  let order: WooOrder;
+  try {
+    order = JSON.parse(rawBody);
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // 8. Handle WooCommerce ping (sent on webhook creation — empty or minimal payload)
+  if (!order.id) {
+    return Response.json({ ok: true, ping: true });
+  }
+
+  // 9. Store last payload for "Test & Detect" feature
+  await prisma.wooCommerceIntegration.update({
+    where: { organizationId: orgId },
+    data: { lastPayload: order as never },
+  });
+
+  // 10. Only process order.created topic
+  if (topic && topic !== "order.created") {
+    return Response.json({ ok: true, skipped: true, reason: `Topic ${topic} not handled` });
+  }
+
+  // 11. Idempotency: check if this order was already processed
+  const existing = await prisma.wooCommerceOrderLog.findFirst({
+    where: {
+      organizationId: orgId,
+      wooOrderId: order.id,
+      status: "COMPLETED",
+    },
+  });
+  if (existing) {
+    // Log as duplicate
+    await prisma.wooCommerceOrderLog.create({
+      data: {
+        organizationId: orgId,
+        wooOrderId: order.id,
+        wooOrderNumber: order.number ?? null,
+        status: "DUPLICATE",
+        payload: order as never,
+      },
+    });
+    return Response.json({ ok: true, duplicate: true });
+  }
+
+  // 12. Process the order asynchronously — respond 200 immediately
+  processWooCommerceOrder(orgId, order, integration).catch((err) => {
+    console.error("[WooCommerce] Background processing error:", err);
+  });
+
+  // 13. Respond 200 immediately (WooCommerce retries on non-200)
+  return Response.json({ ok: true, received: order.id });
+}

--- a/src/components/assets/model-form.tsx
+++ b/src/components/assets/model-form.tsx
@@ -78,6 +78,7 @@ export function ModelForm({ initialData }: ModelFormProps) {
       name: "",
       manufacturer: "",
       modelNumber: "",
+      sku: "",
       categoryId: "",
       description: "",
       assetType: "SERIALIZED",
@@ -120,6 +121,10 @@ export function ModelForm({ initialData }: ModelFormProps) {
           <div className="space-y-2">
             <Label htmlFor="modelNumber">Model Number</Label>
             <Input id="modelNumber" {...form.register("modelNumber")} placeholder="e.g. SM58-LC" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sku">SKU</Label>
+            <Input id="sku" {...form.register("sku")} placeholder="e.g. SHR-SM58-LC" />
           </div>
           <div className="space-y-2">
             <Label>Category</Label>

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -51,6 +51,7 @@ const segmentLabels: Record<string, string> = {
   planner: "Planner",
   sso: "Single Sign-On",
   displays: "Displays",
+  woocommerce: "WooCommerce",
 };
 
 function getPageTitle(pathname: string): string {

--- a/src/lib/validations/model.ts
+++ b/src/lib/validations/model.ts
@@ -4,6 +4,7 @@ export const modelSchema = z.object({
   name: z.string().min(1, "Name is required").max(200),
   manufacturer: z.string().max(200).optional(),
   modelNumber: z.string().max(100).optional(),
+  sku: z.string().max(100).optional(),
   categoryId: z.string().optional(),
   description: z.string().max(2000).optional(),
   image: z.string().optional(),

--- a/src/lib/validations/woocommerce.ts
+++ b/src/lib/validations/woocommerce.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const wooCommerceIntegrationSchema = z.object({
+  isEnabled: z.boolean().default(false),
+  storeUrl: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+  productMatchField: z.enum(["sku", "custom_field", "name"]).default("sku"),
+  customFieldKey: z.string().max(100).optional(),
+  rentalStartKey: z.string().max(100).optional(),
+  rentalEndKey: z.string().max(100).optional(),
+  eventStartKey: z.string().max(100).optional(),
+  deliveryAddressKey: z.string().max(100).optional(),
+  notesKey: z.string().max(100).optional(),
+  dateFormat: z.enum(["auto", "DD/MM/YYYY", "MM/DD/YYYY", "ISO"]).default("auto"),
+  defaultProjectType: z.enum([
+    "DRY_HIRE", "WET_HIRE", "INSTALLATION", "TOUR",
+    "CORPORATE", "THEATRE", "FESTIVAL", "CONFERENCE", "OTHER",
+  ]).default("DRY_HIRE"),
+  autoConfirmEnquiry: z.boolean().default(false),
+  notifyUserIds: z.array(z.string()).default([]),
+});
+
+export type WooCommerceIntegrationFormValues = z.input<typeof wooCommerceIntegrationSchema>;

--- a/src/lib/woocommerce-utils.ts
+++ b/src/lib/woocommerce-utils.ts
@@ -1,0 +1,44 @@
+import crypto from "crypto";
+
+export function verifyWebhookSignature(rawBody: string, signature: string, secret: string): boolean {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("base64");
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+export function flexibleDateParse(value: string, preferredFormat: string = "auto"): Date | null {
+  if (!value || !value.trim()) return null;
+  const trimmed = value.trim();
+
+  // Try ISO 8601 first
+  const isoDate = new Date(trimmed);
+  if (preferredFormat === "ISO" && !isNaN(isoDate.getTime())) return isoDate;
+
+  // DD/MM/YYYY or MM/DD/YYYY
+  const ddmmyyyy = trimmed.match(/^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{4})$/);
+  if (ddmmyyyy) {
+    if (preferredFormat === "DD/MM/YYYY" || preferredFormat === "auto") {
+      const d = new Date(Number(ddmmyyyy[3]), Number(ddmmyyyy[2]) - 1, Number(ddmmyyyy[1]));
+      if (!isNaN(d.getTime())) return d;
+    }
+    if (preferredFormat === "MM/DD/YYYY") {
+      const d = new Date(Number(ddmmyyyy[3]), Number(ddmmyyyy[1]) - 1, Number(ddmmyyyy[2]));
+      if (!isNaN(d.getTime())) return d;
+    }
+  }
+
+  // YYYY-MM-DD (ISO date part)
+  const yyyymmdd = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (yyyymmdd) {
+    const d = new Date(Number(yyyymmdd[1]), Number(yyyymmdd[2]) - 1, Number(yyyymmdd[3]));
+    if (!isNaN(d.getTime())) return d;
+  }
+
+  // Natural language: "15 March 2026", "March 15, 2026", etc.
+  const natural = new Date(trimmed);
+  if (!isNaN(natural.getTime())) return natural;
+
+  return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/onboarding", "/pending-approval"];
+const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/onboarding", "/pending-approval", "/api/integrations/woocommerce/webhook"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -49,6 +49,7 @@ export async function getModels(params?: {
         { name: { contains: search, mode: "insensitive" } },
         { manufacturer: { contains: search, mode: "insensitive" } },
         { modelNumber: { contains: search, mode: "insensitive" } },
+        { sku: { contains: search, mode: "insensitive" } },
       ],
     }),
   };
@@ -110,6 +111,7 @@ export async function createModel(data: ModelFormValues) {
       name: parsed.name,
       manufacturer: parsed.manufacturer,
       modelNumber: parsed.modelNumber,
+      sku: parsed.sku || null,
       categoryId: parsed.categoryId || null,
       description: parsed.description,
       image: parsed.image,
@@ -162,6 +164,7 @@ export async function updateModel(id: string, data: ModelFormValues) {
       name: parsed.name,
       manufacturer: parsed.manufacturer,
       modelNumber: parsed.modelNumber,
+      sku: parsed.sku || null,
       categoryId: parsed.categoryId || null,
       description: parsed.description,
       image: parsed.image,

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -1,0 +1,580 @@
+"use server";
+
+import crypto from "crypto";
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/org-context";
+import { serialize } from "@/lib/serialize";
+import { logActivity } from "@/lib/activity-log";
+import { recalculateProjectTotals } from "@/server/line-items";
+import { flexibleDateParse } from "@/lib/woocommerce-utils";
+import {
+  wooCommerceIntegrationSchema,
+  type WooCommerceIntegrationFormValues,
+} from "@/lib/validations/woocommerce";
+
+// ─── Server Actions (UI) ────────────────────────────────────────────────────
+
+export async function getWooCommerceIntegration() {
+  const { organizationId } = await requirePermission("orgSettings", "read");
+  const integration = await prisma.wooCommerceIntegration.findUnique({
+    where: { organizationId },
+  });
+  return integration ? serialize(integration) : null;
+}
+
+export async function updateWooCommerceIntegration(data: WooCommerceIntegrationFormValues) {
+  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+  const parsed = wooCommerceIntegrationSchema.parse(data);
+
+  const existing = await prisma.wooCommerceIntegration.findUnique({
+    where: { organizationId },
+  });
+
+  const result = await prisma.wooCommerceIntegration.upsert({
+    where: { organizationId },
+    create: {
+      organizationId,
+      webhookSecret: existing?.webhookSecret || generateSecret(),
+      ...parsed,
+      storeUrl: parsed.storeUrl || null,
+      customFieldKey: parsed.customFieldKey || null,
+      rentalStartKey: parsed.rentalStartKey || null,
+      rentalEndKey: parsed.rentalEndKey || null,
+      eventStartKey: parsed.eventStartKey || null,
+      deliveryAddressKey: parsed.deliveryAddressKey || null,
+      notesKey: parsed.notesKey || null,
+    },
+    update: {
+      ...parsed,
+      storeUrl: parsed.storeUrl || null,
+      customFieldKey: parsed.customFieldKey || null,
+      rentalStartKey: parsed.rentalStartKey || null,
+      rentalEndKey: parsed.rentalEndKey || null,
+      eventStartKey: parsed.eventStartKey || null,
+      deliveryAddressKey: parsed.deliveryAddressKey || null,
+      notesKey: parsed.notesKey || null,
+    },
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "wooCommerceIntegration",
+    entityId: result.id,
+    entityName: "WooCommerce Integration",
+    summary: `Updated WooCommerce integration settings`,
+  });
+
+  return serialize(result);
+}
+
+export async function regenerateWebhookSecret() {
+  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+
+  const secret = generateSecret();
+  const result = await prisma.wooCommerceIntegration.upsert({
+    where: { organizationId },
+    create: {
+      organizationId,
+      webhookSecret: secret,
+    },
+    update: {
+      webhookSecret: secret,
+    },
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "wooCommerceIntegration",
+    entityId: result.id,
+    entityName: "WooCommerce Integration",
+    summary: "Regenerated WooCommerce webhook secret",
+  });
+
+  return { secret };
+}
+
+export async function getWooCommerceOrderLogs(params?: {
+  page?: number;
+  pageSize?: number;
+  status?: string;
+}) {
+  const { organizationId } = await requirePermission("orgSettings", "read");
+  const page = params?.page ?? 1;
+  const pageSize = params?.pageSize ?? 20;
+
+  const where = {
+    organizationId,
+    ...(params?.status && { status: params.status as never }),
+  };
+
+  const [items, total] = await Promise.all([
+    prisma.wooCommerceOrderLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        project: { select: { id: true, projectNumber: true, name: true } },
+      },
+    }),
+    prisma.wooCommerceOrderLog.count({ where }),
+  ]);
+
+  return serialize({ items, total, page, pageSize });
+}
+
+export async function retryFailedOrder(logId: string) {
+  const { organizationId } = await requirePermission("orgSettings", "update");
+
+  const log = await prisma.wooCommerceOrderLog.findFirst({
+    where: { id: logId, organizationId, status: "FAILED" },
+  });
+  if (!log) throw new Error("Order log not found or not in FAILED status");
+
+  const integration = await prisma.wooCommerceIntegration.findUnique({
+    where: { organizationId },
+  });
+  if (!integration?.isEnabled) throw new Error("Integration not enabled");
+
+  // Re-process the stored payload
+  await processWooCommerceOrder(organizationId, log.payload as unknown as WooOrder, integration, log.id);
+}
+
+export async function getLastPayloadMetaKeys() {
+  const { organizationId } = await requirePermission("orgSettings", "read");
+
+  const integration = await prisma.wooCommerceIntegration.findUnique({
+    where: { organizationId },
+    select: { lastPayload: true },
+  });
+
+  if (!integration?.lastPayload) return null;
+
+  const order = integration.lastPayload as unknown as WooOrder;
+  const keys = new Set<string>();
+
+  // Collect meta_data keys from order
+  if (order.meta_data) {
+    for (const m of order.meta_data) {
+      keys.add(m.key);
+    }
+  }
+
+  // Collect meta_data keys from line items
+  if (order.line_items) {
+    for (const item of order.line_items) {
+      if (item.meta_data) {
+        for (const m of item.meta_data) {
+          keys.add(m.key);
+        }
+      }
+    }
+  }
+
+  return {
+    orderMeta: order.meta_data?.map((m: { key: string; value: string }) => ({
+      key: m.key,
+      value: String(m.value).substring(0, 200),
+    })) ?? [],
+    lineItemMeta: Array.from(keys).sort(),
+  };
+}
+
+// ─── Webhook Processing (called from API route) ─────────────────────────────
+
+export interface WooOrder {
+  id: number;
+  number?: string;
+  status?: string;
+  billing: {
+    first_name: string;
+    last_name: string;
+    company?: string;
+    email: string;
+    phone?: string;
+    address_1?: string;
+    address_2?: string;
+    city?: string;
+    state?: string;
+    postcode?: string;
+    country?: string;
+  };
+  customer_note?: string;
+  line_items: Array<{
+    name: string;
+    sku?: string;
+    quantity: number;
+    price: string;
+    meta_data?: Array<{ key: string; value: string }>;
+  }>;
+  meta_data?: Array<{ key: string; value: string }>;
+}
+
+interface WooCommerceIntegrationConfig {
+  id: string;
+  organizationId: string;
+  isEnabled: boolean;
+  webhookSecret: string;
+  productMatchField: string;
+  customFieldKey: string | null;
+  rentalStartKey: string | null;
+  rentalEndKey: string | null;
+  eventStartKey: string | null;
+  deliveryAddressKey: string | null;
+  notesKey: string | null;
+  dateFormat: string;
+  defaultProjectType: string;
+  autoConfirmEnquiry: boolean;
+  notifyUserIds: string[];
+}
+
+export async function processWooCommerceOrder(
+  orgId: string,
+  order: WooOrder,
+  integration: WooCommerceIntegrationConfig,
+  existingLogId?: string,
+) {
+  const log = existingLogId
+    ? await prisma.wooCommerceOrderLog.update({
+        where: { id: existingLogId },
+        data: { status: "PROCESSING" },
+      })
+    : await prisma.wooCommerceOrderLog.create({
+        data: {
+          organizationId: orgId,
+          wooOrderId: order.id,
+          wooOrderNumber: order.number ?? null,
+          status: "PROCESSING",
+          payload: order as never,
+        },
+      });
+
+  try {
+    // 1. Create or find client
+    const client = await findOrCreateClient(orgId, order.billing);
+
+    // 2. Extract rental dates from order meta
+    const dates = extractDates(order, integration);
+
+    // 3. Match order line items to GearFlow models
+    const matchResults = await matchProducts(orgId, order.line_items, integration);
+
+    // 4. Generate a project number
+    const projectNumber = await generateWebOrderProjectNumber(orgId, order);
+
+    // 5. Create the project
+    const project = await prisma.project.create({
+      data: {
+        organizationId: orgId,
+        projectNumber,
+        name: order.billing.company
+          ? `${order.billing.company} — Website Order #${order.number || order.id}`
+          : `${order.billing.first_name} ${order.billing.last_name} — Website Order #${order.number || order.id}`,
+        clientId: client.id,
+        status: integration.autoConfirmEnquiry ? "QUOTING" : "ENQUIRY",
+        type: integration.defaultProjectType as never,
+        rentalStartDate: dates.rentalStart ?? null,
+        rentalEndDate: dates.rentalEnd ?? null,
+        eventStartDate: dates.eventStart ?? null,
+        clientNotes: extractNotes(order, integration),
+        tags: ["website-order"],
+      },
+    });
+
+    // 6. Add line items for matched and unmatched products
+    let sortOrder = 0;
+    for (const match of matchResults) {
+      await prisma.projectLineItem.create({
+        data: {
+          organizationId: orgId,
+          projectId: project.id,
+          type: match.modelId ? "EQUIPMENT" : "MISC",
+          modelId: match.modelId || null,
+          description: match.modelId
+            ? null
+            : `[WooCommerce] ${match.wooProductName}${match.wooSku ? ` (SKU: ${match.wooSku})` : ""}`,
+          quantity: match.wooQuantity,
+          unitPrice: match.wooPrice,
+          pricingType: "PER_DAY",
+          duration: dates.rentalStart && dates.rentalEnd
+            ? Math.max(1, Math.ceil((dates.rentalEnd.getTime() - dates.rentalStart.getTime()) / (1000 * 60 * 60 * 24)))
+            : 1,
+          lineTotal: match.wooPrice * match.wooQuantity,
+          sortOrder: sortOrder++,
+        },
+      });
+    }
+
+    // 7. Recalculate project totals
+    await recalculateProjectTotals(project.id);
+
+    // 8. Log success
+    const matchedCount = matchResults.filter((m) => m.matched).length;
+    const totalCount = matchResults.length;
+
+    await prisma.wooCommerceOrderLog.update({
+      where: { id: log.id },
+      data: {
+        status: "COMPLETED",
+        projectId: project.id,
+        clientId: client.id,
+        matchResults: matchResults as never,
+        dateExtraction: dates as never,
+      },
+    });
+
+    // 9. Log activity
+    await logActivity({
+      organizationId: orgId,
+      userId: "system",
+      userName: "WooCommerce",
+      action: "CREATE",
+      entityType: "project",
+      entityId: project.id,
+      entityName: project.projectNumber,
+      summary: `Created project from WooCommerce order #${order.number || order.id} (${matchedCount}/${totalCount} products matched)`,
+      projectId: project.id,
+    });
+
+    // 10. Notify admins
+    if (integration.notifyUserIds.length > 0) {
+      await notifyNewWebsiteOrder(orgId, project, client, matchedCount, totalCount, integration.notifyUserIds);
+    }
+  } catch (error) {
+    await prisma.wooCommerceOrderLog.update({
+      where: { id: log.id },
+      data: {
+        status: "FAILED",
+        errorMessage: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function generateSecret(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+async function findOrCreateClient(orgId: string, billing: WooOrder["billing"]) {
+  // Try to find by email first
+  let client = await prisma.client.findFirst({
+    where: { organizationId: orgId, contactEmail: billing.email },
+  });
+
+  if (!client) {
+    const address = [
+      billing.address_1,
+      billing.address_2,
+      billing.city,
+      billing.state,
+      billing.postcode,
+      billing.country,
+    ].filter(Boolean).join(", ");
+
+    client = await prisma.client.create({
+      data: {
+        organizationId: orgId,
+        name: billing.company || `${billing.first_name} ${billing.last_name}`,
+        type: billing.company ? "COMPANY" : "INDIVIDUAL",
+        contactName: `${billing.first_name} ${billing.last_name}`,
+        contactEmail: billing.email,
+        contactPhone: billing.phone || null,
+        billingAddress: address || null,
+        tags: ["website-order"],
+        isActive: true,
+      },
+    });
+
+    await logActivity({
+      organizationId: orgId,
+      userId: "system",
+      userName: "WooCommerce",
+      action: "CREATE",
+      entityType: "client",
+      entityId: client.id,
+      entityName: client.name,
+      summary: `Auto-created client from WooCommerce order`,
+    });
+  }
+
+  return client;
+}
+
+interface DateExtractionResult {
+  rentalStart: Date | null;
+  rentalEnd: Date | null;
+  eventStart: Date | null;
+  raw: Record<string, string>;
+}
+
+function extractDates(order: WooOrder, integration: WooCommerceIntegrationConfig): DateExtractionResult {
+  const meta = new Map<string, string>();
+  if (order.meta_data) {
+    for (const m of order.meta_data) {
+      meta.set(m.key, m.value);
+    }
+  }
+
+  const raw: Record<string, string> = {};
+  const format = integration.dateFormat;
+
+  function parseDate(key: string | null): Date | null {
+    if (!key) return null;
+    const value = meta.get(key);
+    if (!value) return null;
+    raw[key] = value;
+    return flexibleDateParse(value, format);
+  }
+
+  return {
+    rentalStart: parseDate(integration.rentalStartKey),
+    rentalEnd: parseDate(integration.rentalEndKey),
+    eventStart: parseDate(integration.eventStartKey),
+    raw,
+  };
+}
+
+function extractNotes(order: WooOrder, integration: WooCommerceIntegrationConfig): string | null {
+  const parts: string[] = [];
+
+  // Customer note from WooCommerce
+  if (order.customer_note) {
+    parts.push(order.customer_note);
+  }
+
+  // Custom notes key from meta
+  if (integration.notesKey) {
+    const meta = order.meta_data?.find((m) => m.key === integration.notesKey);
+    if (meta?.value) {
+      parts.push(meta.value);
+    }
+  }
+
+  // Delivery address from meta
+  if (integration.deliveryAddressKey) {
+    const meta = order.meta_data?.find((m) => m.key === integration.deliveryAddressKey);
+    if (meta?.value) {
+      parts.push(`Delivery address: ${meta.value}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+interface MatchResult {
+  wooProductName: string;
+  wooSku: string | null;
+  wooQuantity: number;
+  wooPrice: number;
+  modelId: string | null;
+  modelName: string | null;
+  matched: boolean;
+}
+
+async function matchProducts(
+  orgId: string,
+  lineItems: WooOrder["line_items"],
+  integration: WooCommerceIntegrationConfig,
+): Promise<MatchResult[]> {
+  return Promise.all(
+    lineItems.map(async (item): Promise<MatchResult> => {
+      let model = null;
+
+      switch (integration.productMatchField) {
+        case "sku":
+          if (item.sku) {
+            model = await prisma.model.findFirst({
+              where: { organizationId: orgId, sku: item.sku, isActive: true },
+            });
+            // Fallback to modelNumber if no SKU match
+            if (!model) {
+              model = await prisma.model.findFirst({
+                where: { organizationId: orgId, modelNumber: item.sku, isActive: true },
+              });
+            }
+          }
+          break;
+        case "custom_field":
+          if (integration.customFieldKey) {
+            const gearflowId = item.meta_data?.find(
+              (m) => m.key === integration.customFieldKey,
+            )?.value;
+            if (gearflowId) {
+              model = await prisma.model.findFirst({
+                where: { organizationId: orgId, id: gearflowId },
+              });
+            }
+          }
+          break;
+        case "name":
+          model = await prisma.model.findFirst({
+            where: {
+              organizationId: orgId,
+              name: { contains: item.name, mode: "insensitive" },
+              isActive: true,
+            },
+          });
+          break;
+      }
+
+      return {
+        wooProductName: item.name,
+        wooSku: item.sku ?? null,
+        wooQuantity: item.quantity,
+        wooPrice: parseFloat(item.price),
+        modelId: model?.id ?? null,
+        modelName: model?.name ?? null,
+        matched: !!model,
+      };
+    }),
+  );
+}
+
+async function generateWebOrderProjectNumber(orgId: string, order: WooOrder): Promise<string> {
+  const prefix = `WEB-${order.number || order.id}`;
+  // Check if this project number already exists
+  const existing = await prisma.project.findFirst({
+    where: { organizationId: orgId, projectNumber: prefix },
+  });
+  if (!existing) return prefix;
+  // Append suffix if duplicate
+  return `${prefix}-${Date.now().toString(36).slice(-4)}`;
+}
+
+async function notifyNewWebsiteOrder(
+  orgId: string,
+  project: { id: string; projectNumber: string; name: string },
+  client: { name: string },
+  matchedCount: number,
+  totalCount: number,
+  userIds: string[],
+) {
+  // Create in-app notifications (activity log entries the users can see)
+  const matchStatus =
+    matchedCount === totalCount
+      ? `All ${totalCount} products matched`
+      : `${matchedCount}/${totalCount} products matched`;
+
+  for (const userId of userIds) {
+    await logActivity({
+      organizationId: orgId,
+      userId: "system",
+      userName: "WooCommerce",
+      action: "CREATE",
+      entityType: "notification",
+      entityId: project.id,
+      entityName: project.projectNumber,
+      summary: `New website order: ${project.name} for ${client.name} (${matchStatus})`,
+      projectId: project.id,
+      metadata: { notifyUserId: userId },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- **Model SKUs**: Added optional `sku` field to Model with unique-per-org constraint, searchable and editable in the model form
- **WooCommerce Integration**: One-way webhook pipeline that auto-creates projects from WooCommerce orders
  - HMAC-SHA256 webhook verification
  - Client find-or-create from billing info (matched by email)
  - Product matching via SKU, custom meta field, or fuzzy name
  - Flexible date parsing (DD/MM/YYYY, MM/DD/YYYY, ISO, natural language)
  - Settings UI at `/settings/woocommerce` with connection config, field mapping, Test & Detect, WordPress setup guide, and order log with retry
  - Unmatched products become MISC line items so no data is lost

## Test plan
- [ ] Verify model form shows SKU field and saves correctly
- [ ] Verify model detail page displays SKU in subtitle
- [ ] Verify WooCommerce settings page loads at `/settings/woocommerce`
- [ ] Verify webhook endpoint responds to POST with valid HMAC signature
- [ ] Verify duplicate orders are detected and skipped
- [ ] Verify order log shows processing results

🤖 Generated with [Claude Code](https://claude.com/claude-code)