### PR TITLE
Check availability against stock even when project has no dates

### DIFF
--- a/FEATUREDOCS/11-availability.md
+++ b/FEATUREDOCS/11-availability.md
@@ -9,6 +9,13 @@
 6. `isOverbooked = totalBooked > effectiveStock`
 7. `isReducedStock = unavailableAssets > 0 && totalBooked > effectiveStock - unavailableAssets`
 
+## Dateless Stock Checks
+When a project has **no rental dates**, availability is still calculated:
+- `computeOverbookedStatus` compares this project's line item quantities against total stock (no cross-project overlap)
+- `checkAvailability` returns stock info with `dateless: true` flag — UI shows "in stock" instead of "available"
+- `addLineItem` validates quantity against stock even without dates
+- This catches cases like "2× SM58 on a job but only 1 exists" regardless of dates
+
 ## `computeOverbookedStatus(organizationId, lineItems, startDate, endDate, projectId)`
 - Batches all queries for efficiency (single pass over all line items)
 - Returns `Map<lineItemId, { overBy, totalStock, effectiveStock, totalBooked, reducedOnly, inherited }>`

--- a/src/components/projects/add-equipment-dialog.tsx
+++ b/src/components/projects/add-equipment-dialog.tsx
@@ -84,7 +84,7 @@ export function AddEquipmentDialog({
     (m) => m.id === selectedModelId
   );
 
-  // Model-based availability check
+  // Model-based availability check (works with or without dates)
   const { data: availability, isLoading: availabilityLoading } = useQuery({
     queryKey: [
       "availability",
@@ -97,11 +97,11 @@ export function AddEquipmentDialog({
     queryFn: () =>
       checkAvailability(
         selectedModelId,
-        rentalStartDate!,
-        rentalEndDate!,
+        rentalStartDate ?? null,
+        rentalEndDate ?? null,
         projectId
       ),
-    enabled: mode === "model" && !!selectedModelId && !!rentalStartDate && !!rentalEndDate,
+    enabled: mode === "model" && !!selectedModelId,
   });
 
   // Asset tag lookup
@@ -250,7 +250,7 @@ export function AddEquipmentDialog({
               </div>
 
               {/* Availability */}
-              {selectedModelId && rentalStartDate && rentalEndDate && (
+              {selectedModelId && (
                 <div className="rounded-md border p-3 text-sm">
                   {availabilityLoading ? (
                     <div className="flex items-center gap-2 text-muted-foreground">
@@ -263,10 +263,15 @@ export function AddEquipmentDialog({
                         <span className="font-semibold">{availability.available}</span>{" "}
                         available out of{" "}
                         <span className="font-semibold">{availability.effectiveStock ?? availability.totalStock}</span>{" "}
-                        usable
+                        {availability.dateless ? "in stock" : "usable"}
                         {availability.bookedOnThisProject > 0 && (
                           <span className="text-muted-foreground font-normal">
                             {" "}({availability.bookedOnThisProject} already on this project)
+                          </span>
+                        )}
+                        {availability.dateless && (
+                          <span className="text-muted-foreground font-normal">
+                            {" "}(no dates set — showing stock only)
                           </span>
                         )}
                       </p>

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -112,7 +112,7 @@ export function EditLineItemDialog({
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
   const requestedQty = Number(form.watch("quantity")) || 1;
 
-  // Availability check for equipment items with a model
+  // Availability check for equipment items with a model (works with or without dates)
   const { data: availability } = useQuery({
     queryKey: [
       "availability",
@@ -125,11 +125,11 @@ export function EditLineItemDialog({
     queryFn: () =>
       checkAvailability(
         lineItem!.modelId!,
-        rentalStartDate!,
-        rentalEndDate!,
+        rentalStartDate ?? null,
+        rentalEndDate ?? null,
         projectId,
       ),
-    enabled: open && !!lineItem?.modelId && !!rentalStartDate && !!rentalEndDate,
+    enabled: open && !!lineItem?.modelId,
   });
 
   // Available for this edit = total stock minus all other bookings (excluding this item's current qty)

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -48,8 +48,6 @@ export async function computeOverbookedStatus(
 ): Promise<Map<string, OverbookedInfo>> {
   const overbookedMap = new Map<string, OverbookedInfo>();
 
-  if (!rentalStartDate || !rentalEndDate) return overbookedMap;
-
   // Collect ALL equipment line items with a modelId (including kit children)
   const relevantItems = lineItems.filter(
     (li) => li.modelId && li.status !== "CANCELLED",
@@ -57,27 +55,39 @@ export async function computeOverbookedStatus(
   if (relevantItems.length === 0) return overbookedMap;
 
   const modelIds = [...new Set(relevantItems.map((li) => li.modelId!))];
+  const hasDates = !!rentalStartDate && !!rentalEndDate;
 
   // Batch query: all overlapping bookings for these models across all projects
   // Include BOTH regular items AND kit children — they all consume stock
-  const overlappingBookings = await prisma.projectLineItem.findMany({
-    where: {
-      organizationId,
-      modelId: { in: modelIds },
-      status: { not: "CANCELLED" },
-      project: {
-        isTemplate: false,
-        status: {
-          notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"],
+  // When no dates: only count THIS project's bookings (no date overlap possible)
+  const overlappingBookings = hasDates
+    ? await prisma.projectLineItem.findMany({
+        where: {
+          organizationId,
+          modelId: { in: modelIds },
+          status: { not: "CANCELLED" },
+          project: {
+            isTemplate: false,
+            status: {
+              notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"],
+            },
+            rentalStartDate: { lte: rentalEndDate },
+            rentalEndDate: { gte: rentalStartDate },
+          },
         },
-        rentalStartDate: { lte: rentalEndDate },
-        rentalEndDate: { gte: rentalStartDate },
-      },
-    },
-    select: { modelId: true, quantity: true, projectId: true },
-  });
+        select: { modelId: true, quantity: true, projectId: true },
+      })
+    : await prisma.projectLineItem.findMany({
+        where: {
+          organizationId,
+          modelId: { in: modelIds },
+          status: { not: "CANCELLED" },
+          projectId,
+        },
+        select: { modelId: true, quantity: true, projectId: true },
+      });
 
-  // Sum booked per model (total across all projects)
+  // Sum booked per model (total across all projects, or just this project when dateless)
   const totalBookedByModel = new Map<string, number>();
   const thisProjectBookedByModel = new Map<string, number>();
   for (const booking of overlappingBookings) {

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -20,15 +20,17 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
       select: { rentalStartDate: true, rentalEndDate: true },
     });
 
-    if (project?.rentalStartDate && project?.rentalEndDate) {
-      if (parsed.assetId) {
-        // Check if asset is in a kit
-        const assetCheck = await prisma.asset.findUnique({ where: { id: parsed.assetId }, include: { kit: { select: { assetTag: true } } } });
-        if (assetCheck?.kitId) {
-          throw new Error(`Asset is part of Kit ${assetCheck.kit?.assetTag}. Remove it from the Kit first, or add the Kit to the project instead.`);
-        }
+    const hasDates = !!project?.rentalStartDate && !!project?.rentalEndDate;
 
-        // Specific asset — check if it's booked in an overlapping project
+    if (parsed.assetId) {
+      // Check if asset is in a kit
+      const assetCheck = await prisma.asset.findUnique({ where: { id: parsed.assetId }, include: { kit: { select: { assetTag: true } } } });
+      if (assetCheck?.kitId) {
+        throw new Error(`Asset is part of Kit ${assetCheck.kit?.assetTag}. Remove it from the Kit first, or add the Kit to the project instead.`);
+      }
+
+      // Specific asset — check if it's booked in an overlapping project (only when dates exist)
+      if (hasDates) {
         const conflict = await prisma.projectLineItem.findFirst({
           where: {
             organizationId,
@@ -36,8 +38,8 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
             status: { not: "CANCELLED" },
             project: {
               status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
-              rentalStartDate: { lte: project.rentalEndDate },
-              rentalEndDate: { gte: project.rentalStartDate },
+              rentalStartDate: { lte: project!.rentalEndDate! },
+              rentalEndDate: { gte: project!.rentalStartDate! },
               id: { not: projectId },
             },
           },
@@ -46,46 +48,56 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         if (conflict) {
           throw new Error(`Asset is already booked on ${conflict.project.projectNumber} - ${conflict.project.name}`);
         }
+      }
 
-        // Block truly unavailable assets (retired, lost, in maintenance) but allow checked-out ones
-        // — they may be deployed now but available by the project's dates
-        const asset = await prisma.asset.findUnique({ where: { id: parsed.assetId } });
-        if (asset && (asset.status === "RETIRED" || asset.status === "LOST")) {
-          throw new Error(`Asset is ${asset.status.replace("_", " ").toLowerCase()} and cannot be added`);
-        }
-      } else {
-        // Model-level — check quantity against available stock
-        const model = await prisma.model.findUnique({
-          where: { id: parsed.modelId },
-          include: {
-            assets: { where: { isActive: true } },
-            bulkAssets: { where: { isActive: true } },
-          },
-        });
+      // Block truly unavailable assets (retired, lost) but allow checked-out ones
+      const asset = await prisma.asset.findUnique({ where: { id: parsed.assetId } });
+      if (asset && (asset.status === "RETIRED" || asset.status === "LOST")) {
+        throw new Error(`Asset is ${asset.status.replace("_", " ").toLowerCase()} and cannot be added`);
+      }
+    } else {
+      // Model-level — check quantity against available stock
+      const model = await prisma.model.findUnique({
+        where: { id: parsed.modelId },
+        include: {
+          assets: { where: { isActive: true } },
+          bulkAssets: { where: { isActive: true } },
+        },
+      });
 
-        if (model) {
-          const overlapping = await prisma.projectLineItem.findMany({
-            where: {
-              organizationId,
-              modelId: parsed.modelId,
-              status: { not: "CANCELLED" },
-              project: {
-                status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
-                rentalStartDate: { lte: project.rentalEndDate },
-                rentalEndDate: { gte: project.rentalStartDate },
+      if (model) {
+        // When dates exist, check overlapping bookings across projects
+        // When no dates, check only this project's existing bookings against stock
+        const overlapping = hasDates
+          ? await prisma.projectLineItem.findMany({
+              where: {
+                organizationId,
+                modelId: parsed.modelId,
+                status: { not: "CANCELLED" },
+                project: {
+                  status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
+                  rentalStartDate: { lte: project!.rentalEndDate! },
+                  rentalEndDate: { gte: project!.rentalStartDate! },
+                },
               },
-            },
-          });
+            })
+          : await prisma.projectLineItem.findMany({
+              where: {
+                organizationId,
+                modelId: parsed.modelId,
+                status: { not: "CANCELLED" },
+                projectId,
+              },
+            });
 
-          const booked = overlapping.reduce((sum, li) => sum + li.quantity, 0);
-          const totalStock = model.assetType === "SERIALIZED"
-            ? model.assets.length
-            : model.bulkAssets.reduce((sum, ba) => sum + ba.totalQuantity, 0);
-          const available = Math.max(0, totalStock - booked);
+        const booked = overlapping.reduce((sum, li) => sum + li.quantity, 0);
+        const totalStock = model.assetType === "SERIALIZED"
+          ? model.assets.length
+          : model.bulkAssets.reduce((sum, ba) => sum + ba.totalQuantity, 0);
+        const available = Math.max(0, totalStock - booked);
 
-          if (parsed.quantity > available) {
-            throw new Error(`Only ${available} available (${booked} already booked out of ${totalStock} total)`);
-          }
+        if (parsed.quantity > available) {
+          throw new Error(`Only ${available} available (${booked} already booked out of ${totalStock} total)`);
         }
       }
     }
@@ -432,15 +444,15 @@ export async function reorderLineItems(
 
 export async function checkAvailability(
   modelId: string,
-  rentalStartDate: Date | string,
-  rentalEndDate: Date | string,
+  rentalStartDate?: Date | string | null,
+  rentalEndDate?: Date | string | null,
   excludeProjectId?: string
 ) {
   const { organizationId } = await getOrgContext();
 
-  // Ensure dates are proper Date objects (they may arrive as strings from server action serialization)
-  const startDate = new Date(rentalStartDate);
-  const endDate = new Date(rentalEndDate);
+  const hasDates = !!rentalStartDate && !!rentalEndDate;
+  const startDate = hasDates ? new Date(rentalStartDate) : null;
+  const endDate = hasDates ? new Date(rentalEndDate) : null;
 
   // Get the model with asset type info
   const model = await prisma.model.findUnique({
@@ -452,27 +464,42 @@ export async function checkAvailability(
   });
 
   if (!model) {
-    return serialize({ totalStock: 0, effectiveStock: 0, booked: 0, available: 0, bookedOnThisProject: 0, unavailable: 0, inMaintenance: 0, lost: 0, conflicts: [] as string[] });
+    return serialize({ totalStock: 0, effectiveStock: 0, booked: 0, available: 0, bookedOnThisProject: 0, unavailable: 0, inMaintenance: 0, lost: 0, conflicts: [] as string[], dateless: !hasDates });
   }
 
   // Find overlapping projects (where the project rental period overlaps with the given dates)
   // Include both regular items AND kit children — they all consume stock
-  const overlappingLineItems = await prisma.projectLineItem.findMany({
-    where: {
-      organizationId,
-      modelId,
-      status: { not: "CANCELLED" },
-      project: {
-        isTemplate: false,
-        status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
-        rentalStartDate: { lte: endDate },
-        rentalEndDate: { gte: startDate },
-      },
-    },
-    include: {
-      project: { select: { id: true, name: true, projectNumber: true } },
-    },
-  });
+  // When no dates: only count bookings on the current project (stock-only check)
+  const overlappingLineItems = hasDates
+    ? await prisma.projectLineItem.findMany({
+        where: {
+          organizationId,
+          modelId,
+          status: { not: "CANCELLED" },
+          project: {
+            isTemplate: false,
+            status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
+            rentalStartDate: { lte: endDate! },
+            rentalEndDate: { gte: startDate! },
+          },
+        },
+        include: {
+          project: { select: { id: true, name: true, projectNumber: true } },
+        },
+      })
+    : excludeProjectId
+      ? await prisma.projectLineItem.findMany({
+          where: {
+            organizationId,
+            modelId,
+            status: { not: "CANCELLED" },
+            projectId: excludeProjectId,
+          },
+          include: {
+            project: { select: { id: true, name: true, projectNumber: true } },
+          },
+        })
+      : [];
 
   const bookedOnThisProject = excludeProjectId
     ? overlappingLineItems
@@ -480,16 +507,18 @@ export async function checkAvailability(
         .reduce((sum, li) => sum + li.quantity, 0)
     : 0;
 
-  const conflicts = [
-    ...new Map(
-      overlappingLineItems
-        .filter((li) => !excludeProjectId || li.project.id !== excludeProjectId)
-        .map((li) => [
-          li.project.id,
-          `${li.project.projectNumber} - ${li.project.name}`,
-        ])
-    ).values(),
-  ];
+  const conflicts = hasDates
+    ? [
+        ...new Map(
+          overlappingLineItems
+            .filter((li) => !excludeProjectId || li.project.id !== excludeProjectId)
+            .map((li) => [
+              li.project.id,
+              `${li.project.projectNumber} - ${li.project.name}`,
+            ])
+        ).values(),
+      ]
+    : [];
 
   const booked = overlappingLineItems.reduce(
     (sum, li) => sum + li.quantity,
@@ -507,7 +536,7 @@ export async function checkAvailability(
 
     return serialize({
       totalStock, effectiveStock, booked, available, bookedOnThisProject,
-      unavailable, inMaintenance, lost, conflicts,
+      unavailable, inMaintenance, lost, conflicts, dateless: !hasDates,
     });
   } else {
     // BULK: sum up total quantity across all bulk assets
@@ -519,7 +548,7 @@ export async function checkAvailability(
 
     return serialize({
       totalStock, effectiveStock: totalStock, booked, available, bookedOnThisProject,
-      unavailable: 0, inMaintenance: 0, lost: 0, conflicts,
+      unavailable: 0, inMaintenance: 0, lost: 0, conflicts, dateless: !hasDates,
     });
   }
 }


### PR DESCRIPTION
Previously, overbooking detection was skipped entirely when a project had no rental dates. Now stock is checked regardless — if 2x SM58 are added but only 1 exists, it shows as overbooked even without dates set.

- computeOverbookedStatus: compares project qty vs stock when dateless
- checkAvailability: dates now optional, returns dateless flag for UI
- addLineItem: validates stock even without project dates
- Add/Edit dialogs: show availability info without requiring dates