### PR TITLE
fix(ci): bake NEXT_PUBLIC_CONVEX_URL into prod build (stop Convex crash-loop)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,15 +46,22 @@ jobs:
           pnpm exec prisma migrate deploy
 
       # Deploys the Convex functions + schema to the prod Cloud deployment AND
-      # runs the Next build with the prod NEXT_PUBLIC_CONVEX_URL injected. The
-      # build only runs if the Convex deploy succeeds, so a broken schema/function
-      # fails the deploy as a gate. CONVEX_DEPLOY_KEY is a prod deploy key from the
-      # Convex dashboard (Settings → URL & Deploy Key). Data backfills are NOT
-      # here — they're a one-time manual op (scripts/convex-backfill-all.ts).
+      # runs the Next build. The build only runs if the Convex deploy succeeds, so
+      # a broken schema/function fails the deploy as a gate. CONVEX_DEPLOY_KEY is a
+      # prod deploy key from the Convex dashboard (Settings → URL & Deploy Key).
+      # Data backfills are NOT here — they're a one-time manual op
+      # (scripts/convex-backfill-all.ts).
+      #
+      # `--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL` (CRITICAL): without it,
+      # convex injects the deployment URL as CONVEX_URL, so the Next build never
+      # bakes NEXT_PUBLIC_CONVEX_URL into the client bundle — the app then can't
+      # reach Convex and crash-loops on "Convex is not configured". This forces the
+      # right NEXT_PUBLIC_ name. NEXT_PUBLIC_CONVEX_SITE_URL still comes from the
+      # box's .env (next build + next start both load it).
       - name: Deploy Convex functions + build Next.js app
         run: |
           cd ${{ vars.APP_DIR }}
-          pnpm exec convex deploy --cmd 'pnpm run build'
+          pnpm exec convex deploy --cmd 'pnpm run build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
           NODE_OPTIONS: "--max-old-space-size=4096"
@@ -62,8 +69,10 @@ jobs:
       - name: Restart app + Discord bot
         run: |
           cd ${{ vars.APP_DIR }}
-          # Web app: unchanged, proven path.
-          pm2 restart gearflow
+          # Web app: --update-env so the restarted process picks up any new env
+          # (e.g. Convex URLs added to the box .env) instead of reusing the env it
+          # was first launched with.
+          pm2 restart gearflow --update-env
           # Discord bot: separate process. startOrReload starts it on first
           # deploy and gracefully reloads it thereafter (--only scopes to the bot
           # so the web app config above is never touched by this file).


### PR DESCRIPTION
Hardens the deploy step so the next push to main doesn't reintroduce the 'Convex is not configured' crash-loop we just hit.

**Root cause:** `convex deploy --cmd 'pnpm run build'` injects the deployment URL as `CONVEX_URL` by default, so the Next build never baked `NEXT_PUBLIC_CONVEX_URL` into the client bundle. The server's `getConvexClient` then threw on every request → 502s / crash-loop.

**Fix:**
- `--cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL` on the deploy (canonical Convex+Next pattern)
- `pm2 restart gearflow --update-env` so the restart picks up env changes

⚠️ Merging this triggers a deploy. The prod `.env` now has both Convex URLs, so it should deploy clean — but merge it at a calm moment, not mid-incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)