### PR TITLE
fix(warehouse): deprep removes the assigned unit rows

### DIFF
--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
-import { prepUnit } from "@/server/line-item-fulfillment";
+import { prepUnit, syncLineItemRollup } from "@/server/line-item-fulfillment";
 import type { Prisma } from "@/generated/prisma/client";
 import {
   completeCheckAndPackSchema,
@@ -268,19 +268,71 @@ export async function deprepItem(
       throw new Error("Item is already deployed — return it first");
     }
 
-    // For bulk split items (qty=1 with bulkAssetId), just reset prepStatus like serialized
-    // The split item stays as-is (doesn't merge back into original)
-
-    // Serialized item: clear prepStatus, unassign asset only for non-kit-child items
-    const updated = await tx.projectLineItem.update({
-      where: { id: lineItemId },
-      data: {
-        prepStatus: "PENDING",
-        ...(!lineItem.isKitChild && lineItem.assetId ? { asset: { disconnect: true } } : {}),
+    // Clean up the unit rows. Post-cutover, prep creates a unit per
+    // assigned asset (and marks it PACKED); deprep needs to remove
+    // them or the asset stays "stuck" on the line — visible in the
+    // project view, on dockets, and blocking the asset from being
+    // reassigned to a different line / project. Without this the
+    // line.prepStatus reset is cosmetic.
+    //
+    // asset.status is left alone — prep never marked it CHECKED_OUT,
+    // so it's still AVAILABLE. The unit row carries the assignment;
+    // deleting the unit removes the assignment.
+    const preppedUnits = await tx.projectLineItemUnit.findMany({
+      where: {
+        lineItemId,
+        status: { not: "CHECKED_OUT" },
       },
+      orderBy: { ordinal: "desc" },
+      select: { id: true, quantity: true, bulkAssetId: true, assetId: true },
+    });
+
+    // Partial bulk deprep: a single bulk unit row carries the qty —
+    // reduce its quantity instead of deleting the whole row.
+    const isPartialBulk =
+      preppedUnits.length === 1 &&
+      preppedUnits[0].bulkAssetId &&
+      !preppedUnits[0].assetId &&
+      quantity < preppedUnits[0].quantity;
+    if (isPartialBulk) {
+      await tx.projectLineItemUnit.update({
+        where: { id: preppedUnits[0].id },
+        data: { quantity: preppedUnits[0].quantity - quantity },
+      });
+    } else {
+      // Serialised deprep — remove `quantity` units, highest-ordinal
+      // first (preserves the lower ordinals for staff who already
+      // pulled them physically; also natural LIFO).
+      const removeCount = Math.min(quantity, preppedUnits.length);
+      for (let i = 0; i < removeCount; i++) {
+        await tx.projectLineItemUnit.delete({
+          where: { id: preppedUnits[i].id },
+        });
+      }
+    }
+
+    // Clear legacy line.assetId (kit children excepted — they store
+    // their asset there as an active path, not as a fulfillment row).
+    if (!lineItem.isKitChild && lineItem.assetId) {
+      await tx.projectLineItem.update({
+        where: { id: lineItemId },
+        data: { asset: { disconnect: true } },
+      });
+    }
+
+    // Recompute rollup. With units gone, deriveOrderLinePrepStatus
+    // falls back to whatever was on the line — explicitly reset to
+    // PENDING here so the line returns to the prep tab.
+    await tx.projectLineItem.update({
+      where: { id: lineItemId },
+      data: { prepStatus: "PENDING" },
+    });
+    await syncLineItemRollup(tx, lineItemId);
+
+    return tx.projectLineItem.findUniqueOrThrow({
+      where: { id: lineItemId },
       include: { model: true, asset: true, bulkAsset: true },
     });
-    return updated;
   });
 
   await logActivity({

--- a/src/server/warehouse-prep.int.test.ts
+++ b/src/server/warehouse-prep.int.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/org-context", () => ({
 }));
 
 import { checkOutItems } from "@/server/warehouse";
-import { prepItemDirect, pullItem } from "@/server/check-records";
+import { prepItemDirect, pullItem, deprepItem } from "@/server/check-records";
 
 async function createProjectFixture(orgId: string) {
   return testPrisma.project.create({
@@ -175,6 +175,88 @@ describe("prepItemDirect — fulfillment model", () => {
     expect(units).toHaveLength(1);
     expect(units[0].assetId).toBe(asset.id);
     expect(units[0].prepStatus).toBe("PACKED");
+  });
+
+  it("deprepping a fully-prepped multi-unit line removes its assigned units", async () => {
+    // Regression for the user-reported symptom: prep 10x line (10
+    // units created with asset ids), then click Deprep. Old behaviour
+    // only flipped line.prepStatus — units stayed around with their
+    // asset ids, asset shown as "still assigned" in the project view
+    // and the warehouse couldn't re-prep onto different assets.
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 3);
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "DP-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "DP-2" });
+    const a3 = await createAssetFixture(org.id, model.id, { assetTag: "DP-3" });
+
+    // Prep all 3 units.
+    await prepItemDirect(project.id, line.id, a1.id);
+    await prepItemDirect(project.id, line.id, a2.id);
+    await prepItemDirect(project.id, line.id, a3.id);
+
+    let units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(3);
+
+    // Deprep all 3 in one call (matches the UI's "deprep selected" path).
+    await deprepItem(project.id, line.id, 3);
+
+    units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+    });
+    expect(units).toHaveLength(0);
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.prepStatus).toBe("PENDING");
+    expect(refreshed.assignedQuantity).toBe(0);
+    expect(refreshed.packedQuantity).toBe(0);
+    expect(refreshed.quantity).toBe(3);
+
+    // Assets weren't affected — they were never marked CHECKED_OUT
+    // during prep, so they should still be AVAILABLE.
+    const assets = await testPrisma.asset.findMany({
+      where: { id: { in: [a1.id, a2.id, a3.id] } },
+    });
+    expect(assets.every((a) => a.status === "AVAILABLE")).toBe(true);
+  });
+
+  it("partial deprep keeps remaining prepped units and stays PACKED", async () => {
+    // Deprep 1 of 3 prepped → line still PACKED (2 units left).
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, 3);
+    const assets = [];
+    for (let i = 0; i < 3; i++) {
+      const a = await createAssetFixture(org.id, model.id, { assetTag: `PD-${i}` });
+      assets.push(a);
+      await prepItemDirect(project.id, line.id, a.id);
+    }
+
+    await deprepItem(project.id, line.id, 1);
+
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id }, orderBy: { ordinal: "asc" },
+    });
+    expect(units).toHaveLength(2);
+
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    // 2 units still PACKED → line remains PACKED via rollup derivation.
+    expect(refreshed.prepStatus).toBe("PACKED");
+    expect(refreshed.packedQuantity).toBe(2);
   });
 
   it("operator-set FLAGGED_FAULTY survives a later unit pack", async () => {


### PR DESCRIPTION
## Summary

User-reported: clicking Deprep on a multi-unit prepped line didn't
unassign the asset tags. `line.prepStatus` reset to `PENDING`, but
the `ProjectLineItemUnit` rows stayed around carrying the assignments.
The project view still showed the assets as part of the line, the
warehouse couldn't re-prep onto different assets
(`ensureSerialisedUnit` reused the stale unit), and the docket still
listed them.

**Root cause.** `deprepItem` predates the unit table. It only touched
`line.prepStatus` and the legacy `line.asset.disconnect` — never the
unit rows that prep now writes.

**Fix.**
- Delete the prepped units (highest ordinal first — LIFO matches
  warehouse staff workflow: the last unit pulled is the first one
  back on the shelf).
- Partial bulk deprep reduces the bulk unit's quantity instead of
  deleting the whole row.
- Deprep count is capped at the prepped-unit count.
- `asset.status` is left alone — prep never marked it `CHECKED_OUT`,
  so `AVAILABLE` is correct throughout.
- `syncLineItemRollup` runs after so counters and the derived
  prepStatus reflect the remaining units (partial deprep leaves the
  line `PACKED` if any units remain prepped).

## Test plan

- [x] Two new integration tests:
  - Deprep all 3 units of a 3x line → zero units, prepStatus PENDING,
    rollup counters cleared, all 3 assets stay AVAILABLE
  - Deprep 1 of 3 → 2 units remain, line stays PACKED, packedQuantity=2
- [x] 45 cutover integration tests green
- [x] `npx tsc --noEmit` clean
- [ ] Manual: prep a 10x line, click Deprep on dev → expect units
      removed, line back in prep tab with no asset assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)