### PR TITLE
fix(migration): make group_template_supports_kits idempotent

### DIFF
--- a/prisma/migrations/20260415070000_group_template_supports_kits/migration.sql
+++ b/prisma/migrations/20260415070000_group_template_supports_kits/migration.sql
@@ -18,13 +18,16 @@ DROP TABLE IF EXISTS "kit_preset";
 -- rigid kit. modelId becomes nullable; kitId is added. When a template is
 -- applied, kit items call addKitLineItem and expand to the kit's children.
 
--- AlterTable
+-- AlterTable (idempotent — some envs pre-created these columns via `prisma db push`)
 ALTER TABLE "group_template_item" ALTER COLUMN "modelId" DROP NOT NULL;
-ALTER TABLE "group_template_item" ADD COLUMN "kitId" TEXT;
-ALTER TABLE "group_template_item" ADD COLUMN "sortOrder" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "group_template_item" ADD COLUMN IF NOT EXISTS "kitId" TEXT;
+ALTER TABLE "group_template_item" ADD COLUMN IF NOT EXISTS "sortOrder" INTEGER NOT NULL DEFAULT 0;
 
 -- CreateIndex
-CREATE INDEX "group_template_item_kitId_idx" ON "group_template_item"("kitId");
+CREATE INDEX IF NOT EXISTS "group_template_item_kitId_idx" ON "group_template_item"("kitId");
 
 -- AddForeignKey
-ALTER TABLE "group_template_item" ADD CONSTRAINT "group_template_item_kitId_fkey" FOREIGN KEY ("kitId") REFERENCES "kit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$ BEGIN
+  ALTER TABLE "group_template_item" ADD CONSTRAINT "group_template_item_kitId_fkey" FOREIGN KEY ("kitId") REFERENCES "kit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
Follow-up to #81. The `20260415070000_group_template_supports_kits` migration used bare `ADD COLUMN` / `CREATE INDEX` / `ADD CONSTRAINT`, which blows up on any database where the columns were pre-added via `prisma db push` during dev. Hit on a local dev DB with "column sortOrder of relation group_template_item already exists".

Guards the three operations with `IF NOT EXISTS` and `duplicate_object` exception handlers, matching the pattern already used in `20260326000000_add_billing_weeks_days`. No-ops on clean databases (so prod merge is safe), recovers dev databases that got half-migrated.

## Test plan
- [x] Clean DB: applies normally, columns/index/FK added
- [x] Already-patched DB: `IF NOT EXISTS` skips, no error
- [ ] Deploy to prod via main.yml — should be a clean apply since prod hasn't seen this migration yet

Generated with Claude Code