### PR TITLE
Add worktree setup instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,22 @@ npx prisma generate  # Regenerate Prisma client (after schema changes)
 npx prisma migrate dev --name <name>  # Create + apply migration
 ```
 
-No test framework is configured.
+### Worktree Setup
+
+Git worktrees don't share `node_modules/` or `.env` with the main repo. Run this to bootstrap a new worktree:
+
+```bash
+# Copy .env from main repo (adjust path if needed)
+cp /Users/jayden/code/ttp-assetmanagement/.env .
+
+# Install dependencies
+npm install --legacy-peer-deps
+
+# Generate Prisma client
+npx prisma generate
+```
+
+After this, `npm run dev`, `npm test`, and `npm run build` will all work.
 
 ### DB Setup (first time)
 ```bash


### PR DESCRIPTION
## Summary
- Adds a **Worktree Setup** section to CLAUDE.md with the 3 steps needed to bootstrap a new git worktree: copy `.env`, install deps, generate Prisma client
- Removes stale "No test framework is configured" line (test framework was added in #50)

## Test plan
- [x] Instructions are accurate — tested in this worktree
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)