### PR TITLE
fix(warehouse): guard ItemCheckForm against empty check-list submit (500)

### DIFF
--- a/FEATUREDOCS/37-check-items.md
+++ b/FEATUREDOCS/37-check-items.md
@@ -138,6 +138,12 @@ The Deploy tab is the staging ground on both sides of the truck. The check alway
 
 Models with 0 check items skip the check form entirely. The `model._count.modelCheckItems` count (included in warehouse queries) is checked before opening the form — preserving existing behavior for models without checks. Kit check items use `kit._count.kitCheckItems` similarly.
 
+### Empty check-list guard (defensive)
+
+The warehouse page routes zero-check items to `prepItemDirect`, but two paths can still mount `ItemCheckForm` with an empty list: the brief window while the `getModelCheckItems`/`getKitCheckItems` query is still loading, and the ad-hoc `/check/[assetTag]` page which has no count gate. The form must therefore guard against an empty submit itself.
+
+`allComplete` is computed as `items.length > 0 && items.every(...)`. The `items.length > 0` clause is load-bearing: `Array.prototype.every` returns `true` for an empty array, so without it the submit button (and the keyboard `Enter` path) would be enabled with zero rows and POST an empty `checks[]`. The server schemas in `src/lib/validations/check-item.ts` declare `checks: z.array(...).min(1)`, so an empty array throws an uncaught `ZodError` (`too_small`) → 500. When `items.length === 0`, the form renders a "No check items are configured for this {kit|model}." empty-state instead of a blank form with a dead button. Regression coverage: `src/components/warehouse/__tests__/item-check-form.test.tsx` ("ItemCheckForm with zero check items").
+
 ## Predictive Maintenance
 
 After saving check records, if any check item has a FAIL result:

--- a/src/components/warehouse/__tests__/item-check-form.test.tsx
+++ b/src/components/warehouse/__tests__/item-check-form.test.tsx
@@ -113,7 +113,10 @@ import type { CheckRecordFormValues } from "@/lib/validations/check-item";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function renderForm(overrides: Partial<React.ComponentProps<typeof ItemCheckForm>> = {}) {
+function renderForm(
+  overrides: Partial<React.ComponentProps<typeof ItemCheckForm>> = {},
+  seedData: typeof mockItems = mockItems
+) {
   const onSubmit = vi.fn();
   const onCancel = vi.fn();
   const onOpenChange = vi.fn();
@@ -129,7 +132,7 @@ function renderForm(overrides: Partial<React.ComponentProps<typeof ItemCheckForm
     },
   });
   // Pre-seed the cache so the async query resolves immediately
-  client.setQueryData(["model-check-items", "org-1", "model-1"], mockItems);
+  client.setQueryData(["model-check-items", "org-1", "model-1"], seedData);
 
   const utils = render(
     <QueryClientProvider client={client}>
@@ -314,6 +317,46 @@ describe("ItemCheckForm keyboard shortcuts", () => {
     );
 
     key("a");
+    key("Enter");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: a model/kit with zero configured check items must NOT be
+// submittable. Array.prototype.every returns true for an empty array, so before
+// the `items.length > 0` guard the submit button was enabled and would POST an
+// empty checks[] — which the server's `.min(1)` Zod schema rejects with an
+// uncaught ZodError → 500. Items with no checks are meant to go through
+// prepItemDirect, not this form.
+describe("ItemCheckForm with zero check items", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders an empty-state message instead of check rows", () => {
+    renderForm({}, []);
+    expect(screen.getByText(/No check items are configured/i)).toBeTruthy();
+    // None of the mockItems labels should render.
+    expect(screen.queryByText("Power on")).toBeNull();
+  });
+
+  it("disables the submit button when no checks are configured", () => {
+    renderForm({}, []);
+    // PREP context with failCount === 0 → "Pack Item"
+    const submit = screen.getByRole("button", { name: /Pack Item/i }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("does not call onSubmit when clicking submit with zero checks", () => {
+    const { onSubmit } = renderForm({}, []);
+    const submit = screen.getByRole("button", { name: /Pack Item/i });
+    fireEvent.click(submit);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not call onSubmit on keyboard Enter with zero checks", () => {
+    const { onSubmit } = renderForm({}, []);
     key("Enter");
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/src/components/warehouse/item-check-form.tsx
+++ b/src/components/warehouse/item-check-form.tsx
@@ -245,8 +245,14 @@ export function ItemCheckForm({
     return "PASS";
   }
 
-  // Check if all items have results
-  const allComplete = items.every((mci) => {
+  // Check if all items have results.
+  // The `items.length > 0` guard matters: Array.prototype.every returns true for an
+  // empty array, which would make allComplete true (a) while the check-items query is
+  // still loading and (b) for a model/kit with zero configured checks. Either case
+  // lets the user submit an empty checks[] array, which the server's `.min(1)` Zod
+  // schema rejects with an uncaught ZodError → 500. Items with no checks are meant to
+  // go through prepItemDirect, not this form.
+  const allComplete = items.length > 0 && items.every((mci) => {
     const state = checkStates[mci.checkItem.id];
     if (!state) return false;
     if (mci.checkItem.type === "NOTES") return true; // Notes are always optional
@@ -379,6 +385,12 @@ export function ItemCheckForm({
         <div className="flex items-center justify-center py-16 text-fg-3">
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
           Loading check items...
+        </div>
+      ) : items.length === 0 ? (
+        <div
+          className={`flex items-center justify-center py-16 text-center text-sm text-fg-3 ${embedded ? "px-4" : ""}`}
+        >
+          No check items are configured for this {kitId ? "kit" : "model"}.
         </div>
       ) : (
         <div className={embedded ? "p-4 space-y-1" : "mt-4 space-y-1"}>


### PR DESCRIPTION
## Summary

Fixes the production `ZodError (too_small)` → 500 that fires when `ItemCheckForm` is submitted with **zero** check items.

`allComplete` was computed as `items.every(...)`, and `Array.prototype.every` returns `true` for an empty array — so the submit button (and the keyboard `Enter` path) were enabled with no rows and would POST an empty `checks[]`. The server schemas in `src/lib/validations/check-item.ts` declare `checks: z.array(...).min(1)`, so the empty array threw an uncaught `ZodError` → 500.

Two paths can mount the form with an empty list:
- the brief window while the `getModelCheckItems`/`getKitCheckItems` query is still loading, and
- the ad-hoc `/check/[assetTag]` page, which has no check-count gate.

Items with no checks are meant to flow through `prepItemDirect`, not this form.

## Changes
- Gate `allComplete` on `items.length > 0` so an empty list is never "complete".
- Render a "No check items are configured for this {kit|model}." empty-state instead of a blank form with a dead submit button.
- Add regression tests: disabled submit, no empty POST (click **and** keyboard Enter), empty-state render. (15/15 pass in `item-check-form.test.tsx`.)
- Document the guard in `FEATUREDOCS/37-check-items.md`.

## Scope note
The branch name mentions "schema-drift" + "errors" from the original `/debug` order-of-attack, but investigation showed the migration-pipeline drift and `"use server"` type re-export concerns were already resolved/historical — **only** the empty-checks bug needed a code change. This PR is scoped to that fix alone.

## Pre-existing CI (not introduced here)
`Lint` and `Type Check` are red on this branch from pre-existing issues unrelated to this change (`react-hooks/refs` + unused import in `item-check-form.tsx`, and `never`-type errors in two pdfme **test** files). They don't block deploy (the deploy workflow runs tests + build, which pass). Tracked separately for cleanup.

## Test plan
- [x] `npx vitest run src/components/warehouse/__tests__/item-check-form.test.tsx` → 15/15 pass
- [ ] Manually open `/check/[assetTag]` for an asset whose model has no check items → empty-state shows, submit disabled, no 500
- [ ] Prep an item mid-load → no transient enabled-submit window

🤖 Generated with [Claude Code](https://claude.com/claude-code)