### PR TITLE
fix(ci): point pnpm/action-setup and setup-node at the right lockfile path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,13 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+          working_directory: ${{ vars.APP_DIR }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: ${{ vars.APP_DIR }}/pnpm-lock.yaml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem
The deploy workflow doesn't use `actions/checkout` — it manually `cd`s into `${{ vars.APP_DIR }}` and pulls. Both `pnpm/action-setup@v4` and `actions/setup-node@v4` look for `pnpm-lock.yaml` in the default `GITHUB_WORKSPACE`, but the project files (and lockfile) live in `APP_DIR`.

## Fix
Two small additions:
- **`pnpm/action-setup@v4`** — added `working_directory: ${{ vars.APP_DIR }}` so it locates `pnpm-lock.yaml` in the right directory
- **`actions/setup-node@v4`** — added `cache-dependency-path: ${{ vars.APP_DIR }}/pnpm-lock.yaml` so the pnpm cache key resolves off the correct lockfile

Fixes the "Dependencies lock file is not found" error on deploy.