### PR TITLE
fix: simplify service pricing — rate + discount only, always recalcul…

### DIFF
--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -104,12 +104,6 @@ const SERVICE_TYPE_ICONS: Record<ServiceType, typeof Truck> = {
   MISC: Wrench,
 };
 
-const PRICING_TYPE_LABELS: Record<string, string> = {
-  FLAT: "Flat",
-  PER_HOUR: "/hr",
-  PER_DAY: "/day",
-};
-
 function formatDate(date: string | null | undefined): string {
   if (!date) return "";
   return new Date(date).toLocaleDateString("en-AU", {
@@ -161,9 +155,6 @@ interface ServiceRow {
   longitude: number | null;
   showOnDocuments: boolean;
   unitPrice: number | null;
-  quantity: number;
-  pricingType: string | null;
-  duration: number | null;
   lineTotal: number | null;
   costTotal: number | null;
   discount: number | null;
@@ -1073,9 +1064,6 @@ function ServiceDialog({
         longitude: editingService.longitude as number | null,
         showOnDocuments: (editingService.showOnDocuments as boolean) || false,
         unitPrice: (editingService.unitPrice as number) || undefined,
-        quantity: (editingService.quantity as number) || 1,
-        pricingType: (editingService.pricingType as "PER_DAY" | "PER_HOUR" | "FLAT" | "") || "",
-        duration: (editingService.duration as number) || undefined,
         discount: (editingService.discount as number) || undefined,
         costTotal: (editingService.costTotal as number) || undefined,
         taxable: editingService.taxable !== false,
@@ -1102,9 +1090,6 @@ function ServiceDialog({
         longitude: defaultLng,
         showOnDocuments: (matchingTemplate?.showOnDocuments as boolean) || false,
         unitPrice: (matchingTemplate?.defaultUnitPrice as number) || undefined,
-        quantity: 1,
-        pricingType: (matchingTemplate?.defaultPricingType as "PER_DAY" | "PER_HOUR" | "FLAT" | "") || "",
-        duration: undefined,
         discount: undefined,
         taxable: true,
         vehicleDescription: (matchingTemplate?.defaultVehicle as string) || "",
@@ -1461,53 +1446,14 @@ function ServiceDialog({
               <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-fg-3">
                 Charge to Client
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
-                  <Label>Rate</Label>
+                  <Label>Rate ($)</Label>
                   <Input
                     type="number"
                     step="0.01"
                     {...form.register("unitPrice")}
                     placeholder="0.00"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label>Type</Label>
-                  <Select
-                    value={form.watch("pricingType") || ""}
-                    onValueChange={(v) => form.setValue("pricingType", v as "PER_DAY" | "PER_HOUR" | "FLAT" | "")}
-                  >
-                    <SelectTrigger>
-                      <SelectValue>
-                        {form.watch("pricingType")
-                          ? PRICING_TYPE_LABELS[form.watch("pricingType") as string] || form.watch("pricingType")
-                          : "Flat"}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="FLAT">Flat</SelectItem>
-                      <SelectItem value="PER_HOUR">Per Hour</SelectItem>
-                      <SelectItem value="PER_DAY">Per Day</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label>Duration</Label>
-                  <Input
-                    type="number"
-                    step="0.5"
-                    {...form.register("duration")}
-                    placeholder="1"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label>Qty</Label>
-                  <Input
-                    type="number"
-                    min={1}
-                    {...form.register("quantity")}
                   />
                 </div>
                 <div className="space-y-1.5">

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -20,15 +20,11 @@ import type { ServiceType, LineItemType, PricingType, ProjectPhase } from "@/gen
 
 function calculateServiceLineTotal(
   unitPrice: number | undefined,
-  quantity: number,
-  duration: number | undefined,
   discount: number | undefined,
 ): number | null {
-  if (unitPrice == null) return null;
-  const dur = duration ?? 1;
-  const gross = roundCurrency(unitPrice * quantity * dur);
+  if (unitPrice == null || unitPrice === 0) return null;
   const disc = discount ?? 0;
-  return Math.max(0, roundCurrency(gross - disc));
+  return Math.max(0, roundCurrency(unitPrice - disc));
 }
 
 function serviceTypeToLineItemType(type: ServiceType): LineItemType {
@@ -82,8 +78,6 @@ function buildServiceData(parsed: ReturnType<typeof projectServiceSchema.parse>)
   const serviceEndDate = parsed.endDate ? new Date(parsed.endDate as unknown as string) : serviceDate;
   const lineTotal = calculateServiceLineTotal(
     parsed.unitPrice,
-    parsed.quantity,
-    parsed.duration,
     parsed.discount,
   );
 
@@ -240,13 +234,13 @@ export async function createProjectService(
     return svc;
   });
 
-  // Sync line item if showOnDocuments (outside transaction — calls recalculate)
+  // Sync line item if showOnDocuments
   if (parsed.showOnDocuments) {
     await syncServiceLineItem(service.id);
-  } else if (parsed.costTotal) {
-    // Service has a cost but isn't on documents — still need to update project totals for margin
-    await recalculateProjectTotals(projectId);
   }
+
+  // Always recalculate project totals — service charge/cost affects financials
+  await recalculateProjectTotals(projectId);
 
   await logActivity({
     organizationId,
@@ -351,7 +345,7 @@ export async function updateProjectService(
   if (nowOnDocuments) {
     await syncServiceLineItem(service.id);
   } else if (wasOnDocuments && !nowOnDocuments) {
-    // Unlink line item (Arch fix #7 — always unlink, never delete the line item)
+    // Unlink line item — was on documents, now removed
     if (existing.lineItemId) {
       await prisma.projectLineItem.delete({
         where: { id: existing.lineItemId },
@@ -361,12 +355,10 @@ export async function updateProjectService(
         data: { lineItemId: null },
       });
     }
-    // Recalculate regardless — line item removed or costTotal may have changed
-    await recalculateProjectTotals(existing.projectId);
-  } else if (parsed.costTotal !== undefined) {
-    // Not on documents, costTotal may have changed — update project margin
-    await recalculateProjectTotals(existing.projectId);
   }
+
+  // Always recalculate project totals — service charge/cost affects financials
+  await recalculateProjectTotals(existing.projectId);
 
   await logActivity({
     organizationId,
@@ -880,7 +872,7 @@ async function _createServicesFromTemplateData(
     const created = [];
     for (const svc of toCreate) {
       const lineTotal = svc.unitPrice != null
-        ? calculateServiceLineTotal(svc.unitPrice, 1, 1, 0)
+        ? calculateServiceLineTotal(svc.unitPrice, 0)
         : null;
 
       const service = await tx.projectService.create({


### PR DESCRIPTION
…ate totals

- Remove pricing type, duration, and quantity from service form
- Simplify lineTotal calculation: rate - discount (no more qty × duration)
- Always call recalculateProjectTotals() on create and update (not conditional)
- Remove unused PRICING_TYPE_LABELS constant