### PR TITLE
chore: fix migration workflow script names

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -18,10 +18,10 @@ on:
         required: true
         type: choice
         options:
-          - collapse-historic-splits
-          - collapse-split-siblings
-          - migrate-docket-per-unit
-          - backfill-line-item-units
+          - "collapse:historic-splits"
+          - "collapse:split-siblings"
+          - "migrate:docket-per-unit"
+          - "backfill:line-item-units"
       apply:
         description: "Actually write changes? (default: dry-run only)"
         required: true


### PR DESCRIPTION
Dropdown options used dashes, npm scripts use colons. Caused `npm error Missing script: collapse-historic-splits` on first run.