### PR TITLE
Category picker on add equipment & financial sidebar improvements

### DIFF
--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -733,6 +733,11 @@ export default function ProjectDetailPage({
                     <div className="border-b border-border pb-4">
                       <FinancialSummary
                         equipmentRevenue={project.equipmentRevenue as number | null}
+                        serviceChargeTotal={
+                          project.subtotal != null && project.equipmentRevenue != null
+                            ? Number(project.subtotal) - Number(project.equipmentRevenue)
+                            : null
+                        }
                         serviceCostTotal={project.serviceCostTotal as number | null}
                         labourCostTotal={project.labourCostTotal as number | null}
                         subtotal={project.subtotal as number | null}

--- a/src/components/projects/add-equipment-dialog.tsx
+++ b/src/components/projects/add-equipment-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/validations/line-item";
 import { addLineItem, checkAvailability, lookupAssetByTag } from "@/server/line-items";
 import { getModels } from "@/server/models";
+import { getProjectCategories } from "@/server/project-categories";
 import {
   Dialog,
   DialogContent,
@@ -26,6 +27,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useActiveOrganization } from "@/lib/auth-client";
 
 type AddMode = "model" | "asset-tag";
@@ -62,6 +64,7 @@ export function AddEquipmentDialog({
   const [assetTagInput, setAssetTagInput] = useState("");
   const [lookupTag, setLookupTag] = useState("");
   const [discountMode, setDiscountMode] = useState<"$" | "%">("$");
+  const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId ?? "");
 
   const form = useForm<LineItemFormValues>({
     resolver: zodResolver(lineItemSchema),
@@ -79,6 +82,18 @@ export function AddEquipmentDialog({
     queryFn: () => getModels({ pageSize: 200 }),
     enabled: open,
   });
+
+  // Categories for the optional category picker (only when not pre-set)
+  const { data: categoriesData } = useQuery({
+    queryKey: ["project-categories", projectId],
+    queryFn: () => getProjectCategories(projectId),
+    enabled: open && !categoryId, // only load if no pre-set category
+  });
+
+  const categoryOptions = (categoriesData ?? []).map((c: { id: string; name: string }) => ({
+    value: c.id,
+    label: c.name,
+  }));
 
   const modelOptions = (modelsData?.models || []).map((m) => ({
     value: m.id,
@@ -152,7 +167,8 @@ export function AddEquipmentDialog({
         const gross = Number(data.unitPrice) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
         disc = Math.round(gross * Number(disc) / 100 * 100) / 100;
       }
-      return addLineItem(projectId, { ...data, discount: disc, categoryId, groupId }, overbookConfirmed);
+      const effectiveCategoryId = categoryId || selectedCategoryId || undefined;
+      return addLineItem(projectId, { ...data, discount: disc, categoryId: effectiveCategoryId, groupId }, overbookConfirmed);
     },
     onSuccess: (result) => {
       const data = result as Record<string, unknown> | null;
@@ -180,6 +196,7 @@ export function AddEquipmentDialog({
       isOptional: false,
     });
     setSelectedModelId("");
+    setSelectedCategoryId(categoryId ?? "");
     setAssetTagInput("");
     setLookupTag("");
     setMode("model");
@@ -462,11 +479,30 @@ export function AddEquipmentDialog({
             </div>
           </div>
 
-          {targetLabel && (
+          {targetLabel ? (
             <div className="rounded-md bg-accent/50 px-3 py-2 text-xs text-fg-3">
               Adding to <span className="font-medium text-fg">{targetLabel}</span>
             </div>
-          )}
+          ) : categoryOptions.length > 0 ? (
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <Select value={selectedCategoryId} onValueChange={(v) => setSelectedCategoryId(v ?? "")}>
+                <SelectTrigger>
+                  <SelectValue placeholder="No category">
+                    {selectedCategoryId
+                      ? categoryOptions.find((c: { value: string; label: string }) => c.value === selectedCategoryId)?.label ?? "No category"
+                      : "No category"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">No category</SelectItem>
+                  {categoryOptions.map((c: { value: string; label: string }) => (
+                    <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
 
           <div className="space-y-2">
             <Label htmlFor="eq-notes">Notes</Label>

--- a/src/components/projects/financial-summary.tsx
+++ b/src/components/projects/financial-summary.tsx
@@ -13,6 +13,7 @@ interface GroupBreakdownItem {
 
 interface FinancialSummaryProps {
   equipmentRevenue: number | null;
+  serviceChargeTotal?: number | null;
   serviceCostTotal: number | null;
   labourCostTotal: number | null;
   subtotal: number | null;
@@ -82,6 +83,7 @@ function Row({
 
 export function FinancialSummary({
   equipmentRevenue,
+  serviceChargeTotal,
   serviceCostTotal,
   labourCostTotal,
   subtotal,
@@ -100,9 +102,11 @@ export function FinancialSummary({
   const [showBreakdown, setShowBreakdown] = useState(false);
   const totalVal = total != null ? Number(total) : 0;
   const marginVal = margin != null ? Number(margin) : 0;
-  const costs =
-    (serviceCostTotal != null ? Number(serviceCostTotal) : 0) +
-    (labourCostTotal != null ? Number(labourCostTotal) : 0);
+  const equipmentVal = equipmentRevenue != null ? Number(equipmentRevenue) : 0;
+  const serviceChargeVal = serviceChargeTotal != null ? Number(serviceChargeTotal) : 0;
+  const serviceCostVal = serviceCostTotal != null ? Number(serviceCostTotal) : 0;
+  const labourCostVal = labourCostTotal != null ? Number(labourCostTotal) : 0;
+  const costs = serviceCostVal + labourCostVal;
 
   const allGroupsPriced =
     totalGroupCount != null && pricedGroupCount != null && pricedGroupCount >= totalGroupCount;
@@ -143,9 +147,15 @@ export function FinancialSummary({
 
       <div className="h-px bg-border" />
 
-      {/* Revenue breakdown */}
+      {/* Client revenue breakdown */}
       <div className="space-y-1.5">
-        <Row label="Equipment" value={formatCurrency(equipmentRevenue)} />
+        <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-fg-4">
+          Revenue
+        </div>
+        <Row label="Equipment" value={formatCurrency(equipmentVal)} />
+        {serviceChargeVal > 0 && (
+          <Row label="Services" value={formatCurrency(serviceChargeVal)} />
+        )}
         <Row label="Subtotal" value={formatCurrency(subtotal)} bold />
         {discountPercent != null && Number(discountPercent) > 0 && (
           <Row
@@ -163,15 +173,21 @@ export function FinancialSummary({
 
       <div className="h-px bg-border" />
 
-      {/* Costs */}
+      {/* Business costs */}
       <div className="space-y-1.5">
         <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-fg-4">
           Costs
         </div>
-        <Row label="Services" value={formatCurrency(serviceCostTotal)} />
-        <Row label="Labour" value={formatCurrency(labourCostTotal)} />
-        {costs > 0 && (
+        {serviceCostVal > 0 && (
+          <Row label="Services" value={formatCurrency(serviceCostVal)} />
+        )}
+        {labourCostVal > 0 && (
+          <Row label="Labour" value={formatCurrency(labourCostVal)} />
+        )}
+        {costs > 0 ? (
           <Row label="Total costs" value={formatCurrency(costs)} bold />
+        ) : (
+          <Row label="No costs recorded" value="—" muted />
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- **Category picker** — when adding equipment from the top-level button, users can now optionally select which category the item goes into (selector only appears when categories exist)
- **Financial sidebar** — revenue section now shows Equipment + Services (client charges) separately before Subtotal; costs section conditionally shows Services (business cost) + Labour with clearer layout

## Test plan
- [ ] Add equipment from top-level button — verify category dropdown appears with project categories
- [ ] Add equipment from within a group — verify category picker does NOT appear (pre-set target shown instead)
- [ ] Select a category when adding — verify item lands in correct category
- [ ] Leave category as "No category" — verify item is uncategorized
- [ ] Check financial sidebar shows service charges under Revenue when billable services exist
- [ ] Check financial sidebar shows service/labour costs under Costs section
- [ ] Build passes, all 1545 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)