### PR TITLE
fix(warehouse): line stuck at PULLED after a unit is packed

### DIFF
--- a/src/lib/line-item-units.test.ts
+++ b/src/lib/line-item-units.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeRollupCounters,
   deriveOrderLineStatus,
+  deriveOrderLinePrepStatus,
   nextOrdinal,
   isFullyAssigned,
   type UnitLike,
@@ -102,6 +103,60 @@ describe("deriveOrderLineStatus", () => {
     expect(
       deriveOrderLineStatus("CONFIRMED", [unit({ prepStatus: "PACKED" })]),
     ).toBe("PREPPED");
+  });
+});
+
+describe("deriveOrderLinePrepStatus", () => {
+  it("returns the current prepStatus when no units are packed", () => {
+    expect(deriveOrderLinePrepStatus("PULLED", [])).toBe("PULLED");
+    expect(deriveOrderLinePrepStatus("PENDING", [unit()])).toBe("PENDING");
+    expect(deriveOrderLinePrepStatus(null, [unit()])).toBeNull();
+  });
+
+  it("promotes to PACKED the moment any unit is PACKED", () => {
+    // Regression: a serialised prep packs one unit; the line was stuck
+    // at PULLED so the deploy tab never showed it.
+    expect(
+      deriveOrderLinePrepStatus("PULLED", [unit({ prepStatus: "PACKED" })]),
+    ).toBe("PACKED");
+  });
+
+  it("promotes from null/PENDING to PACKED on any packed unit", () => {
+    expect(
+      deriveOrderLinePrepStatus(null, [unit({ prepStatus: "PACKED" })]),
+    ).toBe("PACKED");
+    expect(
+      deriveOrderLinePrepStatus("PENDING", [unit({ prepStatus: "PACKED" })]),
+    ).toBe("PACKED");
+  });
+
+  it("partial pack on a 10x line: one PACKED unit → line PACKED", () => {
+    // Operator's mental model: as soon as the first unit is prepped,
+    // the line shows up in the deploy tab. Quantity-aware UX handles
+    // "1 of 10 ready" separately via the rollup counters.
+    const units = [
+      unit({ prepStatus: "PACKED" }),
+      ...Array.from({ length: 9 }, () => unit({ prepStatus: null })),
+    ];
+    expect(deriveOrderLinePrepStatus("PULLED", units)).toBe("PACKED");
+  });
+
+  it("preserves FLAGGED_FAULTY override even when units are packed", () => {
+    // completeCheckAndFlag is a manual operator override — a later
+    // unit-rollup must not silently wipe it.
+    expect(
+      deriveOrderLinePrepStatus("FLAGGED_FAULTY", [
+        unit({ prepStatus: "PACKED" }),
+      ]),
+    ).toBe("FLAGGED_FAULTY");
+  });
+
+  it("preserves FLAGGED_TT_OVERDUE override even when units are packed", () => {
+    expect(
+      deriveOrderLinePrepStatus("FLAGGED_TT_OVERDUE", [
+        unit({ prepStatus: "PACKED" }),
+      ]),
+    ).toBe("FLAGGED_TT_OVERDUE");
   });
 });
 

--- a/src/lib/line-item-units.ts
+++ b/src/lib/line-item-units.ts
@@ -111,6 +111,42 @@ export function deriveOrderLineStatus(
 }
 
 /**
+ * Derive the order line's `prepStatus` from its units.
+ *
+ * The line's `prepStatus` drives the warehouse UI's prep ↔ deploy
+ * routing — the deploy tab filters `line.prepStatus === "PACKED"`. With
+ * the fulfillment-model cutover, prep writes a unit's `prepStatus` but
+ * leaves the line's old `prepStatus` (often `PULLED` from the earlier
+ * `pullItem` call) untouched. Result: a line whose unit is packed
+ * never moves from the prep tab to the deploy tab. This helper closes
+ * that gap.
+ *
+ * Rules:
+ *   - Manual flags (`FLAGGED_FAULTY`, `FLAGGED_TT_OVERDUE`) survive —
+ *     they're operator overrides set by `completeCheckAndFlag` and
+ *     must not be wiped by a later unit-rollup.
+ *   - Any unit with `prepStatus === "PACKED"` ⇒ line is `PACKED`
+ *     (the deploy tab needs to see it; quantity-aware deploy UX
+ *     handles partial states separately via the rollup counters).
+ *   - Otherwise, the existing `line.prepStatus` survives — preserves
+ *     PULLED while the operator is still scanning, and `PENDING` on
+ *     fresh lines.
+ */
+export function deriveOrderLinePrepStatus(
+  currentPrepStatus: PrepStatus | null,
+  units: readonly UnitLike[],
+): PrepStatus | null {
+  if (
+    currentPrepStatus === "FLAGGED_FAULTY" ||
+    currentPrepStatus === "FLAGGED_TT_OVERDUE"
+  ) {
+    return currentPrepStatus;
+  }
+  if (units.some((u) => u.prepStatus === "PACKED")) return "PACKED";
+  return currentPrepStatus;
+}
+
+/**
  * Next free `ordinal` for a new unit on an order line. Ordinals are a stable
  * 1..N identity within the line; they never reuse a gap, so a unit keeps its
  * number even after siblings are removed.

--- a/src/server/line-item-fulfillment.ts
+++ b/src/server/line-item-fulfillment.ts
@@ -14,6 +14,7 @@ import type { Prisma } from "@/generated/prisma/client";
 import {
   computeRollupCounters,
   deriveOrderLineStatus,
+  deriveOrderLinePrepStatus,
   nextOrdinal,
 } from "@/lib/line-item-units";
 
@@ -38,7 +39,7 @@ export async function syncLineItemRollup(
 ): Promise<void> {
   const line = await tx.projectLineItem.findUnique({
     where: { id: lineItemId },
-    select: { status: true },
+    select: { status: true, prepStatus: true },
   });
   if (!line) return;
 
@@ -52,6 +53,9 @@ export async function syncLineItemRollup(
     data: {
       ...computeRollupCounters(units),
       status: deriveOrderLineStatus(line.status, units),
+      // The warehouse UI routes prep ↔ deploy on line.prepStatus.
+      // Without this, a packed unit never moves the line off PULLED.
+      prepStatus: deriveOrderLinePrepStatus(line.prepStatus, units),
     },
   });
 }

--- a/src/server/warehouse-prep.int.test.ts
+++ b/src/server/warehouse-prep.int.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/org-context", () => ({
 }));
 
 import { checkOutItems } from "@/server/warehouse";
-import { prepItemDirect } from "@/server/check-records";
+import { prepItemDirect, pullItem } from "@/server/check-records";
 
 async function createProjectFixture(orgId: string) {
   return testPrisma.project.create({
@@ -130,5 +130,80 @@ describe("prepItemDirect — fulfillment model", () => {
     });
     expect(refreshed.status).toBe("CHECKED_OUT");
     expect(refreshed.checkedOutQuantity).toBe(1);
+  });
+
+  it("prep on a PULLED line transitions line.prepStatus to PACKED", async () => {
+    // Regression for the warehouse-UI symptom: operator clicks Pull
+    // (line.prepStatus → PULLED), opens the check form, completes the
+    // check, prep runs — and the line was stuck at PULLED forever
+    // because syncLineItemRollup never derived prepStatus from units.
+    // The deploy tab filters `prepStatus === "PACKED"`, so the line
+    // never moved off the prep tab.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 10);
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "PREP-PULL-1",
+    });
+
+    // Step 1: operator clicks Pull on the line.
+    await pullItem(project.id, line.id);
+    let refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.prepStatus).toBe("PULLED");
+
+    // Step 2: operator scans the first asset tag, completes the check,
+    // prep runs for that single unit. Without the fix this leaves the
+    // line at PULLED; with the fix the line promotes to PACKED.
+    await prepItemDirect(project.id, line.id, asset.id);
+
+    refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.prepStatus).toBe("PACKED");
+    expect(refreshed.packedQuantity).toBe(1);
+    expect(refreshed.quantity).toBe(10);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(1);
+    expect(units[0].assetId).toBe(asset.id);
+    expect(units[0].prepStatus).toBe("PACKED");
+  });
+
+  it("operator-set FLAGGED_FAULTY survives a later unit pack", async () => {
+    // completeCheckAndFlag is the operator override — a later
+    // unit-rollup must not silently wipe it back to PACKED.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 1);
+    const asset = await createAssetFixture(org.id, model.id, {
+      assetTag: "PREP-FLAG-1",
+    });
+
+    // Simulate the operator flagging the line.
+    await testPrisma.projectLineItem.update({
+      where: { id: line.id },
+      data: { prepStatus: "FLAGGED_FAULTY" },
+    });
+
+    // A later prep on a different unit (or a stray rollup) must not
+    // overwrite the flag.
+    await prepItemDirect(project.id, line.id, asset.id);
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.prepStatus).toBe("FLAGGED_FAULTY");
   });
 });


### PR DESCRIPTION
## Summary

Bug surfaced in dev testing: add 10x of a model, click Pull, complete
the check form. The line stayed at `prepStatus=PULLED` and never
appeared in the deploy tab — no assets were assigned visibly, no path
forward.

**Root cause.** The fulfillment-model cutover split prep responsibility:
- `pullItem` writes `line.prepStatus = "PULLED"`.
- `completeCheckAndPack` → `prepUnit` writes `unit.prepStatus = "PACKED"` and
  calls `syncLineItemRollup`.
- But `syncLineItemRollup` only derived `line.status` from units. It
  never touched `line.prepStatus`. So the line stayed PULLED forever.
- The warehouse UI's deploy tab filters `line.prepStatus === "PACKED"`,
  so the line was invisible to deploy.

**Fix.** Add `deriveOrderLinePrepStatus` (pure helper), wire it into
`syncLineItemRollup`, include `prepStatus` in the line SELECT.

Rules:
- `FLAGGED_FAULTY` / `FLAGGED_TT_OVERDUE` survive — they're operator
  overrides from `completeCheckAndFlag` and must not be silently wiped.
- Any unit `prepStatus=PACKED` ⇒ line `PACKED` (quantity-aware UX
  handles 1-of-10 partial states via rollup counters separately).
- Otherwise the existing `prepStatus` survives (preserves PULLED
  while operator is still scanning, PENDING on fresh lines).

## Test plan

- [x] 6 new unit tests for `deriveOrderLinePrepStatus` (including
      partial pack and FLAGGED_* override paths)
- [x] 2 new integration tests reproducing the user's exact dev flow:
      `pullItem(line)` → `prepItemDirect(line, asset)` → assert
      `prepStatus=PACKED`, packedQuantity=1, unit exists
- [x] FLAGGED_FAULTY-survives test confirms the operator override is
      preserved
- [x] 40 cutover integration tests + 1852 unit tests green
- [x] Local dev hot-reloaded; manual reproduction confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)