### PR TITLE
feat: group delivery docket by kit (case) name

### DIFF
--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -202,17 +202,47 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
     });
   }
 
-  // === Group items by category (via groupName) falling back to prepContainer ===
+  // === Group items ===
+  // Delivery docket: group by kit (case) name — kit becomes header, its CHECKED_OUT children become rows.
+  // Non-kit items go under "General" at the bottom.
+  // All other doc types: group by groupName / prepContainer.
   const ungroupedKey = config.documentType === "packing-list" ? "Ungrouped"
     : config.documentType === "delivery-docket" ? "General"
     : "_ungrouped";
 
   const groups = new Map<string, DocumentLineItem[]>();
-  for (const item of filteredItems) {
-    const key = item.groupName || item.prepContainer || ungroupedKey;
-    const arr = groups.get(key) || [];
-    arr.push(item);
-    groups.set(key, arr);
+
+  if (config.documentType === "delivery-docket") {
+    const kitOrder: string[] = [];
+    const generalItems: DocumentLineItem[] = [];
+
+    for (const item of filteredItems) {
+      const isKitParent = !!item.kitId && !item.isKitChild;
+      if (isKitParent) {
+        const kitName = item.kit?.name || item.description || "Kit";
+        const children = (item.childLineItems || []).filter(c => c.status === "CHECKED_OUT");
+        if (children.length > 0) {
+          if (!groups.has(kitName)) {
+            kitOrder.push(kitName);
+            groups.set(kitName, []);
+          }
+          groups.get(kitName)!.push(...children);
+        }
+      } else {
+        generalItems.push(item);
+      }
+    }
+
+    if (generalItems.length > 0) {
+      groups.set(ungroupedKey, generalItems);
+    }
+  } else {
+    for (const item of filteredItems) {
+      const key = item.groupName || item.prepContainer || ungroupedKey;
+      const arr = groups.get(key) || [];
+      arr.push(item);
+      groups.set(key, arr);
+    }
   }
 
   // === Draw table header ===

--- a/src/lib/pdfme/section-renderer.ts
+++ b/src/lib/pdfme/section-renderer.ts
@@ -77,6 +77,46 @@ function getItemGroupKey(item: DocumentLineItem, ungrouped: string): string {
 }
 
 /**
+ * Build kit-based groups for delivery docket.
+ * Kit parents become group headers; their CHECKED_OUT children become the rows.
+ * Non-kit items go under "General" at the bottom.
+ */
+function buildDeliveryDocketGroups(
+  data: DocumentData,
+  docType: DocumentType,
+): { groupOrder: string[]; groups: Map<string, DocumentLineItem[]> } {
+  const parentItems = getFilteredParentItems(data, docType);
+  const groups = new Map<string, DocumentLineItem[]>();
+  const kitOrder: string[] = [];
+  const generalItems: DocumentLineItem[] = [];
+
+  for (const item of parentItems) {
+    const isKitParent = !!item.kitId && !item.isKitChild;
+    if (isKitParent) {
+      const kitName = item.kit?.name || item.description || "Kit";
+      const children = (item.childLineItems || []).filter(c => c.status === "CHECKED_OUT");
+      if (children.length > 0) {
+        if (!groups.has(kitName)) {
+          kitOrder.push(kitName);
+          groups.set(kitName, []);
+        }
+        groups.get(kitName)!.push(...children);
+      }
+    } else {
+      generalItems.push(item);
+    }
+  }
+
+  const groupOrder = [...kitOrder];
+  if (generalItems.length > 0) {
+    groups.set("General", generalItems);
+    groupOrder.push("General");
+  }
+
+  return { groupOrder, groups };
+}
+
+/**
  * Check if a parent item has splittable sub-items (per-unit checkboxes).
  * Returns the total sub-item count, or 0 if not splittable.
  */
@@ -238,9 +278,24 @@ function calculateTableItemHeights(
   settings: TableSectionSettings,
   docType: DocumentType,
 ): number[] {
-  const parentItems = getFilteredParentItems(data, docType);
   const ungrouped = getUngroupedKey(docType);
   const heights: number[] = [];
+
+  // Delivery docket uses kit-based groups (must mirror gearflow-table.ts plugin logic)
+  if (docType === "delivery-docket") {
+    const { groupOrder, groups } = buildDeliveryDocketGroups(data, docType);
+    for (const groupKey of groupOrder) {
+      if (groupKey !== ungrouped && settings.showGroupHeaders) {
+        heights.push(ptToMm(GROUP_HEADER_PT));
+      }
+      for (const item of groups.get(groupKey)!) {
+        heights.push(calculateItemHeight(item, settings));
+      }
+    }
+    return heights;
+  }
+
+  const parentItems = getFilteredParentItems(data, docType);
 
   // Group items by groupName (matching the plugin's rendering order)
   const groups = new Map<string, DocumentLineItem[]>();
@@ -568,14 +623,27 @@ export function computePageLayout(
           const itemHeights = calculateTableItemHeights(data, ts, docType);
 
           // Build mappings first — needed for partial fit calculations
-          const parentItems = getFilteredParentItems(data, docType);
           const ungrouped = getUngroupedKey(docType);
           const groups = new Map<string, DocumentLineItem[]>();
           const groupOrder: string[] = [];
-          for (const item of parentItems) {
-            const key = getItemGroupKey(item, ungrouped);
-            if (!groups.has(key)) { groups.set(key, []); groupOrder.push(key); }
-            groups.get(key)!.push(item);
+          // parentItems: flat array of items (used by getItemAt for partial-fit calculations)
+          let parentItems: DocumentLineItem[] = [];
+
+          if (docType === "delivery-docket") {
+            const docketGroups = buildDeliveryDocketGroups(data, docType);
+            for (const key of docketGroups.groupOrder) {
+              const items = docketGroups.groups.get(key)!;
+              groups.set(key, items);
+              groupOrder.push(key);
+              parentItems.push(...items);
+            }
+          } else {
+            parentItems = getFilteredParentItems(data, docType);
+            for (const item of parentItems) {
+              const key = getItemGroupKey(item, ungrouped);
+              if (!groups.has(key)) { groups.set(key, []); groupOrder.push(key); }
+              groups.get(key)!.push(item);
+            }
           }
 
           // Build mappings: itemHeights index → parentItemIndex (for startIndex)


### PR DESCRIPTION
## Summary
- Delivery docket now groups items by **kit (case) name** instead of category — each kit becomes a bold section header, with all its CHECKED_OUT contents listed as rows beneath it
- Non-kit items (loose gear) appear under a **"General"** section at the bottom
- Kits with no checked-out contents are hidden entirely

## Why
Previously the table grouped by category name, which caused the same model to appear split across multiple groups (e.g., 1× SM58 under "Mics" *and* 8× SM58 as indented children under a "Cases" row). That's messy and hard to use on-site.

## What changed
- `gearflow-table.ts` — delivery-docket branch builds kit-based `groups` map before the render loop; items in kit groups are kit children rendered as regular rows
- `section-renderer.ts` — `buildDeliveryDocketGroups` helper mirrors the plugin logic; `calculateTableItemHeights` and `computePageLayout` use it for correct page-break heights

## Test plan
- [ ] Generate a delivery docket for a project with checked-out kits — verify kit names appear as headers with contents beneath
- [ ] Verify loose (non-kit) checked-out items appear under "General" at the bottom
- [ ] Verify multi-page delivery dockets split correctly at page boundaries
- [ ] Verify a project with no kits shows a flat list (no header cluttering the top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)