### PR TITLE
fix(ci): increase Node memory limit for build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
         run: |
           cd ${{ vars.APP_DIR }}
           pnpm run build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
  
       - name: Restart app + Discord bot
         run: |


### PR DESCRIPTION
## Problem
The deploy build has been failing — but NOT because of npm vs pnpm. That migration was correct.

The actual root cause is that Next.js's TypeScript type checking during `pnpm run build` hits the default ~2GB Node heap limit on the Mac runner and OOMs:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

## Fix
Added `NODE_OPTIONS: "--max-old-space-size=4096"` to the build step to give Node 4GB of heap for the type checker.

All previous deploy workflow changes (npm→pnpm migration, cache cleanup) were correct and kept — they just couldn't deploy because the build was silently OOMing afterwards.