### PR TITLE
docs: add prioritised roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 - **`ARCHITECTURE.md`** — High-level overview with links to all feature docs
 - **`FEATUREDOCS/`** — Individual markdown files for each feature/system
 - **`PROMPT.md`** — Full product spec
+- **`docs/ROADMAP.md`** — Prioritised roadmap: phases, sequencing, effort
+- **`docs/designs/`** — Per-initiative design docs (one per major feature/program)
 
 **When making changes**: Read the relevant `FEATUREDOCS/` file(s) for the feature you're touching. Update them after. Don't read everything — just what's relevant. The [Integration Checklist](./FEATUREDOCS/29-integration-checklist.md) tells you what to wire up for new features.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,12 +37,15 @@ on top of it.
 
 Small, isolated, do now. No dependency on anything else.
 
-### 0.1 — Checkout duplication bug
-**Effort:** S
-Scanning 16x JAGs to deploy them re-adds all 16 serialised assets as new line
-items at the bottom of the project, double-counting everything already there.
-This corrupts project data on a daily-use path. The acute fix is Phase 0; the
-root cause is the line-item model muddle that Phase 1 resolves properly.
+### 0.1 — Checkout duplication bug → promoted to the fulfillment-model rework
+**Effort:** L (was estimated S) · **Status:** planned, build starting
+Scanning units to deploy them produces one project line-item row per physical
+unit instead of one per ordered line — the docket and project screen fragment.
+Investigated and `/autoplan`-reviewed: this is **not** an acute bug, it is the
+one-asset-per-`ProjectLineItem`-row data model showing through. The fix is the
+order-line / fulfillment-unit split — effectively item 1.2 pulled forward.
+Design: [`docs/designs/line-item-fulfillment-model.md`](./designs/line-item-fulfillment-model.md).
+A multi-week, 4-phase build; it supersedes a render-only patch.
 
 ### 0.2 — iCal timezone correctness
 **Effort:** S

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,195 @@
+# GearFlow Roadmap
+
+Operational roadmap for GearFlow, the AV/theatre rental-management platform for
+Two Toned Productions. This document sequences known work into priority phases.
+It is the parent index above the individual design docs in `docs/designs/`.
+
+## How to read this
+
+- **Phases** are priority bands. Ship them roughly in order.
+- **Within a phase**, items are listed in dependency order — do them top to bottom.
+- **Effort** is human-team scale: `S` (< 1 week), `M` (1–2 weeks), `L` (3–4 weeks),
+  `XL` (multi-month). AI-assisted build time is a small fraction of this.
+- Each phase item is a candidate for its own `/autoplan` run — one feature, one
+  plan, one review pipeline. Do not batch unrelated items into a single plan.
+- Finance stays out of scope. Xero owns invoices, payments, quotes, GST. GearFlow
+  is operational tooling. (See `docs/designs/app-cleanup-unification.md`.)
+
+## The big reframe
+
+The backlog reads as ~14 separate items, but five of them are a single organism —
+**how equipment gets onto a project and flows through the warehouse**:
+
+- Groups & categories management on projects
+- Delivery docket + pick slip
+- The checkout duplication bug
+- Bulk check-in
+- Child assets / accessories
+
+They all read and write the same project line-item model. Built piecemeal, that
+model gets reworked five times. They are therefore planned as **one program**
+(Phase 1), model-first: fix the data model once, then the features land cleanly
+on top of it.
+
+---
+
+## Phase 0 — Stop the bleeding
+
+Small, isolated, do now. No dependency on anything else.
+
+### 0.1 — Checkout duplication bug
+**Effort:** S
+Scanning 16x JAGs to deploy them re-adds all 16 serialised assets as new line
+items at the bottom of the project, double-counting everything already there.
+This corrupts project data on a daily-use path. The acute fix is Phase 0; the
+root cause is the line-item model muddle that Phase 1 resolves properly.
+
+### 0.2 — iCal timezone correctness
+**Effort:** S
+Crew calendar feeds show wrong times in Google Calendar — a timezone offset bug.
+Crew acting on wrong call times is an operational hazard. Isolated fix.
+
+---
+
+## Phase 1 — Project & Warehouse Fulfillment
+
+**The priority program.** This is where daily friction lives. Model-first: land
+the data-model changes, then the features fall out cleaner. The proper fix for
+the Phase 0 checkout bug folds in here.
+
+Related design docs: `docs/designs/warehouse-checks.md`,
+`docs/designs/pdf-template-builder.md`.
+
+### 1.1 — Child assets / accessories
+**Effort:** L · **Depends on:** nothing (data-model foundation)
+Attach serialised and bulk assets to other serialised assets — an IEC cable on a
+mixer, an adaptor on a JAG headset mic, two clamps and a TrueCon on a light.
+Foundational: it unlocks the good version of bulk check-in (1.3).
+
+### 1.2 — Groups & categories on projects
+**Effort:** L · **Depends on:** 1.1 (shared line-item model pass)
+The clunky core. Managing assets on a project — grouping them, categorising
+them, moving them between groups, setting pricing — currently takes ages and
+forces delete-and-redo for small changes. Goal: every action available on every
+line type (serialised asset, sub-hire, custom item); fast, smart creation of
+groups/categories; drag/move between them; inline repricing. No destructive
+churn for routine edits.
+
+### 1.3 — Bulk check-in
+**Effort:** M · **Depends on:** 1.1
+A full-checklist check-in screen instead of the broken-down per-item view. For
+child/bulk assets, show the total quantity due back on the job (50 lights = 100
+clamps + 50 TrueCons) and let the operator enter how many are physically in
+front of them and check that count in at once — no per-light drill-down.
+
+### 1.4 — Delivery docket + pick slip
+**Effort:** M · **Depends on:** 1.2
+Rework both documents to be group/category-aware. Make the pick slip actually
+make sense for packing; make delivery-docket categorisation smarter. Ties
+directly to the corrected checkout logic from 0.1 / Phase 1.
+
+---
+
+## Phase 2 — Crew & Services
+
+A separate organism from fulfillment. Tackle after Phase 1.
+
+### 2.1 — Service & crewing overhaul
+**Effort:** XL
+Rethink service management and crewing from the ground up — smarter scheduling,
+tighter integration between services, crew assignments, availability, and
+projects. "Think big" rework, not an incremental patch. Worth its own design doc
+before any build. (iCal correctness already handled in Phase 0.)
+
+---
+
+## Phase 3 — Feature expansion
+
+Net-new capability. Valuable, but not daily-pain — sequence after the core
+workflows are solid.
+
+### 3.1 — Project todo lists
+**Effort:** M
+Add Asana-style todo/task lists to projects so project management lives in
+GearFlow instead of scattered across chat and email.
+
+### 3.2 — Public API
+**Effort:** L
+A documented API for users to programmatically pull data from and drive
+GearFlow. Needs API-key authentication, rate limiting, versioning, and reference
+docs. Recommend shipping **read-only v1 first** (a much smaller, lower-risk
+surface) and adding write endpoints once the read API has real users. API
+reference docs belong with the user guide (see Continuous tracks).
+
+---
+
+## Phase 4 — Experience pass
+
+Polishing a clunky workflow is backwards — fix the flow first (Phases 1–2), then
+make it feel right. Phases 1 and 2 already remove most of the structural
+clunkiness; this phase is the consistency-and-flow sweep across everything else.
+
+### 4.1 — UX / flow overhaul
+**Effort:** L
+A holistic pass so every screen feels like it belongs and flows well. Start by
+auditing `docs/designs/ux-ui-redesign.md` — what it delivered vs. what still
+feels off — so this builds on that work rather than restarting it.
+
+### 4.2 — Mobile overhaul
+**Effort:** L · **Depends on:** 4.1
+The warehouse runs on phones, so mobile quality is semi-operational, not pure
+polish. Still sequence it after the flow fixes — there is no point hardening a
+mobile layout for a workflow that is about to change.
+
+---
+
+## Continuous tracks
+
+These run alongside the phases, not as standalone sprints.
+
+### Dev & Claude documentation
+**Effort:** M · **Cadence:** start alongside Phase 1, keep current
+Overhaul and then maintain `CLAUDE.md`, `ARCHITECTURE.md`, and `FEATUREDOCS/`.
+Every feature after this is built by Claude reading these docs — stale docs tax
+every future task. High-leverage, compounding. Do it early.
+
+### User guide
+**Effort:** M · **Cadence:** parallelizable, can be delegated
+End-user documentation, separate audience from the dev docs. A separate
+Docusaurus repo is the right call. Can run as a background track. Eventually
+hosts the Phase 3.2 API reference.
+
+### Codebase tidy-up
+**Effort:** ongoing · **Cadence:** folded into every phase
+Not a standalone project — it has no done-state and no user-visible outcome.
+When a phase touches a file, that file gets tidied. Refactoring rides along with
+feature work; it never gets its own sprint.
+
+---
+
+## Sequencing summary
+
+```
+Phase 0  Stop the bleeding        ──► now (this week)
+            │
+            ├─ Dev/Claude docs refresh starts here ──────────────┐
+            ▼                                                    │ continuous
+Phase 1  Project & Warehouse Fulfillment  ──► the priority        │
+            ▼                                                    │
+Phase 2  Crew & Services                                         │
+            ▼                                                    │
+Phase 3  Feature expansion (todo lists, API)                     │
+            ▼                                                    │
+Phase 4  Experience pass (UX, mobile)                            │
+                                                                 │
+User guide (Docusaurus) ── parallel background track ────────────┘
+```
+
+## Open decisions
+
+- **API scope (3.2)** — confirmed: external programmatic access for users.
+  Recommendation is read-only v1 first; revisit write scope after read ships.
+- **UX redesign (4.1)** — confirmed: a holistic "fix the clunk" pass.
+  Audit `ux-ui-redesign.md` before building so it extends, not restarts.
+- Phase boundaries are guidance, not contracts. If Phase 2 crewing pain proves
+  sharper than expected, it can jump ahead of late Phase 1.


### PR DESCRIPTION
## Summary

Triages the GearFlow backlog into a sequenced, 5-phase roadmap at `docs/ROADMAP.md`, linked from `CLAUDE.md`.

**The key call:** five backlog items — groups/categories management, delivery docket + pick slip, the checkout duplication bug, bulk check-in, and child assets/accessories — are one organism (the project line-item + warehouse fulfillment pipeline). They all read/write the same model, so they're planned as a single model-first program (Phase 1) instead of five separate efforts that would rework the model five times.

## Phases

- **Phase 0 — Stop the bleeding:** checkout duplication bug, iCal timezone. Small, isolated, now.
- **Phase 1 — Project & Warehouse Fulfillment:** child assets → groups/categories → bulk check-in → docket/pick slip. The priority program.
- **Phase 2 — Crew & Services:** the crewing/services overhaul.
- **Phase 3 — Feature expansion:** project todo lists, public API (read-only v1 first).
- **Phase 4 — Experience pass:** UX/flow overhaul, mobile overhaul — after the workflows are functionally right.
- **Continuous tracks:** dev/Claude docs, user guide (Docusaurus), codebase tidy-up folded into every phase.

Each phase item is a candidate for its own `/autoplan` run.

## Test plan

- [ ] N/A — documentation only