### PR TITLE
feat(kits+templates): delete flow, kit items in templates, save-as-template UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to GearFlow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-15
+
+### Added
+- Kit delete flow: the kit detail page now exposes a `DeleteKitDialog` with two tiers. Archive (soft delete) is always available while the kit is AVAILABLE + active, and is the default; hard delete is an opt-in second option that is blocked whenever any `ProjectLineItem` references the kit, so historical project data is preserved. The dialog surfaces a human-readable reason when hard delete is unavailable. New server actions `canDeleteKit(id)` and `deleteKit(id)` back the UI, gated by the existing `kit:delete` permission.
+- Group templates now support kit items in addition to model items. `GroupTemplateItem` got a nullable `kitId` column and a Zod XOR refine so each row references exactly one of `modelId`/`kitId`. A template can mix both: "FOH Package" = 2x SM57 (model) + 1x rack kit (rigid). `saveGroupAsTemplate` captures both kinds from the source group; `applyGroupTemplate` creates the model lines inside the same transaction as the new group, then delegates kit items to `addKitLineItem` per unit of quantity (so "2x rack kit" becomes two independent parent rows with their full child expansions). Kit expansion failures (conflicts, availability) are collected as warnings rather than aborting the apply, matching warehouse-staff expectations.
+
+### Removed
+- The unused `KitPreset` / `KitPresetItem` tables (introduced in an earlier WIP migration) have been dropped in favor of extending the existing `GroupTemplate` system. The `group_template_supports_kits` migration atomically drops the orphan tables and adds `kitId` + `sortOrder` to `group_template_item`.
+
 ## [0.3.5] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to GearFlow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-15
+
+### Added
+- Group template picker in the project equipment tab's Add Group dialog. Selecting a template auto-fills the group title and flips the create action to apply the template's items; leaving it blank creates an empty group as before.
+- "Save as Template" action on each project group dropdown, with a dialog pre-filled from the group title. Captures the group's model- and kit-backed line items via `saveGroupAsTemplate` and invalidates the templates query so newly saved templates appear immediately in the picker.
+- Group Templates management page at `/settings/group-templates` (nav entry gated by `project:manage_line_items`). Lists all templates sorted by name with expandable item previews (kit vs. model icons, quantity badges), rename/description edit dialog, and a delete dialog that clarifies existing projects keep their line items.
+
+### Fixed
+- `updateGroupTemplate` item-replace path no longer drops `kitId` and `sortOrder` when rebuilding template items.
+
 ## [0.4.0] - 2026-04-15
 
 ### Added

--- a/FEATUREDOCS/09-kits.md
+++ b/FEATUREDOCS/09-kits.md
@@ -41,3 +41,22 @@
 ## Force Return
 - `forceReturnKit()` resets kit + all children (including nested kits and grandchildren) to AVAILABLE, sets line items to RETURNED, always resets location (even to null if no default)
 - Bulk force return available from kit list page selection bar
+
+## Delete Kit
+- Two-tier delete exposed via `DeleteKitDialog` on the kit detail page
+- `archiveKit()` (soft): releases serialized assets, restores bulk quantities, sets `isActive=false, status=RETIRED`. Always available while kit is AVAILABLE + active
+- `deleteKit()` (hard): blocked when any `ProjectLineItem` references the kit (historical data preservation). Transaction clears `kitId` on assets, deletes `KitSerializedItem`/`KitBulkItem`/`KitCheckItem`, removes the `Kit` row
+- `canDeleteKit(id)` predicate feeds the dialog: returns `{ canArchive, canHardDelete, referencingLineItems, reason }` so the UI disables the hard-delete option with a human-readable reason
+- Permission gate: `kit:delete`
+
+## Group Templates with Kit Items
+- `GroupTemplateItem` supports **either** a `modelId` **or** a `kitId` (Zod XOR refine in `src/lib/validations/group-template.ts`)
+- Enables flexible packages: a "Drum Mic Kit" template = 2x SM57 model + 3x e904 model; a "FOH Package" template = 2x SM57 model + 1x rack kit (rigid)
+- `saveGroupAsTemplate` captures both model-backed and kit-backed parent line items from the source group (skips free-text lines and `isKitChild` rows)
+- `applyGroupTemplate` splits template items into model vs kit at apply time:
+  - Model items are created as `ProjectLineItem` rows inside the same transaction as the new `ProjectGroup` (rate pulled from the model at project's rental period)
+  - Kit items are delegated to `addKitLineItem(projectId, kitId, "ITEMIZED", undefined, undefined, categoryId, groupId)` **after** the tx commits, once per unit of `quantity` (so "2x rack kit" becomes two independent parent rows, matching physical pull behavior)
+  - Each kit expansion is wrapped in try/catch: conflicts (e.g., kit already on an overlapping project) are collected as `warnings[]` rather than aborting the whole apply, so warehouse staff still get the model items
+  - Kit expansion runs its own availability check and its own transaction for parent + children + grandchildren
+- Project totals are recalculated via `recalculateProjectTotals()` when any kit items were expanded
+- Activity log summary includes skipped kit warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gearflow-init",
-  "version": "0.1.0",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gearflow-init",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1006.0",
         "@aws-sdk/s3-request-presigner": "^3.1006.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gearflow-init",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gearflow-init",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260415063740_add_kit_presets/migration.sql
+++ b/prisma/migrations/20260415063740_add_kit_presets/migration.sql
@@ -1,0 +1,64 @@
+-- CreateTable
+CREATE TABLE "kit_preset" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "categoryId" TEXT,
+    "notes" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "kit_preset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "kit_preset_item" (
+    "id" TEXT NOT NULL,
+    "presetId" TEXT NOT NULL,
+    "modelId" TEXT,
+    "kitId" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "notes" TEXT,
+
+    CONSTRAINT "kit_preset_item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "kit_preset_organizationId_idx" ON "kit_preset"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "kit_preset_categoryId_idx" ON "kit_preset"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "kit_preset_isActive_idx" ON "kit_preset"("isActive");
+
+-- CreateIndex
+CREATE INDEX "kit_preset_item_presetId_idx" ON "kit_preset_item"("presetId");
+
+-- CreateIndex
+CREATE INDEX "kit_preset_item_modelId_idx" ON "kit_preset_item"("modelId");
+
+-- CreateIndex
+CREATE INDEX "kit_preset_item_kitId_idx" ON "kit_preset_item"("kitId");
+
+-- AddForeignKey
+ALTER TABLE "kit_preset" ADD CONSTRAINT "kit_preset_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kit_preset" ADD CONSTRAINT "kit_preset_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kit_preset" ADD CONSTRAINT "kit_preset_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kit_preset_item" ADD CONSTRAINT "kit_preset_item_presetId_fkey" FOREIGN KEY ("presetId") REFERENCES "kit_preset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kit_preset_item" ADD CONSTRAINT "kit_preset_item_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "model"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kit_preset_item" ADD CONSTRAINT "kit_preset_item_kitId_fkey" FOREIGN KEY ("kitId") REFERENCES "kit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260415070000_group_template_supports_kits/migration.sql
+++ b/prisma/migrations/20260415070000_group_template_supports_kits/migration.sql
@@ -1,0 +1,30 @@
+-- Drop the never-used kit_preset tables (the KitPreset abstraction was
+-- superseded by extending GroupTemplate to support rigid kits, since
+-- GroupTemplate already does 80% of what KitPreset was going to do).
+
+-- DropForeignKey
+ALTER TABLE "kit_preset_item" DROP CONSTRAINT IF EXISTS "kit_preset_item_kitId_fkey";
+ALTER TABLE "kit_preset_item" DROP CONSTRAINT IF EXISTS "kit_preset_item_modelId_fkey";
+ALTER TABLE "kit_preset_item" DROP CONSTRAINT IF EXISTS "kit_preset_item_presetId_fkey";
+ALTER TABLE "kit_preset" DROP CONSTRAINT IF EXISTS "kit_preset_categoryId_fkey";
+ALTER TABLE "kit_preset" DROP CONSTRAINT IF EXISTS "kit_preset_createdById_fkey";
+ALTER TABLE "kit_preset" DROP CONSTRAINT IF EXISTS "kit_preset_organizationId_fkey";
+
+-- DropTable
+DROP TABLE IF EXISTS "kit_preset_item";
+DROP TABLE IF EXISTS "kit_preset";
+
+-- Extend group_template_item so each row can reference EITHER a model or a
+-- rigid kit. modelId becomes nullable; kitId is added. When a template is
+-- applied, kit items call addKitLineItem and expand to the kit's children.
+
+-- AlterTable
+ALTER TABLE "group_template_item" ALTER COLUMN "modelId" DROP NOT NULL;
+ALTER TABLE "group_template_item" ADD COLUMN "kitId" TEXT;
+ALTER TABLE "group_template_item" ADD COLUMN "sortOrder" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "group_template_item_kitId_idx" ON "group_template_item"("kitId");
+
+-- AddForeignKey
+ALTER TABLE "group_template_item" ADD CONSTRAINT "group_template_item_kitId_fkey" FOREIGN KEY ("kitId") REFERENCES "kit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -599,8 +599,8 @@ model Category {
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @updatedAt
 
-  models Model[]
-  kits   Kit[]
+  models     Model[]
+  kits       Kit[]
 
   @@index([organizationId])
   @@index([parentId])
@@ -913,6 +913,7 @@ model Kit {
   media            KitMedia[]
   kitCheckItems    KitCheckItem[]
   checkRecords     CheckRecord[]
+  groupTemplateItems GroupTemplateItem[]
 
   @@unique([organizationId, assetTag])
   @@index([organizationId])
@@ -1442,18 +1443,26 @@ model GroupTemplate {
 
 // ─── Group Template Item ────────────────────────────────────────────────────
 
+// Each template item references EITHER a model (soft line — pick any SM57 at
+// checkout) OR a rigid Kit (hard reference to a pre-built rack/case). Exactly
+// one of modelId / kitId is set. Kit items expand via addKitLineItem when the
+// template is applied, pulling in the kit's children as usual.
 model GroupTemplateItem {
   id              String   @id @default(cuid())
   organizationId  String
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   templateId      String
   template        GroupTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  modelId         String
-  model           Model    @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  modelId         String?
+  model           Model?   @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  kitId           String?
+  kit             Kit?     @relation(fields: [kitId], references: [id], onDelete: Cascade)
   quantity        Int      @default(1)
+  sortOrder       Int      @default(0)
 
   @@index([templateId])
   @@index([modelId])
+  @@index([kitId])
   @@index([organizationId])
   @@map("group_template_item")
 }

--- a/src/app/(app)/kits/[id]/page.tsx
+++ b/src/app/(app)/kits/[id]/page.tsx
@@ -46,6 +46,7 @@ import { FadeIn } from "@/components/ui/motion";
 import { SectionHeader } from "@/components/layout/page-layouts";
 import { ActivityTimeline } from "@/components/activity/activity-timeline";
 import { KitChecksTab } from "@/components/kits/kit-checks-tab";
+import { DeleteKitDialog } from "@/components/kits/delete-kit-dialog";
 import {
   Dialog,
   DialogContent,
@@ -100,6 +101,7 @@ function KitDetailContent({ params }: { params: Promise<{ id: string }> }) {
   // Dialog states – must be declared before any early returns
   const [showAddItem, setShowAddItem] = useState(false);
   const [showAddBulkItem, setShowAddBulkItem] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [stagedItems, setStagedItems] = useState<Array<{ assetId: string; assetTag: string; modelName: string }>>([]);
   const [addBulkAssetId, setAddBulkAssetId] = useState("");
   const [addBulkQuantity, setAddBulkQuantity] = useState(1);
@@ -281,6 +283,16 @@ function KitDetailContent({ params }: { params: Promise<{ id: string }> }) {
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
               </Button>
+              <CanDo resource="kit" action="delete">
+                <Button
+                  variant="outline"
+                  className="text-destructive"
+                  onClick={() => setShowDeleteDialog(true)}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </Button>
+              </CanDo>
             </div>
           </CanDo>
         </div>
@@ -782,6 +794,17 @@ function KitDetailContent({ params }: { params: Promise<{ id: string }> }) {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <DeleteKitDialog
+      kitId={id}
+      kitLabel={kit.name || kit.assetTag}
+      open={showDeleteDialog}
+      onOpenChange={setShowDeleteDialog}
+      onDeleted={() => {
+        queryClient.invalidateQueries({ queryKey: ["kits"] });
+        router.push("/kits");
+      }}
+    />
     </RequirePermission>
   );
 }

--- a/src/app/(app)/settings/group-templates/page.tsx
+++ b/src/app/(app)/settings/group-templates/page.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Bookmark,
+  Trash2,
+  Pencil,
+  Package,
+  Box,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  AlertTriangle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  getGroupTemplates,
+  updateGroupTemplate,
+  deleteGroupTemplate,
+} from "@/server/group-templates";
+import { useCanDo } from "@/lib/use-permissions";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type TemplateItem = {
+  id: string;
+  modelId: string | null;
+  kitId: string | null;
+  quantity: number;
+  sortOrder: number;
+  model: { id: string; name: string } | null;
+  kit: { id: string; name: string; assetTag: string } | null;
+};
+
+type Template = {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items: TemplateItem[];
+};
+
+export default function GroupTemplatesSettingsPage() {
+  const queryClient = useQueryClient();
+  const canManage = useCanDo("project", "manage_line_items");
+
+  const { data: templates = [], isLoading } = useQuery<Template[]>({
+    queryKey: ["group-templates"],
+    queryFn: async () => (await getGroupTemplates()) as unknown as Template[],
+  });
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [editTemplate, setEditTemplate] = useState<Template | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [deleteTemplate, setDeleteTemplate] = useState<Template | null>(null);
+
+  const sorted = useMemo(
+    () => [...templates].sort((a, b) => a.name.localeCompare(b.name)),
+    [templates],
+  );
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, name, description }: { id: string; name: string; description?: string }) =>
+      updateGroupTemplate(id, { name, description }),
+    onSuccess: () => {
+      toast.success("Template updated");
+      queryClient.invalidateQueries({ queryKey: ["group-templates"] });
+      setEditTemplate(null);
+      setEditName("");
+      setEditDescription("");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteGroupTemplate(id),
+    onSuccess: () => {
+      toast.success("Template deleted");
+      queryClient.invalidateQueries({ queryKey: ["group-templates"] });
+      setDeleteTemplate(null);
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  function toggleExpanded(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="t-subtitle text-fg">Group Templates</h2>
+        <p className="text-sm text-fg-3 mt-1">
+          Reusable equipment packages. Build a group in any project, then save it as a template to
+          reuse across future projects. Templates hold model and kit items; free-text lines are skipped.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-fg-3">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border bg-bg-inset/40 p-8 text-center">
+          <Bookmark className="mx-auto h-8 w-8 text-fg-3" />
+          <h3 className="mt-3 text-sm font-semibold text-fg">No templates yet</h3>
+          <p className="mt-1 text-sm text-fg-3 max-w-md mx-auto">
+            On any project&apos;s equipment tab, open a group&apos;s menu and choose
+            &quot;Save as Template&quot; to make it reusable.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {sorted.map((t) => {
+            const isOpen = expanded.has(t.id);
+            return (
+              <div
+                key={t.id}
+                className="rounded-lg border border-border bg-bg-elevated overflow-hidden"
+              >
+                <div className="flex items-center gap-3 p-3">
+                  <button
+                    type="button"
+                    onClick={() => toggleExpanded(t.id)}
+                    className="flex items-center gap-2 text-left flex-1 min-w-0"
+                  >
+                    {isOpen ? (
+                      <ChevronDown className="h-4 w-4 shrink-0 text-fg-3" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 shrink-0 text-fg-3" />
+                    )}
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold text-fg truncate">{t.name}</span>
+                        <Badge variant="outline" className="text-xs">
+                          {t.items.length} item{t.items.length !== 1 ? "s" : ""}
+                        </Badge>
+                      </div>
+                      {t.description && (
+                        <p className="text-xs text-fg-3 mt-0.5 truncate">{t.description}</p>
+                      )}
+                    </div>
+                  </button>
+                  {canManage && (
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => {
+                          setEditTemplate(t);
+                          setEditName(t.name);
+                          setEditDescription(t.description ?? "");
+                        }}
+                        aria-label="Edit template"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => setDeleteTemplate(t)}
+                        aria-label="Delete template"
+                        className="text-[oklch(0.58_0.22_27)]"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                {isOpen && (
+                  <div className="border-t border-border bg-bg-inset/40 px-3 py-2">
+                    {t.items.length === 0 ? (
+                      <p className="text-xs text-fg-3 py-2">No items.</p>
+                    ) : (
+                      <ul className="space-y-1">
+                        {t.items
+                          .slice()
+                          .sort((a, b) => a.sortOrder - b.sortOrder)
+                          .map((item) => {
+                            const isKit = item.kit != null;
+                            const label = isKit
+                              ? `${item.kit!.name} (${item.kit!.assetTag})`
+                              : item.model?.name ?? "Unknown";
+                            return (
+                              <li
+                                key={item.id}
+                                className="flex items-center justify-between gap-2 py-1 text-sm"
+                              >
+                                <div className="flex items-center gap-2 min-w-0">
+                                  {isKit ? (
+                                    <Package className="h-3.5 w-3.5 shrink-0 text-fg-3" />
+                                  ) : (
+                                    <Box className="h-3.5 w-3.5 shrink-0 text-fg-3" />
+                                  )}
+                                  <span className="truncate">{label}</span>
+                                  {isKit && (
+                                    <Badge variant="outline" className="text-[10px]">
+                                      Kit
+                                    </Badge>
+                                  )}
+                                </div>
+                                <span className="text-fg-3 shrink-0">×{item.quantity}</span>
+                              </li>
+                            );
+                          })}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Edit template dialog */}
+      <Dialog
+        open={editTemplate != null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditTemplate(null);
+            setEditName("");
+            setEditDescription("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit Template</DialogTitle>
+            <DialogDescription>
+              Rename or update the description. To change items, save a different group as a new template.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-2">
+              <Label>Name</Label>
+              <Input
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Description</Label>
+              <Textarea
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setEditTemplate(null);
+                setEditName("");
+                setEditDescription("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (editTemplate && editName.trim()) {
+                  updateMut.mutate({
+                    id: editTemplate.id,
+                    name: editName.trim(),
+                    description: editDescription.trim() || undefined,
+                  });
+                }
+              }}
+              disabled={!editName.trim() || updateMut.isPending}
+            >
+              {updateMut.isPending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
+      <Dialog
+        open={deleteTemplate != null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTemplate(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-[oklch(0.75_0.15_70)]" />
+              Delete Template
+            </DialogTitle>
+            <DialogDescription>
+              Delete &quot;{deleteTemplate?.name}&quot;? Projects that already used this template
+              keep their line items; only the template definition is removed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTemplate(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (deleteTemplate) deleteMut.mutate(deleteTemplate.id);
+              }}
+              disabled={deleteMut.isPending}
+            >
+              {deleteMut.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -16,6 +16,7 @@ import {
   Shield,
   ShoppingCart,
   ClipboardCheck,
+  Bookmark,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCanDo } from "@/lib/use-permissions";
@@ -31,6 +32,7 @@ const settingsNav = [
   { title: "Branding", href: "/settings/branding", icon: Palette, permission: "orgSettings" as const },
   { title: "Calendars", href: "/settings/calendars", icon: CalendarSync, permission: "orgSettings" as const },
   { title: "Check Items", href: "/settings/check-items", icon: ClipboardCheck, permission: "checkItem" as const },
+  { title: "Group Templates", href: "/settings/group-templates", icon: Bookmark, permission: "project" as const },
   { title: "Displays", href: "/settings/displays", icon: MonitorPlay, permission: "orgSettings" as const },
   { title: "Team", href: "/settings/team", icon: Users, permission: "orgMembers" as const },
   { title: "WooCommerce", href: "/settings/woocommerce", icon: ShoppingCart, permission: "orgSettings" as const },
@@ -43,6 +45,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
   const canReadMembers = useCanDo("orgMembers", "read");
   const canManageTemplates = useCanDo("document", "manage_templates");
   const canReadCheckItems = useCanDo("checkItem", "read");
+  const canManageLineItems = useCanDo("project", "manage_line_items");
   const { data: activeOrg } = useActiveOrganization();
 
   if (!canReadSettings && !canReadMembers) {
@@ -61,6 +64,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
     if (item.permission === "orgMembers") return canReadMembers;
     if (item.permission === "document") return canManageTemplates;
     if (item.permission === "checkItem") return canReadCheckItems;
+    if (item.permission === "project") return canManageLineItems;
     return true;
   });
 

--- a/src/components/kits/delete-kit-dialog.tsx
+++ b/src/components/kits/delete-kit-dialog.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Loader2, Archive, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { archiveKit, deleteKit, canDeleteKit } from "@/server/kits";
+
+interface DeleteKitDialogProps {
+  kitId: string;
+  kitLabel: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted?: (result: { hardDeleted: boolean }) => void;
+}
+
+type DeleteMode = "archive" | "hard";
+
+export function DeleteKitDialog({
+  kitId,
+  kitLabel,
+  open,
+  onOpenChange,
+  onDeleted,
+}: DeleteKitDialogProps) {
+  const [mode, setMode] = useState<DeleteMode>("archive");
+
+  const { data: info, isLoading: infoLoading } = useQuery({
+    queryKey: ["kit-delete-info", kitId],
+    queryFn: () => canDeleteKit(kitId),
+    enabled: open,
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveKit(kitId),
+    onSuccess: () => {
+      toast.success(`Archived ${kitLabel}`);
+      onOpenChange(false);
+      onDeleted?.({ hardDeleted: false });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteKit(kitId),
+    onSuccess: () => {
+      toast.success(`Deleted ${kitLabel} permanently`);
+      onOpenChange(false);
+      onDeleted?.({ hardDeleted: true });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const pending = archiveMutation.isPending || deleteMutation.isPending;
+  const canArchive = info?.canArchive ?? false;
+  const canHardDelete = info?.canHardDelete ?? false;
+
+  function handleConfirm() {
+    if (mode === "archive") archiveMutation.mutate();
+    else deleteMutation.mutate();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete kit</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          <p className="text-fg-2">
+            What should happen to <span className="font-mono text-fg">{kitLabel}</span>?
+          </p>
+
+          {infoLoading && (
+            <div className="flex items-center gap-2 text-fg-3">
+              <Loader2 className="h-4 w-4 animate-spin" /> Checking references…
+            </div>
+          )}
+
+          {!infoLoading && (
+            <div className="space-y-2">
+              <button
+                type="button"
+                disabled={!canArchive || pending}
+                onClick={() => setMode("archive")}
+                className={`w-full rounded-md border p-3 text-left transition-colors ${
+                  mode === "archive"
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-border-strong"
+                } ${!canArchive ? "cursor-not-allowed opacity-50" : ""}`}
+              >
+                <div className="flex items-start gap-3">
+                  <Archive className="mt-0.5 h-4 w-4 flex-shrink-0 text-fg-2" />
+                  <div className="space-y-1">
+                    <div className="font-medium text-fg">Archive (recommended)</div>
+                    <p className="text-xs text-fg-3">
+                      Releases all contents, hides the kit from lists. Preserves history on past
+                      projects. Can be recovered later.
+                    </p>
+                  </div>
+                </div>
+              </button>
+
+              <button
+                type="button"
+                disabled={!canHardDelete || pending}
+                onClick={() => setMode("hard")}
+                className={`w-full rounded-md border p-3 text-left transition-colors ${
+                  mode === "hard"
+                    ? "border-destructive bg-destructive/5"
+                    : "border-border hover:border-border-strong"
+                } ${!canHardDelete ? "cursor-not-allowed opacity-50" : ""}`}
+              >
+                <div className="flex items-start gap-3">
+                  <Trash2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-destructive" />
+                  <div className="space-y-1">
+                    <div className="font-medium text-fg">Delete permanently</div>
+                    <p className="text-xs text-fg-3">
+                      Releases contents and removes the kit row entirely. Cannot be undone.
+                      {!canHardDelete && info?.reason && (
+                        <span className="mt-1 block text-destructive">{info.reason}</span>
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </button>
+
+              {!canArchive && info?.reason && (
+                <p className="text-xs text-destructive">{info.reason}</p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant={mode === "hard" ? "destructive" : "default"}
+            onClick={handleConfirm}
+            disabled={
+              pending ||
+              infoLoading ||
+              (mode === "archive" && !canArchive) ||
+              (mode === "hard" && !canHardDelete)
+            }
+          >
+            {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {mode === "archive" ? "Archive kit" : "Delete permanently"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -18,7 +18,7 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Plus, FolderPlus, Package, MoreHorizontal, Trash2, Pencil, Loader2, ChevronRight, GripVertical, RefreshCw, AlertTriangle } from "lucide-react";
+import { Plus, FolderPlus, Package, MoreHorizontal, Trash2, Pencil, Loader2, ChevronRight, GripVertical, RefreshCw, AlertTriangle, BookmarkPlus } from "lucide-react";
 import { toast } from "sonner";
 
 import { getProjectCategories } from "@/server/project-categories";
@@ -40,7 +40,7 @@ import {
   getUncategorizedLineItems,
   getProjectOverbookedStatus,
 } from "@/server/project-categories";
-import { getGroupTemplates, applyGroupTemplate } from "@/server/group-templates";
+import { getGroupTemplates, applyGroupTemplate, saveGroupAsTemplate } from "@/server/group-templates";
 import { removeLineItem, updateLineItem, addKitLineItem, checkKitAvailability, reorderLineItems, checkAvailability } from "@/server/line-items";
 import { getKits } from "@/server/kits";
 import {
@@ -255,6 +255,7 @@ function SortableGroupRow({
   onAddEquipment,
   onAddKit,
   onRecalculate,
+  onSaveAsTemplate,
 }: {
   group: GroupData;
   isExpanded: boolean;
@@ -265,6 +266,7 @@ function SortableGroupRow({
   onAddEquipment: () => void;
   onAddKit: () => void;
   onRecalculate?: () => void;
+  onSaveAsTemplate?: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: `grp-${group.id}` });
@@ -341,6 +343,12 @@ function SortableGroupRow({
                   <DropdownMenuItem onClick={onRecalculate}>
                     <RefreshCw className="mr-2 h-3.5 w-3.5" />
                     Recalculate Prices
+                  </DropdownMenuItem>
+                )}
+                {onSaveAsTemplate && (
+                  <DropdownMenuItem onClick={onSaveAsTemplate}>
+                    <BookmarkPlus className="mr-2 h-3.5 w-3.5" />
+                    Save as Template
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem
@@ -660,6 +668,11 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   const [toolbarGroupCategoryId, setToolbarGroupCategoryId] = useState("");
   const [toolbarGroupTemplateId, setToolbarGroupTemplateId] = useState("");
 
+  // Save group as template dialog state
+  const [saveAsTemplateGroup, setSaveAsTemplateGroup] = useState<{ id: string; title: string } | null>(null);
+  const [saveAsTemplateName, setSaveAsTemplateName] = useState("");
+  const [saveAsTemplateDescription, setSaveAsTemplateDescription] = useState("");
+
   // Move line item dialog state
   const [moveLineItemId, setMoveLineItemId] = useState<string | null>(null);
   const [moveTargetGroupId, setMoveTargetGroupId] = useState<string>("__uncategorized__");
@@ -896,6 +909,20 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
       allowOverbook: editOverbookConfirmed,
     });
   }
+
+  const saveAsTemplateMut = useMutation({
+    mutationFn: ({ groupId, name, description }: { groupId: string; name: string; description?: string }) =>
+      saveGroupAsTemplate(groupId, name, description),
+    onSuccess: (t: unknown) => {
+      const name = (t as { name?: string })?.name ?? "Template";
+      toast.success(`Saved as template "${name}"`);
+      queryClient.invalidateQueries({ queryKey: ["group-templates"] });
+      setSaveAsTemplateGroup(null);
+      setSaveAsTemplateName("");
+      setSaveAsTemplateDescription("");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
 
   const createGroupMut = useMutation({
     mutationFn: ({ categoryId, title, templateId }: { categoryId: string; title: string; templateId?: string }) => {
@@ -1294,6 +1321,11 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                                   toast.error(e instanceof Error ? e.message : "Failed to recalculate");
                                 }
                               }}
+                              onSaveAsTemplate={() => {
+                                setSaveAsTemplateGroup({ id: group.id, title: group.title });
+                                setSaveAsTemplateName(group.title);
+                                setSaveAsTemplateDescription(group.description ?? "");
+                              }}
                             />
                             {/* Expanded line items */}
                             {isExpanded && groupItems.length === 0 && (
@@ -1565,6 +1597,72 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
               disabled={!renameCategoryValue.trim() || renameCategoryMut.isPending}
             >
               Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Save group as template dialog */}
+      <Dialog
+        open={saveAsTemplateGroup != null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSaveAsTemplateGroup(null);
+            setSaveAsTemplateName("");
+            setSaveAsTemplateDescription("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Save as Template</DialogTitle>
+            <DialogDescription>
+              Save &quot;{saveAsTemplateGroup?.title}&quot; as a reusable template. Only model- and kit-backed items are captured; free-text lines are skipped.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-2">
+              <Label>Template name</Label>
+              <Input
+                value={saveAsTemplateName}
+                onChange={(e) => setSaveAsTemplateName(e.target.value)}
+                placeholder="e.g. Drum Mic Pack"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Description (optional)</Label>
+              <Input
+                value={saveAsTemplateDescription}
+                onChange={(e) => setSaveAsTemplateDescription(e.target.value)}
+                placeholder="When to use this template..."
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSaveAsTemplateGroup(null);
+                setSaveAsTemplateName("");
+                setSaveAsTemplateDescription("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (saveAsTemplateGroup && saveAsTemplateName.trim()) {
+                  saveAsTemplateMut.mutate({
+                    groupId: saveAsTemplateGroup.id,
+                    name: saveAsTemplateName.trim(),
+                    description: saveAsTemplateDescription.trim() || undefined,
+                  });
+                }
+              }}
+              disabled={!saveAsTemplateName.trim() || saveAsTemplateMut.isPending}
+            >
+              {saveAsTemplateMut.isPending ? "Saving..." : "Save Template"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -658,6 +658,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   const [showAddGroupFromToolbar, setShowAddGroupFromToolbar] = useState(false);
   const [toolbarGroupTitle, setToolbarGroupTitle] = useState("");
   const [toolbarGroupCategoryId, setToolbarGroupCategoryId] = useState("");
+  const [toolbarGroupTemplateId, setToolbarGroupTemplateId] = useState("");
 
   // Move line item dialog state
   const [moveLineItemId, setMoveLineItemId] = useState<string | null>(null);
@@ -1572,13 +1573,13 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
       {/* Add group from toolbar dialog */}
       <Dialog open={showAddGroupFromToolbar} onOpenChange={(open) => {
         setShowAddGroupFromToolbar(open);
-        if (!open) { setToolbarGroupTitle(""); setToolbarGroupCategoryId(""); }
+        if (!open) { setToolbarGroupTitle(""); setToolbarGroupCategoryId(""); setToolbarGroupTemplateId(""); }
       }}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>Add Group</DialogTitle>
             <DialogDescription>
-              Choose a category and name for the new group.
+              Choose a category and name for the new group. Optionally start from a template.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 py-2">
@@ -1595,6 +1596,30 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                 ))}
               </select>
             </div>
+            {templateOptions.length > 0 && (
+              <div className="space-y-2">
+                <Label>Template (optional)</Label>
+                <select
+                  value={toolbarGroupTemplateId}
+                  onChange={(e) => {
+                    const id = e.target.value;
+                    setToolbarGroupTemplateId(id);
+                    if (id && !toolbarGroupTitle.trim()) {
+                      const t = templateOptions.find((o) => o.id === id);
+                      if (t) setToolbarGroupTitle(t.name);
+                    }
+                  }}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <option value="">None (empty group)</option>
+                  {templateOptions.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name} ({t.itemCount} {t.itemCount === 1 ? "item" : "items"})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
             <div className="space-y-2">
               <Label>Group Title</Label>
               <Input
@@ -1603,10 +1628,15 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                 placeholder="e.g. PA System, Lighting Rig"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && toolbarGroupTitle.trim() && toolbarGroupCategoryId) {
-                    createGroupMut.mutate({ categoryId: toolbarGroupCategoryId, title: toolbarGroupTitle.trim() });
+                    createGroupMut.mutate({
+                      categoryId: toolbarGroupCategoryId,
+                      title: toolbarGroupTitle.trim(),
+                      templateId: toolbarGroupTemplateId || undefined,
+                    });
                     setShowAddGroupFromToolbar(false);
                     setToolbarGroupTitle("");
                     setToolbarGroupCategoryId("");
+                    setToolbarGroupTemplateId("");
                   }
                 }}
                 autoFocus
@@ -1618,21 +1648,27 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
               setShowAddGroupFromToolbar(false);
               setToolbarGroupTitle("");
               setToolbarGroupCategoryId("");
+              setToolbarGroupTemplateId("");
             }}>
               Cancel
             </Button>
             <Button
               onClick={() => {
                 if (toolbarGroupTitle.trim() && toolbarGroupCategoryId) {
-                  createGroupMut.mutate({ categoryId: toolbarGroupCategoryId, title: toolbarGroupTitle.trim() });
+                  createGroupMut.mutate({
+                    categoryId: toolbarGroupCategoryId,
+                    title: toolbarGroupTitle.trim(),
+                    templateId: toolbarGroupTemplateId || undefined,
+                  });
                   setShowAddGroupFromToolbar(false);
                   setToolbarGroupTitle("");
                   setToolbarGroupCategoryId("");
+                  setToolbarGroupTemplateId("");
                 }
               }}
               disabled={!toolbarGroupTitle.trim() || !toolbarGroupCategoryId || createGroupMut.isPending}
             >
-              Create
+              {toolbarGroupTemplateId ? "Create from Template" : "Create"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/lib/validations/group-template.test.ts
+++ b/src/lib/validations/group-template.test.ts
@@ -104,13 +104,53 @@ describe("groupTemplateSchema", () => {
     });
   });
 
-  describe("items[].modelId (required)", () => {
-    it("rejects empty modelId", () => {
+  describe("items[] model/kit XOR refine", () => {
+    it("rejects empty modelId with no kitId", () => {
       const result = groupTemplateSchema.safeParse({
         name: "Test",
         items: [{ modelId: "", quantity: 1 }],
       });
       expect(result.success).toBe(false);
+    });
+
+    it("rejects item with neither modelId nor kitId", () => {
+      const result = groupTemplateSchema.safeParse({
+        name: "Test",
+        items: [{ quantity: 1 }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects item with both modelId and kitId", () => {
+      const result = groupTemplateSchema.safeParse({
+        name: "Test",
+        items: [{ modelId: "m-1", kitId: "k-1", quantity: 1 }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a kit-only item", () => {
+      const result = groupTemplateSchema.safeParse({
+        name: "Test",
+        items: [{ kitId: "kit-1", quantity: 1 }],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.items[0].kitId).toBe("kit-1");
+        expect(result.data.items[0].modelId).toBeUndefined();
+      }
+    });
+
+    it("accepts a mixed array of model and kit items", () => {
+      const result = groupTemplateSchema.safeParse({
+        name: "FOH Package",
+        items: [
+          { modelId: "m-1", quantity: 2 },
+          { kitId: "kit-rack-1", quantity: 1 },
+        ],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.items).toHaveLength(2);
     });
   });
 

--- a/src/lib/validations/group-template.ts
+++ b/src/lib/validations/group-template.ts
@@ -1,17 +1,29 @@
 import { z } from "zod";
 
+// Each item references exactly one of modelId or kitId. Model items expand to
+// a single model-level line item at the target model's dailyRate; kit items
+// expand via addKitLineItem (parent + children + optional grandchildren).
+export const groupTemplateItemSchema = z
+  .object({
+    modelId: z.string().optional(),
+    kitId: z.string().optional(),
+    quantity: z.coerce.number().int().min(1).max(9999).default(1),
+    sortOrder: z.coerce.number().int().default(0),
+  })
+  .refine((v) => !!v.modelId !== !!v.kitId, {
+    message: "Each template item must reference either a model or a kit, not both",
+  });
+
 export const groupTemplateSchema = z.object({
   name: z.string().min(1, "Name is required").max(200),
   description: z.string().max(2000).optional(),
-  items: z.array(
-    z.object({
-      modelId: z.string().min(1),
-      quantity: z.coerce.number().int().min(1).default(1),
-    })
-  ).min(1, "At least one item is required"),
+  items: z
+    .array(groupTemplateItemSchema)
+    .min(1, "At least one item is required"),
 });
 
 export type GroupTemplateFormValues = z.input<typeof groupTemplateSchema>;
+export type GroupTemplateItemFormValues = z.input<typeof groupTemplateItemSchema>;
 
 export const applyGroupTemplateSchema = z.object({
   templateId: z.string().min(1),

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -10,6 +10,7 @@ import {
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { calculateSuggestedPrice } from "./project-groups";
+import { addKitLineItem, recalculateProjectTotals } from "./line-items";
 
 export async function getGroupTemplates() {
   const { organizationId } = await requirePermission("project", "read");
@@ -27,8 +28,15 @@ export async function getGroupTemplates() {
               weeklyRate: true,
             },
           },
+          kit: {
+            select: {
+              id: true,
+              name: true,
+              assetTag: true,
+            },
+          },
         },
-        orderBy: { model: { name: "asc" } },
+        orderBy: { sortOrder: "asc" },
       },
     },
     orderBy: { name: "asc" },
@@ -50,10 +58,12 @@ export async function createGroupTemplate(data: GroupTemplateFormValues) {
       name: parsed.name,
       description: parsed.description || null,
       items: {
-        create: parsed.items.map((item) => ({
+        create: parsed.items.map((item, idx) => ({
           organizationId,
-          modelId: item.modelId,
+          modelId: item.modelId ?? null,
+          kitId: item.kitId ?? null,
           quantity: item.quantity,
+          sortOrder: item.sortOrder ?? idx,
         })),
       },
     },
@@ -63,7 +73,9 @@ export async function createGroupTemplate(data: GroupTemplateFormValues) {
           model: {
             select: { id: true, name: true, dailyRate: true, weeklyRate: true },
           },
+          kit: { select: { id: true, name: true, assetTag: true } },
         },
+        orderBy: { sortOrder: "asc" },
       },
     },
   });
@@ -96,16 +108,27 @@ export async function saveGroupAsTemplate(
     where: { id: groupId, organizationId },
     include: {
       lineItems: {
+        // Only parent rows — kit children get auto-expanded on apply via
+        // addKitLineItem, so templating them again would double-count.
         where: { isKitChild: false },
-        select: { modelId: true, quantity: true },
+        select: {
+          modelId: true,
+          kitId: true,
+          quantity: true,
+          sortOrder: true,
+        },
+        orderBy: { sortOrder: "asc" },
       },
     },
   });
 
-  // Only items with a model can be templated
-  const itemsWithModel = group.lineItems.filter((li) => li.modelId != null);
-  if (itemsWithModel.length === 0) {
-    throw new Error("Group has no model-backed items to template");
+  // Only items that reference either a model or a kit can be templated.
+  // Free-text/service lines (no modelId AND no kitId) are skipped.
+  const templatable = group.lineItems.filter(
+    (li) => li.modelId != null || li.kitId != null,
+  );
+  if (templatable.length === 0) {
+    throw new Error("Group has no model- or kit-backed items to template");
   }
 
   const template = await prisma.groupTemplate.create({
@@ -114,10 +137,12 @@ export async function saveGroupAsTemplate(
       name,
       description: description || null,
       items: {
-        create: itemsWithModel.map((li) => ({
+        create: templatable.map((li, idx) => ({
           organizationId,
-          modelId: li.modelId!,
+          modelId: li.modelId ?? null,
+          kitId: li.kitId ?? null,
           quantity: li.quantity,
+          sortOrder: idx,
         })),
       },
     },
@@ -127,7 +152,9 @@ export async function saveGroupAsTemplate(
           model: {
             select: { id: true, name: true, dailyRate: true, weeklyRate: true },
           },
+          kit: { select: { id: true, name: true, assetTag: true } },
         },
+        orderBy: { sortOrder: "asc" },
       },
     },
   });
@@ -160,7 +187,8 @@ export async function applyGroupTemplate(
     where: { id: parsed.templateId, organizationId },
     include: {
       items: {
-        include: { model: true },
+        include: { model: true, kit: true },
+        orderBy: { sortOrder: "asc" },
       },
     },
   });
@@ -177,7 +205,12 @@ export async function applyGroupTemplate(
     select: { defaultRentalPeriod: true, defaultRentalQuantity: true },
   });
 
-  // Create group + line items in a transaction
+  // Split items by type — model items go in the same tx as the group create,
+  // kit items get delegated to addKitLineItem *after* the tx commits so it can
+  // run its own transaction for the parent + children expansion.
+  const modelItems = template.items.filter((i) => i.modelId && i.model);
+  const kitItems = template.items.filter((i) => i.kitId && i.kit);
+
   const group = await prisma.$transaction(async (tx) => {
     const newGroup = await tx.projectGroup.create({
       data: {
@@ -194,15 +227,10 @@ export async function applyGroupTemplate(
       },
     });
 
-    // Get next sort order for line items
-    const maxItemSort = await tx.projectLineItem.aggregate({
-      where: { groupId: newGroup.id },
-      _max: { sortOrder: true },
-    });
+    // Start line-item sortOrder at 0 for a freshly-created group
+    let sortOrder = 0;
 
-    let sortOrder = (maxItemSort._max.sortOrder ?? -1) + 1;
-
-    for (const item of template.items) {
+    for (const item of modelItems) {
       const rentalPeriod =
         newGroup.rentalPeriod ?? project.defaultRentalPeriod ?? "DAILY";
       const rate =
@@ -216,8 +244,8 @@ export async function applyGroupTemplate(
           projectId,
           categoryId: parsed.categoryId,
           groupId: newGroup.id,
-          modelId: item.modelId,
-          description: item.model.name,
+          modelId: item.modelId!,
+          description: item.model!.name,
           quantity: item.quantity,
           unitPrice: rate,
           lineTotal: rate * item.quantity,
@@ -229,12 +257,49 @@ export async function applyGroupTemplate(
     return newGroup;
   });
 
+  // Expand kit items outside the tx. Each call creates parent + children and
+  // runs its own availability check. We skip kits that conflict (already on an
+  // overlapping project) rather than aborting the whole apply, so warehouse
+  // staff still get the model items they can use.
+  const kitWarnings: string[] = [];
+  for (const item of kitItems) {
+    try {
+      // Call addKitLineItem per unit of quantity — a template line of "2x rack
+      // kit" means two independent parent rows, matching how a warehouse would
+      // physically pull two racks.
+      for (let i = 0; i < item.quantity; i++) {
+        await addKitLineItem(
+          projectId,
+          item.kitId!,
+          "ITEMIZED",
+          undefined,
+          undefined,
+          parsed.categoryId,
+          group.id,
+        );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      kitWarnings.push(`${item.kit?.assetTag ?? item.kitId}: ${msg}`);
+    }
+  }
+
   // Calculate suggested price after items are created
   const suggested = await calculateSuggestedPrice(group.id);
   await prisma.projectGroup.update({
     where: { id: group.id },
     data: { suggestedPrice: suggested },
   });
+
+  // Kit expansion touched line items — refresh project totals.
+  if (kitItems.length > 0) {
+    await recalculateProjectTotals(projectId);
+  }
+
+  const summary =
+    kitWarnings.length > 0
+      ? `Applied template "${template.name}" as group "${parsed.title}" with ${template.items.length} item(s); skipped ${kitWarnings.length} kit item(s): ${kitWarnings.join("; ")}`
+      : `Applied template "${template.name}" as group "${parsed.title}" with ${template.items.length} item(s)`;
 
   await logActivity({
     organizationId,
@@ -244,10 +309,10 @@ export async function applyGroupTemplate(
     entityType: "project",
     entityId: projectId,
     entityName: parsed.title,
-    summary: `Applied template "${template.name}" as group "${parsed.title}" with ${template.items.length} item(s)`,
+    summary,
   });
 
-  return serialize(group);
+  return serialize({ ...group, warnings: kitWarnings });
 }
 
 export async function updateGroupTemplate(

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -344,11 +344,13 @@ export async function updateGroupTemplate(
       });
 
       await tx.groupTemplateItem.createMany({
-        data: parsed.map((item) => ({
+        data: parsed.map((item, idx) => ({
           organizationId,
           templateId,
-          modelId: item.modelId,
+          modelId: item.modelId ?? null,
+          kitId: item.kitId ?? null,
           quantity: item.quantity,
+          sortOrder: item.sortOrder ?? idx,
         })),
       });
     }

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -327,6 +327,119 @@ export async function archiveKit(id: string) {
 }
 
 // ---------------------------------------------------------------------------
+// canDeleteKit – predicate for UI to decide which delete options are available
+// ---------------------------------------------------------------------------
+export async function canDeleteKit(id: string) {
+  const { organizationId } = await requirePermission("kit", "delete");
+
+  const kit = await prisma.kit.findUnique({
+    where: { id, organizationId },
+    select: { id: true, status: true, isActive: true },
+  });
+  if (!kit) throw new Error("Kit not found");
+
+  // Archive is allowed whenever the kit is AVAILABLE (matches archiveKit guard).
+  const canArchive = kit.status === "AVAILABLE" && kit.isActive;
+
+  // Hard delete adds two extra constraints: (a) no ProjectLineItem references,
+  // (b) AVAILABLE status. This prevents losing historical project data.
+  const referencingLineItems = await prisma.projectLineItem.count({
+    where: { kitId: id, organizationId },
+  });
+
+  const canHardDelete = kit.status === "AVAILABLE" && kit.isActive && referencingLineItems === 0;
+  let reason: string | undefined;
+
+  if (!canArchive) {
+    reason = kit.status !== "AVAILABLE"
+      ? `Kit status is ${kit.status} — only AVAILABLE kits can be archived or deleted.`
+      : "Kit is already archived.";
+  } else if (!canHardDelete) {
+    reason = `Kit is referenced by ${referencingLineItems} project line item${referencingLineItems === 1 ? "" : "s"}. Archive it instead, or remove it from those projects first.`;
+  }
+
+  return serialize({ canArchive, canHardDelete, referencingLineItems, reason });
+}
+
+// ---------------------------------------------------------------------------
+// deleteKit – hard delete. Releases contents then removes the kit row entirely.
+// Blocked if the kit is referenced by any ProjectLineItem, regardless of status,
+// to preserve historical project data. Use archiveKit for the reversible path.
+// ---------------------------------------------------------------------------
+export async function deleteKit(id: string) {
+  const { organizationId, userId, userName } = await requirePermission("kit", "delete");
+
+  const kit = await prisma.kit.findUnique({
+    where: { id, organizationId },
+    include: {
+      serializedItems: true,
+      bulkItems: true,
+    },
+  });
+  if (!kit) throw new Error("Kit not found");
+  if (kit.status !== "AVAILABLE") {
+    throw new Error("Only AVAILABLE kits can be deleted");
+  }
+
+  const referencingLineItems = await prisma.projectLineItem.count({
+    where: { kitId: id, organizationId },
+  });
+  if (referencingLineItems > 0) {
+    throw new Error(
+      `This kit is referenced by ${referencingLineItems} project line item${
+        referencingLineItems === 1 ? "" : "s"
+      }. Archive it instead, or remove it from those projects first.`,
+    );
+  }
+
+  const tagForLog = kit.assetTag;
+  const nameForLog = kit.name;
+
+  await prisma.$transaction(async (tx) => {
+    // Release serialized assets back to inventory.
+    for (const item of kit.serializedItems) {
+      await tx.asset.update({
+        where: { id: item.assetId },
+        data: { kitId: null, status: "AVAILABLE" },
+      });
+    }
+    await tx.kitSerializedItem.deleteMany({ where: { kitId: id } });
+
+    // Return bulk quantities to their source bulk assets.
+    for (const item of kit.bulkItems) {
+      await tx.bulkAsset.update({
+        where: { id: item.bulkAssetId },
+        data: { availableQuantity: { increment: item.quantity } },
+      });
+    }
+    await tx.kitBulkItem.deleteMany({ where: { kitId: id } });
+
+    // Clean up kit-scoped metadata. KitMedia rows reference S3 files — we drop
+    // the DB rows here and rely on the nightly orphan sweep (or leave the S3
+    // files). Full media cleanup can be layered on later if it becomes a
+    // concern; hard delete is a rarely-used path.
+    await tx.kitCheckItem.deleteMany({ where: { kitId: id } });
+    await tx.kitMedia.deleteMany({ where: { kitId: id } });
+
+    // Finally, remove the kit row. Cascades handle the remaining child relations.
+    await tx.kit.delete({ where: { id, organizationId } });
+  });
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "DELETE",
+    entityType: "kit",
+    entityId: id,
+    entityName: tagForLog,
+    summary: `Permanently deleted kit ${tagForLog} - ${nameForLog}`,
+  });
+
+  return serialize({ id, hardDeleted: true });
+}
+
+// ---------------------------------------------------------------------------
 // addSerializedItemToKit
 // ---------------------------------------------------------------------------
 export async function addSerializedItemToKit(


### PR DESCRIPTION
## Summary
- **Kit delete flow** — two-tier dialog on the kit detail page. Archive (soft, default) is always available; hard delete is blocked when any `ProjectLineItem` references the kit, with a human-readable reason. New `canDeleteKit` / `deleteKit` server actions back the UI.
- **Group templates support kit items** — `GroupTemplateItem` got a nullable `kitId` + Zod XOR refine so each row is exactly one of model/kit. Templates can mix (e.g. "FOH Package" = 2x SM57 + 1x rack kit). Apply creates model lines inside the group tx, then delegates kit items to `addKitLineItem` per unit of quantity so "2x rack kit" becomes two independent parent rows with full child expansions. Kit expansion failures surface as warnings rather than aborting the apply.
- **Save-as-Template + management UI** — each project group now has a "Save as Template" dropdown action with a name/description dialog backed by `saveGroupAsTemplate`. New `/settings/group-templates` page (gated by `project:manage_line_items`) lists all templates with expandable item previews, rename/description edits, and delete. Add Group dialog gained a template picker that auto-fills the title and flips the create action to apply the template.
- **Bug fix** — `updateGroupTemplate` item-replace path no longer drops `kitId` and `sortOrder` when rebuilding items.
- Drops the never-used `kit_preset` / `kit_preset_item` tables from a prior WIP migration in favor of extending GroupTemplate.

## Test plan
- [x] `npm test` — 1671 passing (incl. new XOR refine cases in `group-template.test.ts`)
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors (pre-existing warnings untouched)
- [x] Manual: save a group as template from project equipment tab, appears in `/settings/group-templates`, rename, delete
- [x] Manual: template with mixed model + kit items renders correctly in management page with proper icons
- [ ] Manual: archive a kit with contents, verify assets released + kit hidden from list
- [ ] Manual: hard delete blocked on a kit referenced by a project, reason shown
- [ ] Manual: apply a template containing a rack kit to a project, verify kit expands with children under the new group

Generated with Claude Code