### PR TITLE
fix(ci): migrate deploy workflow from npm to pnpm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,31 +16,40 @@ jobs:
         run: |
           cd ${{ vars.APP_DIR }}
           git pull origin main
- 
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
       - name: Install dependencies
         run: |
           cd ${{ vars.APP_DIR }}
-          npm ci --ignore-scripts --legacy-peer-deps
- 
+          pnpm install --frozen-lockfile
+
       - name: Generate Prisma client
         run: |
           cd ${{ vars.APP_DIR }}
-          npx prisma generate
+          pnpm exec prisma generate
 
       - name: Run tests
         run: |
           cd ${{ vars.APP_DIR }}
-          npm test
+          pnpm test
 
       - name: Run Prisma migrations
         run: |
           cd ${{ vars.APP_DIR }}
-          npx prisma migrate deploy
- 
+          pnpm exec prisma migrate deploy
+
       - name: Build Next.js app
         run: |
           cd ${{ vars.APP_DIR }}
-          npm run build
+          pnpm run build
  
       - name: Restart app + Discord bot
         run: |


### PR DESCRIPTION
## Problem
5 consecutive deploy failures on main since PR #165 merged. The deploy workflow still runs `npm ci` but the project switched to pnpm — `package-lock.json` was deleted in commit b69887df (Prisma 7.8.0 migration).

## Root Cause
- CI workflow (ci.yml) was updated to use pnpm but the deploy workflow (main.yml) was not
- Deploy runs `npm ci --ignore-scripts --legacy-peer-deps` which fails with "no package-lock.json"

## Fix
Migrate main.yml from npm to pnpm:
- Add pnpm/action-setup@v4 (version 9)
- Add actions/setup-node@v4 (node 20, cache pnpm)
- npm ci → pnpm install --frozen-lockfile
- npx prisma generate → pnpm exec prisma generate
- npm test → pnpm test
- npx prisma migrate deploy → pnpm exec prisma migrate deploy
- npm run build → pnpm run build

This is a cherry-pick of the fix already present on PR #168 (dependency-sweep branch), pulled out separately so CI can be restored immediately without waiting for the full dependency sweep review.