### PR TITLE
fix(sso): auto-activate org for SSO users who land without activeOrganizationId

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,6 +8,7 @@ import { BrandingProvider } from "@/components/providers/branding-provider";
 import MiraContextProvider from "@/components/providers/mira-context-provider";
 import { getSession } from "@/lib/auth-server";
 import { getTheOrg } from "@/lib/single-org";
+import { OrgActivator } from "@/components/providers/org-activator";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const session = await getSession();
@@ -27,6 +28,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       <SidebarProvider className="min-h-0 flex-1 md:min-h-svh">
         <BrandingProvider>
           <MiraContextProvider>
+            <OrgActivator />
             <DynamicFavicon />
             <AppSidebar />
             <SidebarInset className="min-h-0">

--- a/src/components/providers/org-activator.tsx
+++ b/src/components/providers/org-activator.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { authClient, organization } from "@/lib/auth-client";
+import { getTheOrgId } from "@/server/public-org";
+
+/**
+ * Auto-sets the active organization for users who arrive without one set.
+ *
+ * SSO login redirects straight to /dashboard via callbackURL, bypassing the
+ * handlePostLogin() call on the login page that calls organization.setActive().
+ * Without an activeOrganizationId in the session, useActiveOrganization() returns
+ * null, orgId is undefined, useCurrentRoleResource skips its fetch, useCanDo()
+ * returns false, and RequirePermission shows "Access Denied" on every page.
+ *
+ * This component detects the gap and heals it once per session on the client.
+ */
+export function OrgActivator() {
+  const { data: session, isPending: sessionPending } =
+    authClient.useSession();
+  const { data: activeOrg, isPending: orgPending } =
+    authClient.useActiveOrganization();
+  const activatingRef = useRef(false);
+
+  useEffect(() => {
+    if (sessionPending || orgPending) return;
+    if (!session || activeOrg || activatingRef.current) return;
+
+    activatingRef.current = true;
+    getTheOrgId()
+      .then((orgData) => {
+        if (orgData) {
+          return organization.setActive({ organizationId: orgData.id });
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        activatingRef.current = false;
+      });
+  }, [session, activeOrg, sessionPending, orgPending]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- SSO login redirects straight to `/dashboard` via `callbackURL`, bypassing `handlePostLogin()` which normally calls `organization.setActive()`
- Without `activeOrganizationId` in the session, `useActiveOrganization()` returns null → `orgId` is undefined → `useCurrentRoleResource()` skips its fetch → `useCanDo()` returns false → `RequirePermission` shows "Access Denied" on every page
- Added `OrgActivator` client component that detects session-present + org-not-active and calls `organization.setActive()` once on mount; wired into `(app)/layout.tsx`

## Test plan

- [ ] Log in via SSO — verify all pages load without "Access Denied"
- [ ] Log in via email/passkey — verify no regression (OrgActivator no-ops when `activeOrg` is already set)
- [ ] Verify OrgActivator only fires once per session (guarded by `activatingRef`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)