### PR TITLE
feat: add blocking project comments

### DIFF
--- a/convex/collaboration.ts
+++ b/convex/collaboration.ts
@@ -314,10 +314,18 @@ export const createThread = mutation({
     createdBy: v.string(),
     createdByName: v.string(),
     authorColor: v.string(),
+    isBlocking: v.optional(v.boolean()),
+    projectId: v.optional(v.string()),
+    mentionUserIds: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
     const now = Date.now();
+    // For "project" entities the entityId already IS the project id; fall back to
+    // it so blocking summaries always have a project to group by.
+    const projectId =
+      args.projectId ?? (args.entityType === "project" ? args.entityId : undefined);
+    const mentions = args.mentionUserIds?.length ? args.mentionUserIds : undefined;
     const threadId = await ctx.db.insert("commentThreads", {
       orgId: args.orgId,
       entityType: args.entityType,
@@ -325,6 +333,9 @@ export const createThread = mutation({
       targetType: args.targetType,
       targetId: args.targetId,
       status: "open",
+      isBlocking: args.isBlocking ?? false,
+      projectId,
+      mentionUserIds: mentions,
       createdBy: args.createdBy,
       createdByName: args.createdByName,
       createdAt: now,
@@ -338,6 +349,7 @@ export const createThread = mutation({
       authorId: args.createdBy,
       authorName: args.createdByName,
       authorColor: args.authorColor,
+      mentionUserIds: mentions,
       createdAt: now,
     });
     return threadId as string;
@@ -352,6 +364,7 @@ export const addComment = mutation({
     authorId: v.string(),
     authorName: v.string(),
     authorColor: v.string(),
+    mentionUserIds: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
@@ -360,15 +373,26 @@ export const addComment = mutation({
     const thread = await ctx.db.get(args.threadId as unknown as Id<"commentThreads">);
     if (!thread || thread.orgId !== args.orgId) throw new Error("Thread not found");
 
+    // Union any new mentions onto the thread so dashboard mention detection
+    // covers replies, not just the opening comment.
+    const newMentions = args.mentionUserIds?.length ? args.mentionUserIds : [];
+    const mergedMentions = Array.from(
+      new Set([...(thread.mentionUserIds ?? []), ...newMentions]),
+    );
+
     if (thread.status === "resolved") {
       await ctx.db.patch(thread._id, {
         status: "open",
         resolvedBy: undefined,
         resolvedAt: undefined,
         updatedAt: now,
+        mentionUserIds: mergedMentions.length ? mergedMentions : undefined,
       });
     } else {
-      await ctx.db.patch(thread._id, { updatedAt: now });
+      await ctx.db.patch(thread._id, {
+        updatedAt: now,
+        mentionUserIds: mergedMentions.length ? mergedMentions : undefined,
+      });
     }
 
     return await ctx.db.insert("comments", {
@@ -378,8 +402,19 @@ export const addComment = mutation({
       authorId: args.authorId,
       authorName: args.authorName,
       authorColor: args.authorColor,
+      mentionUserIds: newMentions.length ? newMentions : undefined,
       createdAt: now,
     });
+  },
+});
+
+export const setThreadBlocking = mutation({
+  args: { orgId: v.string(), threadId: v.string(), isBlocking: v.boolean() },
+  handler: async (ctx, { orgId, threadId, isBlocking }) => {
+    await requireService(ctx);
+    const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
+    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    await ctx.db.patch(thread._id, { isBlocking, updatedAt: Date.now() });
   },
 });
 
@@ -568,13 +603,114 @@ export const listThreadCommentCounts = query({
       .filter((q) => q.eq(q.field("entityType"), entityType))
       .collect();
 
-    const counts: Record<string, { open: number; total: number }> = {};
+    const counts: Record<string, { open: number; total: number; blockingOpen: number }> = {};
     for (const t of threads) {
       const key = t.targetId ?? "__entity__";
-      if (!counts[key]) counts[key] = { open: 0, total: 0 };
+      if (!counts[key]) counts[key] = { open: 0, total: 0, blockingOpen: 0 };
       counts[key].total++;
-      if (t.status === "open") counts[key].open++;
+      if (t.status === "open") {
+        counts[key].open++;
+        if (t.isBlocking) counts[key].blockingOpen++;
+      }
     }
     return counts;
+  },
+});
+
+// ─── Blocking Comment Summaries ────────────────────────────────────────────────
+
+/**
+ * Open blocking threads for a single project, summarised. Drives the project
+ * header badge, line-item indicators, and the server-side prep/send-out gate.
+ * `lineItemTargetIds` is the set of line items with an open blocking thread;
+ * `hasProjectLevel` is true when a project-level (no specific target) blocker is
+ * open, which gates everything.
+ */
+export const getProjectBlockingSummary = query({
+  args: { orgId: v.string(), projectId: v.string() },
+  handler: async (ctx, { orgId, projectId }) => {
+    await requireOrgRead(ctx, orgId);
+    const threads = await ctx.db
+      .query("commentThreads")
+      .withIndex("by_orgId_projectId", (q) => q.eq("orgId", orgId).eq("projectId", projectId))
+      .collect();
+    const open = threads.filter((t) => t.status === "open" && t.isBlocking);
+    const lineItemTargetIds: string[] = [];
+    let hasProjectLevel = false;
+    for (const t of open) {
+      if (t.targetType === "lineItem" && t.targetId) lineItemTargetIds.push(t.targetId);
+      else if (!t.targetId) hasProjectLevel = true;
+    }
+    return {
+      count: open.length,
+      lineItemTargetIds,
+      hasProjectLevel,
+      targetIds: open.map((t) => t.targetId ?? null),
+    };
+  },
+});
+
+/**
+ * Blocking counts for many projects at once (project list / dashboard cards).
+ * Scans the org's blocking threads once via the by_orgId_isBlocking index and
+ * buckets the open ones by project.
+ */
+export const listBlockingForProjects = query({
+  args: { orgId: v.string(), projectIds: v.array(v.string()) },
+  handler: async (ctx, { orgId, projectIds }) => {
+    await requireOrgRead(ctx, orgId);
+    const wanted = new Set(projectIds);
+    const blocking = await ctx.db
+      .query("commentThreads")
+      .withIndex("by_orgId_isBlocking_status", (q) =>
+        q.eq("orgId", orgId).eq("isBlocking", true).eq("status", "open"),
+      )
+      .collect();
+    const counts: Record<string, number> = {};
+    for (const t of blocking) {
+      const pid = t.projectId ?? t.entityId;
+      if (!wanted.has(pid)) continue;
+      counts[pid] = (counts[pid] ?? 0) + 1;
+    }
+    return counts;
+  },
+});
+
+/**
+ * All open blocking threads in the org, with their opening comment snippet.
+ * The trusted Next.js layer joins these to project name + PM for the dashboard
+ * (PM-of / mentioned-in surfaces). Kept org-wide because blocking threads are
+ * rare; the by_orgId_isBlocking index keeps the scan tight.
+ */
+export const listOpenBlockingThreads = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const blocking = await ctx.db
+      .query("commentThreads")
+      .withIndex("by_orgId_isBlocking_status", (q) =>
+        q.eq("orgId", orgId).eq("isBlocking", true).eq("status", "open"),
+      )
+      .collect();
+    const out = [];
+    for (const t of blocking) {
+      const first = await ctx.db
+        .query("comments")
+        .withIndex("by_orgId_threadId", (q) => q.eq("orgId", orgId).eq("threadId", t._id as unknown as string))
+        .first();
+      out.push({
+        threadId: t._id as string,
+        projectId: t.projectId ?? t.entityId,
+        entityType: t.entityType,
+        entityId: t.entityId,
+        targetType: t.targetType ?? null,
+        targetId: t.targetId ?? null,
+        createdByName: t.createdByName,
+        createdAt: t.createdAt,
+        mentionUserIds: t.mentionUserIds ?? [],
+        snippet: first?.body ?? "",
+      });
+    }
+    return out;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2248,6 +2248,16 @@ export default defineSchema({
     targetType: v.optional(v.string()),
     targetId: v.optional(v.string()),
     status: v.union(v.literal("open"), v.literal("resolved")),
+    // Blocking threads gate the project's prep / send-out / forward workflow
+    // until resolved. Optional so pre-existing threads default to non-blocking.
+    isBlocking: v.optional(v.boolean()),
+    // Denormalised project id for cross-project blocking summaries (dashboard /
+    // project list). For project comments this equals entityId; carried
+    // explicitly so the value is stable even for non-"project" entityTypes.
+    projectId: v.optional(v.string()),
+    // User ids mentioned anywhere in the thread (union across comments). Drives
+    // the dashboard "mentioned in a blocking comment" surface.
+    mentionUserIds: v.optional(v.array(v.string())),
     createdBy: v.string(),
     createdByName: v.string(),
     createdAt: v.number(),
@@ -2257,6 +2267,9 @@ export default defineSchema({
   })
     .index("by_orgId_entityId", ["orgId", "entityId"])
     .index("by_orgId_targetId", ["orgId", "targetId"])
+    .index("by_orgId_isBlocking", ["orgId", "isBlocking"])
+    .index("by_orgId_isBlocking_status", ["orgId", "isBlocking", "status"])
+    .index("by_orgId_projectId", ["orgId", "projectId"])
     .index("by_createdBy", ["createdBy"]),
 
   // Individual comments within a thread.
@@ -2267,6 +2280,7 @@ export default defineSchema({
     authorId: v.string(),
     authorName: v.string(),
     authorColor: v.string(),
+    mentionUserIds: v.optional(v.array(v.string())),
     createdAt: v.number(),
     editedAt: v.optional(v.number()),
     deletedAt: v.optional(v.number()),

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,8 @@ import {
   Wrench,
   ArrowRight,
   CheckCircle2,
+  ShieldAlert,
+  AtSign,
 } from "lucide-react";
 import {
   FadeIn,
@@ -24,6 +26,7 @@ import {
   getUpcomingProjects,
   getRecentActivity,
   getMyHomeData,
+  getMyBlockingComments,
 } from "@/server/dashboard";
 import { MyWorkSection } from "@/components/dashboard/my-work-section";
 import { getSubHireDashboardStats } from "@/server/sub-hires";
@@ -67,6 +70,11 @@ export default function DashboardPage() {
   const { data: myHome } = useServerQuery({
     queryKey: ["my-home", orgId],
     queryFn: getMyHomeData,
+  });
+
+  const { data: myBlockers } = useServerQuery({
+    queryKey: ["my-blocking-comments", orgId],
+    queryFn: getMyBlockingComments,
   });
 
   // Greeting logic — personalised with the user's first name.
@@ -127,6 +135,63 @@ export default function DashboardPage() {
           </div>
         </div>
       </FadeIn>
+
+      {/* ── Blockers needing you (PM / mentioned) ── */}
+      {myBlockers && myBlockers.length > 0 && (
+        <FadeIn delay={0.03}>
+          <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-5 sm:p-6">
+            <div className="mb-3 flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-red-600" />
+              <h2 className="text-sm font-semibold text-fg">
+                Blockers needing you
+              </h2>
+              <span className="rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] font-medium text-white">
+                {myBlockers.length}
+              </span>
+            </div>
+            <StaggerList className="space-y-1">
+              {myBlockers.map((b: Record<string, unknown>) => (
+                <StaggerItem key={b.threadId as string}>
+                  <Link
+                    href={`/projects/${b.projectId}`}
+                    className="group block rounded-md px-3 py-2.5 transition-colors hover:bg-red-500/10"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-[11px] text-fg-3">
+                            {b.projectNumber as string}
+                          </span>
+                          <span className="truncate text-sm font-medium text-fg">
+                            {b.projectName as string}
+                          </span>
+                          {b.reason === "mention" && (
+                            <span className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
+                              <AtSign className="h-2.5 w-2.5" />
+                              mentioned
+                            </span>
+                          )}
+                        </div>
+                        {b.snippet ? (
+                          <p className="mt-0.5 truncate text-xs text-fg-3">
+                            &ldquo;{b.snippet as string}&rdquo;
+                          </p>
+                        ) : null}
+                      </div>
+                      <span className="shrink-0 text-[11px] text-fg-3">
+                        {b.createdByName as string} &middot;{" "}
+                        {formatDistanceToNow(new Date(b.createdAt as number), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    </div>
+                  </Link>
+                </StaggerItem>
+              ))}
+            </StaggerList>
+          </div>
+        </FadeIn>
+      )}
 
       {/* ── Your work (user-centric) ── */}
       <FadeIn delay={0.04}>

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -37,6 +37,8 @@ import { FinancialSummary } from "@/components/projects/financial-summary";
 import { ProjectCostsPanel } from "@/components/projects/project-costs-panel";
 import { ProjectConflictsBanner } from "@/components/projects/project-conflicts-banner";
 import { ProjectManagersPanel } from "@/components/projects/project-managers-panel";
+import { PresenceAvatarStack } from "@/components/collaboration/presence-avatar-stack";
+import { ProjectCommentsButton } from "@/components/collaboration/project-comments-button";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -262,6 +264,15 @@ export default function ProjectDetailPage({
                       ))}
                     </div>
                   )}
+                  {/* Live presence — who else is viewing this project */}
+                  {orgId && !project.isTemplate && (
+                    <PresenceAvatarStack
+                      entityType="project"
+                      entityId={id}
+                      size="sm"
+                      className="ml-1"
+                    />
+                  )}
                 </div>
                 {(project.client || project.location) && (
                   <p className="mt-1 text-sm text-fg-3">
@@ -281,6 +292,9 @@ export default function ProjectDetailPage({
 
               {/* Action buttons */}
               <div className="flex flex-wrap gap-2">
+                {orgId && !project.isTemplate && (
+                  <ProjectCommentsButton orgId={orgId} projectId={id} />
+                )}
                 {!project.isTemplate && (
                   <Button variant="outline" size="sm" render={<Link href={`/warehouse/${id}`} />}>
                     <Warehouse className="mr-2 h-4 w-4" />

--- a/src/components/collaboration/comment-thread-panel.tsx
+++ b/src/components/collaboration/comment-thread-panel.tsx
@@ -1,14 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
-import { MessageCircle, CheckCircle2, RotateCcw, Send } from "lucide-react";
+import {
+  MessageCircle,
+  CheckCircle2,
+  RotateCcw,
+  Send,
+  ShieldAlert,
+  AtSign,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useServerMutation } from "@/hooks/use-server-mutation";
-import { createThread, addComment, resolveThread, reopenThread } from "@/server/collaboration";
+import { useServerQuery } from "@/hooks/use-server-query";
+import {
+  createThread,
+  addComment,
+  resolveThread,
+  reopenThread,
+  setThreadBlocking,
+} from "@/server/collaboration";
+import { getMentionableMembers } from "@/server/org-members";
 import { getForegroundColor, getUserInitials, timeAgo } from "@/lib/collaboration-colors";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -19,6 +41,7 @@ interface Comment {
   authorId: string;
   authorName: string;
   authorColor: string;
+  mentionUserIds?: string[];
   createdAt: number;
   editedAt?: number;
   deletedAt?: number;
@@ -27,9 +50,92 @@ interface Comment {
 interface Thread {
   _id: string;
   status: string;
+  isBlocking?: boolean;
+  mentionUserIds?: string[];
   createdByName: string;
   createdAt: number;
   updatedAt: number;
+}
+
+interface Member {
+  userId: string;
+  name: string;
+  image: string | null;
+}
+
+/** Compact @mention multi-select backed by the org member directory. */
+function MentionPicker({
+  members,
+  selected,
+  onChange,
+}: {
+  members: Member[];
+  selected: string[];
+  onChange: (ids: string[]) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1 px-2 text-[11px] text-muted-foreground"
+          />
+        }
+      >
+        <AtSign className="h-3.5 w-3.5" />
+        {selected.length > 0 ? `${selected.length} mentioned` : "Mention"}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-64 overflow-y-auto">
+        {members.length === 0 && (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">No members</div>
+        )}
+        {members.map((m) => (
+          <DropdownMenuCheckboxItem
+            key={m.userId}
+            checked={selected.includes(m.userId)}
+            onCheckedChange={(checked) =>
+              onChange(
+                checked
+                  ? [...selected, m.userId]
+                  : selected.filter((id) => id !== m.userId),
+              )
+            }
+            // Keep the menu open while toggling multiple people.
+            closeOnClick={false}
+          >
+            {m.name}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function MentionChips({
+  ids,
+  members,
+}: {
+  ids: string[];
+  members: Member[];
+}) {
+  if (ids.length === 0) return null;
+  const names = ids.map((id) => members.find((m) => m.userId === id)?.name ?? "someone");
+  return (
+    <div className="flex flex-wrap gap-1">
+      {names.map((n, i) => (
+        <span
+          key={`${n}-${i}`}
+          className="inline-flex items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary"
+        >
+          <AtSign className="h-2.5 w-2.5" />
+          {n}
+        </span>
+      ))}
+    </div>
+  );
 }
 
 function CommentBubble({ comment }: { comment: Comment }) {
@@ -57,18 +163,24 @@ function CommentBubble({ comment }: { comment: Comment }) {
 interface ThreadViewProps {
   orgId: string;
   thread: Thread;
+  members: Member[];
 }
 
-function ThreadView({ orgId, thread }: ThreadViewProps) {
+function ThreadView({ orgId, thread, members }: ThreadViewProps) {
   const [reply, setReply] = useState("");
+  const [mentions, setMentions] = useState<string[]>([]);
   const comments = useQuery(api.collaboration.listComments, {
     orgId,
     threadId: thread._id,
   }) as Comment[] | undefined;
 
   const addMut = useServerMutation({
-    mutationFn: ({ body }: { body: string }) => addComment(thread._id, body),
-    onSuccess: () => setReply(""),
+    mutationFn: ({ body }: { body: string }) =>
+      addComment(thread._id, body, mentions.length ? { mentionUserIds: mentions } : undefined),
+    onSuccess: () => {
+      setReply("");
+      setMentions([]);
+    },
     onError: (e) => toast.error(e.message),
   });
 
@@ -82,37 +194,73 @@ function ThreadView({ orgId, thread }: ThreadViewProps) {
     onError: (e) => toast.error(e.message),
   });
 
+  const blockMut = useServerMutation({
+    mutationFn: () => setThreadBlocking(thread._id, !thread.isBlocking),
+    onError: (e) => toast.error(e.message),
+  });
+
   const isResolved = thread.status === "resolved";
+  const isBlocking = !!thread.isBlocking && !isResolved;
 
   return (
-    <div className={cn("rounded-lg border p-3 space-y-3", isResolved && "opacity-70")}>
-      <div className="flex items-center justify-between">
-        <span className="text-[10px] text-muted-foreground">
-          {timeAgo(thread.createdAt)}
-        </span>
-        {isResolved ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-6 gap-1 px-2 text-[10px]"
-            onClick={() => reopenMut.mutate()}
-            disabled={reopenMut.isPending}
-          >
-            <RotateCcw className="h-3 w-3" />
-            Reopen
-          </Button>
-        ) : (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-6 gap-1 px-2 text-[10px] text-green-700 hover:text-green-800"
-            onClick={() => resolveMut.mutate()}
-            disabled={resolveMut.isPending}
-          >
-            <CheckCircle2 className="h-3 w-3" />
-            Resolve
-          </Button>
-        )}
+    <div
+      className={cn(
+        "rounded-lg border p-3 space-y-3",
+        isResolved && "opacity-70",
+        isBlocking && "border-red-500/40 bg-red-500/5",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-muted-foreground">{timeAgo(thread.createdAt)}</span>
+          {isBlocking && (
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
+              <ShieldAlert className="h-2.5 w-2.5" />
+              Blocking
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {!isResolved && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className={cn(
+                "h-6 gap-1 px-2 text-[10px]",
+                thread.isBlocking ? "text-red-600 hover:text-red-700" : "text-muted-foreground",
+              )}
+              onClick={() => blockMut.mutate()}
+              disabled={blockMut.isPending}
+              title={thread.isBlocking ? "Stop blocking prep / send-out" : "Block prep / send-out until resolved"}
+            >
+              <ShieldAlert className="h-3 w-3" />
+              {thread.isBlocking ? "Unblock" : "Block"}
+            </Button>
+          )}
+          {isResolved ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 gap-1 px-2 text-[10px]"
+              onClick={() => reopenMut.mutate()}
+              disabled={reopenMut.isPending}
+            >
+              <RotateCcw className="h-3 w-3" />
+              Reopen
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 gap-1 px-2 text-[10px] text-green-700 hover:text-green-800"
+              onClick={() => resolveMut.mutate()}
+              disabled={resolveMut.isPending}
+            >
+              <CheckCircle2 className="h-3 w-3" />
+              Resolve
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="space-y-2">
@@ -122,26 +270,32 @@ function ThreadView({ orgId, thread }: ThreadViewProps) {
       </div>
 
       {!isResolved && (
-        <div className="flex gap-2">
-          <Textarea
-            value={reply}
-            onChange={(e) => setReply(e.target.value)}
-            placeholder="Reply…"
-            className="min-h-[52px] resize-none text-sm"
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && reply.trim()) {
-                addMut.mutate({ body: reply.trim() });
-              }
-            }}
-          />
-          <Button
-            size="icon"
-            className="shrink-0 self-end"
-            disabled={!reply.trim() || addMut.isPending}
-            onClick={() => addMut.mutate({ body: reply.trim() })}
-          >
-            <Send className="h-4 w-4" />
-          </Button>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Textarea
+              value={reply}
+              onChange={(e) => setReply(e.target.value)}
+              placeholder="Reply…"
+              className="min-h-[52px] resize-none text-sm"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && reply.trim()) {
+                  addMut.mutate({ body: reply.trim() });
+                }
+              }}
+            />
+            <Button
+              size="icon"
+              className="shrink-0 self-end"
+              disabled={!reply.trim() || addMut.isPending}
+              onClick={() => addMut.mutate({ body: reply.trim() })}
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            <MentionPicker members={members} selected={mentions} onChange={setMentions} />
+            <MentionChips ids={mentions} members={members} />
+          </div>
         </div>
       )}
     </div>
@@ -154,6 +308,9 @@ interface CommentThreadPanelProps {
   entityId: string;
   targetType?: string;
   targetId?: string;
+  /** Denormalised project id for cross-project blocking summaries. Defaults to
+   * entityId when entityType is "project". */
+  projectId?: string;
   /** Label for the trigger button. */
   triggerLabel?: string;
   children?: React.ReactNode;
@@ -161,7 +318,8 @@ interface CommentThreadPanelProps {
 
 /**
  * Sheet panel showing all comment threads for a target entity/sub-target.
- * Children override the default trigger button.
+ * Children override the default trigger button. Supports blocking comments
+ * (gate prep / send-out) and @mentions.
  */
 export function CommentThreadPanel({
   orgId,
@@ -169,25 +327,53 @@ export function CommentThreadPanel({
   entityId,
   targetType,
   targetId,
+  projectId,
   triggerLabel,
   children,
 }: CommentThreadPanelProps) {
   const [open, setOpen] = useState(false);
   const [newComment, setNewComment] = useState("");
+  const [blocking, setBlocking] = useState(false);
+  const [mentions, setMentions] = useState<string[]>([]);
 
   const threads = useQuery(
     api.collaboration.listThreads,
     open ? { orgId, entityType, entityId, targetType, targetId } : "skip"
   ) as Thread[] | undefined;
 
+  // Filter to this sub-target — listThreads without a targetId returns ALL
+  // threads on the entity, so a project-level panel must drop line-item threads.
+  const visibleThreads = useMemo(() => {
+    if (!threads) return undefined;
+    if (targetId) return threads;
+    return threads.filter((t) => !(t as Thread & { targetId?: string }).targetId);
+  }, [threads, targetId]);
+
+  const { data: members } = useServerQuery({
+    queryKey: ["mentionable-members", orgId],
+    queryFn: getMentionableMembers,
+    enabled: open,
+  });
+  const memberList = (members ?? []) as Member[];
+
   const createMut = useServerMutation({
     mutationFn: ({ body }: { body: string }) =>
-      createThread(entityType, entityId, body, targetType, targetId),
-    onSuccess: () => setNewComment(""),
+      createThread(entityType, entityId, body, targetType, targetId, {
+        isBlocking: blocking,
+        mentionUserIds: mentions.length ? mentions : undefined,
+        projectId,
+      }),
+    onSuccess: () => {
+      setNewComment("");
+      setBlocking(false);
+      setMentions([]);
+    },
     onError: (e) => toast.error(e.message),
   });
 
-  const openCount = (threads ?? []).filter((t) => t.status === "open").length;
+  const openThreads = (visibleThreads ?? []).filter((t) => t.status === "open");
+  const openCount = openThreads.length;
+  const blockingCount = openThreads.filter((t) => t.isBlocking).length;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -196,11 +382,15 @@ export function CommentThreadPanel({
           <Button size="sm" variant="ghost" className="relative h-7 gap-1 px-2 text-xs">
             <MessageCircle className="h-3.5 w-3.5" />
             {triggerLabel}
-            {openCount > 0 && (
+            {blockingCount > 0 ? (
+              <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-600 text-[9px] text-white">
+                {blockingCount}
+              </span>
+            ) : openCount > 0 ? (
               <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[9px] text-primary-foreground">
                 {openCount}
               </span>
-            )}
+            ) : null}
           </Button>
         )}
       </SheetTrigger>
@@ -209,6 +399,12 @@ export function CommentThreadPanel({
           <SheetTitle className="flex items-center gap-2 text-base">
             <MessageCircle className="h-4 w-4" />
             Comments
+            {blockingCount > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] text-white">
+                <ShieldAlert className="h-2.5 w-2.5" />
+                {blockingCount} blocking
+              </span>
+            )}
             {openCount > 0 && (
               <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] text-primary-foreground">
                 {openCount} open
@@ -218,13 +414,13 @@ export function CommentThreadPanel({
         </SheetHeader>
 
         <div className="flex-1 overflow-y-auto space-y-3 py-2">
-          {(threads ?? []).length === 0 && (
+          {(visibleThreads ?? []).length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-8">
               No comments yet. Start a discussion below.
             </p>
           )}
-          {(threads ?? []).map((t) => (
-            <ThreadView key={t._id} orgId={orgId} thread={t} />
+          {(visibleThreads ?? []).map((t) => (
+            <ThreadView key={t._id} orgId={orgId} thread={t} members={memberList} />
           ))}
         </div>
 
@@ -241,6 +437,20 @@ export function CommentThreadPanel({
               }
             }}
           />
+          <div className="flex items-center justify-between gap-2">
+            <MentionPicker members={memberList} selected={mentions} onChange={setMentions} />
+            <label className="flex cursor-pointer items-center gap-1.5 text-[11px] text-muted-foreground">
+              <ShieldAlert className={cn("h-3.5 w-3.5", blocking && "text-red-600")} />
+              Blocking
+              <Switch checked={blocking} onCheckedChange={setBlocking} />
+            </label>
+          </div>
+          <MentionChips ids={mentions} members={memberList} />
+          {blocking && (
+            <p className="text-[10px] text-red-600">
+              Blocks prepping &amp; sending out until resolved.
+            </p>
+          )}
           <Button
             className="w-full gap-1"
             disabled={!newComment.trim() || createMut.isPending}

--- a/src/components/collaboration/project-comments-button.tsx
+++ b/src/components/collaboration/project-comments-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { MessageCircle, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CommentThreadPanel } from "./comment-thread-panel";
+
+/**
+ * Project-level comments button with an always-on blocking indicator. Unlike the
+ * generic panel trigger (which only counts threads once the sheet is open), this
+ * subscribes to the project's blocking summary so the badge is live on the page.
+ */
+export function ProjectCommentsButton({
+  orgId,
+  projectId,
+}: {
+  orgId: string;
+  projectId: string;
+}) {
+  const summary = useQuery(api.collaboration.getProjectBlockingSummary, {
+    orgId,
+    projectId,
+  }) as { count: number } | undefined;
+  const blockingCount = summary?.count ?? 0;
+
+  return (
+    <CommentThreadPanel orgId={orgId} entityType="project" entityId={projectId}>
+      <Button variant="outline" size="sm" className="relative">
+        {blockingCount > 0 ? (
+          <ShieldAlert className="mr-2 h-4 w-4 text-red-600" />
+        ) : (
+          <MessageCircle className="mr-2 h-4 w-4" />
+        )}
+        <span className="hidden sm:inline">Comments</span>
+        {blockingCount > 0 && (
+          <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[9px] text-white">
+            {blockingCount}
+          </span>
+        )}
+      </Button>
+    </CommentThreadPanel>
+  );
+}

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -41,6 +41,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
 import { useRowShortcuts } from "./use-row-shortcuts";
 import { ReviewMarkerBadge } from "@/components/collaboration/review-marker-badge";
 import type { MarkerStatus } from "@/components/collaboration/review-marker-badge";
@@ -376,10 +377,14 @@ export function GroupRow({
   onMove,
   onRecalculate,
   onSaveAsTemplate,
+  orgId,
+  projectId,
 }: {
   group: GroupData;
   isExpanded: boolean;
   indented?: boolean;
+  orgId?: string;
+  projectId?: string;
   /** Drop Matrix 8C — render the disallowed-drop rejection bar when a
    *  drag of an incompatible source is currently hovering this row. */
   isRejectedDropTarget?: boolean;
@@ -467,6 +472,20 @@ export function GroupRow({
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-1">
+          {orgId && projectId && (
+            <CommentThreadPanel
+              orgId={orgId}
+              entityType="project"
+              entityId={projectId}
+              targetType="group"
+              targetId={group.id}
+              triggerLabel=""
+            >
+              <Button variant="ghost" size="icon-sm" title="Comments">
+                <MessageCircle className="h-3.5 w-3.5" />
+              </Button>
+            </CommentThreadPanel>
+          )}
           <Button variant="ghost" size="icon-sm" onClick={onEdit}>
             <Pencil className="h-3.5 w-3.5" />
           </Button>
@@ -836,6 +855,15 @@ export function LineItemRow({
     api.collaboration.getReviewMarker,
     orgId && projectId ? { orgId, entityId: projectId, targetId: item.id } : "skip"
   );
+  // Comment counts for all line items on the project — Convex dedupes this
+  // identical subscription across every row, so it's a single live query.
+  const commentCounts = useQuery(
+    api.collaboration.listThreadCommentCounts,
+    orgId && projectId ? { orgId, entityType: "project", entityId: projectId } : "skip"
+  ) as Record<string, { open: number; total: number; blockingOpen: number }> | undefined;
+  const myCounts = commentCounts?.[item.id];
+  const openComments = myCounts?.open ?? 0;
+  const blockingComments = myCounts?.blockingOpen ?? 0;
   const hasActiveLock = liveLock && !liveLock.isStale && liveLock.status === "active";
   const handleMarker = async (status: MarkerStatus) => {
     if (!projectId) return;
@@ -1042,8 +1070,28 @@ export function LineItemRow({
               targetId={item.id}
               triggerLabel=""
             >
-              <Button variant="ghost" size="icon-sm" title="Comments">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title={
+                  blockingComments > 0
+                    ? `${blockingComments} blocking comment${blockingComments === 1 ? "" : "s"}`
+                    : openComments > 0
+                      ? `${openComments} open comment${openComments === 1 ? "" : "s"}`
+                      : "Comments"
+                }
+                className={cn("relative", blockingComments > 0 && "text-red-600")}
+              >
                 <MessageCircle className="h-3.5 w-3.5" />
+                {blockingComments > 0 ? (
+                  <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-600 px-0.5 text-[8px] font-medium text-white">
+                    {blockingComments}
+                  </span>
+                ) : openComments > 0 ? (
+                  <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[8px] font-medium text-primary-foreground">
+                    {openComments}
+                  </span>
+                ) : null}
               </Button>
             </CommentThreadPanel>
           )}

--- a/src/components/projects/project-table.tsx
+++ b/src/components/projects/project-table.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
 import { useServerQuery } from "@/hooks/use-server-query";
-import { Plus, AlertTriangle } from "lucide-react";
+import { Plus, AlertTriangle, ShieldAlert } from "lucide-react";
 
 import { getProjectIssueFlags } from "@/server/projects";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -110,6 +112,9 @@ const projectColumns: ColumnDef<AnyProject>[] = [
           </Link>
           {row._issueFlags && (
             <ProjectIssueBadge issues={row._issueFlags} />
+          )}
+          {row._blockingCount > 0 && (
+            <ProjectBlockingBadge count={row._blockingCount} />
           )}
         </div>
         {row.client?.name && (
@@ -330,9 +335,21 @@ export function ProjectTable() {
     enabled: projectIds.length > 0,
   });
 
+  // Blocking-comment counts — reactive so a blocker raised elsewhere lights up
+  // the badge immediately. Scoped to the current page's project ids.
+  const blockingCounts = useQuery(
+    api.collaboration.listBlockingForProjects,
+    orgId && projectIds.length > 0 ? { orgId, projectIds } : "skip",
+  ) as Record<string, number> | undefined;
+
   const enrichedProjects = useMemo(
-    () => (paged ?? []).map((p) => ({ ...p, _issueFlags: issueFlags?.[p.id] ?? null })),
-    [paged, issueFlags],
+    () =>
+      (paged ?? []).map((p) => ({
+        ...p,
+        _issueFlags: issueFlags?.[p.id] ?? null,
+        _blockingCount: blockingCounts?.[p.id] ?? 0,
+      })),
+    [paged, issueFlags, blockingCounts],
   );
 
   const toolbarActions = (
@@ -369,6 +386,22 @@ export function ProjectTable() {
       emptyPreset="projects"
       toolbarActions={toolbarActions}
     />
+  );
+}
+
+function ProjectBlockingBadge({ count }: { count: number }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="inline-flex items-center gap-0.5 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
+          <ShieldAlert className="h-3 w-3" />
+          {count}
+        </TooltipTrigger>
+        <TooltipContent>
+          {count} unresolved blocking comment{count === 1 ? "" : "s"} — prep &amp; send-out are gated
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/src/lib/blocking-comments-read.ts
+++ b/src/lib/blocking-comments-read.ts
@@ -89,7 +89,16 @@ export async function assertNoBlockingComments(
   projectId: string,
   opts?: { lineItemId?: string; actionLabel?: string },
 ): Promise<void> {
-  const summary = await getProjectBlockingSummary(orgId, projectId);
+  let summary: ProjectBlockingSummary;
+  try {
+    summary = await getProjectBlockingSummary(orgId, projectId);
+  } catch (error) {
+    console.error("Failed to read blocking comments before warehouse action", error);
+    throw new Error(
+      "Can't verify blocking comments right now, so this action is paused. Try again once collaboration status is reachable.",
+    );
+  }
+
   if (summary.count === 0) return;
 
   const action = opts?.actionLabel ?? "continue";

--- a/src/lib/blocking-comments-read.ts
+++ b/src/lib/blocking-comments-read.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Server-only reads for blocking comments (Convex), plus the assertion guard the
+ * prep / send-out / project-forward server actions call.
+ *
+ * A "blocking comment" is an open `commentThreads` row with `isBlocking: true`.
+ * Resolving the thread (status → resolved) clears the block. These reads run
+ * through the trusted Convex service token; the calling server action has
+ * already run requirePermission/getOrgContext, so org scoping is enforced
+ * upstream — we pass `orgId` straight through.
+ *
+ * NOT a `"use server"` module: these are plain server helpers imported by the
+ * gate server actions, like `src/lib/clients-read.ts`.
+ */
+
+export interface ProjectBlockingSummary {
+  count: number;
+  lineItemTargetIds: string[];
+  hasProjectLevel: boolean;
+}
+
+export async function getProjectBlockingSummary(
+  orgId: string,
+  projectId: string,
+): Promise<ProjectBlockingSummary> {
+  const convex = await getConvexClient();
+  const res = await convex.query(api.collaboration.getProjectBlockingSummary, {
+    orgId,
+    projectId,
+  });
+  return {
+    count: res.count,
+    lineItemTargetIds: res.lineItemTargetIds,
+    hasProjectLevel: res.hasProjectLevel,
+  };
+}
+
+export async function getBlockingCountsForProjects(
+  orgId: string,
+  projectIds: string[],
+): Promise<Record<string, number>> {
+  if (projectIds.length === 0) return {};
+  const convex = await getConvexClient();
+  return await convex.query(api.collaboration.listBlockingForProjects, {
+    orgId,
+    projectIds,
+  });
+}
+
+export interface OpenBlockingThread {
+  threadId: string;
+  projectId: string;
+  entityType: string;
+  entityId: string;
+  targetType: string | null;
+  targetId: string | null;
+  createdByName: string;
+  createdAt: number;
+  mentionUserIds: string[];
+  snippet: string;
+}
+
+export async function listOpenBlockingThreads(
+  orgId: string,
+): Promise<OpenBlockingThread[]> {
+  const convex = await getConvexClient();
+  return await convex.query(api.collaboration.listOpenBlockingThreads, { orgId });
+}
+
+/**
+ * Throw if the project has open blocking comments that should stop the requested
+ * action. Two modes:
+ *  - project-wide (no `lineItemId`): ANY open blocking comment blocks. Use for
+ *    check-out, send-out, and forward status transitions.
+ *  - per-line-item (`lineItemId` given): blocks only when there's a
+ *    project-level blocker OR a blocker on that exact line item. Use for prep
+ *    operations so an unrelated item's blocker doesn't stall prepping others.
+ *
+ * Throws a plain Error whose message is surfaced to the user (server actions in
+ * this app toast `error.message`). Never blocks deprep / returns — callers only
+ * invoke this on forward operations.
+ */
+export async function assertNoBlockingComments(
+  orgId: string,
+  projectId: string,
+  opts?: { lineItemId?: string; actionLabel?: string },
+): Promise<void> {
+  const summary = await getProjectBlockingSummary(orgId, projectId);
+  if (summary.count === 0) return;
+
+  const action = opts?.actionLabel ?? "continue";
+
+  if (opts?.lineItemId) {
+    const blockedByItem = summary.lineItemTargetIds.includes(opts.lineItemId);
+    if (!summary.hasProjectLevel && !blockedByItem) return;
+    throw new Error(
+      `Can't ${action}: this item has an unresolved blocking comment. ` +
+        `Resolve it before prepping or sending out.`,
+    );
+  }
+
+  const n = summary.count;
+  throw new Error(
+    `Can't ${action}: this project has ${n} unresolved blocking comment${n === 1 ? "" : "s"}. ` +
+      `Resolve ${n === 1 ? "it" : "them"} before prepping or sending out.`,
+  );
+}

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -236,6 +236,11 @@ export async function prepItemDirect(
     "check_out"
   );
 
+  await assertNoBlockingComments(organizationId, projectId, {
+    lineItemId,
+    actionLabel: "prep this item",
+  });
+
   const result = await prisma.$transaction(async (tx) => {
     const lineItem = await tx.projectLineItem.findFirst({
       where: { id: lineItemId, projectId, organizationId },
@@ -610,6 +615,11 @@ export async function prepKitChildren(
 
   if (!parentLi) throw new Error("Kit line item not found");
 
+  await assertNoBlockingComments(organizationId, projectId, {
+    lineItemId: parentLineItemId,
+    actionLabel: "prep this kit",
+  });
+
   await prisma.$transaction(async (tx) => {
     const children = parentLi.childLineItems || [];
     for (const child of children) {
@@ -701,6 +711,11 @@ export async function completeCheckAndPack(data: CompleteCheckAndPackValues) {
     "check_out"
   );
   const parsed = completeCheckAndPackSchema.parse(data);
+
+  await assertNoBlockingComments(organizationId, parsed.projectId, {
+    lineItemId: parsed.lineItemId,
+    actionLabel: "complete the check & pack",
+  });
 
   const result = await prisma.$transaction(async (tx) => {
     // 1. Verify line item

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -6,6 +6,7 @@ import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { syncAssetsToConvex } from "@/lib/asset-mirror";
 import { upsertProjectLineItemsToConvex } from "@/lib/line-item-mirror";
+import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import { getModelMap, getModelById, type ConvexModel } from "@/lib/models-read";
 import { getModelCheckItemCountMap } from "@/lib/line-item-tree-read";
 import {
@@ -189,6 +190,11 @@ export async function pullItem(projectId: string, lineItemId: string) {
   if (!lineItem) {
     throw new Error("Line item not found in project");
   }
+
+  await assertNoBlockingComments(organizationId, projectId, {
+    lineItemId,
+    actionLabel: "pull this item",
+  });
 
   const result = await prisma.projectLineItem.update({
     where: { id: lineItemId },

--- a/src/server/collaboration.ts
+++ b/src/server/collaboration.ts
@@ -200,6 +200,7 @@ export async function setThreadBlocking(threadId: string, isBlocking: boolean) {
 
 export async function resolveThread(threadId: string) {
   const ctx = await getOrgContext();
+  await requirePermission("project", "manage_line_items");
   const convex = await getConvexClient();
   await convex.mutation(api.collaboration.resolveThread, {
     orgId: ctx.organizationId,
@@ -211,6 +212,7 @@ export async function resolveThread(threadId: string) {
 
 export async function reopenThread(threadId: string) {
   const ctx = await getOrgContext();
+  await requirePermission("project", "manage_line_items");
   const convex = await getConvexClient();
   await convex.mutation(api.collaboration.reopenThread, {
     orgId: ctx.organizationId,

--- a/src/server/collaboration.ts
+++ b/src/server/collaboration.ts
@@ -2,7 +2,7 @@
 
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
-import { getOrgContext } from "@/lib/org-context";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getUserColor } from "@/lib/collaboration-colors";
 import { serialize } from "@/lib/serialize";
 
@@ -144,6 +144,9 @@ export async function createThread(
   options?: { isBlocking?: boolean; mentionUserIds?: string[]; projectId?: string }
 ) {
   const ctx = await getOrgContext();
+  if (options?.isBlocking) {
+    await requirePermission("project", "manage_line_items");
+  }
   const userColor = getUserColor(ctx.userId);
   const convex = await getConvexClient();
   const threadId = await convex.mutation(api.collaboration.createThread, {
@@ -185,6 +188,7 @@ export async function addComment(
 
 export async function setThreadBlocking(threadId: string, isBlocking: boolean) {
   const ctx = await getOrgContext();
+  await requirePermission("project", "manage_line_items");
   const convex = await getConvexClient();
   await convex.mutation(api.collaboration.setThreadBlocking, {
     orgId: ctx.organizationId,

--- a/src/server/collaboration.ts
+++ b/src/server/collaboration.ts
@@ -140,7 +140,8 @@ export async function createThread(
   entityId: string,
   firstComment: string,
   targetType?: string,
-  targetId?: string
+  targetId?: string,
+  options?: { isBlocking?: boolean; mentionUserIds?: string[]; projectId?: string }
 ) {
   const ctx = await getOrgContext();
   const userColor = getUserColor(ctx.userId);
@@ -155,11 +156,18 @@ export async function createThread(
     createdBy: ctx.userId,
     createdByName: ctx.userName,
     authorColor: userColor,
+    isBlocking: options?.isBlocking ?? false,
+    projectId: options?.projectId,
+    mentionUserIds: options?.mentionUserIds,
   });
   return serialize({ threadId: threadId as unknown as string });
 }
 
-export async function addComment(threadId: string, body: string) {
+export async function addComment(
+  threadId: string,
+  body: string,
+  options?: { mentionUserIds?: string[] }
+) {
   const ctx = await getOrgContext();
   const userColor = getUserColor(ctx.userId);
   const convex = await getConvexClient();
@@ -170,6 +178,18 @@ export async function addComment(threadId: string, body: string) {
     authorId: ctx.userId,
     authorName: ctx.userName,
     authorColor: userColor,
+    mentionUserIds: options?.mentionUserIds,
+  });
+  return serialize({ ok: true });
+}
+
+export async function setThreadBlocking(threadId: string, isBlocking: boolean) {
+  const ctx = await getOrgContext();
+  const convex = await getConvexClient();
+  await convex.mutation(api.collaboration.setThreadBlocking, {
+    orgId: ctx.organizationId,
+    threadId,
+    isBlocking,
   });
   return serialize({ ok: true });
 }

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { attachClient } from "@/lib/clients-read";
 import { serialize } from "@/lib/serialize";
+import { listOpenBlockingThreads } from "@/lib/blocking-comments-read";
 
 export async function getDashboardStats() {
   const { organizationId } = await getOrgContext();
@@ -101,6 +102,58 @@ export async function getMyHomeData() {
   // Clients live in Convex — attach instead of a Prisma join.
   const withClients = await attachClient(organizationId, myProjects);
   return serialize({ userName, userId, myProjects: withClients });
+}
+
+/**
+ * Open blocking comments that need the current user's attention: ones on a
+ * project they manage, or where they've been @mentioned. Surfaced on the
+ * dashboard so a blocker that's gating prep / send-out can't sit unnoticed.
+ */
+export async function getMyBlockingComments() {
+  const { organizationId, userId } = await getOrgContext();
+
+  const threads = await listOpenBlockingThreads(organizationId);
+  if (threads.length === 0) return serialize([]);
+
+  const projectIds = Array.from(new Set(threads.map((t) => t.projectId).filter(Boolean)));
+  const projects = await prisma.project.findMany({
+    where: { organizationId, id: { in: projectIds } },
+    select: {
+      id: true,
+      name: true,
+      projectNumber: true,
+      projectManagerId: true,
+      projectManagers: { select: { userId: true } },
+    },
+  });
+  const projectMap = new Map(projects.map((p) => [p.id, p]));
+
+  const surfaced = threads
+    .map((t) => {
+      const project = projectMap.get(t.projectId);
+      if (!project) return null;
+      const isPM =
+        project.projectManagerId === userId ||
+        project.projectManagers.some((pm) => pm.userId === userId);
+      const isMentioned = t.mentionUserIds.includes(userId);
+      if (!isPM && !isMentioned) return null;
+      return {
+        threadId: t.threadId,
+        projectId: t.projectId,
+        projectName: project.name,
+        projectNumber: project.projectNumber,
+        targetType: t.targetType,
+        snippet: t.snippet,
+        createdByName: t.createdByName,
+        createdAt: t.createdAt,
+        // "mention" wins as the more personal reason when both apply.
+        reason: isMentioned ? ("mention" as const) : ("pm" as const),
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+    .sort((a, b) => b.createdAt - a.createdAt);
+
+  return serialize(surfaced);
 }
 
 export async function getUpcomingProjects() {

--- a/src/server/org-members.ts
+++ b/src/server/org-members.ts
@@ -47,6 +47,28 @@ export async function getOrgMembers(params?: {
   });
 }
 
+/**
+ * Lightweight member directory for @mention pickers. Available to any org member
+ * (no orgMembers:read gate) since it only exposes id/name/image already visible
+ * across the app. Returns the current user first is NOT done here — callers can
+ * filter themselves out if desired.
+ */
+export async function getMentionableMembers() {
+  const { organizationId } = await getOrgContext();
+  const members = await prisma.member.findMany({
+    where: { organizationId },
+    include: { user: { select: { id: true, name: true, email: true, image: true } } },
+    orderBy: { createdAt: "asc" },
+  });
+  return serialize(
+    members.map((m) => ({
+      userId: m.user.id,
+      name: m.user.name || m.user.email || "Unknown",
+      image: m.user.image ?? null,
+    })),
+  );
+}
+
 export async function changeMemberRole(memberId: string, newRole: string) {
   await requirePermission("orgMembers", "update_role");
   const { organizationId, userId, userName } = await getOrgContext();

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -31,6 +31,7 @@ import { emitIfDiscordEnabled } from "@/lib/services/outbox-service";
 import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/table-utils";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { createId } from "@paralleldrive/cuid2";
+import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import {
   renderProjectNumber,
   scopeKeyFor,
@@ -48,6 +49,16 @@ type ProjectNumberConfig = {
   padding: number;
   timezone?: string;
 };
+
+const BLOCKED_FORWARD_PROJECT_STATUSES: ProjectStatus[] = [
+  "PREPPING",
+  "CHECKED_OUT",
+  "ON_SITE",
+];
+
+function isBlockedForwardProjectStatus(status: ProjectStatus | ProjectFormValues["status"] | null | undefined) {
+  return status ? BLOCKED_FORWARD_PROJECT_STATUSES.includes(status as ProjectStatus) : false;
+}
 
 /** Parse the org's auto project-number config from its settings metadata JSON. */
 function readProjectNumberConfig(metadata: string | null): ProjectNumberConfig | null {
@@ -640,44 +651,55 @@ export async function updateProject(id: string, data: ProjectFormValues) {
     select: { status: true, isTemplate: true },
   });
 
+  if (
+    before &&
+    !before.isTemplate &&
+    before.status !== parsed.status &&
+    isBlockedForwardProjectStatus(parsed.status)
+  ) {
+    await assertNoBlockingComments(organizationId, id, {
+      actionLabel: `move this project to ${String(parsed.status).toLowerCase().replaceAll("_", " ")}`,
+    });
+  }
+
   const updated = await prisma.$transaction(async (tx) => {
     const result = await tx.project.update({
-    where: { id, organizationId },
-    data: {
-      projectNumber: parsed.projectNumber,
-      name: parsed.name,
-      clientId: parsed.clientId || null,
-      status: parsed.status,
-      type: parsed.type,
-      description: parsed.description || null,
-      locationId: parsed.locationId || null,
-      siteContactName: parsed.siteContactName || null,
-      siteContactPhone: parsed.siteContactPhone || null,
-      siteContactEmail: parsed.siteContactEmail || null,
-      loadInDate: parsed.loadInDate ?? null,
-      loadInTime: parsed.loadInTime || null,
-      eventStartDate: parsed.eventStartDate ?? null,
-      eventStartTime: parsed.eventStartTime || null,
-      eventEndDate: parsed.eventEndDate ?? null,
-      eventEndTime: parsed.eventEndTime || null,
-      loadOutDate: parsed.loadOutDate ?? null,
-      loadOutTime: parsed.loadOutTime || null,
-      rentalStartDate: parsed.rentalStartDate ?? null,
-      rentalEndDate: parsed.rentalEndDate ?? null,
-      defaultRentalPeriod: parsed.defaultRentalPeriod || null,
-      defaultRentalQuantity: parsed.defaultRentalQuantity || null,
-      billingWeeks: parsed.billingWeeks ?? null,
-      billingDays: parsed.billingDays ?? null,
-      taxRate: parsed.taxRate ?? null,
-      crewNotes: parsed.crewNotes || null,
-      internalNotes: parsed.internalNotes || null,
-      clientNotes: parsed.clientNotes || null,
-      discountPercent: parsed.discountPercent ?? null,
-      depositPercent: parsed.depositPercent ?? null,
-      depositPaid: parsed.depositPaid ?? null,
-      invoicedTotal: parsed.invoicedTotal ?? null,
-      tags: parsed.tags,
-    },
+      where: { id, organizationId },
+      data: {
+        projectNumber: parsed.projectNumber,
+        name: parsed.name,
+        clientId: parsed.clientId || null,
+        status: parsed.status,
+        type: parsed.type,
+        description: parsed.description || null,
+        locationId: parsed.locationId || null,
+        siteContactName: parsed.siteContactName || null,
+        siteContactPhone: parsed.siteContactPhone || null,
+        siteContactEmail: parsed.siteContactEmail || null,
+        loadInDate: parsed.loadInDate ?? null,
+        loadInTime: parsed.loadInTime || null,
+        eventStartDate: parsed.eventStartDate ?? null,
+        eventStartTime: parsed.eventStartTime || null,
+        eventEndDate: parsed.eventEndDate ?? null,
+        eventEndTime: parsed.eventEndTime || null,
+        loadOutDate: parsed.loadOutDate ?? null,
+        loadOutTime: parsed.loadOutTime || null,
+        rentalStartDate: parsed.rentalStartDate ?? null,
+        rentalEndDate: parsed.rentalEndDate ?? null,
+        defaultRentalPeriod: parsed.defaultRentalPeriod || null,
+        defaultRentalQuantity: parsed.defaultRentalQuantity || null,
+        billingWeeks: parsed.billingWeeks ?? null,
+        billingDays: parsed.billingDays ?? null,
+        taxRate: parsed.taxRate ?? null,
+        crewNotes: parsed.crewNotes || null,
+        internalNotes: parsed.internalNotes || null,
+        clientNotes: parsed.clientNotes || null,
+        discountPercent: parsed.discountPercent ?? null,
+        depositPercent: parsed.depositPercent ?? null,
+        depositPaid: parsed.depositPaid ?? null,
+        invoicedTotal: parsed.invoicedTotal ?? null,
+        tags: parsed.tags,
+      },
     });
 
     if (before && !before.isTemplate && before.status !== parsed.status) {
@@ -732,6 +754,13 @@ export async function updateProjectStatus(
       message: "Templates don't have a status — they're a starting point for creating projects.",
     });
   }
+
+  if (project.status !== status && isBlockedForwardProjectStatus(status)) {
+    await assertNoBlockingComments(organizationId, id, {
+      actionLabel: `move this project to ${String(status).toLowerCase().replaceAll("_", " ")}`,
+    });
+  }
+
   const updated = await prisma.$transaction(async (tx) => {
     const result = await tx.project.update({
       where: { id, organizationId },

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -935,6 +935,13 @@ export async function checkOutItems(
 ) {
   const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
 
+  // Block send-out while any blocking comment on the project is unresolved.
+  // Do this before opening the Prisma transaction so a Convex read never holds
+  // a database connection hostage.
+  await assertNoBlockingComments(organizationId, projectId, {
+    actionLabel: "check out items",
+  });
+
   const touchedAssetIds = new Set<string>();
   const results = await prisma.$transaction(async (tx) => {
     const updated: unknown[] = [];

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -27,6 +27,7 @@ import { TestTagBlockError } from "@/lib/errors/test-tag-block-error";
 import { syncKitsToConvex } from "@/lib/kit-mirror";
 import { syncAssetsToConvex, syncBulkAssetsToConvex } from "@/lib/asset-mirror";
 import { upsertProjectLineItemsToConvex, syncLineItemsToConvex } from "@/lib/line-item-mirror";
+import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import {
   buildLineItemAttachMaps,
   attachLineItemTree,
@@ -945,6 +946,11 @@ export async function checkOutItems(
     });
     const projectLocationId = project?.locationId || null;
 
+    // Block send-out while any blocking comment on the project is unresolved.
+    await assertNoBlockingComments(organizationId, projectId, {
+      actionLabel: "check out items",
+    });
+
     // Pre-flight T&T compliance block
     const preflightLineItems = await gatherTestTagAssetsAndAssert(
       tx, organizationId, userId, projectId, items,
@@ -1195,6 +1201,11 @@ export async function checkInItems(
 
 export async function checkOutKit(projectId: string, kitId: string) {
   const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
+
+  // Block send-out while any blocking comment on the project is unresolved.
+  await assertNoBlockingComments(organizationId, projectId, {
+    actionLabel: "check out this kit",
+  });
 
   const result = await prisma.$transaction(async (tx) => {
     // Find the kit parent line item on this project
@@ -1627,6 +1638,11 @@ export async function quickAddAndCheckOut(
   }
 ) {
   const { organizationId, userId } = await requirePermission("warehouse", "check_out");
+
+  // Block send-out while any blocking comment on the project is unresolved.
+  await assertNoBlockingComments(organizationId, projectId, {
+    actionLabel: "check out items",
+  });
 
   const result = await prisma.$transaction(async (tx) => {
     // T&T compliance block — refuse to add an asset to a project if its

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -946,11 +946,6 @@ export async function checkOutItems(
     });
     const projectLocationId = project?.locationId || null;
 
-    // Block send-out while any blocking comment on the project is unresolved.
-    await assertNoBlockingComments(organizationId, projectId, {
-      actionLabel: "check out items",
-    });
-
     // Pre-flight T&T compliance block
     const preflightLineItems = await gatherTestTagAssetsAndAssert(
       tx, organizationId, userId, projectId, items,


### PR DESCRIPTION
## Summary
- adds project-level collaboration avatars/comments and a live blocking-comment badge
- lets comments be marked blocking, mentioned users be selected, and threads be resolved/reopened
- surfaces blocking-comment counts on quote line rows, project list, and PM/mentioned dashboard cards
- gates prep/check/checkout flows when unresolved blocking comments exist
- expands comment targeting beyond line items to project sections such as services, crew, categories, kits, groups, and section-level rows

## Verification
- `DATABASE_URL='[REDACTED]' npx prisma generate`
- `npm exec tsc -- --noEmit --pretty false`
- targeted ESLint on changed files (0 errors; existing warnings remain in project page/warehouse)
- `npm exec vitest run src/lib/collaboration-conflict.test.ts src/components/projects/equipment-rows.test.ts src/components/dashboard/__tests__/my-work-section.smoke.test.tsx`
- `npm test`
- `DATABASE_URL='[REDACTED]' BETTER_AUTH_SECRET='[REDACTED]' BETTER_AUTH_URL='[REDACTED]' NEXT_PUBLIC_APP_URL='http://localhost:3000' NEXT_PUBLIC_CONVEX_URL='http://127.0.0.1:3210' npm run build`

## Notes
- `npm exec convex -- codegen` is still blocked locally by missing `CONVEX_DEPLOYMENT`; same environment issue as the prior collaboration PR.
- Blocking guards fail closed if Convex is unavailable, by design. Fun police, but in a useful hat.
