### PR TITLE
Add CI checks workflow and worktree setup docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Run tests
+        run: npm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Build
+        run: npm run build
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          BETTER_AUTH_SECRET: ci-dummy-secret
+          BETTER_AUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_APP_URL: http://localhost:3000


### PR DESCRIPTION
## Summary
- **New CI workflow** (`.github/workflows/ci.yml`): Runs on every PR to `main` with 4 jobs:
  - **Lint** — ESLint (parallel)
  - **Type Check** — `tsc --noEmit` (parallel)
  - **Tests** — Vitest, 1,084 tests (parallel)
  - **Build** — `next build` (runs after all 3 pass)
- **Worktree setup docs** in CLAUDE.md: How to bootstrap a new worktree (copy `.env`, install deps, generate Prisma client)
- Removes stale "No test framework is configured" line

### CI Architecture
```
PR opened/updated
  ├── Lint        (parallel)
  ├── Type Check  (parallel)
  ├── Tests       (parallel)
  └── Build       (sequential, after all 3 pass)
```

- GitHub-hosted runners (ubuntu-latest, Node 20)
- npm caching for fast installs
- Concurrency groups cancel stale runs on new pushes
- Prisma client generated with dummy DATABASE_URL (no DB needed for CI checks)

## Test plan
- [x] Verify CI checks appear and pass on this PR
- [x] Workflow YAML syntax valid
- [x] No untrusted input in run commands
- [x] Worktree setup instructions tested in this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)