### PR TITLE
Fix service financials and restore equipment tab badges

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -38,6 +38,7 @@ import {
   deleteProjectCategory,
   reorderProjectCategories,
   getUncategorizedLineItems,
+  getProjectOverbookedStatus,
 } from "@/server/project-categories";
 import { getGroupTemplates, applyGroupTemplate } from "@/server/group-templates";
 import { removeLineItem, updateLineItem, addKitLineItem, checkKitAvailability, reorderLineItems } from "@/server/line-items";
@@ -55,6 +56,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -97,8 +99,17 @@ interface LineItemData {
   type?: string;
   priceBreakdown?: string | null;
   priceOverridden?: boolean;
+  isSubhire?: boolean;
+  isKitChild?: boolean;
+  kitId?: string | null;
+  pricingMode?: string | null;
+  status?: string;
+  prepStatus?: string | null;
+  supplier?: { name: string } | null;
   model?: { name: string; dailyRate?: unknown; weeklyRate?: unknown; monthlyRate?: unknown } | null;
   asset?: { assetTag?: string | null } | null;
+  kit?: { name?: string } | null;
+  childLineItems?: LineItemData[];
 }
 
 interface GroupData {
@@ -126,6 +137,96 @@ interface CategoryData {
 }
 
 const COL_COUNT = 6;
+
+// ─── Overbooked info type ───────────────────────────────────────────────────
+
+type OverbookedInfo = {
+  overBy: number;
+  totalStock: number;
+  effectiveStock?: number;
+  totalBooked: number;
+  inherited?: boolean;
+  unavailableAssets?: number;
+  reducedOnly?: boolean;
+  hasOverbookedChildren?: boolean;
+  hasReducedChildren?: boolean;
+};
+
+function OverbookedBadge({ info }: { info?: OverbookedInfo | null }) {
+  if (!info) return null;
+
+  const effective = info.effectiveStock ?? info.totalStock;
+  const unavail = info.unavailableAssets || 0;
+
+  // Kit parents with BOTH overbooked and reduced children show two badges
+  if (info.inherited && info.hasOverbookedChildren && info.hasReducedChildren) {
+    return (
+      <>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Badge variant="outline" className="ml-1.5 cursor-help text-xs bg-red-500/10 text-red-600 border-red-500/20">
+                  Overbooked
+                </Badge>
+              }
+            />
+            <TooltipContent>Contains items that are over capacity</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Badge variant="outline" className="ml-1.5 cursor-help text-xs bg-purple-500/10 text-purple-600 border-purple-500/20">
+                  Reduced Stock
+                </Badge>
+              }
+            />
+            <TooltipContent>
+              Contains items with {unavail} asset{unavail !== 1 ? "s" : ""} in maintenance or lost
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </>
+    );
+  }
+
+  const isReduced = info.reducedOnly;
+  const colorClass = isReduced
+    ? "bg-purple-500/10 text-purple-600 border-purple-500/20"
+    : info.inherited
+      ? "bg-amber-500/10 text-amber-600 border-amber-500/20"
+      : "bg-red-500/10 text-red-600 border-red-500/20";
+  const label = isReduced ? "Reduced Stock" : "Overbooked";
+
+  function getTooltip() {
+    if (info!.inherited) {
+      return isReduced
+        ? `Contains items with ${unavail} asset${unavail !== 1 ? "s" : ""} in maintenance or lost`
+        : `Contains items that are ${info!.overBy} over capacity`;
+    }
+    if (isReduced) {
+      return `${info!.overBy} over usable stock — ${unavail} of ${info!.totalStock} in maintenance or lost (${effective} usable, ${info!.totalBooked} booked)`;
+    }
+    return `${info!.overBy} over capacity (${info!.totalBooked} booked / ${effective} usable${unavail > 0 ? `, ${unavail} unavailable` : ""})`;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Badge variant="outline" className={`ml-1.5 cursor-help text-xs ${colorClass}`}>
+              {label}
+            </Badge>
+          }
+        />
+        <TooltipContent>{getTooltip()}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 // ─── Sortable group row ─────────────────────────────────────────────────────
 
@@ -314,12 +415,14 @@ function SortableCategoryRow({
 function SortableLineItemRow({
   item,
   indent,
+  overbookedInfo,
   onEdit,
   onMove,
   onRemove,
 }: {
   item: LineItemData;
   indent: string;
+  overbookedInfo?: OverbookedInfo | null;
   onEdit: () => void;
   onMove: () => void;
   onRemove: () => void;
@@ -358,17 +461,41 @@ function SortableLineItemRow({
           {item.asset?.assetTag && (
             <span className="text-xs text-fg-3">({item.asset.assetTag})</span>
           )}
+          {item.kitId && !item.isKitChild && (
+            <Badge variant="outline" className="ml-1.5 text-xs bg-indigo-500/10 text-indigo-600 border-indigo-500/20">
+              Kit
+            </Badge>
+          )}
+          {item.kitId && !item.isKitChild && item.pricingMode === "ITEMIZED" && (
+            <Badge variant="outline" className="ml-1 text-xs">
+              Itemized
+            </Badge>
+          )}
           {item.isOptional && (
-            <Badge variant="outline" className="ml-2 text-xs bg-amber-500/10 text-amber-600 border-amber-500/20">
+            <Badge variant="outline" className="ml-1.5 text-xs bg-amber-500/10 text-amber-600 border-amber-500/20">
               Optional
             </Badge>
           )}
-          {item.type === "SUBHIRE" && (
-            <Badge variant="outline" className="ml-2 text-xs bg-cyan-500/10 text-cyan-600 border-cyan-500/20">
+          {(item.isSubhire || item.type === "SUBHIRE") && (
+            <Badge variant="outline" className="ml-1.5 text-xs bg-cyan-500/10 text-cyan-600 border-cyan-500/20">
               Subhire
             </Badge>
           )}
+          {item.status === "CANCELLED" && (
+            <Badge variant="outline" className="ml-1.5 text-xs bg-red-500/10 text-red-600 border-red-500/20">
+              Cancelled
+            </Badge>
+          )}
+          {item.prepStatus === "PREPPED" && (
+            <Badge variant="outline" className="ml-1.5 text-xs bg-green-500/10 text-green-600 border-green-500/20">
+              Prepped
+            </Badge>
+          )}
+          <OverbookedBadge info={overbookedInfo} />
         </div>
+        {(item.isSubhire || item.type === "SUBHIRE") && item.supplier && (
+          <p className={`text-xs text-fg-3 mt-0.5 ${indent}`}>via {item.supplier.name}</p>
+        )}
       </TableCell>
       <TableCell className="text-center t-data">{item.quantity}</TableCell>
       <TableCell className="text-right hidden md:table-cell t-data">
@@ -533,6 +660,12 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
     queryKey: ["project-services", projectId],
     queryFn: () => getProjectServices(projectId),
     staleTime: 60_000,
+  });
+
+  const { data: overbookedMap = {} } = useQuery({
+    queryKey: ["project-overbooked", projectId],
+    queryFn: () => getProjectOverbookedStatus(projectId),
+    staleTime: 30_000,
   });
 
   const templateOptions = (templates as { id: string; name: string; description: string | null; items: unknown[] }[]).map(
@@ -1062,6 +1195,7 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
                                 key={item.id}
                                 item={item}
                                 indent="ml-12"
+                                overbookedInfo={(overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                                 onEdit={() => openEditLineItem(item)}
                                 onMove={() => { setMoveLineItemId(item.id); setMoveTargetGroupId(group.id); }}
                                 onRemove={() => removeMut.mutate(item.id)}
@@ -1077,6 +1211,7 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
                           key={item.id}
                           item={item}
                           indent="ml-3"
+                          overbookedInfo={(overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                           onEdit={() => openEditLineItem(item)}
                           onMove={() => { setMoveLineItemId(item.id); setMoveTargetGroupId("__uncategorized__"); }}
                           onRemove={() => removeMut.mutate(item.id)}
@@ -1092,6 +1227,7 @@ export function EquipmentTab({ projectId }: EquipmentTabProps) {
                     key={item.id}
                     item={item}
                     indent=""
+                    overbookedInfo={(overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                     onEdit={() => openEditLineItem(item)}
                     onMove={() => { setMoveLineItemId(item.id); setMoveTargetGroupId("__uncategorized__"); }}
                     onRemove={() => removeMut.mutate(item.id)}

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -826,14 +826,22 @@ export async function recalculateProjectTotals(projectId: string) {
 
   const equipmentRevenue = roundCurrency(groupRevenue + standaloneRevenue);
 
-  // 3. Service costs (costTotal = what it costs us, across all services)
+  // 3. Service financials
   const services = await prisma.projectService.findMany({
     where: { projectId, status: { not: "CANCELLED" } },
-    select: { costTotal: true },
+    select: { costTotal: true, lineTotal: true, showOnDocuments: true },
   });
 
+  // costTotal = what it costs us (all services)
   const serviceCostTotal = roundCurrency(
     services.reduce((sum, s) => sum + (s.costTotal != null ? Number(s.costTotal) : 0), 0)
+  );
+
+  // serviceRevenue = what we charge the client (only billable services shown on documents)
+  const serviceRevenue = roundCurrency(
+    services
+      .filter((s) => s.showOnDocuments)
+      .reduce((sum, s) => sum + (s.lineTotal != null ? Number(s.lineTotal) : 0), 0)
   );
 
   // 4. Labour costs from crew assignments
@@ -846,8 +854,8 @@ export async function recalculateProjectTotals(projectId: string) {
     assignments.reduce((sum, a) => sum + (a.estimatedCost != null ? Number(a.estimatedCost) : 0), 0)
   );
 
-  // 5. Calculate totals
-  const subtotal = equipmentRevenue;
+  // 5. Calculate totals (equipment + billable services)
+  const subtotal = roundCurrency(equipmentRevenue + serviceRevenue);
   const discountPercent = project.discountPercent != null ? Number(project.discountPercent) : 0;
   const discountAmount = roundCurrency(subtotal * (discountPercent / 100));
   const taxableAmount = roundCurrency(subtotal - discountAmount);

--- a/src/server/project-categories.ts
+++ b/src/server/project-categories.ts
@@ -5,21 +5,35 @@ import { requirePermission } from "@/lib/org-context";
 import { projectCategorySchema, type ProjectCategoryFormValues } from "@/lib/validations/project-category";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
+import { computeOverbookedStatus } from "@/lib/availability";
 
 export async function getProjectCategories(projectId: string) {
   const { organizationId } = await requirePermission("project", "read");
+  const lineItemInclude = {
+    model: true,
+    asset: true,
+    bulkAsset: true,
+    kit: true,
+    supplier: { select: { name: true } },
+    childLineItems: {
+      include: {
+        model: true,
+        asset: true,
+        bulkAsset: true,
+        kit: true,
+        supplier: { select: { name: true } },
+      },
+      orderBy: { sortOrder: "asc" as const },
+    },
+  };
+
   const categories = await prisma.projectCategory.findMany({
     where: { projectId, organizationId },
     include: {
       groups: {
         include: {
           lineItems: {
-            include: {
-              model: true,
-              asset: true,
-              bulkAsset: true,
-              kit: true,
-            },
+            include: lineItemInclude,
             orderBy: { sortOrder: "asc" },
           },
         },
@@ -27,12 +41,7 @@ export async function getProjectCategories(projectId: string) {
       },
       lineItems: {
         where: { groupId: null },
-        include: {
-          model: true,
-          asset: true,
-          bulkAsset: true,
-          kit: true,
-        },
+        include: lineItemInclude,
         orderBy: { sortOrder: "asc" },
       },
     },
@@ -170,6 +179,17 @@ export async function getUncategorizedLineItems(projectId: string) {
       asset: true,
       bulkAsset: true,
       kit: true,
+      supplier: { select: { name: true } },
+      childLineItems: {
+        include: {
+          model: true,
+          asset: true,
+          bulkAsset: true,
+          kit: true,
+          supplier: { select: { name: true } },
+        },
+        orderBy: { sortOrder: "asc" },
+      },
     },
     orderBy: { sortOrder: "asc" },
   });
@@ -192,4 +212,62 @@ export async function reorderProjectCategories(
   );
 
   return serialize({ success: true });
+}
+
+/**
+ * Returns a map of lineItemId → overbookedInfo for all line items in a project.
+ * Used by the equipment tab to show overbooked/reduced stock badges.
+ */
+export async function getProjectOverbookedStatus(projectId: string) {
+  const { organizationId } = await requirePermission("project", "read");
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId, organizationId },
+    select: {
+      id: true,
+      rentalStartDate: true,
+      rentalEndDate: true,
+      lineItems: {
+        where: { status: { not: "CANCELLED" } },
+        select: {
+          id: true,
+          modelId: true,
+          kitId: true,
+          quantity: true,
+          isKitChild: true,
+          parentLineItemId: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!project) return serialize({});
+
+  const overbookedMap = await computeOverbookedStatus(
+    organizationId,
+    project.lineItems,
+    project.rentalStartDate,
+    project.rentalEndDate,
+    project.id,
+  );
+
+  // Convert Map to plain object for serialization
+  const result: Record<string, {
+    overBy: number;
+    totalStock: number;
+    effectiveStock?: number;
+    totalBooked: number;
+    inherited?: boolean;
+    unavailableAssets?: number;
+    reducedOnly?: boolean;
+    hasOverbookedChildren?: boolean;
+    hasReducedChildren?: boolean;
+  }> = {};
+
+  for (const [id, info] of overbookedMap) {
+    result[id] = info;
+  }
+
+  return serialize(result);
 }


### PR DESCRIPTION
## Summary
- **Service charges in project totals** — billable services (`showOnDocuments: true`) now have their `lineTotal` added to the project subtotal, flowing through to discount, tax, total, and margin calculations
- **Restore equipment tab badges** — overbooked (red), reduced stock (purple), kit (indigo), subhire (cyan), optional (amber), cancelled, and prepped badges with rich tooltips
- **Expanded data queries** — `getProjectCategories` and `getUncategorizedLineItems` now include supplier info and child line items for complete badge rendering

## Test plan
- [ ] Add a service with a rate and "Show on Documents" enabled — verify project subtotal/total increases
- [ ] Cancel a billable service — verify project totals decrease
- [ ] Check equipment tab shows overbooked badges on items exceeding stock
- [ ] Check subhire items show cyan "Subhire" badge with supplier name
- [ ] Check kit items show indigo "Kit" badge
- [ ] Build passes, all 1545 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)