### PR TITLE
fix: edit dialog wiping modelId + add availability display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-04-16
 
 ### Fixed
+- Editing a line item no longer wipes its model association. The `updateLineItem` server action was unconditionally setting `modelId` to null when the edit dialog didn't send it, which removed the item from all overbook calculations and made the badge disappear after any edit.
 - Edit dialog now correctly warns when a line item is overbooked due to in-maintenance, lost, or retired assets. Previously, the edit dialog compared against raw stock (including unavailable assets), so overbooked items appeared editable without warnings.
 - Adding a second line item for the same model on a project now shows accurate availability. The add dialog previously displayed stale stock counts because cache wasn't refreshed after edits, removes, or moves.
 - Server-side availability enforcement in both add and update paths now uses effective stock (excluding unavailable assets), matching the overbook badge logic.
 
 ### Added
+- Edit dialog now shows full availability info (available count, usable stock, unavailable asset breakdown, conflicting projects), matching the add dialog experience.
 - `computeStockBreakdown` helper centralizes stock calculations across all availability checks, preventing client/server divergence.
 
 ## [0.4.1] - 2026-04-15

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1909,6 +1909,43 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                 value={editQuantity}
                 onChange={(e) => setEditQuantity(e.target.value)}
               />
+              {editAvailability && editLineItem?.modelId && (
+                <div className="space-y-1 pt-1">
+                  <p className={editIsOverbooked ? "text-sm text-red-600 dark:text-red-400" : "text-sm text-fg-3"}>
+                    <span className="font-semibold">{editAvailableForEdit ?? 0}</span>{" "}
+                    available out of{" "}
+                    <span className="font-semibold">{editAvailability.effectiveStock ?? editAvailability.totalStock}</span>{" "}
+                    {editAvailability.dateless ? "in stock" : "usable"}
+                    {editAvailability.dateless && (
+                      <span className="text-fg-3 font-normal">
+                        {" "}(no dates set — showing stock only)
+                      </span>
+                    )}
+                  </p>
+                  {(editAvailability.unavailable ?? 0) > 0 && (
+                    <p className="text-purple-600 dark:text-purple-400 text-xs">
+                      {editAvailability.unavailable} of {editAvailability.totalStock} total not usable
+                      {" "}({[
+                        editAvailability.inMaintenance ? `${editAvailability.inMaintenance} in maintenance` : "",
+                        editAvailability.lost ? `${editAvailability.lost} lost` : "",
+                      ].filter(Boolean).join(", ")})
+                    </p>
+                  )}
+                  {editAvailability.conflicts && editAvailability.conflicts.length > 0 && (
+                    <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <div>
+                        <p className="text-xs font-medium">Conflicts:</p>
+                        <ul className="list-disc pl-4 text-xs">
+                          {editAvailability.conflicts.map((c: string) => (
+                            <li key={c}>{c}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Pricing section */}

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -400,9 +400,12 @@ export async function updateLineItem(id: string, data: LineItemFormValues, allow
     where: { id, organizationId },
     data: {
       type: parsed.type,
-      modelId: parsed.modelId || null,
-      assetId: parsed.assetId || null,
-      bulkAssetId: parsed.bulkAssetId || null,
+      // Only update association fields when explicitly provided — the edit
+      // dialog doesn't send modelId/assetId/bulkAssetId, so undefined here
+      // means "keep the existing value", not "clear it".
+      ...(parsed.modelId !== undefined && { modelId: parsed.modelId || null }),
+      ...(parsed.assetId !== undefined && { assetId: parsed.assetId || null }),
+      ...(parsed.bulkAssetId !== undefined && { bulkAssetId: parsed.bulkAssetId || null }),
       description: parsed.description || null,
       quantity: parsed.quantity,
       unitPrice: parsed.unitPrice ?? null,
@@ -415,7 +418,7 @@ export async function updateLineItem(id: string, data: LineItemFormValues, allow
       isOptional: parsed.isOptional,
       isSubhire: parsed.isSubhire,
       showSubhireOnDocs: parsed.showSubhireOnDocs,
-      supplierId: parsed.supplierId || null,
+      ...(parsed.supplierId !== undefined && { supplierId: parsed.supplierId || null }),
       subhireOrderNumber: parsed.subhireOrderNumber || null,
       // Override detection
       ...(isPriceChanged && {


### PR DESCRIPTION
## Summary

Follow-up to #83. Fixes the actual root cause of the edit dialog losing overbook status, plus adds the availability info display.

- **Editing an item wiped its model association.** `updateLineItem` unconditionally set `modelId` to `null` when the edit dialog didn't send it (the field isn't editable). `parsed.modelId` was `undefined`, and `undefined || null` = `null`. This removed the item from all overbook calculations, making the badge disappear after any edit. Fixed by only updating `modelId`/`assetId`/`bulkAssetId` when explicitly provided.
- **Edit dialog had no availability info.** The add dialog shows "X available out of Y usable" with stock breakdown and conflict lists. The edit dialog had none of this. Now shows the same display below the quantity field.

## Test plan
- [x] All Vitest tests pass (1681 tests, 39 files)
- [x] npm run build clean
- [ ] Manual: Edit an item, verify overbook badge stays after save
- [ ] Manual: Edit dialog shows availability info below quantity field

🤖 Generated with [Claude Code](https://claude.com/claude-code)