### PR TITLE
fix: use valid DocumentType for timeline route

### DIFF
--- a/src/app/api/documents/timeline/[projectId]/route.tsx
+++ b/src/app/api/documents/timeline/[projectId]/route.tsx
@@ -46,7 +46,7 @@ export async function GET(
 
   try {
     // Build standard document data (project, org, branding, etc.)
-    const data = await buildDocumentData(projectId, organizationId, "timeline");
+    const data = await buildDocumentData(projectId, organizationId, "quote");
 
     // Fetch services with crew assignments
     const services = await prisma.projectService.findMany({


### PR DESCRIPTION
"timeline" is not a valid DocumentType. Use "quote" as a neutral type that skips the crew assignment query while satisfying the type system.