### PR TITLE
fix(ci): drop pnpm cache — lockfile not in GITHUB_WORKSPACE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-          working_directory: ${{ vars.APP_DIR }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: ${{ vars.APP_DIR }}/pnpm-lock.yaml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem
The deploy workflow doesn't use `actions/checkout`. It manually `cd`s into `${{ vars.APP_DIR }}` and pulls. Both `pnpm/action-setup` and `actions/setup-node` run in the default `GITHUB_WORKSPACE` directory, but the repo files (including `pnpm-lock.yaml`) live in `APP_DIR`.

PR #170 tried to fix this but:
- `working_directory` is **not** a valid input for `pnpm/action-setup@v4` (warning but doesn't fail)
- `cache-dependency-path: ${{ vars.APP_DIR }}/pnpm-lock.yaml` on `setup-node` errors with "Some specified paths were not resolved" because the path doesn't resolve from the workspace context — and that error kills the job

## Fix
Drop the cache config entirely from `setup-node`. Node binary is already cached on the runner — it resolves from `/Users/jayden/actions-runner/_work/_tool/node/20.20.2/arm64` without issue. Losing the pnpm store cache is negligible for a single deploy step.

Also remove the invalid `working_directory` input from `pnpm/action-setup` (silently ignored before, cleaner without it).