### PR TITLE
feat: warehouse check UX — keyboard shortcuts, scan refocus, deprep check gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to GearFlow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-04-15
+
+### Added
+- Keyboard shortcuts in the warehouse item check form: `P`/`F` to pass/fail the focused PASS_FAIL row with auto-advance, `A` to pass all remaining, `↑`/`↓` to move the focused-row cursor (skips non-PASS_FAIL rows), `Enter` to submit. Shortcuts are suppressed while typing in a text input, while submitting, or with a modifier key held. Desktop-only hint bar in the sheet footer shows the available keys.
+- Deprep check gate: deprepping a returned item whose model has check items now runs a second RETURN-context check at deprep time (the inventory↔staging boundary), in addition to the existing return-scan check. Matches the mental model where Deploy is a staging ground on both sides of the truck. Damaged/flagged items bypass the second check. Kits respect `KitCheckMode` (KIT_LEVEL runs one kit-level check, PER_ITEM runs a queue entry per child).
+- New `completeCheckAndDeprep` server action that writes RETURN-context check records and resets `prepStatus=PENDING` in one transaction.
+- React component test infrastructure (`@testing-library/react` + jsdom) with 11 keyboard-handler tests for `ItemCheckForm`. Existing 1656 node-env validation tests are unaffected.
+
+### Fixed
+- Scan input auto-refocus after check completion: `finishCheckQueue` now returns focus to the correct scan input via `requestAnimationFrame` (PREP → main scan input, RETURN → return-tab scan input, deprep → deploy-tab scan input), letting barcode scanners flow scan-to-scan without a mouse click between checks.
+- Timer leak in `ItemCheckForm` pass-all undo window — the 3-second setTimeout is now cleared on form close and component unmount.
+- `completeCheckAndDeprep` pre-condition guard now strictly enforces `status=RETURNED` and `prepStatus=PACKED`, rejecting CONFIRMED/PREPPING items that could previously have been written against by a race or UI bug.
+
 ## [0.3.4] - 2026-04-15
 
 ### Fixed

--- a/FEATUREDOCS/37-check-items.md
+++ b/FEATUREDOCS/37-check-items.md
@@ -66,6 +66,7 @@ Quality check system integrated into the warehouse prep/return flow. Warehouse o
 | `completeCheckAndPack(data)` | warehouse.scan | Save records + checkout + PACKED |
 | `completeCheckAndFlag(data)` | warehouse.scan | Save records + flag (FAULTY/TT_OVERDUE) |
 | `completeCheckAndStore(data)` | warehouse.scan | Save records + checkin + condition |
+| `completeCheckAndDeprep(data)` | warehouse.check_out | Save RETURN records + reset prepStatus (deprep-gate check) |
 | `saveAdHocCheck(data)` | warehouse.scan | Standalone check (AD_HOC context) |
 | `lookupAssetForAdHocCheck(tag)` | read | Asset lookup for ad-hoc page |
 | `getCheckHistory(assetId, context?)` | read | All records for an asset |
@@ -92,7 +93,7 @@ Quality check system integrated into the warehouse prep/return flow. Warehouse o
 
 ### Warehouse
 
-- **Item Check Form** (`item-check-form.tsx`): Sheet slide-over with check items. Pass/Fail buttons (Fail LEFT red, Pass RIGHT green), measurement with auto-pass/fail, dropdown with isFail, "Pass All" with 3-second undo toast. Supports embedded mode for ad-hoc page.
+- **Item Check Form** (`item-check-form.tsx`): Sheet slide-over with check items. Pass/Fail buttons (Fail LEFT red, Pass RIGHT green), measurement with auto-pass/fail, dropdown with isFail, "Pass All" with 3-second undo toast. Supports embedded mode for ad-hoc page. **Keyboard shortcuts:** `P` pass focused PASS_FAIL row, `F` fail, `A` pass all remaining, `↑`/`↓` move focused-row cursor (skips non-PASS_FAIL rows), `Enter` submit when all answered. Shortcuts are suppressed when focus is on a text input / textarea / number input, while submitting, or with a modifier key held. The focused row gets a `ring-2 ring-primary` highlight. A desktop-only hint bar shows the available keys in the footer.
 - **Close-Out Tab** (`close-out-tab.tsx`): Summary stats, exceptions table, two-step close confirmation.
 - **Batch Close-Out**: Multi-select on warehouse dashboard for returned projects.
 
@@ -107,6 +108,23 @@ Quality check system integrated into the warehouse prep/return flow. Warehouse o
 ## Check Queue
 
 The warehouse page builds a **check queue** when prepping or returning multiple items. Items with check items assigned go through the `ItemCheckForm` sheet one at a time; items without checks are prepped/returned directly via `prepItemDirect` or `deprepItem`.
+
+### Scan Input Auto-Refocus
+
+When a check queue completes (single item or multi-item), `finishCheckQueue` returns focus to the correct scan input via `requestAnimationFrame` (PREP → main scan input, RETURN → return-tab scan input, RETURN-with-fromDeprep → deploy-tab scan input). This lets barcode scanners flow scan-to-scan without a mouse click between checks. The `requestAnimationFrame` delay lets the Sheet focus trap release before the refocus runs, avoiding a race.
+
+### Deprep Check Gate (inbound symmetry)
+
+Outbound flow: `pick/prep → CHECK → deploy (staging) → on truck`.
+Inbound flow: `truck → return → deploy (staging) → CHECK → pick/prep (inventory)`.
+
+The Deploy tab is the staging ground on both sides of the truck. The check always happens at the inventory↔staging boundary. On the inbound side, that means a second RETURN-context check runs at **deprep time** in addition to the existing return-scan check (additive, dual-check). Implementation:
+
+- `handleDeprep` in `src/app/(app)/warehouse/[projectId]/page.tsx` intercepts deprep clicks for returned items (`status === "RETURNED"`, `prepStatus === "PACKED"`) whose model has check items, and builds a check queue with `fromDeprep: true, context: "RETURN"`.
+- On submit, the queue dispatches to `completeCheckAndDeprep` (not `completeCheckAndStore`) which writes RETURN-context `CheckRecord` rows and resets `prepStatus=PENDING` in one transaction — without changing `status` (already RETURNED).
+- Items that were never deployed (outbound deprep) or whose model has no check items bypass the form and call `deprepItem` directly.
+- Flagged/damaged items (`prepStatus !== "PACKED"`) also bypass the form and deprep directly — the return-scan check already captured the fault, and a second pass would be duplicate noise.
+- Kit deprep respects `KitCheckMode` via `startKitCheckFlow(..., fromDeprep=true)`. `KIT_LEVEL` kits get one kit-level check; `PER_ITEM` kits get a queue entry per child. When the queue finishes, `finishCheckQueue` calls `deprepKit` instead of `kitCheckInMutation`.
 
 ### Bulk Items in Check Queue
 - Each selected bulk unit generates a separate `CheckQueueItem` entry

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,10 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/google.maps": "^3.58.1",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -67,11 +71,19 @@
         "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^27.0.1",
         "prisma": "^6.19.2",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -203,6 +215,61 @@
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@authenio/xml-encryption": {
       "version": "2.0.2",
@@ -2867,6 +2934,146 @@
       "license": "MIT",
       "dependencies": {
         "@egjs/component": "^3.0.2"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -7625,6 +7832,105 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -7725,6 +8031,13 @@
       "dependencies": {
         "@types/readdir-glob": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -9682,6 +9995,16 @@
         }
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -10611,6 +10934,27 @@
         "@scena/matrix": "^1.0.0"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -10621,6 +10965,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -10643,6 +11013,67 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/data-view-buffer": {
@@ -10737,6 +11168,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "4.2.1",
@@ -10897,6 +11335,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -10946,6 +11394,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-align": {
       "version": "1.12.4",
@@ -11169,6 +11624,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -13179,6 +13647,19 @@
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -13226,6 +13707,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -13325,6 +13820,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -13745,6 +14250,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -14112,6 +14624,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -14757,6 +15346,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -14803,6 +15402,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -14910,6 +15516,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -15813,6 +16429,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -16153,6 +16782,51 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -17470,6 +18144,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -17797,6 +18485,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -17936,6 +18631,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -18850,6 +19558,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -18975,6 +19696,13 @@
         "standardwebhooks": "1.0.0",
         "uuid": "^10.0.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -20196,6 +20924,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -20211,6 +20952,43 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -21091,6 +21869,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -21141,6 +21941,23 @@
       "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
       "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
       "license": "MIT License"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xpath": {
       "version": "0.0.34",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/google.maps": "^3.58.1",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -73,6 +77,7 @@
     "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^27.0.1",
     "prisma": "^6.19.2",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gearflow-init",
-  "version": "0.1.0",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -95,6 +95,7 @@ import {
   completeCheckAndFlag,
   unpackItem,
   completeCheckAndStore,
+  completeCheckAndDeprep,
   saveKitLevelChecks,
   saveChildItemChecks,
 } from "@/server/check-records";
@@ -360,6 +361,8 @@ function WarehouseProjectPage({
     /** When true, this is a kit queue — on complete, deploy/return the kit atomically */
     kitQueueKitId?: string;
     kitQueueReturnCondition?: "GOOD" | "DAMAGED" | "MISSING";
+    /** When true, this RETURN check was triggered by a deprep action from the deploy tab. */
+    fromDeprep?: boolean;
   } | null>(null);
   const [checkFormSubmitting, setCheckFormSubmitting] = useState(false);
 
@@ -376,6 +379,10 @@ function WarehouseProjectPage({
     /** When set, this queue item is part of a kit PER_ITEM flow */
     kitQueueKitId?: string;
     kitQueueReturnCondition?: "GOOD" | "DAMAGED" | "MISSING";
+    /** When true, this RETURN check was triggered by a deprep action from the deploy tab.
+     *  Used to route focus back to the deploy scan input on completion, and to route
+     *  submission through completeCheckAndStore (which transitions the item back to inventory). */
+    fromDeprep?: boolean;
   };
   const [checkQueue, setCheckQueue] = useState<CheckQueueItem[]>([]);
   const [checkQueueIndex, setCheckQueueIndex] = useState(0);
@@ -393,8 +400,10 @@ function WarehouseProjectPage({
     const first = queue[0];
     setCheckFormData(first);
     setCheckFormOpen(true);
-    // Call pullItem/unpackItem for non-kit items (kit items are deployed atomically at the end)
-    if (!first.kitId && !first.kitQueueKitId) {
+    // Call pullItem/unpackItem for non-kit items (kit items are deployed atomically at the end).
+    // Skip for fromDeprep queues — the item is already returned; we just need to run the check
+    // and then reset prepStatus in completeCheckAndDeprep.
+    if (!first.kitId && !first.kitQueueKitId && !first.fromDeprep) {
       if (first.context === "PREP") {
         pullItem(projectId, first.lineItemId).catch(() => {});
       } else {
@@ -411,8 +420,9 @@ function WarehouseProjectPage({
       setCheckQueueIndex(nextIndex);
       const next = checkQueue[nextIndex];
       setCheckFormData(next);
-      // Pull/unpack non-kit items (kit items are deployed atomically at the end)
-      if (!next.kitId && !next.kitQueueKitId) {
+      // Pull/unpack non-kit items (kit items are deployed atomically at the end).
+      // Skip for fromDeprep — item is already returned.
+      if (!next.kitId && !next.kitQueueKitId && !next.fromDeprep) {
         if (next.context === "PREP") {
           pullItem(projectId, next.lineItemId).catch(() => {});
         } else {
@@ -431,11 +441,25 @@ function WarehouseProjectPage({
     const kitQueueKitId = checkQueue[0]?.kitQueueKitId;
     const kitQueueContext = checkQueue[0]?.context;
     const kitQueueReturnCondition = checkQueue[0]?.kitQueueReturnCondition;
+    const finishedContext = checkQueue[0]?.context;
+    const finishedFromDeprep = checkQueue[0]?.fromDeprep === true;
 
     setCheckFormOpen(false);
     setCheckFormData(null);
     setCheckQueue([]);
     setCheckQueueIndex(0);
+
+    // Return focus to the appropriate scan input so barcode scanners flow uninterrupted.
+    // Wait a frame for the Sheet to release its focus trap before we steal it back.
+    requestAnimationFrame(() => {
+      if (finishedFromDeprep) {
+        deployScanInputRef.current?.focus();
+      } else if (finishedContext === "PREP") {
+        scanInputRef.current?.focus();
+      } else if (finishedContext === "RETURN") {
+        returnScanInputRef.current?.focus();
+      }
+    });
 
     if (kitQueueKitId) {
       if (kitQueueContext === "PREP") {
@@ -451,6 +475,17 @@ function WarehouseProjectPage({
         } else {
           toast.success("Kit prepped — ready to deploy");
           invalidate();
+        }
+      } else if (finishedFromDeprep) {
+        // Kit deprep: checks are already saved, now deprep the kit back to inventory
+        const kitLi = lineItems.find((l) => l.kitId === kitQueueKitId && !l.isKitChild);
+        if (kitLi) {
+          deprepKit(projectId, kitLi.id)
+            .then(() => {
+              toast.success("Kit deprep checked — returned to inventory");
+              invalidate();
+            })
+            .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to deprep kit"));
         }
       } else {
         kitCheckInMutation.mutate(
@@ -491,7 +526,8 @@ function WarehouseProjectPage({
     kitId: string,
     kitLi: LineItem,
     context: "PREP" | "RETURN",
-    kitReturnCondition?: "GOOD" | "DAMAGED" | "MISSING"
+    kitReturnCondition?: "GOOD" | "DAMAGED" | "MISSING",
+    fromDeprep: boolean = false
   ): boolean {
     const kit = kitLi.kit;
     if (!kit) return false;
@@ -513,15 +549,19 @@ function WarehouseProjectPage({
         assetId: "",
         kitQueueKitId: kit.id,
         kitQueueReturnCondition: kitReturnCondition,
+        fromDeprep,
       }];
       return startCheckQueue(queue);
     } else {
       // PER_ITEM: queue each child with model check items
       const queue: CheckQueueItem[] = [];
       for (const child of children) {
-        // Skip children not relevant to current flow
+        // Skip children not relevant to current flow.
+        // Deprep runs on already-returned kits so the children are not CHECKED_OUT anymore —
+        // use the RETURN-with-fromDeprep branch to include them regardless.
         if (context === "PREP" && (child.status === "CHECKED_OUT" || child.status === "CANCELLED")) continue;
-        if (context === "RETURN" && child.status !== "CHECKED_OUT") continue;
+        if (context === "RETURN" && !fromDeprep && child.status !== "CHECKED_OUT") continue;
+        if (context === "RETURN" && fromDeprep && child.status === "CANCELLED") continue;
 
         const hasModelChecks = child.model?._count?.modelCheckItems && child.model._count.modelCheckItems > 0;
         if (!hasModelChecks || !child.modelId) continue;
@@ -541,6 +581,7 @@ function WarehouseProjectPage({
             bulkAssetId: child.bulkAssetId || undefined,
             kitQueueKitId: kit.id,
             kitQueueReturnCondition: kitReturnCondition,
+            fromDeprep,
           });
         }
       }
@@ -2018,22 +2059,92 @@ function WarehouseProjectPage({
                 directIds.push(id);
               }
             });
+
+            // Build a RETURN check queue for returned items that have check items on their model.
+            // Items that were never deployed (outbound deprep) or have no check items bypass this
+            // entirely. Damaged items (prepStatus FLAGGED_FAULTY) also skip the second check.
+            const checkQueueBuild: CheckQueueItem[] = [];
+            const directDeprep: Array<{ lineItemId: string; quantity?: number; isKit?: boolean }> = [];
+
             for (const [lineItemId, count] of bulkDeprepMap) {
-              deprepMutation.mutate({ lineItemId, quantity: count });
+              const li = lineItems.find((l) => l.id === lineItemId);
+              const needsCheck =
+                li?.status === "RETURNED" &&
+                li.prepStatus === "PACKED" &&
+                !!li.model?._count?.modelCheckItems &&
+                li.model._count.modelCheckItems > 0 &&
+                !!li.modelId;
+              if (needsCheck && li) {
+                for (let i = 0; i < count; i++) {
+                  checkQueueBuild.push({
+                    context: "RETURN",
+                    modelId: li.modelId!,
+                    assetTag: li.asset?.assetTag || li.bulkAsset?.assetTag || "",
+                    assetName: `${modelDisplayName(li)}${count > 1 ? ` #${i + 1}` : ""}`,
+                    lineItemId,
+                    assetId: li.assetId || "",
+                    bulkAssetId: li.bulkAssetId || undefined,
+                    fromDeprep: true,
+                  });
+                }
+              } else {
+                directDeprep.push({ lineItemId, quantity: count });
+              }
             }
-            directIds.forEach((id) => {
+
+            for (const id of directIds) {
               const li = lineItems.find((l) => l.id === id);
               if (li && isKitParent(li)) {
-                deprepKit(projectId, id)
+                // Kit deprep with checks: respects KIT_LEVEL / PER_ITEM via startKitCheckFlow
+                if (li.status === "RETURNED" && startKitCheckFlow(li.kitId!, li, "RETURN", "GOOD", true)) {
+                  continue;
+                }
+                directDeprep.push({ lineItemId: id, isKit: true });
+              } else {
+                const needsCheck =
+                  li?.status === "RETURNED" &&
+                  li.prepStatus === "PACKED" &&
+                  !!li.model?._count?.modelCheckItems &&
+                  li.model._count.modelCheckItems > 0 &&
+                  !!li.modelId;
+                if (needsCheck && li) {
+                  checkQueueBuild.push({
+                    context: "RETURN",
+                    modelId: li.modelId!,
+                    assetTag: li.asset?.assetTag || li.bulkAsset?.assetTag || "",
+                    assetName: modelDisplayName(li),
+                    lineItemId: id,
+                    assetId: li.assetId || "",
+                    bulkAssetId: li.bulkAssetId || undefined,
+                    fromDeprep: true,
+                  });
+                } else {
+                  directDeprep.push({ lineItemId: id });
+                }
+              }
+            }
+
+            // Fire direct deprep for items without checks
+            for (const d of directDeprep) {
+              if (d.isKit) {
+                deprepKit(projectId, d.lineItemId)
                   .then(() => {
                     toast.success("Kit removed from prep");
                     invalidate();
                   })
                   .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to deprep kit"));
+              } else if (d.quantity) {
+                deprepMutation.mutate({ lineItemId: d.lineItemId, quantity: d.quantity });
               } else {
-                deprepMutation.mutate(id);
+                deprepMutation.mutate(d.lineItemId);
               }
-            });
+            }
+
+            // Start check queue for items that need it
+            if (checkQueueBuild.length > 0) {
+              startCheckQueue(checkQueueBuild);
+            }
+
             setSelectedOut(new Set());
           }}
           deprepIsPending={deprepMutation.isPending}
@@ -2340,6 +2451,14 @@ function WarehouseProjectPage({
                     prepContainer: selectedContainer || null,
                     checks,
                   });
+                } else if (item.fromDeprep) {
+                  await completeCheckAndDeprep({
+                    projectId,
+                    lineItemId: item.lineItemId,
+                    assetId: item.assetId,
+                    bulkAssetId: item.bulkAssetId,
+                    checks,
+                  });
                 } else {
                   await unpackItem(projectId, item.lineItemId).catch(() => {});
                   await completeCheckAndStore({
@@ -2405,6 +2524,16 @@ function WarehouseProjectPage({
                   });
                   toast.success("Item checked and packed");
                 }
+              } else if (checkFormData.fromDeprep) {
+                // RETURN deprep — item is already returned, just record checks and reset prepStatus
+                await completeCheckAndDeprep({
+                  projectId,
+                  lineItemId: checkFormData.lineItemId,
+                  assetId: checkFormData.assetId,
+                  bulkAssetId: checkFormData.bulkAssetId,
+                  checks,
+                });
+                toast.success("Item checked and returned to inventory");
               } else {
                 // RETURN — condition comes from the check form
                 const condition = returnInfo?.condition || "GOOD";

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -494,8 +494,9 @@ function WarehouseProjectPage({
         );
       }
     } else if (checkQueueDirectItems.length > 0) {
-      const context = checkQueue[0]?.context;
-      if (context === "PREP") {
+      // Reuse the snapshot we captured above — avoid re-reading checkQueue[0]
+      // after setCheckQueue([]) was called.
+      if (finishedContext === "PREP") {
         // Prep remaining items that had no checks (set prepStatus=PACKED)
         // Sequential to avoid race conditions when items share the same lineItemId
         (async () => {

--- a/src/components/warehouse/__tests__/item-check-form.test.tsx
+++ b/src/components/warehouse/__tests__/item-check-form.test.tsx
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockItems = [
+  {
+    id: "mci-1",
+    sortOrder: 0,
+    checkItem: {
+      id: "ci-1",
+      label: "Power on",
+      description: null,
+      type: "PASS_FAIL",
+      category: null,
+      measurementUnit: null,
+      measurementMin: null,
+      measurementMax: null,
+      dropdownOptions: null,
+    },
+  },
+  {
+    id: "mci-2",
+    sortOrder: 1,
+    checkItem: {
+      id: "ci-2",
+      label: "Condition notes",
+      description: null,
+      type: "NOTES",
+      category: null,
+      measurementUnit: null,
+      measurementMin: null,
+      measurementMax: null,
+      dropdownOptions: null,
+    },
+  },
+  {
+    id: "mci-4",
+    sortOrder: 2,
+    checkItem: {
+      id: "ci-4",
+      label: "No visible damage",
+      description: null,
+      type: "PASS_FAIL",
+      category: null,
+      measurementUnit: null,
+      measurementMin: null,
+      measurementMax: null,
+      dropdownOptions: null,
+    },
+  },
+  {
+    id: "mci-5",
+    sortOrder: 3,
+    checkItem: {
+      id: "ci-5",
+      label: "Cables present",
+      description: null,
+      type: "PASS_FAIL",
+      category: null,
+      measurementUnit: null,
+      measurementMin: null,
+      measurementMax: null,
+      dropdownOptions: null,
+    },
+  },
+];
+
+vi.mock("@/server/check-items", () => ({
+  getModelCheckItems: vi.fn(async () => mockItems),
+  getKitCheckItems: vi.fn(async () => mockItems),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: { id: "org-1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Sheet from shadcn/ui uses Base UI which pulls in portals + focus traps that
+// are painful in jsdom. Replace with dumb passthroughs so the form content
+// renders inline.
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="sheet">{children}</div> : null,
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Select also uses Base UI portals — replace with a plain native-ish shim.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { ItemCheckForm } from "../item-check-form";
+import type { CheckRecordFormValues } from "@/lib/validations/check-item";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function renderForm(overrides: Partial<React.ComponentProps<typeof ItemCheckForm>> = {}) {
+  const onSubmit = vi.fn();
+  const onCancel = vi.fn();
+  const onOpenChange = vi.fn();
+  const onPassAllRemaining = vi.fn();
+
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        // Seed cache synchronously so useQuery resolves on first render
+        staleTime: Infinity,
+      },
+    },
+  });
+  // Pre-seed the cache so the async query resolves immediately
+  client.setQueryData(["model-check-items", "org-1", "model-1"], mockItems);
+
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <ItemCheckForm
+        open
+        onOpenChange={onOpenChange}
+        modelId="model-1"
+        assetTag="AST-1"
+        assetName="Test asset"
+        context="PREP"
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        onPassAllRemaining={onPassAllRemaining}
+        {...overrides}
+      />
+    </QueryClientProvider>
+  );
+
+  return { ...utils, onSubmit, onCancel, onOpenChange, onPassAllRemaining };
+}
+
+function key(k: string) {
+  fireEvent.keyDown(document, { key: k });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ItemCheckForm keyboard shortcuts", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders check item labels", () => {
+    renderForm();
+    expect(screen.getByText("Power on")).toBeTruthy();
+    expect(screen.getByText("No visible damage")).toBeTruthy();
+  });
+
+  it("P passes the focused PASS_FAIL row and auto-advances", () => {
+    const { onSubmit } = renderForm();
+
+    // Initial focus is on the first PASS_FAIL (index 0 — "Power on")
+    key("p");
+    // After auto-advance, focus is on index 3 ("No visible damage")
+    key("p");
+    // Focus is now on index 4 ("Cables present")
+    key("p");
+
+    // All three PASS_FAIL rows answered → Enter submits
+    key("Enter");
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [checks] = onSubmit.mock.calls[0];
+    const byId = Object.fromEntries(
+      (checks as CheckRecordFormValues[]).map((c) => [c.checkItemId, c.result])
+    );
+    expect(byId["ci-1"]).toBe("PASS");
+    expect(byId["ci-4"]).toBe("PASS");
+    expect(byId["ci-5"]).toBe("PASS");
+  });
+
+  it("F fails the focused PASS_FAIL row", () => {
+    const { onSubmit } = renderForm();
+
+    key("f"); // fail ci-1, auto-advance to ci-4
+    key("p"); // pass ci-4, auto-advance to ci-5
+    key("p"); // pass ci-5
+    key("Enter");
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [checks] = onSubmit.mock.calls[0];
+    const byId = Object.fromEntries(
+      (checks as CheckRecordFormValues[]).map((c) => [c.checkItemId, c.result])
+    );
+    expect(byId["ci-1"]).toBe("FAIL");
+    expect(byId["ci-4"]).toBe("PASS");
+    expect(byId["ci-5"]).toBe("PASS");
+  });
+
+  it("A passes all remaining PASS_FAIL rows", () => {
+    const { onSubmit } = renderForm();
+
+    key("a");
+    key("Enter");
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [checks] = onSubmit.mock.calls[0];
+    const results = (checks as CheckRecordFormValues[]).filter((c) =>
+      ["ci-1", "ci-4", "ci-5"].includes(c.checkItemId)
+    );
+    expect(results.every((r) => r.result === "PASS")).toBe(true);
+  });
+
+  it("ArrowDown moves cursor to next PASS_FAIL, skipping NOTES", () => {
+    const { onSubmit } = renderForm();
+
+    // Rows: [ci-1 PASS_FAIL, ci-2 NOTES, ci-4 PASS_FAIL, ci-5 PASS_FAIL]
+    // Cursor starts at index 0 (ci-1). ArrowDown should skip ci-2 (NOTES)
+    // and land on ci-4 (index 2). Press F to fail it.
+    key("ArrowDown"); // now on ci-4
+    key("f"); // fail ci-4, auto-advance to ci-5
+    key("p"); // pass ci-5
+    // ci-1 still unanswered → Enter should NOT submit
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Go back up and pass ci-1
+    key("ArrowUp"); // back to ci-4
+    key("ArrowUp"); // back to ci-1
+    key("p");
+    key("Enter");
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [checks] = onSubmit.mock.calls[0];
+    const byId = Object.fromEntries(
+      (checks as CheckRecordFormValues[]).map((c) => [c.checkItemId, c.result])
+    );
+    expect(byId["ci-1"]).toBe("PASS");
+    expect(byId["ci-4"]).toBe("FAIL");
+    expect(byId["ci-5"]).toBe("PASS");
+  });
+
+  it("Enter is a no-op when items are incomplete", () => {
+    const { onSubmit } = renderForm();
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keyboard handler is inert when focus is inside a text input", () => {
+    const { onSubmit, container } = renderForm();
+    // NOTES row renders a textarea (ci-2)
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+    textarea!.focus();
+    fireEvent.keyDown(textarea!, { key: "p" });
+    // No PASS_FAIL row should have been marked — Enter still does nothing
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("modifier keys let the browser handle the event", () => {
+    const { onSubmit } = renderForm();
+    fireEvent.keyDown(document, { key: "p", metaKey: true });
+    fireEvent.keyDown(document, { key: "p", ctrlKey: true });
+    // Row still unanswered → Enter no-op
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("isSubmitting disables keyboard shortcuts", () => {
+    const { onSubmit } = renderForm({ isSubmitting: true });
+    key("a");
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("embedded mode disables keyboard shortcuts", () => {
+    const { onSubmit } = renderForm({ embedded: true });
+    key("a");
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keyboard shortcuts detach when open goes false", () => {
+    const { onSubmit, rerender } = renderForm();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(["model-check-items", "org-1", "model-1"], mockItems);
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <ItemCheckForm
+          open={false}
+          onOpenChange={() => {}}
+          modelId="model-1"
+          assetTag="AST-1"
+          assetName="Test asset"
+          context="PREP"
+          onSubmit={onSubmit}
+          onCancel={() => {}}
+        />
+      </QueryClientProvider>
+    );
+
+    key("a");
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/warehouse/item-check-form.tsx
+++ b/src/components/warehouse/item-check-form.tsx
@@ -148,6 +148,19 @@ export function ItemCheckForm({
     isLoading: false,
   });
 
+  // Clear any pending pass-all undo timer on unmount or when the form closes,
+  // so a stale timeout doesn't fire setState after the component is gone.
+  useEffect(() => {
+    if (!open && passAllUndo) {
+      clearTimeout(passAllUndo);
+      setPassAllUndo(null);
+      passAllUndoRef.current = null;
+    }
+    return () => {
+      if (passAllUndo) clearTimeout(passAllUndo);
+    };
+  }, [open, passAllUndo]);
+
   // Reset states when form opens with new items
   useEffect(() => {
     if (open && items.length > 0) {

--- a/src/components/warehouse/item-check-form.tsx
+++ b/src/components/warehouse/item-check-form.tsx
@@ -127,6 +127,27 @@ export function ItemCheckForm({
   const [returnCondition, setReturnCondition] = useState<"GOOD" | "DAMAGED" | "MISSING">("GOOD");
   const [returnNotes, setReturnNotes] = useState("");
 
+  // Keyboard-shortcut cursor: which row is "active" for P/F keystrokes.
+  // Points at an index within the full items[] array — arrow keys skip non-PASS_FAIL rows.
+  const [focusedRowIndex, setFocusedRowIndex] = useState(0);
+
+  // Refs used by the keyboard handler so it reads the latest props/state without re-binding.
+  const handleSubmitRef = useRef<() => void>(() => {});
+  const handlePassAllRef = useRef<() => void>(() => {});
+  const stateRef = useRef<{
+    items: CheckItemData[];
+    checkStates: Record<string, CheckState>;
+    focusedRowIndex: number;
+    isSubmitting: boolean;
+    isLoading: boolean;
+  }>({
+    items: [],
+    checkStates: {},
+    focusedRowIndex: 0,
+    isSubmitting: false,
+    isLoading: false,
+  });
+
   // Reset states when form opens with new items
   useEffect(() => {
     if (open && items.length > 0) {
@@ -144,6 +165,9 @@ export function ItemCheckForm({
       passAllUndoRef.current = null;
       setReturnCondition("GOOD");
       setReturnNotes("");
+      // Land the keyboard cursor on the first PASS_FAIL row if there is one, else row 0
+      const firstPassFail = items.findIndex((mci) => mci.checkItem.type === "PASS_FAIL");
+      setFocusedRowIndex(firstPassFail >= 0 ? firstPassFail : 0);
     }
   }, [open, items.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -217,6 +241,7 @@ export function ItemCheckForm({
   });
 
   function handleSubmit() {
+    if (!allComplete || isSubmitting) return;
     const checks: CheckRecordFormValues[] = items.map((mci) => {
       const state = checkStates[mci.checkItem.id];
       return {
@@ -241,6 +266,92 @@ export function ItemCheckForm({
   }
 
   const failCount = Object.values(checkStates).filter((s) => s.result === "FAIL").length;
+
+  // ─── Keyboard shortcuts ─────────────────────────────────────────────────
+  // P / F         — pass or fail the focused PASS_FAIL row
+  // A             — pass all remaining PASS_FAIL rows (same as the existing button)
+  // ArrowUp/Down  — move the focused row cursor, skipping non-PASS_FAIL rows
+  // Enter         — submit if all complete
+  // Guards: ignore when any text input/textarea/select/contenteditable has focus,
+  //         and when the form is submitting or loading.
+  // Latest-value refs avoid re-binding the listener on every state tick.
+  // Wire the refs to the latest handlers — both are defined above in render scope.
+  handleSubmitRef.current = handleSubmit;
+  handlePassAllRef.current = handlePassAll;
+  stateRef.current = { items, checkStates, focusedRowIndex, isSubmitting, isLoading };
+
+  useEffect(() => {
+    if (!open || embedded) return;
+
+    function isTypingTarget(el: EventTarget | null): boolean {
+      if (!(el instanceof HTMLElement)) return false;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+      if (el.isContentEditable) return true;
+      return false;
+    }
+
+    function onKey(e: KeyboardEvent) {
+      const s = stateRef.current;
+      if (s.isSubmitting || s.isLoading) return;
+      // Modifier keys → let the browser handle (e.g. Cmd+R)
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      // Don't hijack while the user is typing in a notes/measurement/dropdown field
+      if (isTypingTarget(e.target)) return;
+
+      const key = e.key;
+      const passFailIndices = s.items
+        .map((mci, i) => (mci.checkItem.type === "PASS_FAIL" ? i : -1))
+        .filter((i) => i >= 0);
+
+      if (key === "p" || key === "P" || key === "f" || key === "F") {
+        const focusedItem = s.items[s.focusedRowIndex];
+        if (!focusedItem || focusedItem.checkItem.type !== "PASS_FAIL") return;
+        const result = key === "p" || key === "P" ? "PASS" : "FAIL";
+        e.preventDefault();
+        setCheckStates((prev) => ({
+          ...prev,
+          [focusedItem.checkItem.id]: { ...prev[focusedItem.checkItem.id], result },
+        }));
+        // Auto-advance to next PASS_FAIL row
+        const currentPos = passFailIndices.indexOf(s.focusedRowIndex);
+        if (currentPos >= 0 && currentPos + 1 < passFailIndices.length) {
+          setFocusedRowIndex(passFailIndices[currentPos + 1]);
+        }
+        return;
+      }
+
+      if (key === "a" || key === "A") {
+        if (passFailIndices.length === 0) return;
+        e.preventDefault();
+        handlePassAllRef.current();
+        return;
+      }
+
+      if (key === "ArrowDown" || key === "ArrowUp") {
+        if (passFailIndices.length === 0) return;
+        e.preventDefault();
+        const currentPos = passFailIndices.indexOf(s.focusedRowIndex);
+        if (key === "ArrowDown") {
+          const next = currentPos < 0 ? 0 : Math.min(currentPos + 1, passFailIndices.length - 1);
+          setFocusedRowIndex(passFailIndices[next]);
+        } else {
+          const next = currentPos < 0 ? passFailIndices.length - 1 : Math.max(currentPos - 1, 0);
+          setFocusedRowIndex(passFailIndices[next]);
+        }
+        return;
+      }
+
+      if (key === "Enter") {
+        e.preventDefault();
+        handleSubmitRef.current();
+        return;
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, embedded]);
 
   const contextLabel = context === "PREP" ? "Prep Check" : context === "RETURN" ? "Return Check" : "Ad-Hoc Check";
   const submitLabel = context === "PREP"
@@ -280,6 +391,8 @@ export function ItemCheckForm({
               item={mci}
               state={checkStates[mci.checkItem.id]}
               index={index}
+              isFocused={!embedded && index === focusedRowIndex && mci.checkItem.type === "PASS_FAIL"}
+              onFocus={() => setFocusedRowIndex(index)}
               onUpdate={(updates) => updateCheck(mci.checkItem.id, updates)}
               getMeasurementAutoResult={getMeasurementAutoResult}
             />
@@ -356,6 +469,17 @@ export function ItemCheckForm({
             {submitLabel}
           </Button>
         </div>
+
+        {/* Keyboard-shortcut hint bar — desktop only, non-embedded */}
+        {!embedded && items.some((mci) => mci.checkItem.type === "PASS_FAIL") && (
+          <div className="hidden sm:flex items-center justify-center gap-3 pt-1 text-[10px] text-fg-3 tabular-nums">
+            <span><kbd className="rounded bg-bg-elevated px-1 py-0.5 font-mono">P</kbd> pass</span>
+            <span><kbd className="rounded bg-bg-elevated px-1 py-0.5 font-mono">F</kbd> fail</span>
+            <span><kbd className="rounded bg-bg-elevated px-1 py-0.5 font-mono">A</kbd> pass all</span>
+            <span><kbd className="rounded bg-bg-elevated px-1 py-0.5 font-mono">↑↓</kbd> move</span>
+            <span><kbd className="rounded bg-bg-elevated px-1 py-0.5 font-mono">↵</kbd> submit</span>
+          </div>
+        )}
       </div>
     </>
   );
@@ -411,12 +535,16 @@ function CheckItemRow({
   item,
   state,
   index,
+  isFocused = false,
+  onFocus,
   onUpdate,
   getMeasurementAutoResult,
 }: {
   item: CheckItemData;
   state: CheckState | undefined;
   index: number;
+  isFocused?: boolean;
+  onFocus?: () => void;
   onUpdate: (updates: Partial<CheckState>) => void;
   getMeasurementAutoResult: (
     value: string,
@@ -430,7 +558,10 @@ function CheckItemRow({
 
   return (
     <div
+      onClick={onFocus}
       className={`rounded-lg border p-3 transition-colors ${
+        isFocused ? "ring-2 ring-primary ring-offset-1 ring-offset-bg" : ""
+      } ${
         result === "PASS"
           ? "border-green-500/30 bg-green-500/5"
           : result === "FAIL"

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -437,8 +437,15 @@ export async function completeCheckAndDeprep(data: {
     if (!lineItem) {
       throw new Error("Line item not found in project");
     }
-    if (lineItem.status === "CHECKED_OUT") {
-      throw new Error("Item is still deployed — return it first");
+    if (lineItem.status !== "RETURNED") {
+      throw new Error(
+        `Deprep return check requires RETURNED status (got ${lineItem.status})`
+      );
+    }
+    if (lineItem.prepStatus !== "PACKED") {
+      throw new Error(
+        `Deprep return check requires prepStatus=PACKED (got ${lineItem.prepStatus ?? "null"})`
+      );
     }
 
     // Write RETURN-context check records.

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -404,6 +404,90 @@ export async function deprepItem(
 }
 
 /**
+ * Write RETURN-context check records for an already-returned item and deprep it
+ * (reset prepStatus=PENDING, removing it from the deploy staging area).
+ *
+ * Used by the deploy tab's deprep action when staff are putting returned items back
+ * into inventory — the "post-truck" half of the check symmetry. The item is already
+ * in status=RETURNED (the return-tab scan handled that); this call just records an
+ * additional set of checks at the moment the item physically re-enters inventory,
+ * then transitions prepStatus back to PENDING.
+ *
+ * Pre-condition: line item must have status=RETURNED. Items that never shipped
+ * (status=CONFIRMED) should use the plain deprepItem() path — no return check applies.
+ */
+export async function completeCheckAndDeprep(data: {
+  projectId: string;
+  lineItemId: string;
+  assetId?: string;
+  bulkAssetId?: string | null;
+  checks: CheckRecordFormValues[];
+}) {
+  const { organizationId, userId, userName } = await requirePermission(
+    "warehouse",
+    "check_out"
+  );
+
+  const result = await prisma.$transaction(async (tx) => {
+    const lineItem = await tx.projectLineItem.findFirst({
+      where: { id: data.lineItemId, projectId: data.projectId, organizationId },
+      include: { model: true, asset: true, bulkAsset: true },
+    });
+
+    if (!lineItem) {
+      throw new Error("Line item not found in project");
+    }
+    if (lineItem.status === "CHECKED_OUT") {
+      throw new Error("Item is still deployed — return it first");
+    }
+
+    // Write RETURN-context check records.
+    // assetId may be empty if the return-tab scan already disconnected it — that's OK,
+    // saveCheckRecords skips the asset connect when assetId is falsy.
+    const resolvedAssetId = data.assetId || lineItem.assetId || "";
+    await saveCheckRecords(
+      tx,
+      organizationId,
+      userId,
+      resolvedAssetId,
+      data.lineItemId,
+      data.bulkAssetId || lineItem.bulkAssetId,
+      "RETURN",
+      data.checks
+    );
+
+    // Reset prepStatus to remove from deploy staging. Do not touch status/returnStatus —
+    // the return-tab flow already set those.
+    const updated = await tx.projectLineItem.update({
+      where: { id: data.lineItemId },
+      data: {
+        prepStatus: "PENDING",
+        ...(!lineItem.isKitChild && lineItem.assetId
+          ? { asset: { disconnect: true } }
+          : {}),
+      },
+      include: { model: true, asset: true, bulkAsset: true },
+    });
+    return updated;
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "asset",
+    entityId: data.lineItemId,
+    entityName: result.model?.name || "Line item",
+    summary: "Deprep return check complete — item returned to inventory",
+    projectId: data.projectId,
+    assetId: result.assetId || undefined,
+  });
+
+  return serialize(result);
+}
+
+/**
  * Reverse prep for a kit: set parent + all children/grandchildren back to PENDING.
  */
 export async function deprepKit(


### PR DESCRIPTION
## Summary

Three warehouse check workflow improvements:

1. **Auto-refocus scan input** after a check completes. `finishCheckQueue` returns focus to the correct scan input via `requestAnimationFrame` (PREP → main scan, RETURN → return-tab scan, deprep → deploy-tab scan). Barcode scanners now flow scan-to-scan without a mouse click between checks.
2. **Keyboard shortcuts** in `ItemCheckForm`: `P`/`F` pass/fail the focused row with auto-advance, `A` pass all, `↑`/`↓` move cursor (skips non-PASS_FAIL), `Enter` submit. Guarded against typing targets, modifier keys, and submitting state. Desktop-only hint bar shows the keys.
3. **Deprep check gate** (inbound symmetry). Mental model: Deploy is a staging ground on both sides of the truck; the check belongs at the inventory↔staging boundary. Adds a second RETURN-context check at deprep time (additive, not a move). New `completeCheckAndDeprep` server action writes records + resets `prepStatus=PENDING` in one transaction. Damaged/flagged items bypass the second check. Kits respect `KitCheckMode` — KIT_LEVEL gets one kit-level check, PER_ITEM gets a queue entry per child, and `finishCheckQueue` dispatches to `deprepKit` at the end of a fromDeprep kit queue.

## Also

- Bootstrapped React component test infra (`@testing-library/react` + jsdom) as an opt-in per-file environment. 11 new tests cover the keyboard handler paths (P/F/A/arrows/Enter, typing guard, modifier passthrough, isSubmitting lockout, embedded-mode disable, listener detach on close). Existing 1656 node-env tests untouched.
- Pre-landing review fixes: pass-all undo timer cleanup on close/unmount, stale-closure read of `checkQueue[0]` in `finishCheckQueue` replaced with captured snapshot, `completeCheckAndDeprep` status guard tightened to require `RETURNED` + `PACKED`.

## Test plan

- [x] 1667/1667 unit tests pass (1656 existing + 11 new component tests)
- [x] TypeScript clean on changed files
- [ ] Manual QA: prep flow — scan → `A` → `Enter` → scan next, no click needed
- [ ] Manual QA: return flow — same, on return tab
- [ ] Manual QA: deprep a returned non-damaged serialized item with check items → second check form opens (RETURN context) → submit → item lands in inventory with two CheckRecords
- [ ] Manual QA: deprep a DAMAGED item → no check form, goes straight to maintenance
- [ ] Manual QA: deprep a KIT_LEVEL kit with checks → one kit-level check → `deprepKit` fires
- [ ] Manual QA: deprep a PER_ITEM kit with checks → queue of per-child checks → `deprepKit` fires at end
- [ ] Regression: existing check-out/check-in/overbooking flows unchanged
- [ ] Mobile: form still usable without keyboard (buttons work, no hint bar visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)