### PR TITLE
fix(convex): ConvexError for not-found guards + createIfMissing across all mirror write paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,24 @@ The PDF pipeline has **five independent consumers** of the `DocumentLineItem` sh
 
 History: v0.8.1.0 added group-as-kit rendering. v0.8.1.1 fixed the height-calc miss (tail items dropped). v0.8.1.2 fixed the status-filter miss (groups invisible on dockets). Each was a separate user-impacting deploy that an upfront cross-cutting audit would have caught.
 
+### Convex Mutation Rules
+
+**Always `throw new ConvexError(...)`, never `throw new Error(...)`** inside `convex/*.ts` mutation files.
+
+Convex masks plain `Error` to a generic `InternalServerError` in production. The mirror helpers (`media-mirror.ts`, `crew-scheduling-mirror.ts`, `check-item-assignment-mirror.ts`, etc.) use a `removeIn`/`removeSafe` tolerance pattern that catches `/not found/i` — this only works if the thrown error is a `ConvexError`, whose payload passes through the production boundary intact.
+
+```ts
+import { v, ConvexError } from "convex/values";
+// ...
+if (!doc) throw new ConvexError("myTable not found: " + id);
+```
+
+**Always use `createIfMissing`, never `create`** when mirroring rows into Convex from `src/`.
+
+Concurrent mirror calls or backfill overlap can produce two rows with the same `id`. The `by_cuid` index is non-unique, so both insert; then `.unique()` on that index throws a Convex system error → `InternalServerError`. `createIfMissing` is idempotent and safe.
+
+This applies everywhere a Prisma row is first written to Convex: `src/lib/*-mirror.ts`, `src/server/*.ts`, `src/lib/org-import.ts`.
+
 ### Key Gotchas
 - No `AlertDialog` — use `Dialog` with confirm/cancel buttons
 - `DropdownMenuLabel` must be inside `DropdownMenuGroup`

--- a/convex/assetBulkChildren.ts
+++ b/convex/assetBulkChildren.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -91,7 +91,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetBulkChildren").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetBulkChildren not found: " + id);
+    if (!doc) throw new ConvexError("assetBulkChildren not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -104,7 +104,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetBulkChildren").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetBulkChildren not found: " + id);
+    if (!doc) throw new ConvexError("assetBulkChildren not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/assetMedia.ts
+++ b/convex/assetMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -99,7 +99,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetMedia not found: " + id);
+    if (!doc) throw new ConvexError("assetMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -112,7 +112,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetMedia not found: " + id);
+    if (!doc) throw new ConvexError("assetMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/assetScanLogs.ts
+++ b/convex/assetScanLogs.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -94,7 +94,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetScanLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetScanLogs not found: " + id);
+    if (!doc) throw new ConvexError("assetScanLogs not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -107,7 +107,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assetScanLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assetScanLogs not found: " + id);
+    if (!doc) throw new ConvexError("assetScanLogs not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -149,7 +149,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assets not found: " + id);
+    if (!doc) throw new ConvexError("assets not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -162,7 +162,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("assets not found: " + id);
+    if (!doc) throw new ConvexError("assets not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/brandTemplates.ts
+++ b/convex/brandTemplates.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -87,7 +87,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("brandTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("brandTemplates not found: " + id);
+    if (!doc) throw new ConvexError("brandTemplates not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -100,7 +100,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("brandTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("brandTemplates not found: " + id);
+    if (!doc) throw new ConvexError("brandTemplates not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/bulkAssets.ts
+++ b/convex/bulkAssets.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -113,7 +113,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("bulkAssets not found: " + id);
+    if (!doc) throw new ConvexError("bulkAssets not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -126,7 +126,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("bulkAssets not found: " + id);
+    if (!doc) throw new ConvexError("bulkAssets not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/categories.ts
+++ b/convex/categories.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -94,7 +94,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("categories not found: " + id);
+    if (!doc) throw new ConvexError("categories not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -107,7 +107,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("categories not found: " + id);
+    if (!doc) throw new ConvexError("categories not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/categorySlots.ts
+++ b/convex/categorySlots.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -81,7 +81,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("categorySlots").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("categorySlots not found: " + id);
+    if (!doc) throw new ConvexError("categorySlots not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -92,7 +92,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("categorySlots").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("categorySlots not found: " + id);
+    if (!doc) throw new ConvexError("categorySlots not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/checkItems.ts
+++ b/convex/checkItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -101,7 +101,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("checkItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("checkItems not found: " + id);
+    if (!doc) throw new ConvexError("checkItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -114,7 +114,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("checkItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("checkItems not found: " + id);
+    if (!doc) throw new ConvexError("checkItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/checkRecords.ts
+++ b/convex/checkRecords.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -112,7 +112,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("checkRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("checkRecords not found: " + id);
+    if (!doc) throw new ConvexError("checkRecords not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -125,7 +125,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("checkRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("checkRecords not found: " + id);
+    if (!doc) throw new ConvexError("checkRecords not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/clientMedia.ts
+++ b/convex/clientMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("clientMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("clientMedia not found: " + id);
+    if (!doc) throw new ConvexError("clientMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -109,7 +109,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("clientMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("clientMedia not found: " + id);
+    if (!doc) throw new ConvexError("clientMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/clients.ts
+++ b/convex/clients.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -125,7 +125,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("clients not found: " + id);
+    if (!doc) throw new ConvexError("clients not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -138,7 +138,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("clients not found: " + id);
+    if (!doc) throw new ConvexError("clients not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/collaboration.ts
+++ b/convex/collaboration.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireService } from "./lib/auth";
@@ -371,7 +371,7 @@ export const addComment = mutation({
     const now = Date.now();
 
     const thread = await ctx.db.get(args.threadId as unknown as Id<"commentThreads">);
-    if (!thread || thread.orgId !== args.orgId) throw new Error("Thread not found");
+    if (!thread || thread.orgId !== args.orgId) throw new ConvexError("Thread not found");
 
     // Union any new mentions onto the thread so dashboard mention detection
     // covers replies, not just the opening comment.
@@ -413,7 +413,7 @@ export const setThreadBlocking = mutation({
   handler: async (ctx, { orgId, threadId, isBlocking }) => {
     await requireService(ctx);
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
-    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     await ctx.db.patch(thread._id, { isBlocking, updatedAt: Date.now() });
   },
 });
@@ -423,7 +423,7 @@ export const resolveThread = mutation({
   handler: async (ctx, { orgId, threadId, resolvedBy }) => {
     await requireService(ctx);
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
-    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     const now = Date.now();
     await ctx.db.patch(thread._id, {
       status: "resolved",
@@ -439,7 +439,7 @@ export const reopenThread = mutation({
   handler: async (ctx, { orgId, threadId }) => {
     await requireService(ctx);
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
-    if (!thread || thread.orgId !== orgId) throw new Error("Thread not found");
+    if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     await ctx.db.patch(thread._id, {
       status: "open",
       resolvedBy: undefined,

--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -154,7 +154,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewAssignments not found: " + id);
+    if (!doc) throw new ConvexError("crewAssignments not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -167,7 +167,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewAssignments not found: " + id);
+    if (!doc) throw new ConvexError("crewAssignments not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewAvailabilities.ts
+++ b/convex/crewAvailabilities.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -98,7 +98,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewAvailabilities").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewAvailabilities not found: " + id);
+    if (!doc) throw new ConvexError("crewAvailabilities not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -111,7 +111,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewAvailabilities").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewAvailabilities not found: " + id);
+    if (!doc) throw new ConvexError("crewAvailabilities not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewCertifications.ts
+++ b/convex/crewCertifications.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -85,7 +85,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewCertifications").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewCertifications not found: " + id);
+    if (!doc) throw new ConvexError("crewCertifications not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -96,7 +96,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewCertifications").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewCertifications not found: " + id);
+    if (!doc) throw new ConvexError("crewCertifications not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewMembers.ts
+++ b/convex/crewMembers.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService, getAuthContext, redactFields } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -156,7 +156,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewMembers not found: " + id);
+    if (!doc) throw new ConvexError("crewMembers not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -169,7 +169,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewMembers not found: " + id);
+    if (!doc) throw new ConvexError("crewMembers not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewRoles.ts
+++ b/convex/crewRoles.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -92,7 +92,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewRoles").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewRoles not found: " + id);
+    if (!doc) throw new ConvexError("crewRoles not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -105,7 +105,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewRoles").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewRoles not found: " + id);
+    if (!doc) throw new ConvexError("crewRoles not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewShifts.ts
+++ b/convex/crewShifts.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -88,7 +88,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewShifts").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewShifts not found: " + id);
+    if (!doc) throw new ConvexError("crewShifts not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -99,7 +99,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewShifts").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewShifts not found: " + id);
+    if (!doc) throw new ConvexError("crewShifts not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewSkills.ts
+++ b/convex/crewSkills.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -73,7 +73,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewSkills").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewSkills not found: " + id);
+    if (!doc) throw new ConvexError("crewSkills not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -86,7 +86,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewSkills").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewSkills not found: " + id);
+    if (!doc) throw new ConvexError("crewSkills not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/crewTimeEntries.ts
+++ b/convex/crewTimeEntries.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -110,7 +110,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewTimeEntries not found: " + id);
+    if (!doc) throw new ConvexError("crewTimeEntries not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -123,7 +123,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("crewTimeEntries not found: " + id);
+    if (!doc) throw new ConvexError("crewTimeEntries not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/customFieldDefinitions.ts
+++ b/convex/customFieldDefinitions.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -101,7 +101,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("customFieldDefinitions").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("customFieldDefinitions not found: " + id);
+    if (!doc) throw new ConvexError("customFieldDefinitions not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -114,7 +114,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("customFieldDefinitions").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("customFieldDefinitions not found: " + id);
+    if (!doc) throw new ConvexError("customFieldDefinitions not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/damageEvents.ts
+++ b/convex/damageEvents.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -122,7 +122,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("damageEvents").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("damageEvents not found: " + id);
+    if (!doc) throw new ConvexError("damageEvents not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -135,7 +135,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("damageEvents").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("damageEvents not found: " + id);
+    if (!doc) throw new ConvexError("damageEvents not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/discordAccountLinks.ts
+++ b/convex/discordAccountLinks.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -78,7 +78,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordAccountLinks").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordAccountLinks not found: " + id);
+    if (!doc) throw new ConvexError("discordAccountLinks not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -91,7 +91,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordAccountLinks").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordAccountLinks not found: " + id);
+    if (!doc) throw new ConvexError("discordAccountLinks not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/discordIntegrations.ts
+++ b/convex/discordIntegrations.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -130,7 +130,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordIntegrations not found: " + id);
+    if (!doc) throw new ConvexError("discordIntegrations not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -143,7 +143,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordIntegrations not found: " + id);
+    if (!doc) throw new ConvexError("discordIntegrations not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/discordLinkTokens.ts
+++ b/convex/discordLinkTokens.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -87,7 +87,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordLinkTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordLinkTokens not found: " + id);
+    if (!doc) throw new ConvexError("discordLinkTokens not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -100,7 +100,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordLinkTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordLinkTokens not found: " + id);
+    if (!doc) throw new ConvexError("discordLinkTokens not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/discordOutboxes.ts
+++ b/convex/discordOutboxes.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -97,7 +97,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordOutboxes").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordOutboxes not found: " + id);
+    if (!doc) throw new ConvexError("discordOutboxes not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -110,7 +110,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("discordOutboxes").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("discordOutboxes not found: " + id);
+    if (!doc) throw new ConvexError("discordOutboxes not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/documentTemplates.ts
+++ b/convex/documentTemplates.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -111,7 +111,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("documentTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("documentTemplates not found: " + id);
+    if (!doc) throw new ConvexError("documentTemplates not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -124,7 +124,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("documentTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("documentTemplates not found: " + id);
+    if (!doc) throw new ConvexError("documentTemplates not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/fileUploads.ts
+++ b/convex/fileUploads.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -99,7 +99,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("fileUploads not found: " + id);
+    if (!doc) throw new ConvexError("fileUploads not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -112,7 +112,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("fileUploads not found: " + id);
+    if (!doc) throw new ConvexError("fileUploads not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/groupTemplateItems.ts
+++ b/convex/groupTemplateItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -81,7 +81,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("groupTemplateItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("groupTemplateItems not found: " + id);
+    if (!doc) throw new ConvexError("groupTemplateItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -94,7 +94,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("groupTemplateItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("groupTemplateItems not found: " + id);
+    if (!doc) throw new ConvexError("groupTemplateItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/groupTemplates.ts
+++ b/convex/groupTemplates.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -78,7 +78,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("groupTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("groupTemplates not found: " + id);
+    if (!doc) throw new ConvexError("groupTemplates not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -91,7 +91,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("groupTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("groupTemplates not found: " + id);
+    if (!doc) throw new ConvexError("groupTemplates not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/kitBulkItems.ts
+++ b/convex/kitBulkItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -90,7 +90,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitBulkItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitBulkItems not found: " + id);
+    if (!doc) throw new ConvexError("kitBulkItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -103,7 +103,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitBulkItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitBulkItems not found: " + id);
+    if (!doc) throw new ConvexError("kitBulkItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/kitCheckItems.ts
+++ b/convex/kitCheckItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -79,7 +79,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitCheckItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitCheckItems not found: " + id);
+    if (!doc) throw new ConvexError("kitCheckItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -92,7 +92,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitCheckItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitCheckItems not found: " + id);
+    if (!doc) throw new ConvexError("kitCheckItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/kitMedia.ts
+++ b/convex/kitMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -99,7 +99,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitMedia not found: " + id);
+    if (!doc) throw new ConvexError("kitMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -112,7 +112,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitMedia not found: " + id);
+    if (!doc) throw new ConvexError("kitMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/kitSerializedItems.ts
+++ b/convex/kitSerializedItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -87,7 +87,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitSerializedItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitSerializedItems not found: " + id);
+    if (!doc) throw new ConvexError("kitSerializedItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -100,7 +100,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kitSerializedItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kitSerializedItems not found: " + id);
+    if (!doc) throw new ConvexError("kitSerializedItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -140,7 +140,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kits not found: " + id);
+    if (!doc) throw new ConvexError("kits not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -153,7 +153,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("kits not found: " + id);
+    if (!doc) throw new ConvexError("kits not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/lineItemMergeMaps.ts
+++ b/convex/lineItemMergeMaps.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -90,7 +90,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("lineItemMergeMaps").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("lineItemMergeMaps not found: " + id);
+    if (!doc) throw new ConvexError("lineItemMergeMaps not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -103,7 +103,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("lineItemMergeMaps").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("lineItemMergeMaps not found: " + id);
+    if (!doc) throw new ConvexError("lineItemMergeMaps not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/locationMedia.ts
+++ b/convex/locationMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("locationMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("locationMedia not found: " + id);
+    if (!doc) throw new ConvexError("locationMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -109,7 +109,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("locationMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("locationMedia not found: " + id);
+    if (!doc) throw new ConvexError("locationMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/locations.ts
+++ b/convex/locations.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -101,7 +101,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("locations not found: " + id);
+    if (!doc) throw new ConvexError("locations not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -114,7 +114,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("locations not found: " + id);
+    if (!doc) throw new ConvexError("locations not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/maintenanceRecordAssets.ts
+++ b/convex/maintenanceRecordAssets.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -69,7 +69,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("maintenanceRecordAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("maintenanceRecordAssets not found: " + id);
+    if (!doc) throw new ConvexError("maintenanceRecordAssets not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -80,7 +80,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("maintenanceRecordAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("maintenanceRecordAssets not found: " + id);
+    if (!doc) throw new ConvexError("maintenanceRecordAssets not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/maintenanceRecords.ts
+++ b/convex/maintenanceRecords.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -125,7 +125,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("maintenanceRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("maintenanceRecords not found: " + id);
+    if (!doc) throw new ConvexError("maintenanceRecords not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -138,7 +138,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("maintenanceRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("maintenanceRecords not found: " + id);
+    if (!doc) throw new ConvexError("maintenanceRecords not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/modelBulkAccessories.ts
+++ b/convex/modelBulkAccessories.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -87,7 +87,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelBulkAccessories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelBulkAccessories not found: " + id);
+    if (!doc) throw new ConvexError("modelBulkAccessories not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -100,7 +100,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelBulkAccessories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelBulkAccessories not found: " + id);
+    if (!doc) throw new ConvexError("modelBulkAccessories not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/modelCheckItems.ts
+++ b/convex/modelCheckItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -79,7 +79,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelCheckItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelCheckItems not found: " + id);
+    if (!doc) throw new ConvexError("modelCheckItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -92,7 +92,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelCheckItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelCheckItems not found: " + id);
+    if (!doc) throw new ConvexError("modelCheckItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/modelMedia.ts
+++ b/convex/modelMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -99,7 +99,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelMedia not found: " + id);
+    if (!doc) throw new ConvexError("modelMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -112,7 +112,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("modelMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("modelMedia not found: " + id);
+    if (!doc) throw new ConvexError("modelMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/models.ts
+++ b/convex/models.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -161,7 +161,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("models not found: " + id);
+    if (!doc) throw new ConvexError("models not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -174,7 +174,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("models not found: " + id);
+    if (!doc) throw new ConvexError("models not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/notificationDismissals.ts
+++ b/convex/notificationDismissals.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -75,7 +75,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("notificationDismissals").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("notificationDismissals not found: " + id);
+    if (!doc) throw new ConvexError("notificationDismissals not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -88,7 +88,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("notificationDismissals").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("notificationDismissals not found: " + id);
+    if (!doc) throw new ConvexError("notificationDismissals not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/notificationEmailLogs.ts
+++ b/convex/notificationEmailLogs.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -75,7 +75,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("notificationEmailLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("notificationEmailLogs not found: " + id);
+    if (!doc) throw new ConvexError("notificationEmailLogs not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -88,7 +88,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("notificationEmailLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("notificationEmailLogs not found: " + id);
+    if (!doc) throw new ConvexError("notificationEmailLogs not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectCategories.ts
+++ b/convex/projectCategories.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -93,7 +93,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectCategories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectCategories not found: " + id);
+    if (!doc) throw new ConvexError("projectCategories not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -106,7 +106,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectCategories").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectCategories not found: " + id);
+    if (!doc) throw new ConvexError("projectCategories not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectGroups.ts
+++ b/convex/projectGroups.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -124,7 +124,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectGroups not found: " + id);
+    if (!doc) throw new ConvexError("projectGroups not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -137,7 +137,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectGroups not found: " + id);
+    if (!doc) throw new ConvexError("projectGroups not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectLineItemUnits.ts
+++ b/convex/projectLineItemUnits.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -124,7 +124,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectLineItemUnits not found: " + id);
+    if (!doc) throw new ConvexError("projectLineItemUnits not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -137,7 +137,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectLineItemUnits not found: " + id);
+    if (!doc) throw new ConvexError("projectLineItemUnits not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -238,7 +238,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectLineItems not found: " + id);
+    if (!doc) throw new ConvexError("projectLineItems not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -251,7 +251,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectLineItems not found: " + id);
+    if (!doc) throw new ConvexError("projectLineItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectManagers.ts
+++ b/convex/projectManagers.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -87,7 +87,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectManagers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectManagers not found: " + id);
+    if (!doc) throw new ConvexError("projectManagers not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -100,7 +100,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectManagers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectManagers not found: " + id);
+    if (!doc) throw new ConvexError("projectManagers not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectMedia.ts
+++ b/convex/projectMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectMedia not found: " + id);
+    if (!doc) throw new ConvexError("projectMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -109,7 +109,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectMedia not found: " + id);
+    if (!doc) throw new ConvexError("projectMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectNumberSequences.ts
+++ b/convex/projectNumberSequences.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -75,7 +75,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectNumberSequences").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectNumberSequences not found: " + id);
+    if (!doc) throw new ConvexError("projectNumberSequences not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -88,7 +88,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectNumberSequences").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectNumberSequences not found: " + id);
+    if (!doc) throw new ConvexError("projectNumberSequences not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectServices.ts
+++ b/convex/projectServices.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -178,7 +178,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectServices not found: " + id);
+    if (!doc) throw new ConvexError("projectServices not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -191,7 +191,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectServices not found: " + id);
+    if (!doc) throw new ConvexError("projectServices not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -121,7 +121,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectTasks").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectTasks not found: " + id);
+    if (!doc) throw new ConvexError("projectTasks not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -134,7 +134,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projectTasks").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projectTasks not found: " + id);
+    if (!doc) throw new ConvexError("projectTasks not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -212,7 +212,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projects not found: " + id);
+    if (!doc) throw new ConvexError("projects not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -225,7 +225,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("projects not found: " + id);
+    if (!doc) throw new ConvexError("projects not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/savedReports.ts
+++ b/convex/savedReports.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -116,7 +116,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("savedReports").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("savedReports not found: " + id);
+    if (!doc) throw new ConvexError("savedReports not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -129,7 +129,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("savedReports").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("savedReports not found: " + id);
+    if (!doc) throw new ConvexError("savedReports not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/savedTableViews.ts
+++ b/convex/savedTableViews.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -88,7 +88,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("savedTableViews").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("savedTableViews not found: " + id);
+    if (!doc) throw new ConvexError("savedTableViews not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -101,7 +101,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("savedTableViews").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("savedTableViews not found: " + id);
+    if (!doc) throw new ConvexError("savedTableViews not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/sectionPresets.ts
+++ b/convex/sectionPresets.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -81,7 +81,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("sectionPresets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("sectionPresets not found: " + id);
+    if (!doc) throw new ConvexError("sectionPresets not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -94,7 +94,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("sectionPresets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("sectionPresets not found: " + id);
+    if (!doc) throw new ConvexError("sectionPresets not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/serviceTemplates.ts
+++ b/convex/serviceTemplates.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -106,7 +106,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("serviceTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("serviceTemplates not found: " + id);
+    if (!doc) throw new ConvexError("serviceTemplates not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -119,7 +119,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("serviceTemplates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("serviceTemplates not found: " + id);
+    if (!doc) throw new ConvexError("serviceTemplates not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/siteSettings.ts
+++ b/convex/siteSettings.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("siteSettings").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("siteSettings not found: " + id);
+    if (!doc) throw new ConvexError("siteSettings not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -107,7 +107,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("siteSettings").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("siteSettings not found: " + id);
+    if (!doc) throw new ConvexError("siteSettings not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/stocktakeItems.ts
+++ b/convex/stocktakeItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -100,7 +100,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("stocktakeItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("stocktakeItems not found: " + id);
+    if (!doc) throw new ConvexError("stocktakeItems not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -111,7 +111,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("stocktakeItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("stocktakeItems not found: " + id);
+    if (!doc) throw new ConvexError("stocktakeItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/stocktakes.ts
+++ b/convex/stocktakes.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -118,7 +118,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("stocktakes").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("stocktakes not found: " + id);
+    if (!doc) throw new ConvexError("stocktakes not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -131,7 +131,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("stocktakes").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("stocktakes not found: " + id);
+    if (!doc) throw new ConvexError("stocktakes not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/subHireGroups.ts
+++ b/convex/subHireGroups.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -93,7 +93,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireGroups").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireGroups not found: " + id);
+    if (!doc) throw new ConvexError("subHireGroups not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -104,7 +104,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireGroups").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireGroups not found: " + id);
+    if (!doc) throw new ConvexError("subHireGroups not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/subHireItems.ts
+++ b/convex/subHireItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -109,7 +109,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireItems not found: " + id);
+    if (!doc) throw new ConvexError("subHireItems not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -120,7 +120,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireItems not found: " + id);
+    if (!doc) throw new ConvexError("subHireItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/subHireMedia.ts
+++ b/convex/subHireMedia.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireMedia not found: " + id);
+    if (!doc) throw new ConvexError("subHireMedia not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -109,7 +109,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHireMedia").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHireMedia not found: " + id);
+    if (!doc) throw new ConvexError("subHireMedia not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/subHires.ts
+++ b/convex/subHires.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -139,7 +139,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHires").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHires not found: " + id);
+    if (!doc) throw new ConvexError("subHires not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -152,7 +152,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subHires").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subHires not found: " + id);
+    if (!doc) throw new ConvexError("subHires not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/subTestRecords.ts
+++ b/convex/subTestRecords.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -103,7 +103,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subTestRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subTestRecords not found: " + id);
+    if (!doc) throw new ConvexError("subTestRecords not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -114,7 +114,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("subTestRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("subTestRecords not found: " + id);
+    if (!doc) throw new ConvexError("subTestRecords not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/supplierModelRates.ts
+++ b/convex/supplierModelRates.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -85,7 +85,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierModelRates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierModelRates not found: " + id);
+    if (!doc) throw new ConvexError("supplierModelRates not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -98,7 +98,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierModelRates").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierModelRates not found: " + id);
+    if (!doc) throw new ConvexError("supplierModelRates not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/supplierOrderItems.ts
+++ b/convex/supplierOrderItems.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -90,7 +90,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierOrderItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierOrderItems not found: " + id);
+    if (!doc) throw new ConvexError("supplierOrderItems not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -101,7 +101,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierOrderItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierOrderItems not found: " + id);
+    if (!doc) throw new ConvexError("supplierOrderItems not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/supplierOrders.ts
+++ b/convex/supplierOrders.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -113,7 +113,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierOrders").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierOrders not found: " + id);
+    if (!doc) throw new ConvexError("supplierOrders not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -126,7 +126,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("supplierOrders").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("supplierOrders not found: " + id);
+    if (!doc) throw new ConvexError("supplierOrders not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/suppliers.ts
+++ b/convex/suppliers.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -115,7 +115,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("suppliers not found: " + id);
+    if (!doc) throw new ConvexError("suppliers not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -128,7 +128,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("suppliers not found: " + id);
+    if (!doc) throw new ConvexError("suppliers not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/testProfiles.ts
+++ b/convex/testProfiles.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -107,7 +107,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testProfiles").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testProfiles not found: " + id);
+    if (!doc) throw new ConvexError("testProfiles not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -120,7 +120,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testProfiles").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testProfiles not found: " + id);
+    if (!doc) throw new ConvexError("testProfiles not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/testTagAssets.ts
+++ b/convex/testTagAssets.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -127,7 +127,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagAssets not found: " + id);
+    if (!doc) throw new ConvexError("testTagAssets not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -140,7 +140,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagAssets not found: " + id);
+    if (!doc) throw new ConvexError("testTagAssets not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/testTagAuditorTokens.ts
+++ b/convex/testTagAuditorTokens.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -93,7 +93,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagAuditorTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagAuditorTokens not found: " + id);
+    if (!doc) throw new ConvexError("testTagAuditorTokens not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -106,7 +106,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagAuditorTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagAuditorTokens not found: " + id);
+    if (!doc) throw new ConvexError("testTagAuditorTokens not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/testTagRecords.ts
+++ b/convex/testTagRecords.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -175,7 +175,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagRecords not found: " + id);
+    if (!doc) throw new ConvexError("testTagRecords not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -188,7 +188,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("testTagRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("testTagRecords not found: " + id);
+    if (!doc) throw new ConvexError("testTagRecords not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/userNotificationPreferences.ts
+++ b/convex/userNotificationPreferences.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -96,7 +96,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("userNotificationPreferences").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("userNotificationPreferences not found: " + id);
+    if (!doc) throw new ConvexError("userNotificationPreferences not found: " + id);
     await ctx.db.patch(doc._id, patch);
     return doc._id;
   },
@@ -107,7 +107,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("userNotificationPreferences").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("userNotificationPreferences not found: " + id);
+    if (!doc) throw new ConvexError("userNotificationPreferences not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/warehouseCloses.ts
+++ b/convex/warehouseCloses.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
@@ -85,7 +85,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("warehouseCloses not found: " + id);
+    if (!doc) throw new ConvexError("warehouseCloses not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -98,7 +98,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("warehouseCloses not found: " + id);
+    if (!doc) throw new ConvexError("warehouseCloses not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/warehouseDashboardTokens.ts
+++ b/convex/warehouseDashboardTokens.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -93,7 +93,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("warehouseDashboardTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("warehouseDashboardTokens not found: " + id);
+    if (!doc) throw new ConvexError("warehouseDashboardTokens not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -106,7 +106,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("warehouseDashboardTokens").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("warehouseDashboardTokens not found: " + id);
+    if (!doc) throw new ConvexError("warehouseDashboardTokens not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/wooCommerceIntegrations.ts
+++ b/convex/wooCommerceIntegrations.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
@@ -120,7 +120,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("wooCommerceIntegrations not found: " + id);
+    if (!doc) throw new ConvexError("wooCommerceIntegrations not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -133,7 +133,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("wooCommerceIntegrations not found: " + id);
+    if (!doc) throw new ConvexError("wooCommerceIntegrations not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/convex/wooCommerceOrderLogs.ts
+++ b/convex/wooCommerceOrderLogs.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
 import * as enums from "./lib/validators";
@@ -97,7 +97,7 @@ export const update = mutation({
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("wooCommerceOrderLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("wooCommerceOrderLogs not found: " + id);
+    if (!doc) throw new ConvexError("wooCommerceOrderLogs not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
@@ -110,7 +110,7 @@ export const remove = mutation({
   handler: async (ctx, { id }) => {
     await requireService(ctx);
     const doc = await ctx.db.query("wooCommerceOrderLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!doc) throw new Error("wooCommerceOrderLogs not found: " + id);
+    if (!doc) throw new ConvexError("wooCommerceOrderLogs not found: " + id);
     await ctx.db.delete(doc._id);
   },
 });

--- a/src/lib/asset-mirror.ts
+++ b/src/lib/asset-mirror.ts
@@ -53,12 +53,12 @@ async function remove(fn: AnyRef, id: string) {
 }
 
 // ─── Serialized assets ─────────────────────────────────────────────────────────
-export const mirrorAssetCreate = (row: Record<string, unknown>) => create(api.assets.create, row);
+export const mirrorAssetCreate = (row: Record<string, unknown>) => create(api.assets.createIfMissing, row);
 export const patchAssetInConvex = (id: string, row: Record<string, unknown>) => patch(api.assets.update, id, row);
 export const removeAssetFromConvex = (id: string) => remove(api.assets.remove, id);
 
 // ─── Bulk assets ─────────────────────────────────────────────────────────────
-export const mirrorBulkAssetCreate = (row: Record<string, unknown>) => create(api.bulkAssets.create, row);
+export const mirrorBulkAssetCreate = (row: Record<string, unknown>) => create(api.bulkAssets.createIfMissing, row);
 export const patchBulkAssetInConvex = (id: string, row: Record<string, unknown>) => patch(api.bulkAssets.update, id, row);
 export const removeBulkAssetFromConvex = (id: string) => remove(api.bulkAssets.remove, id);
 

--- a/src/lib/check-item-assignment-mirror.ts
+++ b/src/lib/check-item-assignment-mirror.ts
@@ -100,7 +100,7 @@ async function upsertIn(
 // ─── model_check_item ──────────────────────────────────────────────────────────
 
 export const mirrorModelCheckItemCreate = (row: Row) =>
-  createIn(api.modelCheckItems.create, modelCheckItemDoc(row));
+  createIn(api.modelCheckItems.createIfMissing, modelCheckItemDoc(row));
 
 export const removeModelCheckItemFromConvex = (id: string) =>
   removeIn(api.modelCheckItems.remove, id);
@@ -117,7 +117,7 @@ export async function syncModelCheckItemsForModels(modelIds: Array<string | null
   const rows = await prisma.modelCheckItem.findMany({ where: { modelId: { in: unique } } });
   for (const row of rows as unknown as Row[]) {
     await upsertIn(
-      api.modelCheckItems.create,
+      api.modelCheckItems.createIfMissing,
       api.modelCheckItems.update,
       api.modelCheckItems.getById,
       row.id as string,
@@ -129,7 +129,7 @@ export async function syncModelCheckItemsForModels(modelIds: Array<string | null
 // ─── kit_check_item ──────────────────────────────────────────────────────────
 
 export const mirrorKitCheckItemCreate = (row: Row) =>
-  createIn(api.kitCheckItems.create, kitCheckItemDoc(row));
+  createIn(api.kitCheckItems.createIfMissing, kitCheckItemDoc(row));
 
 export const removeKitCheckItemFromConvex = (id: string) =>
   removeIn(api.kitCheckItems.remove, id);
@@ -143,7 +143,7 @@ export async function syncKitCheckItemsForKit(kitId: string) {
   const rows = await prisma.kitCheckItem.findMany({ where: { kitId } });
   for (const row of rows as unknown as Row[]) {
     await upsertIn(
-      api.kitCheckItems.create,
+      api.kitCheckItems.createIfMissing,
       api.kitCheckItems.update,
       api.kitCheckItems.getById,
       row.id as string,

--- a/src/lib/crew-mirror.ts
+++ b/src/lib/crew-mirror.ts
@@ -50,15 +50,15 @@ async function remove(fn: AnyRef, id: string) {
 }
 
 // ─── Crew members ────────────────────────────────────────────────────────────
-export const mirrorCrewMemberCreate = (row: Record<string, unknown>) => create(api.crewMembers.create, row);
+export const mirrorCrewMemberCreate = (row: Record<string, unknown>) => create(api.crewMembers.createIfMissing, row);
 export const patchCrewMemberInConvex = (id: string, row: Record<string, unknown>) => patch(api.crewMembers.update, id, row);
 export const removeCrewMemberFromConvex = (id: string) => remove(api.crewMembers.remove, id);
 
 // ─── Crew roles ──────────────────────────────────────────────────────────────
-export const mirrorCrewRoleCreate = (row: Record<string, unknown>) => create(api.crewRoles.create, row);
+export const mirrorCrewRoleCreate = (row: Record<string, unknown>) => create(api.crewRoles.createIfMissing, row);
 export const patchCrewRoleInConvex = (id: string, row: Record<string, unknown>) => patch(api.crewRoles.update, id, row);
 export const removeCrewRoleFromConvex = (id: string) => remove(api.crewRoles.remove, id);
 
 // ─── Crew skills (m2m to members stays Prisma-only) ──────────────────────────
-export const mirrorCrewSkillCreate = (row: Record<string, unknown>) => create(api.crewSkills.create, row);
+export const mirrorCrewSkillCreate = (row: Record<string, unknown>) => create(api.crewSkills.createIfMissing, row);
 export const removeCrewSkillFromConvex = (id: string) => remove(api.crewSkills.remove, id);

--- a/src/lib/crew-scheduling-mirror.ts
+++ b/src/lib/crew-scheduling-mirror.ts
@@ -85,25 +85,25 @@ async function upsert(getRef: AnyQueryRef, createRef: AnyRef, updateRef: AnyRef,
 }
 
 // ─── Crew assignments ──────────────────────────────────────────────────────────
-export const mirrorCrewAssignmentCreate = (row: Record<string, unknown>) => create(api.crewAssignments.create, row);
+export const mirrorCrewAssignmentCreate = (row: Record<string, unknown>) => create(api.crewAssignments.createIfMissing, row);
 export const patchCrewAssignmentInConvex = (id: string, row: Record<string, unknown>) => patch(api.crewAssignments.update, id, row);
 export const removeCrewAssignmentFromConvex = (id: string) => removeSafe(api.crewAssignments.remove, id);
 
 // ─── Crew shifts ─────────────────────────────────────────────────────────────
-export const mirrorCrewShiftCreate = (row: Record<string, unknown>) => create(api.crewShifts.create, row);
+export const mirrorCrewShiftCreate = (row: Record<string, unknown>) => create(api.crewShifts.createIfMissing, row);
 export const patchCrewShiftInConvex = (id: string, row: Record<string, unknown>) => patch(api.crewShifts.update, id, row);
 export const removeCrewShiftFromConvex = (id: string) => removeSafe(api.crewShifts.remove, id);
 
 // ─── Crew availability ─────────────────────────────────────────────────────────
-export const mirrorCrewAvailabilityCreate = (row: Record<string, unknown>) => create(api.crewAvailabilities.create, row);
+export const mirrorCrewAvailabilityCreate = (row: Record<string, unknown>) => create(api.crewAvailabilities.createIfMissing, row);
 export const removeCrewAvailabilityFromConvex = (id: string) => removeSafe(api.crewAvailabilities.remove, id);
 
 // ─── Crew certifications ─────────────────────────────────────────────────────────
-export const mirrorCrewCertificationCreate = (row: Record<string, unknown>) => create(api.crewCertifications.create, row);
+export const mirrorCrewCertificationCreate = (row: Record<string, unknown>) => create(api.crewCertifications.createIfMissing, row);
 export const removeCrewCertificationFromConvex = (id: string) => removeSafe(api.crewCertifications.remove, id);
 
 // ─── Crew time entries ─────────────────────────────────────────────────────────
-export const mirrorCrewTimeEntryCreate = (row: Record<string, unknown>) => create(api.crewTimeEntries.create, row);
+export const mirrorCrewTimeEntryCreate = (row: Record<string, unknown>) => create(api.crewTimeEntries.createIfMissing, row);
 export const patchCrewTimeEntryInConvex = (id: string, row: Record<string, unknown>) => patch(api.crewTimeEntries.update, id, row);
 export const removeCrewTimeEntryFromConvex = (id: string) => removeSafe(api.crewTimeEntries.remove, id);
 
@@ -148,16 +148,16 @@ export async function syncCrewTimeEntriesToConvex(ids: Array<string | null | und
   if (unique.length === 0) return;
   const rows = await prisma.crewTimeEntry.findMany({ where: { id: { in: unique } } });
   for (const t of rows) {
-    await upsert(api.crewTimeEntries.getById, api.crewTimeEntries.create, api.crewTimeEntries.update, t as unknown as Record<string, unknown>);
+    await upsert(api.crewTimeEntries.getById, api.crewTimeEntries.createIfMissing, api.crewTimeEntries.update, t as unknown as Record<string, unknown>);
   }
 }
 
 async function upsertAssignmentWithChildren(row: Record<string, unknown>) {
   const shifts = (row.shifts as Array<Record<string, unknown>>) ?? [];
   const timeEntries = (row.timeEntries as Array<Record<string, unknown>>) ?? [];
-  await upsert(api.crewAssignments.getById, api.crewAssignments.create, api.crewAssignments.update, row);
-  for (const s of shifts) await upsert(api.crewShifts.getById, api.crewShifts.create, api.crewShifts.update, s);
-  for (const t of timeEntries) await upsert(api.crewTimeEntries.getById, api.crewTimeEntries.create, api.crewTimeEntries.update, t);
+  await upsert(api.crewAssignments.getById, api.crewAssignments.createIfMissing, api.crewAssignments.update, row);
+  for (const s of shifts) await upsert(api.crewShifts.getById, api.crewShifts.createIfMissing, api.crewShifts.update, s);
+  for (const t of timeEntries) await upsert(api.crewTimeEntries.getById, api.crewTimeEntries.createIfMissing, api.crewTimeEntries.update, t);
 }
 
 // ─── Cascade snapshots + removal ─────────────────────────────────────────────────

--- a/src/lib/damage-mirror.ts
+++ b/src/lib/damage-mirror.ts
@@ -45,7 +45,7 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorDamageCreate = (row: Record<string, unknown>) => create(api.damageEvents.create, row);
+export const mirrorDamageCreate = (row: Record<string, unknown>) => create(api.damageEvents.createIfMissing, row);
 export const patchDamageInConvex = (id: string, row: Record<string, unknown>) => patch(api.damageEvents.update, id, row);
 export const removeDamageFromConvex = (id: string) => remove(api.damageEvents.remove, id);
 

--- a/src/lib/file-upload-mirror.ts
+++ b/src/lib/file-upload-mirror.ts
@@ -20,8 +20,8 @@ import { api } from "../../convex/_generated/api";
 /** Mirror a freshly written Prisma fileUpload row into Convex (create). */
 export async function mirrorFileUploadCreate(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.fileUploads.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.fileUploads.create>,
+    api.fileUploads.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.fileUploads.createIfMissing>,
   );
 }
 

--- a/src/lib/kit-mirror.ts
+++ b/src/lib/kit-mirror.ts
@@ -51,16 +51,16 @@ async function remove(fn: AnyRef, id: string) {
 }
 
 // ─── Kit (parent) ─────────────────────────────────────────────────────────────
-export const mirrorKitCreate = (row: Record<string, unknown>) => create(api.kits.create, row);
+export const mirrorKitCreate = (row: Record<string, unknown>) => create(api.kits.createIfMissing, row);
 export const patchKitInConvex = (id: string, row: Record<string, unknown>) => patch(api.kits.update, id, row);
 export const removeKitFromConvex = (id: string) => remove(api.kits.remove, id);
 
 // ─── Kit serialized items ──────────────────────────────────────────────────────
-export const mirrorKitSerializedItemCreate = (row: Record<string, unknown>) => create(api.kitSerializedItems.create, row);
+export const mirrorKitSerializedItemCreate = (row: Record<string, unknown>) => create(api.kitSerializedItems.createIfMissing, row);
 export const removeKitSerializedItemFromConvex = (id: string) => remove(api.kitSerializedItems.remove, id);
 
 // ─── Kit bulk items ─────────────────────────────────────────────────────────────
-export const mirrorKitBulkItemCreate = (row: Record<string, unknown>) => create(api.kitBulkItems.create, row);
+export const mirrorKitBulkItemCreate = (row: Record<string, unknown>) => create(api.kitBulkItems.createIfMissing, row);
 export const removeKitBulkItemFromConvex = (id: string) => remove(api.kitBulkItems.remove, id);
 
 /**

--- a/src/lib/line-item-mirror.ts
+++ b/src/lib/line-item-mirror.ts
@@ -51,7 +51,7 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorLineItemCreate = (row: Record<string, unknown>) => create(api.projectLineItems.create, row);
+export const mirrorLineItemCreate = (row: Record<string, unknown>) => create(api.projectLineItems.createIfMissing, row);
 export const patchLineItemInConvex = (id: string, row: Record<string, unknown>) => patch(api.projectLineItems.update, id, row);
 export const removeLineItemFromConvex = (id: string) => remove(api.projectLineItems.remove, id);
 

--- a/src/lib/maintenance-mirror.ts
+++ b/src/lib/maintenance-mirror.ts
@@ -49,7 +49,7 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorMaintenanceCreate = (row: Record<string, unknown>) => create(api.maintenanceRecords.create, row);
+export const mirrorMaintenanceCreate = (row: Record<string, unknown>) => create(api.maintenanceRecords.createIfMissing, row);
 export const patchMaintenanceInConvex = (id: string, row: Record<string, unknown>) => patch(api.maintenanceRecords.update, id, row);
 export const removeMaintenanceFromConvex = (id: string) => remove(api.maintenanceRecords.remove, id);
 

--- a/src/lib/media-mirror.ts
+++ b/src/lib/media-mirror.ts
@@ -163,7 +163,10 @@ async function upsertIn(spec: MediaSpec, id: string, doc: Row) {
 
 /** Mirror a freshly written Prisma media row into Convex (targeted create). */
 export async function mirrorMediaCreate(kind: MediaKind, row: Row) {
-  await createIn(MEDIA_SPECS[kind].convex.create, mediaDoc(kind, row));
+  // createIfMissing guards against concurrent creates (e.g. two rapid uploads or
+  // a backfill running alongside a live create). Plain create would insert a
+  // duplicate id, then any subsequent .unique() lookup on by_cuid would throw.
+  await createIn(MEDIA_SPECS[kind].convex.createIfMissing, mediaDoc(kind, row));
 }
 
 /**

--- a/src/lib/org-import.ts
+++ b/src/lib/org-import.ts
@@ -245,7 +245,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.categories.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.categories.createIfMissing, toConvexDoc(created) as any);
   });
 
   // ── 3. Locations (hierarchical; dual-written: Prisma FK anchor + Convex doc) ──
@@ -260,7 +260,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.locations.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.locations.createIfMissing, toConvexDoc(created) as any);
   });
 
   // ── 4. Suppliers (dual-written: Prisma FK anchor + Convex reactive doc) ──
@@ -275,7 +275,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.suppliers.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.suppliers.createIfMissing, toConvexDoc(created) as any);
   }
 
   // ── 5. Models ────────────────────────────────────────────────────
@@ -291,7 +291,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.models.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.models.createIfMissing, toConvexDoc(created) as any);
   }
 
   // ── 6. Kits ──────────────────────────────────────────────────────
@@ -394,7 +394,7 @@ export async function importOrganization(
   // ── 11. Clients (live in Convex) ─────────────────────────────────
   for (const r of manifest.clients as Rec[]) {
     const id = newId("client", r.id);
-    await (await getConvexClient()).mutation(api.clients.create, {
+    await (await getConvexClient()).mutation(api.clients.createIfMissing, {
       id,
       organizationId: newOrgId,
       name: String(r.name),
@@ -676,7 +676,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.fileUploads.create, toConvexDoc(createdFile) as any);
+    await (await getConvexClient()).mutation(api.fileUploads.createIfMissing, toConvexDoc(createdFile) as any);
   }
 
   // ── 19b. Update image URL references on models, assets, kits ────
@@ -785,7 +785,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.groupTemplates.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.groupTemplates.createIfMissing, toConvexDoc(created) as any);
   }
   for (const r of (manifest.groupTemplateItems ?? []) as Rec[]) {
     const templateId = remap("groupTemplate", r.templateId);
@@ -815,7 +815,7 @@ export async function importOrganization(
         organizationId: newOrgId,
       } as any,
     });
-    await (await getConvexClient()).mutation(api.crewRoles.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.crewRoles.createIfMissing, toConvexDoc(created) as any);
   }
   for (const r of (manifest.crewSkills ?? []) as Rec[]) {
     const id = newId("crewSkill", r.id);
@@ -826,7 +826,7 @@ export async function importOrganization(
         organizationId: newOrgId,
       } as any,
     });
-    await (await getConvexClient()).mutation(api.crewSkills.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.crewSkills.createIfMissing, toConvexDoc(created) as any);
   }
   for (const r of (manifest.crewMembers ?? []) as Rec[]) {
     const id = newId("crewMember", r.id);
@@ -845,7 +845,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.crewMembers.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.crewMembers.createIfMissing, toConvexDoc(created) as any);
   }
   // Re-link crew members <-> skills (implicit m:n join table)
   for (const link of (manifest.crewMemberSkills ?? []) as Array<{
@@ -963,7 +963,7 @@ export async function importOrganization(
         updatedAt: safeDate(r.updatedAt),
       } as any,
     });
-    await (await getConvexClient()).mutation(api.checkItems.create, toConvexDoc(created) as any);
+    await (await getConvexClient()).mutation(api.checkItems.createIfMissing, toConvexDoc(created) as any);
   }
   for (const r of (manifest.modelCheckItems ?? []) as Rec[]) {
     const modelId = remap("model", r.modelId);

--- a/src/lib/project-grouping-mirror.ts
+++ b/src/lib/project-grouping-mirror.ts
@@ -52,12 +52,12 @@ async function remove(fn: AnyRef, id: string) {
 }
 
 // ─── Project categories ────────────────────────────────────────────────────────
-export const mirrorProjectCategoryCreate = (row: Record<string, unknown>) => create(api.projectCategories.create, row);
+export const mirrorProjectCategoryCreate = (row: Record<string, unknown>) => create(api.projectCategories.createIfMissing, row);
 export const patchProjectCategoryInConvex = (id: string, row: Record<string, unknown>) => patch(api.projectCategories.update, id, row);
 export const removeProjectCategoryFromConvex = (id: string) => remove(api.projectCategories.remove, id);
 
 // ─── Project groups ────────────────────────────────────────────────────────────
-export const mirrorProjectGroupCreate = (row: Record<string, unknown>) => create(api.projectGroups.create, row);
+export const mirrorProjectGroupCreate = (row: Record<string, unknown>) => create(api.projectGroups.createIfMissing, row);
 export const patchProjectGroupInConvex = (id: string, row: Record<string, unknown>) => patch(api.projectGroups.update, id, row);
 export const removeProjectGroupFromConvex = (id: string) => remove(api.projectGroups.remove, id);
 

--- a/src/lib/project-mirror.ts
+++ b/src/lib/project-mirror.ts
@@ -47,7 +47,7 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorProjectCreate = (row: Record<string, unknown>) => create(api.projects.create, row);
+export const mirrorProjectCreate = (row: Record<string, unknown>) => create(api.projects.createIfMissing, row);
 export const patchProjectInConvex = (id: string, row: Record<string, unknown>) => patch(api.projects.update, id, row);
 export const removeProjectFromConvex = (id: string) => remove(api.projects.remove, id);
 

--- a/src/lib/project-subtable-mirror.ts
+++ b/src/lib/project-subtable-mirror.ts
@@ -74,7 +74,7 @@ export async function syncProjectServicesToConvex(orgId: string, projectId: stri
     {
       listByProject: api.projectServices.listByProject,
       getById: api.projectServices.getById,
-      create: api.projectServices.create,
+      create: api.projectServices.createIfMissing,
       update: api.projectServices.update,
       remove: api.projectServices.remove,
     },
@@ -90,7 +90,7 @@ export async function syncProjectTasksToConvex(orgId: string, projectId: string)
     {
       listByProject: api.projectTasks.listByProject,
       getById: api.projectTasks.getById,
-      create: api.projectTasks.create,
+      create: api.projectTasks.createIfMissing,
       update: api.projectTasks.update,
       remove: api.projectTasks.remove,
     },
@@ -106,7 +106,7 @@ export async function syncProjectManagersToConvex(orgId: string, projectId: stri
     {
       listByProject: api.projectManagers.listByProject,
       getById: api.projectManagers.getById,
-      create: api.projectManagers.create,
+      create: api.projectManagers.createIfMissing,
       update: api.projectManagers.update,
       remove: api.projectManagers.remove,
     },

--- a/src/lib/saved-reports-mirror.ts
+++ b/src/lib/saved-reports-mirror.ts
@@ -38,6 +38,6 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorSavedReportCreate = (row: Record<string, unknown>) => create(api.savedReports.create, row);
+export const mirrorSavedReportCreate = (row: Record<string, unknown>) => create(api.savedReports.createIfMissing, row);
 export const patchSavedReportInConvex = (id: string, row: Record<string, unknown>) => patch(api.savedReports.update, id, row);
 export const removeSavedReportFromConvex = (id: string) => remove(api.savedReports.remove, id);

--- a/src/lib/saved-views-mirror.ts
+++ b/src/lib/saved-views-mirror.ts
@@ -39,7 +39,7 @@ async function upsert(row: Record<string, unknown>) {
     await convex.mutation(api.savedTableViews.update, { id, patch: rest } as any);
   } else {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await convex.mutation(api.savedTableViews.create, toConvexDoc(strip(row)) as any);
+    await convex.mutation(api.savedTableViews.createIfMissing, toConvexDoc(strip(row)) as any);
   }
 }
 

--- a/src/lib/sub-hire-mirror.ts
+++ b/src/lib/sub-hire-mirror.ts
@@ -56,27 +56,27 @@ function strip(row: Record<string, unknown>): Record<string, unknown> {
 }
 
 // ─── Sub-hire ────────────────────────────────────────────────────────────────
-export const mirrorSubHireCreate = (row: Record<string, unknown>) => create(api.subHires.create, strip(row));
+export const mirrorSubHireCreate = (row: Record<string, unknown>) => create(api.subHires.createIfMissing, strip(row));
 export const patchSubHireInConvex = (id: string, row: Record<string, unknown>) => patch(api.subHires.update, id, strip(row));
 export const removeSubHireFromConvex = (id: string) => remove(api.subHires.remove, id);
 
 // ─── Sub-hire items ────────────────────────────────────────────────────────────
-export const mirrorSubHireItemCreate = (row: Record<string, unknown>) => create(api.subHireItems.create, strip(row));
+export const mirrorSubHireItemCreate = (row: Record<string, unknown>) => create(api.subHireItems.createIfMissing, strip(row));
 export const patchSubHireItemInConvex = (id: string, row: Record<string, unknown>) => patch(api.subHireItems.update, id, strip(row));
 export const removeSubHireItemFromConvex = (id: string) => remove(api.subHireItems.remove, id);
 
 // ─── Sub-hire groups ────────────────────────────────────────────────────────────
-export const mirrorSubHireGroupCreate = (row: Record<string, unknown>) => create(api.subHireGroups.create, strip(row));
+export const mirrorSubHireGroupCreate = (row: Record<string, unknown>) => create(api.subHireGroups.createIfMissing, strip(row));
 export const patchSubHireGroupInConvex = (id: string, row: Record<string, unknown>) => patch(api.subHireGroups.update, id, strip(row));
 export const removeSubHireGroupFromConvex = (id: string) => remove(api.subHireGroups.remove, id);
 
 // ─── Supplier orders ────────────────────────────────────────────────────────────
-export const mirrorSupplierOrderCreate = (row: Record<string, unknown>) => create(api.supplierOrders.create, strip(row));
+export const mirrorSupplierOrderCreate = (row: Record<string, unknown>) => create(api.supplierOrders.createIfMissing, strip(row));
 export const patchSupplierOrderInConvex = (id: string, row: Record<string, unknown>) => patch(api.supplierOrders.update, id, strip(row));
 export const removeSupplierOrderFromConvex = (id: string) => remove(api.supplierOrders.remove, id);
 
 // ─── Supplier order items ────────────────────────────────────────────────────────
-export const mirrorSupplierOrderItemCreate = (row: Record<string, unknown>) => create(api.supplierOrderItems.create, strip(row));
+export const mirrorSupplierOrderItemCreate = (row: Record<string, unknown>) => create(api.supplierOrderItems.createIfMissing, strip(row));
 export const patchSupplierOrderItemInConvex = (id: string, row: Record<string, unknown>) => patch(api.supplierOrderItems.update, id, strip(row));
 export const removeSupplierOrderItemFromConvex = (id: string) => remove(api.supplierOrderItems.remove, id);
 
@@ -90,9 +90,9 @@ export async function syncSubHireToConvex(subHireId: string | null | undefined) 
   });
   if (!sh) return;
   const { items, groups, ...head } = sh;
-  await upsert(api.subHires.getById, api.subHires.create, api.subHires.update, head as unknown as Record<string, unknown>);
-  for (const it of items) await upsert(api.subHireItems.getById, api.subHireItems.create, api.subHireItems.update, it as unknown as Record<string, unknown>);
-  for (const g of groups) await upsert(api.subHireGroups.getById, api.subHireGroups.create, api.subHireGroups.update, g as unknown as Record<string, unknown>);
+  await upsert(api.subHires.getById, api.subHires.createIfMissing, api.subHires.update, head as unknown as Record<string, unknown>);
+  for (const it of items) await upsert(api.subHireItems.getById, api.subHireItems.createIfMissing, api.subHireItems.update, it as unknown as Record<string, unknown>);
+  for (const g of groups) await upsert(api.subHireGroups.getById, api.subHireGroups.createIfMissing, api.subHireGroups.update, g as unknown as Record<string, unknown>);
 }
 
 /** Re-read a whole supplier_order (head + items) from Prisma and upsert each. */
@@ -104,8 +104,8 @@ export async function syncSupplierOrderToConvex(orderId: string | null | undefin
   });
   if (!order) return;
   const { items, ...head } = order;
-  await upsert(api.supplierOrders.getById, api.supplierOrders.create, api.supplierOrders.update, head as unknown as Record<string, unknown>);
-  for (const it of items) await upsert(api.supplierOrderItems.getById, api.supplierOrderItems.create, api.supplierOrderItems.update, it as unknown as Record<string, unknown>);
+  await upsert(api.supplierOrders.getById, api.supplierOrders.createIfMissing, api.supplierOrders.update, head as unknown as Record<string, unknown>);
+  for (const it of items) await upsert(api.supplierOrderItems.getById, api.supplierOrderItems.createIfMissing, api.supplierOrderItems.update, it as unknown as Record<string, unknown>);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/template-mirror.ts
+++ b/src/lib/template-mirror.ts
@@ -40,11 +40,11 @@ async function remove(fn: AnyRef, id: string) {
 }
 
 // ─── Document templates ──────────────────────────────────────────────────────
-export const mirrorDocumentTemplateCreate = (row: Record<string, unknown>) => create(api.documentTemplates.create, row);
+export const mirrorDocumentTemplateCreate = (row: Record<string, unknown>) => create(api.documentTemplates.createIfMissing, row);
 export const patchDocumentTemplateInConvex = (id: string, row: Record<string, unknown>) => patch(api.documentTemplates.update, id, row);
 export const removeDocumentTemplateFromConvex = (id: string) => remove(api.documentTemplates.remove, id);
 
 // ─── Service templates ───────────────────────────────────────────────────────
-export const mirrorServiceTemplateCreate = (row: Record<string, unknown>) => create(api.serviceTemplates.create, row);
+export const mirrorServiceTemplateCreate = (row: Record<string, unknown>) => create(api.serviceTemplates.createIfMissing, row);
 export const patchServiceTemplateInConvex = (id: string, row: Record<string, unknown>) => patch(api.serviceTemplates.update, id, row);
 export const removeServiceTemplateFromConvex = (id: string) => remove(api.serviceTemplates.remove, id);

--- a/src/lib/warehouse-close-mirror.ts
+++ b/src/lib/warehouse-close-mirror.ts
@@ -32,5 +32,5 @@ async function remove(fn: AnyRef, id: string) {
   await (await getConvexClient()).mutation(fn, { id } as any);
 }
 
-export const mirrorWarehouseCloseCreate = (row: Record<string, unknown>) => create(api.warehouseCloses.create, row);
+export const mirrorWarehouseCloseCreate = (row: Record<string, unknown>) => create(api.warehouseCloses.createIfMissing, row);
 export const removeWarehouseCloseFromConvex = (id: string) => remove(api.warehouseCloses.remove, id);

--- a/src/server/brand-templates.ts
+++ b/src/server/brand-templates.ts
@@ -23,8 +23,8 @@ import {
 /** Mirror a freshly written Prisma brand-template row into Convex (create). */
 async function mirrorBrandTemplateToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.brandTemplates.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.brandTemplates.create>,
+    api.brandTemplates.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.brandTemplates.createIfMissing>,
   );
 }
 

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -20,8 +20,8 @@ import { logActivity } from "@/lib/activity-log";
 /** Mirror a freshly written Prisma category row into Convex (create). */
 async function mirrorCategoryToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.categories.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.categories.create>,
+    api.categories.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.categories.createIfMissing>,
   );
 }
 

--- a/src/server/check-items.ts
+++ b/src/server/check-items.ts
@@ -33,8 +33,8 @@ import {
 /** Mirror a freshly written Prisma check-item row into Convex (create). */
 async function mirrorCheckItemToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.checkItems.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.checkItems.create>,
+    api.checkItems.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.checkItems.createIfMissing>,
   );
 }
 

--- a/src/server/clients.ts
+++ b/src/server/clients.ts
@@ -150,7 +150,7 @@ export async function createClient(data: ClientFormValues) {
 
   const id = createId();
   const now = Date.now();
-  await (await getConvexClient()).mutation(api.clients.create, {
+  await (await getConvexClient()).mutation(api.clients.createIfMissing, {
     id,
     organizationId,
     ...toClientFields(parsed),

--- a/src/server/csv.ts
+++ b/src/server/csv.ts
@@ -17,8 +17,8 @@ import { logActivity } from "@/lib/activity-log";
 // source) just like the Models server actions — see src/server/models.ts.
 async function mirrorModelCreate(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.models.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.models.create>,
+    api.models.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.models.createIfMissing>,
   );
 }
 async function mirrorModelPatch(id: string, row: Record<string, unknown>) {

--- a/src/server/custom-fields.ts
+++ b/src/server/custom-fields.ts
@@ -38,8 +38,8 @@ import { translatePrismaError, UserFacingError } from "@/lib/errors";
 /** Mirror a freshly written Prisma custom-field row into Convex (create). */
 async function mirrorCustomFieldToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.customFieldDefinitions.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.customFieldDefinitions.create>,
+    api.customFieldDefinitions.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.customFieldDefinitions.createIfMissing>,
   );
 }
 

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -28,8 +28,8 @@ import { addKitLineItem, recalculateProjectTotals } from "./line-items";
 async function mirrorGroupTemplateToConvex(row: Record<string, unknown>) {
   const { items: _items, ...scalar } = row;
   await (await getConvexClient()).mutation(
-    api.groupTemplates.create,
-    toConvexDoc(scalar) as FunctionArgs<typeof api.groupTemplates.create>,
+    api.groupTemplates.createIfMissing,
+    toConvexDoc(scalar) as FunctionArgs<typeof api.groupTemplates.createIfMissing>,
   );
 }
 

--- a/src/server/locations.ts
+++ b/src/server/locations.ts
@@ -27,8 +27,8 @@ import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/
 /** Mirror a freshly written Prisma location row into Convex (create). */
 async function mirrorLocationToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.locations.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.locations.create>,
+    api.locations.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.locations.createIfMissing>,
   );
 }
 

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -27,8 +27,8 @@ import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/
 /** Mirror a freshly written Prisma model row into Convex (create). */
 async function mirrorModelToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.models.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.models.create>,
+    api.models.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.models.createIfMissing>,
   );
 }
 

--- a/src/server/section-presets.ts
+++ b/src/server/section-presets.ts
@@ -18,8 +18,8 @@ import { templateSectionsSchema } from "@/lib/validations/template-section";
 /** Mirror a freshly written Prisma section-preset row into Convex (create). */
 async function mirrorSectionPresetToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.sectionPresets.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.sectionPresets.create>,
+    api.sectionPresets.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.sectionPresets.createIfMissing>,
   );
 }
 

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -25,8 +25,8 @@ import type { ColumnDef } from "@/components/ui/data-table";
 /** Mirror a freshly written Prisma supplier row into Convex (create). */
 async function mirrorSupplierToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.suppliers.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.suppliers.create>,
+    api.suppliers.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.suppliers.createIfMissing>,
   );
 }
 

--- a/src/server/test-tag-profiles.ts
+++ b/src/server/test-tag-profiles.ts
@@ -20,8 +20,8 @@ import { SEED_PROFILES } from "@/lib/test-profiles/seed-data";
 /** Mirror a freshly written Prisma test-profile row into Convex (create). */
 async function mirrorTestProfileToConvex(row: Record<string, unknown>) {
   await (await getConvexClient()).mutation(
-    api.testProfiles.create,
-    toConvexDoc(row) as FunctionArgs<typeof api.testProfiles.create>,
+    api.testProfiles.createIfMissing,
+    toConvexDoc(row) as FunctionArgs<typeof api.testProfiles.createIfMissing>,
   );
 }
 

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -415,7 +415,7 @@ async function findOrCreateClient(orgId: string, billing: WooOrder["billing"]) {
     const id = createId();
     const now = Date.now();
     const name = hasCompany ? billing.company!.trim() : `${billing.first_name} ${billing.last_name}`;
-    await (await getConvexClient()).mutation(api.clients.create, {
+    await (await getConvexClient()).mutation(api.clients.createIfMissing, {
       id,
       organizationId: orgId,
       name,


### PR DESCRIPTION
## Summary

- **Root cause 1 — broken `removeIn` tolerance**: All 166 "not found" guards in Convex mutation files used plain `throw new Error(...)`. Convex masks plain errors to a generic `InternalServerError` in production, so the `removeIn`/`removeSafe` catch blocks checking `/not found/i.test(e.message)` never matched — they received the masked message and re-threw, surfacing as intermittent user-facing errors.
- **Fix**: Changed all 166 guards across all 82 `convex/*.ts` mutation files to `throw new ConvexError(...)`. `ConvexError` payloads pass through the production boundary with the real message intact, so tolerance catches now work correctly.
- **Root cause 2 — duplicate record risk**: All mirror `create` calls used plain `.create` instead of `.createIfMissing`. Concurrent mirror calls or backfill overlap could insert duplicate `id` values; then `.unique()` on the `by_cuid` index throws a Convex system error → `InternalServerError`.
- **Fix**: Switched all 31 affected `src/` files (mirror helpers + server actions + org-import) to `createIfMissing`.

## Test plan

- [x] All 95 unit test files pass (2266 tests)
- [x] No new TypeScript errors introduced
- [x] `ConvexError` import added to each modified `convex/*.ts` file
- [x] All mirror files (`media-mirror`, `check-item-assignment-mirror`, `crew-scheduling-mirror`, `project-subtable-mirror`, `file-upload-mirror`, `saved-views-mirror`) updated to `createIfMissing`
- [x] All server action files that called `api.X.create` updated to `api.X.createIfMissing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)