### PR TITLE
fix: resolve removeChild crash and navigation bugs

### DIFF
--- a/src/app/(app)/assets/models/[id]/page.tsx
+++ b/src/app/(app)/assets/models/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo } from "react";
+import { use, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { PageMeta } from "@/components/layout/page-meta";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -52,6 +52,14 @@ const statusColors: Record<string, string> = {
 };
 
 export default function ModelDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
+      <ModelDetailContent params={params} />
+    </Suspense>
+  );
+}
+
+function ModelDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/app/(app)/kits/[id]/page.tsx
+++ b/src/app/(app)/kits/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState, useRef, useCallback, useMemo } from "react";
+import { use, useState, useRef, useCallback, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { PageMeta } from "@/components/layout/page-meta";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -84,6 +84,14 @@ function formatDate(date: Date | string | null | undefined) {
 }
 
 export default function KitDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
+      <KitDetailContent params={params} />
+    </Suspense>
+  );
+}
+
+function KitDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,20 +58,20 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+        <DomPatch />
       </head>
       <body
         className={`${dmSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
-        <DomPatch />
         <GlobalErrorBoundary>
           <ThemeProvider>
             <GoogleMapsProvider>
               <QueryProvider>{children}</QueryProvider>
             </GoogleMapsProvider>
           </ThemeProvider>
+          <Toaster />
         </GlobalErrorBoundary>
-        <Toaster />
       </body>
     </html>
   );

--- a/src/app/warehouse/display/[token]/page.tsx
+++ b/src/app/warehouse/display/[token]/page.tsx
@@ -66,34 +66,41 @@ export default function WarehouseDisplayPage({
   const [data, setData] = useState<DisplayData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [clock, setClock] = useState(new Date());
-
-  const fetchData = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/warehouse/display/${token}`);
-      if (!res.ok) {
-        setError(res.status === 404 ? "Display not found or revoked" : "Failed to load");
-        return;
-      }
-      const json = await res.json();
-      setData(json);
-      setLastUpdated(new Date());
-      setError(null);
-    } catch {
-      // Keep old data, show stale indicator
-      if (!data) setError("Unable to connect");
-    }
-  }, [token, data]);
+  // Initialize clock as null to avoid hydration mismatch (server vs client Date)
+  const [clock, setClock] = useState<Date | null>(null);
 
   // Initial fetch + 60s refresh
+  // fetchData depends only on `token` — NOT on `data`, which caused an infinite
+  // re-fetch loop (data changes → new fetchData → effect re-runs → fetch → data changes)
   useEffect(() => {
+    let hasData = false;
+
+    async function fetchData() {
+      try {
+        const res = await fetch(`/api/warehouse/display/${token}`);
+        if (!res.ok) {
+          setError(res.status === 404 ? "Display not found or revoked" : "Failed to load");
+          return;
+        }
+        const json = await res.json();
+        setData(json);
+        setLastUpdated(new Date());
+        setError(null);
+        hasData = true;
+      } catch {
+        // Keep old data, show stale indicator
+        if (!hasData) setError("Unable to connect");
+      }
+    }
+
     fetchData();
     const interval = setInterval(fetchData, 60_000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [token]);
 
-  // Clock tick every second
+  // Clock tick every second — start on mount to avoid hydration mismatch
   useEffect(() => {
+    setClock(new Date());
     const interval = setInterval(() => setClock(new Date()), 1000);
     return () => clearInterval(interval);
   }, []);
@@ -138,7 +145,7 @@ function StandardLayout({
   lastUpdated,
 }: {
   data: DisplayData;
-  clock: Date;
+  clock: Date | null;
   lastUpdated: Date | null;
 }) {
   return (
@@ -220,7 +227,7 @@ function CompactLayout({
   lastUpdated,
 }: {
   data: DisplayData;
-  clock: Date;
+  clock: Date | null;
   lastUpdated: Date | null;
 }) {
   return (
@@ -276,7 +283,7 @@ function DispatchOnlyLayout({
   lastUpdated,
 }: {
   data: DisplayData;
-  clock: Date;
+  clock: Date | null;
   lastUpdated: Date | null;
 }) {
   return (
@@ -322,15 +329,16 @@ function DispatchOnlyLayout({
 
 // ─── Shared Components ───────────────────────────────────────────────────────
 
-function Header({ data, clock }: { data: DisplayData; clock: Date }) {
+function Header({ data, clock }: { data: DisplayData; clock: Date | null }) {
   const title = data.locationName || data.orgName;
-  const dateStr = clock.toLocaleDateString(undefined, {
+  const now = clock ?? new Date();
+  const dateStr = now.toLocaleDateString(undefined, {
     weekday: "short",
     day: "numeric",
     month: "short",
     year: "numeric",
   });
-  const timeStr = clock.toLocaleTimeString(undefined, {
+  const timeStr = now.toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",

--- a/src/components/dom-patch.tsx
+++ b/src/components/dom-patch.tsx
@@ -1,61 +1,39 @@
-"use client";
-
-import { useEffect } from "react";
-
 /**
+ * Synchronous DOM patch that must run before React hydration.
+ *
  * Patches Node.prototype.removeChild and Node.prototype.insertBefore
  * to gracefully handle cases where React tries to manipulate a DOM node
  * that has already been removed (by browser extensions, theme switching,
- * or hydration mismatches).
+ * dynamic favicon, or hydration mismatches).
  *
- * This fixes the recurring "Cannot read properties of null (reading 'removeChild')"
- * TypeError in Next.js + React 19.
+ * This is a Server Component that injects an inline <script> so the patch
+ * executes as part of the HTML — before any React code runs. The previous
+ * "use client" + useEffect approach left a window during hydration where
+ * the patch wasn't active, which is exactly when most crashes occur.
  */
 export function DomPatch() {
-  useEffect(() => {
-    // Only patch once
-    if (
-      (Node.prototype.removeChild as unknown as { __patched?: boolean })
-        .__patched
-    ) {
-      return;
-    }
+  // Static string — no user input, no XSS risk.
+  const patchScript = `(function(){
+  if(Node.prototype.removeChild.__patched) return;
+  var origRC = Node.prototype.removeChild;
+  Node.prototype.removeChild = function(child){
+    if(child && child.parentNode !== this) return child;
+    return origRC.call(this, child);
+  };
+  Node.prototype.removeChild.__patched = true;
 
-    const originalRemoveChild = Node.prototype.removeChild;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Node.prototype.removeChild = function <T extends Node>(child: T): T {
-      if (child.parentNode !== this) {
-        if (process.env.NODE_ENV === "development") {
-          console.warn(
-            "DomPatch: removeChild called on a node that is not a child. Ignoring.",
-            { parent: this, child }
-          );
-        }
-        return child;
-      }
-      return originalRemoveChild.call(this, child) as T;
-    };
-    (Node.prototype.removeChild as unknown as { __patched: boolean }).__patched =
-      true;
+  var origIB = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function(newNode, refNode){
+    if(refNode && refNode.parentNode !== this) return newNode;
+    return origIB.call(this, newNode, refNode);
+  };
+})();`;
 
-    const originalInsertBefore = Node.prototype.insertBefore;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Node.prototype.insertBefore = function <T extends Node>(
-      newNode: T,
-      referenceNode: Node | null
-    ): T {
-      if (referenceNode && referenceNode.parentNode !== this) {
-        if (process.env.NODE_ENV === "development") {
-          console.warn(
-            "DomPatch: insertBefore called with a reference node that is not a child. Ignoring.",
-            { parent: this, newNode, referenceNode }
-          );
-        }
-        return newNode;
-      }
-      return originalInsertBefore.call(this, newNode, referenceNode) as T;
-    };
-  }, []);
-
-  return null;
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: patchScript,
+      }}
+    />
+  );
 }

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -57,9 +57,10 @@ export class GlobalErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      // Return children immediately — the setTimeout above will clear the error
-      // state, triggering a clean re-render
-      return this.props.children;
+      // Render null so React unmounts the broken subtree.
+      // The setTimeout in componentDidUpdate will clear hasError,
+      // causing a clean remount of children on the next tick.
+      return null;
     }
     return this.props.children;
   }

--- a/src/components/layout/dynamic-favicon.tsx
+++ b/src/components/layout/dynamic-favicon.tsx
@@ -57,19 +57,25 @@ export function DynamicFavicon() {
   const primaryColor = settings?.branding?.primaryColor || "#0d9488";
 
   useEffect(() => {
-    const existing = document.querySelectorAll('link[rel="icon"], link[rel="shortcut icon"]');
-    existing.forEach((el) => el.remove());
+    const FAVICON_ID = "gearflow-dynamic-favicon";
 
-    const link = document.createElement("link");
-    link.rel = "icon";
+    // Reuse our own managed element — never remove React-owned <link> nodes.
+    // Removing nodes that React tracks in its fiber tree causes the
+    // "Cannot read properties of null (reading 'removeChild')" crash
+    // when the reconciler tries to manipulate the <head> on navigation.
+    let link = document.getElementById(FAVICON_ID) as HTMLLinkElement | null;
+    if (!link) {
+      link = document.createElement("link");
+      link.id = FAVICON_ID;
+      link.rel = "icon";
+      link.type = "image/svg+xml";
+      document.head.appendChild(link);
+    }
 
     const iconPaths = platformIcon ? getIconPaths(platformIcon) : null;
     const fallbackLetter = platformName.charAt(0).toUpperCase();
     const svg = buildFaviconSvg(iconPaths, primaryColor, fallbackLetter);
     link.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
-    link.type = "image/svg+xml";
-
-    document.head.appendChild(link);
   }, [platformIcon, primaryColor, platformName]);
 
   return null;

--- a/src/server/availability.ts
+++ b/src/server/availability.ts
@@ -142,7 +142,7 @@ export async function getAssetBookings(
       status: { not: "CANCELLED" },
       project: {
         isTemplate: false,
-        status: { notIn: ["CANCELLED"] },
+        status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
         rentalStartDate: { lte: end },
         rentalEndDate: { gte: start },
       },
@@ -197,7 +197,7 @@ export async function getKitBookings(
       status: { not: "CANCELLED" },
       project: {
         isTemplate: false,
-        status: { notIn: ["CANCELLED"] },
+        status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
         rentalStartDate: { lte: end },
         rentalEndDate: { gte: start },
       },


### PR DESCRIPTION
## Summary

Fixes the recurring "Cannot read properties of null (reading 'removeChild')" crash that occurs randomly during navigation, plus several related data and UI bugs.

### Root Cause Chain (removeChild crash)
- **DynamicFavicon** was calling `el.remove()` on `<link>` nodes that React's fiber tree still tracks. On the next navigation, React tries `removeChild` on a node that's already gone → crash.
- **DomPatch** safety net used `useEffect` (fires after hydration), leaving a window during hydration where the patch wasn't active — exactly when most crashes occur.
- **GlobalErrorBoundary** returned `this.props.children` in both error and normal states, so React never unmounted/remounted the broken subtree.

### Fixes Applied (8 files)

**Wave 1 — Stop the crashes:**
- `dynamic-favicon.tsx`: Update favicon href in-place via a stable `#gearflow-dynamic-favicon` element instead of removing/recreating React-owned nodes
- `dom-patch.tsx`: Converted to Server Component with inline `<script>` — patch runs synchronously before React hydration
- `layout.tsx`: Moved `<DomPatch />` to `<head>`, moved `<Toaster />` inside `<GlobalErrorBoundary>`
- `error-boundary.tsx`: Returns `null` in error state to force React unmount/remount cycle

**Wave 2 — Data integrity:**
- `availability.ts`: `getAssetBookings` and `getKitBookings` now exclude RETURNED, COMPLETED, INVOICED statuses (matching `getModelBookings`)

**Wave 3 — Frontend bugs:**
- `models/[id]/page.tsx` + `kits/[id]/page.tsx`: Wrapped `useSearchParams` in `<Suspense>` boundary
- `warehouse/display/[token]/page.tsx`: Fixed infinite re-fetch loop (`data` in `useCallback` deps) and hydration mismatch (`useState(new Date())`)

## Pre-Landing Review
No issues found.

## QA Verification
- ✅ Production build passes (zero type/compile errors)
- ✅ 16 page navigations tested with zero console errors
- ✅ `Node.prototype.removeChild.__patched === true` confirmed active
- ✅ `#gearflow-dynamic-favicon` element confirmed using in-place updates

## Test plan
- [x] Build passes (`npm run build`)
- [x] Rapid navigation across 16 pages — zero removeChild errors
- [x] Model detail page loads with Suspense boundary
- [x] Kit detail page loads with Suspense boundary
- [x] Warehouse display doesn't infinite-loop fetch
- [x] Dynamic favicon persists across navigation without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)