### PR TITLE
feat: section headers for ungrouped/uncategorized items

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1432,6 +1432,16 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                 })}
 
                 {/* Uncategorized items */}
+                {hasCategories && hasUncategorized && (
+                  <TableRow className="bg-bg-inset/30">
+                    <TableCell colSpan={COL_COUNT} className="py-2 px-1">
+                      <div className="flex items-center gap-1.5">
+                        <div className="w-6" />
+                        <h3 className="text-sm font-semibold text-fg-4">Uncategorized</h3>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
                 {(uncategorizedItems as LineItemData[]).filter((i) => !isRealKitChild(i)).map((item) => (
                   <SortableLineItemRow
                     key={item.id}

--- a/src/components/warehouse/deploy-tab.tsx
+++ b/src/components/warehouse/deploy-tab.tsx
@@ -167,7 +167,7 @@ export function DeployTab({
               <TableBody>
                 {deployContainerGroups.map(({ container, entries }) => (
                   <Fragment key={container || "__ungrouped"}>
-                    {container && (
+                    {container ? (
                       <TableRow className="bg-bg-inset/50">
                         <TableCell colSpan={5} className="py-1.5">
                           <div className="flex items-center justify-between">
@@ -184,6 +184,15 @@ export function DeployTab({
                             >
                               <X className="h-3.5 w-3.5" />
                             </button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ) : deployContainerGroups.some((g) => g.container !== null) && (
+                      <TableRow className="bg-bg-inset/30">
+                        <TableCell colSpan={5} className="py-1.5">
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-fg-4 uppercase tracking-wide">
+                            <Package className="h-3.5 w-3.5" />
+                            No Container
                           </div>
                         </TableCell>
                       </TableRow>

--- a/src/components/warehouse/return-tab.tsx
+++ b/src/components/warehouse/return-tab.tsx
@@ -194,12 +194,21 @@ export function ReturnTab({
               <TableBody>
                 {returnContainerGroups.map(({ container, entries }) => (
                   <Fragment key={container || "__ungrouped"}>
-                    {container && (
+                    {container ? (
                       <TableRow className="bg-bg-inset/50">
                         <TableCell colSpan={5} className="py-1.5">
                           <div className="flex items-center gap-1.5 text-xs font-semibold text-fg-2 uppercase tracking-wide">
                             <Package className="h-3.5 w-3.5" />
                             {container}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ) : returnContainerGroups.some((g) => g.container !== null) && (
+                      <TableRow className="bg-bg-inset/30">
+                        <TableCell colSpan={5} className="py-1.5">
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-fg-4 uppercase tracking-wide">
+                            <Package className="h-3.5 w-3.5" />
+                            No Container
                           </div>
                         </TableCell>
                       </TableRow>


### PR DESCRIPTION
## Summary

Items with no prep container or no category were previously invisible as "orphans" — they'd render bare below the last named group, making it look like they belonged there.

**Warehouse — Deploy tab** and **Return tab**: a muted "No Container" section header now appears above ungrouped items when the project also has named containers. Same styling language as named container headers but visually subdued (lighter background, muted text) so the distinction is clear.

**Project — Equipment tab**: an "Uncategorized" section header now appears above items that have no assigned category, when at least one category exists on the project.

All three headers are **conditional** — they only show when there's a mix of grouped and ungrouped items. A project with no containers/categories at all sees no change.

## Changes

- [`deploy-tab.tsx`](src/components/warehouse/deploy-tab.tsx) — `container ?` ternary replaces `container &&`, false branch shows "No Container" when named containers exist
- [`return-tab.tsx`](src/components/warehouse/return-tab.tsx) — same pattern
- [`equipment-tab.tsx`](src/components/projects/equipment-tab.tsx) — "Uncategorized" `TableRow` inserted before uncategorized items when `hasCategories && hasUncategorized`

## Test plan
- [ ] Project with mixed categories + uncategorized items: "Uncategorized" header visible above bare items
- [ ] Project with only uncategorized items: no header (no noise)
- [ ] Warehouse deploy tab with containers + containerless items: "No Container" section visible
- [ ] Warehouse deploy tab with no containers at all: no header
- [ ] Same for return tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)