### PR TITLE
feat: custom line items with category/group placement

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -649,6 +649,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   const [customItemPricingType, setCustomItemPricingType] = useState<"PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR">("FLAT");
   const [customItemDuration, setCustomItemDuration] = useState("1");
   const [customItemNotes, setCustomItemNotes] = useState("");
+  const [customItemCategoryId, setCustomItemCategoryId] = useState("");
+  const [customItemGroupId, setCustomItemGroupId] = useState("");
 
   // Sub-hire order dialog state
   const [showSubHireOrderDialog, setShowSubHireOrderDialog] = useState(false);
@@ -843,6 +845,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
       setCustomItemPricingType("FLAT");
       setCustomItemDuration("1");
       setCustomItemNotes("");
+      setCustomItemCategoryId("");
+      setCustomItemGroupId("");
       toast.success("Custom item added");
     },
     onError: (e: Error) => toast.error(e.message),
@@ -2188,6 +2192,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
             setCustomItemPricingType("FLAT");
             setCustomItemDuration("1");
             setCustomItemNotes("");
+            setCustomItemCategoryId("");
+            setCustomItemGroupId("");
           }
         }}
       >
@@ -2208,6 +2214,40 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                 onChange={(e) => setCustomItemName(e.target.value)}
                 maxLength={200}
               />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Category</Label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={customItemCategoryId}
+                  onChange={(e) => {
+                    setCustomItemCategoryId(e.target.value);
+                    setCustomItemGroupId("");
+                  }}
+                >
+                  <option value="">Uncategorized</option>
+                  {(categories as CategoryData[]).map((cat) => (
+                    <option key={cat.id} value={cat.id}>{cat.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Group</Label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={customItemGroupId}
+                  onChange={(e) => setCustomItemGroupId(e.target.value)}
+                  disabled={!customItemCategoryId}
+                >
+                  <option value="">No group</option>
+                  {customItemCategoryId && (categories as CategoryData[])
+                    .find((c) => c.id === customItemCategoryId)
+                    ?.groups.map((g) => (
+                      <option key={g.id} value={g.id}>{g.title}</option>
+                    ))}
+                </select>
+              </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
@@ -2285,6 +2325,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                   pricingType: customItemPricingType,
                   duration: customItemPricingType !== "FLAT" ? (parseInt(customItemDuration) || 1) : 1,
                   notes: customItemNotes.trim() || undefined,
+                  categoryId: customItemCategoryId || undefined,
+                  groupId: customItemGroupId || undefined,
                 });
               }}
             >

--- a/src/lib/validations/line-item.ts
+++ b/src/lib/validations/line-item.ts
@@ -36,6 +36,7 @@ export const customLineItemSchema = z.object({
   pricingType: z.enum(["PER_DAY", "PER_WEEK", "FLAT", "PER_HOUR"]).default("FLAT"),
   duration: z.coerce.number().int().min(1).max(3650).default(1),
   discount: z.coerce.number().min(0).max(999999.99).optional(),
+  categoryId: z.string().optional(),
   groupId: z.string().optional(),
   notes: z.string().max(500).optional(),
   isOptional: z.boolean().default(false),

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -588,6 +588,7 @@ export async function addCustomLineItem(projectId: string, data: CustomLineItemF
       discount: parsed.discount ?? null,
       notes: parsed.notes ?? null,
       isOptional: parsed.isOptional,
+      categoryId: parsed.categoryId ?? null,
       groupId: parsed.groupId ?? null,
       groupName: groupName ?? null,
       lineTotal,


### PR DESCRIPTION
## Summary

**Custom line items** — free-text items for gear not in your inventory, with full category and group placement support.

**Custom Item feature**
- `isCustomItem Boolean @default(false)` on `ProjectLineItem`
- Migration: non-destructive column add, backward compatible
- `addCustomLineItem()` server action — validated input, `requirePermission` enforced, org-scoped
- `lineTotal` and `sortOrder` computed on creation so custom items contribute correctly to project revenue
- "Custom Item" button in Equipment tab toolbar → dialog
- "Custom" muted badge in equipment list and all 3 warehouse tabs (Pick/Prep, Deploy, Return)
- Appears on all PDFs (quote, invoice, packing list, delivery docket, return sheet)
- Full warehouse cycle via button/checkbox — no barcode required
- Overbooked detection skips custom items

**Category & Group placement**
- Category dropdown in the dialog lists all project categories
- Group dropdown filters to the selected category's groups
- Changing category resets group selection
- Item appears nested in the chosen category/group in the equipment list

## Test Coverage

- 24 new tests for `customLineItemSchema` — 100% path coverage
- 1705/1705 tests pass

## Fixes included

- `lineTotal` and `sortOrder` set on creation (adversarial review: would have silently shown $0 revenue)
- `splitLineItem` copies `isCustomItem` so split items retain the badge
- `OPTIMIZED` removed from `customLineItemSchema` (no-op for custom items, would produce broken pricing state)
- Project-to-org validation before write (clean error instead of raw Prisma FK violation)

## Test plan

- [x] All 1705 tests pass
- [x] Build clean (no TS errors)
- [ ] Manual: Custom Item button in Equipment tab
- [ ] Manual: Item appears in correct category/group
- [ ] Manual: Custom badge visible in all 3 warehouse tabs
- [ ] Manual: Item appears on Quote/Invoice with correct price

🤖 Generated with [Claude Code](https://claude.com/claude-code)