### PR TITLE
PDF docket: render asset tags from units

### DIFF
--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -11,12 +11,31 @@ import type { DocumentData, DocumentLineItem, CrewEntry, CallSheetDayData, Docum
 
 const DEFAULT_DOC_COLOR = "#0d4f4f";
 
+/**
+ * Per-unit asset selection. The line item include below pulls these in
+ * so renderers can show every physical asset assigned to a multi-qty
+ * line — not just the legacy `line.asset` (which is null post-cutover).
+ * CANCELLED units are filtered out; everything else is included so the
+ * docket reflects what's actually packed.
+ */
+const unitInclude = {
+  orderBy: { ordinal: "asc" as const },
+  where: { status: { not: "CANCELLED" as const } },
+  select: {
+    id: true,
+    status: true,
+    asset: { select: { assetTag: true } },
+    bulkAsset: { select: { assetTag: true } },
+  },
+} as const;
+
 /** Deep include for line items — 2 levels of children for nested kits */
 const lineItemInclude = {
   model: { include: { category: true } },
   asset: true,
   bulkAsset: true,
   kit: true,
+  units: unitInclude,
   supplier: { select: { name: true } },
   category: { select: { id: true, name: true, sortOrder: true } },
   group: { select: { id: true, title: true, sortOrder: true, categoryId: true } },
@@ -27,6 +46,7 @@ const lineItemInclude = {
       asset: true,
       bulkAsset: true,
       kit: true,
+      units: unitInclude,
       supplier: { select: { name: true } },
       category: { select: { id: true, name: true, sortOrder: true } },
       group: { select: { id: true, title: true, sortOrder: true, categoryId: true } },
@@ -36,6 +56,7 @@ const lineItemInclude = {
           model: { include: { category: true } },
           asset: true,
           bulkAsset: true,
+          units: unitInclude,
           supplier: { select: { name: true } },
         },
       },

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -135,10 +135,32 @@ function getItemName(item: DocumentLineItem, isKit: boolean): string {
   return item.description || "-";
 }
 
-/** Get asset tag display */
-function getAssetTag(item: DocumentLineItem, isKit: boolean): string {
+/**
+ * Get asset tag display for a line. Preference order:
+ *   1. Kit row → the kit's own tag
+ *   2. Units present (post-cutover, multi-quantity deployed line) →
+ *      join up to 2 unit tags, then "+N more" if there are extras.
+ *      One unit collapses to its single tag so single-asset lines
+ *      look identical to the pre-cutover output.
+ *   3. Legacy line.asset (kit children, un-migrated splits)
+ *   4. Bulk asset tag
+ *   5. "-"
+ *
+ * The column is 80pt wide at courier-8 — two short tags fit. Anything
+ * longer truncates visually but the data is still in the system; a
+ * future docket revamp can render per-unit rows.
+ */
+export function getAssetTag(item: DocumentLineItem, isKit: boolean): string {
   if (isKit) {
     return item.kit?.assetTag || "-";
+  }
+  const unitTags = (item.units ?? [])
+    .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
+    .filter((t): t is string => !!t);
+  if (unitTags.length > 0) {
+    if (unitTags.length === 1) return unitTags[0];
+    if (unitTags.length === 2) return unitTags.join(", ");
+    return `${unitTags[0]}, ${unitTags[1]} +${unitTags.length - 2}`;
   }
   return item.asset?.assetTag || item.bulkAsset?.assetTag || "-";
 }
@@ -722,8 +744,10 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
               }
 
               case "assetTag": {
-                const tag = child.asset?.assetTag || child.bulkAsset?.assetTag
-                  || (isNestedKit ? (child.kit?.assetTag || "-") : "-");
+                // Same unit-aware logic as the top-level row.
+                const tag = isNestedKit
+                  ? (child.kit?.assetTag || "-")
+                  : getAssetTag(child, false);
                 page.drawText(tag, {
                   x: childCellX,
                   y: childTextY,
@@ -884,7 +908,8 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
                   }
 
                   case "assetTag": {
-                    const tag = nested.asset?.assetTag || nested.bulkAsset?.assetTag || "-";
+                    // Nested-kit asset uses the same unit-aware logic.
+                    const tag = getAssetTag(nested, false);
                     page.drawText(tag, {
                       x: nestedCellX,
                       y: nestedTextY,

--- a/src/lib/pdfme/plugins/get-asset-tag.test.ts
+++ b/src/lib/pdfme/plugins/get-asset-tag.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for getAssetTag — the docket / packing-list / return-sheet
+ * helper that picks what to render in the "Asset Tag" column.
+ *
+ * Post-cutover, a deployed multi-quantity line has units, not a
+ * `line.asset`. The helper must prefer the unit-tag list and degrade
+ * gracefully to legacy fields for single-asset and kit-child rows.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getAssetTag } from "./gearflow-table";
+import type { DocumentLineItem } from "../types";
+
+function lineItem(over: Partial<DocumentLineItem>): DocumentLineItem {
+  return {
+    id: "li-1",
+    description: null,
+    quantity: 1,
+    checkedOutQuantity: 0,
+    unitPrice: null,
+    pricingType: "PER_DAY",
+    duration: 1,
+    discount: null,
+    lineTotal: null,
+    groupName: null,
+    categoryName: null,
+    groupTitle: null,
+    isOptional: false,
+    notes: null,
+    status: "CONFIRMED",
+    model: null,
+    asset: null,
+    bulkAsset: null,
+    ...over,
+  };
+}
+
+describe("getAssetTag", () => {
+  it("kit row → kit tag", () => {
+    const li = lineItem({
+      kit: { assetTag: "KIT-1", name: "Lighting Kit" },
+      kitId: "k-1",
+    });
+    expect(getAssetTag(li, true)).toBe("KIT-1");
+  });
+
+  it("kit row with no kit tag → dash", () => {
+    expect(getAssetTag(lineItem({ kitId: "k-1" }), true)).toBe("-");
+  });
+
+  it("single unit → unit's tag (no commas)", () => {
+    const li = lineItem({
+      quantity: 1,
+      units: [
+        { id: "u1", asset: { assetTag: "STAGE-001" }, bulkAsset: null, status: "CHECKED_OUT" },
+      ],
+    });
+    expect(getAssetTag(li, false)).toBe("STAGE-001");
+  });
+
+  it("two units → comma-joined", () => {
+    const li = lineItem({
+      quantity: 2,
+      units: [
+        { id: "u1", asset: { assetTag: "MIC-001" }, bulkAsset: null, status: "CHECKED_OUT" },
+        { id: "u2", asset: { assetTag: "MIC-002" }, bulkAsset: null, status: "CHECKED_OUT" },
+      ],
+    });
+    expect(getAssetTag(li, false)).toBe("MIC-001, MIC-002");
+  });
+
+  it("more than two units → first two + '+N'", () => {
+    const li = lineItem({
+      quantity: 10,
+      units: Array.from({ length: 10 }, (_, i) => ({
+        id: `u${i}`,
+        asset: { assetTag: `P2-${String(i + 1).padStart(3, "0")}` },
+        bulkAsset: null,
+        status: "CHECKED_OUT",
+      })),
+    });
+    expect(getAssetTag(li, false)).toBe("P2-001, P2-002 +8");
+  });
+
+  it("falls back to legacy line.asset when no units (kit child shape)", () => {
+    const li = lineItem({
+      isKitChild: true,
+      asset: { assetTag: "CHILD-ASSET" },
+    });
+    expect(getAssetTag(li, false)).toBe("CHILD-ASSET");
+  });
+
+  it("falls back to bulkAsset when no units and no asset", () => {
+    const li = lineItem({
+      bulkAsset: { assetTag: "BULK-CABLE" },
+    });
+    expect(getAssetTag(li, false)).toBe("BULK-CABLE");
+  });
+
+  it("empty units array → falls back to legacy fields", () => {
+    const li = lineItem({
+      units: [],
+      asset: { assetTag: "ONLY-LEGACY" },
+    });
+    expect(getAssetTag(li, false)).toBe("ONLY-LEGACY");
+  });
+
+  it("units present but none have a tag → falls back to legacy", () => {
+    const li = lineItem({
+      units: [{ id: "u1", asset: null, bulkAsset: null, status: "CONFIRMED" }],
+      bulkAsset: { assetTag: "FALLBACK" },
+    });
+    expect(getAssetTag(li, false)).toBe("FALLBACK");
+  });
+
+  it("nothing assigned anywhere → dash", () => {
+    expect(getAssetTag(lineItem({}), false)).toBe("-");
+  });
+
+  it("bulk unit's bulkAsset tag also works", () => {
+    const li = lineItem({
+      units: [
+        { id: "u1", asset: null, bulkAsset: { assetTag: "BULK-XLR" }, status: "CHECKED_OUT" },
+      ],
+    });
+    expect(getAssetTag(li, false)).toBe("BULK-XLR");
+  });
+});

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -81,6 +81,18 @@ export interface DocumentLineItem {
   asset: { assetTag: string } | null;
   bulkAsset: { assetTag: string } | null;
   kit?: { assetTag: string; name: string } | null;
+  /**
+   * Per-physical-unit assignments under the fulfillment model. A line
+   * with quantity > 1 that's been deployed has one unit per physical
+   * thing; renderers prefer this list over the legacy `asset` field
+   * when present so docs show every assigned tag, not just the first.
+   */
+  units?: Array<{
+    id: string;
+    asset: { assetTag: string } | null;
+    bulkAsset: { assetTag: string } | null;
+    status: string;
+  }>;
   childLineItems?: DocumentLineItem[];
 }
 


### PR DESCRIPTION
## Summary

Closes the loop on the original delivery-docket bug. Pre-cutover, a
`10x` line was split into ten 1x rows so each row could show its asset
tag — that's the bug that started this whole rework. Post-cutover the
line stays one row with ten units; but the PDF builder only read
`line.asset` / `line.bulkAsset`, which are null for a unit-deployed
line, so the docket rendered "-" in the Asset Tag column.

Now:
1. The line-item Prisma include pulls `units` (non-CANCELLED) at every
   nesting level — top-level, kit child, nested kit grand-child.
2. `DocumentLineItem` has a typed `units` array.
3. `getAssetTag` prefers unit-derived tags:
   - 1 unit  → its tag alone (unchanged from single-asset output)
   - 2 units → `TAG-001, TAG-002`
   - 3+      → `TAG-001, TAG-002 +N`
   Falls back to `line.asset` (kit-child shape) and then `bulkAsset`
   so single-asset rows look identical to before.
4. Kit-child and nested-kit render paths now use the same helper.

The 80pt column at courier-8 fits two short tags. Three or more
truncates visually with `+N`; the data is available for a future
multi-line revamp.

## Test plan

- [x] 11 new unit tests for `getAssetTag` (kit row, single unit, two
      units, many units, legacy fallback, bulk asset, empty)
- [x] All 1846 unit tests green
- [x] `npm run build` green
- [x] `npx tsc --noEmit` clean (excluding pre-existing pdfme test-type errors)

## Follow-ups (intentionally deferred)

- Multi-line asset-tag cell with per-unit checkboxes — better for
  warehouse scan-tick workflows. Requires variable row-height surgery
  in the table plugin. Tracked in TODOS once a UX decision lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)