### PR TITLE
fix(warehouse): return + checks actually returns the units & assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "reconcile:bulk": "tsx --env-file=.env scripts/reconcile-bulk-availability.ts",
     "backfill:line-item-units": "tsx --env-file=.env scripts/backfill-line-item-units.ts",
     "collapse:split-siblings": "tsx --env-file=.env scripts/collapse-split-siblings.ts",
+    "migrate:docket-per-unit": "tsx --env-file=.env scripts/migrate-docket-per-unit.ts",
     "lint:server-actions": "tsx scripts/audit-server-actions.ts"
   },
   "dependencies": {

--- a/scripts/migrate-docket-per-unit.ts
+++ b/scripts/migrate-docket-per-unit.ts
@@ -1,0 +1,60 @@
+/**
+ * One-time data migration: turn on `showPerUnitCheckboxes` for every
+ * saved delivery-docket template that has it explicitly false in its
+ * settings JSON. The system default was flipped in code (v0.7.x), but
+ * organisations that customised their docket template before that
+ * change saved `false` and still get the old single-row rendering.
+ *
+ * Idempotent — re-running is a no-op. Reversible — operators can
+ * toggle the flag off via the document template editor.
+ *
+ * Usage:
+ *   tsx --env-file=.env scripts/migrate-docket-per-unit.ts            # dry-run
+ *   tsx --env-file=.env scripts/migrate-docket-per-unit.ts --apply    # writes
+ */
+
+import { prisma } from "../src/lib/prisma";
+
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  const templates = await prisma.documentTemplate.findMany({
+    where: { type: "delivery-docket", settings: { not: null } },
+    select: { id: true, name: true, organizationId: true, settings: true },
+  });
+
+  let touched = 0;
+  for (const t of templates) {
+    if (!t.settings) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(t.settings);
+    } catch {
+      console.log(`SKIP ${t.id} (${t.name}) — settings not valid JSON`);
+      continue;
+    }
+    const s = parsed as Record<string, unknown>;
+    const table = (s.table as Record<string, unknown> | undefined) ?? {};
+    if (table.showPerUnitCheckboxes === false) {
+      table.showPerUnitCheckboxes = true;
+      s.table = table;
+      console.log(
+        `${apply ? "FIX " : "PLAN"} ${t.id} (${t.name}) — flip showPerUnitCheckboxes false → true`,
+      );
+      if (apply) {
+        await prisma.documentTemplate.update({
+          where: { id: t.id },
+          data: { settings: JSON.stringify(s) },
+        });
+      }
+      touched += 1;
+    } else {
+      console.log(`OK   ${t.id} (${t.name}) — already on or undefined`);
+    }
+  }
+  console.log();
+  console.log(`Summary: ${touched} template(s) ${apply ? "updated" : "would be updated"}`);
+}
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -4,7 +4,11 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
-import { prepUnit, syncLineItemRollup } from "@/server/line-item-fulfillment";
+import {
+  prepUnit,
+  syncLineItemRollup,
+  returnLineUnits,
+} from "@/server/line-item-fulfillment";
 import type { Prisma } from "@/generated/prisma/client";
 import {
   completeCheckAndPackSchema,
@@ -826,27 +830,7 @@ export async function completeCheckAndStore(
       parsed.checks
     );
 
-    // 3. Map condition to return status
-    let returnStatus: "STORED" | "DAMAGED" | "LOST";
-    let assetStatus: "AVAILABLE" | "IN_MAINTENANCE" | "LOST";
-
-    switch (parsed.condition) {
-      case "DAMAGED":
-        returnStatus = "DAMAGED";
-        assetStatus = "IN_MAINTENANCE";
-        break;
-      case "MISSING":
-        returnStatus = "LOST";
-        assetStatus = "LOST";
-        break;
-      case "GOOD":
-      default:
-        returnStatus = "STORED";
-        assetStatus = "AVAILABLE";
-        break;
-    }
-
-    // 4. Determine return location
+    // 3. Determine return location
     let locationId = parsed.locationId || null;
     if (!locationId) {
       const defaultLocation = await tx.location.findFirst({
@@ -856,68 +840,41 @@ export async function completeCheckAndStore(
       locationId = defaultLocation?.id || null;
     }
 
-    // 5. Perform checkin (replicates checkInItems internal logic)
-    const resolvedAssetIdForReturn = parsed.assetId || lineItem.assetId;
-    const isBulk = resolvedAssetIdForReturn
-      ? false
-      : (!!lineItem.bulkAssetId || (!lineItem.assetId && lineItem.quantity > 1));
+    // 4. Perform the actual return via the canonical helper — same
+    //    code path checkInItems uses, so a multi-unit line's units
+    //    and assets all get flipped, not just the order-line counter.
+    //    Pre-cutover this function hand-rolled the checkin, which
+    //    only touched `line.returnedQuantity` and left units / assets
+    //    stuck in CHECKED_OUT — the root cause of "return didn't
+    //    release the assets" on multi-quantity serialised lines.
+    const { unitsFlipped, assetsTouched } = await returnLineUnits(tx, {
+      organizationId,
+      projectId: parsed.projectId,
+      lineItemId: parsed.lineItemId,
+      assetId: parsed.assetId,
+      bulkAssetId: parsed.bulkAssetId,
+      returnCondition: parsed.condition,
+      quantity: 1,
+      notes: parsed.notes,
+      userId,
+      defaultLocationId: locationId,
+    });
 
-    if (isBulk) {
-      const newReturnedQty = lineItem.returnedQuantity + 1;
-      const fullyReturned = newReturnedQty >= lineItem.checkedOutQuantity;
+    // 5. Sync rollup counters + derived status.
+    await syncLineItemRollup(tx, parsed.lineItemId);
 
-      await tx.projectLineItem.update({
-        where: { id: parsed.lineItemId },
-        data: {
-          returnedQuantity: newReturnedQty,
-          status: fullyReturned ? "RETURNED" : "CHECKED_OUT",
-          returnedAt: fullyReturned ? new Date() : lineItem.returnedAt,
-          ...(fullyReturned
-            ? { returnedBy: { connect: { id: userId } } }
-            : {}),
-          returnCondition: fullyReturned
-            ? parsed.condition
-            : lineItem.returnCondition,
-          returnNotes: parsed.notes || lineItem.returnNotes,
-          returnStatus,
-        },
-      });
-    } else {
-      await tx.projectLineItem.update({
-        where: { id: parsed.lineItemId },
-        data: {
-          status: "RETURNED",
-          returnedQuantity: 1,
-          returnedAt: new Date(),
-          returnedBy: { connect: { id: userId } },
-          returnCondition: parsed.condition,
-          returnNotes: parsed.notes || null,
-          asset: lineItem.assetId ? { disconnect: true } : undefined,
-          returnStatus,
-        },
-      });
-
-      if (lineItem.assetId) {
-        await tx.asset.update({
-          where: { id: lineItem.assetId },
-          data: {
-            status: assetStatus,
-            locationId,
-          },
-        });
-      }
-    }
-
-    // 6. Create scan log
+    // 6. Scan log
     await tx.assetScanLog.create({
       data: {
         organizationId,
-        assetId: lineItem.assetId || null,
+        assetId: assetsTouched.length === 1 ? assetsTouched[0] : null,
         bulkAssetId: lineItem.bulkAssetId || null,
         projectId: parsed.projectId,
         action: "CHECK_IN",
         scannedById: userId,
-        notes: parsed.notes || `Checked + ${returnStatus.toLowerCase()}`,
+        notes:
+          parsed.notes ||
+          `Checked + returned ${unitsFlipped || assetsTouched.length} unit(s)`,
       },
     });
 

--- a/src/server/line-item-fulfillment.ts
+++ b/src/server/line-item-fulfillment.ts
@@ -138,6 +138,191 @@ export async function ensureBulkUnit(
 }
 
 /**
+ * Map a return condition to the canonical asset status to set on
+ * checkin. Centralised so checkInItems, completeCheckAndStore, and
+ * any future caller stay in sync.
+ */
+export function assetStatusFromReturnCondition(
+  cond: "GOOD" | "DAMAGED" | "MISSING",
+): "AVAILABLE" | "IN_MAINTENANCE" | "LOST" {
+  if (cond === "DAMAGED") return "IN_MAINTENANCE";
+  if (cond === "MISSING") return "LOST";
+  return "AVAILABLE";
+}
+
+/**
+ * Return one or many units on a line. THE single source of truth for
+ * what "returning" means physically: flip the matching unit row(s) to
+ * RETURNED, restore the asset(s), update location.
+ *
+ * Three modes:
+ *   - `assetId` given → return exactly that asset's unit (scan flow).
+ *   - `bulkAssetId` given → accumulate quantity onto the bulk unit row.
+ *   - Neither → "return whole line": find every still-out unit and
+ *     flip each. Falls back to flipping the order line directly if no
+ *     units exist (kit children + legacy lines).
+ *
+ * Caller is responsible for the `requirePermission` check and the
+ * surrounding $transaction. This function MUST run inside one. Caller
+ * also handles syncLineItemRollup at the end (so multiple returns on
+ * the same line in one outer call only re-roll once).
+ *
+ * Returns the count of unit rows that were actually flipped (useful
+ * for scan-log notes; the caller can decide whether to write a log).
+ */
+export async function returnLineUnits(
+  tx: Prisma.TransactionClient,
+  args: {
+    organizationId: string;
+    projectId: string;
+    lineItemId: string;
+    /** Specific asset being returned via a scan. */
+    assetId?: string | null;
+    /** Bulk asset for legacy bulk lines (line.bulkAssetId). */
+    bulkAssetId?: string | null;
+    returnCondition: "GOOD" | "DAMAGED" | "MISSING";
+    quantity?: number;
+    notes?: string | null;
+    /** User performing the return — stamped on unit + asset scan log. */
+    userId: string;
+    /** Where the asset goes back to. */
+    defaultLocationId: string | null;
+  },
+): Promise<{ unitsFlipped: number; assetsTouched: string[] }> {
+  const assetStatus = assetStatusFromReturnCondition(args.returnCondition);
+  const lineItem = await tx.projectLineItem.findFirstOrThrow({
+    where: {
+      id: args.lineItemId,
+      projectId: args.projectId,
+      organizationId: args.organizationId,
+    },
+  });
+
+  // ── 1. Specific asset (scan) ────────────────────────────────────
+  const targetAssetId = args.assetId || lineItem.assetId || null;
+  if (targetAssetId) {
+    const unit = await tx.projectLineItemUnit.findUnique({
+      where: {
+        lineItemId_assetId: {
+          lineItemId: lineItem.id,
+          assetId: targetAssetId,
+        },
+      },
+      select: { id: true, status: true },
+    });
+    if (!unit) {
+      // Kit child / legacy line — no unit; flip the line + asset directly.
+      await tx.projectLineItem.update({
+        where: { id: lineItem.id },
+        data: {
+          status: "RETURNED",
+          returnedQuantity: lineItem.quantity,
+          returnedAt: new Date(),
+          returnedBy: { connect: { id: args.userId } },
+          returnCondition: args.returnCondition,
+          returnNotes: args.notes || null,
+        },
+      });
+      await tx.asset.update({
+        where: { id: targetAssetId },
+        data: { status: assetStatus, locationId: args.defaultLocationId },
+      });
+      return { unitsFlipped: 0, assetsTouched: [targetAssetId] };
+    }
+    // Guarded transition.
+    const flipped = await tx.projectLineItemUnit.updateMany({
+      where: { id: unit.id, status: "CHECKED_OUT" },
+      data: {
+        status: "RETURNED",
+        returnedAt: new Date(),
+        returnedById: args.userId,
+        returnCondition: args.returnCondition,
+        returnNotes: args.notes || null,
+      },
+    });
+    if (flipped.count > 0) {
+      await tx.asset.update({
+        where: { id: targetAssetId },
+        data: { status: assetStatus, locationId: args.defaultLocationId },
+      });
+    }
+    return { unitsFlipped: flipped.count, assetsTouched: [targetAssetId] };
+  }
+
+  // ── 2. Bulk line return ────────────────────────────────────────
+  const targetBulkId = args.bulkAssetId || lineItem.bulkAssetId || null;
+  if (targetBulkId) {
+    const returnQty = args.quantity || 1;
+    const unit = await tx.projectLineItemUnit.findFirst({
+      where: { lineItemId: lineItem.id, bulkAssetId: targetBulkId },
+    });
+    if (unit) {
+      const newReturned = Math.min(
+        unit.quantity,
+        unit.returnedQuantity + returnQty,
+      );
+      const fullyReturned = newReturned >= unit.quantity;
+      await tx.projectLineItemUnit.update({
+        where: { id: unit.id },
+        data: {
+          returnedQuantity: newReturned,
+          status: fullyReturned ? "RETURNED" : "CHECKED_OUT",
+          returnedAt: fullyReturned ? new Date() : unit.returnedAt,
+          returnedById: fullyReturned ? args.userId : unit.returnedById,
+          returnCondition: args.returnCondition,
+          returnNotes: args.notes || unit.returnNotes,
+        },
+      });
+    }
+    return { unitsFlipped: unit ? 1 : 0, assetsTouched: [] };
+  }
+
+  // ── 3. Return-whole-line ───────────────────────────────────────
+  // No specific asset and no line-level bulk: find every still-out
+  // unit on this line and flip each. If there are none, the line is
+  // a kit child / generic — flip the line itself.
+  const outUnits = await tx.projectLineItemUnit.findMany({
+    where: { lineItemId: lineItem.id, status: "CHECKED_OUT" },
+  });
+  if (outUnits.length === 0) {
+    await tx.projectLineItem.update({
+      where: { id: lineItem.id },
+      data: {
+        status: "RETURNED",
+        returnedQuantity: lineItem.checkedOutQuantity || lineItem.quantity,
+        returnedAt: new Date(),
+        returnedBy: { connect: { id: args.userId } },
+        returnCondition: args.returnCondition,
+        returnNotes: args.notes || null,
+      },
+    });
+    return { unitsFlipped: 0, assetsTouched: [] };
+  }
+  const assetsTouched: string[] = [];
+  for (const u of outUnits) {
+    await tx.projectLineItemUnit.update({
+      where: { id: u.id },
+      data: {
+        status: "RETURNED",
+        returnedAt: new Date(),
+        returnedById: args.userId,
+        returnCondition: args.returnCondition,
+        returnNotes: args.notes || null,
+        ...(u.bulkAssetId ? { returnedQuantity: u.quantity } : {}),
+      },
+    });
+    if (u.assetId) {
+      await tx.asset.update({
+        where: { id: u.assetId },
+        data: { status: assetStatus, locationId: args.defaultLocationId },
+      });
+      assetsTouched.push(u.assetId);
+    }
+  }
+  return { unitsFlipped: outUnits.length, assetsTouched };
+}
+
+/**
  * Mark a unit prepped/packed (the pick-and-pack step before checkout).
  * Serialised and bulk lines get a PACKED unit row; a generic line with no
  * asset assigned just carries prepStatus on the order line. Rolls the line

--- a/src/server/warehouse-checkin.int.test.ts
+++ b/src/server/warehouse-checkin.int.test.ts
@@ -34,6 +34,7 @@ import {
   checkInItems,
   lookupAssetForScan,
 } from "@/server/warehouse";
+import { completeCheckAndStore } from "@/server/check-records";
 
 async function createProjectFixture(orgId: string) {
   return testPrisma.project.create({
@@ -302,5 +303,94 @@ describe("checkInItems — fulfillment model round-trip", () => {
     expect(after.reason).toBeNull();
     expect(after.lineItemId).toBe(line.id);
     expect(after.assetId).toBe(asset.id);
+  });
+
+  it("completeCheckAndStore on a multi-unit line returns every unit + asset", async () => {
+    // The bug from deep review: completeCheckAndStore hand-rolled its
+    // own checkin logic — only incremented line.returnedQuantity and
+    // flipped line.status. On a multi-unit serialised line the units
+    // and physical assets stayed CHECKED_OUT forever. Fix delegates
+    // to returnLineUnits (the same code path checkInItems uses).
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const model = await createModelFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const line = await createLineItemFixture(org.id, project.id, model.id, {
+      quantity: 3,
+    });
+    const a1 = await createAssetFixture(org.id, model.id, { assetTag: "RX-1" });
+    const a2 = await createAssetFixture(org.id, model.id, { assetTag: "RX-2" });
+    const a3 = await createAssetFixture(org.id, model.id, { assetTag: "RX-3" });
+
+    // Deploy all 3.
+    await checkOutItems(project.id, [
+      { lineItemId: line.id, assetId: a1.id },
+      { lineItemId: line.id, assetId: a2.id },
+      { lineItemId: line.id, assetId: a3.id },
+    ]);
+
+    // Need a CheckItem so completeCheckAndStore's `checks` array is
+    // valid (the schema requires >= 1).
+    const checkItem = await testPrisma.checkItem.create({
+      data: {
+        organizationId: org.id,
+        label: "Visual inspection",
+        type: "PASS_FAIL",
+      },
+    });
+    const checks = [{
+      checkItemId: checkItem.id,
+      result: "PASS" as const,
+      photos: [],
+    }];
+
+    // Pre-cutover the warehouse UI calls this once per unit (queue of
+    // N check forms). Each call should flip exactly one unit + asset.
+    await completeCheckAndStore({
+      projectId: project.id,
+      lineItemId: line.id,
+      assetId: a1.id,
+      checks,
+      condition: "GOOD",
+    });
+    await completeCheckAndStore({
+      projectId: project.id,
+      lineItemId: line.id,
+      assetId: a2.id,
+      checks,
+      condition: "DAMAGED",
+    });
+    await completeCheckAndStore({
+      projectId: project.id,
+      lineItemId: line.id,
+      assetId: a3.id,
+      checks,
+      condition: "MISSING",
+    });
+
+    // Units all RETURNED with the correct condition.
+    const units = await testPrisma.projectLineItemUnit.findMany({
+      where: { lineItemId: line.id },
+      orderBy: { ordinal: "asc" },
+    });
+    expect(units.every((u) => u.status === "RETURNED")).toBe(true);
+
+    // Assets transitioned per their return condition.
+    const a1After = await testPrisma.asset.findUniqueOrThrow({ where: { id: a1.id } });
+    const a2After = await testPrisma.asset.findUniqueOrThrow({ where: { id: a2.id } });
+    const a3After = await testPrisma.asset.findUniqueOrThrow({ where: { id: a3.id } });
+    expect(a1After.status).toBe("AVAILABLE");        // GOOD
+    expect(a2After.status).toBe("IN_MAINTENANCE");   // DAMAGED
+    expect(a3After.status).toBe("LOST");             // MISSING
+
+    // Line rolled up properly.
+    const refreshed = await testPrisma.projectLineItem.findUniqueOrThrow({
+      where: { id: line.id },
+    });
+    expect(refreshed.status).toBe("RETURNED");
+    expect(refreshed.returnedQuantity).toBe(3);
+    expect(refreshed.checkedOutQuantity).toBe(0);
   });
 });

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -10,6 +10,7 @@ import {
   syncLineItemRollup,
   ensureSerialisedUnit,
   ensureBulkUnit,
+  returnLineUnits,
 } from "@/server/line-item-fulfillment";
 import {
   adjustBulkAvailability,
@@ -786,210 +787,49 @@ export async function checkInItems(
     const defaultLocationId = defaultLocation?.id || null;
 
     for (const item of items) {
-      // Verify line item belongs to this project and org
-      const lineItem = await tx.projectLineItem.findFirst({
-        where: {
-          id: item.lineItemId,
-          projectId,
-          organizationId,
-        },
+      // Delegate the unit / asset surgery to the canonical helper —
+      // also used by completeCheckAndStore so the two paths can't drift.
+      const { unitsFlipped, assetsTouched } = await returnLineUnits(tx, {
+        organizationId,
+        projectId,
+        lineItemId: item.lineItemId,
+        assetId: item.assetId,
+        returnCondition: item.returnCondition,
+        quantity: item.quantity,
+        notes: item.notes,
+        userId,
+        defaultLocationId,
       });
 
-      if (!lineItem) {
-        throw new Error(`Line item ${item.lineItemId} not found in project`);
-      }
-
-      const targetAssetId = item.assetId || lineItem.assetId || null;
-
-      if (targetAssetId) {
-        // ── Serialised return — flip the unit, restore the asset ─────────
-        const assetStatus: "AVAILABLE" | "IN_MAINTENANCE" | "LOST" =
-          item.returnCondition === "DAMAGED"
-            ? "IN_MAINTENANCE"
-            : item.returnCondition === "MISSING"
-              ? "LOST"
-              : "AVAILABLE";
-
-        const unit = await tx.projectLineItemUnit.findUnique({
-          where: {
-            lineItemId_assetId: {
-              lineItemId: lineItem.id,
-              assetId: targetAssetId,
-            },
-          },
-          select: { id: true },
-        });
-
-        if (!unit) {
-          // No unit row — a kit child or an un-migrated legacy line that
-          // still carries its asset directly. Return the line itself.
-          await tx.projectLineItem.update({
-            where: { id: lineItem.id },
-            data: {
-              status: "RETURNED",
-              returnedQuantity: 1,
-              returnedAt: new Date(),
-              returnedBy: { connect: { id: userId } },
-              returnCondition: item.returnCondition,
-              returnNotes: item.notes || null,
-            },
-          });
-          await tx.asset.update({
-            where: { id: targetAssetId },
-            data: { status: assetStatus, locationId: defaultLocationId },
-          });
-          await tx.assetScanLog.create({
-            data: {
-              organizationId,
-              assetId: targetAssetId,
-              projectId,
-              action: "CHECK_IN",
-              scannedById: userId,
-              notes: item.notes || null,
-            },
-          });
-          updated.push(
-            await tx.projectLineItem.findUnique({
-              where: { id: lineItem.id },
-              include: { model: true, asset: true, bulkAsset: true },
-            }),
-          );
-          continue;
-        }
-
-        // Guarded transition — only return a unit that is still out.
-        const flipped = await tx.projectLineItemUnit.updateMany({
-          where: { id: unit.id, status: "CHECKED_OUT" },
-          data: {
-            status: "RETURNED",
-            returnedAt: new Date(),
-            returnedById: userId,
-            returnCondition: item.returnCondition,
-            returnNotes: item.notes || null,
-          },
-        });
-
-        if (flipped.count > 0) {
-          await tx.asset.update({
-            where: { id: targetAssetId },
-            data: { status: assetStatus, locationId: defaultLocationId },
-          });
-          await tx.assetScanLog.create({
-            data: {
-              organizationId,
-              assetId: targetAssetId,
-              projectId,
-              action: "CHECK_IN",
-              scannedById: userId,
-              notes: item.notes || null,
-            },
-          });
-        }
-      } else if (lineItem.bulkAssetId) {
-        // ── Bulk return — accumulate onto the bulk unit row ──────────────
-        const returnQty = item.quantity || 1;
-        const unit = await tx.projectLineItemUnit.findFirst({
-          where: { lineItemId: lineItem.id, bulkAssetId: lineItem.bulkAssetId },
-        });
-        if (unit) {
-          const newReturned = Math.min(
-            unit.quantity,
-            unit.returnedQuantity + returnQty,
-          );
-          const fullyReturned = newReturned >= unit.quantity;
-          await tx.projectLineItemUnit.update({
-            where: { id: unit.id },
-            data: {
-              returnedQuantity: newReturned,
-              status: fullyReturned ? "RETURNED" : "CHECKED_OUT",
-              returnedAt: fullyReturned ? new Date() : unit.returnedAt,
-              returnedById: fullyReturned ? userId : unit.returnedById,
-              returnCondition: item.returnCondition,
-              returnNotes: item.notes || unit.returnNotes,
-            },
-          });
-        }
+      // Scan log: one entry per checkin call, with a useful note for
+      // bulk / line-level returns.
+      if (assetsTouched.length === 1) {
         await tx.assetScanLog.create({
           data: {
             organizationId,
-            bulkAssetId: lineItem.bulkAssetId,
+            assetId: assetsTouched[0],
             projectId,
             action: "CHECK_IN",
             scannedById: userId,
-            notes: item.notes || `Returned ${returnQty}`,
+            notes: item.notes || null,
           },
         });
-      } else {
-        // No specific asset scanned — the "return whole line" path. Return
-        // every unit still out on this line.
-        const outUnits = await tx.projectLineItemUnit.findMany({
-          where: { lineItemId: lineItem.id, status: "CHECKED_OUT" },
+      } else if (unitsFlipped > 0 || assetsTouched.length > 0) {
+        await tx.assetScanLog.create({
+          data: {
+            organizationId,
+            projectId,
+            action: "CHECK_IN",
+            scannedById: userId,
+            notes: item.notes || `Returned ${unitsFlipped} unit(s)`,
+          },
         });
-
-        if (outUnits.length > 0) {
-          for (const u of outUnits) {
-            await tx.projectLineItemUnit.update({
-              where: { id: u.id },
-              data: {
-                status: "RETURNED",
-                returnedAt: new Date(),
-                returnedById: userId,
-                returnCondition: item.returnCondition,
-                returnNotes: item.notes || null,
-                ...(u.bulkAssetId ? { returnedQuantity: u.quantity } : {}),
-              },
-            });
-            if (u.assetId) {
-              const assetStatus =
-                item.returnCondition === "DAMAGED"
-                  ? "IN_MAINTENANCE"
-                  : item.returnCondition === "MISSING"
-                    ? "LOST"
-                    : "AVAILABLE";
-              await tx.asset.update({
-                where: { id: u.assetId },
-                data: { status: assetStatus, locationId: defaultLocationId },
-              });
-            }
-          }
-          await tx.assetScanLog.create({
-            data: {
-              organizationId,
-              projectId,
-              action: "CHECK_IN",
-              scannedById: userId,
-              notes: item.notes || `Returned ${outUnits.length} unit(s)`,
-            },
-          });
-        } else {
-          // Genuinely no units — flip the order line directly.
-          await tx.projectLineItem.update({
-            where: { id: lineItem.id },
-            data: {
-              status: "RETURNED",
-              returnedQuantity:
-                lineItem.checkedOutQuantity || lineItem.quantity,
-              returnedAt: new Date(),
-              returnedBy: { connect: { id: userId } },
-              returnCondition: item.returnCondition,
-              returnNotes: item.notes || null,
-            },
-          });
-          updated.push(
-            await tx.projectLineItem.findUnique({
-              where: { id: lineItem.id },
-              include: { model: true, asset: true, bulkAsset: true },
-            }),
-          );
-          continue;
-        }
       }
 
-      // Roll the unit change up onto the order line.
-      await syncLineItemRollup(tx, lineItem.id);
+      await syncLineItemRollup(tx, item.lineItemId);
       updated.push(
         await tx.projectLineItem.findUnique({
-          where: { id: lineItem.id },
+          where: { id: item.lineItemId },
           include: { model: true, asset: true, bulkAsset: true },
         }),
       );


### PR DESCRIPTION
## Deep-review summary

User-reported on dev: returned a prepped 10x line, assets didn't release; docket still shows `TTP00022, TTP00023 +8` instead of per-unit rows. Did a proper audit instead of more whack-a-mole.

### Bug 1 (real): `completeCheckAndStore` never touched units/assets

This is the post-return-check writer (the warehouse "check + store" flow). It pre-dated the unit table and had its own hand-rolled checkin that only incremented `line.returnedQuantity` and flipped `line.status`. For a multi-quantity serialised line, all 10 units stayed `CHECKED_OUT` and all 10 physical assets stayed `CHECKED_OUT` even though the line "thought" it was returned. Exactly the user's symptom.

**Fix.** Extracted `returnLineUnits` into `line-item-fulfillment.ts` as the single source of truth for "perform a return" — handles all three shapes (specific-asset scan, bulk-line, return-whole-line) and walks units + assets + scan log consistently. Both `checkInItems` and `completeCheckAndStore` now call it.

### Bug 2: saved docket templates pinned `showPerUnitCheckboxes=false`

The earlier fix turned on per-unit sub-rows in the **system defaults**. But the user's org had a custom default docket template (stored as JSON in `document_template.settings`) with the old `false` baked in — so the saved template kept overriding the new default.

**Fix.** `scripts/migrate-docket-per-unit.ts` finds every saved delivery-docket template with the flag explicitly false and flips it true. Dry-run default, `--apply` opt-in, idempotent.

### Bug 3: 10 stranded assets in the user's DB

(Reconciled separately — not in this PR.)

## Lifecycle spec (now enforced)

| Transition | Caller | Units | Assets | Line |
|---|---|---|---|---|
| Return (scan) | `checkInItems` serialised | flip unit → RETURNED | asset → AVAILABLE/IN_MAINT/LOST | rollup |
| Return (line) | `checkInItems` return-whole-line | iterate, flip each | each asset | rollup |
| **Return + check** (was broken) | `completeCheckAndStore` | **now flips units** | **now flips assets** | rollup |

## Test plan

- [x] 46 cutover integration tests green
- [x] New test reproduces the bug: deploy 3 → completeCheckAndStore × 3 with GOOD/DAMAGED/MISSING → asserts every unit RETURNED + assets transitioned to AVAILABLE/IN_MAINTENANCE/LOST
- [x] `npx tsc --noEmit` clean

## Operator step (one-time, post-deploy)

Run `npm run migrate:docket-per-unit -- --apply` against prod to flip the saved docket templates. Dry-run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)