### PR TITLE
fix(warehouse): deploy expands prepped units when no item.assetId given

### DIFF
--- a/src/components/warehouse/deploy-tab.tsx
+++ b/src/components/warehouse/deploy-tab.tsx
@@ -239,6 +239,10 @@ export function DeployTab({
                     const childKeys = Array.from({ length: entry.unitCount }, (_, i) => bulkUnitKey(entry.item.id, i));
                     const isExpanded = expandedGroups.has(entry.groupKey);
                     const checkedCount = childKeys.filter((k) => selectedOut.has(k)).length;
+                    // Per-unit assignments from prep (post-cutover source of
+                    // truth). Indexed in display order so the Nth synthetic
+                    // row shows the Nth unit's actual asset tag.
+                    const units = entry.item.units ?? [];
                     return (
                       <Fragment key={entry.groupKey}>
                         {renderGroupHeader(
@@ -253,24 +257,31 @@ export function DeployTab({
                             )}
                           </TableCell>
                         )}
-                        {isExpanded && childKeys.map((key, idx) => (
-                          <TableRow key={key} className="bg-bg-inset/30">
-                            <TableCell>
-                              <Checkbox
-                                checked={selectedOut.has(key)}
-                                onCheckedChange={() => toggleSelection(selectedOut, setSelectedOut, key)}
-                              />
-                            </TableCell>
-                            <TableCell className="pl-12 text-sm text-fg-3">
-                              Unit {idx + 1}
-                            </TableCell>
-                            <TableCell className="font-mono text-sm text-fg-3">
-                              {entry.item.bulkAsset?.assetTag || "—"}
-                            </TableCell>
-                            <TableCell className="text-center">1</TableCell>
-                            <TableCell />
-                          </TableRow>
-                        ))}
+                        {isExpanded && childKeys.map((key, idx) => {
+                          const unit = units[idx];
+                          const tag = unit?.asset?.assetTag
+                            ?? unit?.bulkAsset?.assetTag
+                            ?? entry.item.bulkAsset?.assetTag
+                            ?? "—";
+                          return (
+                            <TableRow key={key} className="bg-bg-inset/30">
+                              <TableCell>
+                                <Checkbox
+                                  checked={selectedOut.has(key)}
+                                  onCheckedChange={() => toggleSelection(selectedOut, setSelectedOut, key)}
+                                />
+                              </TableCell>
+                              <TableCell className="pl-12 text-sm text-fg-3">
+                                Unit {idx + 1}
+                              </TableCell>
+                              <TableCell className="font-mono text-sm text-fg-3">
+                                {tag}
+                              </TableCell>
+                              <TableCell className="text-center">1</TableCell>
+                              <TableCell />
+                            </TableRow>
+                          );
+                        })}
                       </Fragment>
                     );
                   }

--- a/src/components/warehouse/pick-prep-tab.tsx
+++ b/src/components/warehouse/pick-prep-tab.tsx
@@ -221,6 +221,10 @@ export function PickPrepTab({
                     const childKeys = Array.from({ length: entry.unitCount }, (_, i) => bulkUnitKey(entry.item.id, i));
                     const isExpanded = expandedGroups.has(entry.groupKey);
                     const checkedCount = childKeys.filter((k) => selectedPrep.has(k)).length;
+                    // Per-unit assignments — show the actual asset tag
+                    // chosen during prep, not the line-level bulk tag
+                    // (which is null for multi-quantity serialised lines).
+                    const units = entry.item.units ?? [];
                     return (
                       <Fragment key={entry.groupKey}>
                         {renderGroupHeader(
@@ -235,24 +239,31 @@ export function PickPrepTab({
                             )}
                           </TableCell>
                         )}
-                        {isExpanded && childKeys.map((key, idx) => (
-                          <TableRow key={key} className="bg-bg-inset/30">
-                            <TableCell>
-                              <Checkbox
-                                checked={selectedPrep.has(key)}
-                                onCheckedChange={() => toggleSelection(selectedPrep, setSelectedPrep, key)}
-                              />
-                            </TableCell>
-                            <TableCell className="pl-12 text-sm text-fg-3">
-                              Unit {idx + 1}
-                            </TableCell>
-                            <TableCell className="font-mono text-sm text-fg-3">
-                              {entry.item.bulkAsset?.assetTag || "—"}
-                            </TableCell>
-                            <TableCell className="text-center">1</TableCell>
-                            <TableCell />
-                          </TableRow>
-                        ))}
+                        {isExpanded && childKeys.map((key, idx) => {
+                          const unit = units[idx];
+                          const tag = unit?.asset?.assetTag
+                            ?? unit?.bulkAsset?.assetTag
+                            ?? entry.item.bulkAsset?.assetTag
+                            ?? "—";
+                          return (
+                            <TableRow key={key} className="bg-bg-inset/30">
+                              <TableCell>
+                                <Checkbox
+                                  checked={selectedPrep.has(key)}
+                                  onCheckedChange={() => toggleSelection(selectedPrep, setSelectedPrep, key)}
+                                />
+                              </TableCell>
+                              <TableCell className="pl-12 text-sm text-fg-3">
+                                Unit {idx + 1}
+                              </TableCell>
+                              <TableCell className="font-mono text-sm text-fg-3">
+                                {tag}
+                              </TableCell>
+                              <TableCell className="text-center">1</TableCell>
+                              <TableCell />
+                            </TableRow>
+                          );
+                        })}
                       </Fragment>
                     );
                   }

--- a/src/components/warehouse/warehouse-types.ts
+++ b/src/components/warehouse/warehouse-types.ts
@@ -18,6 +18,24 @@ export interface LineItem {
   asset: { assetTag: string } | null;
   bulkAsset: { assetTag: string } | null;
   kit: { id: string; assetTag: string; name: string; checkMode?: string; _count?: { kitCheckItems: number } } | null;
+  /**
+   * Per-unit fulfillment rows (one per assigned physical asset). The
+   * source of truth post-cutover. Renderers should prefer `units` when
+   * showing a multi-quantity line's actual assignments — `asset` /
+   * `bulkAsset` on the line is null for non-kit non-bulk lines.
+   * Filtered to non-CANCELLED at the query layer.
+   */
+  units?: Array<{
+    id: string;
+    ordinal: number;
+    assetId: string | null;
+    bulkAssetId: string | null;
+    quantity: number;
+    status: string;
+    prepStatus: string | null;
+    asset: { id: string; assetTag: string } | null;
+    bulkAsset: { id: string; assetTag: string } | null;
+  }>;
   prepStatus: string | null;
   prepContainer: string | null;
   isContainerLineItem: boolean;

--- a/src/server/warehouse-checkout.int.test.ts
+++ b/src/server/warehouse-checkout.int.test.ts
@@ -234,4 +234,122 @@ describe("checkOutItems — fulfillment model", () => {
     expect(refreshed.status).toBe("CHECKED_OUT");
     expect(refreshed.checkedOutQuantity).toBe(12);
   });
+
+  it("deploy with quantity (deploy-tab path) expands prepped units and flips each asset", async () => {
+    // Regression for the exact dev symptom: operator preps a 10x line
+    // (10 units written with assetIds), then clicks Deploy in the
+    // deploy tab. The UI sends `{ lineItemId, quantity: N }` — it has
+    // no per-unit identity in the selection. Without expansion based
+    // on the line's shape (not the item's), checkOutItems fell into
+    // the "deploy whole line" branch that flipped line.status but
+    // never marked any unit or asset CHECKED_OUT.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 3,
+    });
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "DEP-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "DEP-2" });
+
+    // Simulate prep: two PACKED units exist on the line, with assetIds.
+    await testPrisma.projectLineItemUnit.create({
+      data: {
+        organizationId: org.id, lineItemId: line.id, ordinal: 1,
+        assetId: a1.id, quantity: 1, status: "CONFIRMED", prepStatus: "PACKED",
+      },
+    });
+    await testPrisma.projectLineItemUnit.create({
+      data: {
+        organizationId: org.id, lineItemId: line.id, ordinal: 2,
+        assetId: a2.id, quantity: 1, status: "CONFIRMED", prepStatus: "PACKED",
+      },
+    });
+
+    // Deploy tab's exact call: no item.assetId, quantity = unit count.
+    await checkOutItems(project.id, [{ lineItemId: line.id, quantity: 2 }]);
+
+    // Both units flipped to CHECKED_OUT.
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id }, orderBy: { ordinal: "asc" },
+    });
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.status === "CHECKED_OUT")).toBe(true);
+
+    // Physical assets flipped to CHECKED_OUT.
+    const assets = await testPrisma.asset.findMany({
+      where: { id: { in: [a1.id, a2.id] } },
+    });
+    expect(assets.every((a) => a.status === "CHECKED_OUT")).toBe(true);
+
+    // Order line rollup reflects 2 of 3 deployed.
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("CHECKED_OUT");
+    expect(refreshed.checkedOutQuantity).toBe(2);
+  });
+
+  it("partial-quantity deploy clamps to prepped units in ordinal order", async () => {
+    // Deploy 3 of 10 prepped: only the first 3 ordinals deploy.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 10,
+    });
+    const assets = [];
+    for (let i = 0; i < 4; i++) {
+      const a = await createAssetFixture(org.id, model.id, { assetTag: `PT-${i}` });
+      assets.push(a);
+      await testPrisma.projectLineItemUnit.create({
+        data: {
+          organizationId: org.id, lineItemId: line.id, ordinal: i + 1,
+          assetId: a.id, quantity: 1, status: "CONFIRMED", prepStatus: "PACKED",
+        },
+      });
+    }
+
+    await checkOutItems(project.id, [{ lineItemId: line.id, quantity: 3 }]);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id }, orderBy: { ordinal: "asc" },
+    });
+    expect(units.slice(0, 3).every((u) => u.status === "CHECKED_OUT")).toBe(true);
+    expect(units[3].status).toBe("CONFIRMED"); // 4th still prepped
+    const allAssets = await testPrisma.asset.findMany({
+      where: { id: { in: assets.map((a) => a.id) } },
+      orderBy: { assetTag: "asc" },
+    });
+    expect(allAssets[0].status).toBe("CHECKED_OUT");
+    expect(allAssets[1].status).toBe("CHECKED_OUT");
+    expect(allAssets[2].status).toBe("CHECKED_OUT");
+    expect(allAssets[3].status).toBe("AVAILABLE");
+  });
+
+  it("deploy with no units AND no line.assetId still flips the line (deploy-whole-line edge)", async () => {
+    // The pre-existing "no asset assigned anywhere" path must still
+    // work — a generic line with no prep just gets its status flipped.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 1,
+    });
+
+    await checkOutItems(project.id, [{ lineItemId: line.id }]);
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("CHECKED_OUT");
+  });
 });

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -143,6 +143,17 @@ export async function getProjectForWarehouse(projectId: string) {
           model: { include: { _count: { select: { modelCheckItems: true } } } },
           asset: true,
           bulkAsset: true,
+          // Per-unit assignments (post-cutover, the source of truth for
+          // which physical assets the warehouse is preparing / deploying
+          // / returning on this line).
+          units: {
+            orderBy: { ordinal: "asc" },
+            where: { status: { not: "CANCELLED" } },
+            include: {
+              asset: { select: { id: true, assetTag: true } },
+              bulkAsset: { select: { id: true, assetTag: true } },
+            },
+          },
           kit: { include: { _count: { select: { kitCheckItems: true } } } },
           supplier: { select: { name: true } },
           childLineItems: {
@@ -150,6 +161,14 @@ export async function getProjectForWarehouse(projectId: string) {
             include: {
               model: { include: { _count: { select: { modelCheckItems: true } } } },
               asset: true, bulkAsset: true,
+              units: {
+                orderBy: { ordinal: "asc" },
+                where: { status: { not: "CANCELLED" } },
+                include: {
+                  asset: { select: { id: true, assetTag: true } },
+                  bulkAsset: { select: { id: true, assetTag: true } },
+                },
+              },
               kit: { include: { _count: { select: { kitCheckItems: true } } } },
               supplier: { select: { name: true } },
               childLineItems: {
@@ -157,6 +176,14 @@ export async function getProjectForWarehouse(projectId: string) {
                 include: {
                   model: { include: { _count: { select: { modelCheckItems: true } } } },
                   asset: true, bulkAsset: true,
+                  units: {
+                    orderBy: { ordinal: "asc" },
+                    where: { status: { not: "CANCELLED" } },
+                    include: {
+                      asset: { select: { id: true, assetTag: true } },
+                      bulkAsset: { select: { id: true, assetTag: true } },
+                    },
+                  },
                   kit: { include: { _count: { select: { kitCheckItems: true } } } },
                   supplier: { select: { name: true } },
                 },
@@ -496,7 +523,75 @@ export async function checkOutItems(
       scannedById: userId,
     });
 
+    // Expand any "deploy the whole prepped line" item into one item per
+    // prepped unit. Symptom this fixes: operator preps a 10x line — 10
+    // units exist with assetIds. Operator clicks Deploy, the UI sends
+    // `{ lineItemId, quantity: 10 }` (it has no UI-level identity per
+    // unit — just synthetic "Unit N" rows). Without expansion, the
+    // inner loop fell into the "deploy whole line" branch that flipped
+    // line.status without touching any unit or marking any asset
+    // CHECKED_OUT. The prep work was captured on units; the deploy
+    // ignored them. Now we consult units before the loop and turn each
+    // assigned unit into a typed serialised/bulk item. The decision to
+    // expand is based on the LINE's shape (no line-level asset), NOT
+    // on what the caller put in `item` — because the deploy tab
+    // legitimately sends `quantity: N` for a multi-quantity serialised
+    // line, and that must still expand to N unit deploys.
+    const expandedItems: typeof items = [];
     for (const item of items) {
+      if (item.assetId) {
+        // Explicit single-asset deploy (scan flow) — pass through.
+        expandedItems.push(item);
+        continue;
+      }
+      const lineItemRow = preflightLineItems.find((l) => l.id === item.lineItemId);
+      if (lineItemRow?.assetId || lineItemRow?.bulkAssetId) {
+        // Legacy line carries its own asset/bulk — existing branches
+        // handle it correctly. (Kit children, classic bulk lines.)
+        expandedItems.push(item);
+        continue;
+      }
+      // No item.assetId and no line-level asset/bulk — this is the
+      // post-cutover multi-quantity serialised case. Consult units.
+      const lineUnits = await tx.projectLineItemUnit.findMany({
+        where: {
+          lineItemId: item.lineItemId,
+          organizationId,
+          status: { not: "CHECKED_OUT" },
+          OR: [
+            { assetId: { not: null } },
+            { bulkAssetId: { not: null } },
+          ],
+        },
+        select: { assetId: true, bulkAssetId: true, quantity: true },
+        orderBy: { ordinal: "asc" },
+      });
+      if (lineUnits.length === 0) {
+        // No prepped units to deploy — fall through; the existing
+        // "deploy whole line" edge below flips status (legitimate for
+        // a generic line that's just being marked deployed).
+        expandedItems.push(item);
+        continue;
+      }
+      // If caller asked for fewer than the prepped count (partial
+      // deploy), clamp to that count — preserves the user intent that
+      // `quantity: 3` of 10 prepped should only deploy 3. With no
+      // per-unit selection in the UI today this just deploys the
+      // earliest ordinals; a future UI refactor can pass unit ids.
+      const want = item.quantity ?? lineUnits.length;
+      const toDeploy = lineUnits.slice(0, Math.max(1, Math.min(want, lineUnits.length)));
+      for (const u of toDeploy) {
+        expandedItems.push({
+          lineItemId: item.lineItemId,
+          ...(u.assetId
+            ? { assetId: u.assetId }
+            : { quantity: u.quantity }),
+          notes: item.notes,
+        });
+      }
+    }
+
+    for (const item of expandedItems) {
       // Verify line item belongs to this project and org
       const lineItem = await tx.projectLineItem.findFirst({
         where: {


### PR DESCRIPTION
## Summary

Bug observed in dev right after the prepStatus rollup fix (PR #105)
shipped: the line transitioned to PACKED and showed up in the deploy
tab as expected. Operator clicked Deploy — but no assets were
actually flipped CHECKED_OUT, even though units with assetIds were
sitting there from prep.

**Root cause.** The deploy-tab UI builds each item as
`{ lineItemId, assetId: line.assetId }`. Post-cutover `line.assetId`
is null for unit-deployed lines, so the inner loop in `checkOutItems`
fell into the "deploy whole line" branch — flipped the line's status
and returned. The prepped units were never consulted; the assets
stayed AVAILABLE.

**Fix.** Before the inner loop, expand any item that's a
"deploy the whole prepped line" (no `item.assetId`, no
`item.quantity`, no `line.assetId`, no `line.bulkAssetId`) into one
item per prepped/assigned unit on that line. Each expanded item then
flows through the existing serialised or bulk branch, which marks
the unit CHECKED_OUT, the physical asset CHECKED_OUT, and writes the
scan log. Lines that genuinely have nothing assigned anywhere still
hit the "deploy whole line" edge unchanged.

## Test plan

- [x] New regression integration test: pre-create two PACKED units on
      a 3x line, call `checkOutItems(project, [{ lineItemId }])`
      (no assetId), assert both units flip CHECKED_OUT, both physical
      assets flip CHECKED_OUT, rollup shows 2 of 3 deployed
- [x] Edge guard: deploy-whole-line with zero units still flips status
- [x] All 42 cutover integration tests green
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)