### PR TITLE
docs(roadmap): mark Phase 0.2 iCal timezone fix as shipped

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,10 +47,16 @@ order-line / fulfillment-unit split — effectively item 1.2 pulled forward.
 Design: [`docs/designs/line-item-fulfillment-model.md`](./designs/line-item-fulfillment-model.md).
 A multi-week, 4-phase build; it supersedes a render-only patch.
 
-### 0.2 — iCal timezone correctness
+### 0.2 — iCal timezone correctness ✅ Shipped v0.7.1.0
 **Effort:** S
-Crew calendar feeds show wrong times in Google Calendar — a timezone offset bug.
-Crew acting on wrong call times is an operational hazard. Isolated fix.
+Crew calendar feeds showed wrong times in Google Calendar — a timezone offset
+bug. Root cause: `formatICalDate` used server-local time and emitted unanchored
+floating-time DATE-TIMEs. Fix: TZID + VTIMEZONE block anchoring (AU, NZ, UK,
+US zones, UTC fallback), UTC DTSTAMP per RFC 5545, `Intl.DateTimeFormat`-based
+tz conversion (no new deps), org timezone read from `OrgSettings.timezone`.
+16 regression tests in `src/lib/ical.test.ts`. See
+[FEATUREDOCS/31](../FEATUREDOCS/31-crew-management.md) for the library
+reference.
 
 ---
 


### PR DESCRIPTION
## Summary

Post-release doc sync via /document-release. Only one stale doc surfaced after v0.7.1.0: [docs/ROADMAP.md](docs/ROADMAP.md) still described Phase 0.2 "iCal timezone correctness" as pending work. Marked shipped with root-cause summary + FEATUREDOCS/31 link.

Everything else was already current as of the v0.7.1.0 merge:
- ✅ `TODOS.md` — iCal item struck through with ✅ FIXED writeup
- ✅ `CHANGELOG.md` — v0.7.1.0 entry with full root-cause + fix
- ✅ `FEATUREDOCS/31-crew-management.md` — iCal library section updated with TZID/VTIMEZONE strategy
- ✅ `CLAUDE.md` — Deploy Configuration section added during /setup-deploy
- ✅ `README.md` — generic iCal mention, no staleness
- ✅ `ARCHITECTURE.md` — no iCal references, no staleness

## Test plan

- [x] Docs-only change, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)