### PR TITLE
docs: free-text/custom lines deploy without asset tags (intended)

### DIFF
--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -115,6 +115,8 @@ Custom line items (`isCustomItem: true`) appear in all three warehouse tabs with
 
 **Deploy:** Custom items appear in the deploy list. Since `isBulk` check (`!lineItem.assetId && lineItem.quantity > 1`) routes them to the bulk checkout path, all units deploy at once via button press.
 
+**Free-text / custom lines cannot carry asset tags (intended).** A line with no catalog model (`modelId: null`, including `isCustomItem` lines) deploys generically: `lookupAssetForScan` binds a scanned asset to a line by matching `modelId`, so a model-less line can never have a physical asset assigned, and `checkOutItems` falls through to the "deploy whole line" branch (flips status, no unit, no asset). Consequence: such a line shows **no per-unit asset tags on the delivery docket** — only its name + quantity — even with `showPerUnitCheckboxes` on. This is by design: free-text lines are for ad-hoc/consumable items (cables, gaffer). Serialised gear that needs asset-tag tracking must be entered as a **catalog model**, not typed by name. (Product decision 2026-05-30: keep free-text non-tracked rather than override the scan match or add a line→model link flow.)
+
 **Return:** Custom items appear in the return list. They are returned via the return button; no asset tag scan possible.
 
 **Checkout server path:** `checkOutItems()` handles custom items without changes — null `assetId` + qty=1 takes the serialized path (skips asset status checks), qty>1 takes the bulk path (deploys full quantity).


### PR DESCRIPTION
## Summary
Documents the product decision (2026-05-30) for BUG 2 — "deploying the e-835-S didn't ask for an asset tag."

Root cause (confirmed against prod data — 0 mergeable splits in the project): the e-835-S is a **free-text line** (`modelId: null`). Structurally:
- `lookupAssetForScan` binds a scanned asset to a line by matching `modelId` (`warehouse.ts:389-412`) — a model-less line can never have a physical asset assigned.
- `checkOutItems` deploys a model-less line via the "deploy whole line" branch (`warehouse.ts:570-575`) — flips status, no unit, no asset tag.

Consequence: free-text/custom lines show no per-unit asset tags on the delivery docket, only name + qty.

Decision: **keep free-text lines non-tracked** (don't override the scan match, don't build a line→model link flow). Serialised gear that needs tag tracking should be entered as a catalog model. This PR records that in `FEATUREDOCS/12-warehouse.md` so it isn't re-investigated.

No code change.

## Test plan
- [x] Docs-only; no code or tests affected
- [x] Pairs with PR #118 (per-unit docket rows) — catalog-backed lines now expand per-unit; free-text lines intentionally do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)