### PR TITLE
Phase 3: line-item fulfillment-model cutover (3.2-3.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:integration": "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/gearflow_test vitest run --config vitest.integration.config.ts",
     "reconcile:bulk": "tsx --env-file=.env scripts/reconcile-bulk-availability.ts",
     "backfill:line-item-units": "tsx --env-file=.env scripts/backfill-line-item-units.ts",
+    "collapse:split-siblings": "tsx --env-file=.env scripts/collapse-split-siblings.ts",
     "lint:server-actions": "tsx scripts/audit-server-actions.ts"
   },
   "dependencies": {

--- a/prisma/migrations/20260522010000_add_line_item_merge_map/migration.sql
+++ b/prisma/migrations/20260522010000_add_line_item_merge_map/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "line_item_merge_map" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "oldLineItemId" TEXT NOT NULL,
+    "canonicalLineItemId" TEXT NOT NULL,
+    "movedUnitId" TEXT,
+    "checkRecordsRepointed" INTEGER NOT NULL DEFAULT 0,
+    "damageEventsRepointed" INTEGER NOT NULL DEFAULT 0,
+    "serviceRepointed" BOOLEAN NOT NULL DEFAULT false,
+    "notes" TEXT,
+    "mergedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "line_item_merge_map_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "line_item_merge_map_oldLineItemId_key" ON "line_item_merge_map"("oldLineItemId");
+
+-- CreateIndex
+CREATE INDEX "line_item_merge_map_organizationId_idx" ON "line_item_merge_map"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "line_item_merge_map_canonicalLineItemId_idx" ON "line_item_merge_map"("canonicalLineItemId");
+
+-- AddForeignKey
+ALTER TABLE "line_item_merge_map" ADD CONSTRAINT "line_item_merge_map_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,7 @@ model Organization {
   projects                 Project[]
   projectLineItems         ProjectLineItem[]
   projectLineItemUnits     ProjectLineItemUnit[]
+  lineItemMergeMaps        LineItemMergeMap[]
   scanLogs                 AssetScanLog[]
   suppliers                Supplier[]
   supplierOrders           SupplierOrder[]
@@ -1503,6 +1504,43 @@ model ProjectLineItemUnit {
   @@index([organizationId, bulkAssetId, status])
   @@index([lineItemId, status])
   @@map("project_line_item_unit")
+}
+
+/// Audit trail for the Phase 3.8 split-sibling collapse migration.
+///
+/// When the historic data has lines that splitLineItem fragmented into
+/// per-asset siblings, the collapse migration merges them back onto one
+/// canonical order line — moving each sibling's ProjectLineItemUnit, its
+/// CheckRecord / DamageEvent rows, and its ProjectService onto the
+/// canonical, then deactivating the old row. This table records the
+/// mapping so the merge can be audited and (if needed) reversed.
+///
+/// Permanent — never auto-cleaned. One row per merged (old) line item.
+model LineItemMergeMap {
+  id                   String   @id @default(cuid())
+  organizationId       String
+  organization         Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  /// The line item that was merged away. Kept in the projectLineItem
+  /// table (status: CANCELLED, quantity: 0, assetId: null) so historical
+  /// data isn't destroyed — only made inert.
+  oldLineItemId        String   @unique
+  /// The line item the units / records were re-pointed to.
+  canonicalLineItemId  String
+  /// The unit row that carried the old line's asset/bulk allocation
+  /// after the move. Null when the old row had no unit (rare —
+  /// pre-Phase-2a rows or kit children).
+  movedUnitId          String?
+  checkRecordsRepointed Int      @default(0)
+  damageEventsRepointed Int      @default(0)
+  serviceRepointed     Boolean  @default(false)
+  /// Free-form notes captured at merge time (eg. the equivalence-key
+  /// snapshot, dry-run vs. apply, the run id).
+  notes                String?
+  mergedAt             DateTime @default(now())
+
+  @@index([organizationId])
+  @@index([canonicalLineItemId])
+  @@map("line_item_merge_map")
 }
 
 // ─── Project Category ───────────────────────────────────────────────────────

--- a/scripts/collapse-split-siblings.ts
+++ b/scripts/collapse-split-siblings.ts
@@ -1,0 +1,114 @@
+/**
+ * Phase 3.8 — split-sibling collapse migration (CLI wrapper).
+ *
+ * Plan / apply logic lives in `src/server/split-sibling-collapse.ts`;
+ * pure equivalence-key + planning helpers in
+ * `src/lib/split-sibling-collapse.ts`. This file is just the CLI veneer
+ * (arg parsing, reporting, exit codes).
+ *
+ * See docs/designs/line-item-fulfillment-model.md (Phase 2b).
+ *
+ * Usage:
+ *   tsx --env-file=.env scripts/collapse-split-siblings.ts             # dry-run
+ *   tsx --env-file=.env scripts/collapse-split-siblings.ts --apply     # writes
+ *   tsx --env-file=.env scripts/collapse-split-siblings.ts --org <id>
+ *   tsx --env-file=.env scripts/collapse-split-siblings.ts --project <id>
+ *
+ * DRY-RUN BY DEFAULT. The --apply flag is the only way to mutate data;
+ * the script prints every move first so a human can sanity-check.
+ */
+
+import { prisma } from "../src/lib/prisma";
+import { runCollapse } from "../src/server/split-sibling-collapse";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const orgIdx = args.indexOf("--org");
+const orgFilter = orgIdx >= 0 ? args[orgIdx + 1] : undefined;
+const projIdx = args.indexOf("--project");
+const projectFilter = projIdx >= 0 ? args[projIdx + 1] : undefined;
+const runId = `run-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+
+async function main() {
+  console.log("Split-sibling collapse migration (Phase 3.8)");
+  console.log("─".repeat(60));
+  console.log(`Mode:    ${apply ? "APPLY (will mutate)" : "dry-run"}`);
+  if (orgFilter) console.log(`Org:     ${orgFilter}`);
+  if (projectFilter) console.log(`Project: ${projectFilter}`);
+  console.log(`Run id:  ${runId}`);
+  console.log();
+
+  const { stats, plans, mergeable, flagged } = await runCollapse({
+    apply,
+    organizationId: orgFilter,
+    projectId: projectFilter,
+    runId,
+  });
+
+  console.log(`Equivalence groups (size ≥ 2): ${plans.length}`);
+  console.log(`  Mergeable: ${mergeable.length}`);
+  console.log(`  Flagged:   ${flagged.length}`);
+  console.log();
+
+  if (flagged.length > 0) {
+    console.log("Flagged groups (NOT merged):");
+    for (const g of flagged) {
+      console.log(
+        `  - canonical=${g.canonicalId}  flags=${g.flags.join(",")}  members=${g.moves.length + 1}`,
+      );
+    }
+    console.log();
+  }
+
+  // Print one line per mergeable group + one per move, with project /
+  // model context for human review.
+  const canonicalIds = mergeable.map((m) => m.canonicalId);
+  const canonicalRows = canonicalIds.length
+    ? await prisma.projectLineItem.findMany({
+        where: { id: { in: canonicalIds } },
+        select: {
+          id: true,
+          project: { select: { projectNumber: true } },
+          model: { select: { name: true } },
+        },
+      })
+    : [];
+  const byId = new Map(canonicalRows.map((c) => [c.id, c]));
+
+  for (const plan of mergeable) {
+    const c = byId.get(plan.canonicalId);
+    console.log(
+      `  ${apply ? "MERGE" : "PLAN "}  ${c?.project.projectNumber ?? "?"}  ${c?.model?.name ?? "?"}  canonical=${plan.canonicalId}  merging ${plan.moves.length}`,
+    );
+    for (const m of plan.moves) {
+      console.log(
+        `         ← ${m.siblingId} ${m.assetId ? `asset=${m.assetId}` : `bulk=${m.bulkAssetId}`} qty=${m.quantity}`,
+      );
+    }
+  }
+
+  console.log();
+  console.log("Summary");
+  console.log("─".repeat(60));
+  console.log(`  Mergeable groups:        ${stats.groupsMergeable}`);
+  console.log(`  Flagged groups:          ${stats.groupsFlagged}`);
+  console.log(`  Sibling rows ${apply ? "merged" : "would merge"}:  ${stats.rowsMergedAway}`);
+  if (apply) {
+    console.log(`  Units moved:             ${stats.unitsMoved}`);
+    console.log(`  CheckRecords repointed:  ${stats.checkRecordsRepointed}`);
+    console.log(`  DamageEvents repointed:  ${stats.damageEventsRepointed}`);
+    console.log(`  Services repointed:      ${stats.servicesRepointed}`);
+  } else {
+    console.log();
+    console.log("Re-run with --apply to execute.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("ERROR:", err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -520,7 +520,7 @@ function WarehouseProjectPage({
         })().catch((e) => showError(e));
       } else {
         checkInMutation.mutate(
-          { items: checkQueueDirectItems.map((i) => ({ lineItemId: i.lineItemId, returnCondition: (i.returnCondition || "GOOD") as "GOOD" | "DAMAGED" | "MISSING", quantity: i.quantity, notes: i.notes })) },
+          { items: checkQueueDirectItems.map((i) => ({ lineItemId: i.lineItemId, assetId: i.assetId, returnCondition: (i.returnCondition || "GOOD") as "GOOD" | "DAMAGED" | "MISSING", quantity: i.quantity, notes: i.notes })) },
           { onSuccess: () => { toast.success(`Returned remaining items`); setReturnNotes(""); } }
         );
       }
@@ -642,7 +642,7 @@ function WarehouseProjectPage({
 
   const checkInMutation = useMutation({
     mutationFn: async (data: {
-      items: Array<{ lineItemId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING"; quantity?: number; notes?: string }>;
+      items: Array<{ lineItemId: string; assetId?: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING"; quantity?: number; notes?: string }>;
     }) => {
       const result = await checkInItems(projectId, data.items);
       // Sync container status for affected containers
@@ -1088,6 +1088,7 @@ function WarehouseProjectPage({
             {
               items: [{
                 lineItemId: result.lineItemId,
+                assetId: result.assetId ?? undefined,
                 returnCondition: returnCondition as "GOOD" | "DAMAGED" | "MISSING",
                 notes: returnNotes || undefined,
               }],
@@ -1828,6 +1829,7 @@ function WarehouseProjectPage({
     // Return non-kit items
     const items = Array.from(qtyMap.entries()).map(([lineItemId, qty]) => ({
       lineItemId,
+      assetId: lineItems.find((l) => l.id === lineItemId)?.assetId || undefined,
       returnCondition: returnCondition as "GOOD" | "DAMAGED" | "MISSING",
       quantity: qty,
       notes: returnNotes || undefined,
@@ -1867,7 +1869,7 @@ function WarehouseProjectPage({
       if (queue.length > 0) {
         startCheckQueue(
           queue,
-          withoutCheckItems.map((i) => ({ lineItemId: i.lineItemId, returnCondition: i.returnCondition, quantity: i.quantity, notes: i.notes }))
+          withoutCheckItems.map((i) => ({ lineItemId: i.lineItemId, assetId: i.assetId, returnCondition: i.returnCondition, quantity: i.quantity, notes: i.notes }))
         );
         setReturnNotes("");
         return;

--- a/src/lib/reservation-conflicts.int.test.ts
+++ b/src/lib/reservation-conflicts.int.test.ts
@@ -79,6 +79,29 @@ async function addLineItem(
   });
 }
 
+/**
+ * Assign an asset to a line item via a ProjectLineItemUnit row — the
+ * fulfillment model. Mirrors what checkout does (ensureSerialisedUnit).
+ */
+async function addUnit(
+  orgId: string,
+  lineItemId: string,
+  assetId: string,
+  status: "CONFIRMED" | "CHECKED_OUT" | "RETURNED" = "CHECKED_OUT",
+  ordinal = 0,
+) {
+  return testPrisma.projectLineItemUnit.create({
+    data: {
+      organizationId: orgId,
+      lineItemId,
+      assetId,
+      ordinal,
+      quantity: 1,
+      status,
+    },
+  });
+}
+
 describe("findProjectConflictsCore", () => {
   beforeEach(async () => {
     await setupIntegrationTest();
@@ -152,6 +175,63 @@ describe("findProjectConflictsCore", () => {
     expect(conflicts).toHaveLength(0);
   });
 
+  it("flags an asset booked via a ProjectLineItemUnit on the other project", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const asset = await createAssetFixture(org.id, model.id, { assetTag: "A1" });
+
+    const projA = await createProject(org.id, new Date("2026-06-01"), new Date("2026-06-10"));
+    const projB = await createProject(org.id, new Date("2026-06-05"), new Date("2026-06-15"));
+    // This project assigns via legacy line.assetId.
+    await addLineItem(org.id, projA.id, model.id, asset.id);
+    // The other project deploys the same asset via a unit (fulfillment model).
+    const liB = await addLineItem(org.id, projB.id, model.id, null);
+    await addUnit(org.id, liB.id, asset.id);
+
+    const conflicts = await findProjectConflictsCore(projA.id, org.id);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].assetId).toBe(asset.id);
+    expect(conflicts[0].conflictingProject.id).toBe(projB.id);
+  });
+
+  it("flags when THIS project's assignment is a unit, not line.assetId", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const asset = await createAssetFixture(org.id, model.id, { assetTag: "A1" });
+
+    const projA = await createProject(org.id, new Date("2026-06-01"), new Date("2026-06-10"));
+    const projB = await createProject(org.id, new Date("2026-06-05"), new Date("2026-06-15"));
+    // This project deploys the asset via a unit.
+    const liA = await addLineItem(org.id, projA.id, model.id, null);
+    await addUnit(org.id, liA.id, asset.id);
+    // The other project holds the same asset on a legacy line.
+    await addLineItem(org.id, projB.id, model.id, asset.id);
+
+    const conflicts = await findProjectConflictsCore(projA.id, org.id);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].assetId).toBe(asset.id);
+    expect(conflicts[0].lineItemId).toBe(liA.id);
+    expect(conflicts[0].conflictingProject.id).toBe(projB.id);
+  });
+
+  it("does NOT flag a unit whose status is RETURNED", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const asset = await createAssetFixture(org.id, model.id, { assetTag: "A1" });
+
+    const projA = await createProject(org.id, new Date("2026-06-01"), new Date("2026-06-10"));
+    const projB = await createProject(org.id, new Date("2026-06-05"), new Date("2026-06-15"));
+    await addLineItem(org.id, projA.id, model.id, asset.id);
+    const liB = await addLineItem(org.id, projB.id, model.id, null);
+    await addUnit(org.id, liB.id, asset.id, "RETURNED");
+
+    const conflicts = await findProjectConflictsCore(projA.id, org.id);
+    expect(conflicts).toHaveLength(0);
+  });
+
   it("ignores CANCELLED line items on the other project", async () => {
     const org = await createOrgFixture();
     await createUserFixture(org.id);
@@ -206,6 +286,26 @@ describe("findSwapCandidatesCore", () => {
     // alsoBooked is on another overlapping project
     const other = await createProject(org.id, new Date("2026-06-05"), new Date("2026-06-12"));
     await addLineItem(org.id, other.id, model.id, alsoBooked.id);
+
+    const candidates = await findSwapCandidatesCore(li.id, org.id);
+    expect(candidates.map((c) => c.assetId)).toEqual([free.id]);
+  });
+
+  it("excludes assets booked via a unit on an overlapping live project", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const booked = await createAssetFixture(org.id, model.id, { assetTag: "BOOKED" });
+    const unitBooked = await createAssetFixture(org.id, model.id, { assetTag: "UNIT" });
+    const free = await createAssetFixture(org.id, model.id, { assetTag: "FREE" });
+
+    const proj = await createProject(org.id, new Date("2026-06-01"), new Date("2026-06-10"));
+    const li = await addLineItem(org.id, proj.id, model.id, booked.id);
+
+    // unitBooked is deployed via a unit on another overlapping project.
+    const other = await createProject(org.id, new Date("2026-06-05"), new Date("2026-06-12"));
+    const otherLi = await addLineItem(org.id, other.id, model.id, null);
+    await addUnit(org.id, otherLi.id, unitBooked.id);
 
     const candidates = await findSwapCandidatesCore(li.id, org.id);
     expect(candidates.map((c) => c.assetId)).toEqual([free.id]);
@@ -284,6 +384,26 @@ describe("swapLineItemAssetCore", () => {
     // Someone books `raced` on an overlapping project between list + click.
     const other = await createProject(org.id, new Date("2026-06-03"), new Date("2026-06-08"));
     await addLineItem(org.id, other.id, model.id, raced.id);
+
+    await expect(
+      swapLineItemAssetCore(li.id, raced.id, org.id),
+    ).rejects.toThrow(/just booked/i);
+  });
+
+  it("rejects a target booked via a unit in the window (race guard)", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const oldAsset = await createAssetFixture(org.id, model.id, { assetTag: "OLD" });
+    const raced = await createAssetFixture(org.id, model.id, { assetTag: "RACED" });
+
+    const proj = await createProject(org.id, new Date("2026-06-01"), new Date("2026-06-10"));
+    const li = await addLineItem(org.id, proj.id, model.id, oldAsset.id);
+
+    // `raced` gets deployed via a unit on an overlapping project.
+    const other = await createProject(org.id, new Date("2026-06-03"), new Date("2026-06-08"));
+    const otherLi = await addLineItem(org.id, other.id, model.id, null);
+    await addUnit(org.id, otherLi.id, raced.id);
 
     await expect(
       swapLineItemAssetCore(li.id, raced.id, org.id),

--- a/src/lib/reservation-conflicts.ts
+++ b/src/lib/reservation-conflicts.ts
@@ -59,77 +59,154 @@ export async function findProjectConflictsCore(
   });
   if (!project?.rentalStartDate || !project.rentalEndDate) return [];
 
-  // Asset-bearing line items on this project.
-  const lineItems = await prisma.projectLineItem.findMany({
-    where: {
-      projectId,
-      organizationId,
-      assetId: { not: null },
-      status: { not: "CANCELLED" },
-    },
-    select: {
-      id: true,
-      assetId: true,
-      modelId: true,
-      asset: { select: { assetTag: true, model: { select: { name: true } } } },
-    },
-  });
-  if (lineItems.length === 0) return [];
+  const projectSelect = {
+    id: true,
+    projectNumber: true,
+    name: true,
+    status: true,
+    rentalStartDate: true,
+    rentalEndDate: true,
+  } as const;
 
-  const assetIds = lineItems
-    .map((li) => li.assetId)
-    .filter((id): id is string => id != null);
-
-  // Other-project line items that book any of these assets in an
-  // overlapping window.
-  const overlaps = await prisma.projectLineItem.findMany({
-    where: {
-      organizationId,
-      assetId: { in: assetIds },
-      status: { not: "CANCELLED" },
-      projectId: { not: projectId },
-      project: {
-        isTemplate: false,
-        status: { notIn: [...DEAD_PROJECT_STATUSES] },
-        rentalStartDate: { lte: project.rentalEndDate },
-        rentalEndDate: { gte: project.rentalStartDate },
+  // This project's asset assignments — from legacy line.assetId rows AND
+  // from ProjectLineItemUnit rows (the fulfillment model). Deployed assets
+  // now live on units, so both sources must be checked.
+  const [assetLines, assetUnits] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where: {
+        projectId,
+        organizationId,
+        assetId: { not: null },
+        status: { not: "CANCELLED" },
       },
-    },
-    select: {
-      id: true,
-      assetId: true,
-      project: {
-        select: {
-          id: true,
-          projectNumber: true,
-          name: true,
-          status: true,
-          rentalStartDate: true,
-          rentalEndDate: true,
+      select: {
+        id: true,
+        assetId: true,
+        modelId: true,
+        asset: { select: { assetTag: true, model: { select: { name: true } } } },
+      },
+    }),
+    prisma.projectLineItemUnit.findMany({
+      where: {
+        organizationId,
+        assetId: { not: null },
+        status: { not: "RETURNED" },
+        lineItem: { projectId, status: { not: "CANCELLED" } },
+      },
+      select: {
+        lineItemId: true,
+        assetId: true,
+        asset: {
+          select: {
+            assetTag: true,
+            modelId: true,
+            model: { select: { name: true } },
+          },
         },
       },
-    },
-  });
+    }),
+  ]);
 
-  // Index overlaps by assetId for the join.
-  const overlapByAsset = new Map<string, (typeof overlaps)[number]>();
-  for (const o of overlaps) {
+  interface AssetRef {
+    lineItemId: string;
+    assetId: string;
+    modelId: string | null;
+    assetTag: string;
+    modelName: string;
+  }
+  const here: AssetRef[] = [
+    ...assetLines
+      .filter((l) => l.assetId)
+      .map((l) => ({
+        lineItemId: l.id,
+        assetId: l.assetId as string,
+        modelId: l.modelId,
+        assetTag: l.asset?.assetTag ?? "—",
+        modelName: l.asset?.model?.name ?? "—",
+      })),
+    ...assetUnits
+      .filter((u) => u.assetId)
+      .map((u) => ({
+        lineItemId: u.lineItemId,
+        assetId: u.assetId as string,
+        modelId: u.asset?.modelId ?? null,
+        assetTag: u.asset?.assetTag ?? "—",
+        modelName: u.asset?.model?.name ?? "—",
+      })),
+  ];
+  if (here.length === 0) return [];
+
+  const assetIds = [...new Set(here.map((r) => r.assetId))];
+  const projectWindow = {
+    isTemplate: false,
+    status: { notIn: [...DEAD_PROJECT_STATUSES] },
+    rentalStartDate: { lte: project.rentalEndDate },
+    rentalEndDate: { gte: project.rentalStartDate },
+  };
+
+  // Overlapping other-project bookings of those assets — both tables.
+  const [overlapLines, overlapUnits] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where: {
+        organizationId,
+        assetId: { in: assetIds },
+        status: { not: "CANCELLED" },
+        projectId: { not: projectId },
+        project: projectWindow,
+      },
+      select: { id: true, assetId: true, project: { select: projectSelect } },
+    }),
+    prisma.projectLineItemUnit.findMany({
+      where: {
+        organizationId,
+        assetId: { in: assetIds },
+        status: { not: "RETURNED" },
+        lineItem: {
+          projectId: { not: projectId },
+          status: { not: "CANCELLED" },
+          project: projectWindow,
+        },
+      },
+      select: {
+        lineItemId: true,
+        assetId: true,
+        lineItem: { select: { project: { select: projectSelect } } },
+      },
+    }),
+  ]);
+
+  const overlapByAsset = new Map<
+    string,
+    { id: string; project: (typeof overlapLines)[number]["project"] }
+  >();
+  for (const o of overlapLines) {
     if (o.assetId && !overlapByAsset.has(o.assetId)) {
-      overlapByAsset.set(o.assetId, o);
+      overlapByAsset.set(o.assetId, { id: o.id, project: o.project });
+    }
+  }
+  for (const o of overlapUnits) {
+    if (o.assetId && !overlapByAsset.has(o.assetId)) {
+      overlapByAsset.set(o.assetId, {
+        id: o.lineItemId,
+        project: o.lineItem.project,
+      });
     }
   }
 
   const conflicts: ReservationConflict[] = [];
-  for (const li of lineItems) {
-    if (!li.assetId) continue;
-    const overlap = overlapByAsset.get(li.assetId);
+  const seen = new Set<string>();
+  for (const r of here) {
+    const overlap = overlapByAsset.get(r.assetId);
     if (!overlap) continue;
+    const key = `${r.lineItemId}:${r.assetId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
     conflicts.push({
-      lineItemId: li.id,
-      assetId: li.assetId,
-      assetTag: li.asset?.assetTag ?? "—",
-      modelId: li.modelId ?? "",
-      modelName: li.asset?.model?.name ?? "—",
+      lineItemId: r.lineItemId,
+      assetId: r.assetId,
+      assetTag: r.assetTag,
+      modelId: r.modelId ?? "",
+      modelName: r.modelName,
       conflictingProject: overlap.project,
       conflictingLineItemId: overlap.id,
     });
@@ -191,23 +268,45 @@ export async function findSwapCandidatesCore(
   });
   if (assets.length === 0) return [];
 
-  // Which of those are booked in an overlapping live project?
-  const booked = await prisma.projectLineItem.findMany({
-    where: {
-      organizationId,
-      assetId: { in: assets.map((a) => a.id) },
-      status: { not: "CANCELLED" },
-      id: { not: lineItemId },
-      project: {
-        isTemplate: false,
-        status: { notIn: [...DEAD_PROJECT_STATUSES] },
-        rentalStartDate: { lte: rentalEndDate },
-        rentalEndDate: { gte: rentalStartDate },
+  // Which of those are booked in an overlapping live project? Bookings
+  // live on legacy line.assetId rows AND on ProjectLineItemUnit rows
+  // (the fulfillment model) — both tables must be checked or a swap
+  // candidate that's actually deployed via a unit looks free.
+  const candidateAssetIds = assets.map((a) => a.id);
+  const projectWindow = {
+    isTemplate: false,
+    status: { notIn: [...DEAD_PROJECT_STATUSES] },
+    rentalStartDate: { lte: rentalEndDate },
+    rentalEndDate: { gte: rentalStartDate },
+  };
+  const [bookedLines, bookedUnits] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where: {
+        organizationId,
+        assetId: { in: candidateAssetIds },
+        status: { not: "CANCELLED" },
+        id: { not: lineItemId },
+        project: projectWindow,
       },
-    },
-    select: { assetId: true },
-  });
-  const bookedIds = new Set(booked.map((b) => b.assetId));
+      select: { assetId: true },
+    }),
+    prisma.projectLineItemUnit.findMany({
+      where: {
+        organizationId,
+        assetId: { in: candidateAssetIds },
+        status: { not: "RETURNED" },
+        lineItemId: { not: lineItemId },
+        lineItem: {
+          status: { not: "CANCELLED" },
+          project: projectWindow,
+        },
+      },
+      select: { assetId: true },
+    }),
+  ]);
+  const bookedIds = new Set<string>();
+  for (const b of bookedLines) if (b.assetId) bookedIds.add(b.assetId);
+  for (const b of bookedUnits) if (b.assetId) bookedIds.add(b.assetId);
 
   return assets
     .filter((a) => a.id !== lineItem.assetId && !bookedIds.has(a.id))
@@ -269,24 +368,44 @@ export async function swapLineItemAssetCore(
   const { rentalStartDate, rentalEndDate } = lineItem.project;
   await prisma.$transaction(async (tx) => {
     if (rentalStartDate && rentalEndDate) {
-      const conflict = await tx.projectLineItem.findFirst({
-        where: {
-          organizationId,
-          assetId: newAssetId,
-          status: { not: "CANCELLED" },
-          id: { not: lineItemId },
-          project: {
-            isTemplate: false,
-            status: { notIn: [...DEAD_PROJECT_STATUSES] },
-            rentalStartDate: { lte: rentalEndDate },
-            rentalEndDate: { gte: rentalStartDate },
+      const projectWindow = {
+        isTemplate: false,
+        status: { notIn: [...DEAD_PROJECT_STATUSES] },
+        rentalStartDate: { lte: rentalEndDate },
+        rentalEndDate: { gte: rentalStartDate },
+      };
+      // Re-check both the legacy line.assetId rows AND the unit table —
+      // a fresh deployment may have landed on a ProjectLineItemUnit.
+      const [lineConflict, unitConflict] = await Promise.all([
+        tx.projectLineItem.findFirst({
+          where: {
+            organizationId,
+            assetId: newAssetId,
+            status: { not: "CANCELLED" },
+            id: { not: lineItemId },
+            project: projectWindow,
           },
-        },
-        select: { project: { select: { projectNumber: true } } },
-      });
-      if (conflict) {
+          select: { project: { select: { projectNumber: true } } },
+        }),
+        tx.projectLineItemUnit.findFirst({
+          where: {
+            organizationId,
+            assetId: newAssetId,
+            status: { not: "RETURNED" },
+            lineItemId: { not: lineItemId },
+            lineItem: { status: { not: "CANCELLED" }, project: projectWindow },
+          },
+          select: {
+            lineItem: { select: { project: { select: { projectNumber: true } } } },
+          },
+        }),
+      ]);
+      const conflictProjectNumber =
+        lineConflict?.project.projectNumber ??
+        unitConflict?.lineItem.project.projectNumber;
+      if (conflictProjectNumber) {
         throw new Error(
-          `Asset ${newAsset.assetTag} was just booked on ${conflict.project.projectNumber}. Pick another.`,
+          `Asset ${newAsset.assetTag} was just booked on ${conflictProjectNumber}. Pick another.`,
         );
       }
     }

--- a/src/lib/split-sibling-collapse.test.ts
+++ b/src/lib/split-sibling-collapse.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure-helper tests for the split-sibling collapse plan. No Prisma —
+ * the script's DB side is covered by an integration test.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  equivalenceKey,
+  pickCanonical,
+  planGroup,
+  planAll,
+  type CollapseRow,
+} from "./split-sibling-collapse";
+
+function row(over: Partial<CollapseRow>): CollapseRow {
+  return {
+    id: "li-1",
+    organizationId: "org-1",
+    projectId: "proj-1",
+    type: "EQUIPMENT",
+    modelId: "model-1",
+    assetId: "asset-1",
+    bulkAssetId: null,
+    kitId: null,
+    isKitChild: false,
+    parentLineItemId: null,
+    pricingMode: null,
+    description: null,
+    quantity: 1,
+    unitPrice: "100.00",
+    pricingType: "PER_DAY",
+    duration: 1,
+    discount: null,
+    priceOverridden: false,
+    overrideReason: null,
+    sortOrder: 0,
+    groupName: null,
+    categoryId: null,
+    groupId: null,
+    notes: null,
+    isOptional: false,
+    isContainerLineItem: false,
+    isCustomItem: false,
+    showSubhireOnDocs: false,
+    supplierId: null,
+    subhireOrderNumber: null,
+    supplierOrderId: null,
+    subHireId: null,
+    subHireItemId: null,
+    subHireGroupId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("equivalenceKey", () => {
+  it("two split siblings (same line, different assets) share a key", () => {
+    const a = row({ id: "a", assetId: "asset-A" });
+    const b = row({ id: "b", assetId: "asset-B" });
+    expect(equivalenceKey(a)).toBe(equivalenceKey(b));
+  });
+
+  it("normalises decimal precision — 100 == 100.00 == 100.000", () => {
+    const a = row({ unitPrice: "100" });
+    const b = row({ unitPrice: "100.00" });
+    const c = row({ unitPrice: 100 });
+    expect(equivalenceKey(a)).toBe(equivalenceKey(b));
+    expect(equivalenceKey(b)).toBe(equivalenceKey(c));
+  });
+
+  it("different unitPrice ⇒ different key (don't merge)", () => {
+    const a = row({ unitPrice: "100.00" });
+    const b = row({ unitPrice: "150.00" });
+    expect(equivalenceKey(a)).not.toBe(equivalenceKey(b));
+  });
+
+  it.each([
+    ["description", "stage", "FOH"],
+    ["notes", "matched pair", null],
+    ["groupName", "Mics", "Backline"],
+    ["groupId", "g-1", "g-2"],
+    ["categoryId", "c-1", null],
+    ["pricingType", "PER_DAY", "PER_WEEK"],
+    ["duration", 1, 3],
+    ["isOptional", true, false],
+    ["isContainerLineItem", true, false],
+    ["isCustomItem", true, false],
+    ["supplierId", "s-1", null],
+    ["subhireOrderNumber", "SO-1", null],
+    ["subHireId", "sh-1", null],
+    ["priceOverridden", true, false],
+    ["overrideReason", "season discount", null],
+    ["showSubhireOnDocs", true, false],
+  ] as const)("differing %s splits the key", (field, a, b) => {
+    const ra = row({ [field]: a } as Partial<CollapseRow>);
+    const rb = row({ [field]: b } as Partial<CollapseRow>);
+    expect(equivalenceKey(ra)).not.toBe(equivalenceKey(rb));
+  });
+
+  it("ignores fields that are EXPECTED to differ across siblings", () => {
+    // assetId, quantity, sortOrder, createdAt — each sibling has its own.
+    const a = row({
+      id: "a",
+      assetId: "X",
+      quantity: 1,
+      sortOrder: 0,
+      createdAt: new Date("2026-01-01"),
+    });
+    const b = row({
+      id: "b",
+      assetId: "Y",
+      quantity: 1,
+      sortOrder: 5,
+      createdAt: new Date("2026-02-01"),
+    });
+    expect(equivalenceKey(a)).toBe(equivalenceKey(b));
+  });
+});
+
+describe("pickCanonical", () => {
+  it("picks smallest sortOrder", () => {
+    const a = row({ id: "a", sortOrder: 5 });
+    const b = row({ id: "b", sortOrder: 1 });
+    const c = row({ id: "c", sortOrder: 3 });
+    expect(pickCanonical([a, b, c]).id).toBe("b");
+  });
+
+  it("breaks sortOrder ties with oldest createdAt", () => {
+    const a = row({ id: "a", sortOrder: 0, createdAt: new Date("2026-02-01") });
+    const b = row({ id: "b", sortOrder: 0, createdAt: new Date("2026-01-01") });
+    expect(pickCanonical([a, b]).id).toBe("b");
+  });
+
+  it("breaks all ties with lexicographic id (stable)", () => {
+    const ts = new Date("2026-01-01");
+    const a = row({ id: "li-zzz", sortOrder: 0, createdAt: ts });
+    const b = row({ id: "li-aaa", sortOrder: 0, createdAt: ts });
+    expect(pickCanonical([a, b]).id).toBe("li-aaa");
+  });
+});
+
+describe("planGroup", () => {
+  it("plans a clean 3-way split — canonical + two moves", () => {
+    const a = row({ id: "a", assetId: "X", sortOrder: 0 });
+    const b = row({ id: "b", assetId: "Y", sortOrder: 1 });
+    const c = row({ id: "c", assetId: "Z", sortOrder: 2 });
+    const plan = planGroup([a, b, c]);
+    expect(plan.flags).toEqual([]);
+    expect(plan.canonicalId).toBe("a");
+    expect(plan.moves.map((m) => m.siblingId).sort()).toEqual(["b", "c"]);
+  });
+
+  it("flags a row with no asset assigned (not a split sibling)", () => {
+    const a = row({ id: "a", assetId: "X" });
+    const b = row({ id: "b", assetId: null, bulkAssetId: null });
+    const plan = planGroup([a, b]);
+    expect(plan.flags).toContain("row-without-asset-or-bulk");
+    expect(plan.moves).toEqual([]);
+  });
+
+  it("flags duplicate assetId across siblings (schema-impossible but defensive)", () => {
+    const a = row({ id: "a", assetId: "X" });
+    const b = row({ id: "b", assetId: "X" });
+    const plan = planGroup([a, b]);
+    expect(plan.flags.some((f) => f.startsWith("duplicate-asset-"))).toBe(true);
+    expect(plan.moves).toEqual([]);
+  });
+
+  it("flags kit children — they're never merged", () => {
+    const a = row({ id: "a", assetId: "X", isKitChild: true, kitId: "k-1" });
+    const b = row({ id: "b", assetId: "Y", isKitChild: true, kitId: "k-1" });
+    const plan = planGroup([a, b]);
+    expect(plan.flags).toContain("kit-children-in-group");
+    expect(plan.moves).toEqual([]);
+  });
+
+  it("supports bulk-asset siblings", () => {
+    const a = row({
+      id: "a",
+      assetId: null,
+      bulkAssetId: "bulk-1",
+      quantity: 3,
+      sortOrder: 0,
+    });
+    const b = row({
+      id: "b",
+      assetId: null,
+      bulkAssetId: "bulk-2",
+      quantity: 5,
+      sortOrder: 1,
+    });
+    const plan = planGroup([a, b]);
+    expect(plan.flags).toEqual([]);
+    expect(plan.canonicalId).toBe("a");
+    expect(plan.moves[0]).toMatchObject({
+      siblingId: "b",
+      bulkAssetId: "bulk-2",
+      quantity: 5,
+    });
+  });
+});
+
+describe("planAll", () => {
+  it("buckets by key, drops singletons, plans groups", () => {
+    const mergeable1 = row({ id: "m1", assetId: "X", description: "stage" });
+    const mergeable2 = row({ id: "m2", assetId: "Y", description: "stage" });
+    const mergeable3 = row({ id: "m3", assetId: "Z", description: "stage" });
+    const different = row({ id: "d1", assetId: "Q", description: "FOH" });
+    const plans = planAll([mergeable1, mergeable2, mergeable3, different]);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].moves).toHaveLength(2);
+  });
+
+  it("emits one plan per equivalence group when there are several", () => {
+    const stageA = row({ id: "sa", assetId: "X", description: "stage" });
+    const stageB = row({ id: "sb", assetId: "Y", description: "stage" });
+    const fohA = row({ id: "fa", assetId: "P", description: "FOH" });
+    const fohB = row({ id: "fb", assetId: "Q", description: "FOH" });
+    const plans = planAll([stageA, stageB, fohA, fohB]);
+    expect(plans).toHaveLength(2);
+  });
+
+  it("returns flagged groups too, with empty moves", () => {
+    const a = row({ id: "a", assetId: "X" });
+    const b = row({ id: "b", assetId: "X" }); // duplicate asset
+    const plans = planAll([a, b]);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].moves).toEqual([]);
+    expect(plans[0].flags.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/split-sibling-collapse.ts
+++ b/src/lib/split-sibling-collapse.ts
@@ -1,0 +1,258 @@
+/**
+ * Pure helpers for the Phase 3.8 split-sibling collapse migration.
+ *
+ * See docs/designs/line-item-fulfillment-model.md (Phase 2b).
+ *
+ * The historic data contains `ProjectLineItem` rows that the retired
+ * `splitLineItem` function fragmented into per-asset qty-1 siblings.
+ * Post-cutover this is the wrong shape — a `10x SM57` order line should
+ * be ONE row with ten `ProjectLineItemUnit` rows, not ten lines.
+ *
+ * The collapse migration merges sibling rows back onto one canonical
+ * order line under a STRICT full-equivalence key — every order-level
+ * field identical. Anything that doesn't match is flagged, not merged.
+ *
+ * This module only computes the *plan*: which rows merge into which,
+ * which groups are mergeable, and which are flagged. The DB mutation
+ * (move units, repoint CheckRecord / DamageEvent, deactivate old rows,
+ * write `LineItemMergeMap`) is the script's job.
+ *
+ * Lives outside `"use server"` so the script and unit tests drive it
+ * directly without a session.
+ */
+
+/**
+ * Decimal-ish stringifier. Prisma returns Decimal objects; tests pass
+ * strings or numbers. Normalise to a string with a trailing zero
+ * trimmed, or null. `0` and `0.00` collapse to the same key — important
+ * because price equality must not depend on display formatting.
+ */
+function normDecimal(v: unknown): string | null {
+  if (v === null || v === undefined) return null;
+  // Prisma Decimal has toString(); plain number / string both work.
+  const s = String(v);
+  // Strip trailing zeros after decimal, then a dangling dot.
+  if (s.includes(".")) return s.replace(/0+$/, "").replace(/\.$/, "");
+  return s;
+}
+
+/**
+ * The minimum row shape `equivalenceKey` + `planGroup` need. Mirrors
+ * `ProjectLineItem` fields exactly; using a subset lets unit tests skip
+ * the Prisma client. Decimal-typed fields accept `unknown` so callers
+ * can pass Prisma Decimal | string | number.
+ */
+export interface CollapseRow {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  type: string;
+  modelId: string | null;
+  assetId: string | null;
+  bulkAssetId: string | null;
+  kitId: string | null;
+  isKitChild: boolean;
+  parentLineItemId: string | null;
+  pricingMode: string | null;
+  description: string | null;
+  quantity: number;
+  unitPrice: unknown;
+  pricingType: string;
+  duration: number;
+  discount: unknown;
+  priceOverridden: boolean;
+  overrideReason: string | null;
+  sortOrder: number;
+  groupName: string | null;
+  categoryId: string | null;
+  groupId: string | null;
+  notes: string | null;
+  isOptional: boolean;
+  isContainerLineItem: boolean;
+  isCustomItem: boolean;
+  showSubhireOnDocs: boolean;
+  supplierId: string | null;
+  subhireOrderNumber: string | null;
+  supplierOrderId: string | null;
+  subHireId: string | null;
+  subHireItemId: string | null;
+  subHireGroupId: string | null;
+  createdAt: Date;
+}
+
+/**
+ * The strict full-equivalence key. Two rows are mergeable only if their
+ * keys are byte-identical.
+ *
+ * Deliberately EXCLUDED:
+ *  - `id`, `createdAt`, `updatedAt` — instance identity.
+ *  - `quantity` — siblings of a `10x` split each carry `1`, but it's
+ *    exactly what we're summing.
+ *  - `assetId`, `bulkAssetId` — what makes them split-siblings, not what
+ *    makes them mergeable. Each sibling has a different one.
+ *  - `sortOrder` — splits re-numbered it; the canonical row's order is
+ *    what survives.
+ *  - rollup counters (`assignedQuantity` / `packedQuantity` / etc.) —
+ *    derived state, will be recomputed post-merge.
+ *  - lifecycle (`status`, `checkedOutAt`, `returnedAt`, `returnCondition`,
+ *    `returnStatus`, `returnNotes`, `prepStatus`, `prepContainer`) — also
+ *    per-unit state; the unit table is the source of truth post-cutover.
+ *  - `lineTotal`, `priceBreakdown` — derived from unitPrice + duration +
+ *    quantity + discount; recomputed naturally when quantity sums.
+ *  - `isOptional`-but-equal across siblings is included.
+ *
+ * INCLUDED — every order-level identity field. Differ on any of these
+ * and the rows are commercially different lines that must not merge.
+ */
+export function equivalenceKey(row: CollapseRow): string {
+  const obj = {
+    projectId: row.projectId,
+    type: row.type,
+    modelId: row.modelId,
+    kitId: row.kitId,
+    isKitChild: row.isKitChild,
+    parentLineItemId: row.parentLineItemId,
+    pricingMode: row.pricingMode,
+    description: row.description,
+    unitPrice: normDecimal(row.unitPrice),
+    pricingType: row.pricingType,
+    duration: row.duration,
+    discount: normDecimal(row.discount),
+    priceOverridden: row.priceOverridden,
+    overrideReason: row.overrideReason,
+    groupName: row.groupName,
+    categoryId: row.categoryId,
+    groupId: row.groupId,
+    notes: row.notes,
+    isOptional: row.isOptional,
+    isContainerLineItem: row.isContainerLineItem,
+    isCustomItem: row.isCustomItem,
+    showSubhireOnDocs: row.showSubhireOnDocs,
+    supplierId: row.supplierId,
+    subhireOrderNumber: row.subhireOrderNumber,
+    supplierOrderId: row.supplierOrderId,
+    subHireId: row.subHireId,
+    subHireItemId: row.subHireItemId,
+    subHireGroupId: row.subHireGroupId,
+  };
+  return JSON.stringify(obj);
+}
+
+/**
+ * Pick the canonical row to merge siblings INTO. Smallest sortOrder
+ * wins — that's the row that was at the top of the section before the
+ * split. Ties broken by oldest createdAt; final tie by id (stable).
+ *
+ * The canonical is mutated in place (its quantity grows, its rollup
+ * recomputes). Siblings are deactivated.
+ */
+export function pickCanonical<T extends Pick<CollapseRow, "id" | "sortOrder" | "createdAt">>(
+  rows: T[],
+): T {
+  if (rows.length === 0) throw new Error("pickCanonical: empty input");
+  return [...rows].sort((a, b) => {
+    if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+    const at = a.createdAt.getTime();
+    const bt = b.createdAt.getTime();
+    if (at !== bt) return at - bt;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  })[0];
+}
+
+export interface PlannedMove {
+  /** The sibling row that will be deactivated. */
+  siblingId: string;
+  /** Asset the sibling holds (one of assetId / bulkAssetId is set). */
+  assetId: string | null;
+  bulkAssetId: string | null;
+  /** Quantity added to the canonical. */
+  quantity: number;
+}
+
+export interface GroupPlan {
+  key: string;
+  canonicalId: string;
+  moves: PlannedMove[];
+  /** Reasons this group was flagged. Empty == mergeable. */
+  flags: string[];
+}
+
+/**
+ * Plan a single equivalence-key group. Returns the canonical, the
+ * sibling moves, and any flags. A group with flags is NOT merged — the
+ * script reports it and moves on.
+ *
+ * Mergeability invariants:
+ *   - ≥ 2 rows in the group.
+ *   - Every row has either `assetId` or `bulkAssetId` set (otherwise
+ *     it's a generic order line, not a split sibling).
+ *   - No two rows share an `assetId` (a split is one-asset-per-row).
+ *   - All rows in the group share the same equivalence key (caller's
+ *     responsibility — we trust the grouping).
+ */
+export function planGroup(rows: CollapseRow[]): GroupPlan {
+  const key = rows[0] ? equivalenceKey(rows[0]) : "";
+  const flags: string[] = [];
+
+  if (rows.length < 2) {
+    return { key, canonicalId: rows[0]?.id ?? "", moves: [], flags: ["single-row-group"] };
+  }
+
+  // Every row in a split-sibling set must carry an asset. A row with
+  // neither asset nor bulkAsset is a generic order line — not the kind
+  // splitLineItem produced.
+  const allHaveAsset = rows.every((r) => r.assetId || r.bulkAssetId);
+  if (!allHaveAsset) flags.push("row-without-asset-or-bulk");
+
+  // Duplicate assets across siblings — schema-impossible after the
+  // ProjectLineItemUnit unique constraint lands, but historic split
+  // siblings predate that. Defensive guard.
+  const seenAssetIds = new Set<string>();
+  for (const r of rows) {
+    if (!r.assetId) continue;
+    if (seenAssetIds.has(r.assetId)) {
+      flags.push(`duplicate-asset-${r.assetId}`);
+    }
+    seenAssetIds.add(r.assetId);
+  }
+
+  // Kit children get collapsed at most one row, so a group of ≥ 2 kit
+  // children with the same parent would already be wrong. Flag and
+  // skip.
+  if (rows.some((r) => r.isKitChild)) flags.push("kit-children-in-group");
+
+  const canonical = pickCanonical(rows);
+  const moves: PlannedMove[] = [];
+  if (flags.length === 0) {
+    for (const r of rows) {
+      if (r.id === canonical.id) continue;
+      moves.push({
+        siblingId: r.id,
+        assetId: r.assetId,
+        bulkAssetId: r.bulkAssetId,
+        quantity: r.quantity,
+      });
+    }
+  }
+  return { key, canonicalId: canonical.id, moves, flags };
+}
+
+/**
+ * Bucket a flat list of rows by their equivalence key, then plan each
+ * bucket. Groups of size 1 are dropped — they have nothing to merge.
+ */
+export function planAll(rows: CollapseRow[]): GroupPlan[] {
+  const byKey = new Map<string, CollapseRow[]>();
+  for (const r of rows) {
+    const k = equivalenceKey(r);
+    const list = byKey.get(k);
+    if (list) list.push(r);
+    else byKey.set(k, [r]);
+  }
+  const plans: GroupPlan[] = [];
+  for (const group of byKey.values()) {
+    if (group.length < 2) continue;
+    plans.push(planGroup(group));
+  }
+  return plans;
+}

--- a/src/lib/utilization.ts
+++ b/src/lib/utilization.ts
@@ -33,6 +33,7 @@
  */
 
 import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
 
 export interface UtilizationPeriod {
   /** Inclusive start. Defaults to asset.createdAt. */
@@ -104,31 +105,86 @@ export async function computeAssetUtilization(
   const period: UtilizationPeriod = { start: periodStart, end: periodEnd };
   const periodDays = daysBetween(period.start, period.end);
 
-  // Bookings: line items with this exact asset assigned, not cancelled,
-  // on projects that aren't templates.
-  const bookings = await prisma.projectLineItem.findMany({
-    where: {
-      assetId,
-      organizationId,
-      status: { not: "CANCELLED" },
-      project: {
-        isTemplate: false,
-        status: { notIn: ["CANCELLED"] },
-        rentalStartDate: { not: null },
-        rentalEndDate: { not: null },
+  // Bookings: this exact asset assigned, not cancelled, on non-template
+  // projects. Assignments live on legacy line.assetId rows AND on
+  // ProjectLineItemUnit rows (the fulfillment model) — both tables count.
+  const projectFilter: Prisma.ProjectWhereInput = {
+    isTemplate: false,
+    status: { notIn: ["CANCELLED"] },
+    rentalStartDate: { not: null },
+    rentalEndDate: { not: null },
+  };
+  const [bookingLines, bookingUnits] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where: {
+        assetId,
+        organizationId,
+        status: { not: "CANCELLED" },
+        project: projectFilter,
       },
-    },
-    select: {
-      lineTotal: true,
-      project: {
-        select: {
-          id: true,
-          rentalStartDate: true,
-          rentalEndDate: true,
+      select: {
+        id: true,
+        lineTotal: true,
+        project: {
+          select: { id: true, rentalStartDate: true, rentalEndDate: true },
         },
       },
-    },
-  });
+    }),
+    prisma.projectLineItemUnit.findMany({
+      where: {
+        assetId,
+        organizationId,
+        status: { not: "CANCELLED" },
+        lineItem: { status: { not: "CANCELLED" }, project: projectFilter },
+      },
+      select: {
+        lineItemId: true,
+        lineItem: {
+          select: {
+            lineTotal: true,
+            quantity: true,
+            project: {
+              select: { id: true, rentalStartDate: true, rentalEndDate: true },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  // Unify both sources into one booking shape. A line either carries
+  // line.assetId (legacy) or has units (fulfillment model) — disjoint in
+  // practice, but dedup by lineItemId guards against a row in both. Unit
+  // revenue is pro-rated by line quantity so an N-unit line isn't counted
+  // N times; legacy single-asset lines keep their full-lineTotal behaviour.
+  interface Booking {
+    rentalStartDate: Date | null;
+    rentalEndDate: Date | null;
+    revenue: number;
+    projectId: string;
+  }
+  const bookings: Booking[] = [];
+  const seenLineIds = new Set<string>();
+  for (const l of bookingLines) {
+    seenLineIds.add(l.id);
+    bookings.push({
+      rentalStartDate: l.project.rentalStartDate,
+      rentalEndDate: l.project.rentalEndDate,
+      revenue: l.lineTotal != null ? Number(l.lineTotal) : 0,
+      projectId: l.project.id,
+    });
+  }
+  for (const u of bookingUnits) {
+    if (seenLineIds.has(u.lineItemId)) continue;
+    const qty = u.lineItem.quantity > 0 ? u.lineItem.quantity : 1;
+    bookings.push({
+      rentalStartDate: u.lineItem.project.rentalStartDate,
+      rentalEndDate: u.lineItem.project.rentalEndDate,
+      revenue:
+        u.lineItem.lineTotal != null ? Number(u.lineItem.lineTotal) / qty : 0,
+      projectId: u.lineItem.project.id,
+    });
+  }
 
   let bookingDays = 0;
   let revenue = 0;
@@ -136,25 +192,21 @@ export async function computeAssetUtilization(
   const projectIds = new Set<string>();
 
   for (const b of bookings) {
-    if (!b.project.rentalStartDate || !b.project.rentalEndDate) continue;
-    const window = clampWindow(
-      b.project.rentalStartDate,
-      b.project.rentalEndDate,
-      period,
-    );
+    if (!b.rentalStartDate || !b.rentalEndDate) continue;
+    const window = clampWindow(b.rentalStartDate, b.rentalEndDate, period);
     if (!window) continue;
     bookingDays += daysBetween(window.start, window.end);
-    // Revenue attribution: count this asset's line total in full if any
-    // part of the booking overlaps the period. This avoids pro-rating a
-    // bundle price across days, which the operator never sees in their
-    // numbers anyway. For period reporting, this means a booking that
+    // Revenue attribution: count this asset's (pro-rated) line total in
+    // full if any part of the booking overlaps the period. This avoids
+    // pro-rating a bundle price across days, which the operator never
+    // sees in their numbers anyway. For period reporting, a booking that
     // straddles the period boundary lands fully in whichever period
     // you're looking at — acceptable; the operator can shorten the window
     // if precision matters.
-    if (b.lineTotal != null) revenue += Number(b.lineTotal);
-    projectIds.add(b.project.id);
-    if (!lastBookingEnd || b.project.rentalEndDate > lastBookingEnd) {
-      lastBookingEnd = b.project.rentalEndDate;
+    revenue += b.revenue;
+    projectIds.add(b.projectId);
+    if (!lastBookingEnd || b.rentalEndDate > lastBookingEnd) {
+      lastBookingEnd = b.rentalEndDate;
     }
   }
 

--- a/src/server/availability.ts
+++ b/src/server/availability.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
 import { getOrgContext } from "@/lib/org-context";
 
@@ -135,45 +136,82 @@ export async function getAssetBookings(
   const start = new Date(params.startDate);
   const end = new Date(params.endDate);
 
-  const lineItems = await prisma.projectLineItem.findMany({
-    where: {
-      organizationId,
-      assetId,
-      status: { not: "CANCELLED" },
-      project: {
-        isTemplate: false,
-        status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
-        rentalStartDate: { lte: end },
-        rentalEndDate: { gte: start },
-      },
-    },
-    include: {
-      project: {
-        select: {
-          id: true,
-          projectNumber: true,
-          name: true,
-          status: true,
-          rentalStartDate: true,
-          rentalEndDate: true,
-          client: { select: { name: true } },
-        },
-      },
-    },
-    orderBy: { project: { rentalStartDate: "asc" } },
-  });
+  // An asset is booked via a legacy line.assetId row OR via a
+  // ProjectLineItemUnit row (the fulfillment model) — query both.
+  const projectWindow: Prisma.ProjectWhereInput = {
+    isTemplate: false,
+    status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
+    rentalStartDate: { lte: end },
+    rentalEndDate: { gte: start },
+  };
+  const projectSelect = {
+    id: true,
+    projectNumber: true,
+    name: true,
+    status: true,
+    rentalStartDate: true,
+    rentalEndDate: true,
+    client: { select: { name: true } },
+  } as const;
 
-  const bookings: BookingEntry[] = lineItems.map((li) => ({
-    id: li.id,
-    projectId: li.project.id,
-    projectNumber: li.project.projectNumber,
-    projectName: li.project.name,
-    clientName: li.project.client?.name || null,
-    projectStatus: li.project.status,
-    rentalStartDate: li.project.rentalStartDate?.toISOString() || "",
-    rentalEndDate: li.project.rentalEndDate?.toISOString() || "",
-    quantity: li.quantity,
-  }));
+  const [lineItems, units] = await Promise.all([
+    prisma.projectLineItem.findMany({
+      where: {
+        organizationId,
+        assetId,
+        status: { not: "CANCELLED" },
+        project: projectWindow,
+      },
+      include: { project: { select: projectSelect } },
+      orderBy: { project: { rentalStartDate: "asc" } },
+    }),
+    prisma.projectLineItemUnit.findMany({
+      where: {
+        organizationId,
+        assetId,
+        status: { not: "CANCELLED" },
+        lineItem: { status: { not: "CANCELLED" }, project: projectWindow },
+      },
+      select: {
+        lineItemId: true,
+        lineItem: { select: { project: { select: projectSelect } } },
+      },
+      orderBy: { lineItem: { project: { rentalStartDate: "asc" } } },
+    }),
+  ]);
+
+  const seenLineIds = new Set<string>();
+  const bookings: BookingEntry[] = [];
+  for (const li of lineItems) {
+    seenLineIds.add(li.id);
+    bookings.push({
+      id: li.id,
+      projectId: li.project.id,
+      projectNumber: li.project.projectNumber,
+      projectName: li.project.name,
+      clientName: li.project.client?.name || null,
+      projectStatus: li.project.status,
+      rentalStartDate: li.project.rentalStartDate?.toISOString() || "",
+      rentalEndDate: li.project.rentalEndDate?.toISOString() || "",
+      quantity: li.quantity,
+    });
+  }
+  for (const u of units) {
+    if (seenLineIds.has(u.lineItemId)) continue;
+    const p = u.lineItem.project;
+    bookings.push({
+      id: u.lineItemId,
+      projectId: p.id,
+      projectNumber: p.projectNumber,
+      projectName: p.name,
+      clientName: p.client?.name || null,
+      projectStatus: p.status,
+      rentalStartDate: p.rentalStartDate?.toISOString() || "",
+      rentalEndDate: p.rentalEndDate?.toISOString() || "",
+      // One unit == one physical asset booked.
+      quantity: 1,
+    });
+  }
 
   return serialize(bookings) as BookingEntry[];
 }

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
+import { prepUnit } from "@/server/line-item-fulfillment";
 import type { Prisma } from "@/generated/prisma/client";
 import {
   completeCheckAndPackSchema,
@@ -18,69 +19,6 @@ import {
 } from "@/lib/validations/check-item";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-/**
- * Split a single unit off a multi-quantity line item.
- * Creates a new qty=1 line item copying all shared fields from the original,
- * decrements the original's quantity, and recalculates lineTotal for both.
- *
- * @param tx - Prisma transaction client
- * @param lineItem - The original line item to split from (must have quantity > 1)
- * @param overrides - Fields to set on the new split item (e.g. assetId, status, prepStatus)
- * @returns The newly created qty=1 line item (with model, asset, bulkAsset included)
- */
-export async function splitLineItem(
-  tx: Prisma.TransactionClient,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lineItem: any,
-  overrides: Record<string, unknown> = {}
-) {
-  const splitItem = await tx.projectLineItem.create({
-    data: {
-      organizationId: lineItem.organizationId,
-      projectId: lineItem.projectId,
-      type: lineItem.type,
-      modelId: lineItem.modelId,
-      description: lineItem.description,
-      quantity: 1,
-      unitPrice: lineItem.unitPrice,
-      pricingType: lineItem.pricingType,
-      duration: lineItem.duration,
-      discount: lineItem.discount,
-      lineTotal: lineItem.unitPrice
-        ? lineItem.unitPrice.toNumber() * lineItem.duration
-        : null,
-      sortOrder: lineItem.sortOrder,
-      groupName: lineItem.groupName,
-      notes: lineItem.notes,
-      isOptional: lineItem.isOptional,
-      isCustomItem: lineItem.isCustomItem,
-      showSubhireOnDocs: lineItem.showSubhireOnDocs,
-      supplierId: lineItem.supplierId,
-      subhireOrderNumber: lineItem.subhireOrderNumber,
-      supplierOrderId: lineItem.supplierOrderId,
-      isKitChild: lineItem.isKitChild,
-      parentLineItemId: lineItem.parentLineItemId,
-      pricingMode: lineItem.pricingMode,
-      ...overrides,
-    },
-    include: { model: true, asset: true, bulkAsset: true },
-  });
-
-  // Decrement original line item's quantity and recalculate lineTotal
-  const newQty = lineItem.quantity - 1;
-  await tx.projectLineItem.update({
-    where: { id: lineItem.id },
-    data: {
-      quantity: newQty,
-      lineTotal: lineItem.unitPrice
-        ? lineItem.unitPrice.toNumber() * newQty * lineItem.duration
-        : null,
-    },
-  });
-
-  return splitItem;
-}
 
 async function saveCheckRecords(
   tx: Prisma.TransactionClient,
@@ -278,57 +216,15 @@ export async function prepItemDirect(
       throw new Error("Line item not found in project");
     }
 
-    // Bulk = any multi-qty item without a specific serialized asset.
-    // Covers items with bulkAssetId AND generic multi-qty items (no assetId).
-    // Uses the same split approach as serialized items: split off qty=1 with PACKED.
-    const isBulk = !assetId && !lineItem.assetId && lineItem.quantity > 1;
-
-    if (isBulk) {
-      return await splitLineItem(tx, lineItem, {
-        bulkAssetId: lineItem.bulkAssetId,
-        status: "CONFIRMED",
-        prepStatus: "PACKED",
-        ...(prepContainer !== undefined ? { prepContainer } : {}),
-      });
-    }
-
-    // Bulk/generic item with qty=1 (last unit or already split): just mark PACKED
-    if (!assetId && !lineItem.assetId && lineItem.quantity === 1) {
-
-      const updated = await tx.projectLineItem.update({
-        where: { id: lineItemId },
-        data: {
-          status: "CONFIRMED",
-          prepStatus: "PACKED",
-          ...(prepContainer !== undefined ? { prepContainer } : {}),
-        },
-        include: { model: true, asset: true, bulkAsset: true },
-      });
-      return updated;
-    }
-
-    // Serialized: if quantity > 1 and assetId provided, split off a line item
-    if (lineItem.quantity > 1 && assetId) {
-      return await splitLineItem(tx, lineItem, {
-        assetId,
-        status: "CONFIRMED",
-        prepStatus: "PACKED",
-        ...(prepContainer !== undefined ? { prepContainer } : {}),
-      });
-    }
-
-    // Normal serialized item (qty=1 with assetId)
-    const updated = await tx.projectLineItem.update({
-      where: { id: lineItemId },
-      data: {
-        ...(assetId ? { asset: { connect: { id: assetId } } } : {}),
-        status: "CONFIRMED",
-        prepStatus: "PACKED",
-        ...(prepContainer !== undefined ? { prepContainer } : {}),
-      },
-      include: { model: true, asset: true, bulkAsset: true },
+    // Prep creates/marks a ProjectLineItemUnit — never splits the line.
+    return prepUnit(tx, {
+      organizationId,
+      lineItemId,
+      assetId: assetId ?? null,
+      bulkAssetId: assetId ? null : lineItem.bulkAssetId,
+      quantity,
+      prepContainer,
     });
-    return updated;
   });
 
   await logActivity({
@@ -719,59 +615,13 @@ export async function completeCheckAndPack(data: CompleteCheckAndPackValues) {
       parsed.checks
     );
 
-    // 3. Set prepStatus to PACKED (no checkout — deploy is a separate step)
-    // Bulk = any multi-qty item without a specific serialized asset.
-    const isBulk = !parsed.assetId && !lineItem.assetId && lineItem.quantity > 1;
-
-    if (isBulk) {
-      const splitItem = await splitLineItem(tx, lineItem, {
-        bulkAssetId: lineItem.bulkAssetId,
-        status: "CONFIRMED",
-        prepStatus: "PACKED",
-        ...(parsed.prepContainer !== undefined ? { prepContainer: parsed.prepContainer } : {}),
-      });
-      return { updatedItem: splitItem, resolvedAssetId };
-    }
-
-    // Bulk/generic item with qty=1 (last unit): just mark PACKED
-    if (!parsed.assetId && !lineItem.assetId && lineItem.quantity === 1) {
-      await tx.projectLineItem.update({
-        where: { id: parsed.lineItemId },
-        data: {
-          status: "CONFIRMED",
-          prepStatus: "PACKED",
-          ...(parsed.prepContainer !== undefined ? { prepContainer: parsed.prepContainer } : {}),
-        },
-      });
-    } else {
-      // Serialized asset — split if multi-qty with specific asset
-      if (lineItem.quantity > 1 && parsed.assetId) {
-        const splitItem = await splitLineItem(tx, lineItem, {
-          assetId: parsed.assetId,
-          status: "CONFIRMED",
-          prepStatus: "PACKED",
-          ...(parsed.prepContainer !== undefined ? { prepContainer: parsed.prepContainer } : {}),
-        });
-        return { updatedItem: splitItem, resolvedAssetId: parsed.assetId };
-      }
-
-      // Normal serialized prep (quantity == 1)
-      await tx.projectLineItem.update({
-        where: { id: parsed.lineItemId },
-        data: {
-          ...(parsed.assetId
-            ? { asset: { connect: { id: parsed.assetId } } }
-            : {}),
-          status: "CONFIRMED",
-          prepStatus: "PACKED",
-          ...(parsed.prepContainer !== undefined ? { prepContainer: parsed.prepContainer } : {}),
-        },
-      });
-    }
-
-    const updatedItem = await tx.projectLineItem.findUnique({
-      where: { id: parsed.lineItemId },
-      include: { model: true, asset: true, bulkAsset: true },
+    // 3. Prep — create/mark the unit (no checkout; deploy is a separate step).
+    const updatedItem = await prepUnit(tx, {
+      organizationId,
+      lineItemId: parsed.lineItemId,
+      assetId: parsed.assetId ?? null,
+      bulkAssetId: parsed.assetId ? null : lineItem.bulkAssetId,
+      prepContainer: parsed.prepContainer,
     });
 
     return { updatedItem, resolvedAssetId };

--- a/src/server/line-item-fulfillment.ts
+++ b/src/server/line-item-fulfillment.ts
@@ -132,3 +132,75 @@ export async function ensureBulkUnit(
   });
   return { id: unit.id, created: true };
 }
+
+/**
+ * Mark a unit prepped/packed (the pick-and-pack step before checkout).
+ * Serialised and bulk lines get a PACKED unit row; a generic line with no
+ * asset assigned just carries prepStatus on the order line. Rolls the line
+ * up and returns it (with model/asset/bulkAsset included).
+ */
+export async function prepUnit(
+  tx: Prisma.TransactionClient,
+  args: {
+    organizationId: string;
+    lineItemId: string;
+    assetId?: string | null;
+    bulkAssetId?: string | null;
+    quantity?: number;
+    prepContainer?: string | null;
+  },
+) {
+  if (args.assetId) {
+    const { id } = await ensureSerialisedUnit(tx, {
+      organizationId: args.organizationId,
+      lineItemId: args.lineItemId,
+      assetId: args.assetId,
+    });
+    await tx.projectLineItemUnit.update({
+      where: { id },
+      data: {
+        status: "CONFIRMED",
+        prepStatus: "PACKED",
+        ...(args.prepContainer !== undefined
+          ? { prepContainer: args.prepContainer }
+          : {}),
+      },
+    });
+  } else if (args.bulkAssetId) {
+    const { id } = await ensureBulkUnit(tx, {
+      organizationId: args.organizationId,
+      lineItemId: args.lineItemId,
+      bulkAssetId: args.bulkAssetId,
+      quantity: args.quantity ?? 1,
+    });
+    await tx.projectLineItemUnit.update({
+      where: { id },
+      data: {
+        status: "CONFIRMED",
+        prepStatus: "PACKED",
+        ...(args.quantity !== undefined ? { quantity: args.quantity } : {}),
+        ...(args.prepContainer !== undefined
+          ? { prepContainer: args.prepContainer }
+          : {}),
+      },
+    });
+  } else {
+    // Generic line, no serial scanned — mark prep state on the line itself.
+    await tx.projectLineItem.update({
+      where: { id: args.lineItemId },
+      data: {
+        status: "CONFIRMED",
+        prepStatus: "PACKED",
+        ...(args.prepContainer !== undefined
+          ? { prepContainer: args.prepContainer }
+          : {}),
+      },
+    });
+  }
+
+  await syncLineItemRollup(tx, args.lineItemId);
+  return tx.projectLineItem.findUniqueOrThrow({
+    where: { id: args.lineItemId },
+    include: { model: true, asset: true, bulkAsset: true },
+  });
+}

--- a/src/server/line-item-fulfillment.ts
+++ b/src/server/line-item-fulfillment.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared transaction-level helpers for the line-item fulfillment model.
+ *
+ * The order line (`ProjectLineItem`) keeps its quantity and its denormalised
+ * rollup fields; the truth for each physical unit lives in
+ * `ProjectLineItemUnit`. Checkout / check-in / prep / kit flows all mutate
+ * unit rows and then call `syncLineItemRollup` so the order line never
+ * drifts from its units.
+ *
+ * See docs/designs/line-item-fulfillment-model.md.
+ */
+
+import type { Prisma } from "@/generated/prisma/client";
+import {
+  computeRollupCounters,
+  deriveOrderLineStatus,
+  nextOrdinal,
+} from "@/lib/line-item-units";
+
+/** Columns the rollup needs off each unit row. */
+const UNIT_ROLLUP_SELECT = {
+  quantity: true,
+  returnedQuantity: true,
+  status: true,
+  prepStatus: true,
+  returnCondition: true,
+  returnStatus: true,
+} as const;
+
+/**
+ * Recompute a line item's rollup counters and derived display status from
+ * its unit rows, and persist them. MUST be called inside the same
+ * transaction as the unit write that triggered it.
+ */
+export async function syncLineItemRollup(
+  tx: Prisma.TransactionClient,
+  lineItemId: string,
+): Promise<void> {
+  const line = await tx.projectLineItem.findUnique({
+    where: { id: lineItemId },
+    select: { status: true },
+  });
+  if (!line) return;
+
+  const units = await tx.projectLineItemUnit.findMany({
+    where: { lineItemId },
+    select: UNIT_ROLLUP_SELECT,
+  });
+
+  await tx.projectLineItem.update({
+    where: { id: lineItemId },
+    data: {
+      ...computeRollupCounters(units),
+      status: deriveOrderLineStatus(line.status, units),
+    },
+  });
+}
+
+/**
+ * Find the existing unit for a (lineItem, asset) pair, or create one.
+ * Serialised assets are one unit per asset (`quantity` 1); the
+ * `[lineItemId, assetId]` unique index makes this idempotent under
+ * concurrent scans.
+ */
+export async function ensureSerialisedUnit(
+  tx: Prisma.TransactionClient,
+  args: {
+    organizationId: string;
+    lineItemId: string;
+    assetId: string;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const existing = await tx.projectLineItemUnit.findUnique({
+    where: {
+      lineItemId_assetId: {
+        lineItemId: args.lineItemId,
+        assetId: args.assetId,
+      },
+    },
+    select: { id: true },
+  });
+  if (existing) return { id: existing.id, created: false };
+
+  const siblings = await tx.projectLineItemUnit.findMany({
+    where: { lineItemId: args.lineItemId },
+    select: { ordinal: true },
+  });
+  const unit = await tx.projectLineItemUnit.create({
+    data: {
+      organizationId: args.organizationId,
+      lineItemId: args.lineItemId,
+      ordinal: nextOrdinal(siblings),
+      assetId: args.assetId,
+      quantity: 1,
+      status: "CONFIRMED",
+    },
+    select: { id: true },
+  });
+  return { id: unit.id, created: true };
+}
+
+/**
+ * Find the bulk unit row for a line, or create it. A bulk line has a single
+ * unit row carrying the quantity (bulk assets are a stock pool, not
+ * individually identifiable units).
+ */
+export async function ensureBulkUnit(
+  tx: Prisma.TransactionClient,
+  args: {
+    organizationId: string;
+    lineItemId: string;
+    bulkAssetId: string;
+    quantity: number;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const existing = await tx.projectLineItemUnit.findFirst({
+    where: { lineItemId: args.lineItemId, bulkAssetId: args.bulkAssetId },
+    select: { id: true },
+  });
+  if (existing) return { id: existing.id, created: false };
+
+  const unit = await tx.projectLineItemUnit.create({
+    data: {
+      organizationId: args.organizationId,
+      lineItemId: args.lineItemId,
+      ordinal: 1,
+      bulkAssetId: args.bulkAssetId,
+      quantity: args.quantity,
+      status: "CONFIRMED",
+    },
+    select: { id: true },
+  });
+  return { id: unit.id, created: true };
+}

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import {
   lineItemSchema,
@@ -43,27 +44,54 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         });
       }
 
-      // Specific asset — check if it's booked in an overlapping project (only when dates exist)
+      // Specific asset — check if it's booked in an overlapping project
+      // (only when dates exist). The asset may be assigned via a legacy
+      // line.assetId row OR via a ProjectLineItemUnit (the fulfillment
+      // model) — both tables must be checked.
       if (hasDates) {
-        const conflict = await prisma.projectLineItem.findFirst({
-          where: {
-            organizationId,
-            assetId: parsed.assetId,
-            status: { not: "CANCELLED" },
-            project: {
-              status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
-              rentalStartDate: { lte: project!.rentalEndDate! },
-              rentalEndDate: { gte: project!.rentalStartDate! },
-              id: { not: projectId },
+        const conflictWindow: Prisma.ProjectWhereInput = {
+          status: { notIn: ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"] },
+          isTemplate: false,
+          rentalStartDate: { lte: project!.rentalEndDate! },
+          rentalEndDate: { gte: project!.rentalStartDate! },
+          id: { not: projectId },
+        };
+        const [lineConflict, unitConflict] = await Promise.all([
+          prisma.projectLineItem.findFirst({
+            where: {
+              organizationId,
+              assetId: parsed.assetId,
+              status: { not: "CANCELLED" },
+              project: conflictWindow,
             },
-          },
-          include: { project: { select: { projectNumber: true, name: true } } },
-        });
-        if (conflict) {
+            select: { project: { select: { projectNumber: true, name: true } } },
+          }),
+          prisma.projectLineItemUnit.findFirst({
+            where: {
+              organizationId,
+              assetId: parsed.assetId,
+              status: { not: "RETURNED" },
+              lineItem: {
+                status: { not: "CANCELLED" },
+                project: conflictWindow,
+              },
+            },
+            select: {
+              lineItem: {
+                select: {
+                  project: { select: { projectNumber: true, name: true } },
+                },
+              },
+            },
+          }),
+        ]);
+        const conflictProject =
+          lineConflict?.project ?? unitConflict?.lineItem.project;
+        if (conflictProject) {
           throw new UserFacingError({
             code: "ASSET_DOUBLE_BOOKED",
             title: "Asset already booked",
-            message: `This asset is booked on ${conflict.project.projectNumber} — ${conflict.project.name} during those dates.`,
+            message: `This asset is booked on ${conflictProject.projectNumber} — ${conflictProject.name} during those dates.`,
             hint: "Pick a different asset, adjust the rental dates, or remove it from the other project.",
           });
         }

--- a/src/server/split-sibling-collapse.int.test.ts
+++ b/src/server/split-sibling-collapse.int.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Integration tests for the Phase 3.8 split-sibling collapse migration.
+ *
+ * Pure helper logic is unit-tested in
+ * `src/lib/split-sibling-collapse.test.ts`. These tests drive the
+ * end-to-end transaction: shape the DB like real historic split-sibling
+ * data, run the collapse, assert the post-state.
+ *
+ * Each test verifies one of:
+ *   - mergeable group: 3 split siblings collapse to 1 canonical line +
+ *     3 units, sibling rows deactivated, CheckRecord/DamageEvent
+ *     repointed, audit row written, rollup counters recomputed.
+ *   - flagged group: divergent unitPrice ⇒ not merged.
+ *   - dry-run: zero mutations, plan reflects what would happen.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+  createAssetFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { runCollapse } from "@/server/split-sibling-collapse";
+
+async function createProject(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Collapse Test",
+      taxRate: 0,
+    },
+  });
+}
+
+/**
+ * Create what historic `splitLineItem` produced: one ProjectLineItem
+ * per asset, qty 1, all sharing the same order-level fields. Also
+ * creates the Phase-2a-style unit row for each.
+ */
+async function createSplitSiblings(
+  orgId: string,
+  projectId: string,
+  modelId: string,
+  assetIds: string[],
+  overrides: { unitPrice?: number; description?: string; sortOrder?: number } = {},
+) {
+  const lines: { id: string; assetId: string }[] = [];
+  for (let i = 0; i < assetIds.length; i++) {
+    const line = await testPrisma.projectLineItem.create({
+      data: {
+        organizationId: orgId,
+        projectId,
+        modelId,
+        assetId: assetIds[i],
+        type: "EQUIPMENT",
+        quantity: 1,
+        unitPrice: overrides.unitPrice ?? 100,
+        pricingType: "FLAT",
+        duration: 1,
+        lineTotal: overrides.unitPrice ?? 100,
+        description: overrides.description ?? null,
+        sortOrder: (overrides.sortOrder ?? 0) + i,
+        status: "CONFIRMED",
+      },
+    });
+    // Phase 2a unit.
+    await testPrisma.projectLineItemUnit.create({
+      data: {
+        organizationId: orgId,
+        lineItemId: line.id,
+        ordinal: 1,
+        assetId: assetIds[i],
+        quantity: 1,
+        status: "CONFIRMED",
+      },
+    });
+    lines.push({ id: line.id, assetId: assetIds[i] });
+  }
+  return lines;
+}
+
+describe("runCollapse — split-sibling collapse", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("dry-run reports the merge plan and mutates nothing", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "DR-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "DR-2" });
+    const lines = await createSplitSiblings(org.id, project.id, model.id, [a1.id, a2.id]);
+
+    const result = await runCollapse({
+      apply: false,
+      projectId: project.id,
+      runId: "test-dry",
+    });
+
+    expect(result.mergeable).toHaveLength(1);
+    expect(result.mergeable[0].moves).toHaveLength(1);
+    expect(result.flagged).toHaveLength(0);
+
+    // No mutations.
+    for (const l of lines) {
+      const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+        where: { id: l.id },
+      });
+      expect(refreshed.quantity).toBe(1);
+      expect(refreshed.status).toBe("CONFIRMED");
+    }
+    expect(await testPrisma.lineItemMergeMap.count()).toBe(0);
+  });
+
+  it("apply: three siblings collapse to one canonical with three units", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "A1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "A2" });
+    const a3 = await createAssetFixture(org.id, model.id, { assetTag: "A3" });
+    const [canonical, s1, s2] = await createSplitSiblings(
+      org.id,
+      project.id,
+      model.id,
+      [a1.id, a2.id, a3.id],
+      { sortOrder: 0 },
+    );
+
+    const result = await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "test-apply",
+    });
+
+    expect(result.stats.groupsMergeable).toBe(1);
+    expect(result.stats.rowsMergedAway).toBe(2);
+    expect(result.stats.unitsMoved).toBe(2);
+
+    // Canonical: quantity grows to 3, units count = 3.
+    const can = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: canonical.id },
+    });
+    expect(can.quantity).toBe(3);
+    expect(can.status).not.toBe("CANCELLED");
+    const canUnits = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: canonical.id },
+      orderBy: { ordinal: "asc" },
+    });
+    expect(canUnits).toHaveLength(3);
+    // Each unit points at a distinct asset, ordinals are unique.
+    expect(new Set(canUnits.map((u) => u.assetId))).toEqual(
+      new Set([a1.id, a2.id, a3.id]),
+    );
+    expect(new Set(canUnits.map((u) => u.ordinal)).size).toBe(3);
+
+    // Siblings: inert.
+    for (const s of [s1, s2]) {
+      const r = await testPrisma.projectLineItem.findUniqueOrThrow({
+        where: { id: s.id },
+      });
+      expect(r.status).toBe("CANCELLED");
+      expect(r.quantity).toBe(0);
+      expect(r.assetId).toBeNull();
+    }
+
+    // Audit rows persisted.
+    const maps = await testPrisma.lineItemMergeMap.findMany({
+      where: { canonicalLineItemId: canonical.id },
+    });
+    expect(maps).toHaveLength(2);
+    expect(maps.every((m) => m.notes?.includes("test-apply"))).toBe(true);
+  });
+
+  it("CheckRecord rows on a sibling get repointed onto the canonical with lineItemUnitId set", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "CR-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "CR-2" });
+    const [canonical, sibling] = await createSplitSiblings(
+      org.id,
+      project.id,
+      model.id,
+      [a1.id, a2.id],
+    );
+
+    // Set up a CheckItem + CheckRecord on the sibling.
+    const checkItem = await testPrisma.checkItem.create({
+      data: {
+        organizationId: org.id,
+        label: "Functional check",
+        type: "PASS_FAIL",
+      },
+    });
+    const checkRecord = await testPrisma.checkRecord.create({
+      data: {
+        organizationId: org.id,
+        context: "PREP",
+        lineItemId: sibling.id,
+        assetId: a2.id,
+        checkItemId: checkItem.id,
+        checkItemLabelSnapshot: "Functional check",
+        checkItemTypeSnapshot: "PASS_FAIL",
+        result: "PASS",
+        performedById: user.id,
+      },
+    });
+
+    await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "test-cr",
+    });
+
+    const refreshed = await testPrisma.checkRecord.findUniqueOrThrow({
+      where: { id: checkRecord.id },
+    });
+    expect(refreshed.lineItemId).toBe(canonical.id);
+    // The matching-asset CheckRecord should now point at the moved unit.
+    const movedUnit = await testPrisma.projectLineItemUnit.findFirstOrThrow({
+      where: { lineItemId: canonical.id, assetId: a2.id },
+    });
+    expect(refreshed.lineItemUnitId).toBe(movedUnit.id);
+  });
+
+  it("DamageEvent rows on a sibling get repointed similarly", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "DE-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "DE-2" });
+    const [canonical, sibling] = await createSplitSiblings(
+      org.id,
+      project.id,
+      model.id,
+      [a1.id, a2.id],
+    );
+
+    const damage = await testPrisma.damageEvent.create({
+      data: {
+        organizationId: org.id,
+        projectId: project.id,
+        lineItemId: sibling.id,
+        assetId: a2.id,
+        severity: "MINOR",
+        status: "OPEN",
+        createdById: user.id,
+      },
+    });
+
+    await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "test-de",
+    });
+
+    const refreshed = await testPrisma.damageEvent.findUniqueOrThrow({
+      where: { id: damage.id },
+    });
+    expect(refreshed.lineItemId).toBe(canonical.id);
+    const movedUnit = await testPrisma.projectLineItemUnit.findFirstOrThrow({
+      where: { lineItemId: canonical.id, assetId: a2.id },
+    });
+    expect(refreshed.lineItemUnitId).toBe(movedUnit.id);
+  });
+
+  it("flags a group with divergent unitPrice — refuses to merge", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "FX-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "FX-2" });
+    await createSplitSiblings(org.id, project.id, model.id, [a1.id], { unitPrice: 100 });
+    await createSplitSiblings(org.id, project.id, model.id, [a2.id], { unitPrice: 150 });
+
+    const result = await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "test-flag",
+    });
+
+    // Two singleton equivalence groups ⇒ neither merges.
+    expect(result.mergeable).toHaveLength(0);
+    expect(await testPrisma.lineItemMergeMap.count()).toBe(0);
+  });
+
+  it("flags a group with divergent description but otherwise identical", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "DS-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "DS-2" });
+    const a3 = await createAssetFixture(org.id, model.id, { assetTag: "DS-3" });
+    await createSplitSiblings(org.id, project.id, model.id, [a1.id, a2.id], {
+      description: "stage",
+    });
+    await createSplitSiblings(org.id, project.id, model.id, [a3.id], {
+      description: "FOH",
+    });
+
+    const result = await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "test-desc",
+    });
+
+    expect(result.mergeable).toHaveLength(1); // only the "stage" pair
+    expect(result.mergeable[0].moves).toHaveLength(1);
+    const audit = await testPrisma.lineItemMergeMap.findMany();
+    expect(audit).toHaveLength(1);
+  });
+
+  it("idempotent: a second run finds nothing to merge", async () => {
+    const org = await createOrgFixture();
+    await createUserFixture(org.id);
+    const model = await createModelFixture(org.id);
+    const project = await createProject(org.id);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "ID-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "ID-2" });
+    await createSplitSiblings(org.id, project.id, model.id, [a1.id, a2.id]);
+
+    await runCollapse({ apply: true, projectId: project.id, runId: "first" });
+    const second = await runCollapse({
+      apply: true,
+      projectId: project.id,
+      runId: "second",
+    });
+    expect(second.stats.groupsMergeable).toBe(0);
+    expect(second.stats.rowsMergedAway).toBe(0);
+  });
+});

--- a/src/server/split-sibling-collapse.ts
+++ b/src/server/split-sibling-collapse.ts
@@ -1,0 +1,293 @@
+/**
+ * Apply-side of the Phase 3.8 split-sibling collapse migration.
+ *
+ * The pure plan / equivalence-key logic lives in
+ * `src/lib/split-sibling-collapse.ts`. This module owns the
+ * transactional writes: moving units, repointing CheckRecord /
+ * DamageEvent / ProjectService FKs, deactivating the sibling row, and
+ * writing the LineItemMergeMap audit row.
+ *
+ * Lives outside `"use server"` so the script and integration tests can
+ * drive it directly.
+ *
+ * See docs/designs/line-item-fulfillment-model.md (Phase 2b).
+ */
+
+import { prisma } from "@/lib/prisma";
+import {
+  planAll,
+  type CollapseRow,
+  type GroupPlan,
+} from "@/lib/split-sibling-collapse";
+import { nextOrdinal } from "@/lib/line-item-units";
+import { syncLineItemRollup } from "@/server/line-item-fulfillment";
+
+export interface CollapseRunStats {
+  groupsTotal: number;
+  groupsMergeable: number;
+  groupsFlagged: number;
+  rowsMergedAway: number;
+  unitsMoved: number;
+  checkRecordsRepointed: number;
+  damageEventsRepointed: number;
+  servicesRepointed: number;
+  /** Echoed back for logging — caller-supplied. */
+  runId: string;
+}
+
+export interface CollapseRunResult {
+  stats: CollapseRunStats;
+  plans: GroupPlan[];
+  /** Plans where flags.length === 0. */
+  mergeable: GroupPlan[];
+  flagged: GroupPlan[];
+}
+
+/** Snapshot of the columns the planner needs. */
+const CANDIDATE_SELECT = {
+  id: true,
+  organizationId: true,
+  projectId: true,
+  type: true,
+  modelId: true,
+  assetId: true,
+  bulkAssetId: true,
+  kitId: true,
+  isKitChild: true,
+  parentLineItemId: true,
+  pricingMode: true,
+  description: true,
+  quantity: true,
+  unitPrice: true,
+  pricingType: true,
+  duration: true,
+  discount: true,
+  priceOverridden: true,
+  overrideReason: true,
+  sortOrder: true,
+  groupName: true,
+  categoryId: true,
+  groupId: true,
+  notes: true,
+  isOptional: true,
+  isContainerLineItem: true,
+  isCustomItem: true,
+  showSubhireOnDocs: true,
+  supplierId: true,
+  subhireOrderNumber: true,
+  supplierOrderId: true,
+  subHireId: true,
+  subHireItemId: true,
+  subHireGroupId: true,
+  createdAt: true,
+} as const;
+
+export interface RunOptions {
+  /** Pass true to actually mutate. Otherwise plan-only. */
+  apply: boolean;
+  /** Scope to one org. */
+  organizationId?: string;
+  /** Scope to one project (helpful for testing). */
+  projectId?: string;
+  /** Stamped on every LineItemMergeMap row. */
+  runId: string;
+}
+
+/**
+ * Find every split-sibling group in scope, plan the merges, and
+ * (if `apply`) execute them group by group. Each group runs in its own
+ * transaction so one pathological group fails alone.
+ */
+export async function runCollapse(opts: RunOptions): Promise<CollapseRunResult> {
+  const candidates = await prisma.projectLineItem.findMany({
+    where: {
+      ...(opts.organizationId ? { organizationId: opts.organizationId } : {}),
+      ...(opts.projectId ? { projectId: opts.projectId } : {}),
+      type: "EQUIPMENT",
+      OR: [{ assetId: { not: null } }, { bulkAssetId: { not: null } }],
+      isKitChild: false,
+      // Skip already-merged-away rows.
+      NOT: { AND: [{ status: "CANCELLED" }, { quantity: 0 }] },
+    },
+    select: CANDIDATE_SELECT,
+    orderBy: [{ projectId: "asc" }, { sortOrder: "asc" }, { createdAt: "asc" }],
+  });
+
+  const plans = planAll(candidates as unknown as CollapseRow[]);
+  const mergeable = plans.filter((p) => p.flags.length === 0);
+  const flagged = plans.filter((p) => p.flags.length > 0);
+
+  const stats: CollapseRunStats = {
+    groupsTotal: plans.length,
+    groupsMergeable: mergeable.length,
+    groupsFlagged: flagged.length,
+    rowsMergedAway: 0,
+    unitsMoved: 0,
+    checkRecordsRepointed: 0,
+    damageEventsRepointed: 0,
+    servicesRepointed: 0,
+    runId: opts.runId,
+  };
+
+  if (!opts.apply) {
+    // Dry-run still reports what WOULD merge.
+    for (const p of mergeable) stats.rowsMergedAway += p.moves.length;
+    return { stats, plans, mergeable, flagged };
+  }
+
+  for (const plan of mergeable) {
+    // Re-find canonical's org each iteration — cheaper than building a
+    // map and clearer for the audit row.
+    const canonical = await prisma.projectLineItem.findUnique({
+      where: { id: plan.canonicalId },
+      select: { organizationId: true },
+    });
+    if (!canonical) continue;
+    await mergeGroup(plan, canonical.organizationId, opts.runId, stats);
+  }
+
+  return { stats, plans, mergeable, flagged };
+}
+
+/**
+ * Execute one merge group atomically. Exported for the integration test.
+ */
+export async function mergeGroup(
+  plan: GroupPlan,
+  organizationId: string,
+  runId: string,
+  stats: CollapseRunStats,
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const canonicalUnits = await tx.projectLineItemUnit.findMany({
+      where: { lineItemId: plan.canonicalId },
+      select: { ordinal: true },
+    });
+    const usedOrdinals = new Set(canonicalUnits.map((u) => u.ordinal));
+
+    let quantityAdded = 0;
+
+    for (const move of plan.moves) {
+      // Look up the sibling's existing unit (Phase 2a backfill creates
+      // one per asset). Absent ⇒ pre-Phase-2a or kit child — repoint
+      // FKs anyway, just skip the lineItemUnitId enrichment.
+      let unit: { id: string } | null = null;
+      if (move.assetId) {
+        unit = await tx.projectLineItemUnit.findUnique({
+          where: {
+            lineItemId_assetId: {
+              lineItemId: move.siblingId,
+              assetId: move.assetId,
+            },
+          },
+          select: { id: true },
+        });
+      } else if (move.bulkAssetId) {
+        unit = await tx.projectLineItemUnit.findFirst({
+          where: {
+            lineItemId: move.siblingId,
+            bulkAssetId: move.bulkAssetId,
+          },
+          select: { id: true },
+        });
+      }
+
+      let movedUnitId: string | null = null;
+      if (unit) {
+        let ord = nextOrdinal(
+          [...usedOrdinals].map((o) => ({ ordinal: o })),
+        );
+        // Defensive: nextOrdinal returns max+1; loop in case of races.
+        while (usedOrdinals.has(ord)) ord += 1;
+        usedOrdinals.add(ord);
+
+        await tx.projectLineItemUnit.update({
+          where: { id: unit.id },
+          data: { lineItemId: plan.canonicalId, ordinal: ord },
+        });
+        movedUnitId = unit.id;
+        stats.unitsMoved += 1;
+      }
+
+      // Repoint CheckRecord — first the matching-asset rows get
+      // lineItemUnitId filled too; remaining rows just get the FK
+      // updated.
+      if (movedUnitId && (move.assetId || move.bulkAssetId)) {
+        const matched = await tx.checkRecord.updateMany({
+          where: {
+            lineItemId: move.siblingId,
+            ...(move.assetId
+              ? { assetId: move.assetId }
+              : { bulkAssetId: move.bulkAssetId }),
+          },
+          data: { lineItemId: plan.canonicalId, lineItemUnitId: movedUnitId },
+        });
+        stats.checkRecordsRepointed += matched.count;
+      }
+      const remaining = await tx.checkRecord.updateMany({
+        where: { lineItemId: move.siblingId },
+        data: { lineItemId: plan.canonicalId },
+      });
+      stats.checkRecordsRepointed += remaining.count;
+
+      if (movedUnitId && (move.assetId || move.bulkAssetId)) {
+        const matched = await tx.damageEvent.updateMany({
+          where: {
+            lineItemId: move.siblingId,
+            ...(move.assetId
+              ? { assetId: move.assetId }
+              : { bulkAssetId: move.bulkAssetId }),
+          },
+          data: { lineItemId: plan.canonicalId, lineItemUnitId: movedUnitId },
+        });
+        stats.damageEventsRepointed += matched.count;
+      }
+      const remainingDmg = await tx.damageEvent.updateMany({
+        where: { lineItemId: move.siblingId },
+        data: { lineItemId: plan.canonicalId },
+      });
+      stats.damageEventsRepointed += remainingDmg.count;
+
+      const serviceMove = await tx.projectService.updateMany({
+        where: { lineItemId: move.siblingId },
+        data: { lineItemId: plan.canonicalId },
+      });
+      stats.servicesRepointed += serviceMove.count;
+
+      // Audit row — permanent. Never auto-cleaned.
+      await tx.lineItemMergeMap.create({
+        data: {
+          organizationId,
+          oldLineItemId: move.siblingId,
+          canonicalLineItemId: plan.canonicalId,
+          movedUnitId,
+          checkRecordsRepointed: 0, // per-row counts aggregate at stats level
+          damageEventsRepointed: 0,
+          serviceRepointed: serviceMove.count > 0,
+          notes: `${runId} | key=${plan.key}`,
+        },
+      });
+
+      // Deactivate the sibling: keep the row for audit, drop its
+      // booking footprint so every reader treats it as gone.
+      await tx.projectLineItem.update({
+        where: { id: move.siblingId },
+        data: {
+          assetId: null,
+          bulkAssetId: null,
+          quantity: 0,
+          status: "CANCELLED",
+          notes: `[merged into ${plan.canonicalId} on ${new Date().toISOString()} (${runId})]`,
+        },
+      });
+      stats.rowsMergedAway += 1;
+      quantityAdded += move.quantity;
+    }
+
+    await tx.projectLineItem.update({
+      where: { id: plan.canonicalId },
+      data: { quantity: { increment: quantityAdded } },
+    });
+    await syncLineItemRollup(tx, plan.canonicalId);
+  });
+}

--- a/src/server/warehouse-checkin.int.test.ts
+++ b/src/server/warehouse-checkin.int.test.ts
@@ -29,7 +29,11 @@ vi.mock("@/lib/org-context", () => ({
   getOrgContext: async () => h.ctx,
 }));
 
-import { checkOutItems, checkInItems } from "@/server/warehouse";
+import {
+  checkOutItems,
+  checkInItems,
+  lookupAssetForScan,
+} from "@/server/warehouse";
 
 async function createProjectFixture(orgId: string) {
   return testPrisma.project.create({
@@ -188,5 +192,74 @@ describe("checkInItems — fulfillment model round-trip", () => {
     });
     expect(refreshed.status).toBe("RETURNED");
     expect(refreshed.returnedQuantity).toBe(10);
+  });
+
+  it("returning a line with no asset specified returns every out unit", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 2,
+    });
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "WL-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "WL-2" });
+
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: a1.id },
+      { lineItemId: line.id, assetId: a2.id },
+    ]);
+    // "Return whole line" — no assetId given.
+    await checkInItems(project.id, [
+      { lineItemId: line.id, returnCondition: "GOOD" },
+    ]);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units.every((u) => u.status === "RETURNED")).toBe(true);
+    const assets = await testPrisma.asset.findMany({
+      where: { id: { in: [a1.id, a2.id] } },
+    });
+    expect(assets.every((a) => a.status === "AVAILABLE")).toBe(true);
+  });
+
+  it("lookupAssetForScan resolves a deployed asset for check-in via its unit", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 1,
+    });
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "SCAN-1",
+    });
+
+    // Before deployment: nothing to check in.
+    const before = (await lookupAssetForScan(
+      project.id,
+      "SCAN-1",
+      "checkin",
+    )) as { reason: string | null };
+    expect(before.reason).toBe("not_checked_out");
+
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: asset.id },
+    ]);
+
+    // After deployment: resolves to the line + asset, ready to return.
+    const after = (await lookupAssetForScan(
+      project.id,
+      "SCAN-1",
+      "checkin",
+    )) as { reason: string | null; lineItemId: string | null; assetId: string | null };
+    expect(after.reason).toBeNull();
+    expect(after.lineItemId).toBe(line.id);
+    expect(after.assetId).toBe(asset.id);
   });
 });

--- a/src/server/warehouse-checkin.int.test.ts
+++ b/src/server/warehouse-checkin.int.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration tests for check-in under the line-item fulfillment model
+ * (Phase 3.4). Exercises the full deploy → return round-trip so checkout
+ * and check-in are verified together — the eng review rated check-in the
+ * highest-risk piece (a wrong rewrite strands an asset CHECKED_OUT).
+ *
+ * `@/lib/org-context` is mocked so the real warehouse.ts logic runs
+ * against the Postgres test DB.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+  createAssetFixture,
+  createBulkAssetFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import { checkOutItems, checkInItems } from "@/server/warehouse";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Test Project",
+      taxRate: 0,
+    },
+  });
+}
+
+async function createLineItemFixture(
+  orgId: string,
+  projectId: string,
+  modelId: string,
+  overrides?: { quantity?: number; bulkAssetId?: string },
+) {
+  return testPrisma.projectLineItem.create({
+    data: {
+      organizationId: orgId,
+      projectId,
+      modelId,
+      quantity: overrides?.quantity ?? 1,
+      bulkAssetId: overrides?.bulkAssetId ?? null,
+      status: "CONFIRMED",
+    },
+  });
+}
+
+describe("checkInItems — fulfillment model round-trip", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("deploy two, return one then the other — counters track partial state", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 3,
+    });
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "RT-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "RT-2" });
+
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: a1.id },
+      { lineItemId: line.id, assetId: a2.id },
+    ]);
+
+    // Return the first unit.
+    await checkInItems(project.id, [
+      { lineItemId: line.id, assetId: a1.id, returnCondition: "GOOD" },
+    ]);
+
+    let refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    // One unit back, one still out — line stays CHECKED_OUT.
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.checkedOutQuantity).toBe(1);
+    expect(refreshed.returnedQuantity).toBe(1);
+    expect(
+      (await testPrisma.asset.findUniqueOrThrow({ where: { id: a1.id } }))
+        .status,
+    ).toBe("AVAILABLE");
+
+    // Return the second.
+    await checkInItems(project.id, [
+      { lineItemId: line.id, assetId: a2.id, returnCondition: "GOOD" },
+    ]);
+
+    refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("RETURNED");
+    expect(refreshed.checkedOutQuantity).toBe(0);
+    expect(refreshed.returnedQuantity).toBe(2);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units.every((u) => u.status === "RETURNED")).toBe(true);
+  });
+
+  it("a damaged return sends the asset to maintenance and counts the damage", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 1,
+    });
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "DMG-1",
+    });
+
+    await checkOutItems(project.id, [{ lineItemId: line.id, assetId: asset.id }]);
+    await checkInItems(project.id, [
+      { lineItemId: line.id, assetId: asset.id, returnCondition: "DAMAGED" },
+    ]);
+
+    expect(
+      (await testPrisma.asset.findUniqueOrThrow({ where: { id: asset.id } }))
+        .status,
+    ).toBe("IN_MAINTENANCE");
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.damagedQuantity).toBe(1);
+    expect(refreshed.status).toBe("RETURNED");
+  });
+
+  it("bulk return accumulates from partial to fully returned", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const bulk = await createBulkAssetFixture(org.id, model.id, {
+      assetTag: "BULK-RT",
+      total: 30,
+    });
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 10,
+      bulkAssetId: bulk.id,
+    });
+
+    await checkOutItems(project.id, [{ lineItemId: line.id, quantity: 10 }]);
+    await checkInItems(project.id, [
+      { lineItemId: line.id, returnCondition: "GOOD", quantity: 4 },
+    ]);
+
+    let refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.returnedQuantity).toBe(4);
+    expect(refreshed.checkedOutQuantity).toBe(6);
+
+    await checkInItems(project.id, [
+      { lineItemId: line.id, returnCondition: "GOOD", quantity: 6 },
+    ]);
+    refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("RETURNED");
+    expect(refreshed.returnedQuantity).toBe(10);
+  });
+});

--- a/src/server/warehouse-checkin.int.test.ts
+++ b/src/server/warehouse-checkin.int.test.ts
@@ -226,6 +226,47 @@ describe("checkInItems — fulfillment model round-trip", () => {
     expect(assets.every((a) => a.status === "AVAILABLE")).toBe(true);
   });
 
+  it("checks in a kit-child line (asset on the line, no unit row)", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "KIT-CHILD-1",
+      status: "CHECKED_OUT",
+    });
+    // A kit child: asset pinned to the line directly, deployed, no unit row.
+    const child = await testPrisma.projectLineItem.create({
+      data: {
+        organizationId: org.id,
+        projectId: project.id,
+        modelId: model.id,
+        quantity: 1,
+        isKitChild: true,
+        assetId: asset.id,
+        status: "CHECKED_OUT",
+      },
+    });
+
+    await checkInItems(project.id, [
+      { lineItemId: child.id, assetId: asset.id, returnCondition: "GOOD" },
+    ]);
+
+    expect(
+      (await testPrisma.asset.findUniqueOrThrow({ where: { id: asset.id } }))
+        .status,
+    ).toBe("AVAILABLE");
+    expect(
+      (
+        await testPrisma.projectLineItem.findUniqueOrThrow({
+          where: { id: child.id },
+        })
+      ).status,
+    ).toBe("RETURNED");
+  });
+
   it("lookupAssetForScan resolves a deployed asset for check-in via its unit", async () => {
     const org = await createOrgFixture();
     const user = await createUserFixture(org.id);

--- a/src/server/warehouse-checkout.int.test.ts
+++ b/src/server/warehouse-checkout.int.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for checkout under the line-item fulfillment model
+ * (Phase 3.2 of docs/designs/line-item-fulfillment-model.md).
+ *
+ * The invariant under test: scanning an asset to deploy creates a
+ * ProjectLineItemUnit and rolls it up onto the order line. It must NEVER
+ * split a qty-N line into N rows — the bug this whole rework fixes.
+ *
+ * `checkOutItems` gates on `requirePermission`, which needs a request
+ * scope, so `@/lib/org-context` is mocked with a hoisted mutable context;
+ * the real warehouse.ts logic then runs against the Postgres test DB.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+  createAssetFixture,
+  createBulkAssetFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import { checkOutItems } from "@/server/warehouse";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Test Project",
+      taxRate: 0,
+    },
+  });
+}
+
+async function createLineItemFixture(
+  orgId: string,
+  projectId: string,
+  modelId: string,
+  overrides?: { quantity?: number; bulkAssetId?: string },
+) {
+  return testPrisma.projectLineItem.create({
+    data: {
+      organizationId: orgId,
+      projectId,
+      modelId,
+      quantity: overrides?.quantity ?? 1,
+      bulkAssetId: overrides?.bulkAssetId ?? null,
+      status: "CONFIRMED",
+    },
+  });
+}
+
+describe("checkOutItems — fulfillment model", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("scanning assets onto a qty-N line creates units, never splits the line", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 5,
+    });
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "A-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "A-2" });
+
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: a1.id },
+      { lineItemId: line.id, assetId: a2.id },
+    ]);
+
+    // The order line is still ONE row, quantity untouched — no split.
+    const lineCount = await testPrisma.projectLineItem.count({
+      where: { projectId: project.id },
+    });
+    expect(lineCount).toBe(1);
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.quantity).toBe(5);
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.assignedQuantity).toBe(2);
+    expect(refreshed.checkedOutQuantity).toBe(2);
+
+    // Two unit rows, one per scanned asset, both checked out.
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+      orderBy: { ordinal: "asc" },
+    });
+    expect(units).toHaveLength(2);
+    expect(units.map((u) => u.assetId).sort()).toEqual([a1.id, a2.id].sort());
+    expect(units.every((u) => u.status === "CHECKED_OUT")).toBe(true);
+    expect(units.map((u) => u.ordinal).sort()).toEqual([1, 2]);
+
+    // The physical assets are marked deployed.
+    const assets = await testPrisma.asset.findMany({
+      where: { id: { in: [a1.id, a2.id] } },
+    });
+    expect(assets.every((a) => a.status === "CHECKED_OUT")).toBe(true);
+  });
+
+  it("re-scanning an already-deployed asset is idempotent", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 3,
+    });
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "DUP-1",
+    });
+
+    await checkOutItems(project.id, [{ lineItemId: line.id, assetId: asset.id }]);
+    // Same scan again — must not create a second unit or throw.
+    await checkOutItems(project.id, [{ lineItemId: line.id, assetId: asset.id }]);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(1);
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.assignedQuantity).toBe(1);
+  });
+
+  it("bulk checkout creates one bulk unit carrying the quantity", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const bulk = await createBulkAssetFixture(org.id, model.id, {
+      assetTag: "CABLE-BULK",
+      total: 50,
+    });
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 12,
+      bulkAssetId: bulk.id,
+    });
+
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, quantity: 12 },
+    ]);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(1);
+    expect(units[0].bulkAssetId).toBe(bulk.id);
+    expect(units[0].quantity).toBe(12);
+    expect(units[0].status).toBe("CHECKED_OUT");
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.checkedOutQuantity).toBe(12);
+  });
+});

--- a/src/server/warehouse-prep.int.test.ts
+++ b/src/server/warehouse-prep.int.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration tests for prep under the line-item fulfillment model
+ * (Phase 3.5). Prep creates/marks a ProjectLineItemUnit (prepStatus PACKED)
+ * instead of splitting the line — and a later checkout must reuse that same
+ * unit, not create a second one.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+  createAssetFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import { checkOutItems } from "@/server/warehouse";
+import { prepItemDirect } from "@/server/check-records";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Test Project",
+      taxRate: 0,
+    },
+  });
+}
+
+async function createLineItemFixture(
+  orgId: string,
+  projectId: string,
+  modelId: string,
+  quantity: number,
+) {
+  return testPrisma.projectLineItem.create({
+    data: {
+      organizationId: orgId,
+      projectId,
+      modelId,
+      quantity,
+      status: "CONFIRMED",
+    },
+  });
+}
+
+describe("prepItemDirect — fulfillment model", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("prepping an asset marks a PACKED unit, never splits the line", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 5);
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "PREP-1",
+    });
+
+    await prepItemDirect(project.id, line.id, asset.id);
+
+    expect(
+      await testPrisma.projectLineItem.count({
+        where: { projectId: project.id },
+      }),
+    ).toBe(1);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(1);
+    expect(units[0].assetId).toBe(asset.id);
+    expect(units[0].prepStatus).toBe("PACKED");
+    expect(units[0].status).toBe("CONFIRMED");
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.quantity).toBe(5);
+    expect(refreshed.status).toBe("PREPPED");
+    expect(refreshed.packedQuantity).toBe(1);
+  });
+
+  it("checkout reuses the unit a prep already created — no duplicate", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 3);
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "PREP-DEPLOY-1",
+    });
+
+    await prepItemDirect(project.id, line.id, asset.id);
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: asset.id },
+    ]);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    // Same unit, transitioned PACKED → CHECKED_OUT — not a second row.
+    expect(units).toHaveLength(1);
+    expect(units[0].status).toBe("CHECKED_OUT");
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.checkedOutQuantity).toBe(1);
+  });
+});

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -617,6 +617,8 @@ export async function checkInItems(
   projectId: string,
   items: Array<{
     lineItemId: string;
+    /** The scanned serialised asset being returned. Omit for bulk returns. */
+    assetId?: string;
     returnCondition: "GOOD" | "DAMAGED" | "MISSING";
     quantity?: number;
     notes?: string;
@@ -648,63 +650,38 @@ export async function checkInItems(
         throw new Error(`Line item ${item.lineItemId} not found in project`);
       }
 
-      // With the split approach, deployed bulk items are qty=1 and behave like serialized.
-      // Only unsplit bulk items (qty > 1 with bulkAssetId) use the bulk return path.
-      const isBulk = !lineItem.assetId && lineItem.quantity > 1;
-      const returnQty = item.quantity || 1;
+      const targetAssetId = item.assetId || lineItem.assetId || null;
 
-      if (isBulk) {
-        // Unsplit bulk item — shouldn't normally reach here in the split flow,
-        // but handle gracefully
-        const newReturnedQty = lineItem.returnedQuantity + returnQty;
-        const fullyReturned = newReturnedQty >= lineItem.checkedOutQuantity;
-
-        const updatedItem = await tx.projectLineItem.update({
-          where: { id: item.lineItemId },
-          data: {
-            returnedQuantity: newReturnedQty,
-            status: fullyReturned ? "RETURNED" : "CHECKED_OUT",
-            returnedAt: fullyReturned ? new Date() : lineItem.returnedAt,
-            ...(fullyReturned ? { returnedBy: { connect: { id: userId } } } : {}),
-            returnCondition: fullyReturned ? item.returnCondition : lineItem.returnCondition,
-            returnNotes: item.notes || lineItem.returnNotes,
+      if (targetAssetId) {
+        // ── Serialised return — flip the unit, restore the asset ─────────
+        const unit = await tx.projectLineItemUnit.findUnique({
+          where: {
+            lineItemId_assetId: {
+              lineItemId: lineItem.id,
+              assetId: targetAssetId,
+            },
           },
-          include: { model: true, asset: true, bulkAsset: true },
+          select: { id: true },
         });
-
-        // Create scan log entry
-        await tx.assetScanLog.create({
-          data: {
-            organizationId,
-            bulkAssetId: lineItem.bulkAssetId,
-            projectId,
-            action: "CHECK_IN",
-            scannedById: userId,
-            notes: item.notes || `Returned ${returnQty} of ${lineItem.checkedOutQuantity}`,
-          },
-        });
-
-        updated.push(updatedItem);
-      } else {
-        // Serialized asset — unassign the specific asset so any asset of that model can be used next time
-        const updatedItem = await tx.projectLineItem.update({
-          where: { id: item.lineItemId },
+        if (!unit) {
+          throw new Error(
+            `That asset is not deployed on line item ${item.lineItemId}`,
+          );
+        }
+        // Guarded transition — only return a unit that is still out.
+        const flipped = await tx.projectLineItemUnit.updateMany({
+          where: { id: unit.id, status: "CHECKED_OUT" },
           data: {
             status: "RETURNED",
-            returnedQuantity: 1,
             returnedAt: new Date(),
-            returnedBy: { connect: { id: userId } },
+            returnedById: userId,
             returnCondition: item.returnCondition,
             returnNotes: item.notes || null,
-            asset: lineItem.assetId ? { disconnect: true } : undefined,
           },
-          include: { model: true, asset: true, bulkAsset: true },
         });
 
-        // Update serialized asset status and restore location based on return condition
-        if (lineItem.assetId) {
+        if (flipped.count > 0) {
           let assetStatus: "AVAILABLE" | "IN_MAINTENANCE" | "LOST";
-
           switch (item.returnCondition) {
             case "DAMAGED":
               assetStatus = "IN_MAINTENANCE";
@@ -717,31 +694,86 @@ export async function checkInItems(
               assetStatus = "AVAILABLE";
               break;
           }
-
           await tx.asset.update({
-            where: { id: lineItem.assetId },
+            where: { id: targetAssetId },
+            data: { status: assetStatus, locationId: defaultLocationId },
+          });
+          await tx.assetScanLog.create({
             data: {
-              status: assetStatus,
-              // Restore location to default, or clear it if no default exists
-              locationId: defaultLocationId,
+              organizationId,
+              assetId: targetAssetId,
+              projectId,
+              action: "CHECK_IN",
+              scannedById: userId,
+              notes: item.notes || null,
             },
           });
         }
-
-        // Create scan log entry
+      } else if (lineItem.bulkAssetId) {
+        // ── Bulk return — accumulate onto the bulk unit row ──────────────
+        const returnQty = item.quantity || 1;
+        const unit = await tx.projectLineItemUnit.findFirst({
+          where: { lineItemId: lineItem.id, bulkAssetId: lineItem.bulkAssetId },
+        });
+        if (unit) {
+          const newReturned = Math.min(
+            unit.quantity,
+            unit.returnedQuantity + returnQty,
+          );
+          const fullyReturned = newReturned >= unit.quantity;
+          await tx.projectLineItemUnit.update({
+            where: { id: unit.id },
+            data: {
+              returnedQuantity: newReturned,
+              status: fullyReturned ? "RETURNED" : "CHECKED_OUT",
+              returnedAt: fullyReturned ? new Date() : unit.returnedAt,
+              returnedById: fullyReturned ? userId : unit.returnedById,
+              returnCondition: item.returnCondition,
+              returnNotes: item.notes || unit.returnNotes,
+            },
+          });
+        }
         await tx.assetScanLog.create({
           data: {
             organizationId,
-            assetId: lineItem.assetId || null,
+            bulkAssetId: lineItem.bulkAssetId,
             projectId,
             action: "CHECK_IN",
             scannedById: userId,
-            notes: item.notes || null,
+            notes: item.notes || `Returned ${returnQty}`,
           },
         });
-
-        updated.push(updatedItem);
+      } else {
+        // No unit to target — flip the order line directly (the
+        // deploy-whole-line edge that checkout handles the same way).
+        await tx.projectLineItem.update({
+          where: { id: lineItem.id },
+          data: {
+            status: "RETURNED",
+            returnedQuantity: lineItem.checkedOutQuantity || lineItem.quantity,
+            returnedAt: new Date(),
+            returnedBy: { connect: { id: userId } },
+            returnCondition: item.returnCondition,
+            returnNotes: item.notes || null,
+          },
+        });
+        updated.push(
+          await tx.projectLineItem.findUnique({
+            where: { id: lineItem.id },
+            include: { model: true, asset: true, bulkAsset: true },
+          }),
+        );
+        continue;
       }
+
+      // Roll the unit change up onto the order line.
+      await syncLineItemRollup(tx, lineItem.id);
+      updated.push(
+        await tx.projectLineItem.findUnique({
+          where: { id: lineItem.id },
+          include: { model: true, asset: true, bulkAsset: true },
+        }),
+      );
     }
 
     return updated;

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -283,40 +283,112 @@ export async function lookupAssetForScan(
     }
   }
 
-  // For serialized assets, first try to find a line item with this exact asset assigned
+  // ── Resolve which order line this scan applies to ─────────────────────
+  // A deployed/assigned serialised asset is pinned to a line by a
+  // ProjectLineItemUnit, not by ProjectLineItem.assetId.
   let lineItem = null;
+
   if (asset) {
-    lineItem = await prisma.projectLineItem.findFirst({
+    const unit = await prisma.projectLineItemUnit.findFirst({
+      where: {
+        assetId: asset.id,
+        lineItem: {
+          projectId,
+          organizationId,
+          status: { notIn: ["CANCELLED"] },
+        },
+      },
+      select: { lineItemId: true, status: true },
+    });
+
+    if (mode === "checkin") {
+      // Check-in must target a unit that is still out.
+      if (!unit || unit.status !== "CHECKED_OUT") {
+        return serialize({
+          found: true as const, type: "serialized" as const,
+          lineItemId: null, assetId: asset.id, assetName,
+          reason: "not_checked_out" as const,
+        });
+      }
+      return serialize({
+        found: true as const, type: "serialized" as const,
+        lineItemId: unit.lineItemId, assetId: asset.id, assetName, reason: null,
+      });
+    }
+
+    // checkout
+    if (unit) {
+      if (unit.status === "CHECKED_OUT") {
+        return serialize({
+          found: true as const, type: "serialized" as const,
+          lineItemId: null, assetId: null, assetName,
+          reason: "already_checked_out" as const,
+        });
+      }
+      // Already assigned (prepped) to a line — deploy onto that line.
+      return serialize({
+        found: true as const, type: "serialized" as const,
+        lineItemId: unit.lineItemId, assetId: asset.id, assetName, reason: null,
+      });
+    }
+
+    // Not on this project yet — block if it is out on another job.
+    if (asset.status === "CHECKED_OUT") {
+      const otherUnit = await prisma.projectLineItemUnit.findFirst({
+        where: {
+          assetId: asset.id,
+          status: "CHECKED_OUT",
+          lineItem: { projectId: { not: projectId }, organizationId },
+        },
+        select: {
+          lineItem: {
+            select: { project: { select: { name: true, projectNumber: true } } },
+          },
+        },
+      });
+      const otherProject = otherUnit?.lineItem.project;
+      const detail = otherProject
+        ? ` on ${otherProject.name}${otherProject.projectNumber ? ` (${otherProject.projectNumber})` : ""}`
+        : "";
+      return serialize({
+        found: true as const, type: "serialized" as const,
+        lineItemId: null, assetId: null, assetName,
+        reason: "asset_checked_out_elsewhere" as const, detail,
+      });
+    }
+
+    // Find an order line of this model with spare capacity.
+    const candidates = await prisma.projectLineItem.findMany({
       where: {
         projectId,
         organizationId,
-        assetId: asset.id,
+        modelId,
+        isKitChild: false,
         status: { notIn: ["CANCELLED"] },
       },
       orderBy: { sortOrder: "asc" },
     });
-  }
-
-  // If no exact asset match, find by modelId (only for checkout or bulk items — never for serialized check-in)
-  if (!lineItem && !(mode === "checkin" && asset)) {
+    lineItem =
+      candidates.find((li) => li.assignedQuantity < li.quantity) ?? null;
+  } else {
+    // Bulk asset — find its order line on the project.
     lineItem = await prisma.projectLineItem.findFirst({
       where: {
         projectId,
         organizationId,
         modelId,
         isKitChild: false,
-        status: { notIn: ["CANCELLED", ...(mode === "checkout" ? ["CHECKED_OUT" as const] : [])] },
-        // For checkout, don't match a line item that already has a different asset assigned
-        ...(asset ? { assetId: null } : {}),
+        status: { notIn: ["CANCELLED"] },
       },
       orderBy: { sortOrder: "asc" },
     });
   }
 
   if (!lineItem) {
-    const reason = mode === "checkin" && asset
-      ? "not_checked_out" as const  // Serialized asset not assigned/checked out on this project
-      : "not_on_project" as const;
+    const reason =
+      mode === "checkin" && asset
+        ? ("not_checked_out" as const)
+        : ("not_on_project" as const);
     return serialize({
       found: true as const,
       type: null,
@@ -331,68 +403,31 @@ export async function lookupAssetForScan(
     });
   }
 
-  // Determine if the line item is bulk (multi-quantity without serialized asset)
-  // Split items (qty=1) go through the serialized path naturally.
-  // If a serialized asset was scanned, treat it as serialized even if the line item has qty > 1
-  const isBulk = asset
-    ? false
-    : !lineItem.assetId && lineItem.quantity > 1;
-
-  if (isBulk) {
-    if (mode === "checkout") {
-      // In the split flow, all units are split off before checkout.
-      // If qty > 1 still, they haven't all been prepped yet.
-      if (lineItem.status === "CHECKED_OUT") {
-        return serialize({ found: true as const, type: "bulk" as const, lineItemId: null, assetId: null, assetName, reason: "already_checked_out" as const });
-      }
-    } else {
-      // checkin — need units that are checked out but not yet returned
-      if (lineItem.status !== "CHECKED_OUT") {
-        return serialize({ found: true as const, type: "bulk" as const, lineItemId: null, assetId: null, assetName, reason: "already_returned" as const });
+  // Bulk scan
+  if (!asset) {
+    if (mode === "checkin") {
+      const outUnit = await prisma.projectLineItemUnit.findFirst({
+        where: { lineItemId: lineItem.id, status: "CHECKED_OUT" },
+        select: { id: true },
+      });
+      if (!outUnit) {
+        return serialize({
+          found: true as const, type: "bulk" as const, lineItemId: null,
+          assetId: null, assetName, reason: "already_returned" as const,
+        });
       }
     }
-
-    return serialize({ found: true as const, type: "bulk" as const, lineItemId: lineItem.id, assetId: null, assetName, reason: null });
+    return serialize({
+      found: true as const, type: "bulk" as const, lineItemId: lineItem.id,
+      assetId: null, assetName, reason: null,
+    });
   }
 
-  // Serialized asset
-  if (mode === "checkout") {
-    if (lineItem.status === "CHECKED_OUT") {
-      return serialize({ found: true as const, type: "serialized" as const, lineItemId: null, assetId: null, assetName, reason: "already_checked_out" as const });
-    }
-    // Check if the physical asset is already checked out on another project
-    if (asset && asset.status === "CHECKED_OUT") {
-      // Find which project has it
-      const otherLineItem = await prisma.projectLineItem.findFirst({
-        where: {
-          organizationId,
-          assetId: asset.id,
-          status: "CHECKED_OUT",
-          projectId: { not: projectId },
-        },
-        include: { project: { select: { name: true, projectNumber: true } } },
-      });
-      const otherProject = otherLineItem?.project;
-      const detail = otherProject
-        ? ` on ${otherProject.name}${otherProject.projectNumber ? ` (${otherProject.projectNumber})` : ""}`
-        : "";
-      return serialize({
-        found: true as const,
-        type: "serialized" as const,
-        lineItemId: null,
-        assetId: null,
-        assetName,
-        reason: "asset_checked_out_elsewhere" as const,
-        detail,
-      });
-    }
-  } else {
-    if (lineItem.status !== "CHECKED_OUT") {
-      return serialize({ found: true as const, type: "serialized" as const, lineItemId: null, assetId: null, assetName, reason: "not_checked_out" as const });
-    }
-  }
-
-  return serialize({ found: true as const, type: "serialized" as const, lineItemId: lineItem.id, assetId: asset?.id || null, assetName, reason: null });
+  // Serialised checkout onto a line with capacity.
+  return serialize({
+    found: true as const, type: "serialized" as const,
+    lineItemId: lineItem.id, assetId: asset.id, assetName, reason: null,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -744,26 +779,69 @@ export async function checkInItems(
           },
         });
       } else {
-        // No unit to target — flip the order line directly (the
-        // deploy-whole-line edge that checkout handles the same way).
-        await tx.projectLineItem.update({
-          where: { id: lineItem.id },
-          data: {
-            status: "RETURNED",
-            returnedQuantity: lineItem.checkedOutQuantity || lineItem.quantity,
-            returnedAt: new Date(),
-            returnedBy: { connect: { id: userId } },
-            returnCondition: item.returnCondition,
-            returnNotes: item.notes || null,
-          },
+        // No specific asset scanned — the "return whole line" path. Return
+        // every unit still out on this line.
+        const outUnits = await tx.projectLineItemUnit.findMany({
+          where: { lineItemId: lineItem.id, status: "CHECKED_OUT" },
         });
-        updated.push(
-          await tx.projectLineItem.findUnique({
+
+        if (outUnits.length > 0) {
+          for (const u of outUnits) {
+            await tx.projectLineItemUnit.update({
+              where: { id: u.id },
+              data: {
+                status: "RETURNED",
+                returnedAt: new Date(),
+                returnedById: userId,
+                returnCondition: item.returnCondition,
+                returnNotes: item.notes || null,
+                ...(u.bulkAssetId ? { returnedQuantity: u.quantity } : {}),
+              },
+            });
+            if (u.assetId) {
+              const assetStatus =
+                item.returnCondition === "DAMAGED"
+                  ? "IN_MAINTENANCE"
+                  : item.returnCondition === "MISSING"
+                    ? "LOST"
+                    : "AVAILABLE";
+              await tx.asset.update({
+                where: { id: u.assetId },
+                data: { status: assetStatus, locationId: defaultLocationId },
+              });
+            }
+          }
+          await tx.assetScanLog.create({
+            data: {
+              organizationId,
+              projectId,
+              action: "CHECK_IN",
+              scannedById: userId,
+              notes: item.notes || `Returned ${outUnits.length} unit(s)`,
+            },
+          });
+        } else {
+          // Genuinely no units — flip the order line directly.
+          await tx.projectLineItem.update({
             where: { id: lineItem.id },
-            include: { model: true, asset: true, bulkAsset: true },
-          }),
-        );
-        continue;
+            data: {
+              status: "RETURNED",
+              returnedQuantity:
+                lineItem.checkedOutQuantity || lineItem.quantity,
+              returnedAt: new Date(),
+              returnedBy: { connect: { id: userId } },
+              returnCondition: item.returnCondition,
+              returnNotes: item.notes || null,
+            },
+          });
+          updated.push(
+            await tx.projectLineItem.findUnique({
+              where: { id: lineItem.id },
+              include: { model: true, asset: true, bulkAsset: true },
+            }),
+          );
+          continue;
+        }
       }
 
       // Roll the unit change up onto the order line.

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -689,6 +689,13 @@ export async function checkInItems(
 
       if (targetAssetId) {
         // ── Serialised return — flip the unit, restore the asset ─────────
+        const assetStatus: "AVAILABLE" | "IN_MAINTENANCE" | "LOST" =
+          item.returnCondition === "DAMAGED"
+            ? "IN_MAINTENANCE"
+            : item.returnCondition === "MISSING"
+              ? "LOST"
+              : "AVAILABLE";
+
         const unit = await tx.projectLineItemUnit.findUnique({
           where: {
             lineItemId_assetId: {
@@ -698,11 +705,44 @@ export async function checkInItems(
           },
           select: { id: true },
         });
+
         if (!unit) {
-          throw new Error(
-            `That asset is not deployed on line item ${item.lineItemId}`,
+          // No unit row — a kit child or an un-migrated legacy line that
+          // still carries its asset directly. Return the line itself.
+          await tx.projectLineItem.update({
+            where: { id: lineItem.id },
+            data: {
+              status: "RETURNED",
+              returnedQuantity: 1,
+              returnedAt: new Date(),
+              returnedBy: { connect: { id: userId } },
+              returnCondition: item.returnCondition,
+              returnNotes: item.notes || null,
+            },
+          });
+          await tx.asset.update({
+            where: { id: targetAssetId },
+            data: { status: assetStatus, locationId: defaultLocationId },
+          });
+          await tx.assetScanLog.create({
+            data: {
+              organizationId,
+              assetId: targetAssetId,
+              projectId,
+              action: "CHECK_IN",
+              scannedById: userId,
+              notes: item.notes || null,
+            },
+          });
+          updated.push(
+            await tx.projectLineItem.findUnique({
+              where: { id: lineItem.id },
+              include: { model: true, asset: true, bulkAsset: true },
+            }),
           );
+          continue;
         }
+
         // Guarded transition — only return a unit that is still out.
         const flipped = await tx.projectLineItemUnit.updateMany({
           where: { id: unit.id, status: "CHECKED_OUT" },
@@ -716,19 +756,6 @@ export async function checkInItems(
         });
 
         if (flipped.count > 0) {
-          let assetStatus: "AVAILABLE" | "IN_MAINTENANCE" | "LOST";
-          switch (item.returnCondition) {
-            case "DAMAGED":
-              assetStatus = "IN_MAINTENANCE";
-              break;
-            case "MISSING":
-              assetStatus = "LOST";
-              break;
-            case "GOOD":
-            default:
-              assetStatus = "AVAILABLE";
-              break;
-          }
           await tx.asset.update({
             where: { id: targetAssetId },
             data: { status: assetStatus, locationId: defaultLocationId },

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -6,7 +6,11 @@ import { serialize } from "@/lib/serialize";
 import { computeOverbookedStatus } from "@/lib/availability";
 import type { Prisma } from "@/generated/prisma/client";
 import { logActivity } from "@/lib/activity-log";
-import { splitLineItem } from "@/server/check-records";
+import {
+  syncLineItemRollup,
+  ensureSerialisedUnit,
+  ensureBulkUnit,
+} from "@/server/line-item-fulfillment";
 import {
   adjustBulkAvailability,
   coalesceAdjustments,
@@ -452,29 +456,95 @@ export async function checkOutItems(
         throw new Error(`Line item ${item.lineItemId} not found in project`);
       }
 
-      // With the split approach, prepped items are qty=1 and behave like serialized.
-      // Only unsplit multi-qty items without a serialized asset use the bulk checkout path.
-      const isBulk = item.assetId
-        ? false
-        : !lineItem.assetId && lineItem.quantity > 1;
-      const checkoutQty = item.quantity || 1;
+      // Fulfillment model: scanning an asset onto a line creates a
+      // ProjectLineItemUnit, never a split line item. The order line keeps
+      // its quantity; syncLineItemRollup rolls the units back up onto it.
+      const targetAssetId = item.assetId || lineItem.assetId || null;
 
-      if (isBulk) {
-        // Unsplit bulk item — shouldn't normally reach here in the split flow,
-        // but handle gracefully: deploy the whole item at once.
-        const updatedItem = await tx.projectLineItem.update({
-          where: { id: item.lineItemId },
+      if (targetAssetId) {
+        // ── Serialised checkout — one unit per physical asset ────────────
+        const assetRecord = await tx.asset.findUnique({
+          where: { id: targetAssetId },
+          select: { status: true, assetTag: true },
+        });
+        if (assetRecord && assetRecord.status === "CHECKED_OUT") {
+          // Already deployed. Idempotent if it is this line's own unit;
+          // otherwise the asset is genuinely double-booked.
+          const ownUnit = await tx.projectLineItemUnit.findUnique({
+            where: {
+              lineItemId_assetId: {
+                lineItemId: lineItem.id,
+                assetId: targetAssetId,
+              },
+            },
+            select: { status: true },
+          });
+          if (ownUnit && ownUnit.status === "CHECKED_OUT") continue;
+          throw new Error(`Asset ${assetRecord.assetTag} is already deployed`);
+        }
+        if (
+          assetRecord &&
+          (assetRecord.status === "RETIRED" ||
+            assetRecord.status === "IN_MAINTENANCE" ||
+            assetRecord.status === "LOST")
+        ) {
+          throw new Error(
+            `Asset ${assetRecord.assetTag} is ${assetRecord.status
+              .replace("_", " ")
+              .toLowerCase()} and cannot be deployed`,
+          );
+        }
+
+        const { id: unitId } = await ensureSerialisedUnit(tx, {
+          organizationId,
+          lineItemId: lineItem.id,
+          assetId: targetAssetId,
+        });
+        // Guarded transition — only flip a unit that is not already out.
+        await tx.projectLineItemUnit.updateMany({
+          where: { id: unitId, status: { not: "CHECKED_OUT" } },
           data: {
-            checkedOutQuantity: lineItem.quantity,
-            returnedQuantity: lineItem.status === "RETURNED" ? 0 : lineItem.returnedQuantity,
             status: "CHECKED_OUT",
             checkedOutAt: new Date(),
-            checkedOutBy: { connect: { id: userId } },
+            checkedOutById: userId,
           },
-          include: { model: true, asset: true, bulkAsset: true },
         });
 
-        // Create scan log entry
+        await tx.asset.update({
+          where: { id: targetAssetId },
+          data: {
+            status: "CHECKED_OUT",
+            ...(projectLocationId && { locationId: projectLocationId }),
+          },
+        });
+        await tx.assetScanLog.create({
+          data: {
+            organizationId,
+            assetId: targetAssetId,
+            projectId,
+            action: "CHECK_OUT",
+            scannedById: userId,
+            notes: item.notes || null,
+          },
+        });
+      } else if (lineItem.bulkAssetId) {
+        // ── Bulk checkout — one unit row carrying the quantity ───────────
+        const checkoutQty = item.quantity || lineItem.quantity;
+        const { id: unitId } = await ensureBulkUnit(tx, {
+          organizationId,
+          lineItemId: lineItem.id,
+          bulkAssetId: lineItem.bulkAssetId,
+          quantity: checkoutQty,
+        });
+        await tx.projectLineItemUnit.update({
+          where: { id: unitId },
+          data: {
+            status: "CHECKED_OUT",
+            quantity: checkoutQty,
+            checkedOutAt: new Date(),
+            checkedOutById: userId,
+          },
+        });
         await tx.assetScanLog.create({
           data: {
             organizationId,
@@ -482,118 +552,40 @@ export async function checkOutItems(
             projectId,
             action: "CHECK_OUT",
             scannedById: userId,
-            notes: item.notes || `Checked out ${checkoutQty} of ${lineItem.quantity}`,
+            notes:
+              item.notes ||
+              `Checked out ${checkoutQty} of ${lineItem.quantity}`,
           },
         });
-
-        updated.push(updatedItem);
       } else {
-        // Serialized asset checkout
-
-        // Verify the asset isn't already checked out on another project
-        const assetIdToCheck = item.assetId || lineItem.assetId;
-        if (assetIdToCheck) {
-          const assetRecord = await tx.asset.findUnique({
-            where: { id: assetIdToCheck },
-            select: { status: true, assetTag: true },
-          });
-          if (assetRecord && assetRecord.status === "CHECKED_OUT") {
-            if (lineItem.status === "CHECKED_OUT") {
-              continue;
-            }
-            throw new Error(`Asset ${assetRecord.assetTag} is already deployed`);
-          }
-          if (assetRecord && (assetRecord.status === "RETIRED" || assetRecord.status === "IN_MAINTENANCE" || assetRecord.status === "LOST")) {
-            throw new Error(`Asset ${assetRecord.assetTag} is ${assetRecord.status.replace("_", " ").toLowerCase()} and cannot be deployed`);
-          }
-        }
-
-        // If the line item has quantity > 1 and we're assigning a specific asset,
-        // split off a new line item with qty=1 for this asset. This handles the case
-        // where e.g. "4x SM57" gets individual assets assigned during checkout.
-        let targetLineItemId = item.lineItemId;
-        if (lineItem.quantity > 1 && item.assetId) {
-          const splitItem = await splitLineItem(tx, lineItem, {
-            status: "CHECKED_OUT",
-            checkedOutQuantity: 1,
-            checkedOutAt: new Date(),
-            checkedOutById: userId,
-            assetId: item.assetId,
-          });
-
-          // Mark the asset as checked out
-          await tx.asset.update({
-            where: { id: item.assetId },
-            data: {
-              status: "CHECKED_OUT",
-              ...(projectLocationId && { locationId: projectLocationId }),
-            },
-          });
-
-          // Create scan log entry
-          await tx.assetScanLog.create({
-            data: {
-              organizationId,
-              assetId: item.assetId,
-              projectId,
-              action: "CHECK_OUT",
-              scannedById: userId,
-              notes: item.notes || null,
-            },
-          });
-
-          updated.push(splitItem);
-          continue; // Skip the normal update path
-        }
-
-        // Normal serialized checkout (quantity == 1 or no assetId provided)
-        const updateData: Prisma.ProjectLineItemUpdateInput = {
-          status: "CHECKED_OUT",
-          checkedOutQuantity: 1,
-          returnedQuantity: 0,
-          returnCondition: null,
-          returnNotes: null,
-          returnedAt: null,
-          checkedOutAt: new Date(),
-          checkedOutBy: { connect: { id: userId } },
-        };
-
-        if (item.assetId) {
-          updateData.asset = { connect: { id: item.assetId } };
-        }
-
-        const updatedItem = await tx.projectLineItem.update({
-          where: { id: targetLineItemId },
-          data: updateData,
-          include: { model: true, asset: true, bulkAsset: true },
-        });
-
-        // Mark the serialized asset as checked out and update location to project venue
-        const assetIdToUpdate = item.assetId || lineItem.assetId;
-        if (assetIdToUpdate) {
-          await tx.asset.update({
-            where: { id: assetIdToUpdate },
-            data: {
-              status: "CHECKED_OUT",
-              ...(projectLocationId && { locationId: projectLocationId }),
-            },
-          });
-        }
-
-        // Create scan log entry
-        await tx.assetScanLog.create({
+        // No serialised asset and no bulk asset assigned — nothing to make a
+        // unit from. Flip the order line directly (deploy-whole-line edge).
+        await tx.projectLineItem.update({
+          where: { id: lineItem.id },
           data: {
-            organizationId,
-            assetId: assetIdToUpdate || null,
-            projectId,
-            action: "CHECK_OUT",
-            scannedById: userId,
-            notes: item.notes || null,
+            status: "CHECKED_OUT",
+            checkedOutQuantity: lineItem.quantity,
+            checkedOutAt: new Date(),
+            checkedOutBy: { connect: { id: userId } },
           },
         });
-
-        updated.push(updatedItem);
+        updated.push(
+          await tx.projectLineItem.findUnique({
+            where: { id: lineItem.id },
+            include: { model: true, asset: true, bulkAsset: true },
+          }),
+        );
+        continue;
       }
+
+      // Roll the unit change up onto the order line.
+      await syncLineItemRollup(tx, lineItem.id);
+      updated.push(
+        await tx.projectLineItem.findUnique({
+          where: { id: lineItem.id },
+          include: { model: true, asset: true, bulkAsset: true },
+        }),
+      );
     }
 
     return updated;


### PR DESCRIPTION
## Summary

Cuts the warehouse + readers over to the line-item fulfillment model
(`ProjectLineItemUnit`). The order line keeps its `quantity` and never
splits; one unit row per assigned physical thing. Retires the
`splitLineItem` code path.

Builds on PR #99 (Phase 1 schema + Phase 2a backfill + Phase 3.1
helpers). Design doc: `docs/designs/line-item-fulfillment-model.md`.

- **3.2 Checkout** — writes unit rows via `ensureSerialisedUnit` /
  `ensureBulkUnit`, guarded transitions, rollup synced.
- **3.3 Scan-lookup** — resolves a scan via the unit table (find the
  still-out unit on check-in; find a line with capacity on checkout).
- **3.4 Check-in** — targets units; `assetId` threaded through the UI;
  no-unit fallback flips legacy kit-child / pre-cutover lines directly.
- **3.5 Prep** — `prepUnit` creates / marks PACKED units; `splitLineItem`
  retired (zero callers remain).
- **3.6 Kit check-in** — uses the no-unit fallback path; kit children
  carry `line.assetId` with no unit row, and check-in handles both shapes.
- **3.7 Readers** — `reservation-conflicts.ts`, `utilization.ts`,
  `availability.getAssetBookings`, `line-items.addLineItem`
  double-booked guard, and the `swapLineItemAsset` TOCTOU re-check all
  union `projectLineItem.assetId` with `projectLineItemUnit.assetId`.
- **3.8 Split-sibling collapse migration** — `LineItemMergeMap` audit
  table + `npm run collapse:split-siblings` script (dry-run by default,
  `--apply` opt-in). Strict full-equivalence key; flag-don't-merge for
  any divergence; moves units, repoints `CheckRecord` / `DamageEvent` /
  `ProjectService`, deactivates the sibling (`status: CANCELLED`, `qty
  0`, asset cleared), recomputes rollup. **The migration is built and
  tested only — not run on prod.** A human gates the apply.

## Test plan

- [x] 45 new unit tests (units helpers, equivalence-key, plan)
- [x] 37 new integration tests across checkout / check-in / prep /
      reservation-conflicts / collapse — all green
- [x] Full unit suite green (1835 tests)
- [x] Full integration suite green (173 tests; one pre-existing
      module-load failure in `group-revenue-custom-items.int.test.ts`
      is unrelated — same failure on `main`)
- [x] `npm run build` green
- [x] `npx tsc --noEmit` clean (excluding pre-existing pdfme test errors)
- [ ] Dry-run `npm run collapse:split-siblings` against a prod data
      copy and diff docket 260102 before/after — **operator step,
      gated on a human reviewer**
- [ ] After dry-run review: `npm run collapse:split-siblings -- --apply`
      on prod

## Follow-ups (intentionally out of scope)

- Phase 4: drop `ProjectLineItem.assetId` / `bulkAssetId` once all
  readers are verified in prod.
- PDF docket: optional render of per-unit asset tags on the line row
  (the one-row-per-line bug is already fixed by the cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)