### PR TITLE
fix: show per-unit asset tags everywhere; fix pass-all deprep error

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -118,6 +118,14 @@ interface LineItemData {
   supplier?: { name: string } | null;
   model?: { name: string; dailyRate?: unknown; weeklyRate?: unknown; monthlyRate?: unknown } | null;
   asset?: { assetTag?: string | null } | null;
+  /** Post-cutover per-unit assignments. Source of truth for which
+   *  physical assets a multi-quantity line is using. */
+  units?: Array<{
+    id: string;
+    ordinal: number;
+    asset?: { id: string; assetTag: string } | null;
+    bulkAsset?: { id: string; assetTag: string } | null;
+  }>;
   kit?: { name?: string } | null;
   childLineItems?: LineItemData[];
 }
@@ -496,9 +504,30 @@ function SortableLineItemRow({
           {hasChildren && (
             <span className="text-xs text-fg-3">{item.childLineItems!.length} item{item.childLineItems!.length !== 1 ? "s" : ""}</span>
           )}
-          {item.asset?.assetTag && (
-            <span className="text-xs text-fg-3">({item.asset.assetTag})</span>
-          )}
+          {(() => {
+            // Show asset tags from per-unit fulfillment if present
+            // (post-cutover, line.asset is null on multi-quantity
+            // serialised lines — the tags live on units). Single-asset
+            // legacy lines still render via item.asset.assetTag.
+            const unitTags = (item.units ?? [])
+              .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
+              .filter((t): t is string => !!t);
+            if (unitTags.length === 1) {
+              return <span className="text-xs text-fg-3">({unitTags[0]})</span>;
+            }
+            if (unitTags.length > 1) {
+              return (
+                <span className="text-xs text-fg-3">
+                  ({unitTags.slice(0, 2).join(", ")}
+                  {unitTags.length > 2 ? ` +${unitTags.length - 2}` : ""})
+                </span>
+              );
+            }
+            if (item.asset?.assetTag) {
+              return <span className="text-xs text-fg-3">({item.asset.assetTag})</span>;
+            }
+            return null;
+          })()}
           {item.kitId && !item.isKitChild && (
             <Badge variant="outline" className="ml-1.5 text-xs bg-indigo-500/10 text-indigo-600 border-indigo-500/20">
               Kit

--- a/src/components/warehouse/return-tab.tsx
+++ b/src/components/warehouse/return-tab.tsx
@@ -255,6 +255,11 @@ export function ReturnTab({
                     const childKeys = Array.from({ length: entry.unitCount }, (_, i) => bulkUnitKey(entry.item.id, i));
                     const isExpanded = expandedGroups.has(entry.groupKey);
                     const checkedCount = childKeys.filter((k) => selectedIn.has(k)).length;
+                    // Render per-unit asset tags from the fulfillment
+                    // units. Pre-cutover this column was always the
+                    // line-level bulkAsset tag (null for serialised
+                    // multi-quantity lines).
+                    const units = entry.item.units ?? [];
                     return (
                       <Fragment key={entry.groupKey}>
                         {renderGroupHeader(
@@ -269,24 +274,31 @@ export function ReturnTab({
                             )}
                           </TableCell>
                         )}
-                        {isExpanded && childKeys.map((key, idx) => (
-                          <TableRow key={key} className="bg-bg-inset/30">
-                            <TableCell>
-                              <Checkbox
-                                checked={selectedIn.has(key)}
-                                onCheckedChange={() => toggleSelection(selectedIn, setSelectedIn, key)}
-                              />
-                            </TableCell>
-                            <TableCell className="pl-12 text-sm text-fg-3">
-                              Unit {idx + 1}
-                            </TableCell>
-                            <TableCell className="font-mono text-sm text-fg-3">
-                              {entry.item.bulkAsset?.assetTag || "—"}
-                            </TableCell>
-                            <TableCell className="text-center">1</TableCell>
-                            <TableCell />
-                          </TableRow>
-                        ))}
+                        {isExpanded && childKeys.map((key, idx) => {
+                          const unit = units[idx];
+                          const tag = unit?.asset?.assetTag
+                            ?? unit?.bulkAsset?.assetTag
+                            ?? entry.item.bulkAsset?.assetTag
+                            ?? "—";
+                          return (
+                            <TableRow key={key} className="bg-bg-inset/30">
+                              <TableCell>
+                                <Checkbox
+                                  checked={selectedIn.has(key)}
+                                  onCheckedChange={() => toggleSelection(selectedIn, setSelectedIn, key)}
+                                />
+                              </TableCell>
+                              <TableCell className="pl-12 text-sm text-fg-3">
+                                Unit {idx + 1}
+                              </TableCell>
+                              <TableCell className="font-mono text-sm text-fg-3">
+                                {tag}
+                              </TableCell>
+                              <TableCell className="text-center">1</TableCell>
+                              <TableCell />
+                            </TableRow>
+                          );
+                        })}
                       </Fragment>
                     );
                   }

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -599,10 +599,16 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
         currentY -= rowContentHeight;
       } // end if (!isContinuation)
 
-      // === Per-unit checkboxes (packing list, qty > 1, non-kit) ===
+      // === Per-unit checkboxes (packing list / docket / return-sheet) ===
+      // Renders one sub-row per physical unit on a multi-quantity line,
+      // labelled with the unit's actual asset tag (post-cutover, this is
+      // the source of truth — `line.asset` is null on multi-quantity
+      // serialised lines). Falls back to "Item - N" for legacy lines
+      // that have no units yet.
       if (config.showPerUnitCheckboxes && !isKit && item.quantity > 1) {
         const shortName = item.model?.name || item.description || "Item";
         const checkedOut = item.checkedOutQuantity || 0;
+        const units = item.units ?? [];
         // Skip already-rendered sub-items on continuation pages
         const subStart = (isFirstRenderedItem && startSubIndex > 0) ? startSubIndex : 0;
         for (let i = subStart; i < item.quantity; i++) {
@@ -611,11 +617,19 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
           const puY = currentY - puHeight + 3;
           const indentX = tableX + 26;
           drawCheckbox(page, pdfLib, indentX, puY, 7, i < checkedOut);
-          page.drawText(`${shortName} - ${i + 1}`, {
+          const unit = units[i];
+          const tag =
+            unit?.asset?.assetTag ??
+            unit?.bulkAsset?.assetTag ??
+            null;
+          const label = tag
+            ? `Unit ${i + 1} — ${tag}`
+            : `${shortName} - ${i + 1}`;
+          page.drawText(label, {
             x: indentX + 11,
             y: puY,
             size: 7,
-            font: fonts.regular,
+            font: tag ? fonts.courier : fonts.regular,
             color: lightTextColor,
           });
           currentY -= puHeight;
@@ -791,20 +805,27 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
 
           currentY -= childRowHeight;
 
-          // Per-unit checkboxes for child items
+          // Per-unit checkboxes for child items (same unit-aware logic
+          // as the top-level row).
           if (config.showPerUnitCheckboxes && !isNestedKit && child.quantity > 1) {
             const childCheckedOut = child.checkedOutQuantity || 0;
+            const childUnits = child.units ?? [];
             for (let i = 0; i < child.quantity; i++) {
               const puHeight = 10;
               if (currentY - puHeight < bottomBoundary) { overflow = true; break; }
               const puY = currentY - puHeight + 3;
               const indentX = tableX + 38;
               drawCheckbox(page, pdfLib, indentX, puY, 7, i < childCheckedOut);
-              page.drawText(`${childName} - ${i + 1}`, {
+              const unit = childUnits[i];
+              const tag = unit?.asset?.assetTag ?? unit?.bulkAsset?.assetTag ?? null;
+              const label = tag
+                ? `Unit ${i + 1} — ${tag}`
+                : `${childName} - ${i + 1}`;
+              page.drawText(label, {
                 x: indentX + 11,
                 y: puY,
                 size: 7,
-                font: fonts.regular,
+                font: tag ? fonts.courier : fonts.regular,
                 color: lightTextColor,
               });
               currentY -= puHeight;

--- a/src/lib/pdfme/template-settings.ts
+++ b/src/lib/pdfme/template-settings.ts
@@ -220,6 +220,10 @@ export function getDefaultSettings(docType: DocumentType): TemplateSettings {
       base.table.showCheckboxes = true;
       base.table.showRowNumbers = true;
       base.table.showAssetTags = true;
+      // Per-unit sub-rows so a 10x line lists every assigned asset tag
+      // for the client to tick off on receipt — the whole reason the
+      // line-item fulfillment rework happened.
+      base.table.showPerUnitCheckboxes = true;
       base.table.showPricing = false;
       base.table.showBadges = false;
       base.table.showNotes = false;

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -338,9 +338,19 @@ export async function completeCheckAndDeprep(data: {
         `Deprep return check requires RETURNED status (got ${lineItem.status})`
       );
     }
-    if (lineItem.prepStatus !== "PACKED") {
+    // Idempotent on prepStatus. A multi-unit line generates N sequential
+    // completeCheckAndDeprep calls — the first resets prepStatus from
+    // PACKED to PENDING, and the remaining calls would have failed a
+    // strict PACKED-only precondition. We still want each call to save
+    // its check records (one per asset), and resetting prepStatus to
+    // PENDING is idempotent. Only reject states that indicate the line
+    // never went through prep at all (eg FLAGGED_FAULTY).
+    if (
+      lineItem.prepStatus !== "PACKED" &&
+      lineItem.prepStatus !== "PENDING"
+    ) {
       throw new Error(
-        `Deprep return check requires prepStatus=PACKED (got ${lineItem.prepStatus ?? "null"})`
+        `Deprep return check expected prepStatus=PACKED or PENDING (got ${lineItem.prepStatus ?? "null"})`
       );
     }
 

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -19,6 +19,22 @@ const projectFilterColumns: FilterColumnDef[] = [
   { id: "type", filterType: "enum" },
 ];
 
+/**
+ * Per-unit fulfillment rows to thread through every line-item include
+ * on `getProject`. The project view's equipment tab uses these to show
+ * each physical asset assigned to a multi-quantity line (post-cutover
+ * `line.asset` is null for those — the assignments live on units).
+ * CANCELLED units are filtered out at the query layer.
+ */
+const PROJECT_UNIT_INCLUDE = {
+  orderBy: { ordinal: "asc" as const },
+  where: { status: { not: "CANCELLED" as const } },
+  include: {
+    asset: { select: { id: true, assetTag: true } },
+    bulkAsset: { select: { id: true, assetTag: true } },
+  },
+} as const;
+
 async function generateTemplateCode(organizationId: string): Promise<string> {
   const count = await prisma.project.count({
     where: { organizationId, isTemplate: true },
@@ -200,8 +216,12 @@ export async function getProject(id: string) {
               lineItems: {
                 include: {
                   model: true, asset: true, bulkAsset: true, kit: true,
+                  units: PROJECT_UNIT_INCLUDE,
                   childLineItems: {
-                    include: { model: true, asset: true, bulkAsset: true, kit: true },
+                    include: {
+                      model: true, asset: true, bulkAsset: true, kit: true,
+                      units: PROJECT_UNIT_INCLUDE,
+                    },
                     orderBy: { sortOrder: "asc" },
                   },
                 },
@@ -214,8 +234,12 @@ export async function getProject(id: string) {
             where: { groupId: null },
             include: {
               model: true, asset: true, bulkAsset: true, kit: true,
+              units: PROJECT_UNIT_INCLUDE,
               childLineItems: {
-                include: { model: true, asset: true, bulkAsset: true, kit: true },
+                include: {
+                  model: true, asset: true, bulkAsset: true, kit: true,
+                  units: PROJECT_UNIT_INCLUDE,
+                },
                 orderBy: { sortOrder: "asc" },
               },
             },
@@ -231,11 +255,16 @@ export async function getProject(id: string) {
           bulkAsset: true,
           kit: true,
           supplier: true,
+          units: PROJECT_UNIT_INCLUDE,
           childLineItems: {
             include: {
               model: true, asset: true, bulkAsset: true, kit: true,
+              units: PROJECT_UNIT_INCLUDE,
               childLineItems: {
-                include: { model: true, asset: true, bulkAsset: true },
+                include: {
+                  model: true, asset: true, bulkAsset: true,
+                  units: PROJECT_UNIT_INCLUDE,
+                },
                 orderBy: { sortOrder: "asc" },
               },
             },


### PR DESCRIPTION
## Summary

User-tested four issues on dev after the deploy fix shipped:

1. **Pass-all returns crashed** with `Deprep return check requires prepStatus=PACKED (got PENDING)`. The strict precondition rejected every iteration past the first on a multi-unit return — the first call resets prepStatus, the second sees PENDING and throws. Made the check idempotent (PACKED OR PENDING).

2. **Return tab showed `—` for every unit's asset tag** (same root cause as the deploy tab pre-fix). The bulk-group renderer read the line-level `bulkAsset.assetTag` — null on a serialised multi-quantity line. Now reads `entry.item.units[idx]`.

3. **Project equipment-tab showed no asset tags on multi-quantity lines.** `getProject` never included `units`, so the equipment tab couldn't see them. Added `units` at every line-item nesting level (categories→groups→lineItems, categories→lineItems, top-level lineItems, plus child / grandchild). Renderer shows `(TAG-1)`, `(TAG-1, TAG-2 +N)`, falls back to legacy.

4. **PDF delivery docket asset-tag column showed `TTP00022, TTP00023 +8`** truncated, instead of listing every unit. Turned on `showPerUnitCheckboxes` for delivery-docket and updated the sub-row label to show the actual unit asset tag in courier (`Unit 1 — TTP00022`).

## Test plan

- [x] 1852 unit tests green
- [x] 17 cutover integration tests green
- [x] `npx tsc --noEmit` clean
- [ ] Re-pull a delivery docket on the test 10x line → expect 10 sub-rows with actual asset tags
- [ ] Run pass-all returns on a multi-unit returned line → expect all check records saved, no crash
- [ ] Open the project view → expect asset tags showing per multi-quantity line

🤖 Generated with [Claude Code](https://claude.com/claude-code)