### PR TITLE
v0.10.0.0 feat: uncategorized project groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to GearFlow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0.0] - 2026-06-04
+
+Project groups can now live in the Uncategorized zone, matching how sub-hire groups already work. Deleting a category no longer destroys the groups inside it.
+
+### Added
+- **Project groups in Uncategorized.** Both the toolbar "Add Group" dialog and
+  each group's "Move" dialog now offer an Uncategorized destination. Groups
+  created without a category live alongside orphan sub-hire groups in the
+  project's Uncategorized zone, with the same kebab actions (Edit, Edit Price,
+  Add Equipment / Kit, Move, Delete) as categorised groups.
+- **`getUncategorizedProjectGroups(projectId)` server query** — mirrors
+  `getUncategorizedSubHireGroups`, scoped to org + project. The equipment tab
+  uses it to render orphan project groups in the same loop as orphan sub-hires.
+
+### Changed
+- **`ProjectGroup.categoryId` is now nullable** (Prisma schema + DB migration
+  `20260604030000_uncategorized_project_groups`). The FK's `onDelete` switched
+  from `CASCADE` to `SET NULL`, so deleting a `ProjectCategory` orphans its
+  groups instead of destroying them along with all their line items. Groups
+  surface in the Uncategorized zone afterwards.
+- **`createProjectGroup` sortOrder scope** — the aggregate that picks the next
+  `sortOrder` now includes `projectId`. Without this, null-category groups
+  across every project in the org would have shared one sortOrder pool.
+- **Validation schemas accept `null` categoryId** —
+  `projectGroupSchema.categoryId` and
+  `moveProjectGroupToCategorySchema.categoryId` are now nullable. The old
+  v0.9.3.0 unit test that asserted "rejects a null categoryId" flipped to
+  assert acceptance.
+
+### Fixed
+- **`moveProjectGroupToCategory` to Uncategorized.** When the destination is
+  null, the action skips advisory locking and category-slot inserts, drops any
+  existing slot for the group, and clears the line items' `categoryId` —
+  matching the sub-hire equivalent's behaviour.
+
 ## [0.9.3.0] - 2026-06-04
 
 The line-item Move action splits into two clearer choices.

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -64,12 +64,23 @@ marginPercent = margin / total × 100
 ## Categories (`ProjectCategory`)
 - Top-level organiser for equipment (e.g. "RF", "IEM", "PA")
 - Sort order via `sortOrder` field, drag-and-drop reorderable
-- Deleting a category cascades: groups deleted, all line items become uncategorized
+- Deleting a category orphans its groups and line items into the
+  Uncategorized zone (FK is `ON DELETE SET NULL` for both
+  `ProjectGroup.categoryId` and `ProjectLineItem.categoryId` — the
+  group FK switched from CASCADE to SET NULL in v0.10.0.0 so deleting
+  a category no longer destroys its groups along with every contained
+  line item)
 - Server actions: `src/server/project-categories.ts`
 
 ## Groups (`ProjectGroup`) — The Billable Unit
 - Groups are the billable units on quotes/invoices
 - Fields: `title`, `description` (free-text for quote), `quantity`, `price`
+- `categoryId` is **nullable since v0.10.0.0** — a group can live in
+  the project's Uncategorized zone (mirrors `SubHireGroup.targetCategoryId`).
+  The toolbar "Add Group" dialog and per-group Move dialog both offer
+  Uncategorized as a destination. `createProjectGroup` scopes its
+  `sortOrder` aggregate by `projectId` so each project's Uncategorized
+  zone has its own sequence.
 - `suggestedPrice` auto-calculated from tracked assets' rates inside the group
 - User can override `price` or accept the suggestion with one click
 - Assets inside a group are for **tracking only** — never shown on quotes
@@ -161,7 +172,10 @@ HEADER (full width):
 - Line items indented under their parent group, drag-and-drop reorderable
 - Single flat `DndContext` with prefixed IDs (categories, groups, items all in one context)
 - Inline "Add Group" button in toolbar with template picker
-- Uncategorized line items shown at the bottom
+- Uncategorized zone at the bottom holds orphan line items, orphan
+  sub-hire groups, **and orphan project groups** (since v0.10.0.0) —
+  fetched via `getUncategorizedProjectGroups` from
+  [`src/server/category-slots.ts`](../src/server/category-slots.ts)
 - Line item edit dialog; separate "Move to category" and "Move to group" dialogs (split in v0.9.3.0 — see [47-cross-type-equipment-unification.md](./47-cross-type-equipment-unification.md))
 - Category rename (inline) and delete with cascade warning
 

--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -36,6 +36,14 @@ per-table `sortOrder` field, so existing projects keep working.
 `SubHireGroup.targetCategoryId` is the placement field for sub-hire groups
 inside a project. `null` means uncategorised.
 
+`ProjectGroup.categoryId` is **nullable since v0.10.0.0** (migration
+`20260604030000_uncategorized_project_groups`) and `null` means
+uncategorised — the same convention sub-hire groups already used. The
+FK's `onDelete` switched from `CASCADE` to `SET NULL` at the same time,
+so deleting a `ProjectCategory` now orphans its groups (they reappear
+under Uncategorized) instead of destroying them together with every
+contained line item.
+
 ## Server actions
 
 All in [`src/server/category-slots.ts`](../src/server/category-slots.ts).
@@ -44,8 +52,9 @@ Validations in [`src/lib/validations/category-slot.ts`](../src/lib/validations/c
 | Action | Purpose | Permission |
 |---|---|---|
 | `getUncategorizedSubHireGroups(projectId)` | Read counterpart to `getUncategorizedLineItems`. Returns groups with `targetCategoryId IS NULL`. | `project:read` |
+| `getUncategorizedProjectGroups(projectId)` | Project-group counterpart added in v0.10.0.0. Returns groups with `categoryId IS NULL` (including line items + child line items in the same include shape used by `getProjectCategories`) so the equipment tab can render orphan project groups in the Uncategorized zone next to orphan sub-hire groups and standalone uncategorised line items. | `project:read` |
 | `moveSubHireGroupToCategory(groupId, categoryId\|null)` | Placement-only update. Does NOT trigger `syncSubHireToProject` regenerate — just updates targetCategoryId, the synthetic parent line item's categoryId, and the slot row. Calls `recalculateProjectTotals` once. | `project:manage_line_items` + `subHire:update` |
-| `moveProjectGroupToCategory(groupId, categoryId)` | Project-group counterpart to the sub-hire move. Updates `ProjectGroup.categoryId`, every contained `ProjectLineItem.categoryId`, and the slot row in one transaction guarded by the same destination-category advisory lock. Destination is required — `ProjectGroup.categoryId` is NOT NULL, so there is no "uncategorised project group" state. | `project:manage_line_items` |
+| `moveProjectGroupToCategory(groupId, categoryId\|null)` | Project-group counterpart to the sub-hire move. Updates `ProjectGroup.categoryId`, every contained `ProjectLineItem.categoryId`, and the slot row in one transaction. Destination is **nullable since v0.10.0.0** — passing `null` drops the slot, clears the line items' `categoryId`, and bypasses the advisory lock (no slot insert means nothing to race on). A non-null destination still takes the same `pg_advisory_xact_lock` keyed on the destination category that protects the sub-hire move. | `project:manage_line_items` |
 | `reorderMixedGroupsInCategory(categoryId, orderedIds[])` | Reorders a mixed array of `pg-<id>` / `shg-<id>` prefixed IDs by updating `CategorySlot.sortOrder`. Uses a Postgres advisory lock (`pg_advisory_xact_lock`) keyed on the category id to serialize concurrent reorders, plus a phase-1 negation step to free the positive sortOrder range before writing new values. | `project:manage_line_items` + `subHire:update` |
 | `createCategoryAndPlaceGroup(projectId, name, slot)` | Atomic: creates a new ProjectCategory at the END of the project's category list, places the chosen group (project or sub-hire) inside it via a slot row, and syncs the group's own placement field. Both branches (project + sub-hire) also `updateMany` the contained line items' `categoryId` so PDFs and reports that filter by category see the new home — the project-group branch missed this until v0.9.2.0. Used by the inline "Create category" affordance in the Move dialog. | `project:manage_line_items` |
 
@@ -132,8 +141,9 @@ All under `src/components/projects/`:
 - **`MoveProjectGroupDialog`** — project-group counterpart, same
   `ComboboxPicker` + `creatable` shape. Calls `moveProjectGroupToCategory`
   for existing destinations and `createCategoryAndPlaceGroup` for new
-  ones. Destination is required (no "uncategorised" option), so the
-  Confirm button stays disabled until a category is picked.
+  ones. Since v0.10.0.0 the picker also offers an Uncategorized
+  destination (mirrors `MoveSubHireGroupDialog`), which submits
+  `categoryId: null`.
 - **`MoveItemToCategoryDialog`** — picks a destination `ProjectCategory`
   (or "Uncategorized") for a single line item. Always lands the item
   with `groupId: null` so it appears as a standalone item under the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gearflow-init",
-  "version": "0.9.3.0",
+  "version": "0.10.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260604030000_uncategorized_project_groups/migration.sql
+++ b/prisma/migrations/20260604030000_uncategorized_project_groups/migration.sql
@@ -1,0 +1,18 @@
+-- Make ProjectGroup.categoryId nullable + change FK from CASCADE to SET NULL.
+--
+-- Why: v0.9.4.0 allows groups to live in the project's Uncategorized
+-- zone, mirroring how SubHireGroup.targetCategoryId already works.
+-- Switching the FK from ON DELETE CASCADE to ON DELETE SET NULL means
+-- deleting a category now orphans its groups (they appear under
+-- Uncategorized) instead of silently destroying them with their items.
+
+ALTER TABLE "project_group"
+  DROP CONSTRAINT "project_group_categoryId_fkey";
+
+ALTER TABLE "project_group"
+  ALTER COLUMN "categoryId" DROP NOT NULL;
+
+ALTER TABLE "project_group"
+  ADD CONSTRAINT "project_group_categoryId_fkey"
+  FOREIGN KEY ("categoryId") REFERENCES "project_category"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1602,13 +1602,18 @@ model CategorySlot {
 // ─── Project Group ──────────────────────────────────────────────────────────
 
 model ProjectGroup {
-  id             String          @id @default(cuid())
+  id             String           @id @default(cuid())
   organizationId String
-  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   projectId      String
-  project        Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  categoryId     String
-  category       ProjectCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  project        Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  // Nullable since v0.9.4.0 — groups can live in the project's
+  // Uncategorized zone, mirroring SubHireGroup.targetCategoryId.
+  // The relation's onDelete switched from Cascade to SetNull so
+  // deleting a category no longer destroys its groups; they
+  // become orphaned and surface in the Uncategorized zone.
+  categoryId     String?
+  category       ProjectCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   title          String
   description    String?
   quantity       Int             @default(1)

--- a/src/components/projects/add-group-toolbar-dialog.tsx
+++ b/src/components/projects/add-group-toolbar-dialog.tsx
@@ -37,10 +37,15 @@ export interface TemplateOption {
 }
 
 export interface AddGroupValues {
-  categoryId: string;
+  /** null = create the group in the project's Uncategorized zone
+   *  (since v0.9.4.0; mirrors how sub-hire groups can already be
+   *  uncategorised). */
+  categoryId: string | null;
   title: string;
   templateId?: string;
 }
+
+const UNCATEGORISED_VALUE = "__uncategorized__";
 
 interface AddGroupToolbarDialogProps {
   open: boolean;
@@ -75,7 +80,7 @@ function AddGroupToolbarDialogBody({
   function handleSubmit() {
     if (!title.trim() || !categoryId) return;
     onSubmit({
-      categoryId,
+      categoryId: categoryId === UNCATEGORISED_VALUE ? null : categoryId,
       title: title.trim(),
       templateId: templateId || undefined,
     });
@@ -107,6 +112,7 @@ function AddGroupToolbarDialogBody({
             className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             <option value="">Select category...</option>
+            <option value={UNCATEGORISED_VALUE}>Uncategorized</option>
             {categories.map((cat) => (
               <option key={cat.id} value={cat.id}>{cat.name}</option>
             ))}

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/server/project-categories";
 import {
   getUncategorizedSubHireGroups,
+  getUncategorizedProjectGroups,
   moveSubHireGroupToCategory,
   reorderMixedGroupsInCategory,
 } from "@/server/category-slots";
@@ -254,6 +255,12 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
     staleTime: 60_000,
   });
 
+  const { data: uncategorizedProjectGroups = [] } = useQuery({
+    queryKey: ["uncategorized-project-groups", projectId],
+    queryFn: () => getUncategorizedProjectGroups(projectId),
+    staleTime: 60_000,
+  });
+
   const { data: templates = [] } = useQuery({
     queryKey: ["group-templates"],
     queryFn: () => getGroupTemplates(),
@@ -287,6 +294,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
     queryClient.invalidateQueries({ queryKey });
     queryClient.invalidateQueries({ queryKey: ["uncategorized-items", projectId] });
     queryClient.invalidateQueries({ queryKey: ["uncategorized-subhire-groups", projectId] });
+    queryClient.invalidateQueries({ queryKey: ["uncategorized-project-groups", projectId] });
     queryClient.invalidateQueries({ queryKey: ["project", projectId] });
     queryClient.invalidateQueries({ queryKey: ["project-overbooked", projectId] });
     // Any mutation that changes line item quantity/presence must refresh
@@ -377,8 +385,15 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   });
 
   const createGroupMut = useMutation({
-    mutationFn: ({ categoryId, title, templateId }: { categoryId: string; title: string; templateId?: string }) => {
+    mutationFn: ({ categoryId, title, templateId }: { categoryId: string | null; title: string; templateId?: string }) => {
       if (templateId) {
+        // Templates are category-scoped concepts — fall back to no-template
+        // when the user picks Uncategorised so they can still create the
+        // group structurally. The template can be applied via a follow-up
+        // move + recalculate if they later want to materialise its items.
+        if (!categoryId) {
+          return createProjectGroup(projectId, { categoryId: null, title, quantity: 1 });
+        }
         return applyGroupTemplate(projectId, { templateId, categoryId, title });
       }
       return createProjectGroup(projectId, { categoryId, title, quantity: 1 });
@@ -658,8 +673,11 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   const typedCategories = categories as CategoryData[];
   const hasCategories = typedCategories.length > 0;
   const orphanSubHireGroups = uncategorizedSubHireGroups as SubHireGroupData[];
+  const orphanProjectGroups = uncategorizedProjectGroups as GroupData[];
   const hasUncategorized =
-    (uncategorizedItems as LineItemData[]).length > 0 || orphanSubHireGroups.length > 0;
+    (uncategorizedItems as LineItemData[]).length > 0 ||
+    orphanSubHireGroups.length > 0 ||
+    orphanProjectGroups.length > 0;
 
   // Build a set of draft sub-hire IDs so we can badge unconfirmed items
   const draftSubHireIds = new Set<string>();
@@ -1054,6 +1072,81 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                     onRemove={() => removeMut.mutate(item.id)}
                   />
                 ))}
+                {/* Orphan PROJECT groups — categoryId IS NULL (v0.9.4.0
+                    allows groups to live uncategorised). Render with the
+                    full GroupRow affordances (kebab, Move, Delete) so
+                    they're first-class citizens of the Uncategorized
+                    zone alongside orphan sub-hire groups. */}
+                {orphanProjectGroups.map((group) => {
+                  const isExpanded = expandedGroups.has(group.id);
+                  const priceVal = group.price != null ? Number(group.price) : null;
+                  const groupItems = (group.lineItems ?? []).filter((i: LineItemData) => !isHiddenFromList(i));
+                  return (
+                    <React.Fragment key={`pg-${group.id}`}>
+                      <GroupRow
+                        group={group}
+                        isExpanded={isExpanded}
+                        isRejectedDropTarget={rejectedDropTargetId === `grp-${group.id}`}
+                        showCostColumn={showCostColumn}
+                        onToggle={() => toggleGroup(group.id)}
+                        onDelete={() => {
+                          setDeleteGroupId(group.id);
+                          setDeleteGroupInfo({
+                            title: group.title,
+                            price: priceVal ?? 0,
+                            itemCount: groupItems.length,
+                          });
+                        }}
+                        onEdit={() => setEditGroupData(group)}
+                        onEditPrice={() => setPriceEditTarget({
+                          kind: "project",
+                          groupId: group.id,
+                          title: group.title,
+                          price: priceVal,
+                        })}
+                        onAddEquipment={() => {
+                          setUnifiedAddTarget({ groupId: group.id, label: `Uncategorized > ${group.title}` });
+                          setUnifiedAddKind("own-stock");
+                          setShowUnifiedAdd(true);
+                        }}
+                        onAddKit={() => {
+                          setUnifiedAddTarget({ groupId: group.id, label: `Uncategorized > ${group.title}` });
+                          setUnifiedAddKind("kit");
+                          setShowUnifiedAdd(true);
+                        }}
+                        onMove={() => setMoveProjectGroup({ id: group.id, title: group.title })}
+                      />
+                      {isExpanded && groupItems.length === 0 && (
+                        <TableRow className="hover:bg-transparent">
+                          <TableCell colSpan={colCount} className="py-3 text-center text-xs text-fg-4">
+                            No items in this group yet. Add equipment to get started.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                      {isExpanded && groupItems.map((item: LineItemData) => (
+                        <LineItemRow
+                          key={item.id}
+                          item={item}
+                          indent="ml-12"
+                          overbookedInfo={item.subHireId != null ? undefined : (overbookedMap as Record<string, OverbookedInfo>)[item.id]}
+                          isUnconfirmed={!!item.subHireId && draftSubHireIds.has(item.subHireId)}
+                          showCostColumn={showCostColumn}
+                          isExpanded={expandedParents.has(item.id)}
+                          onToggle={() => toggleParent(item.id)}
+                          onEdit={() => setEditLineItem(item)}
+                          onMoveToCategory={() => setMoveItemToCategory({
+                            lineItemId: item.id,
+                          })}
+                          onMoveToGroup={() => setMoveItemToGroup({
+                            lineItemId: item.id,
+                            initialGroupId: group.id,
+                          })}
+                          onRemove={() => removeMut.mutate(item.id)}
+                        />
+                      ))}
+                    </React.Fragment>
+                  );
+                })}
                 {/* Orphan sub-hire groups — targetCategoryId IS NULL.
                     S13 from the test plan: must surface here, not vanish. */}
                 {orphanSubHireGroups.map((shGroup) => {

--- a/src/components/projects/move-project-group-dialog.tsx
+++ b/src/components/projects/move-project-group-dialog.tsx
@@ -36,6 +36,8 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 
+const UNCATEGORISED_VALUE = "__uncategorised__";
+
 interface CategoryOption {
   id: string;
   name: string;
@@ -79,11 +81,11 @@ function MoveProjectGroupDialogBody({
   onInvalidate,
 }: MoveProjectGroupDialogProps) {
   const queryClient = useQueryClient();
-  // Seed with the first available category if any — saves a click in the
-  // common case where the user is moving INTO a specific category they
-  // already see in the list. Empty string when there are no categories
-  // (rare — they'd be looking at the create-by-name path).
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string>("");
+  // Seed with Uncategorised — a meaningful default that doesn't
+  // require the user to remember which category they picked last.
+  // Picking a category from the dropdown still lets them move into
+  // a specific destination; typing a new name routes to create-by-name.
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string>(UNCATEGORISED_VALUE);
 
   function refreshCaches() {
     onInvalidate();
@@ -93,15 +95,20 @@ function MoveProjectGroupDialogBody({
   const moveMut = useMutation({
     mutationFn: async () => {
       if (!groupId) throw new Error("No project group selected");
-      if (!selectedCategoryId) throw new Error("Pick a destination category");
+      if (!selectedCategoryId) throw new Error("Pick a destination");
       return moveProjectGroupToCategory({
         groupId,
-        categoryId: selectedCategoryId,
+        categoryId:
+          selectedCategoryId === UNCATEGORISED_VALUE ? null : selectedCategoryId,
       });
     },
     onSuccess: () => {
       refreshCaches();
-      toast.success("Moved group");
+      toast.success(
+        selectedCategoryId === UNCATEGORISED_VALUE
+          ? "Moved group to uncategorised"
+          : "Moved group",
+      );
       onOpenChange(false);
     },
     onError: (e: Error) => toast.error(e.message),
@@ -130,7 +137,7 @@ function MoveProjectGroupDialogBody({
     // ComboboxPicker emits ids from its options list; the creatable
     // footer routes typed-but-unmatched text here as a create intent.
     const matched = categories.find((c) => c.id === value);
-    if (matched) {
+    if (matched || value === UNCATEGORISED_VALUE) {
       setSelectedCategoryId(value);
       return;
     }
@@ -152,7 +159,10 @@ function MoveProjectGroupDialogBody({
           <ComboboxPicker
             value={selectedCategoryId}
             onChange={handlePickValue}
-            options={categories.map((c) => ({ value: c.id, label: c.name }))}
+            options={[
+              { value: UNCATEGORISED_VALUE, label: "Uncategorised" },
+              ...categories.map((c) => ({ value: c.id, label: c.name })),
+            ]}
             placeholder="Select or type to create"
             searchPlaceholder="Search categories or type a new name..."
             emptyMessage="No matching category."

--- a/src/lib/validations/category-slot.test.ts
+++ b/src/lib/validations/category-slot.test.ts
@@ -40,15 +40,15 @@ describe("moveProjectGroupToCategorySchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects a null categoryId — project groups MUST land in a category", () => {
-    // Distinct from sub-hire groups, which CAN go to uncategorised.
-    // Schema-level guard catches a client that accidentally tries to
-    // route a project group through the "Uncategorised" picker option.
+  it("accepts a null categoryId — move to Uncategorized (since v0.9.4.0)", () => {
+    // Mirrors moveSubHireGroupToCategorySchema. Project groups can now
+    // live uncategorised — the same picker that routes sub-hire groups
+    // through the Uncategorised option also routes project groups.
     const result = moveProjectGroupToCategorySchema.safeParse({
       groupId: "g-1",
       categoryId: null,
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("rejects missing fields entirely", () => {

--- a/src/lib/validations/category-slot.ts
+++ b/src/lib/validations/category-slot.ts
@@ -35,14 +35,15 @@ export const moveSubHireGroupToCategorySchema = z.object({
 export type MoveSubHireGroupToCategoryInput = z.input<typeof moveSubHireGroupToCategorySchema>;
 
 /**
- * Move a ProjectGroup to a different ProjectCategory. Unlike sub-hire
- * groups, ProjectGroup.categoryId is NOT NULL in the schema, so the
- * destination is required — there is no "uncategorised project group"
- * state.
+ * Move a ProjectGroup to a different ProjectCategory, or to the
+ * Uncategorized zone (categoryId = null) since v0.9.4.0. Mirrors
+ * `moveSubHireGroupToCategorySchema` — both group kinds can live
+ * uncategorized.
  */
 export const moveProjectGroupToCategorySchema = z.object({
   groupId: z.string().min(1),
-  categoryId: z.string().min(1),
+  /** null = move to uncategorised */
+  categoryId: z.string().min(1).nullable(),
 });
 export type MoveProjectGroupToCategoryInput = z.input<typeof moveProjectGroupToCategorySchema>;
 

--- a/src/lib/validations/project-group.ts
+++ b/src/lib/validations/project-group.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 export const projectGroupSchema = z.object({
-  categoryId: z.string().min(1, "Category is required"),
+  // Nullable since v0.9.4.0 — a group can be created directly in the
+  // project's Uncategorized zone (categoryId stays null on the row).
+  categoryId: z.string().min(1).nullable(),
   title: z.string().min(1, "Title is required").max(200),
   description: z.string().max(2000).optional(),
   quantity: z.coerce.number().int().min(1).default(1),

--- a/src/server/category-slots.int.test.ts
+++ b/src/server/category-slots.int.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/server/line-items", async (importOriginal) => {
 import {
   moveSubHireGroupToCategory,
   moveProjectGroupToCategory,
+  getUncategorizedProjectGroups,
   reorderMixedGroupsInCategory,
   createCategoryAndPlaceGroup,
   getUncategorizedSubHireGroups,
@@ -893,5 +894,161 @@ describe("moveProjectGroupToCategory — concurrent move advisory lock", () => {
     expect(slots[0].projectCategoryId).toBe(catB.id);
     const pgAfter = await testPrisma.projectGroup.findUniqueOrThrow({ where: { id: pg.id } });
     expect(pgAfter.categoryId).toBe(catB.id);
+  });
+});
+
+// ── v0.9.4.0 — uncategorised project groups ─────────────────────────────────
+
+describe("moveProjectGroupToCategory — null destination (move to Uncategorised)", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+    h.recalcSpy.mockClear();
+  });
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("moves a categorised group to Uncategorised: clears categoryId, drops slot, syncs line items", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const project = await createProjectFixture(org.id);
+    const catA = await createCategoryFixture(org.id, project.id, "A", 0);
+    const pg = await createGroupFixture(org.id, project.id, catA.id, "PG", 0);
+    const item = await testPrisma.projectLineItem.create({
+      data: {
+        organizationId: org.id, projectId: project.id,
+        groupId: pg.id, categoryId: catA.id,
+        description: "Item", quantity: 1,
+      },
+    });
+    await testPrisma.categorySlot.create({
+      data: { projectCategoryId: catA.id, projectGroupId: pg.id, sortOrder: 0 },
+    });
+
+    const result = await moveProjectGroupToCategory({
+      groupId: pg.id, categoryId: null,
+    });
+    expect(result).toMatchObject({ success: true });
+
+    const pgAfter = await testPrisma.projectGroup.findUniqueOrThrow({ where: { id: pg.id } });
+    expect(pgAfter.categoryId).toBeNull();
+
+    const itemAfter = await testPrisma.projectLineItem.findUniqueOrThrow({ where: { id: item.id } });
+    expect(itemAfter.categoryId).toBeNull();
+
+    const slots = await testPrisma.categorySlot.findMany({
+      where: { projectGroupId: pg.id },
+    });
+    expect(slots).toHaveLength(0);
+
+    expect(h.recalcSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves an uncategorised group INTO a category: creates a fresh slot at the end", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const project = await createProjectFixture(org.id);
+    const cat = await createCategoryFixture(org.id, project.id, "Audio", 0);
+
+    // Pre-populate the destination with two existing slots so we can
+    // assert the new one lands at sortOrder 2.
+    const pgInCat1 = await createGroupFixture(org.id, project.id, cat.id, "X1", 0);
+    const pgInCat2 = await createGroupFixture(org.id, project.id, cat.id, "X2", 1);
+    await testPrisma.categorySlot.create({
+      data: { projectCategoryId: cat.id, projectGroupId: pgInCat1.id, sortOrder: 0 },
+    });
+    await testPrisma.categorySlot.create({
+      data: { projectCategoryId: cat.id, projectGroupId: pgInCat2.id, sortOrder: 1 },
+    });
+
+    // Seed the orphan project group (categoryId = null) directly.
+    const orphan = await testPrisma.projectGroup.create({
+      data: {
+        organizationId: org.id, projectId: project.id,
+        categoryId: null, title: "Orphan", sortOrder: 0,
+      },
+    });
+
+    await moveProjectGroupToCategory({ groupId: orphan.id, categoryId: cat.id });
+
+    const orphanAfter = await testPrisma.projectGroup.findUniqueOrThrow({ where: { id: orphan.id } });
+    expect(orphanAfter.categoryId).toBe(cat.id);
+
+    const slot = await testPrisma.categorySlot.findFirstOrThrow({
+      where: { projectGroupId: orphan.id },
+    });
+    expect(slot.projectCategoryId).toBe(cat.id);
+    expect(slot.sortOrder).toBe(2);
+  });
+
+  it("is a no-op when an already-uncategorised group is moved to null again", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const project = await createProjectFixture(org.id);
+    const orphan = await testPrisma.projectGroup.create({
+      data: {
+        organizationId: org.id, projectId: project.id,
+        categoryId: null, title: "Orphan", sortOrder: 0,
+      },
+    });
+
+    const result = await moveProjectGroupToCategory({
+      groupId: orphan.id, categoryId: null,
+    });
+    expect(result).toMatchObject({ success: true, noop: true });
+    expect(h.recalcSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("getUncategorizedProjectGroups", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("returns project groups with null categoryId for the requested project, scoped to org", async () => {
+    const orgA = await createOrgFixture({ slug: "org-a" });
+    const orgB = await createOrgFixture({ slug: "org-b" });
+    const userA = await createUserFixture(orgA.id, "owner");
+    h.ctx = { organizationId: orgA.id, userId: userA.id, userName: "A" };
+
+    const projectA = await createProjectFixture(orgA.id);
+    const catA = await createCategoryFixture(orgA.id, projectA.id, "A");
+    // Mix of one categorised + one orphan in our project — only the
+    // orphan should come back.
+    await createGroupFixture(orgA.id, projectA.id, catA.id, "PG-in-cat");
+    const orphanInA = await testPrisma.projectGroup.create({
+      data: {
+        organizationId: orgA.id, projectId: projectA.id,
+        categoryId: null, title: "Orphan-A", sortOrder: 0,
+      },
+    });
+
+    // Second project in same org — its orphan must NOT leak in.
+    const projectA2 = await createProjectFixture(orgA.id);
+    await testPrisma.projectGroup.create({
+      data: {
+        organizationId: orgA.id, projectId: projectA2.id,
+        categoryId: null, title: "Orphan-A2", sortOrder: 0,
+      },
+    });
+
+    // Other org's orphan must NOT leak in.
+    const projectB = await createProjectFixture(orgB.id);
+    await testPrisma.projectGroup.create({
+      data: {
+        organizationId: orgB.id, projectId: projectB.id,
+        categoryId: null, title: "Orphan-B", sortOrder: 0,
+      },
+    });
+
+    const result = await getUncategorizedProjectGroups(projectA.id);
+    const titles = (result as Array<{ id: string; title: string }>).map((g) => g.title);
+    expect(titles).toEqual([orphanInA.title]);
   });
 });

--- a/src/server/category-slots.ts
+++ b/src/server/category-slots.ts
@@ -98,6 +98,53 @@ export async function getUncategorizedSubHireGroups(projectId: string) {
   return serialize(groups);
 }
 
+/**
+ * Project groups with no category placement (`categoryId IS NULL`).
+ * Mirrors `getUncategorizedSubHireGroups` so the equipment tab can
+ * render orphan project groups in the same Uncategorized zone — both
+ * group kinds and standalone uncategorised line items now live there
+ * together.
+ *
+ * Available since v0.9.4.0 when `ProjectGroup.categoryId` became
+ * nullable. Includes line items so each row can expand its members
+ * without an additional query (matches the include shape used by
+ * `getProjectCategories` for categorised groups).
+ */
+export async function getUncategorizedProjectGroups(projectId: string) {
+  const { organizationId } = await requirePermission("project", "read");
+  const groups = await prisma.projectGroup.findMany({
+    where: {
+      categoryId: null,
+      projectId,
+      organizationId,
+    },
+    include: {
+      lineItems: {
+        include: {
+          model: true,
+          asset: true,
+          bulkAsset: true,
+          kit: true,
+          supplier: { select: { name: true } },
+          childLineItems: {
+            include: {
+              model: true,
+              asset: true,
+              bulkAsset: true,
+              kit: true,
+              supplier: { select: { name: true } },
+            },
+            orderBy: { sortOrder: "asc" as const },
+          },
+        },
+        orderBy: { sortOrder: "asc" },
+      },
+    },
+    orderBy: { sortOrder: "asc" },
+  });
+  return serialize(groups);
+}
+
 // ── Mutations ───────────────────────────────────────────────────────────────
 
 /**
@@ -222,24 +269,27 @@ export async function moveSubHireGroupToCategory(
 }
 
 /**
- * Move a ProjectGroup to a different ProjectCategory.
+ * Move a ProjectGroup to a different ProjectCategory, or to the
+ * Uncategorized zone when `categoryId` is null.
  *
  * Updates three things in one transaction:
- *   - `ProjectGroup.categoryId` — the canonical placement.
+ *   - `ProjectGroup.categoryId` — the canonical placement (now nullable
+ *     since v0.9.4.0).
  *   - `ProjectLineItem.categoryId` for every item in the group — keeps
  *     line-item category in sync so any filter that scopes by category
  *     (PDFs, reports) sees the move.
- *   - `CategorySlot` row — appended to the end of the destination
- *     category so the unified mixed-group order stays consistent with
- *     sub-hire groups already living there.
- *
- * Unlike `moveSubHireGroupToCategory`, the destination is required —
- * `ProjectGroup.categoryId` is NOT NULL in the schema.
+ *   - `CategorySlot` row — when destination is a category, append at
+ *     the end of its slot list so the unified mixed-group order stays
+ *     consistent with sub-hire groups already living there. When the
+ *     destination is null, the slot is deleted and not recreated
+ *     (mirrors the sub-hire move flow).
  *
  * Concurrency: the same `pg_advisory_xact_lock` keyed on destination
  * categoryId that protects sub-hire moves (Finding 7.2 / S11). Two
  * parallel moves of the same group would otherwise race on
  * `UNIQUE(projectCategoryId, sortOrder)` when inserting their CategorySlot.
+ * Null destination (move to uncategorised) bypasses the lock — no slot
+ * gets inserted, so there's nothing to race on.
  *
  * Permission gate: only `project:manage_line_items` (no sub-hire perm
  * needed — this action never touches sub-hire data).
@@ -253,8 +303,9 @@ export async function moveProjectGroupToCategory(
     "manage_line_items",
   );
 
-  // Cross-org / cross-project validation: the group AND the destination
-  // category must both belong to this org and to the same project.
+  // Cross-org / cross-project validation: the group must belong to
+  // this org, and if a destination category was supplied it must too,
+  // in the same project.
   const group = await prisma.projectGroup.findFirst({
     where: { id: parsed.groupId, organizationId },
     select: { id: true, projectId: true, categoryId: true, title: true },
@@ -263,32 +314,42 @@ export async function moveProjectGroupToCategory(
     throw new Error("Project group not found");
   }
 
-  const category = await prisma.projectCategory.findFirst({
-    where: { id: parsed.categoryId, organizationId },
-    select: { id: true, projectId: true, name: true },
-  });
-  if (!category) {
-    throw new Error("Destination category not found");
-  }
-  if (category.projectId !== group.projectId) {
-    throw new Error("Cannot move project group across projects");
+  let destCategoryId: string | null = null;
+  let destCategoryName: string | null = null;
+  if (parsed.categoryId) {
+    const category = await prisma.projectCategory.findFirst({
+      where: { id: parsed.categoryId, organizationId },
+      select: { id: true, projectId: true, name: true },
+    });
+    if (!category) {
+      throw new Error("Destination category not found");
+    }
+    if (category.projectId !== group.projectId) {
+      throw new Error("Cannot move project group across projects");
+    }
+    destCategoryId = category.id;
+    destCategoryName = category.name;
   }
 
   // No-op fast path — saves a transaction round-trip when the user
   // picks the same category the group is already in (e.g. accidental
   // double-confirm in the move dialog).
-  if (group.categoryId === parsed.categoryId) {
+  if (group.categoryId === destCategoryId) {
     return serialize({ success: true, noop: true });
   }
 
   await prisma.$transaction(async (tx) => {
     // Serialize concurrent moves into the same destination category.
-    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${parsed.categoryId})::bigint)`;
+    // Skip the lock for null destinations — without a slot insert,
+    // there is no UNIQUE constraint to race on.
+    if (destCategoryId) {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${destCategoryId})::bigint)`;
+    }
 
     // 1. Move the group itself.
     await tx.projectGroup.update({
       where: { id: parsed.groupId },
-      data: { categoryId: parsed.categoryId },
+      data: { categoryId: destCategoryId },
     });
 
     // 2. Keep line-item categoryId in sync. Items follow their group —
@@ -299,25 +360,28 @@ export async function moveProjectGroupToCategory(
         groupId: parsed.groupId,
         organizationId,
       },
-      data: { categoryId: parsed.categoryId },
+      data: { categoryId: destCategoryId },
     });
 
     // 3. Update the CategorySlot — delete any existing slot for this
-    //    project group and insert a fresh one at the end of the
-    //    destination category's slot list. Mirrors the sub-hire flow.
+    //    project group; if a category was chosen, insert a fresh one
+    //    at the end of its slot list. Null destination just deletes
+    //    the old slot (mirrors the sub-hire flow).
     await tx.categorySlot.deleteMany({ where: { projectGroupId: parsed.groupId } });
-    const lastSlot = await tx.categorySlot.findFirst({
-      where: { projectCategoryId: parsed.categoryId },
-      orderBy: { sortOrder: "desc" },
-      select: { sortOrder: true },
-    });
-    await tx.categorySlot.create({
-      data: {
-        projectCategoryId: parsed.categoryId,
-        projectGroupId: parsed.groupId,
-        sortOrder: (lastSlot?.sortOrder ?? -1) + 1,
-      },
-    });
+    if (destCategoryId) {
+      const lastSlot = await tx.categorySlot.findFirst({
+        where: { projectCategoryId: destCategoryId },
+        orderBy: { sortOrder: "desc" },
+        select: { sortOrder: true },
+      });
+      await tx.categorySlot.create({
+        data: {
+          projectCategoryId: destCategoryId,
+          projectGroupId: parsed.groupId,
+          sortOrder: (lastSlot?.sortOrder ?? -1) + 1,
+        },
+      });
+    }
   });
 
   await recalculateProjectTotals(group.projectId);
@@ -329,7 +393,9 @@ export async function moveProjectGroupToCategory(
     entityType: "project",
     entityId: group.projectId,
     entityName: `Project group ${group.title}`,
-    summary: `Moved project group to category ${category.name}`,
+    summary: destCategoryName
+      ? `Moved project group to category ${destCategoryName}`
+      : `Moved project group to uncategorised`,
   });
 
   return serialize({ success: true });

--- a/src/server/project-groups.ts
+++ b/src/server/project-groups.ts
@@ -215,9 +215,13 @@ export async function createProjectGroup(
   const { organizationId, userId, userName } = await requirePermission("project", "manage_line_items");
   const parsed = projectGroupSchema.parse(data);
 
-  // Get next sort order within category
+  // Get next sort order within the (project, category) bucket.
+  // Scoping by projectId matters when categoryId is null — without
+  // it, orphan groups from other projects in the same org would
+  // share the same null sortOrder pool. With it, each project's
+  // Uncategorized zone has its own independent sequence.
   const maxSort = await prisma.projectGroup.aggregate({
-    where: { categoryId: parsed.categoryId, organizationId },
+    where: { categoryId: parsed.categoryId, projectId, organizationId },
     _max: { sortOrder: true },
   });
 

--- a/src/server/sub-hires.ts
+++ b/src/server/sub-hires.ts
@@ -678,7 +678,7 @@ async function recalculateSubHireTotals(subHireId: string) {
 function resolvePlacement(
   entity: { targetGroupId?: string | null; targetCategoryId?: string | null },
   orderDefaults: { defaultTargetGroupId?: string | null; defaultTargetCategoryId?: string | null },
-  groupCategoryMap: Map<string, string>, // projectGroupId → categoryId
+  groupCategoryMap: Map<string, string | null>, // projectGroupId → categoryId (null for uncategorised groups)
 ): { groupId: string | null; categoryId: string | null } {
   const gId = entity.targetGroupId ?? orderDefaults.defaultTargetGroupId ?? null;
   if (gId) {
@@ -722,7 +722,7 @@ async function generateSubHireLineItemsTx(
   for (const i of subHire.items) {
     if (i.targetGroupId) targetGroupIds.add(i.targetGroupId);
   }
-  const groupCategoryMap = new Map<string, string>();
+  const groupCategoryMap = new Map<string, string | null>();
   if (targetGroupIds.size > 0) {
     const projectGroups = await tx.projectGroup.findMany({
       where: { id: { in: [...targetGroupIds] } },
@@ -911,7 +911,7 @@ async function syncNewSubHireLineItem(
     };
 
     // Build group→category map for any referenced project groups
-    const groupCategoryMap = new Map<string, string>();
+    const groupCategoryMap = new Map<string, string | null>();
     const gId = item.targetGroupId ?? orderDefaults.defaultTargetGroupId;
     if (gId) {
       const pg = await prisma.projectGroup.findUnique({


### PR DESCRIPTION
## Summary

Project groups can now live in the Uncategorized zone, matching how sub-hire groups already work. Deleting a category no longer destroys the groups inside it.

**Schema**
- `ProjectGroup.categoryId` now nullable (Prisma + migration `20260604030000_uncategorized_project_groups`)
- FK `onDelete` switched `CASCADE` → `SET NULL` — deleting a `ProjectCategory` orphans its groups instead of destroying them along with all their line items

**Server**
- New `getUncategorizedProjectGroups(projectId)` (mirrors `getUncategorizedSubHireGroups`)
- `moveProjectGroupToCategory` accepts null destinations: skips advisory lock + slot insert, drops existing slot, clears line items' `categoryId`
- `createProjectGroup` sortOrder aggregate now scopes by `projectId` (was missing — would have collided across projects in the same org)
- `sub-hires.ts` `groupCategoryMap` widened to `Map<string, string | null>`

**Validations**
- `projectGroupSchema.categoryId` + `moveProjectGroupToCategorySchema.categoryId` accept `null`

**UI**
- `AddGroupToolbarDialog` exposes "Uncategorized" in the category select
- `MoveProjectGroupDialog` exposes "Uncategorised" in the ComboboxPicker; default seed lands on it
- `equipment-tab` renders orphan project groups before orphan sub-hire groups in the Uncategorized zone, with full kebab + indented children

## Test Coverage

- 4 new integration tests in `src/server/category-slots.int.test.ts` covering move categorised → null, null → categorised (slot creation), no-op null → null (returns `{success: true, noop: true}`), and `getUncategorizedProjectGroups` org+project scoping
- 1 unit test flipped in `src/lib/validations/category-slot.test.ts` (rejects-null → accepts-null since v0.10.0.0)
- Vitest: 1992/1992 pass (29/29 in `category-slots.int.test.ts`)

## Pre-Landing Review

Mirrors the v0.9.0.0 F1/F2 patterns that landed clean. Bug-fix-in-passing: `createProjectGroup` sortOrder aggregate now scopes by `projectId` — without it, null-category groups across all projects in the org would have shared one sortOrder pool. Concurrency: null destination skips the advisory lock (no slot insert = no UNIQUE race).

## Plan Completion

All 6 tasks DONE (#59–#64): schema migration, validations, server actions + query, dialog updates, equipment-tab render, integration tests.

## Test plan

- [x] `npm test` passes (1992/1992)
- [x] `npx tsc --noEmit` clean
- [x] Integration suite green (29/29 in `category-slots.int.test.ts`, including 4 new null-path cases)
- [ ] Manual: open a project, add a group without picking a category — confirm it lands in Uncategorized with full kebab
- [ ] Manual: move an existing project group to Uncategorized via the kebab → Move dialog — confirm slot drops, line items lose categoryId
- [ ] Manual: delete a category that has groups inside — confirm groups orphan (no CASCADE wipe) and surface in Uncategorized
- [ ] Self-hosted deploy runs `prisma migrate deploy` on the new migration without drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)