### PR TITLE
fix: rewrite call sheets to service-based format

### DIFF
--- a/src/app/api/documents/call-sheet/[projectId]/route.tsx
+++ b/src/app/api/documents/call-sheet/[projectId]/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireOrganization } from "@/lib/auth-server";
-import { generatePdf, generateCallSheetPdf } from "@/lib/pdfme/generate-pdf";
+import { generateCallSheetPdf } from "@/lib/pdfme/generate-pdf";
 
 export async function GET(
   request: NextRequest,
@@ -8,7 +8,6 @@ export async function GET(
 ) {
   const { projectId } = await params;
   const url = new URL(request.url);
-  const dateParam = url.searchParams.get("date");
   const datesParam = url.searchParams.get("dates");
   const allDates = url.searchParams.get("allDates") === "true";
   const crewMemberId = url.searchParams.get("crewMemberId") || undefined;
@@ -63,27 +62,14 @@ export async function GET(
   }
 
   try {
-    const isMultiDay = allDates || !!callSheetDates?.length || !!crewMemberId || !!crewRoleId;
-
-    let pdf: Uint8Array;
-    if (isMultiDay) {
-      pdf = await generateCallSheetPdf(projectId, organizationId, {
-        callSheetDates,
-        allDates,
-        crewMemberId,
-        crewRoleId,
-        templateId,
-      });
-    } else {
-      const callSheetDate = dateParam ? new Date(dateParam) : undefined;
-      if (dateParam && isNaN(callSheetDate!.getTime())) {
-        return NextResponse.json(
-          { error: `Invalid date: ${dateParam}` },
-          { status: 400 }
-        );
-      }
-      pdf = await generatePdf(projectId, organizationId, "call-sheet", callSheetDate, templateId);
-    }
+    // Always use service-based call sheet generator
+    const pdf = await generateCallSheetPdf(projectId, organizationId, {
+      callSheetDates,
+      allDates,
+      crewMemberId,
+      crewRoleId,
+      templateId,
+    });
 
     const filename = `CallSheet-${projectId}.pdf`;
     return new NextResponse(Buffer.from(pdf), {

--- a/src/app/api/documents/timeline/[projectId]/route.tsx
+++ b/src/app/api/documents/timeline/[projectId]/route.tsx
@@ -4,7 +4,6 @@ import { requireOrganization } from "@/lib/auth-server";
 import { prisma } from "@/lib/prisma";
 import { buildDocumentData } from "@/lib/pdfme/build-document-data";
 import {
-  buildTimelineTemplate,
   buildTimelineInputs,
   DEFAULT_TIMELINE_SETTINGS,
 } from "@/lib/pdfme/templates/timeline";
@@ -81,8 +80,7 @@ export async function GET(
       costTotal: s.costTotal ? Number(s.costTotal) : null,
     }));
 
-    const inputs = buildTimelineInputs(data, timelineServices, settings);
-    const template = buildTimelineTemplate(inputs.length);
+    const { inputs, template } = buildTimelineInputs(data, timelineServices, settings);
 
     const pdf = await generate({
       template,

--- a/src/components/projects/call-sheet-dialog.tsx
+++ b/src/components/projects/call-sheet-dialog.tsx
@@ -73,25 +73,21 @@ export function CallSheetDialog({
     enabled: open,
   });
 
-  // Derive all available dates: shift dates + project milestone dates
+  // Derive available dates from service dates
   const availableDates = useMemo(() => {
     const dateSet = new Set<string>();
 
-    // Collect shift dates from crew assignments
-    if (crewQuery.data) {
-      for (const assignment of crewQuery.data) {
-        if (assignment.shifts) {
-          for (const shift of assignment.shifts) {
-            if (shift.date) {
-              dateSet.add(formatDateKey(new Date(shift.date)));
-            }
-          }
+    // Collect service dates (matches what the PDF actually generates)
+    if (datesQuery.data?.serviceDates) {
+      for (const sd of datesQuery.data.serviceDates) {
+        if (sd.date) {
+          dateSet.add(formatDateKey(new Date(sd.date)));
         }
       }
     }
 
-    // Collect project milestone dates
-    if (datesQuery.data) {
+    // Fall back to project milestone dates if no service dates
+    if (dateSet.size === 0 && datesQuery.data) {
       const { loadInDate, eventStartDate, eventEndDate, loadOutDate } = datesQuery.data;
       if (loadInDate) dateSet.add(formatDateKey(new Date(loadInDate)));
       if (eventStartDate) dateSet.add(formatDateKey(new Date(eventStartDate)));
@@ -100,25 +96,21 @@ export function CallSheetDialog({
     }
 
     return Array.from(dateSet).sort();
-  }, [crewQuery.data, datesQuery.data]);
+  }, [datesQuery.data]);
 
-  // Count crew per date
+  // Count crew per date (from service crew assignments)
   const crewCountByDate = useMemo(() => {
     const counts: Record<string, number> = {};
-    if (!crewQuery.data) return counts;
+    if (!datesQuery.data?.serviceDates) return counts;
 
-    for (const assignment of crewQuery.data) {
-      if (assignment.shifts) {
-        for (const shift of assignment.shifts) {
-          if (shift.date) {
-            const key = formatDateKey(new Date(shift.date));
-            counts[key] = (counts[key] ?? 0) + 1;
-          }
-        }
+    for (const sd of datesQuery.data.serviceDates) {
+      if (sd.date) {
+        const key = formatDateKey(new Date(sd.date));
+        counts[key] = (counts[key] ?? 0) + sd.crewCount;
       }
     }
     return counts;
-  }, [crewQuery.data]);
+  }, [datesQuery.data]);
 
   // Crew member options for select (deduplicated)
   const crewOptions = useMemo(() => {

--- a/src/components/projects/call-sheet-dialog.tsx
+++ b/src/components/projects/call-sheet-dialog.tsx
@@ -120,13 +120,18 @@ export function CallSheetDialog({
     return counts;
   }, [crewQuery.data]);
 
-  // Crew member options for select
+  // Crew member options for select (deduplicated)
   const crewOptions = useMemo(() => {
     if (!crewQuery.data) return [];
-    return crewQuery.data.map((a) => ({
-      id: a.crewMember.id,
-      label: `${a.crewMember.firstName} ${a.crewMember.lastName}`,
-    }));
+    const seen = new Map<string, string>();
+    for (const a of crewQuery.data) {
+      if (!seen.has(a.crewMember.id)) {
+        seen.set(a.crewMember.id, `${a.crewMember.firstName} ${a.crewMember.lastName}`);
+      }
+    }
+    return Array.from(seen, ([id, label]) => ({ id, label })).sort((a, b) =>
+      a.label.localeCompare(b.label)
+    );
   }, [crewQuery.data]);
 
   // Role options for select

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -171,8 +171,10 @@ export async function generatePdf(
 }
 
 /**
- * Generate a multi-day or per-person call sheet PDF.
- * Expands crew-table sections per date, inserting day-header sections.
+ * Generate a call sheet PDF.
+ * Queries project services directly, groups by date, shows crew per service.
+ * Each date gets a section header. Each row: crew member, service, role, call, wrap, notes.
+ * Automatically paginates across multiple pages.
  */
 export async function generateCallSheetPdf(
   projectId: string,
@@ -185,60 +187,11 @@ export async function generateCallSheetPdf(
     templateId?: string;
   },
 ): Promise<Uint8Array> {
-  // 1. Build data with multi-date/per-person options
-  const data = await buildDocumentData(projectId, organizationId, "call-sheet", undefined, {
-    callSheetDates: options.callSheetDates,
-    allDates: options.allDates,
-    crewMemberId: options.crewMemberId,
-    crewRoleId: options.crewRoleId,
-  });
+  const {
+    buildCallSheetFromServices,
+  } = await import("./templates/call-sheet-services");
 
-  // 2. Load template
-  const loaded = await loadTemplate(organizationId, "call-sheet", options.templateId);
-
-  // 3. Get sections (section-based template or system default)
-  let sections: TemplateSection[];
-  if (loaded.sections) {
-    sections = loaded.sections;
-  } else {
-    sections = getDefaultSections("call-sheet");
-  }
-
-  // 4. Per-person title override
-  if (options.crewMemberId && data.crew.length > 0) {
-    const personName = data.crew[0].name;
-    const headerIdx = sections.findIndex(s => s.type === "header");
-    if (headerIdx >= 0) {
-      const headerSettings = { ...sections[headerIdx].settings } as import("./section-types").HeaderSectionSettings;
-      headerSettings.documentTitle = `CALL SHEET \u2014 ${personName}`;
-      sections = sections.map((s, i) => i === headerIdx ? { ...s, settings: headerSettings } : s);
-    }
-  }
-
-  // 5. Expand sections for multi-day
-  const crewByDay = data.crew_by_day || [];
-  if (crewByDay.length > 0) {
-    sections = expandSectionsForDates(sections, crewByDay, data);
-  }
-
-  // 6. Render and generate
-  const docColor = loaded.brandAccentColor || data.org_document_color;
-  const { template, inputs } = renderSections(
-    sections,
-    data,
-    "call-sheet",
-    docColor,
-    loaded.brandFooterText || undefined,
-    loaded.brandFooterSecondLine || undefined,
-  );
-
-  const pdf = await generate({
-    template,
-    inputs,
-    plugins: gearflowPlugins,
-    options: { font: getPdfmeFonts() },
-  });
-
+  const pdf = await buildCallSheetFromServices(projectId, organizationId, options);
   return pdf;
 }
 

--- a/src/lib/pdfme/templates/call-sheet-services.ts
+++ b/src/lib/pdfme/templates/call-sheet-services.ts
@@ -28,15 +28,15 @@ const SECTION_HEADER_HEIGHT_MM = 6.3;
 // Layout
 const HEADER_Y = MARGIN;
 const HEADER_H = 25;
-const INFO_Y = 42;
-const INFO_H = 18;
-const TABLE_START_Y = 63;
+const INFO_Y = HEADER_Y + HEADER_H + 1; // 40mm
+const INFO_H = 12;
+const TABLE_START_Y = INFO_Y + INFO_H + 1; // 53mm
 const FOOTER_H = 10;
 const TABLE_END_Y = PAGE_HEIGHT - MARGIN - FOOTER_H - 2;
 const TABLE_CONTENT_HEIGHT = TABLE_END_Y - TABLE_START_Y;
 
 // Continuation pages (no info block)
-const CONT_TABLE_START_Y = HEADER_Y + HEADER_H + 4;
+const CONT_TABLE_START_Y = HEADER_Y + HEADER_H + 2;
 const CONT_TABLE_CONTENT_HEIGHT = TABLE_END_Y - CONT_TABLE_START_Y;
 
 const SERVICE_TYPE_LABELS: Record<string, string> = {

--- a/src/lib/pdfme/templates/call-sheet-services.ts
+++ b/src/lib/pdfme/templates/call-sheet-services.ts
@@ -68,13 +68,29 @@ function buildColumns(): DataTableColumn[] {
   ];
 }
 
+interface PaginatedPage {
+  sections: DataTableSection[];
+  contentHeight: number; // actual content height in mm (for sizing the table schema)
+}
+
+/**
+ * Calculate actual content height for a set of sections (including table header).
+ */
+function calcContentHeight(sections: DataTableSection[]): number {
+  let h = TABLE_HEADER_HEIGHT_MM;
+  for (const s of sections) {
+    h += SECTION_HEADER_HEIGHT_MM + s.rows.length * TABLE_ROW_HEIGHT_MM;
+  }
+  return h;
+}
+
 /**
  * Paginate sections across pages.
  */
 function paginateSections(
   sections: DataTableSection[],
-): DataTableSection[][] {
-  const pages: DataTableSection[][] = [];
+): PaginatedPage[] {
+  const pages: PaginatedPage[] = [];
   let currentPageSections: DataTableSection[] = [];
   let currentHeight = TABLE_HEADER_HEIGHT_MM;
   let isFirstPage = true;
@@ -105,7 +121,7 @@ function paginateSections(
     let remainingRows = section.rows.slice(rowsThatFit);
 
     if (currentPageSections.length > 0) {
-      pages.push(currentPageSections);
+      pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
       currentPageSections = [];
       currentHeight = TABLE_HEADER_HEIGHT_MM;
       isFirstPage = false;
@@ -126,7 +142,7 @@ function paginateSections(
       currentHeight = TABLE_HEADER_HEIGHT_MM + SECTION_HEADER_HEIGHT_MM + batch.length * TABLE_ROW_HEIGHT_MM;
 
       if (remainingRows.length > 0) {
-        pages.push(currentPageSections);
+        pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
         currentPageSections = [];
         currentHeight = TABLE_HEADER_HEIGHT_MM;
       }
@@ -134,19 +150,19 @@ function paginateSections(
   }
 
   if (currentPageSections.length > 0) {
-    pages.push(currentPageSections);
+    pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
   }
 
-  return pages.length > 0 ? pages : [[]];
+  return pages.length > 0 ? pages : [{ sections: [], contentHeight: TABLE_HEADER_HEIGHT_MM }];
 }
 
-function buildTemplate(pageCount: number): Template {
+function buildTemplate(paginatedPages: PaginatedPage[]): Template {
   const schemas: Template["schemas"] = [];
 
-  for (let i = 0; i < pageCount; i++) {
+  for (let i = 0; i < paginatedPages.length; i++) {
     const isFirstPage = i === 0;
     const tableY = isFirstPage ? TABLE_START_Y : CONT_TABLE_START_Y;
-    const tableH = isFirstPage ? TABLE_CONTENT_HEIGHT : CONT_TABLE_CONTENT_HEIGHT;
+    const tableH = paginatedPages[i].contentHeight;
 
     const pageSchemas: Template["schemas"][number] = [
       {
@@ -314,16 +330,25 @@ export async function buildCallSheetFromServices(
   const sortedKeys = Array.from(groups.keys()).sort();
   const sections: DataTableSection[] = sortedKeys.map(key => {
     const group = groups.get(key)!;
+    // For per-person view, only show the crew name on the first row per person
+    const seenNames = new Set<string>();
     return {
       title: group.dateLabel,
-      rows: group.rows.map(r => ({
-        crewName: r.crewName,
-        service: r.service,
-        role: r.role,
-        call: r.call,
-        wrap: r.wrap,
-        notes: r.notes,
-      })),
+      rows: group.rows.map(r => {
+        let displayName = r.crewName;
+        if (options.crewMemberId && seenNames.has(r.crewName)) {
+          displayName = "";
+        }
+        seenNames.add(r.crewName);
+        return {
+          crewName: displayName,
+          service: r.service,
+          role: r.role,
+          call: r.call,
+          wrap: r.wrap,
+          notes: r.notes,
+        };
+      }),
     };
   });
 
@@ -341,9 +366,9 @@ export async function buildCallSheetFromServices(
 
   // 6. Paginate and build template
   const columns = buildColumns();
-  const paginatedSections = paginateSections(sections);
-  const pageCount = paginatedSections.length;
-  const template = buildTemplate(pageCount);
+  const paginatedPages = paginateSections(sections);
+  const pageCount = paginatedPages.length;
+  const template = buildTemplate(paginatedPages);
 
   // 7. Build header config
   const headerConfig: PageHeaderConfig = {
@@ -387,7 +412,7 @@ export async function buildCallSheetFromServices(
 
     pageInput[`table_${i}`] = JSON.stringify({
       columns,
-      sections: paginatedSections[i],
+      sections: paginatedPages[i].sections,
       documentColor: docColor,
     });
 

--- a/src/lib/pdfme/templates/call-sheet-services.ts
+++ b/src/lib/pdfme/templates/call-sheet-services.ts
@@ -1,0 +1,424 @@
+/**
+ * Service-based call sheet PDF generator.
+ * Queries project services directly, groups by date, shows crew per service.
+ * Each date gets a section header in the data table.
+ * Columns: Crew Member, Service, Role, Call, Wrap, Notes.
+ * Auto-paginates across multiple pages using gearflowDataTable.
+ */
+import { generate } from "@pdfme/generator";
+import type { Template } from "@pdfme/common";
+import { prisma } from "@/lib/prisma";
+import { gearflowPlugins } from "../plugins";
+import { getPdfmeFonts } from "../fonts";
+import { buildDocumentData } from "../build-document-data";
+import type { DocumentData, PageHeaderConfig, FooterConfig } from "../types";
+import type { DataTableColumn, DataTableSection } from "../plugins/gearflow-data-table";
+import { formatDate } from "../plugins/helpers";
+
+const PAGE_WIDTH = 297; // landscape A4
+const PAGE_HEIGHT = 210;
+const MARGIN = 14;
+const CONTENT_W = PAGE_WIDTH - MARGIN * 2; // 269mm
+
+// Row heights in mm (match gearflow-data-table.ts)
+const TABLE_ROW_HEIGHT_MM = 5;
+const TABLE_HEADER_HEIGHT_MM = 5.6;
+const SECTION_HEADER_HEIGHT_MM = 6.3;
+
+// Layout
+const HEADER_Y = MARGIN;
+const HEADER_H = 25;
+const INFO_Y = 42;
+const INFO_H = 18;
+const TABLE_START_Y = 63;
+const FOOTER_H = 10;
+const TABLE_END_Y = PAGE_HEIGHT - MARGIN - FOOTER_H - 2;
+const TABLE_CONTENT_HEIGHT = TABLE_END_Y - TABLE_START_Y;
+
+// Continuation pages (no info block)
+const CONT_TABLE_START_Y = HEADER_Y + HEADER_H + 4;
+const CONT_TABLE_CONTENT_HEIGHT = TABLE_END_Y - CONT_TABLE_START_Y;
+
+const SERVICE_TYPE_LABELS: Record<string, string> = {
+  DELIVERY: "Delivery",
+  PICKUP: "Pickup",
+  BUMP_IN: "Bump In",
+  BUMP_OUT: "Bump Out",
+  LABOUR: "Labour",
+  MISC: "Misc",
+};
+
+interface ServiceRow {
+  crewName: string;
+  service: string;
+  role: string;
+  call: string;
+  wrap: string;
+  notes: string;
+}
+
+function buildColumns(): DataTableColumn[] {
+  return [
+    { key: "crewName", label: "Crew Member", width: 3 },
+    { key: "service", label: "Service", width: 2 },
+    { key: "role", label: "Role", width: 2 },
+    { key: "call", label: "Call", width: 1.2, align: "center" },
+    { key: "wrap", label: "Wrap", width: 1.2, align: "center" },
+    { key: "notes", label: "Notes", width: 2.5 },
+  ];
+}
+
+/**
+ * Paginate sections across pages.
+ */
+function paginateSections(
+  sections: DataTableSection[],
+): DataTableSection[][] {
+  const pages: DataTableSection[][] = [];
+  let currentPageSections: DataTableSection[] = [];
+  let currentHeight = TABLE_HEADER_HEIGHT_MM;
+  let isFirstPage = true;
+  const maxHeight = () => isFirstPage ? TABLE_CONTENT_HEIGHT : CONT_TABLE_CONTENT_HEIGHT;
+
+  for (const section of sections) {
+    const sectionHeaderH = SECTION_HEADER_HEIGHT_MM;
+    const sectionRowsH = section.rows.length * TABLE_ROW_HEIGHT_MM;
+    const totalSectionH = sectionHeaderH + sectionRowsH;
+
+    if (currentHeight + totalSectionH <= maxHeight()) {
+      currentPageSections.push(section);
+      currentHeight += totalSectionH;
+      continue;
+    }
+
+    // Split rows across pages
+    const availableForRows = maxHeight() - currentHeight - sectionHeaderH;
+    const rowsThatFit = Math.max(0, Math.floor(availableForRows / TABLE_ROW_HEIGHT_MM));
+
+    if (rowsThatFit > 0) {
+      currentPageSections.push({
+        title: section.title,
+        rows: section.rows.slice(0, rowsThatFit),
+      });
+    }
+
+    let remainingRows = section.rows.slice(rowsThatFit);
+
+    if (currentPageSections.length > 0) {
+      pages.push(currentPageSections);
+      currentPageSections = [];
+      currentHeight = TABLE_HEADER_HEIGHT_MM;
+      isFirstPage = false;
+    }
+
+    while (remainingRows.length > 0) {
+      const contAvailable = CONT_TABLE_CONTENT_HEIGHT - TABLE_HEADER_HEIGHT_MM - SECTION_HEADER_HEIGHT_MM;
+      const contRowsFit = Math.max(1, Math.floor(contAvailable / TABLE_ROW_HEIGHT_MM));
+      const batch = remainingRows.slice(0, contRowsFit);
+      remainingRows = remainingRows.slice(contRowsFit);
+
+      currentPageSections.push({
+        title: remainingRows.length > 0
+          ? `${section.title} (cont.)`
+          : section.title + (rowsThatFit > 0 ? " (cont.)" : ""),
+        rows: batch,
+      });
+      currentHeight = TABLE_HEADER_HEIGHT_MM + SECTION_HEADER_HEIGHT_MM + batch.length * TABLE_ROW_HEIGHT_MM;
+
+      if (remainingRows.length > 0) {
+        pages.push(currentPageSections);
+        currentPageSections = [];
+        currentHeight = TABLE_HEADER_HEIGHT_MM;
+      }
+    }
+  }
+
+  if (currentPageSections.length > 0) {
+    pages.push(currentPageSections);
+  }
+
+  return pages.length > 0 ? pages : [[]];
+}
+
+function buildTemplate(pageCount: number): Template {
+  const schemas: Template["schemas"] = [];
+
+  for (let i = 0; i < pageCount; i++) {
+    const isFirstPage = i === 0;
+    const tableY = isFirstPage ? TABLE_START_Y : CONT_TABLE_START_Y;
+    const tableH = isFirstPage ? TABLE_CONTENT_HEIGHT : CONT_TABLE_CONTENT_HEIGHT;
+
+    const pageSchemas: Template["schemas"][number] = [
+      {
+        name: `header_${i}`,
+        type: "gearflowPageHeader",
+        content: "",
+        position: { x: MARGIN, y: HEADER_Y },
+        width: CONTENT_W,
+        height: HEADER_H,
+      },
+    ];
+
+    if (isFirstPage) {
+      pageSchemas.push(
+        {
+          name: "projectInfo",
+          type: "text",
+          content: "",
+          position: { x: MARGIN, y: INFO_Y },
+          width: CONTENT_W / 2 - 4,
+          height: INFO_H,
+          fontSize: 9,
+          fontColor: "#1a1a1a",
+        },
+        {
+          name: "venueInfo",
+          type: "text",
+          content: "",
+          position: { x: MARGIN + CONTENT_W / 2, y: INFO_Y },
+          width: CONTENT_W / 2 - 4,
+          height: INFO_H,
+          fontSize: 9,
+          fontColor: "#1a1a1a",
+        },
+      );
+    }
+
+    pageSchemas.push({
+      name: `table_${i}`,
+      type: "gearflowDataTable",
+      content: "",
+      position: { x: MARGIN, y: tableY },
+      width: CONTENT_W,
+      height: tableH,
+    });
+
+    pageSchemas.push({
+      name: `footer_${i}`,
+      type: "gearflowPageFooter",
+      content: "",
+      position: { x: MARGIN, y: PAGE_HEIGHT - MARGIN - FOOTER_H },
+      width: CONTENT_W,
+      height: FOOTER_H,
+    });
+
+    schemas.push(pageSchemas);
+  }
+
+  return {
+    basePdf: {
+      width: PAGE_WIDTH,
+      height: PAGE_HEIGHT,
+      padding: [MARGIN, MARGIN, MARGIN, MARGIN],
+    },
+    schemas,
+  };
+}
+
+export async function buildCallSheetFromServices(
+  projectId: string,
+  organizationId: string,
+  options: {
+    callSheetDates?: Date[];
+    allDates?: boolean;
+    crewMemberId?: string;
+    crewRoleId?: string;
+    templateId?: string;
+  },
+): Promise<Uint8Array> {
+  // 1. Get org/project data for header/footer
+  const data = await buildDocumentData(projectId, organizationId, "quote");
+
+  // 2. Query services with crew assignments
+  const services = await prisma.projectService.findMany({
+    where: {
+      organizationId,
+      projectId,
+      status: { not: "CANCELLED" },
+    },
+    include: {
+      crewAssignments: {
+        where: {
+          status: { notIn: ["CANCELLED", "DECLINED"] },
+          ...(options.crewMemberId ? { crewMemberId: options.crewMemberId } : {}),
+          ...(options.crewRoleId ? { crewRoleId: options.crewRoleId } : {}),
+        },
+        include: {
+          crewMember: {
+            select: { id: true, firstName: true, lastName: true, phone: true },
+          },
+          crewRole: { select: { name: true } },
+        },
+      },
+    },
+    orderBy: [{ date: "asc" }, { sortOrder: "asc" }],
+  });
+
+  // 3. Group by date, build rows
+  const groups = new Map<string, { dateLabel: string; rows: ServiceRow[] }>();
+
+  for (const s of services) {
+    const dateKey = s.date
+      ? new Date(s.date).toISOString().slice(0, 10)
+      : "no-date";
+
+    if (!groups.has(dateKey)) {
+      const dateLabel = dateKey === "no-date"
+        ? "Unscheduled"
+        : formatCallSheetDate(dateKey);
+      groups.set(dateKey, { dateLabel, rows: [] });
+    }
+
+    const group = groups.get(dateKey)!;
+    const serviceLabel = s.title || SERVICE_TYPE_LABELS[s.type] || s.type;
+
+    if (s.crewAssignments.length === 0) {
+      // Service with no crew assigned
+      group.rows.push({
+        crewName: "-",
+        service: serviceLabel,
+        role: "-",
+        call: s.startTime || "-",
+        wrap: s.endTime || "-",
+        notes: s.notes || "",
+      });
+    } else {
+      // Deduplicate crew per service (same person, different assignments)
+      const seenCrew = new Map<string, ServiceRow>();
+      for (const ca of s.crewAssignments) {
+        const crewId = ca.crewMember.id;
+        const name = `${ca.crewMember.firstName} ${ca.crewMember.lastName}`;
+        const role = ca.crewRole?.name || "-";
+
+        if (seenCrew.has(crewId)) {
+          const existing = seenCrew.get(crewId)!;
+          if (role !== "-" && existing.role !== role && !existing.role.split(", ").includes(role)) {
+            existing.role = `${existing.role}, ${role}`;
+          }
+        } else {
+          seenCrew.set(crewId, {
+            crewName: name,
+            service: serviceLabel,
+            role,
+            call: s.startTime || "-",
+            wrap: s.endTime || "-",
+            notes: s.notes || "",
+          });
+        }
+      }
+      group.rows.push(...seenCrew.values());
+    }
+  }
+
+  // 4. Build sections sorted by date
+  const sortedKeys = Array.from(groups.keys()).sort();
+  const sections: DataTableSection[] = sortedKeys.map(key => {
+    const group = groups.get(key)!;
+    return {
+      title: group.dateLabel,
+      rows: group.rows.map(r => ({
+        crewName: r.crewName,
+        service: r.service,
+        role: r.role,
+        call: r.call,
+        wrap: r.wrap,
+        notes: r.notes,
+      })),
+    };
+  });
+
+  // 5. Build title
+  const docColor = data.org_document_color;
+  let docTitle = "Call Sheet";
+  if (options.crewMemberId && services.length > 0) {
+    const firstCrew = services
+      .flatMap(s => s.crewAssignments)
+      .find(ca => ca.crewMember.id === options.crewMemberId);
+    if (firstCrew) {
+      docTitle = `Call Sheet - ${firstCrew.crewMember.firstName} ${firstCrew.crewMember.lastName}`;
+    }
+  }
+
+  // 6. Paginate and build template
+  const columns = buildColumns();
+  const paginatedSections = paginateSections(sections);
+  const pageCount = paginatedSections.length;
+  const template = buildTemplate(pageCount);
+
+  // 7. Build header config
+  const headerConfig: PageHeaderConfig = {
+    orgName: data.org_name,
+    orgDetails: [data.org_phone, data.org_email].filter(Boolean).join("\n"),
+    docTitle,
+    docMeta: `${data.project_number}\n${data.document_date}`,
+    logoData: data.org_logo,
+    iconData: data.org_icon,
+    documentLogoMode: "icon",
+    showOrgNameOnDocuments: true,
+    documentColor: docColor,
+  };
+
+  // 8. Build info
+  const projectLines = [data.project_name];
+  if (data.rental_start !== "-") {
+    projectLines.push(`${data.rental_start} - ${data.rental_end}`);
+  }
+
+  const venueLines: string[] = [];
+  if (data.venue_name) venueLines.push(data.venue_name);
+  if (data.venue_address) venueLines.push(data.venue_address);
+  if (data.site_contact_name) {
+    venueLines.push(`Contact: ${data.site_contact_name}`);
+    if (data.site_contact_phone) venueLines.push(`Ph: ${data.site_contact_phone}`);
+  }
+
+  // 9. Build inputs per page
+  const inputs: Record<string, string>[] = [];
+
+  for (let i = 0; i < pageCount; i++) {
+    const pageInput: Record<string, string> = {};
+
+    pageInput[`header_${i}`] = JSON.stringify(headerConfig);
+
+    if (i === 0) {
+      pageInput.projectInfo = projectLines.join("\n");
+      pageInput.venueInfo = venueLines.join("\n") || "-";
+    }
+
+    pageInput[`table_${i}`] = JSON.stringify({
+      columns,
+      sections: paginatedSections[i],
+      documentColor: docColor,
+    });
+
+    const footerConfig: FooterConfig = {
+      text: data.org_name,
+      pageNumber: pageCount > 1 ? `Page ${i + 1} of ${pageCount}` : "",
+    };
+    pageInput[`footer_${i}`] = JSON.stringify(footerConfig);
+
+    inputs.push(pageInput);
+  }
+
+  // 10. Generate PDF
+  const pdf = await generate({
+    template,
+    inputs,
+    plugins: gearflowPlugins,
+    options: { font: getPdfmeFonts() },
+  });
+
+  return pdf;
+}
+
+/** Format date as "Monday, 7 April 2026" */
+function formatCallSheetDate(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00Z");
+  return d.toLocaleDateString("en-AU", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/lib/pdfme/templates/call-sheet-services.ts
+++ b/src/lib/pdfme/templates/call-sheet-services.ts
@@ -262,7 +262,8 @@ export async function buildCallSheetFromServices(
     const serviceLabel = s.title || SERVICE_TYPE_LABELS[s.type] || s.type;
 
     if (s.crewAssignments.length === 0) {
-      // Service with no crew assigned
+      // Skip services with no matching crew when filtering by person/role
+      if (options.crewMemberId || options.crewRoleId) continue;
       group.rows.push({
         crewName: "-",
         service: serviceLabel,
@@ -299,9 +300,9 @@ export async function buildCallSheetFromServices(
     }
   }
 
-  // 4. Build sections sorted by date
+  // 4. Build sections sorted by date (skip empty groups)
   const sortedKeys = Array.from(groups.keys()).sort();
-  const sections: DataTableSection[] = sortedKeys.map(key => {
+  const sections: DataTableSection[] = sortedKeys.filter(key => groups.get(key)!.rows.length > 0).map(key => {
     const group = groups.get(key)!;
     // For per-person view, only show the crew name on the first row per person
     const seenNames = new Set<string>();

--- a/src/lib/pdfme/templates/call-sheet-services.ts
+++ b/src/lib/pdfme/templates/call-sheet-services.ts
@@ -28,15 +28,13 @@ const SECTION_HEADER_HEIGHT_MM = 6.3;
 // Layout
 const HEADER_Y = MARGIN;
 const HEADER_H = 25;
-const INFO_Y = HEADER_Y + HEADER_H + 1; // 40mm
-const INFO_H = 12;
-const TABLE_START_Y = INFO_Y + INFO_H + 1; // 53mm
+const TABLE_START_Y = HEADER_Y + HEADER_H + 3; // small gap after header
 const FOOTER_H = 10;
 const TABLE_END_Y = PAGE_HEIGHT - MARGIN - FOOTER_H - 2;
 const TABLE_CONTENT_HEIGHT = TABLE_END_Y - TABLE_START_Y;
 
-// Continuation pages (no info block)
-const CONT_TABLE_START_Y = HEADER_Y + HEADER_H + 2;
+// Continuation pages
+const CONT_TABLE_START_Y = HEADER_Y + HEADER_H + 3;
 const CONT_TABLE_CONTENT_HEIGHT = TABLE_END_Y - CONT_TABLE_START_Y;
 
 const SERVICE_TYPE_LABELS: Record<string, string> = {
@@ -174,31 +172,6 @@ function buildTemplate(paginatedPages: PaginatedPage[]): Template {
         height: HEADER_H,
       },
     ];
-
-    if (isFirstPage) {
-      pageSchemas.push(
-        {
-          name: "projectInfo",
-          type: "text",
-          content: "",
-          position: { x: MARGIN, y: INFO_Y },
-          width: CONTENT_W / 2 - 4,
-          height: INFO_H,
-          fontSize: 9,
-          fontColor: "#1a1a1a",
-        },
-        {
-          name: "venueInfo",
-          type: "text",
-          content: "",
-          position: { x: MARGIN + CONTENT_W / 2, y: INFO_Y },
-          width: CONTENT_W / 2 - 4,
-          height: INFO_H,
-          fontSize: 9,
-          fontColor: "#1a1a1a",
-        },
-      );
-    }
 
     pageSchemas.push({
       name: `table_${i}`,
@@ -383,32 +356,13 @@ export async function buildCallSheetFromServices(
     documentColor: docColor,
   };
 
-  // 8. Build info
-  const projectLines = [data.project_name];
-  if (data.rental_start !== "-") {
-    projectLines.push(`${data.rental_start} - ${data.rental_end}`);
-  }
-
-  const venueLines: string[] = [];
-  if (data.venue_name) venueLines.push(data.venue_name);
-  if (data.venue_address) venueLines.push(data.venue_address);
-  if (data.site_contact_name) {
-    venueLines.push(`Contact: ${data.site_contact_name}`);
-    if (data.site_contact_phone) venueLines.push(`Ph: ${data.site_contact_phone}`);
-  }
-
-  // 9. Build inputs per page
+  // 8. Build inputs per page
   const inputs: Record<string, string>[] = [];
 
   for (let i = 0; i < pageCount; i++) {
     const pageInput: Record<string, string> = {};
 
     pageInput[`header_${i}`] = JSON.stringify(headerConfig);
-
-    if (i === 0) {
-      pageInput.projectInfo = projectLines.join("\n");
-      pageInput.venueInfo = venueLines.join("\n") || "-";
-    }
 
     pageInput[`table_${i}`] = JSON.stringify({
       columns,

--- a/src/lib/pdfme/templates/timeline.ts
+++ b/src/lib/pdfme/templates/timeline.ts
@@ -165,12 +165,25 @@ function buildSections(
  * Split sections across pages. Each page gets a subset of sections/rows
  * that fit within the available height.
  */
+interface PaginatedPage {
+  sections: DataTableSection[];
+  contentHeight: number;
+}
+
+function calcContentHeight(sections: DataTableSection[]): number {
+  let h = TABLE_HEADER_HEIGHT_MM;
+  for (const s of sections) {
+    h += SECTION_HEADER_HEIGHT_MM + s.rows.length * TABLE_ROW_HEIGHT_MM;
+  }
+  return h;
+}
+
 function paginateSections(
   sections: DataTableSection[],
-): DataTableSection[][] {
-  const pages: DataTableSection[][] = [];
+): PaginatedPage[] {
+  const pages: PaginatedPage[] = [];
   let currentPageSections: DataTableSection[] = [];
-  let currentHeight = TABLE_HEADER_HEIGHT_MM; // account for column headers
+  let currentHeight = TABLE_HEADER_HEIGHT_MM;
   let isFirstPage = true;
   const maxHeight = () => isFirstPage ? TABLE_CONTENT_HEIGHT : CONT_TABLE_CONTENT_HEIGHT;
 
@@ -179,19 +192,16 @@ function paginateSections(
     const sectionRowsH = section.rows.length * TABLE_ROW_HEIGHT_MM;
     const totalSectionH = sectionHeaderH + sectionRowsH;
 
-    // Does the whole section fit on the current page?
     if (currentHeight + totalSectionH <= maxHeight()) {
       currentPageSections.push(section);
       currentHeight += totalSectionH;
       continue;
     }
 
-    // Section doesn't fit entirely. Split rows across pages.
     const availableForRows = maxHeight() - currentHeight - sectionHeaderH;
     const rowsThatFit = Math.max(0, Math.floor(availableForRows / TABLE_ROW_HEIGHT_MM));
 
     if (rowsThatFit > 0) {
-      // Put some rows on this page
       currentPageSections.push({
         title: section.title,
         rows: section.rows.slice(0, rowsThatFit),
@@ -199,20 +209,17 @@ function paginateSections(
       currentHeight += sectionHeaderH + rowsThatFit * TABLE_ROW_HEIGHT_MM;
     }
 
-    // Start new page(s) for remaining rows
     let remainingRows = section.rows.slice(rowsThatFit);
 
-    // Flush current page
     if (currentPageSections.length > 0) {
-      pages.push(currentPageSections);
+      pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
       currentPageSections = [];
       currentHeight = TABLE_HEADER_HEIGHT_MM;
       isFirstPage = false;
     }
 
     while (remainingRows.length > 0) {
-      const contMaxH = CONT_TABLE_CONTENT_HEIGHT;
-      const contAvailable = contMaxH - TABLE_HEADER_HEIGHT_MM - SECTION_HEADER_HEIGHT_MM;
+      const contAvailable = CONT_TABLE_CONTENT_HEIGHT - TABLE_HEADER_HEIGHT_MM - SECTION_HEADER_HEIGHT_MM;
       const contRowsFit = Math.max(1, Math.floor(contAvailable / TABLE_ROW_HEIGHT_MM));
       const batch = remainingRows.slice(0, contRowsFit);
       remainingRows = remainingRows.slice(contRowsFit);
@@ -224,28 +231,27 @@ function paginateSections(
       currentHeight = TABLE_HEADER_HEIGHT_MM + SECTION_HEADER_HEIGHT_MM + batch.length * TABLE_ROW_HEIGHT_MM;
 
       if (remainingRows.length > 0) {
-        pages.push(currentPageSections);
+        pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
         currentPageSections = [];
         currentHeight = TABLE_HEADER_HEIGHT_MM;
       }
     }
   }
 
-  // Flush last page
   if (currentPageSections.length > 0) {
-    pages.push(currentPageSections);
+    pages.push({ sections: currentPageSections, contentHeight: calcContentHeight(currentPageSections) });
   }
 
-  return pages.length > 0 ? pages : [[]];
+  return pages.length > 0 ? pages : [{ sections: [], contentHeight: TABLE_HEADER_HEIGHT_MM }];
 }
 
-export function buildTimelineTemplate(pageCount: number): Template {
+export function buildTimelineTemplate(paginatedPages: PaginatedPage[]): Template {
   const schemas: Template["schemas"] = [];
 
-  for (let i = 0; i < pageCount; i++) {
+  for (let i = 0; i < paginatedPages.length; i++) {
     const isFirstPage = i === 0;
     const tableY = isFirstPage ? TABLE_START_Y : CONT_TABLE_START_Y;
-    const tableH = isFirstPage ? TABLE_CONTENT_HEIGHT : CONT_TABLE_CONTENT_HEIGHT;
+    const tableH = paginatedPages[i].contentHeight;
 
     const pageSchemas: Template["schemas"][number] = [
       {
@@ -321,12 +327,13 @@ export function buildTimelineInputs(
   data: DocumentData,
   services: TimelineService[],
   settings: TimelineSettings = DEFAULT_TIMELINE_SETTINGS,
-): Record<string, string>[] {
+): { inputs: Record<string, string>[]; template: Template } {
   const docColor = data.org_document_color;
   const columns = buildColumns(settings);
   const sections = buildSections(services, settings);
-  const paginatedSections = paginateSections(sections);
-  const pageCount = paginatedSections.length;
+  const paginatedPages = paginateSections(sections);
+  const pageCount = paginatedPages.length;
+  const template = buildTimelineTemplate(paginatedPages);
 
   // Header config
   const headerConfig: PageHeaderConfig = {
@@ -376,7 +383,7 @@ export function buildTimelineInputs(
     // Data table for this page
     const tableConfig = {
       columns,
-      sections: paginatedSections[i],
+      sections: paginatedPages[i].sections,
       documentColor: docColor,
     };
     pageInput[`table_${i}`] = JSON.stringify(tableConfig);
@@ -391,5 +398,5 @@ export function buildTimelineInputs(
     inputs.push(pageInput);
   }
 
-  return inputs;
+  return { inputs, template };
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -929,15 +929,30 @@ export async function deleteProject(id: string) {
 /** Get project milestone dates for call sheet dialog */
 export async function getCallSheetDates(projectId: string) {
   const { organizationId } = await getOrgContext();
-  const project = await prisma.project.findUnique({
-    where: { id: projectId, organizationId },
-    select: {
-      loadInDate: true,
-      eventStartDate: true,
-      eventEndDate: true,
-      loadOutDate: true,
-    },
-  });
+  const [project, services] = await Promise.all([
+    prisma.project.findUnique({
+      where: { id: projectId, organizationId },
+      select: {
+        loadInDate: true,
+        eventStartDate: true,
+        eventEndDate: true,
+        loadOutDate: true,
+      },
+    }),
+    prisma.projectService.findMany({
+      where: { projectId, organizationId, status: { not: "CANCELLED" } },
+      select: {
+        date: true,
+        _count: { select: { crewAssignments: true } },
+      },
+      orderBy: { date: "asc" },
+    }),
+  ]);
   if (!project) throw new Error("Project not found");
-  return serialize(project);
+  return serialize({
+    ...project,
+    serviceDates: services
+      .filter((s) => s.date != null)
+      .map((s) => ({ date: s.date, crewCount: s._count.crewAssignments })),
+  });
 }


### PR DESCRIPTION
## Summary
- Rewrites call sheet PDF to query ProjectService directly instead of crew assignments
- Groups services by date, each date gets a section header with full date label
- Each row shows: Crew Member, Service, Role, Call, Wrap, Notes
- All call sheet API routes now use the new service-based generator (removes old crew-table path)

## Test plan
- [ ] Generate call sheet for a project with services across multiple dates
- [ ] Verify each date appears as a section header
- [ ] Verify crew members appear under their assigned services
- [ ] Verify per-person filtering still works (`?crewMemberId=`)
- [ ] Verify pagination works when services overflow one page

🤖 Generated with [Claude Code](https://claude.com/claude-code)