### PR TITLE
v0.19.6.1 fix: refresh Convex service token mid-loop in high-volume backfills

### DIFF
--- a/scripts/convex-backfill-asset-scan-logs.ts
+++ b/scripts/convex-backfill-asset-scan-logs.ts
@@ -19,12 +19,14 @@ import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../convex/_generated/api";
 
 async function main() {
-  const convex = await getConvexClient();
   let created = 0;
   let skipped = 0;
 
   const rows = await prisma.assetScanLog.findMany();
   for (const row of rows) {
+    // Re-fetch the client each iteration so the 5-min service token refreshes
+    // mid-loop (this table is high-volume and the loop can exceed the TTL).
+    const convex = await getConvexClient();
     const __res = await convex.mutation(
       api.assetScanLogs.createIfMissing,
       toConvexDoc(row) as FunctionArgs<typeof api.assetScanLogs.createIfMissing>,

--- a/scripts/convex-backfill-check-records.ts
+++ b/scripts/convex-backfill-check-records.ts
@@ -44,13 +44,15 @@ function strip(row: Record<string, unknown>): Record<string, unknown> {
 }
 
 async function main() {
-  const convex = await getConvexClient();
   let created = 0;
   let skipped = 0;
 
   const records = await prisma.checkRecord.findMany();
   for (const r of records) {
     const doc = strip(toConvexDoc(r as unknown as Record<string, unknown>));
+    // Re-fetch the client each iteration so the 5-min service token refreshes
+    // mid-loop (this table can be high-volume and the loop can exceed the TTL).
+    const convex = await getConvexClient();
     const __res = await convex.mutation(
       api.checkRecords.createIfMissing,
       doc as FunctionArgs<typeof api.checkRecords.createIfMissing>,


### PR DESCRIPTION
## Summary
`asset-scan-logs` and `check-records` backfills can loop past the 5-minute service-token TTL. They fetched the Convex client once before the loop, so on high-volume tables the token expired mid-run:

```
Error: InvalidAuthHeader: Could not validate token: Token expired 6 seconds ago
```

Fix: re-fetch the client each iteration. `getConvexClient()` returns the cached client and re-mints the service token ~30s before expiry, so the loop survives arbitrarily long backfills. Idempotent — re-running skips already-created rows.

Found in production while running the post-Coolify-migration backfills (the 7 sub-table backfills completed; these two high-volume event tables hit the TTL).

## Test plan
- [x] tsx transpiles (scripts run); behavior change is per-iteration client fetch
- [x] Re-ran in prod container to completion after the same fix applied via sed

🤖 Generated with [Claude Code](https://claude.com/claude-code)