### PR TITLE
Add location mapping and docs for WooCommerce integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,6 +62,7 @@ Detailed docs for each system are in the [`FEATUREDOCS/`](./FEATUREDOCS/) folder
 | 32 | [Preps](./FEATUREDOCS/32-preps.md) | Prep-kits (temporary kits), case assets, project staging |
 | 33 | [Enterprise SSO](./FEATUREDOCS/33-enterprise-sso.md) | SAML 2.0/OIDC SSO, provisioning modes, group mapping, enforcement |
 | 34 | [Reporting System](./FEATUREDOCS/34-reporting-system.md) | Report engine, ~30 pre-built reports, custom report builder, CSV export |
+| 35 | [WooCommerce Integration](./FEATUREDOCS/35-woocommerce-integration.md) | Webhook-driven order import, client/product matching, location auto-creation |
 
 **When making changes**: Read the relevant feature doc(s) first, follow documented patterns, and update the relevant doc(s) after. If no doc exists for the feature you're working on, create a new numbered file in `FEATUREDOCS/` and add it to the table above.
 

--- a/FEATUREDOCS/05-server-actions-api.md
+++ b/FEATUREDOCS/05-server-actions-api.md
@@ -57,7 +57,7 @@ export async function getItems({ page, pageSize, search, sort, order }) {
 | `test-tag-records.ts` | `createTestTagRecord`, `recalculateTestTagStatus` |
 | `test-tag-reports.ts` | 10 report functions + CSV exports |
 | `document-templates.ts` | `getDocumentTemplates`, `getDocumentTemplate`, `createDocumentTemplate`, `updateDocumentTemplate`, `publishDocumentTemplate`, `setDefaultTemplate`, `unsetDefaultTemplate`, `deleteDocumentTemplate`, `duplicateSystemDefault`, `getPublishedTemplatesForDropdown` |
-| `woocommerce.ts` | `getWooCommerceIntegration`, `updateWooCommerceIntegration`, `regenerateWebhookSecret`, `getWooCommerceOrderLogs`, `retryFailedOrder`, `getLastPayloadMetaKeys`, `processWooCommerceOrder`, `verifyWebhookSignature`, `flexibleDateParse` |
+| `woocommerce.ts` | `getWooCommerceIntegration`, `updateWooCommerceIntegration`, `regenerateWebhookSecret`, `getWooCommerceOrderLogs`, `retryFailedOrder`, `getLastPayloadMetaKeys`, `processWooCommerceOrder` |
 
 ## API Routes
 | Route | Method | Purpose |

--- a/FEATUREDOCS/35-woocommerce-integration.md
+++ b/FEATUREDOCS/35-woocommerce-integration.md
@@ -1,0 +1,111 @@
+# WooCommerce Integration
+
+Automatically creates GearFlow projects from WooCommerce orders via webhook.
+
+## Architecture
+
+### Database Models
+
+| Model | Purpose |
+|-------|---------|
+| `WooCommerceIntegration` | Per-org config (one row per org). Stores webhook secret, matching strategy, field mapping, defaults |
+| `WooCommerceOrderLog` | Audit log of every webhook delivery. Status: `PROCESSING`, `COMPLETED`, `FAILED`, `DUPLICATE` |
+
+**Schema additions:**
+- `Model.sku` — Optional SKU field for WooCommerce product matching
+- `WooCommerceIntegration.locationMetaKey` / `defaultLocationId` — Location mapping config
+
+### Webhook Flow
+
+```
+WooCommerce (order.created) → POST /api/integrations/woocommerce/webhook
+  1. Ping detection (accept without HMAC for webhook creation)
+  2. Parse JSON body
+  3. Resolve organization (single-org auto-detect or ?org= param)
+  4. Load integration config, verify enabled
+  5. HMAC-SHA256 signature verification (timing-safe)
+  6. Idempotency check (skip if same order already COMPLETED)
+  7. Store lastPayload (for Test & Detect UI)
+  8. Respond 200 immediately
+  9. Background: processWooCommerceOrder()
+```
+
+### Order Processing (`processWooCommerceOrder`)
+
+1. **Find or create client** — Email match (exact), fuzzy company match (Dice coefficient >= 0.7), or auto-create
+   - If order has company name and email matches an INDIVIDUAL client, skips to company matching
+   - Company matching normalizes names (strips Pty Ltd, Inc, LLC, etc.) before comparing
+2. **Extract dates** — Maps order meta keys to rental start/end and event date
+3. **Match products** — Three strategies:
+   - `sku` — WooCommerce SKU → Model.sku, falls back to Model.modelNumber
+   - `custom_field` — Meta field value → Model.id
+   - `name` — Product name → Model.name (case-insensitive contains)
+4. **Resolve location** — Meta key → fuzzy match existing locations (name + address, substring, bigram), auto-creates VENUE if no match
+5. **Create project** — With client, dates, location, line items (EQUIPMENT for matched, MISC for unmatched)
+6. **Recalculate totals**, log activity, notify configured users
+
+### Client Matching Strategy
+
+```
+Email exact match → use (unless INDIVIDUAL + order has company)
+  ↓ no match
+Company fuzzy match (Dice coefficient ≥ 0.7)
+  ↓ no match
+Auto-create client (COMPANY if company name, INDIVIDUAL otherwise)
+```
+
+Company name normalization strips: Pty Ltd, Inc, LLC, Corp, GmbH, Holdings, etc.
+
+### Location Resolution
+
+```
+Location meta key configured?
+  ↓ yes, meta value present
+  Exact name match (case-insensitive)
+  → Address match (case-insensitive)
+  → Substring match (name or address, either direction)
+  → Bigram fuzzy match (Dice coefficient ≥ 0.6)
+  → Auto-create new VENUE location
+  ↓ no meta key or empty value
+  Default location ID (if configured)
+  → null
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `prisma/schema.prisma` | `WooCommerceIntegration`, `WooCommerceOrderLog`, `WooOrderLogStatus` enum, `Model.sku` |
+| `src/server/woocommerce.ts` | Server actions + `processWooCommerceOrder` background processor |
+| `src/lib/woocommerce-utils.ts` | `verifyWebhookSignature` (HMAC-SHA256), `flexibleDateParse` (multi-format) |
+| `src/lib/validations/woocommerce.ts` | Zod schema for settings form |
+| `src/app/api/integrations/woocommerce/webhook/route.ts` | POST webhook endpoint (public, in middleware allowlist) |
+| `src/app/(app)/settings/woocommerce/page.tsx` | Settings UI (enable/disable, connection, matching, dates, location, defaults, setup guide, order log) |
+
+## Settings Page Sections
+
+1. **Enable/Disable** — Master toggle
+2. **Connection** — Store URL, webhook URL (copy), webhook secret (show/copy/regenerate)
+3. **Product Matching** — Strategy select (SKU / custom field / name), custom field key input
+4. **Date Field Mapping** — Meta keys for rental start/end, event date, delivery address, notes. Date format select. Test & Detect panel (reads `lastPayload` to show available meta keys)
+5. **Location Mapping** — Location meta key input, default location dropdown (fetches from `getLocations`)
+6. **Project Defaults** — Default project type, auto-advance to Quoting toggle
+7. **WordPress Setup Guide** — Collapsible instructions for WooCommerce webhook setup
+8. **Recent Orders** — Order log table with status badges, match summaries, retry button for failed orders
+
+## Key Gotchas
+
+- `verifyWebhookSignature` and `flexibleDateParse` are in `src/lib/woocommerce-utils.ts` (NOT in the server action file) because `"use server"` requires all exports to be async
+- WooCommerce ping requests are accepted without HMAC verification (topic: `action.woocommerce_webhook_delivery` or missing `id`)
+- The webhook secret in GearFlow must be copied to WooCommerce's webhook Secret field — they must match
+- Prisma `Json` fields need `as unknown as Type` casting (e.g., `log.payload as unknown as WooOrder`)
+- `PricingType` enum uses `PER_DAY` not `DAILY`
+- Select components need explicit `defaultValues` in `useForm` to avoid controlled/uncontrolled warnings
+
+## Migrations
+
+| Migration | Purpose |
+|-----------|---------|
+| `20260318000000_add_sku_to_model` | Add `sku` column to `model` table + unique index |
+| `20260318000001_add_woocommerce_integration` | Create `woocommerce_integration` and `woocommerce_order_log` tables, `WooOrderLogStatus` enum |
+| `20260318000002_add_woocommerce_location_mapping` | Add `locationMetaKey` and `defaultLocationId` to `woocommerce_integration` |

--- a/prisma/migrations/20260318000002_add_woocommerce_location_mapping/migration.sql
+++ b/prisma/migrations/20260318000002_add_woocommerce_location_mapping/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "woocommerce_integration" ADD COLUMN "locationMetaKey" TEXT;
+ALTER TABLE "woocommerce_integration" ADD COLUMN "defaultLocationId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1976,6 +1976,10 @@ model WooCommerceIntegration {
   // Date format preference
   dateFormat        String  @default("auto")  // "auto", "DD/MM/YYYY", "MM/DD/YYYY", "ISO"
 
+  // Location mapping
+  locationMetaKey    String?                  // WooCommerce meta key containing venue/location name
+  defaultLocationId  String?                  // Fallback location if no meta key match
+
   // Defaults for created projects
   defaultProjectType String @default("DRY_HIRE")
   autoConfirmEnquiry Boolean @default(false)  // If true, set status to QUOTING instead of ENQUIRY

--- a/src/app/(app)/settings/woocommerce/page.tsx
+++ b/src/app/(app)/settings/woocommerce/page.tsx
@@ -33,6 +33,7 @@ import {
   getLastPayloadMetaKeys,
   retryFailedOrder,
 } from "@/server/woocommerce";
+import { getLocations } from "@/server/locations";
 import { useActiveOrganization } from "@/lib/auth-client";
 
 import { Button } from "@/components/ui/button";
@@ -94,6 +95,13 @@ export default function WooCommerceSettingsPage() {
     enabled: !!orgId && showMetaDetect,
   });
 
+  const { data: locationsData } = useQuery({
+    queryKey: ["locations", orgId],
+    queryFn: () => getLocations({ pageSize: 200 }),
+    enabled: !!orgId,
+  });
+  const locationsList = locationsData?.locations as { id: string; name: string }[] | undefined;
+
   const form = useForm<WooCommerceIntegrationFormValues>({
     resolver: zodResolver(wooCommerceIntegrationSchema),
     defaultValues: {
@@ -106,6 +114,8 @@ export default function WooCommerceSettingsPage() {
       eventStartKey: "",
       deliveryAddressKey: "",
       notesKey: "",
+      locationMetaKey: "",
+      defaultLocationId: "",
       dateFormat: "auto",
       defaultProjectType: "DRY_HIRE",
       autoConfirmEnquiry: false,
@@ -122,6 +132,8 @@ export default function WooCommerceSettingsPage() {
           eventStartKey: integration.eventStartKey || "",
           deliveryAddressKey: integration.deliveryAddressKey || "",
           notesKey: integration.notesKey || "",
+          locationMetaKey: integration.locationMetaKey || "",
+          defaultLocationId: integration.defaultLocationId || "",
           dateFormat: (integration.dateFormat || "auto") as "auto" | "DD/MM/YYYY" | "MM/DD/YYYY" | "ISO",
           defaultProjectType: integration.defaultProjectType as WooCommerceIntegrationFormValues["defaultProjectType"],
           autoConfirmEnquiry: integration.autoConfirmEnquiry,
@@ -418,6 +430,62 @@ export default function WooCommerceSettingsPage() {
                 {...form.register("notesKey")}
                 placeholder="e.g. order_notes"
               />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Location Mapping */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Location Mapping</CardTitle>
+            <CardDescription>
+              Map a WooCommerce order meta field to a project location. If the value matches an existing
+              location it will be used; otherwise a new venue location is created automatically.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="locationMetaKey">Location Meta Key</Label>
+              <Input
+                id="locationMetaKey"
+                {...form.register("locationMetaKey")}
+                placeholder="e.g. venue_name or delivery_location"
+              />
+              <p className="text-xs text-muted-foreground">
+                The WooCommerce order meta key containing the venue or delivery location name/address.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Default Location (fallback)</Label>
+              <Controller
+                name="defaultLocationId"
+                control={form.control}
+                render={({ field }) => (
+                  <Select value={field.value || ""} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {field.value
+                          ? locationsList?.find(
+                              (l) => l.id === field.value,
+                            )?.name ?? "Unknown"
+                          : "None (no fallback)"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">None (no fallback)</SelectItem>
+                      {locationsList?.map((loc) => (
+                        <SelectItem key={loc.id} value={loc.id}>
+                          {loc.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <p className="text-xs text-muted-foreground">
+                Used when no location meta key is set, or the meta field is empty.
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/src/lib/validations/woocommerce.ts
+++ b/src/lib/validations/woocommerce.ts
@@ -10,6 +10,8 @@ export const wooCommerceIntegrationSchema = z.object({
   eventStartKey: z.string().max(100).optional(),
   deliveryAddressKey: z.string().max(100).optional(),
   notesKey: z.string().max(100).optional(),
+  locationMetaKey: z.string().max(100).optional(),
+  defaultLocationId: z.string().optional().or(z.literal("")),
   dateFormat: z.enum(["auto", "DD/MM/YYYY", "MM/DD/YYYY", "ISO"]).default("auto"),
   defaultProjectType: z.enum([
     "DRY_HIRE", "WET_HIRE", "INSTALLATION", "TOUR",

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -43,6 +43,8 @@ export async function updateWooCommerceIntegration(data: WooCommerceIntegrationF
       eventStartKey: parsed.eventStartKey || null,
       deliveryAddressKey: parsed.deliveryAddressKey || null,
       notesKey: parsed.notesKey || null,
+      locationMetaKey: parsed.locationMetaKey || null,
+      defaultLocationId: parsed.defaultLocationId || null,
     },
     update: {
       ...parsed,
@@ -53,6 +55,8 @@ export async function updateWooCommerceIntegration(data: WooCommerceIntegrationF
       eventStartKey: parsed.eventStartKey || null,
       deliveryAddressKey: parsed.deliveryAddressKey || null,
       notesKey: parsed.notesKey || null,
+      locationMetaKey: parsed.locationMetaKey || null,
+      defaultLocationId: parsed.defaultLocationId || null,
     },
   });
 
@@ -228,6 +232,8 @@ interface WooCommerceIntegrationConfig {
   eventStartKey: string | null;
   deliveryAddressKey: string | null;
   notesKey: string | null;
+  locationMetaKey: string | null;
+  defaultLocationId: string | null;
   dateFormat: string;
   defaultProjectType: string;
   autoConfirmEnquiry: boolean;
@@ -265,10 +271,13 @@ export async function processWooCommerceOrder(
     // 3. Match order line items to GearFlow models
     const matchResults = await matchProducts(orgId, order.line_items, integration);
 
-    // 4. Generate a project number
+    // 4. Resolve location (from meta field or default)
+    const locationId = await resolveLocation(orgId, order, integration);
+
+    // 5. Generate a project number
     const projectNumber = await generateWebOrderProjectNumber(orgId, order);
 
-    // 5. Create the project
+    // 6. Create the project
     const project = await prisma.project.create({
       data: {
         organizationId: orgId,
@@ -279,6 +288,7 @@ export async function processWooCommerceOrder(
         clientId: client.id,
         status: integration.autoConfirmEnquiry ? "QUOTING" : "ENQUIRY",
         type: integration.defaultProjectType as never,
+        locationId: locationId ?? null,
         rentalStartDate: dates.rentalStart ?? null,
         rentalEndDate: dates.rentalEnd ?? null,
         eventStartDate: dates.eventStart ?? null,
@@ -287,7 +297,7 @@ export async function processWooCommerceOrder(
       },
     });
 
-    // 6. Add line items for matched and unmatched products
+    // 7. Add line items for matched and unmatched products
     let sortOrder = 0;
     for (const match of matchResults) {
       await prisma.projectLineItem.create({
@@ -311,10 +321,10 @@ export async function processWooCommerceOrder(
       });
     }
 
-    // 7. Recalculate project totals
+    // 8. Recalculate project totals
     await recalculateProjectTotals(project.id);
 
-    // 8. Log success
+    // 9. Log success
     const matchedCount = matchResults.filter((m) => m.matched).length;
     const totalCount = matchResults.length;
 
@@ -329,7 +339,7 @@ export async function processWooCommerceOrder(
       },
     });
 
-    // 9. Log activity
+    // 10. Log activity
     await logActivity({
       organizationId: orgId,
       userId: "system",
@@ -342,7 +352,7 @@ export async function processWooCommerceOrder(
       projectId: project.id,
     });
 
-    // 10. Notify admins
+    // 11. Notify admins
     if (integration.notifyUserIds.length > 0) {
       await notifyNewWebsiteOrder(orgId, project, client, matchedCount, totalCount, integration.notifyUserIds);
     }
@@ -502,6 +512,122 @@ function diceCoefficient(a: Set<string>, b: Set<string>): number {
   }
 
   return (2 * intersection) / (a.size + b.size);
+}
+
+/**
+ * Resolve a project location from WooCommerce order meta.
+ * 1. If a locationMetaKey is configured, try to match the meta value to an existing Location
+ *    (exact name, address/substring, or bigram fuzzy match).
+ * 2. If no match found, auto-create a new VENUE location from the meta value.
+ * 3. Fall back to defaultLocationId if no meta key is set or the field is empty.
+ */
+async function resolveLocation(
+  orgId: string,
+  order: WooOrder,
+  integration: WooCommerceIntegrationConfig,
+): Promise<string | null> {
+  // Try to match from meta field
+  if (integration.locationMetaKey) {
+    const metaValue = order.meta_data?.find(
+      (m) => m.key === integration.locationMetaKey,
+    )?.value;
+
+    if (metaValue?.trim()) {
+      const locationName = metaValue.trim();
+
+      // 1. Exact name match (case-insensitive)
+      const exactName = await prisma.location.findFirst({
+        where: {
+          organizationId: orgId,
+          name: { equals: locationName, mode: "insensitive" },
+        },
+        select: { id: true },
+      });
+      if (exactName) return exactName.id;
+
+      // 2. Address match (case-insensitive)
+      const addressMatch = await prisma.location.findFirst({
+        where: {
+          organizationId: orgId,
+          address: { equals: locationName, mode: "insensitive" },
+        },
+        select: { id: true },
+      });
+      if (addressMatch) return addressMatch.id;
+
+      // 3. Fuzzy match against all locations (name + address)
+      const candidates = await prisma.location.findMany({
+        where: { organizationId: orgId },
+        select: { id: true, name: true, address: true },
+      });
+
+      const normalizedInput = locationName.toLowerCase().trim();
+      let bestMatch: { id: string; score: number } | null = null;
+
+      for (const candidate of candidates) {
+        const normalizedName = candidate.name.toLowerCase().trim();
+        const normalizedAddress = candidate.address?.toLowerCase().trim() ?? "";
+
+        // Substring match (either direction) on name or address
+        if (
+          normalizedName.includes(normalizedInput) ||
+          normalizedInput.includes(normalizedName) ||
+          (normalizedAddress && (
+            normalizedAddress.includes(normalizedInput) ||
+            normalizedInput.includes(normalizedAddress)
+          ))
+        ) {
+          return candidate.id;
+        }
+
+        // Bigram similarity on name
+        const inputBigrams = getBigrams(normalizedInput);
+        const nameBigrams = getBigrams(normalizedName);
+        const nameScore = diceCoefficient(inputBigrams, nameBigrams);
+
+        // Also try address similarity
+        let addrScore = 0;
+        if (normalizedAddress) {
+          const addrBigrams = getBigrams(normalizedAddress);
+          addrScore = diceCoefficient(inputBigrams, addrBigrams);
+        }
+
+        const bestScore = Math.max(nameScore, addrScore);
+        if (bestScore >= 0.6 && (!bestMatch || bestScore > bestMatch.score)) {
+          bestMatch = { id: candidate.id, score: bestScore };
+        }
+      }
+
+      if (bestMatch) return bestMatch.id;
+
+      // 4. No match — create a new VENUE location
+      const newLocation = await prisma.location.create({
+        data: {
+          organizationId: orgId,
+          name: locationName,
+          type: "VENUE",
+          // If the meta value looks like an address (contains comma or numbers), store as address too
+          address: /\d/.test(locationName) || locationName.includes(",") ? locationName : null,
+        },
+      });
+
+      await logActivity({
+        organizationId: orgId,
+        userId: "system",
+        userName: "WooCommerce",
+        action: "CREATE",
+        entityType: "location",
+        entityId: newLocation.id,
+        entityName: newLocation.name,
+        summary: `Auto-created venue location from WooCommerce order`,
+      });
+
+      return newLocation.id;
+    }
+  }
+
+  // Fall back to default location
+  return integration.defaultLocationId || null;
 }
 
 interface DateExtractionResult {


### PR DESCRIPTION
Orders can now map a meta field to a project location with fuzzy matching (name, address, substring, bigram). Auto-creates VENUE locations when no match found. Includes FEATUREDOCS/35 and ARCHITECTURE.md update.