### PR TITLE
Remove service line items, add billable services section

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -22,6 +22,7 @@ import { Plus, FolderPlus, Package, ArrowUpRight, MoreHorizontal, Trash2, Pencil
 import { toast } from "sonner";
 
 import { getProjectCategories } from "@/server/project-categories";
+import { getProjectServices } from "@/server/project-services";
 import {
   createProjectGroup,
   updateProjectGroup,
@@ -525,6 +526,12 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
   const { data: templates = [] } = useQuery({
     queryKey: ["group-templates"],
     queryFn: () => getGroupTemplates(),
+    staleTime: 60_000,
+  });
+
+  const { data: servicesData } = useQuery({
+    queryKey: ["project-services", projectId],
+    queryFn: () => getProjectServices(projectId),
     staleTime: 60_000,
   });
 
@@ -1096,6 +1103,41 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
           </Table>
         </div>
       )}
+
+      {/* ─── Billable Services on Documents ─────────────────────────────────── */}
+      {(() => {
+        const billable = (servicesData ?? []).filter(
+          (s: { showOnDocuments: boolean; status: string }) => s.showOnDocuments && s.status !== "CANCELLED"
+        );
+        if (billable.length === 0) return null;
+        return (
+          <div className="mt-6 rounded-lg border border-border/50 bg-card">
+            <div className="flex items-center gap-2 border-b border-border/50 px-4 py-3">
+              <h3 className="text-sm font-medium text-muted-foreground">Services on Documents</h3>
+              <span className="text-xs text-muted-foreground/60">({billable.length})</span>
+            </div>
+            <div className="divide-y divide-border/30">
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {billable.map((svc: any) => (
+                <div key={svc.id} className="flex items-center justify-between px-4 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm">{svc.title}</span>
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{svc.type.replace("_", " ")}</span>
+                  </div>
+                  <div className="flex items-center gap-4 text-sm">
+                    {svc.lineTotal != null && Number(svc.lineTotal) > 0 && (
+                      <span className="text-foreground">{formatCurrency(Number(svc.lineTotal))}</span>
+                    )}
+                    {svc.costTotal != null && Number(svc.costTotal) > 0 && (
+                      <span className="text-xs text-muted-foreground">Cost: {formatCurrency(Number(svc.costTotal))}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       {/* ─── Dialogs ────────────────────────────────────────────────────────── */}
 

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -286,6 +286,44 @@ export async function buildDocumentData(
     lineItems = rawLineItems;
   }
 
+  // ─── Append billable services as virtual line items ─────────────────────────
+  // Services with showOnDocuments appear on quotes/invoices as their own section
+  const billableServices = await prisma.projectService.findMany({
+    where: {
+      projectId,
+      organizationId,
+      showOnDocuments: true,
+      status: { not: "CANCELLED" },
+    },
+    orderBy: { sortOrder: "asc" },
+  });
+
+  if (billableServices.length > 0) {
+    for (const svc of billableServices) {
+      lineItems.push({
+        id: `svc-${svc.id}`,
+        description: svc.title,
+        quantity: 1,
+        checkedOutQuantity: 0,
+        unitPrice: svc.unitPrice ? Number(svc.unitPrice) : null,
+        pricingType: "FLAT",
+        duration: 1,
+        discount: svc.discount ? Number(svc.discount) : null,
+        lineTotal: svc.lineTotal ? Number(svc.lineTotal) : null,
+        groupName: "Services",
+        categoryName: "Services",
+        groupTitle: null,
+        isGroupRow: false,
+        isOptional: false,
+        notes: svc.description || null,
+        status: "CONFIRMED",
+        model: null,
+        asset: null,
+        bulkAsset: null,
+      } as DocumentLineItem);
+    }
+  }
+
   // Compute totals for packing list / delivery docket
   const topLevelItems = lineItems.filter((i) => !i.isKitChild && !i.isContainerLineItem);
   const totalItems = topLevelItems.reduce((sum, i) => {

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -14,7 +14,7 @@ import { roundCurrency } from "@/lib/formatters";
 import { sendCrewOffer } from "@/server/crew-communication";
 import { recalculateProjectTotals } from "@/server/line-items";
 import { SERVICE_TYPE_LABELS } from "@/lib/constants/services";
-import type { ServiceType, LineItemType, PricingType, ProjectPhase } from "@/generated/prisma/client";
+import type { ServiceType, PricingType, ProjectPhase } from "@/generated/prisma/client";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -25,20 +25,6 @@ function calculateServiceLineTotal(
   if (unitPrice == null || unitPrice === 0) return null;
   const disc = discount ?? 0;
   return Math.max(0, roundCurrency(unitPrice - disc));
-}
-
-function serviceTypeToLineItemType(type: ServiceType): LineItemType {
-  switch (type) {
-    case "DELIVERY":
-    case "PICKUP":
-      return "TRANSPORT";
-    case "BUMP_IN":
-    case "BUMP_OUT":
-    case "LABOUR":
-      return "LABOUR";
-    case "MISC":
-      return "SERVICE";
-  }
 }
 
 function serviceTypeToPhase(type: ServiceType): ProjectPhase {
@@ -234,11 +220,6 @@ export async function createProjectService(
     return svc;
   });
 
-  // Sync line item if showOnDocuments
-  if (parsed.showOnDocuments) {
-    await syncServiceLineItem(service.id);
-  }
-
   // Always recalculate project totals — service charge/cost affects financials
   await recalculateProjectTotals(projectId);
 
@@ -338,23 +319,15 @@ export async function updateProjectService(
     return svc;
   });
 
-  // Sync line item based on showOnDocuments
-  const wasOnDocuments = existing.showOnDocuments;
-  const nowOnDocuments = parsed.showOnDocuments;
-
-  if (nowOnDocuments) {
-    await syncServiceLineItem(service.id);
-  } else if (wasOnDocuments && !nowOnDocuments) {
-    // Unlink line item — was on documents, now removed
-    if (existing.lineItemId) {
-      await prisma.projectLineItem.delete({
-        where: { id: existing.lineItemId },
-      });
-      await prisma.projectService.update({
-        where: { id },
-        data: { lineItemId: null },
-      });
-    }
+  // Clean up any legacy linked line item
+  if (existing.lineItemId) {
+    await prisma.projectLineItem.delete({
+      where: { id: existing.lineItemId },
+    }).catch(() => {});
+    await prisma.projectService.update({
+      where: { id },
+      data: { lineItemId: null },
+    });
   }
 
   // Always recalculate project totals — service charge/cost affects financials
@@ -563,90 +536,6 @@ export async function updateServiceCrewStatus(
   });
 
   return serialize({ updated: updatedCount });
-}
-
-// ─── Line Item Sync ───────────────────────────────────────────────────────────
-
-async function syncServiceLineItem(serviceId: string) {
-  const service = await prisma.projectService.findUnique({
-    where: { id: serviceId },
-  });
-  if (!service || !service.showOnDocuments) return;
-
-  const lineItemType = serviceTypeToLineItemType(service.type);
-  const pricingType = service.pricingType ?? "FLAT";
-  const duration = service.duration ? Number(service.duration) : 1;
-  const unitPrice = service.unitPrice ? Number(service.unitPrice) : null;
-  const discount = service.discount ? Number(service.discount) : null;
-  const lineTotal = service.lineTotal ? Number(service.lineTotal) : null;
-
-  if (service.lineItemId) {
-    // Guard: verify line item exists and is NOT a kit child (Arch fix #6)
-    const existingLineItem = await prisma.projectLineItem.findUnique({
-      where: { id: service.lineItemId },
-      select: { id: true, isKitChild: true },
-    });
-    if (!existingLineItem) {
-      // Line item was deleted externally — unlink and create fresh
-      await prisma.projectService.update({
-        where: { id: serviceId },
-        data: { lineItemId: null },
-      });
-    } else if (existingLineItem.isKitChild) {
-      // Service line items can never be kit children — unlink silently
-      await prisma.projectService.update({
-        where: { id: serviceId },
-        data: { lineItemId: null },
-      });
-    } else {
-      // Update existing line item
-      await prisma.projectLineItem.update({
-        where: { id: service.lineItemId },
-        data: {
-          type: lineItemType,
-          description: service.title,
-          quantity: service.quantity,
-          unitPrice,
-          pricingType,
-          duration: duration,
-          discount,
-          lineTotal,
-        },
-      });
-      await recalculateProjectTotals(service.projectId);
-      return;
-    }
-  }
-
-  // Create new line item
-  const maxSort = await prisma.projectLineItem.aggregate({
-    where: { projectId: service.projectId },
-    _max: { sortOrder: true },
-  });
-
-  const lineItem = await prisma.projectLineItem.create({
-    data: {
-      organizationId: service.organizationId,
-      projectId: service.projectId,
-      type: lineItemType,
-      description: service.title,
-      quantity: service.quantity,
-      unitPrice,
-      pricingType,
-      duration: duration,
-      discount,
-      lineTotal,
-      sortOrder: (maxSort._max.sortOrder ?? -1) + 1,
-      groupName: "Services",
-    },
-  });
-
-  await prisma.projectService.update({
-    where: { id: serviceId },
-    data: { lineItemId: lineItem.id },
-  });
-
-  await recalculateProjectTotals(service.projectId);
 }
 
 // ─── Generate Services (Phase 1) ─────────────────────────────────────────────
@@ -902,13 +791,7 @@ async function _createServicesFromTemplateData(
   });
 
   // Sync line items for services that show on documents
-  let lineItemsCreated = 0;
-  for (const svc of createdServices) {
-    if (svc.showOnDocuments) {
-      await syncServiceLineItem(svc.id);
-      lineItemsCreated++;
-    }
-  }
+  await recalculateProjectTotals(projectId);
 
   await logActivity({
     organizationId,
@@ -924,7 +807,6 @@ async function _createServicesFromTemplateData(
 
   return serialize({
     created: createdServices.length,
-    lineItemsCreated,
   });
 }
 
@@ -1063,12 +945,7 @@ export async function cloneServicesFromProject(
     return results;
   });
 
-  // Sync line items for cloned services
-  for (const svc of created) {
-    if (svc.showOnDocuments) {
-      await syncServiceLineItem(svc.id);
-    }
-  }
+  await recalculateProjectTotals(targetProjectId);
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## Summary
- **Remove `syncServiceLineItem()`** — services no longer create `ProjectLineItem` records in the equipment tab
- **Billable services on PDFs** — services with `showOnDocuments: true` are injected as virtual line items directly in `build-document-data.ts`
- **Equipment tab section** — new "Services on Documents" read-only section below the equipment table showing billable service titles, types, and pricing

## Test plan
- [ ] Verify services no longer appear as line items in equipment tab
- [ ] Create a service with `showOnDocuments: true` and confirm it appears in the new "Services on Documents" section
- [ ] Generate a quote/invoice PDF and confirm billable services appear under a "Services" group
- [ ] Delete/cancel a service and verify project totals recalculate correctly
- [ ] Build passes, all 1545 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)