### PR TITLE
feat: add quote collaboration primitives

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as collaboration from "../collaboration.js";
 import type * as assetBulkChildren from "../assetBulkChildren.js";
 import type * as assetDetail from "../assetDetail.js";
 import type * as assetMedia from "../assetMedia.js";
@@ -105,6 +106,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  collaboration: typeof collaboration;
   assetBulkChildren: typeof assetBulkChildren;
   assetDetail: typeof assetDetail;
   assetMedia: typeof assetMedia;

--- a/convex/collaboration.ts
+++ b/convex/collaboration.ts
@@ -1,0 +1,580 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { query, mutation } from "./_generated/server";
+import { requireOrgRead, requireService } from "./lib/auth";
+
+/**
+ * Convex collaboration substrate — presence, edit locks, comment threads,
+ * review markers, and activity events.
+ *
+ * AUTH: all mutations require the trusted backend SERVICE token (writes flow
+ * browser → Next.js server action → Convex, same as the rest of the app).
+ * Queries use org-scoped user reads: requireOrgRead(ctx, orgId).
+ *
+ * Presence TTL: 45 s from lastSeenAt. Heartbeat every 15 s.
+ * Lock TTL: 40 s from heartbeatAt. Heartbeat every 10 s while editor is open.
+ */
+
+// ─── Presence ────────────────────────────────────────────────────────────────
+
+export const heartbeatPresence = mutation({
+  args: {
+    orgId: v.string(),
+    userId: v.string(),
+    userName: v.string(),
+    userColor: v.string(),
+    avatarUrl: v.optional(v.string()),
+    entityType: v.string(),
+    entityId: v.string(),
+    section: v.optional(v.string()),
+    mode: v.union(v.literal("viewing"), v.literal("editing")),
+    activeTargetType: v.optional(v.string()),
+    activeTargetId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+    const expiresAt = now + 45_000;
+
+    const existing = await ctx.db
+      .query("collaborationPresence")
+      .withIndex("by_orgId_userId_entityType_entityId", (q) =>
+        q.eq("orgId", args.orgId).eq("userId", args.userId).eq("entityType", args.entityType).eq("entityId", args.entityId)
+      )
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        userName: args.userName,
+        userColor: args.userColor,
+        avatarUrl: args.avatarUrl,
+        section: args.section,
+        mode: args.mode,
+        activeTargetType: args.activeTargetType,
+        activeTargetId: args.activeTargetId,
+        lastSeenAt: now,
+        expiresAt,
+      });
+    } else {
+      await ctx.db.insert("collaborationPresence", {
+        ...args,
+        lastSeenAt: now,
+        expiresAt,
+      });
+    }
+  },
+});
+
+export const clearPresence = mutation({
+  args: { orgId: v.string(), userId: v.string(), entityType: v.string(), entityId: v.string() },
+  handler: async (ctx, { orgId, userId, entityType, entityId }) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("collaborationPresence")
+      .withIndex("by_orgId_userId_entityType_entityId", (q) =>
+        q.eq("orgId", orgId).eq("userId", userId).eq("entityType", entityType).eq("entityId", entityId)
+      )
+      .first();
+    if (existing) await ctx.db.delete(existing._id);
+  },
+});
+
+export const listPresence = query({
+  args: { orgId: v.string(), entityType: v.string(), entityId: v.string() },
+  handler: async (ctx, { orgId, entityType, entityId }) => {
+    await requireOrgRead(ctx, orgId);
+    const now = Date.now();
+    const rows = await ctx.db
+      .query("collaborationPresence")
+      .withIndex("by_orgId_entityType_entityId", (q) =>
+        q.eq("orgId", orgId).eq("entityType", entityType).eq("entityId", entityId)
+      )
+      .collect();
+    return rows.filter((r) => r.expiresAt > now);
+  },
+});
+
+// ─── Locks ───────────────────────────────────────────────────────────────────
+
+const LOCK_TTL_MS = 40_000; // 30 s grace on top of the 10 s heartbeat interval
+
+export const acquireLock = mutation({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.string(),
+    targetId: v.string(),
+    ownerUserId: v.string(),
+    ownerName: v.string(),
+    ownerColor: v.string(),
+    clientSessionId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+
+    const existing = await ctx.db
+      .query("collaborationLocks")
+      .withIndex("by_orgId_entityType_entityId_targetType_targetId", (q) =>
+        q.eq("orgId", args.orgId).eq("entityType", args.entityType).eq("entityId", args.entityId).eq("targetType", args.targetType).eq("targetId", args.targetId)
+      )
+      .filter((q) => q.eq(q.field("status"), "active"))
+      .first();
+
+    if (existing) {
+      const isOwner = existing.ownerUserId === args.ownerUserId && existing.clientSessionId === args.clientSessionId;
+      const isStale = existing.expiresAt < now;
+
+      if (isStale || isOwner) {
+        await ctx.db.patch(existing._id, {
+          ownerUserId: args.ownerUserId,
+          ownerName: args.ownerName,
+          ownerColor: args.ownerColor,
+          clientSessionId: args.clientSessionId,
+          heartbeatAt: now,
+          expiresAt: now + LOCK_TTL_MS,
+          releasedAt: undefined,
+          status: "active",
+        });
+        return { acquired: true, lockId: existing._id as string, isOwner: true };
+      }
+
+      return {
+        acquired: false,
+        lockId: existing._id as string,
+        ownerName: existing.ownerName,
+        ownerUserId: existing.ownerUserId,
+        ownerColor: existing.ownerColor,
+        expiresAt: existing.expiresAt,
+      };
+    }
+
+    const lockId = await ctx.db.insert("collaborationLocks", {
+      orgId: args.orgId,
+      entityType: args.entityType,
+      entityId: args.entityId,
+      targetType: args.targetType,
+      targetId: args.targetId,
+      ownerUserId: args.ownerUserId,
+      ownerName: args.ownerName,
+      ownerColor: args.ownerColor,
+      acquiredAt: now,
+      heartbeatAt: now,
+      expiresAt: now + LOCK_TTL_MS,
+      status: "active",
+      clientSessionId: args.clientSessionId,
+    });
+    return { acquired: true, lockId: lockId as string, isOwner: true };
+  },
+});
+
+export const heartbeatLock = mutation({
+  args: {
+    orgId: v.string(),
+    lockId: v.string(),
+    ownerUserId: v.string(),
+    clientSessionId: v.string(),
+  },
+  handler: async (ctx, { orgId, lockId, ownerUserId, clientSessionId }) => {
+    await requireService(ctx);
+    // Cast string arg to Id for ctx.db.get (Convex Id IS a string at runtime)
+    const doc = await ctx.db.get(lockId as unknown as Id<"collaborationLocks">);
+    if (!doc || doc.orgId !== orgId || doc.ownerUserId !== ownerUserId || doc.clientSessionId !== clientSessionId || doc.status !== "active") return false;
+    const now = Date.now();
+    await ctx.db.patch(doc._id, { heartbeatAt: now, expiresAt: now + LOCK_TTL_MS, clientSessionId });
+    return true;
+  },
+});
+
+export const releaseLock = mutation({
+  args: { orgId: v.string(), lockId: v.string(), ownerUserId: v.string(), clientSessionId: v.string() },
+  handler: async (ctx, { orgId, lockId, ownerUserId, clientSessionId }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.get(lockId as unknown as Id<"collaborationLocks">);
+    if (!doc || doc.orgId !== orgId || doc.ownerUserId !== ownerUserId || doc.clientSessionId !== clientSessionId) return false;
+    await ctx.db.patch(doc._id, { status: "released", releasedAt: Date.now() });
+    return true;
+  },
+});
+
+export const takeoverLock = mutation({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.string(),
+    targetId: v.string(),
+    ownerUserId: v.string(),
+    ownerName: v.string(),
+    ownerColor: v.string(),
+    clientSessionId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("collaborationLocks")
+      .withIndex("by_orgId_entityType_entityId_targetType_targetId", (q) =>
+        q.eq("orgId", args.orgId).eq("entityType", args.entityType).eq("entityId", args.entityId).eq("targetType", args.targetType).eq("targetId", args.targetId)
+      )
+      .filter((q) => q.eq(q.field("status"), "active"))
+      .first();
+
+    if (!existing) return { acquired: false as const, reason: "no_lock" };
+    if (existing.expiresAt >= now && existing.ownerUserId !== args.ownerUserId) {
+      return { acquired: false as const, reason: "not_stale", ownerName: existing.ownerName };
+    }
+
+    await ctx.db.patch(existing._id, {
+      ownerUserId: args.ownerUserId,
+      ownerName: args.ownerName,
+      ownerColor: args.ownerColor,
+      clientSessionId: args.clientSessionId,
+      heartbeatAt: now,
+      expiresAt: now + LOCK_TTL_MS,
+    });
+    return { acquired: true as const, lockId: existing._id as string };
+  },
+});
+
+export const getLock = query({
+  args: { orgId: v.string(), entityType: v.string(), entityId: v.string(), targetType: v.string(), targetId: v.string() },
+  handler: async (ctx, { orgId, entityType, entityId, targetType, targetId }) => {
+    await requireOrgRead(ctx, orgId);
+    const now = Date.now();
+    const lock = await ctx.db
+      .query("collaborationLocks")
+      .withIndex("by_orgId_entityType_entityId_targetType_targetId", (q) =>
+        q.eq("orgId", orgId).eq("entityType", entityType).eq("entityId", entityId).eq("targetType", targetType).eq("targetId", targetId)
+      )
+      .filter((q) => q.eq(q.field("status"), "active"))
+      .first();
+    if (!lock) return null;
+    return { ...lock, isStale: lock.expiresAt < now };
+  },
+});
+
+export const listLocksForEntity = query({
+  args: { orgId: v.string(), entityType: v.string(), entityId: v.string() },
+  handler: async (ctx, { orgId, entityType, entityId }) => {
+    await requireOrgRead(ctx, orgId);
+    const now = Date.now();
+    const locks = await ctx.db
+      .query("collaborationLocks")
+      .withIndex("by_orgId_entityType_entityId_targetType_targetId", (q) =>
+        q.eq("orgId", orgId).eq("entityType", entityType).eq("entityId", entityId)
+      )
+      .filter((q) => q.eq(q.field("status"), "active"))
+      .collect();
+    return locks.map((l) => ({ ...l, isStale: l.expiresAt < now }));
+  },
+});
+
+// ─── Comment Threads ─────────────────────────────────────────────────────────
+
+export const listThreads = query({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.optional(v.string()),
+    targetId: v.optional(v.string()),
+  },
+  handler: async (ctx, { orgId, entityType, entityId, targetType, targetId }) => {
+    await requireOrgRead(ctx, orgId);
+    if (targetId) {
+      return await ctx.db
+        .query("commentThreads")
+        .withIndex("by_orgId_targetId", (q) => q.eq("orgId", orgId).eq("targetId", targetId))
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("entityType"), entityType),
+            q.eq(q.field("entityId"), entityId),
+            q.eq(q.field("targetType"), targetType)
+          )
+        )
+        .collect();
+    }
+    return await ctx.db
+      .query("commentThreads")
+      .withIndex("by_orgId_entityId", (q) => q.eq("orgId", orgId).eq("entityId", entityId))
+      .collect();
+  },
+});
+
+export const createThread = mutation({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.optional(v.string()),
+    targetId: v.optional(v.string()),
+    firstComment: v.string(),
+    createdBy: v.string(),
+    createdByName: v.string(),
+    authorColor: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+    const threadId = await ctx.db.insert("commentThreads", {
+      orgId: args.orgId,
+      entityType: args.entityType,
+      entityId: args.entityId,
+      targetType: args.targetType,
+      targetId: args.targetId,
+      status: "open",
+      createdBy: args.createdBy,
+      createdByName: args.createdByName,
+      createdAt: now,
+      updatedAt: now,
+    });
+    // threadId is Id<"commentThreads"> which IS a string at runtime
+    await ctx.db.insert("comments", {
+      orgId: args.orgId,
+      threadId: threadId as unknown as string,
+      body: args.firstComment,
+      authorId: args.createdBy,
+      authorName: args.createdByName,
+      authorColor: args.authorColor,
+      createdAt: now,
+    });
+    return threadId as string;
+  },
+});
+
+export const addComment = mutation({
+  args: {
+    orgId: v.string(),
+    threadId: v.string(),
+    body: v.string(),
+    authorId: v.string(),
+    authorName: v.string(),
+    authorColor: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+
+    const thread = await ctx.db.get(args.threadId as unknown as Id<"commentThreads">);
+    if (!thread || thread.orgId !== args.orgId) throw new Error("Thread not found");
+
+    if (thread.status === "resolved") {
+      await ctx.db.patch(thread._id, {
+        status: "open",
+        resolvedBy: undefined,
+        resolvedAt: undefined,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.patch(thread._id, { updatedAt: now });
+    }
+
+    return await ctx.db.insert("comments", {
+      orgId: args.orgId,
+      threadId: args.threadId,
+      body: args.body,
+      authorId: args.authorId,
+      authorName: args.authorName,
+      authorColor: args.authorColor,
+      createdAt: now,
+    });
+  },
+});
+
+export const resolveThread = mutation({
+  args: { orgId: v.string(), threadId: v.string(), resolvedBy: v.string() },
+  handler: async (ctx, { orgId, threadId, resolvedBy }) => {
+    await requireService(ctx);
+    const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
+    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    const now = Date.now();
+    await ctx.db.patch(thread._id, {
+      status: "resolved",
+      resolvedBy,
+      resolvedAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const reopenThread = mutation({
+  args: { orgId: v.string(), threadId: v.string() },
+  handler: async (ctx, { orgId, threadId }) => {
+    await requireService(ctx);
+    const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
+    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    await ctx.db.patch(thread._id, {
+      status: "open",
+      resolvedBy: undefined,
+      resolvedAt: undefined,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const listComments = query({
+  args: { orgId: v.string(), threadId: v.string() },
+  handler: async (ctx, { orgId, threadId }) => {
+    await requireOrgRead(ctx, orgId);
+    const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
+    if (!thread || thread.orgId !== orgId) return [];
+    const rows = await ctx.db
+      .query("comments")
+      .withIndex("by_orgId_threadId", (q) => q.eq("orgId", orgId).eq("threadId", threadId))
+      .collect();
+    return rows.filter((c) => c.orgId === orgId && !c.deletedAt);
+  },
+});
+
+// ─── Review Markers ───────────────────────────────────────────────────────────
+
+export const getReviewMarker = query({
+  args: { orgId: v.string(), entityId: v.string(), targetId: v.string() },
+  handler: async (ctx, { orgId, entityId, targetId }) => {
+    await requireOrgRead(ctx, orgId);
+    return await ctx.db
+      .query("reviewMarkers")
+      .withIndex("by_orgId_targetId", (q) => q.eq("orgId", orgId).eq("targetId", targetId))
+      .filter((q) => q.eq(q.field("entityId"), entityId))
+      .first();
+  },
+});
+
+export const listReviewMarkersForEntity = query({
+  args: { orgId: v.string(), entityType: v.string(), entityId: v.string() },
+  handler: async (ctx, { orgId, entityType, entityId }) => {
+    await requireOrgRead(ctx, orgId);
+    return await ctx.db
+      .query("reviewMarkers")
+      .withIndex("by_orgId_entityId", (q) => q.eq("orgId", orgId).eq("entityId", entityId))
+      .filter((q) => q.eq(q.field("entityType"), entityType))
+      .collect();
+  },
+});
+
+export const setReviewMarker = mutation({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.string(),
+    targetId: v.string(),
+    status: v.union(v.literal("needs_review"), v.literal("follow_up"), v.literal("resolved")),
+    reason: v.optional(v.string()),
+    note: v.optional(v.string()),
+    createdBy: v.string(),
+    createdByName: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const now = Date.now();
+
+    const existing = await ctx.db
+      .query("reviewMarkers")
+      .withIndex("by_orgId_targetId", (q) =>
+        q.eq("orgId", args.orgId).eq("targetId", args.targetId)
+      )
+      .filter((q) => q.eq(q.field("entityId"), args.entityId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        status: args.status,
+        reason: args.reason,
+        note: args.note,
+        updatedAt: now,
+        resolvedBy: args.status === "resolved" ? args.createdBy : undefined,
+        resolvedAt: args.status === "resolved" ? now : undefined,
+      });
+      return existing._id as string;
+    }
+
+    return (await ctx.db.insert("reviewMarkers", {
+      orgId: args.orgId,
+      entityType: args.entityType,
+      entityId: args.entityId,
+      targetType: args.targetType,
+      targetId: args.targetId,
+      status: args.status,
+      reason: args.reason,
+      note: args.note,
+      createdBy: args.createdBy,
+      createdByName: args.createdByName,
+      createdAt: now,
+      updatedAt: now,
+    })) as string;
+  },
+});
+
+// ─── Activity Events ──────────────────────────────────────────────────────────
+
+export const logActivityEvent = mutation({
+  args: {
+    orgId: v.string(),
+    actorUserId: v.string(),
+    actorName: v.string(),
+    actorColor: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.optional(v.string()),
+    targetId: v.optional(v.string()),
+    action: v.string(),
+    summary: v.string(),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    await ctx.db.insert("activityEvents", {
+      ...args,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const listActivityEvents = query({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { orgId, entityType, entityId, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const rows = await ctx.db
+      .query("activityEvents")
+      .withIndex("by_orgId_entityId_createdAt", (q) =>
+        q.eq("orgId", orgId).eq("entityId", entityId)
+      )
+      .order("desc")
+      .take(limit ?? 50);
+    // filter in-memory since index already narrows to entityId
+    return rows.filter((r) => r.entityType === entityType);
+  },
+});
+
+export const listThreadCommentCounts = query({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+  },
+  handler: async (ctx, { orgId, entityType, entityId }) => {
+    await requireOrgRead(ctx, orgId);
+    const threads = await ctx.db
+      .query("commentThreads")
+      .withIndex("by_orgId_entityId", (q) => q.eq("orgId", orgId).eq("entityId", entityId))
+      .filter((q) => q.eq(q.field("entityType"), entityType))
+      .collect();
+
+    const counts: Record<string, { open: number; total: number }> = {};
+    for (const t of threads) {
+      const key = t.targetId ?? "__entity__";
+      if (!counts[key]) counts[key] = { open: 0, total: 0 };
+      counts[key].total++;
+      if (t.status === "open") counts[key].open++;
+    }
+    return counts;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2193,4 +2193,127 @@ export default defineSchema({
     .index("by_organizationId_userId_tableId_name", ["organizationId", "userId", "tableId", "name"])
     .index("by_userId_tableId", ["userId", "tableId"]),
 
+  // ─── Collaboration substrate ───────────────────────────────────────────────
+
+  // Who is currently viewing / editing a collaborative entity.
+  // TTL: expiresAt = lastSeenAt + 45 s. Stale rows are excluded by queries
+  // (not hard-deleted) so clients can let them age out naturally.
+  collaborationPresence: defineTable({
+    orgId: v.string(),
+    userId: v.string(),
+    userName: v.string(),
+    userColor: v.string(),
+    avatarUrl: v.optional(v.string()),
+    entityType: v.string(), // "project" | "asset" | "client"
+    entityId: v.string(),
+    section: v.optional(v.string()),
+    mode: v.union(v.literal("viewing"), v.literal("editing")),
+    activeTargetType: v.optional(v.string()),
+    activeTargetId: v.optional(v.string()),
+    lastSeenAt: v.number(),
+    expiresAt: v.number(),
+  })
+    .index("by_orgId_entityType_entityId", ["orgId", "entityType", "entityId"])
+    .index("by_orgId_userId_entityType_entityId", ["orgId", "userId", "entityType", "entityId"])
+    .index("by_expiresAt", ["expiresAt"]),
+
+  // Record-level edit locks. Prevents two users editing the same target
+  // simultaneously. Atomic acquire; heartbeat extends expiresAt.
+  collaborationLocks: defineTable({
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.string(), // "lineItem" | "section" | "asset" | "client"
+    targetId: v.string(),
+    ownerUserId: v.string(),
+    ownerName: v.string(),
+    ownerColor: v.string(),
+    acquiredAt: v.number(),
+    heartbeatAt: v.number(),
+    expiresAt: v.number(),
+    releasedAt: v.optional(v.number()),
+    status: v.union(v.literal("active"), v.literal("released"), v.literal("expired")),
+    clientSessionId: v.string(),
+  })
+    .index("by_orgId_entityType_entityId_targetType_targetId", ["orgId", "entityType", "entityId", "targetType", "targetId"])
+    .index("by_ownerUserId_status", ["ownerUserId", "status"])
+    .index("by_expiresAt", ["expiresAt"]),
+
+  // Comment threads. Each thread belongs to an entity (e.g. project) and
+  // optionally a sub-target (e.g. a specific line item).
+  commentThreads: defineTable({
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.optional(v.string()),
+    targetId: v.optional(v.string()),
+    status: v.union(v.literal("open"), v.literal("resolved")),
+    createdBy: v.string(),
+    createdByName: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    resolvedBy: v.optional(v.string()),
+    resolvedAt: v.optional(v.number()),
+  })
+    .index("by_orgId_entityId", ["orgId", "entityId"])
+    .index("by_orgId_targetId", ["orgId", "targetId"])
+    .index("by_createdBy", ["createdBy"]),
+
+  // Individual comments within a thread.
+  comments: defineTable({
+    orgId: v.string(),
+    threadId: v.string(), // Convex _id of the commentThreads doc
+    body: v.string(),
+    authorId: v.string(),
+    authorName: v.string(),
+    authorColor: v.string(),
+    createdAt: v.number(),
+    editedAt: v.optional(v.number()),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_threadId", ["threadId"])
+    .index("by_orgId_threadId", ["orgId", "threadId"])
+    .index("by_orgId_authorId", ["orgId", "authorId"]),
+
+  // Lightweight review/follow-up markers on quote line items and sections.
+  // Separate from comment threads: a marker can exist without a discussion.
+  reviewMarkers: defineTable({
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.string(),
+    targetId: v.string(),
+    status: v.union(v.literal("needs_review"), v.literal("follow_up"), v.literal("resolved")),
+    reason: v.optional(v.string()),
+    note: v.optional(v.string()),
+    createdBy: v.string(),
+    createdByName: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    resolvedBy: v.optional(v.string()),
+    resolvedAt: v.optional(v.number()),
+  })
+    .index("by_orgId_entityId", ["orgId", "entityId"])
+    .index("by_orgId_targetId", ["orgId", "targetId"])
+    .index("by_createdBy", ["createdBy"]),
+
+  // Lightweight activity log for collaboration context (not an audit trail).
+  // Records quote changes, comments, markers for the project activity feed.
+  activityEvents: defineTable({
+    orgId: v.string(),
+    actorUserId: v.string(),
+    actorName: v.string(),
+    actorColor: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    targetType: v.optional(v.string()),
+    targetId: v.optional(v.string()),
+    action: v.string(),
+    summary: v.string(),
+    metadata: v.optional(v.any()),
+    createdAt: v.number(),
+  })
+    .index("by_orgId_entityId_createdAt", ["orgId", "entityId", "createdAt"])
+    .index("by_orgId_createdAt", ["orgId", "createdAt"]),
+
 });

--- a/src/components/collaboration/activity-feed.tsx
+++ b/src/components/collaboration/activity-feed.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { getForegroundColor, getUserInitials, timeAgo } from "@/lib/collaboration-colors";
+import { cn } from "@/lib/utils";
+
+interface ActivityEvent {
+  _id: string;
+  actorUserId: string;
+  actorName: string;
+  actorColor: string;
+  entityType: string;
+  entityId: string;
+  targetType?: string;
+  targetId?: string;
+  action: string;
+  summary: string;
+  metadata?: unknown;
+  createdAt: number;
+}
+
+function ActivityRow({ event }: { event: ActivityEvent }) {
+  const initials = getUserInitials(event.actorName);
+  const fg = getForegroundColor(event.actorColor);
+
+  return (
+    <div className="flex gap-2.5 py-2">
+      <div
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[9px] font-bold mt-0.5"
+        style={{ background: event.actorColor, color: fg }}
+      >
+        {initials}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm leading-snug">
+          <span className="font-medium">{event.actorName}</span>{" "}
+          <span className="text-muted-foreground">{event.summary}</span>
+        </p>
+        <p className="text-[10px] text-muted-foreground mt-0.5">{timeAgo(event.createdAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+interface ProjectActivityFeedProps {
+  orgId: string;
+  entityType: string;
+  entityId: string;
+  limit?: number;
+  className?: string;
+  emptyText?: string;
+}
+
+/**
+ * Realtime activity feed for a collaborative entity. Subscribes to Convex
+ * and updates whenever new activity is logged.
+ */
+export function ProjectActivityFeed({
+  orgId,
+  entityType,
+  entityId,
+  limit = 30,
+  className,
+  emptyText = "No recent activity.",
+}: ProjectActivityFeedProps) {
+  const events = useQuery(
+    api.collaboration.listActivityEvents,
+    orgId ? { orgId, entityType, entityId, limit } : "skip"
+  ) as ActivityEvent[] | undefined;
+
+  if (!events) return null;
+
+  return (
+    <div className={cn("divide-y", className)}>
+      {events.length === 0 && (
+        <p className="py-4 text-center text-sm text-muted-foreground">{emptyText}</p>
+      )}
+      {events.map((e) => (
+        <ActivityRow key={e._id} event={e} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/collaboration/comment-thread-panel.tsx
+++ b/src/components/collaboration/comment-thread-panel.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { MessageCircle, CheckCircle2, RotateCcw, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { createThread, addComment, resolveThread, reopenThread } from "@/server/collaboration";
+import { getForegroundColor, getUserInitials, timeAgo } from "@/lib/collaboration-colors";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+interface Comment {
+  _id: string;
+  body: string;
+  authorId: string;
+  authorName: string;
+  authorColor: string;
+  createdAt: number;
+  editedAt?: number;
+  deletedAt?: number;
+}
+
+interface Thread {
+  _id: string;
+  status: string;
+  createdByName: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function CommentBubble({ comment }: { comment: Comment }) {
+  const initials = getUserInitials(comment.authorName);
+  const fg = getForegroundColor(comment.authorColor);
+  return (
+    <div className="flex gap-2">
+      <div
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[9px] font-bold"
+        style={{ background: comment.authorColor, color: fg }}
+      >
+        {initials}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs font-medium">{comment.authorName}</span>
+          <span className="text-[10px] text-muted-foreground">{timeAgo(comment.createdAt)}</span>
+        </div>
+        <p className="mt-0.5 whitespace-pre-wrap break-words text-sm leading-snug">{comment.body}</p>
+      </div>
+    </div>
+  );
+}
+
+interface ThreadViewProps {
+  orgId: string;
+  thread: Thread;
+}
+
+function ThreadView({ orgId, thread }: ThreadViewProps) {
+  const [reply, setReply] = useState("");
+  const comments = useQuery(api.collaboration.listComments, {
+    orgId,
+    threadId: thread._id,
+  }) as Comment[] | undefined;
+
+  const addMut = useServerMutation({
+    mutationFn: ({ body }: { body: string }) => addComment(thread._id, body),
+    onSuccess: () => setReply(""),
+    onError: (e) => toast.error(e.message),
+  });
+
+  const resolveMut = useServerMutation({
+    mutationFn: () => resolveThread(thread._id),
+    onError: (e) => toast.error(e.message),
+  });
+
+  const reopenMut = useServerMutation({
+    mutationFn: () => reopenThread(thread._id),
+    onError: (e) => toast.error(e.message),
+  });
+
+  const isResolved = thread.status === "resolved";
+
+  return (
+    <div className={cn("rounded-lg border p-3 space-y-3", isResolved && "opacity-70")}>
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-muted-foreground">
+          {timeAgo(thread.createdAt)}
+        </span>
+        {isResolved ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 gap-1 px-2 text-[10px]"
+            onClick={() => reopenMut.mutate()}
+            disabled={reopenMut.isPending}
+          >
+            <RotateCcw className="h-3 w-3" />
+            Reopen
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 gap-1 px-2 text-[10px] text-green-700 hover:text-green-800"
+            onClick={() => resolveMut.mutate()}
+            disabled={resolveMut.isPending}
+          >
+            <CheckCircle2 className="h-3 w-3" />
+            Resolve
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {(comments ?? []).map((c) => (
+          <CommentBubble key={c._id} comment={c} />
+        ))}
+      </div>
+
+      {!isResolved && (
+        <div className="flex gap-2">
+          <Textarea
+            value={reply}
+            onChange={(e) => setReply(e.target.value)}
+            placeholder="Reply…"
+            className="min-h-[52px] resize-none text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && reply.trim()) {
+                addMut.mutate({ body: reply.trim() });
+              }
+            }}
+          />
+          <Button
+            size="icon"
+            className="shrink-0 self-end"
+            disabled={!reply.trim() || addMut.isPending}
+            onClick={() => addMut.mutate({ body: reply.trim() })}
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CommentThreadPanelProps {
+  orgId: string;
+  entityType: string;
+  entityId: string;
+  targetType?: string;
+  targetId?: string;
+  /** Label for the trigger button. */
+  triggerLabel?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Sheet panel showing all comment threads for a target entity/sub-target.
+ * Children override the default trigger button.
+ */
+export function CommentThreadPanel({
+  orgId,
+  entityType,
+  entityId,
+  targetType,
+  targetId,
+  triggerLabel,
+  children,
+}: CommentThreadPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [newComment, setNewComment] = useState("");
+
+  const threads = useQuery(
+    api.collaboration.listThreads,
+    open ? { orgId, entityType, entityId, targetType, targetId } : "skip"
+  ) as Thread[] | undefined;
+
+  const createMut = useServerMutation({
+    mutationFn: ({ body }: { body: string }) =>
+      createThread(entityType, entityId, body, targetType, targetId),
+    onSuccess: () => setNewComment(""),
+    onError: (e) => toast.error(e.message),
+  });
+
+  const openCount = (threads ?? []).filter((t) => t.status === "open").length;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger>
+        {children ?? (
+          <Button size="sm" variant="ghost" className="relative h-7 gap-1 px-2 text-xs">
+            <MessageCircle className="h-3.5 w-3.5" />
+            {triggerLabel}
+            {openCount > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[9px] text-primary-foreground">
+                {openCount}
+              </span>
+            )}
+          </Button>
+        )}
+      </SheetTrigger>
+      <SheetContent side="right" className="w-[360px] sm:w-[400px] flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2 text-base">
+            <MessageCircle className="h-4 w-4" />
+            Comments
+            {openCount > 0 && (
+              <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] text-primary-foreground">
+                {openCount} open
+              </span>
+            )}
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-3 py-2">
+          {(threads ?? []).length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              No comments yet. Start a discussion below.
+            </p>
+          )}
+          {(threads ?? []).map((t) => (
+            <ThreadView key={t._id} orgId={orgId} thread={t} />
+          ))}
+        </div>
+
+        <div className="border-t pt-3 space-y-2">
+          <Textarea
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+            placeholder="Start a new discussion…"
+            className="resize-none text-sm"
+            rows={3}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && newComment.trim()) {
+                createMut.mutate({ body: newComment.trim() });
+              }
+            }}
+          />
+          <Button
+            className="w-full gap-1"
+            disabled={!newComment.trim() || createMut.isPending}
+            onClick={() => createMut.mutate({ body: newComment.trim() })}
+          >
+            <Send className="h-4 w-4" />
+            Post comment
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/collaboration/live-quote-row-status.tsx
+++ b/src/components/collaboration/live-quote-row-status.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { MessageCircle, Pencil } from "lucide-react";
+import { ReviewMarkerBadge, type MarkerStatus } from "./review-marker-badge";
+import { timeAgo } from "@/lib/collaboration-colors";
+import { cn } from "@/lib/utils";
+
+interface LiveQuoteRowStatusProps {
+  orgId: string;
+  entityId: string; // projectId
+  targetId: string; // lineItemId
+  /** Comment count badge (open thread count). */
+  openCommentCount?: number;
+  /** Review marker for this row. */
+  markerStatus?: MarkerStatus;
+  markerReason?: string;
+  /** Name of the user who last updated this row (passed from parent when available). */
+  updatedByName?: string;
+  /** Timestamp of the last update, for "updated X ago" label. */
+  updatedAt?: number;
+  className?: string;
+}
+
+/**
+ * Badge strip on a quote line item row showing:
+ * - editing lock badge (Pencil + name, when someone is editing)
+ * - comment count badge (open threads)
+ * - review/follow-up/resolved marker badge
+ * - recently-updated label
+ */
+export function LiveQuoteRowStatus({
+  orgId,
+  entityId,
+  targetId,
+  openCommentCount,
+  markerStatus,
+  markerReason,
+  updatedByName,
+  updatedAt,
+  className,
+}: LiveQuoteRowStatusProps) {
+  const lock = useQuery(
+    api.collaboration.getLock,
+    orgId ? { orgId, entityType: "project", entityId, targetType: "lineItem", targetId } : "skip"
+  );
+
+  const [showUpdated, setShowUpdated] = useState(false);
+  const [prevUpdatedAt, setPrevUpdatedAt] = useState(updatedAt);
+
+  // Flash the "updated" state briefly when updatedAt changes
+  useEffect(() => {
+    if (updatedAt !== undefined && updatedAt !== prevUpdatedAt) {
+      setShowUpdated(true);
+      setPrevUpdatedAt(updatedAt);
+      const t = setTimeout(() => setShowUpdated(false), 4000);
+      return () => clearTimeout(t);
+    }
+  }, [updatedAt, prevUpdatedAt]);
+
+  const hasLock = lock && !lock.isStale && lock.status === "active";
+  const showEmpty = !hasLock && !openCommentCount && !markerStatus && !showUpdated;
+
+  if (showEmpty) return null;
+
+  return (
+    <div className={cn("flex items-center gap-1 flex-wrap", className)}>
+      {hasLock && (
+        <span
+          className="inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none"
+          style={{
+            background: lock.ownerColor + "22",
+            borderColor: lock.ownerColor + "66",
+            color: lock.ownerColor,
+          }}
+        >
+          <Pencil className="h-2.5 w-2.5" />
+          {lock.ownerName.split(" ")[0]}
+        </span>
+      )}
+
+      {openCommentCount != null && openCommentCount > 0 && (
+        <span className="inline-flex items-center gap-0.5 rounded border border-muted-foreground/30 bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+          <MessageCircle className="h-2.5 w-2.5" />
+          {openCommentCount}
+        </span>
+      )}
+
+      {markerStatus && (
+        <ReviewMarkerBadge status={markerStatus} reason={markerReason} />
+      )}
+
+      {showUpdated && updatedByName && (
+        <span className="text-[10px] text-muted-foreground">
+          Updated by {updatedByName}{updatedAt ? ` ${timeAgo(updatedAt)}` : ""}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Subtle pulse ring on a row that is being edited by another user. */
+export function EditingRowHighlight({
+  orgId,
+  entityId,
+  targetId,
+  myUserId,
+}: {
+  orgId: string;
+  entityId: string;
+  targetId: string;
+  myUserId?: string;
+}) {
+  const lock = useQuery(
+    api.collaboration.getLock,
+    orgId ? { orgId, entityType: "project", entityId, targetType: "lineItem", targetId } : "skip"
+  );
+
+  const isOtherEditing = lock && !lock.isStale && lock.status === "active" && lock.ownerUserId !== myUserId;
+
+  if (!isOtherEditing) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 rounded-sm motion-safe:animate-pulse"
+      style={{ boxShadow: `0 0 0 1.5px ${lock.ownerColor}55` }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/collaboration/locked-editor-overlay.tsx
+++ b/src/components/collaboration/locked-editor-overlay.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Lock, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { timeAgo } from "@/lib/collaboration-colors";
+import type { LockState } from "@/hooks/use-collaboration";
+
+interface LockedEditorOverlayProps {
+  lockState: LockState;
+  onTakeover?: () => void;
+  className?: string;
+}
+
+/**
+ * Banner shown inside a read-only editor when another user holds the lock.
+ * For stale locks, offers a "Take over" recovery action.
+ */
+export function LockedEditorOverlay({ lockState, onTakeover, className }: LockedEditorOverlayProps) {
+  if (lockState.status !== "blocked" && lockState.status !== "stale") return null;
+
+  const isStale = lockState.status === "stale";
+  const ownerName = lockState.ownerName;
+  const ownerColor = lockState.ownerColor;
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/40 ${className ?? ""}`}
+      role="status"
+    >
+      <span
+        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-white"
+        style={{ background: ownerColor }}
+      >
+        {isStale ? <Clock className="h-3 w-3" /> : <Lock className="h-3 w-3" />}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        {isStale ? (
+          <p className="text-amber-800 dark:text-amber-200">
+            <strong>{ownerName}</strong> was editing this, but their session seems inactive.
+            Lock expired {timeAgo(lockState.expiresAt)}.
+          </p>
+        ) : (
+          <p className="text-amber-800 dark:text-amber-200">
+            <strong>{ownerName}</strong> is currently editing this.
+            You can view it now — editing is locked until they finish.
+          </p>
+        )}
+
+        {isStale && onTakeover && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-2 h-7 text-xs border-amber-300 hover:bg-amber-100 dark:border-amber-700 dark:hover:bg-amber-900/40"
+            onClick={onTakeover}
+          >
+            Take over editing
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/collaboration/presence-avatar-stack.tsx
+++ b/src/components/collaboration/presence-avatar-stack.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { getUserInitials, getForegroundColor } from "@/lib/collaboration-colors";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { usePresence } from "@/hooks/use-collaboration";
+import { cn } from "@/lib/utils";
+
+interface PresenceAvatarProps {
+  userName: string;
+  userColor: string;
+  avatarUrl?: string;
+  mode?: string;
+  section?: string;
+  size?: "sm" | "md";
+}
+
+function PresenceAvatar({ userName, userColor, avatarUrl, mode, section, size = "md" }: PresenceAvatarProps) {
+  const initials = getUserInitials(userName);
+  const fg = getForegroundColor(userColor);
+  const dim = size === "sm" ? "h-6 w-6 text-[10px]" : "h-8 w-8 text-xs";
+
+  const label = mode === "editing"
+    ? `${userName} — editing${section ? ` (${section})` : ""}`
+    : `${userName} — viewing`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <div
+          className={cn(
+            "relative flex items-center justify-center rounded-full ring-2 ring-background select-none shrink-0 overflow-hidden",
+            dim,
+            mode === "editing" && "ring-offset-1 ring-offset-background"
+          )}
+          style={{ background: userColor, color: fg, boxShadow: `0 0 0 2px ${userColor}` }}
+          aria-label={label}
+        >
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={avatarUrl} alt={userName} className="h-full w-full object-cover" />
+          ) : (
+            <span className="font-medium leading-none">{initials}</span>
+          )}
+          {mode === "editing" && (
+            <span className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-green-500 ring-1 ring-background" />
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+interface PresenceAvatarStackProps {
+  entityType: string;
+  entityId: string;
+  className?: string;
+  maxVisible?: number;
+  size?: "sm" | "md";
+}
+
+/**
+ * Shows a compact stack of avatars for users currently present on an entity.
+ * Registers the current user's presence and heartbeats automatically.
+ */
+export function PresenceAvatarStack({
+  entityType,
+  entityId,
+  className,
+  maxVisible = 5,
+  size = "md",
+}: PresenceAvatarStackProps) {
+  const { others } = usePresence({ entityType, entityId });
+
+  if (others.length === 0) return null;
+
+  const visible = others.slice(0, maxVisible);
+  const overflow = others.length - visible.length;
+
+  return (
+    <TooltipProvider>
+      <div className={cn("flex items-center -space-x-2", className)}>
+        {visible.map((user) => (
+          <PresenceAvatar
+            key={user.userId}
+            userName={user.userName}
+            userColor={user.userColor}
+            avatarUrl={user.avatarUrl}
+            mode={user.mode}
+            section={user.section}
+            size={size}
+          />
+        ))}
+        {overflow > 0 && (
+          <div
+            className={cn(
+              "flex items-center justify-center rounded-full bg-muted text-muted-foreground ring-2 ring-background text-xs font-medium",
+              size === "sm" ? "h-6 w-6 text-[10px]" : "h-8 w-8"
+            )}
+          >
+            +{overflow}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/collaboration/review-marker-badge.tsx
+++ b/src/components/collaboration/review-marker-badge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type MarkerStatus = "needs_review" | "follow_up" | "resolved";
+
+const markerConfig: Record<MarkerStatus, { label: string; className: string }> = {
+  needs_review: {
+    label: "Needs review",
+    className: "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/40 dark:text-amber-300 dark:border-amber-700",
+  },
+  follow_up: {
+    label: "Follow up",
+    className: "bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-700",
+  },
+  resolved: {
+    label: "Resolved",
+    className: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900/40 dark:text-green-300 dark:border-green-700",
+  },
+};
+
+interface ReviewMarkerBadgeProps {
+  status: MarkerStatus;
+  reason?: string;
+  className?: string;
+}
+
+/** Small inline badge showing a review/follow-up/resolved marker. */
+export function ReviewMarkerBadge({ status, reason, className }: ReviewMarkerBadgeProps) {
+  const cfg = markerConfig[status];
+  const label = reason ? `${cfg.label}: ${reason}` : cfg.label;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none",
+        cfg.className,
+        className
+      )}
+      title={label}
+    >
+      {label.length > 20 ? cfg.label : label}
+    </span>
+  );
+}

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -14,6 +14,8 @@
 
 import { useState } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";
+import { useEditLock } from "@/hooks/use-collaboration";
+import { LockedEditorOverlay } from "@/components/collaboration/locked-editor-overlay";
 import { AlertTriangle, Loader2 } from "lucide-react";
 
 import {
@@ -52,7 +54,12 @@ interface EditLineItemDialogProps {
   orgId?: string;
   isPending: boolean;
   onClose: () => void;
-  onSubmit: (id: string, data: EditLineItemPayload, allowOverbook: boolean) => void;
+  onSubmit: (
+    id: string,
+    data: EditLineItemPayload,
+    allowOverbook: boolean,
+    baseUpdatedAt?: string | number | null,
+  ) => void;
 }
 
 export function EditLineItemDialog(props: EditLineItemDialogProps) {
@@ -77,6 +84,19 @@ function EditLineItemDialogBody({
   onClose,
   onSubmit,
 }: EditLineItemDialogProps & { item: LineItemData }) {
+  // Edit lock — acquire while this dialog body is mounted. Released on unmount.
+  const { lockState, isLocked, isStale, takeover } = useEditLock({
+    entityType: "project",
+    entityId: projectId,
+    targetType: "lineItem",
+    targetId: item.id,
+    active: true,
+    enabled: !!orgId,
+  });
+
+  // Disable the whole form when another user holds an active lock
+  const formDisabled = isLocked;
+
   // Form state — seeded from item via useState initializers. Each fresh
   // open remounts the body (keyed by item.id) so these always reflect
   // the row that was clicked.
@@ -96,6 +116,14 @@ function EditLineItemDialogBody({
   );
   const [notes, setNotes] = useState(item.notes ?? "");
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
+
+  // Optimistic-concurrency baseline — captured once when the editor opens
+  // (the body remounts per item.id, so the initializer runs fresh each open).
+  const [baseUpdatedAt] = useState<string | number | null>(() => {
+    const u = item.updatedAt;
+    if (u == null) return null;
+    return u instanceof Date ? u.toISOString() : u;
+  });
 
   // Availability query — only runs for model-backed items. Same query
   // key shape as the equipment add form's check so React Query
@@ -168,6 +196,7 @@ function EditLineItemDialogBody({
         notes: notes || undefined,
       },
       overbookConfirmed,
+      baseUpdatedAt,
     );
   }
 
@@ -176,13 +205,24 @@ function EditLineItemDialogBody({
       <DialogHeader>
         <DialogTitle>Edit Item</DialogTitle>
       </DialogHeader>
-      <div className="space-y-4 py-2">
+
+      {/* Collaboration lock overlay — shown when another user holds the lock */}
+      {(isLocked || isStale) && (
+        <LockedEditorOverlay
+          lockState={lockState}
+          onTakeover={isStale ? () => void takeover() : undefined}
+          className="mb-2"
+        />
+      )}
+
+      <div className={`space-y-4 py-2 ${formDisabled ? "pointer-events-none opacity-60" : ""}`}>
         <div className="space-y-2">
           <Label htmlFor="edit-description">Description</Label>
           <Input
             id="edit-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
+            disabled={formDisabled}
           />
         </div>
 
@@ -194,6 +234,7 @@ function EditLineItemDialogBody({
             min={1}
             value={quantity}
             onChange={(e) => setQuantity(e.target.value)}
+            disabled={formDisabled}
           />
           {availability && item.modelId && (
             <div className="space-y-1 pt-1">
@@ -223,8 +264,8 @@ function EditLineItemDialogBody({
                   <div>
                     <p className="text-xs font-medium">Conflicts:</p>
                     <ul className="list-disc pl-4 text-xs">
-                      {availability.conflicts.map((c: string) => (
-                        <li key={c}>{c}</li>
+                      {availability.conflicts.map((c) => (
+                        <li key={String(c)}>{String(c)}</li>
                       ))}
                     </ul>
                   </div>
@@ -311,7 +352,7 @@ function EditLineItemDialogBody({
           />
         </div>
 
-        {isOverbooked && (
+        {!formDisabled && isOverbooked && (
           <div className="rounded-md border border-red-500/50 bg-red-500/10 p-3 space-y-2">
             <p className="text-sm font-medium text-red-600 dark:text-red-400">
               <AlertTriangle className="inline-block mr-1.5 h-3.5 w-3.5" />
@@ -347,7 +388,7 @@ function EditLineItemDialogBody({
         </Button>
         <Button
           onClick={handleSave}
-          disabled={isPending || (isOverbooked && !overbookConfirmed)}
+          disabled={formDisabled || isPending || (isOverbooked && !overbookConfirmed)}
         >
           {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Save

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -10,6 +10,8 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
 import {
   GripVertical,
   ChevronRight,
@@ -20,6 +22,7 @@ import {
   Pencil,
   RefreshCw,
   AlertTriangle,
+  MessageCircle,
   BookmarkPlus,
   Handshake,
   ArrowRightLeft,
@@ -39,6 +42,11 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { TableCell, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/formatters";
 import { useRowShortcuts } from "./use-row-shortcuts";
+import { ReviewMarkerBadge } from "@/components/collaboration/review-marker-badge";
+import type { MarkerStatus } from "@/components/collaboration/review-marker-badge";
+import { CommentThreadPanel } from "@/components/collaboration/comment-thread-panel";
+import { setReviewMarker } from "@/server/collaboration";
+import { toast } from "sonner";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -85,6 +93,9 @@ export interface LineItemData {
   }>;
   kit?: { name?: string } | null;
   childLineItems?: LineItemData[];
+  /** Optimistic-concurrency baseline — Prisma `updatedAt` (serialised). Sent
+   *  back on save so the server can reject stale writes (collaboration). */
+  updatedAt?: string | Date | number | null;
 }
 
 export interface GroupData {
@@ -777,6 +788,8 @@ export function LineItemRow({
   isExpanded,
   isSelected,
   showCostColumn,
+  orgId,
+  projectId,
   onToggle,
   onEdit,
   onMoveToCategory,
@@ -794,6 +807,9 @@ export function LineItemRow({
   /** 8H — render the Cost column cell. Standalone line items don't carry
    *  a supplier-cost concept, so the cell renders an em-dash. */
   showCostColumn?: boolean;
+  /** Collaboration: org and project identifiers for live status badges. */
+  orgId?: string;
+  projectId?: string;
   onToggle?: () => void;
   onEdit: () => void;
   /** Opens the "Move to category" dialog. The item lands under a
@@ -810,6 +826,26 @@ export function LineItemRow({
   const hasChildren = desc.hasChildren;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: `li-${item.id}` });
+
+  // Collaboration: reactive lock and review marker for this row
+  const liveLock = useQuery(
+    api.collaboration.getLock,
+    orgId && projectId ? { orgId, entityType: "project", entityId: projectId, targetType: "lineItem", targetId: item.id } : "skip"
+  );
+  const liveMarker = useQuery(
+    api.collaboration.getReviewMarker,
+    orgId && projectId ? { orgId, entityId: projectId, targetId: item.id } : "skip"
+  );
+  const hasActiveLock = liveLock && !liveLock.isStale && liveLock.status === "active";
+  const handleMarker = async (status: MarkerStatus) => {
+    if (!projectId) return;
+    try {
+      await setReviewMarker("project", projectId, "lineItem", item.id, status);
+      toast.success(status === "resolved" ? "Marker resolved" : "Marker updated");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update marker");
+    }
+  };
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -938,6 +974,27 @@ export function LineItemRow({
             </Badge>
           )}
           <OverbookedBadge info={overbookedInfo} />
+          {/* Collaboration badges: editing lock + review marker */}
+          {hasActiveLock && (
+            <span
+              className="inline-flex items-center gap-0.5 rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none ml-1"
+              style={{
+                background: liveLock.ownerColor + "22",
+                borderColor: liveLock.ownerColor + "66",
+                color: liveLock.ownerColor,
+              }}
+              title={`${liveLock.ownerName} is editing`}
+            >
+              ✏ {liveLock.ownerName.split(" ")[0]}
+            </span>
+          )}
+          {liveMarker && liveMarker.status !== "resolved" && (
+            <ReviewMarkerBadge
+              status={liveMarker.status as MarkerStatus}
+              reason={liveMarker.reason}
+              className="ml-1"
+            />
+          )}
         </div>
         {desc.isSubhire && item.supplier && (
           <p className={`text-xs text-fg-3 mt-0.5 ${indent}`}>via {item.supplier.name}</p>
@@ -976,6 +1033,20 @@ export function LineItemRow({
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-1">
+          {orgId && projectId && (
+            <CommentThreadPanel
+              orgId={orgId}
+              entityType="project"
+              entityId={projectId}
+              targetType="lineItem"
+              targetId={item.id}
+              triggerLabel=""
+            >
+              <Button variant="ghost" size="icon-sm" title="Comments">
+                <MessageCircle className="h-3.5 w-3.5" />
+              </Button>
+            </CommentThreadPanel>
+          )}
           <Button variant="ghost" size="icon-sm" onClick={onEdit}>
             <Pencil className="h-3.5 w-3.5" />
           </Button>
@@ -994,6 +1065,20 @@ export function LineItemRow({
                   <ArrowRightLeft className="mr-2 h-3.5 w-3.5" />
                   Move to group
                 </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleMarker("needs_review")}>
+                  <BookmarkPlus className="mr-2 h-3.5 w-3.5" />
+                  Needs review
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleMarker("follow_up")}>
+                  <Handshake className="mr-2 h-3.5 w-3.5" />
+                  Follow up
+                </DropdownMenuItem>
+                {liveMarker && liveMarker.status !== "resolved" && (
+                  <DropdownMenuItem onClick={() => handleMarker("resolved")}>
+                    <RefreshCw className="mr-2 h-3.5 w-3.5" />
+                    Resolve marker
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   onClick={onRemove}
                   className="text-[oklch(0.58_0.22_27)]"

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -352,8 +352,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
   });
 
   const updateLineItemMut = useServerMutation({
-    mutationFn: ({ id, data, allowOverbook }: { id: string; data: Record<string, unknown>; allowOverbook?: boolean }) =>
-      updateLineItem(id, data as Parameters<typeof updateLineItem>[1], allowOverbook ?? false),
+    mutationFn: ({ id, data, allowOverbook, baseUpdatedAt }: { id: string; data: Record<string, unknown>; allowOverbook?: boolean; baseUpdatedAt?: string | number | null }) =>
+      updateLineItem(id, data as Parameters<typeof updateLineItem>[1], allowOverbook ?? false, baseUpdatedAt),
     onSuccess: () => {
       invalidate();
       setEditLineItem(null);
@@ -1097,6 +1097,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                                 key={item.id}
                                 item={item}
                                 indent="ml-12"
+                                orgId={orgId}
+                                projectId={projectId}
                                 overbookedInfo={item.subHireId != null ? undefined : (overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                                 isUnconfirmed={!!item.subHireId && draftSubHireIds.has(item.subHireId)}
                                 showCostColumn={showCostColumn}
@@ -1126,6 +1128,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                           key={item.id}
                           item={item}
                           indent="ml-3"
+                          orgId={orgId}
+                          projectId={projectId}
                           overbookedInfo={item.subHireId != null ? undefined : (overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                           isUnconfirmed={!!item.subHireId && draftSubHireIds.has(item.subHireId)}
                           showCostColumn={showCostColumn}
@@ -1164,6 +1168,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                     key={item.id}
                     item={item}
                     indent=""
+                    orgId={orgId}
+                    projectId={projectId}
                     overbookedInfo={item.subHireId != null ? undefined : (overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                     isUnconfirmed={!!item.subHireId && draftSubHireIds.has(item.subHireId)}
                     showCostColumn={showCostColumn}
@@ -1237,6 +1243,8 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
                           key={item.id}
                           item={item}
                           indent="ml-12"
+                          orgId={orgId}
+                          projectId={projectId}
                           overbookedInfo={item.subHireId != null ? undefined : (overbookedMap as Record<string, OverbookedInfo>)[item.id]}
                           isUnconfirmed={!!item.subHireId && draftSubHireIds.has(item.subHireId)}
                           showCostColumn={showCostColumn}
@@ -1519,11 +1527,12 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate }: Equi
         orgId={orgId}
         isPending={updateLineItemMut.isPending}
         onClose={() => setEditLineItem(null)}
-        onSubmit={(id, data, allowOverbook) =>
+        onSubmit={(id, data, allowOverbook, baseUpdatedAt) =>
           updateLineItemMut.mutate({
             id,
             data: data as unknown as Record<string, unknown>,
             allowOverbook,
+            baseUpdatedAt,
           })
         }
       />

--- a/src/hooks/use-collaboration.ts
+++ b/src/hooks/use-collaboration.ts
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useRef, useCallback, useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { useActiveOrganization, useSession } from "@/lib/auth-client";
+import { getUserColor, getUserInitials } from "@/lib/collaboration-colors";
+import { useServerMutation } from "./use-server-mutation";
+import {
+  heartbeatPresence,
+  clearPresence,
+  acquireLock,
+  heartbeatLock,
+  releaseLock,
+  takeoverLock,
+} from "@/server/collaboration";
+
+/**
+ * Stable client session id — differentiates same-user in two tabs.
+ * Stored in sessionStorage so it survives hot-reload but not tab close.
+ */
+export function getClientSessionId(): string {
+  if (typeof sessionStorage === "undefined") return "ssr";
+  const key = "__collab_session_id__";
+  let id = sessionStorage.getItem(key);
+  if (!id) {
+    id = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    sessionStorage.setItem(key, id);
+  }
+  return id;
+}
+
+// ─── Presence ─────────────────────────────────────────────────────────────────
+
+interface UsePresenceOptions {
+  entityType: string;
+  entityId: string;
+  section?: string;
+  /** Disable when the entity/org aren't ready yet. */
+  enabled?: boolean;
+}
+
+export interface PresenceUser {
+  userId: string;
+  userName: string;
+  userColor: string;
+  avatarUrl?: string;
+  mode: string;
+  section?: string;
+  activeTargetType?: string;
+  activeTargetId?: string;
+  lastSeenAt: number;
+}
+
+/**
+ * Register presence for the current user on an entity and return the list of
+ * other active users. Heartbeats every 15 s; clears on unmount (best-effort).
+ */
+export function usePresence(options: UsePresenceOptions) {
+  const { entityType, entityId, section, enabled = true } = options;
+  const { data: activeOrg } = useActiveOrganization();
+  const { data: session } = useSession();
+  const orgId = activeOrg?.id;
+
+  // Keep a stable ref to beat/clear fns so the interval closure never stales
+  const beatFnRef = useRef<() => void>(() => {});
+  const clearFnRef = useRef<() => void>(() => {});
+
+  const heartbeatMut = useServerMutation({
+    mutationFn: () =>
+      heartbeatPresence(entityType, entityId, "viewing", section),
+    onError: (e) => console.warn("[presence] heartbeat failed", e),
+  });
+
+  const clearMut = useServerMutation({
+    mutationFn: () => clearPresence(entityType, entityId),
+    onError: () => {},
+  });
+
+  // Update stable refs each render so interval closure always calls latest
+  useEffect(() => {
+    beatFnRef.current = () => heartbeatMut.mutate();
+    clearFnRef.current = () => clearMut.mutate();
+  });
+
+  const presence = useQuery(
+    api.collaboration.listPresence,
+    orgId && enabled
+      ? { orgId, entityType, entityId }
+      : "skip"
+  ) as PresenceUser[] | undefined;
+
+  useEffect(() => {
+    if (!enabled || !orgId) return;
+    beatFnRef.current();
+    const interval = setInterval(() => beatFnRef.current(), 15_000);
+    return () => {
+      clearInterval(interval);
+      clearFnRef.current();
+    };
+  }, [enabled, orgId, entityType, entityId, section]);
+
+  const myUserId = session?.user?.id;
+  const others = useMemo(
+    () => (presence ?? []).filter((p) => p.userId !== myUserId),
+    [presence, myUserId]
+  );
+
+  return { presence: presence ?? [], others };
+}
+
+// ─── Edit Lock ─────────────────────────────────────────────────────────────────
+
+export type LockState =
+  | { status: "idle" }
+  | { status: "held"; lockId: string; isSameUser: boolean; sessionId: string }
+  | { status: "blocked"; ownerName: string; ownerColor: string; ownerUserId: string; expiresAt: number; lockId: string }
+  | { status: "stale"; ownerName: string; ownerColor: string; expiresAt: number; lockId: string }
+  | { status: "error"; message: string };
+
+interface UseEditLockOptions {
+  entityType: string;
+  entityId: string;
+  targetType: string;
+  targetId: string;
+  /** Only attempt to acquire the lock when true (e.g. when the editor opens). */
+  active?: boolean;
+  enabled?: boolean;
+}
+
+/**
+ * Manage an edit lock for a specific target (e.g. a line item).
+ * - Acquires when `active` becomes true.
+ * - Heartbeats every 10 s while active.
+ * - Releases on deactivate or unmount.
+ * - Returns the reactive lock state so other subscribers see who holds it.
+ */
+export function useEditLock(options: UseEditLockOptions) {
+  const { entityType, entityId, targetType, targetId, active = true, enabled = true } = options;
+  const { data: activeOrg } = useActiveOrganization();
+  const { data: session } = useSession();
+  const orgId = activeOrg?.id;
+  const myUserId = session?.user?.id;
+  // Stable session id — memo so it never changes for this component instance
+  const clientSessionId = useMemo(() => getClientSessionId(), []);
+
+  const lockIdRef = useRef<string | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeRef = useRef(active);
+  useEffect(() => { activeRef.current = active; });
+
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatTimerRef.current) {
+      clearInterval(heartbeatTimerRef.current);
+      heartbeatTimerRef.current = null;
+    }
+  }, []);
+
+  const startHeartbeat = useCallback((lockId: string) => {
+    lockIdRef.current = lockId;
+    stopHeartbeat();
+    heartbeatTimerRef.current = setInterval(async () => {
+      if (!lockIdRef.current || !activeRef.current) return;
+      await heartbeatFnRef.current({ lockId: lockIdRef.current, sid: clientSessionId });
+    }, 10_000);
+  }, [clientSessionId, stopHeartbeat]);
+
+  // Stable fn refs for effect closures
+  const acquireFnRef = useRef<(sid: string) => Promise<unknown>>(() => Promise.resolve(null));
+  const heartbeatFnRef = useRef<(args: { lockId: string; sid: string }) => Promise<unknown>>(() => Promise.resolve(null));
+  const releaseFnRef = useRef<(lockId: string) => Promise<unknown>>(() => Promise.resolve(null));
+  const takeoverFnRef = useRef<(sid: string) => Promise<unknown>>(() => Promise.resolve(null));
+
+  const acquireMut = useServerMutation({
+    mutationFn: (sid: string) =>
+      acquireLock(entityType, entityId, targetType, targetId, sid),
+    onError: (e) => console.warn("[lock] acquire failed", e),
+  });
+
+  const heartbeatMut = useServerMutation({
+    mutationFn: ({ lockId, sid }: { lockId: string; sid: string }) =>
+      heartbeatLock(lockId, sid),
+    onError: () => {},
+  });
+
+  const releaseMut = useServerMutation({
+    mutationFn: (lockId: string) => releaseLock(lockId, clientSessionId),
+    onError: () => {},
+  });
+
+  const takeoverMut = useServerMutation({
+    mutationFn: (sid: string) =>
+      takeoverLock(entityId, targetId, entityType, targetType, sid),
+    onError: (e) => console.warn("[lock] takeover failed", e),
+  });
+
+  useEffect(() => {
+    acquireFnRef.current = (sid) => acquireMut.mutateAsync(sid);
+    heartbeatFnRef.current = (args) => heartbeatMut.mutateAsync(args);
+    releaseFnRef.current = (lockId) => releaseMut.mutateAsync(lockId);
+    takeoverFnRef.current = (sid) => takeoverMut.mutateAsync(sid);
+  });
+
+  // Reactive lock view for all subscribers via Convex subscription
+  const liveLock = useQuery(
+    api.collaboration.getLock,
+    orgId && enabled ? { orgId, entityType, entityId, targetType, targetId } : "skip"
+  );
+
+  // Acquire / heartbeat / release lifecycle
+  useEffect(() => {
+    if (!enabled || !orgId || !active) {
+      // If we have a lock and became inactive, release it
+      if (!active && lockIdRef.current) {
+        const id = lockIdRef.current;
+        lockIdRef.current = null;
+        releaseFnRef.current(id).catch(() => {});
+      }
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const raw = await acquireFnRef.current(clientSessionId);
+      if (cancelled) return;
+      const result = raw as { acquired: boolean; lockId?: string } | null;
+      if (result?.acquired && result.lockId) {
+        startHeartbeat(result.lockId);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      stopHeartbeat();
+      if (lockIdRef.current) {
+        const id = lockIdRef.current;
+        lockIdRef.current = null;
+        releaseFnRef.current(id).catch(() => {});
+      }
+    };
+  }, [enabled, orgId, active, entityType, entityId, targetType, targetId, clientSessionId, startHeartbeat, stopHeartbeat]);
+
+  // Derive lock state from live Convex subscription
+  const lockState = useMemo((): LockState => {
+    if (!liveLock) return { status: "idle" };
+    const isOwner = liveLock.ownerUserId === myUserId && liveLock.clientSessionId === clientSessionId;
+    const isStale = liveLock.isStale;
+    const lockId = String(liveLock._id);
+    if (isOwner) {
+      return {
+        status: "held",
+        lockId,
+        isSameUser: true,
+        sessionId: liveLock.clientSessionId,
+      };
+    }
+    if (isStale) {
+      return {
+        status: "stale",
+        ownerName: liveLock.ownerName,
+        ownerColor: liveLock.ownerColor,
+        expiresAt: liveLock.expiresAt,
+        lockId,
+      };
+    }
+    return {
+      status: "blocked",
+      ownerName: liveLock.ownerName,
+      ownerColor: liveLock.ownerColor,
+      ownerUserId: liveLock.ownerUserId,
+      expiresAt: liveLock.expiresAt,
+      lockId,
+    };
+  }, [liveLock, myUserId, clientSessionId]);
+
+  const takeover = useCallback(async () => {
+    if (!orgId) return null;
+    const raw = await takeoverFnRef.current(clientSessionId);
+    const result = raw as { acquired: boolean; lockId?: string } | null;
+    if (result?.acquired && result.lockId) {
+      startHeartbeat(result.lockId);
+      await heartbeatFnRef.current({ lockId: result.lockId, sid: clientSessionId });
+    }
+    return result;
+  }, [orgId, clientSessionId, startHeartbeat]);
+
+  const isLocked = lockState.status === "blocked";
+  const isHeld = lockState.status === "held";
+  const isStale = lockState.status === "stale";
+
+  return { lockState, isLocked, isHeld, isStale, takeover, liveLock };
+}
+
+// ─── User colour helper hook ──────────────────────────────────────────────────
+
+/** Returns the current user's stable collaboration colour and initials. */
+export function useCurrentUserCollab() {
+  const { data: session } = useSession();
+  const userId = session?.user?.id ?? "";
+  const name = session?.user?.name ?? "?";
+  return {
+    color: getUserColor(userId),
+    initials: getUserInitials(name),
+    name,
+    userId,
+    avatarUrl: (session?.user as { image?: string } | undefined)?.image ?? undefined,
+  };
+}

--- a/src/lib/collaboration-colors.ts
+++ b/src/lib/collaboration-colors.ts
@@ -1,0 +1,65 @@
+/**
+ * Deterministic user colours for collaboration features.
+ *
+ * Each user gets a stable colour derived from their userId so it never
+ * changes between sessions. Red/orange are excluded to avoid collision with
+ * GearFlow's error/warning semantics.
+ */
+
+// 12 distinct colours covering the hue wheel, skipping red and orange.
+export const COLLAB_COLORS = [
+  "#2563eb", // blue
+  "#7c3aed", // violet
+  "#db2777", // pink
+  "#0891b2", // cyan
+  "#059669", // emerald
+  "#65a30d", // lime
+  "#d97706", // amber — warm but not error-red
+  "#0d9488", // teal
+  "#4f46e5", // indigo
+  "#9333ea", // purple
+  "#0284c7", // sky
+  "#16a34a", // green
+] as const;
+
+/** Derive a stable colour hex from a user id string. Pure function, no random. */
+export function getUserColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return COLLAB_COLORS[hash % COLLAB_COLORS.length];
+}
+
+/** Derive display initials from a display name (up to 2 characters). */
+export function getUserInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Return a CSS-safe foreground colour (white or near-black) that is legible
+ * against the given background hex colour.
+ */
+export function getForegroundColor(bgHex: string): string {
+  const r = parseInt(bgHex.slice(1, 3), 16) / 255;
+  const g = parseInt(bgHex.slice(3, 5), 16) / 255;
+  const b = parseInt(bgHex.slice(5, 7), 16) / 255;
+  // Perceived luminance (sRGB)
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return lum > 0.35 ? "#1a1a1a" : "#ffffff";
+}
+
+/** How long ago a timestamp was, as a human-readable string. */
+export function timeAgo(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const diffS = Math.floor(diffMs / 1000);
+  if (diffS < 30) return "just now";
+  if (diffS < 60) return `${diffS}s ago`;
+  const diffM = Math.floor(diffS / 60);
+  if (diffM < 60) return `${diffM}m ago`;
+  const diffH = Math.floor(diffM / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  return `${Math.floor(diffH / 24)}d ago`;
+}

--- a/src/lib/collaboration-conflict.test.ts
+++ b/src/lib/collaboration-conflict.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { toRevisionMs, isStaleRevision } from "./collaboration-conflict";
+
+describe("toRevisionMs", () => {
+  it("returns epoch ms unchanged for finite numbers", () => {
+    expect(toRevisionMs(1717000000000)).toBe(1717000000000);
+    expect(toRevisionMs(0)).toBe(0);
+  });
+
+  it("converts a Date to epoch ms", () => {
+    const d = new Date("2026-06-14T10:00:00.000Z");
+    expect(toRevisionMs(d)).toBe(d.getTime());
+  });
+
+  it("parses ISO strings", () => {
+    expect(toRevisionMs("2026-06-14T10:00:00.000Z")).toBe(
+      Date.parse("2026-06-14T10:00:00.000Z"),
+    );
+  });
+
+  it("returns null for missing or unparseable input", () => {
+    expect(toRevisionMs(null)).toBeNull();
+    expect(toRevisionMs(undefined)).toBeNull();
+    expect(toRevisionMs("not a date")).toBeNull();
+    expect(toRevisionMs(new Date("nope"))).toBeNull();
+    expect(toRevisionMs(NaN)).toBeNull();
+    expect(toRevisionMs(Infinity)).toBeNull();
+  });
+});
+
+describe("isStaleRevision", () => {
+  const base = "2026-06-14T10:00:00.000Z";
+
+  it("is stale when the record was updated after the editor's baseline", () => {
+    expect(isStaleRevision("2026-06-14T10:00:05.000Z", base)).toBe(true);
+  });
+
+  it("is not stale when current equals the baseline", () => {
+    expect(isStaleRevision(base, base)).toBe(false);
+  });
+
+  it("is not stale when the baseline is newer than current (clock skew / no-op)", () => {
+    expect(isStaleRevision("2026-06-14T09:59:00.000Z", base)).toBe(false);
+  });
+
+  it("fails open when either revision is unknown", () => {
+    expect(isStaleRevision(null, base)).toBe(false);
+    expect(isStaleRevision(base, null)).toBe(false);
+    expect(isStaleRevision(undefined, undefined)).toBe(false);
+  });
+
+  it("handles mixed Date / number / string inputs", () => {
+    const baseDate = new Date(base);
+    expect(isStaleRevision(baseDate.getTime() + 1000, baseDate)).toBe(true);
+    expect(isStaleRevision(baseDate, baseDate.getTime())).toBe(false);
+  });
+});

--- a/src/lib/collaboration-conflict.ts
+++ b/src/lib/collaboration-conflict.ts
@@ -1,0 +1,49 @@
+/**
+ * Optimistic-concurrency helpers for the collaboration substrate.
+ *
+ * Edit locks are advisory: they keep two users from editing the same target at
+ * once, but a lock can expire (heartbeat missed, tab crashed) while an editor
+ * still has stale form state open. The server-side revision check is the real
+ * guard — it rejects a save when the record changed underneath the editor since
+ * they opened it, regardless of lock state.
+ *
+ * The "revision" is just the record's `updatedAt`. The client captures it when
+ * the editor opens (`baseUpdatedAt`) and sends it back on save; the server
+ * compares it to the current `updatedAt`. Pure functions, no I/O — unit tested.
+ */
+
+export type RevisionInput = string | number | Date | null | undefined;
+
+/**
+ * Normalise a revision value (Date, epoch ms, or ISO string) to epoch ms.
+ * Returns null when the value is missing or unparseable — callers treat null
+ * as "unknown", which means the conflict check is skipped (fail-open) rather
+ * than blocking a legitimate save on bad data.
+ */
+export function toRevisionMs(value: RevisionInput): number | null {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * True when the record changed since the editor's baseline — i.e. the current
+ * revision is strictly newer than the baseline the editor opened with.
+ *
+ * Fail-open: if either side is unknown (null), we cannot prove staleness, so we
+ * allow the save. This keeps the check from blocking saves when a client did
+ * not send a baseline (older client, or a code path with no `updatedAt`).
+ */
+export function isStaleRevision(current: RevisionInput, base: RevisionInput): boolean {
+  const c = toRevisionMs(current);
+  const b = toRevisionMs(base);
+  if (c == null || b == null) return false;
+  return c > b;
+}

--- a/src/server/collaboration.ts
+++ b/src/server/collaboration.ts
@@ -1,0 +1,254 @@
+"use server";
+
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { getOrgContext } from "@/lib/org-context";
+import { getUserColor } from "@/lib/collaboration-colors";
+import { serialize } from "@/lib/serialize";
+
+/**
+ * Server actions for the collaboration substrate.
+ *
+ * All Convex mutations require the service token (browser writes are rejected).
+ * Server actions are the trusted bridge: browser → Next.js server action →
+ * Convex (service token). Org scoping is validated via getOrgContext().
+ */
+
+// ─── Presence ─────────────────────────────────────────────────────────────────
+
+export async function heartbeatPresence(
+  entityType: string,
+  entityId: string,
+  mode: "viewing" | "editing",
+  section?: string,
+  activeTargetType?: string,
+  activeTargetId?: string
+) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+
+  await convex.mutation(api.collaboration.heartbeatPresence, {
+    orgId: ctx.organizationId,
+    userId: ctx.userId,
+    userName: ctx.userName,
+    userColor,
+    avatarUrl: ctx.user.image ?? undefined,
+    entityType,
+    entityId,
+    section,
+    mode,
+    activeTargetType,
+    activeTargetId,
+  });
+
+  return serialize({ ok: true });
+}
+
+export async function clearPresence(entityType: string, entityId: string) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.clearPresence, {
+    orgId: ctx.organizationId,
+    userId: ctx.userId,
+    entityType,
+    entityId,
+  });
+  return serialize({ ok: true });
+}
+
+// ─── Locks ────────────────────────────────────────────────────────────────────
+
+export async function acquireLock(
+  entityType: string,
+  entityId: string,
+  targetType: string,
+  targetId: string,
+  clientSessionId: string
+) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+
+  const result = await convex.mutation(api.collaboration.acquireLock, {
+    orgId: ctx.organizationId,
+    entityType,
+    entityId,
+    targetType,
+    targetId,
+    ownerUserId: ctx.userId,
+    ownerName: ctx.userName,
+    ownerColor: userColor,
+    clientSessionId,
+  });
+
+  return serialize(result);
+}
+
+export async function heartbeatLock(lockId: string, clientSessionId: string) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  const ok = await convex.mutation(api.collaboration.heartbeatLock, {
+    orgId: ctx.organizationId,
+    lockId,
+    ownerUserId: ctx.userId,
+    clientSessionId,
+  });
+  return serialize({ ok });
+}
+
+export async function releaseLock(lockId: string, clientSessionId: string) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.releaseLock, {
+    orgId: ctx.organizationId,
+    lockId,
+    ownerUserId: ctx.userId,
+    clientSessionId,
+  });
+  return serialize({ ok: true });
+}
+
+export async function takeoverLock(
+  entityId: string,
+  targetId: string,
+  entityType: string,
+  targetType: string,
+  clientSessionId: string
+) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+  const result = await convex.mutation(api.collaboration.takeoverLock, {
+    orgId: ctx.organizationId,
+    entityType,
+    entityId,
+    targetType,
+    targetId,
+    ownerUserId: ctx.userId,
+    ownerName: ctx.userName,
+    ownerColor: userColor,
+    clientSessionId,
+  });
+  return serialize(result);
+}
+
+// ─── Comments ─────────────────────────────────────────────────────────────────
+
+export async function createThread(
+  entityType: string,
+  entityId: string,
+  firstComment: string,
+  targetType?: string,
+  targetId?: string
+) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+  const threadId = await convex.mutation(api.collaboration.createThread, {
+    orgId: ctx.organizationId,
+    entityType,
+    entityId,
+    targetType,
+    targetId,
+    firstComment,
+    createdBy: ctx.userId,
+    createdByName: ctx.userName,
+    authorColor: userColor,
+  });
+  return serialize({ threadId: threadId as unknown as string });
+}
+
+export async function addComment(threadId: string, body: string) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.addComment, {
+    orgId: ctx.organizationId,
+    threadId,
+    body,
+    authorId: ctx.userId,
+    authorName: ctx.userName,
+    authorColor: userColor,
+  });
+  return serialize({ ok: true });
+}
+
+export async function resolveThread(threadId: string) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.resolveThread, {
+    orgId: ctx.organizationId,
+    threadId,
+    resolvedBy: ctx.userId,
+  });
+  return serialize({ ok: true });
+}
+
+export async function reopenThread(threadId: string) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.reopenThread, {
+    orgId: ctx.organizationId,
+    threadId,
+  });
+  return serialize({ ok: true });
+}
+
+// ─── Review Markers ──────────────────────────────────────────────────────────
+
+export async function setReviewMarker(
+  entityType: string,
+  entityId: string,
+  targetType: string,
+  targetId: string,
+  status: "needs_review" | "follow_up" | "resolved",
+  reason?: string,
+  note?: string
+) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.setReviewMarker, {
+    orgId: ctx.organizationId,
+    entityType,
+    entityId,
+    targetType,
+    targetId,
+    status,
+    reason,
+    note,
+    createdBy: ctx.userId,
+    createdByName: ctx.userName,
+  });
+  return serialize({ ok: true });
+}
+
+// ─── Activity ─────────────────────────────────────────────────────────────────
+
+export async function logCollabActivity(
+  entityType: string,
+  entityId: string,
+  action: string,
+  summary: string,
+  targetType?: string,
+  targetId?: string,
+  metadata?: Record<string, unknown>
+) {
+  const ctx = await getOrgContext();
+  const userColor = getUserColor(ctx.userId);
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.logActivityEvent, {
+    orgId: ctx.organizationId,
+    actorUserId: ctx.userId,
+    actorName: ctx.userName,
+    actorColor: userColor,
+    entityType,
+    entityId,
+    targetType,
+    targetId,
+    action,
+    summary,
+    metadata,
+  });
+  return serialize({ ok: true });
+}

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -21,6 +21,7 @@ import { optimizePrice, computeTotalDays } from "@/lib/pricing";
 import { getOrgDaysPerMonth } from "@/lib/org-pricing";
 import { UserFacingError } from "@/lib/errors";
 import { computeStockBreakdown } from "@/lib/availability";
+import { isStaleRevision } from "@/lib/collaboration-conflict";
 
 /**
  * Expand a serialised asset's permanent accessories into child line items.
@@ -559,7 +560,18 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
   return serialize({ ...result, supplier });
 }
 
-export async function updateLineItem(id: string, data: LineItemFormValues, allowOverbook = false) {
+export async function updateLineItem(
+  id: string,
+  data: LineItemFormValues,
+  allowOverbook = false,
+  /**
+   * Optional optimistic-concurrency baseline: the `updatedAt` the editor opened
+   * with. If the row has changed since (someone else saved while this editor was
+   * open, e.g. after a lock expired), the save is rejected with a conflict. When
+   * omitted the check is skipped — edit locks remain the first line of defence.
+   */
+  baseUpdatedAt?: string | number | null,
+) {
   const { organizationId, userId, userName } = await requirePermission("project", "manage_line_items");
   const parsed = lineItemSchema.parse(data);
 
@@ -573,8 +585,22 @@ export async function updateLineItem(id: string, data: LineItemFormValues, allow
       quantity: true,
       modelId: true,
       subHireId: true,
+      updatedAt: true,
     },
   });
+
+  // Optimistic-concurrency guard: reject stale saves even when the edit lock
+  // has lapsed. The editor sends the `updatedAt` it opened with; if the row is
+  // now newer, someone else saved in the meantime.
+  if (existing && isStaleRevision(existing.updatedAt, baseUpdatedAt)) {
+    throw new UserFacingError({
+      code: "STALE_LINE_ITEM",
+      title: "Item changed",
+      message:
+        "This line item was updated by someone else while you had it open.",
+      hint: "Close and reopen the item to see the latest values, then re-apply your change.",
+    });
+  }
 
   // Server-side availability enforcement for equipment (mirrors addLineItem).
   // Only re-validate on quantity increase. Editing other fields on an


### PR DESCRIPTION
## Summary
- Adds a Convex-backed collaboration substrate for presence, edit locks, comments, review markers, and lightweight activity events.
- Wires quote line item editing into collaboration locks with read-only blocked state, stale lock takeover, heartbeat/release handling, row editing/review badges, and line-item comments.
- Adds stable user colour/initial fallback helpers plus optimistic `updatedAt` conflict checks for quote line item saves.
- Adds reusable collaboration UI primitives for future asset/client/location rollout.

## Test Plan
- `npm exec tsc -- --noEmit --pretty false`
- `npm exec eslint -- convex/schema.ts convex/collaboration.ts src/server/collaboration.ts src/hooks/use-collaboration.ts src/lib/collaboration-colors.ts src/lib/collaboration-conflict.ts src/lib/collaboration-conflict.test.ts src/components/collaboration src/components/projects/edit-line-item-dialog.tsx src/components/projects/equipment-rows.tsx src/components/projects/equipment-tab.tsx` — passes with existing warnings only
- `npm exec vitest run src/lib/collaboration-conflict.test.ts src/lib/validations/project.test.ts src/lib/validations/project-category.test.ts src/lib/validations/project-group.test.ts src/lib/project-number.test.ts`
- `npm test`
- `DATABASE_URL='postgresql://postgres:***@localhost:5432/gearflow?schema=public' BETTER_AUTH_SECRET='test-s...hars' BETTER_AUTH_URL='http:/...3000' NEXT_PUBLIC_APP_URL='http://localhost:3000' NEXT_PUBLIC_CONVEX_URL='http://127.0.0.1:3210' npm run build`

## Notes / Risks
- `npm exec convex -- codegen` is blocked locally because no `CONVEX_DEPLOYMENT` is configured.
- Quote-row collaboration currently uses per-row Convex subscriptions; acceptable for v1, but should be batched before very large quote pages become common. Fun police says: later, not never.
- Locking is UX + heartbeat backed; server-side hard safety is the `updatedAt` stale-save guard on line item updates.
- Asset/client/location rollout is intentionally left to later PRs; this PR adds reusable primitives and focuses the first integration on quote line items.
