### PR TITLE
Phase 4a: T&T preflight gathers asset ids from units

### DIFF
--- a/docs/designs/line-item-fulfillment-model.md
+++ b/docs/designs/line-item-fulfillment-model.md
@@ -156,6 +156,31 @@ ignores `groupId`, `categoryId`, `subHireId`, `sortOrder`, `description`,
 4. **Phase 4 — Drop** the old `assetId` / `bulkAssetId` on `ProjectLineItem`
    once all readers are migrated and verified.
 
+   **Status (post-Phase-3 audit, v0.7.0.0):** The original "drop both
+   columns" framing turned out to be too coarse. The Phase 4 audit
+   surfaced two *legitimate* active uses that aren't legacy:
+
+   - **Kit children** carry their asset directly on `line.assetId` (no
+     unit row) — `checkOutKit` writes it; `checkInItems` has a no-unit
+     fallback that reads it. Dropping the column would break the kit
+     flow.
+   - **Bulk-line order intent** lives on `line.bulkAssetId`. It's set
+     at line creation (the operator picks which bulk to draw from)
+     and consumed at prep/checkout to know which `BulkAsset` the unit
+     should reference. Dropping the column erases the assignment.
+
+   The audit also found one *correctness* gap that was a real Phase 4
+   prerequisite — the checkout T&T preflight (`warehouse.ts:462-478`)
+   only gathered `line.assetId` / `line.bulkAssetId`, so a prepped
+   FAILED-T&T asset that lived on a unit slipped past the gate. Fixed
+   in Phase 4a (v0.7.0.x) by unioning unit-table asset ids into the
+   preflight set.
+
+   Wholesale column drop is **deferred** until a follow-on design
+   answers (a) where kit-children store their asset assignment, and
+   (b) where bulk-line order intent lives. The columns are no longer
+   blocking new development.
+
 Single-tenant data (one company) makes a transactional cutover with a verified
 dry-run feasible; the `oldLineItemId` mapping table is the rollback safety net,
 so a long dual-write window is not required.

--- a/src/server/warehouse-checkout.int.test.ts
+++ b/src/server/warehouse-checkout.int.test.ts
@@ -149,6 +149,57 @@ describe("checkOutItems — fulfillment model", () => {
     expect(refreshed.assignedQuantity).toBe(1);
   });
 
+  it("T&T preflight blocks when the failed asset lives on a unit (not line.assetId)", async () => {
+    // Phase 4a regression guard. Pre-cutover, checkout's T&T preflight
+    // scanned line.assetId + line.bulkAssetId. Post-cutover a prepped
+    // asset lives on ProjectLineItemUnit and line.assetId is null —
+    // without the unit-aware preflight, a prepped FAILED-T&T asset
+    // would slip past the gate. The preflight now also reads units.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 1,
+    });
+    const failedAsset = await createAssetFixture(org.id, model.id, {
+      assetTag: "TT-FAIL",
+    });
+    // FAILED T&T record on the asset.
+    await testPrisma.testTagAsset.create({
+      data: {
+        organizationId: org.id,
+        testTagId: `TT-${createId().slice(0, 6)}`,
+        description: "Phase 4a preflight test",
+        status: "FAILED",
+        assetId: failedAsset.id,
+        isActive: true,
+      },
+    });
+    // Prep already created a unit for this line + asset. Line.assetId
+    // stays null (the post-cutover shape).
+    await testPrisma.projectLineItemUnit.create({
+      data: {
+        organizationId: org.id,
+        lineItemId: line.id,
+        ordinal: 1,
+        assetId: failedAsset.id,
+        quantity: 1,
+        status: "CONFIRMED",
+        prepStatus: "PACKED",
+      },
+    });
+
+    // Caller does NOT pass assetId — the unit is supposed to carry it.
+    // Without the fix, the preflight set is empty for this line and
+    // the failed asset gets deployed silently.
+    await expect(
+      checkOutItems(project.id, [{ lineItemId: line.id }]),
+    ).rejects.toMatchObject({ name: "TestTagBlockError" });
+  });
+
   it("bulk checkout creates one bulk unit carrying the quantity", async () => {
     const org = await createOrgFixture();
     const user = await createUserFixture(org.id);

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -459,17 +459,36 @@ export async function checkOutItems(
     // every serialized and bulk asset id involved, and assert none have a
     // failed/overdue Test & Tag record. Throws TestTagBlockError on block,
     // rolling back the whole batch (no partial check-out across the items).
-    const preflightLineItems = await tx.projectLineItem.findMany({
-      where: { id: { in: items.map((i) => i.lineItemId) }, organizationId, projectId },
-      select: { id: true, assetId: true, bulkAssetId: true },
-    });
+    //
+    // Three sources contribute to the asset set:
+    //   1) legacy `line.assetId` / `line.bulkAssetId` (kit children + bulk
+    //      lines + un-migrated splits)
+    //   2) ProjectLineItemUnit rows already on the line (prep created
+    //      them; checkout would mark CHECKED_OUT)
+    //   3) `item.assetId` from the incoming scans (post-cutover scans
+    //      land here before the unit is written)
+    // Without (2) a prepped asset on a fresh order line could slip past
+    // the T&T check, since (1) is null on post-cutover lines.
+    const lineItemIds = items.map((i) => i.lineItemId);
+    const [preflightLineItems, preflightUnits] = await Promise.all([
+      tx.projectLineItem.findMany({
+        where: { id: { in: lineItemIds }, organizationId, projectId },
+        select: { id: true, assetId: true, bulkAssetId: true },
+      }),
+      tx.projectLineItemUnit.findMany({
+        where: { lineItemId: { in: lineItemIds }, organizationId },
+        select: { assetId: true, bulkAssetId: true },
+      }),
+    ]);
     const preflightAssetIds = [
-      ...preflightLineItems.map((li) => li.assetId).filter(Boolean) as string[],
-      ...items.map((i) => i.assetId).filter(Boolean) as string[],
+      ...(preflightLineItems.map((li) => li.assetId).filter(Boolean) as string[]),
+      ...(preflightUnits.map((u) => u.assetId).filter(Boolean) as string[]),
+      ...(items.map((i) => i.assetId).filter(Boolean) as string[]),
     ];
-    const preflightBulkIds = preflightLineItems
-      .map((li) => li.bulkAssetId)
-      .filter(Boolean) as string[];
+    const preflightBulkIds = [
+      ...(preflightLineItems.map((li) => li.bulkAssetId).filter(Boolean) as string[]),
+      ...(preflightUnits.map((u) => u.bulkAssetId).filter(Boolean) as string[]),
+    ];
     await assertTestTagAllowsCheckout(tx, organizationId, {
       assetIds: preflightAssetIds,
       bulkAssetIds: preflightBulkIds,


### PR DESCRIPTION
## Summary

Closes a correctness gap surfaced by the Phase 4 readiness audit. The
checkout T&T preflight gathered asset ids only from `line.assetId` /
`line.bulkAssetId` — post-cutover those columns are null for non-kit
non-bulk lines because the assignment lives on a
`ProjectLineItemUnit`. A prepped asset with a FAILED or OVERDUE T&T
record therefore slipped past the compliance gate.

Fix: the preflight now unions three sources:
1. Legacy `line.assetId` / `line.bulkAssetId` (kit children + bulk
   lines + un-migrated splits)
2. `ProjectLineItemUnit` rows on the same lines (prep created them)
3. Inbound `item.assetId` scans (post-cutover scans land here before
   the unit is written)

Also updates the design doc — the audit found that
`line.assetId` for kit children and `line.bulkAssetId` for bulk-line
order intent are NOT legacy, so the wholesale Phase 4 column drop is
deferred until a follow-on design decides where those active uses
live. The columns are no longer blocking new development.

## Test plan

- [x] New regression test in `warehouse-checkout.int.test.ts`:
      line with no `line.assetId`, unit pre-created pointing at a
      FAILED-T&T asset, `checkOutItems` called without
      `item.assetId` → throws `TestTagBlockError` (passes; would NOT
      pass without the fix).
- [x] All 4 checkout integration tests green
- [x] `npx tsc --noEmit` clean
- [x] No behaviour change on the happy path (kit / bulk / serialised
      checkout tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)