### PR TITLE
chore: workflow_dispatch for one-off data migrations

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,102 @@
+name: Run migration
+
+# Manually-triggered data migrations. Pick which script to run from the
+# GitHub Actions UI ("Run workflow"). Runs on the same self-hosted
+# runner the deploy workflow uses, so it inherits prod env + DATABASE_URL.
+#
+# Dry-run by default. Set "apply" to true to actually mutate.
+#
+# Security: workflow_dispatch inputs are passed via `env:` and quoted
+# with $"..." so free-text inputs (project_id, org_id) can't inject
+# shell. Script choice is restricted to a fixed enum.
+
+on:
+  workflow_dispatch:
+    inputs:
+      script:
+        description: "Which migration to run"
+        required: true
+        type: choice
+        options:
+          - collapse-historic-splits
+          - collapse-split-siblings
+          - migrate-docket-per-unit
+          - backfill-line-item-units
+      apply:
+        description: "Actually write changes? (default: dry-run only)"
+        required: true
+        type: boolean
+        default: false
+      project_id:
+        description: "Optional: scope to one project id (e.g. cmnsi9uj100dthxbxqnh93ufe). Leave blank for all."
+        required: false
+        type: string
+      org_id:
+        description: "Optional: scope to one organization id. Leave blank for all."
+        required: false
+        type: string
+
+jobs:
+  migrate:
+    name: ${{ inputs.script }} (${{ inputs.apply && 'APPLY' || 'dry-run' }})
+    runs-on: self-hosted
+    timeout-minutes: 15
+
+    steps:
+      - name: Show plan
+        env:
+          SCRIPT: ${{ inputs.script }}
+          APPLY: ${{ inputs.apply }}
+          PROJECT_ID: ${{ inputs.project_id }}
+          ORG_ID: ${{ inputs.org_id }}
+        run: |
+          echo "================================================================"
+          echo "Migration:   $SCRIPT"
+          if [ "$APPLY" = "true" ]; then
+            echo "Mode:        APPLY (will mutate)"
+          else
+            echo "Mode:        dry-run (read-only)"
+          fi
+          echo "Project:     ${PROJECT_ID:-(all)}"
+          echo "Org:         ${ORG_ID:-(all)}"
+          echo "================================================================"
+
+      - name: Pull latest code
+        run: |
+          cd "${{ vars.APP_DIR }}"
+          git pull origin main
+
+      - name: Install dependencies
+        run: |
+          cd "${{ vars.APP_DIR }}"
+          npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Generate Prisma client
+        run: |
+          cd "${{ vars.APP_DIR }}"
+          npx prisma generate
+
+      - name: Run migration
+        env:
+          SCRIPT: ${{ inputs.script }}
+          APPLY: ${{ inputs.apply }}
+          PROJECT_ID: ${{ inputs.project_id }}
+          ORG_ID: ${{ inputs.org_id }}
+        run: |
+          cd "${{ vars.APP_DIR }}"
+          # Build args array — quoting via "$VAR" prevents any shell
+          # tokenisation of free-text inputs.
+          set --
+          if [ "$APPLY" = "true" ]; then
+            set -- "$@" --apply
+          fi
+          if [ -n "$PROJECT_ID" ]; then
+            set -- "$@" --project "$PROJECT_ID"
+          fi
+          if [ -n "$ORG_ID" ]; then
+            set -- "$@" --org "$ORG_ID"
+          fi
+          # SCRIPT is constrained to the choice enum above so it's safe
+          # to interpolate into the run command.
+          echo "Running: npm run $SCRIPT -- $*"
+          npm run "$SCRIPT" -- "$@"


### PR DESCRIPTION
## Summary

Adds a manually-triggered workflow so prod data migrations can run on the existing self-hosted runner (which already has the prod DB connection) without needing a stable SSH shell.

After this lands, the migration flow becomes:
1. Open GitHub → Actions → "Run migration" → "Run workflow"
2. Pick which script: \`collapse-historic-splits\` / \`collapse-split-siblings\` / \`migrate-docket-per-unit\` / \`backfill-line-item-units\`
3. Tick "apply" only when ready to mutate (default: dry-run only)
4. Optionally scope to one project or org
5. Watch the output in the Actions log

## Safety

- Dry-run is the default; \`--apply\` only fires when the operator explicitly ticks the box
- Script choice is restricted to a fixed enum (no arbitrary command injection)
- Free-text inputs (project id, org id) are passed via \`env:\` and shell-quoted; can't break out of the args
- No secrets in workflow inputs — runs on the self-hosted runner that already has DATABASE_URL

## Test plan

- [x] Workflow file syntactically valid; no checks gating it (workflow_dispatch only)
- [ ] Manual: trigger \`collapse-historic-splits\` with \`apply=false\` and \`project_id=cmnsi9uj100dthxbxqnh93ufe\` → should print the dry-run plan in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)