### PR TITLE
feat(convex): read-rewire crew dashboard to Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -7,7 +7,9 @@
 > for Better Auth + RBAC + activityLog. Full phased plan (A read-rewiring →
 > B write-inversion → C drop tables), scope, and ground rules:
 > [`docs/designs/convex-domain-only-decommission.md`](../docs/designs/convex-domain-only-decommission.md).
-> Currently PAUSED before Phase A; all dual-write groundwork is shipped + backfilled.
+> **Phase A read-rewiring IN PROGRESS (2026-06-16):** leaf surfaces converting one
+> PR at a time — Test & Tag reports (PR #194) + crew dashboard done. See
+> [Phase A — read-rewiring](#phase-a--read-rewiring-domain-only-decommission) below.
 
 ## Overview
 
@@ -2634,6 +2636,46 @@ hidden — this only smooths the "random" single-shot failures. This does NOT
 re-introduce a Prisma fallback: a *map miss* still yields `null` (mirror-freshness
 invariant preserved); only a *thrown* transient error is retried. Regression tests:
 `src/lib/convex-client.test.ts`, `src/lib/convex-auth-guards.test.ts`.
+
+## Phase A — read-rewiring (domain-only decommission)
+
+The endgame's first phase: move every remaining Prisma **domain read** to Convex,
+one leaf surface per PR, validated before merge. Full plan + ground rules in
+[`docs/designs/convex-domain-only-decommission.md`](../docs/designs/convex-domain-only-decommission.md).
+
+**Pattern (proven on the leaves below):** a thin `src/lib/<x>-read.ts` with
+Convex fetchers + mappers (epoch-ms → `Date`, absent optionals → `null`,
+Decimal → `number`, Prisma-required-but-Convex-optional fields coerced) + pure,
+unit-tested filter predicates that re-implement the old Prisma `where`; the server
+action keeps its shape (still called via `useServerQuery`) but reads Convex and
+does `orderBy`/`include` as JS sort/attach. Postgres null-ordering replicated
+(ASC = NULLS LAST, DESC = NULLS FIRST). No Prisma fallback — a map miss is `null`.
+Auth-owned joins (`User`: `testedBy`/`approvedBy`/etc.) stay on Prisma forever.
+Validation: pure unit tests (CI) + a local row-for-row golden-diff vs Prisma on
+seeded dev data (see the design doc's "Env note for validators").
+
+### Test & Tag reports — DONE (PR #194)
+
+`src/server/test-tag-reports.ts` (10 builders + CSV + counts) → Convex via
+`src/lib/test-tag-read.ts`. New `subTestRecords.listByRecordIds` query;
+`ReportFilters` moved to `src/lib/test-tag-report-types.ts`. Also fixed
+`convex-backfill-all.ts` to include the 9 Phase-6 sub-table backfills.
+
+### Crew dashboard — DONE
+
+`src/server/crew-dashboard.ts` (6 read-only widgets: picker list, stat counts,
+pending timesheets, active assignments, pending offers, upcoming shifts) → Convex
+via `src/lib/crew-scheduling-read.ts` (assignments / time entries / shifts /
+certifications). Members+roles from `crew-read.ts`, projects from
+`projects-read.ts`. `crew_shift` / `crew_certification` have no org column
+(parent-scoped) → hand-added `crewShifts.listByOrg` / `crewCertifications.listByOrg`
+that join via assignments / members. Counts + the `_sum(totalHours)` aggregate
+computed in JS over the org-scoped lists. Dev data: `npm run seed:crew`.
+
+> **Deploy gate (crew):** the crew **scheduling** tables (assignment / shift /
+> certification / time entry) must be backfilled in **prod** Convex before this
+> merges, else the dashboard reads empty. Run `convex:backfill:crew-scheduling`
+> (and `:crew`) in prod first if not already done.
 
 ## Conventions
 

--- a/convex/crewCertifications.ts
+++ b/convex/crewCertifications.ts
@@ -32,6 +32,31 @@ export const getById = query({
   },
 });
 
+/**
+ * All certifications for an org. crewCertification has no org column (it's
+ * scoped to its crew member), so join via crewMembers.by_organizationId.
+ * HAND-ADDED for the Phase A crew-dashboard read-rewiring.
+ */
+export const listByOrg = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    const members = await ctx.db
+      .query("crewMembers")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    const out = [];
+    for (const m of members) {
+      const certs = await ctx.db
+        .query("crewCertifications")
+        .withIndex("by_crewMemberId", (q) => q.eq("crewMemberId", m.id))
+        .collect();
+      out.push(...certs);
+    }
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/crewShifts.ts
+++ b/convex/crewShifts.ts
@@ -32,6 +32,31 @@ export const getById = query({
   },
 });
 
+/**
+ * All shifts for an org. crewShift has no org column (it's scoped to its
+ * assignment), so join via crewAssignments.by_organizationId.
+ * HAND-ADDED for the Phase A crew-dashboard read-rewiring.
+ */
+export const listByOrg = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    const assignments = await ctx.db
+      .query("crewAssignments")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    const out = [];
+    for (const a of assignments) {
+      const shifts = await ctx.db
+        .query("crewShifts")
+        .withIndex("by_assignmentId", (q) => q.eq("assignmentId", a.id))
+        .collect();
+      out.push(...shifts);
+    }
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/docs/designs/convex-domain-only-decommission.md
+++ b/docs/designs/convex-domain-only-decommission.md
@@ -6,9 +6,10 @@
 > (see [`FEATUREDOCS/54`](../../FEATUREDOCS/54-convex-data-layer.md) and
 > [`convex-hybrid-migration.md`](./convex-hybrid-migration.md)).
 
-> **Status: PAUSED before Phase A.** Everything below Phase 0 ("Done") is shipped
-> and stable. Phases A/B/C are not started. Tracked as tasks #4 (Phase A), #5
-> (Phase B), #6 (Phase C).
+> **Status: Phase A IN PROGRESS (2026-06-16).** Everything below Phase 0 ("Done")
+> is shipped and stable. Phase A read-rewiring underway — leaf surfaces converting
+> one PR at a time (see the Phase A progress log below). Phases B/C not started.
+> Tracked as tasks #4 (Phase A), #5 (Phase B), #6 (Phase C).
 
 ---
 
@@ -145,6 +146,28 @@ integration test, not just plugin-level tests.
    (`org-export`, `test-tag-reports`), `document-templates`, stocktake lists.
 2. Mid: crew cluster, test-tag cluster, sub-hire detail/list, supplier-orders.
 3. Keystone: line-item-tree reader → getProject → warehouse → pull-sheet → PDF.
+
+### Phase A progress log
+
+- **`test-tag-reports.ts` — DONE (PR #194).** Read-only reports/CSV/counts →
+  Convex via `src/lib/test-tag-read.ts`. `testedBy` (User) stays Prisma. Fixed
+  `convex-backfill-all.ts` to include the 9 Phase-6 sub-table backfills.
+- **`crew-dashboard.ts` — DONE.** 6 read-only dashboard widgets → Convex via
+  `src/lib/crew-scheduling-read.ts` (assignment/timeEntry/shift/cert) + crew-read +
+  projects-read. Added org-scoped `crewShifts.listByOrg` / `crewCertifications.listByOrg`
+  (parent-join, no org column). **Pre-merge deploy gate: backfill the crew
+  scheduling tables in prod Convex first** (`convex:backfill:crew-scheduling`),
+  else the widgets read empty. Validated with unit tests + golden-diff on
+  `npm run seed:crew` data.
+
+**Env note for validators.** The dev worktree *can* run live Convex reads/backfills
+against the shared dev deployment by overriding the service-token issuer to match
+it: prefix commands with `BETTER_AUTH_URL="https://preview.lab.rvlt.app"` (the
+local `BETTER_AUTH_SECRET` already matches the dev JWKS). The shared dev DB starts
+empty — seed (`npm run seed` + `seed:test-tag` + `seed:crew`), then
+`BETTER_AUTH_URL=… npx tsx … scripts/convex-backfill-all.ts`, then the parity
+check. Caveat: the shared dev backend is volatile (other worktrees/previews mutate
+it) — re-run the relevant backfill right before validating.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:server-actions": "tsx scripts/audit-server-actions.ts",
     "bot:start": "tsx --env-file=.env scripts/discord-bot.ts",
     "seed": "tsx --env-file=.env prisma/seed.ts",
+    "seed:crew": "tsx --env-file=.env scripts/seed-crew-dev.ts",
     "convex:schema": "node scripts/generate-convex-schema.cjs .",
     "convex:crud": "node scripts/generate-convex-crud.cjs .",
     "convex:backfill:clients": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-clients.ts",

--- a/scripts/seed-crew-dev.ts
+++ b/scripts/seed-crew-dev.ts
@@ -1,0 +1,155 @@
+/**
+ * Dev seed — crew cluster data for validating the Phase A read-rewiring of
+ * `src/server/crew-dashboard.ts` (and future crew-cluster work) against Convex.
+ *
+ * Creates roles, members, and the project-coupled scheduling sub-tables
+ * (assignments across statuses, time entries, shifts, certifications) attached to
+ * the existing seed project. Idempotent — keyed off the seed prefix.
+ *
+ *   npm run seed:crew   (after `npm run seed` so a project exists)
+ */
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../src/generated/prisma/client";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const PFX = "CREWSEED";
+const day = 24 * 60 * 60 * 1000;
+const now = Date.now();
+const d = (offsetDays: number) => new Date(now + offsetDays * day);
+
+async function main() {
+  console.log("[crew-seed] starting");
+  const org = await prisma.organization.findFirst({ orderBy: { createdAt: "asc" } });
+  if (!org) throw new Error("[crew-seed] no organization");
+  const orgId = org.id;
+
+  const project = await prisma.project.findFirst({ where: { organizationId: orgId, isTemplate: false }, orderBy: { createdAt: "asc" } });
+  if (!project) throw new Error("[crew-seed] no project — run `npm run seed` first");
+
+  // ── roles ───────────────────────────────────────────────────────────────────
+  const roleDefs = [
+    { name: `${PFX} Audio Tech`, color: "#3b82f6", sortOrder: 0 },
+    { name: `${PFX} Lighting Op`, color: "#f59e0b", sortOrder: 1 },
+  ];
+  const roles: { id: string; name: string }[] = [];
+  for (const r of roleDefs) {
+    const existing = await prisma.crewRole.findFirst({ where: { organizationId: orgId, name: r.name } });
+    const row = existing ?? (await prisma.crewRole.create({
+      data: { organizationId: orgId, name: r.name, color: r.color, sortOrder: r.sortOrder, isActive: true },
+    }));
+    roles.push({ id: row.id, name: row.name });
+  }
+
+  // ── members ─────────────────────────────────────────────────────────────────
+  const memberDefs = [
+    { firstName: "Ava", lastName: `${PFX}-Stone`, department: "Audio", roleIdx: 0, email: `ava.${PFX.toLowerCase()}@example.com` },
+    { firstName: "Ben", lastName: `${PFX}-Lowe`, department: "Lighting", roleIdx: 1, email: `ben.${PFX.toLowerCase()}@example.com` },
+    { firstName: "Cara", lastName: `${PFX}-Hill`, department: "Audio", roleIdx: 0, email: `cara.${PFX.toLowerCase()}@example.com` },
+  ];
+  const members: { id: string; firstName: string; lastName: string }[] = [];
+  for (const m of memberDefs) {
+    const existing = await prisma.crewMember.findFirst({ where: { organizationId: orgId, lastName: m.lastName } });
+    const row = existing ?? (await prisma.crewMember.create({
+      data: {
+        organizationId: orgId, firstName: m.firstName, lastName: m.lastName, email: m.email,
+        department: m.department, type: "FREELANCER", status: "ACTIVE", isActive: true,
+        icalEnabled: false, crewRoleId: roles[m.roleIdx].id,
+      },
+    }));
+    members.push({ id: row.id, firstName: row.firstName, lastName: row.lastName });
+  }
+
+  // ── assignments (varied statuses) ────────────────────────────────────────────
+  const asgDefs = [
+    { memberIdx: 0, roleIdx: 0, status: "CONFIRMED", phase: "EVENT", startDate: d(-1), endDate: d(3) },
+    { memberIdx: 1, roleIdx: 1, status: "ACCEPTED", phase: "BUMP_IN", startDate: d(0), endDate: null },
+    { memberIdx: 2, roleIdx: 0, status: "PENDING", phase: "EVENT", startDate: d(5), endDate: d(7) },
+    { memberIdx: 0, roleIdx: 0, status: "OFFERED", phase: "BUMP_OUT", startDate: d(8), endDate: d(9) },
+    { memberIdx: 1, roleIdx: 1, status: "CANCELLED", phase: "EVENT", startDate: d(2), endDate: d(4) },
+  ];
+  const assignments: { id: string; status: string; memberIdx: number }[] = [];
+  for (const a of asgDefs) {
+    const existing = await prisma.crewAssignment.findFirst({
+      where: { organizationId: orgId, projectId: project.id, crewMemberId: members[a.memberIdx].id, status: a.status as never, startDate: a.startDate },
+    });
+    const row = existing ?? (await prisma.crewAssignment.create({
+      data: {
+        organizationId: orgId, projectId: project.id, crewMemberId: members[a.memberIdx].id,
+        crewRoleId: roles[a.roleIdx].id, status: a.status as never, phase: a.phase as never,
+        isProjectManager: false, startDate: a.startDate, endDate: a.endDate,
+      },
+    }));
+    assignments.push({ id: row.id, status: a.status, memberIdx: a.memberIdx });
+  }
+  const confirmedAsg = assignments.find((a) => a.status === "CONFIRMED")!;
+
+  // ── time entries ──────────────────────────────────────────────────────────────
+  const teDefs = [
+    { memberIdx: 0, assignmentIdx: 0, date: d(-1), status: "SUBMITTED", totalHours: 8, start: "08:00", end: "16:00" },
+    { memberIdx: 1, assignmentIdx: 1, date: d(-2), status: "SUBMITTED", totalHours: 6, start: "09:00", end: "15:00" },
+    { memberIdx: 0, assignmentIdx: 0, date: d(-3), status: "APPROVED", totalHours: 7.5, start: "08:00", end: "15:30" },
+    { memberIdx: 2, assignmentIdx: null, date: d(-4), status: "APPROVED", totalHours: 5, start: "10:00", end: "15:00" },
+    { memberIdx: 0, assignmentIdx: 0, date: d(-30), status: "APPROVED", totalHours: 9, start: "08:00", end: "17:00" },
+  ];
+  for (const t of teDefs) {
+    const existing = await prisma.crewTimeEntry.findFirst({
+      where: { organizationId: orgId, crewMemberId: members[t.memberIdx].id, date: t.date },
+    });
+    if (existing) continue;
+    await prisma.crewTimeEntry.create({
+      data: {
+        organizationId: orgId, crewMemberId: members[t.memberIdx].id,
+        assignmentId: t.assignmentIdx != null ? assignments[t.assignmentIdx].id : null,
+        date: t.date, startTime: t.start, endTime: t.end, breakMinutes: 30,
+        totalHours: t.totalHours, status: t.status as never,
+        description: t.assignmentIdx == null ? "General warehouse" : null,
+      },
+    });
+  }
+
+  // ── shifts (on the CONFIRMED assignment) ─────────────────────────────────────
+  const shiftDefs = [
+    { date: d(1), status: "SCHEDULED", callTime: "08:00", endTime: "16:00" },
+    { date: d(2), status: "SCHEDULED", callTime: "08:00", endTime: "16:00" },
+    { date: d(3), status: "SCHEDULED", callTime: "09:00", endTime: "17:00" },
+    { date: d(-2), status: "SCHEDULED", callTime: "08:00", endTime: "16:00" }, // past → excluded
+    { date: d(4), status: "CANCELLED", callTime: "08:00", endTime: "16:00" }, // cancelled → excluded
+  ];
+  for (const s of shiftDefs) {
+    const existing = await prisma.crewShift.findFirst({ where: { assignmentId: confirmedAsg.id, date: s.date } });
+    if (existing) continue;
+    await prisma.crewShift.create({
+      data: { assignmentId: confirmedAsg.id, date: s.date, status: s.status as never, callTime: s.callTime, endTime: s.endTime, breakMinutes: 30 },
+    });
+  }
+
+  // ── certifications ───────────────────────────────────────────────────────────
+  const certDefs = [
+    { memberIdx: 0, name: "White Card", status: "CURRENT", expiry: d(300) },
+    { memberIdx: 1, name: "EWP Licence", status: "EXPIRING_SOON", expiry: d(20) },
+    { memberIdx: 2, name: "Test & Tag Cert", status: "EXPIRED", expiry: d(-10) },
+  ];
+  for (const c of certDefs) {
+    const existing = await prisma.crewCertification.findFirst({ where: { crewMemberId: members[c.memberIdx].id, name: c.name } });
+    if (existing) continue;
+    await prisma.crewCertification.create({
+      data: { crewMemberId: members[c.memberIdx].id, name: c.name, status: c.status as never, expiryDate: c.expiry },
+    });
+  }
+
+  const counts = {
+    roles: await prisma.crewRole.count({ where: { organizationId: orgId } }),
+    members: await prisma.crewMember.count({ where: { organizationId: orgId } }),
+    assignments: await prisma.crewAssignment.count({ where: { organizationId: orgId } }),
+    timeEntries: await prisma.crewTimeEntry.count({ where: { organizationId: orgId } }),
+    shifts: await prisma.crewShift.count(),
+    certifications: await prisma.crewCertification.count(),
+  };
+  console.log("[crew-seed] done:", JSON.stringify(counts));
+  await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/crew-scheduling-read.test.ts
+++ b/src/lib/crew-scheduling-read.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { mapAssignment, mapTimeEntry, mapShift, mapCertification } from "@/lib/crew-scheduling-read";
+
+describe("crew-scheduling-read mappers", () => {
+  it("mapAssignment converts dates and normalises absent optionals", () => {
+    const m = mapAssignment({
+      id: "a1", organizationId: "o", projectId: "p", crewMemberId: "m", status: "CONFIRMED",
+      isProjectManager: true, startDate: 1_700_000_000_000,
+      // crewRoleId / phase / endDate / createdAt absent
+    } as never);
+    expect(m.startDate).toBeInstanceOf(Date);
+    expect(m.startDate?.getTime()).toBe(1_700_000_000_000);
+    expect(m.endDate).toBeNull();
+    expect(m.crewRoleId).toBeNull();
+    expect(m.phase).toBeNull();
+    expect(m.isProjectManager).toBe(true);
+    expect(m.status).toBe("CONFIRMED");
+  });
+
+  it("mapAssignment defaults isProjectManager to false when absent", () => {
+    const m = mapAssignment({ id: "a", organizationId: "o", projectId: "p", crewMemberId: "m", status: "PENDING" } as never);
+    expect(m.isProjectManager).toBe(false);
+  });
+
+  it("mapTimeEntry converts date and keeps numeric totalHours; null when absent", () => {
+    const withHours = mapTimeEntry({
+      id: "t", organizationId: "o", crewMemberId: "m", date: 1_700_000_000_000,
+      startTime: "08:00", endTime: "16:00", status: "APPROVED", totalHours: 7.5, assignmentId: "a",
+    } as never);
+    expect(withHours.date).toBeInstanceOf(Date);
+    expect(withHours.totalHours).toBe(7.5);
+    expect(withHours.assignmentId).toBe("a");
+
+    const noHours = mapTimeEntry({
+      id: "t2", organizationId: "o", crewMemberId: "m", date: 1, startTime: "08:00", endTime: "16:00", status: "SUBMITTED",
+    } as never);
+    expect(noHours.totalHours).toBeNull();
+    expect(noHours.assignmentId).toBeNull();
+    expect(noHours.description).toBeNull();
+  });
+
+  it("mapShift converts date and normalises call/end times", () => {
+    const m = mapShift({ id: "s", assignmentId: "a", date: 1_700_000_000_000, status: "SCHEDULED", callTime: "08:00" } as never);
+    expect(m.date.getTime()).toBe(1_700_000_000_000);
+    expect(m.callTime).toBe("08:00");
+    expect(m.endTime).toBeNull();
+  });
+
+  it("mapCertification reduces to id/member/status", () => {
+    const m = mapCertification({ id: "c", crewMemberId: "m", status: "EXPIRED", name: "X" } as never);
+    expect(m).toEqual({ id: "c", crewMemberId: "m", status: "EXPIRED" });
+  });
+});

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -1,0 +1,138 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the project-coupled crew scheduling sub-tables
+ * (crew_assignment / crew_time_entry / crew_shift / crew_certification) — Phase A
+ * read-rewiring of the Convex domain-only decommission.
+ *
+ * All four are dual-written (see src/lib/crew-scheduling-mirror.ts). These helpers
+ * read the Convex copy and shape it back into the Prisma-row form the crew
+ * dashboard expects (epoch-ms → Date, absent optionals → null, Decimal → number).
+ * Members/roles come from `crew-read.ts`; projects from `projects-read.ts`;
+ * `testedBy`/`approvedBy`/`confirmedBy` users stay on Prisma (auth, out of scope).
+ *
+ * `crew_shift` and `crew_certification` have no org column (parent-scoped), so the
+ * hand-added `crewShifts.listByOrg` / `crewCertifications.listByOrg` queries join
+ * via crewAssignments / crewMembers respectively.
+ */
+
+type RawAssignment = Doc<"crewAssignments">;
+type RawTimeEntry = Doc<"crewTimeEntries">;
+type RawShift = Doc<"crewShifts">;
+type RawCertification = Doc<"crewCertifications">;
+
+const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
+const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+const req = <T>(v: T | undefined): T => v as T;
+
+export interface CrewAssignmentRow {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  crewMemberId: string;
+  crewRoleId: string | null;
+  status: string;
+  phase: string | null;
+  isProjectManager: boolean;
+  startDate: Date | null;
+  endDate: Date | null;
+  createdAt: Date | null;
+}
+
+export interface CrewTimeEntryRow {
+  id: string;
+  organizationId: string;
+  assignmentId: string | null;
+  crewMemberId: string;
+  description: string | null;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  totalHours: number | null;
+  status: string;
+}
+
+export interface CrewShiftRow {
+  id: string;
+  assignmentId: string;
+  date: Date;
+  callTime: string | null;
+  endTime: string | null;
+  status: string;
+}
+
+export interface CrewCertificationRow {
+  id: string;
+  crewMemberId: string;
+  status: string;
+}
+
+export function mapAssignment(d: RawAssignment): CrewAssignmentRow {
+  return {
+    id: d.id,
+    organizationId: req(d.organizationId),
+    projectId: req(d.projectId),
+    crewMemberId: req(d.crewMemberId),
+    crewRoleId: orNull(d.crewRoleId),
+    status: req(d.status),
+    phase: orNull(d.phase),
+    isProjectManager: d.isProjectManager ?? false,
+    startDate: toDate(d.startDate),
+    endDate: toDate(d.endDate),
+    createdAt: toDate(d.createdAt),
+  };
+}
+
+export function mapTimeEntry(d: RawTimeEntry): CrewTimeEntryRow {
+  return {
+    id: d.id,
+    organizationId: req(d.organizationId),
+    assignmentId: orNull(d.assignmentId),
+    crewMemberId: req(d.crewMemberId),
+    description: orNull(d.description),
+    date: new Date(req(d.date)),
+    startTime: req(d.startTime),
+    endTime: req(d.endTime),
+    totalHours: orNull(d.totalHours),
+    status: req(d.status),
+  };
+}
+
+export function mapShift(d: RawShift): CrewShiftRow {
+  return {
+    id: d.id,
+    assignmentId: req(d.assignmentId),
+    date: new Date(req(d.date)),
+    callTime: orNull(d.callTime),
+    endTime: orNull(d.endTime),
+    status: req(d.status),
+  };
+}
+
+export function mapCertification(d: RawCertification): CrewCertificationRow {
+  return { id: d.id, crewMemberId: req(d.crewMemberId), status: req(d.status) };
+}
+
+// ─── Fetchers ─────────────────────────────────────────────────────────────────
+
+export async function getAssignmentsByOrg(orgId: string): Promise<CrewAssignmentRow[]> {
+  const rows = (await (await getConvexClient()).query(api.crewAssignments.list, { orgId })) as RawAssignment[];
+  return rows.map(mapAssignment);
+}
+
+export async function getTimeEntriesByOrg(orgId: string): Promise<CrewTimeEntryRow[]> {
+  const rows = (await (await getConvexClient()).query(api.crewTimeEntries.list, { orgId })) as RawTimeEntry[];
+  return rows.map(mapTimeEntry);
+}
+
+export async function getShiftsByOrg(orgId: string): Promise<CrewShiftRow[]> {
+  const rows = (await (await getConvexClient()).query(api.crewShifts.listByOrg, { orgId })) as RawShift[];
+  return rows.map(mapShift);
+}
+
+export async function getCertificationsByOrg(orgId: string): Promise<CrewCertificationRow[]> {
+  const rows = (await (await getConvexClient()).query(api.crewCertifications.listByOrg, { orgId })) as RawCertification[];
+  return rows.map(mapCertification);
+}

--- a/src/server/crew-dashboard.ts
+++ b/src/server/crew-dashboard.ts
@@ -1,33 +1,87 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
+import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getProjectsByOrg } from "@/lib/projects-read";
+import {
+  getAssignmentsByOrg,
+  getTimeEntriesByOrg,
+  getShiftsByOrg,
+  getCertificationsByOrg,
+  type CrewAssignmentRow,
+} from "@/lib/crew-scheduling-read";
+
+// Crew dashboard reads moved off Prisma to Convex (Phase A read-rewiring of the
+// domain-only decommission). Members/roles, scheduling sub-tables, and projects
+// all come from Convex; the old Prisma where/orderBy/include become JS
+// filter/sort/attach. All functions are read-only.
+
+const ms = (d: Date | null) => (d ? d.getTime() : null);
+/** Postgres ASC default = NULLS LAST. */
+function cmpDateAsc(a: Date | null, b: Date | null): number {
+  const av = ms(a), bv = ms(b);
+  if (av === null && bv === null) return 0;
+  if (av === null) return 1;
+  if (bv === null) return -1;
+  return av - bv;
+}
+/** Postgres DESC default = NULLS FIRST. */
+function cmpDateDesc(a: Date | null, b: Date | null): number {
+  const av = ms(a), bv = ms(b);
+  if (av === null && bv === null) return 0;
+  if (av === null) return -1;
+  if (bv === null) return 1;
+  return bv - av;
+}
+
+async function projectMap(orgId: string) {
+  const projects = await getProjectsByOrg(orgId);
+  return new Map(projects.map((p) => [p.id, p]));
+}
 
 export async function getCrewPickerList() {
   const { organizationId } = await getOrgContext();
 
-  const members = await prisma.crewMember.findMany({
-    where: { organizationId, isActive: true, status: "ACTIVE" },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      department: true,
-      crewRole: { select: { name: true } },
-      assignments: {
-        where: { status: { notIn: ["CANCELLED", "DECLINED"] } },
-        include: {
-          project: { select: { id: true, name: true, projectNumber: true } },
-          crewRole: { select: { id: true, name: true } },
-        },
-        orderBy: { startDate: "desc" },
-      },
-    },
-    orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
-  });
+  const [members, roleMap, assignments, projects] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getAssignmentsByOrg(organizationId),
+    projectMap(organizationId),
+  ]);
 
-  return serialize(members);
+  // Assignments per member (exclude cancelled/declined), newest start first.
+  const byMember = new Map<string, CrewAssignmentRow[]>();
+  for (const a of assignments) {
+    if (a.status === "CANCELLED" || a.status === "DECLINED") continue;
+    const arr = byMember.get(a.crewMemberId);
+    if (arr) arr.push(a);
+    else byMember.set(a.crewMemberId, [a]);
+  }
+  for (const arr of byMember.values()) arr.sort((x, y) => cmpDateDesc(x.startDate, y.startDate));
+
+  const active = members
+    .filter((m) => m.isActive !== false && m.status === "ACTIVE")
+    .sort((a, b) => a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName));
+
+  const result = active.map((m) => ({
+    id: m.id,
+    firstName: m.firstName,
+    lastName: m.lastName,
+    department: m.department ?? null,
+    crewRole: m.crewRoleId ? { name: roleMap.get(m.crewRoleId)?.name ?? null } : null,
+    assignments: (byMember.get(m.id) ?? []).map((a) => {
+      const proj = projects.get(a.projectId);
+      return {
+        id: a.id,
+        status: a.status,
+        project: proj ? { id: proj.id, name: proj.name, projectNumber: proj.projectNumber } : null,
+        crewRole: a.crewRoleId ? { id: a.crewRoleId, name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+      };
+    }),
+  }));
+
+  return serialize(result);
 }
 
 export async function getCrewDashboardStats() {
@@ -37,55 +91,30 @@ export async function getCrewDashboardStats() {
   const weekAgo = new Date(now);
   weekAgo.setDate(weekAgo.getDate() - 7);
 
-  const [
-    totalActive,
-    activeAssignments,
-    pendingOffers,
-    submittedTime,
-    hoursThisWeek,
-    expiringCerts,
-  ] = await Promise.all([
-    prisma.crewMember.count({
-      where: { organizationId, isActive: true, status: "ACTIVE" },
-    }),
-    prisma.crewAssignment.count({
-      where: {
-        organizationId,
-        status: "CONFIRMED",
-        OR: [{ endDate: { gte: now } }, { endDate: null }],
-      },
-    }),
-    prisma.crewAssignment.count({
-      where: {
-        organizationId,
-        status: { in: ["PENDING", "OFFERED"] },
-      },
-    }),
-    prisma.crewTimeEntry.count({
-      where: { organizationId, status: "SUBMITTED" },
-    }),
-    prisma.crewTimeEntry.aggregate({
-      where: {
-        organizationId,
-        status: { in: ["APPROVED", "EXPORTED"] },
-        date: { gte: weekAgo },
-      },
-      _sum: { totalHours: true },
-    }),
-    prisma.crewCertification.count({
-      where: {
-        status: { in: ["EXPIRED", "EXPIRING_SOON"] },
-        crewMember: { organizationId },
-      },
-    }),
+  const [members, assignments, timeEntries, certifications] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getTimeEntriesByOrg(organizationId),
+    getCertificationsByOrg(organizationId),
   ]);
+
+  const totalActive = members.filter((m) => m.isActive !== false && m.status === "ACTIVE").length;
+  const activeAssignments = assignments.filter(
+    (a) => a.status === "CONFIRMED" && (a.endDate === null || a.endDate.getTime() >= now.getTime()),
+  ).length;
+  const pendingOffers = assignments.filter((a) => a.status === "PENDING" || a.status === "OFFERED").length;
+  const submittedTime = timeEntries.filter((t) => t.status === "SUBMITTED").length;
+  const hoursThisWeek = timeEntries
+    .filter((t) => (t.status === "APPROVED" || t.status === "EXPORTED") && t.date.getTime() >= weekAgo.getTime())
+    .reduce((sum, t) => sum + (t.totalHours ?? 0), 0);
+  const expiringCerts = certifications.filter((c) => c.status === "EXPIRED" || c.status === "EXPIRING_SOON").length;
 
   return {
     totalActive,
     activeAssignments,
     pendingOffers,
     submittedTime,
-    hoursThisWeek: Number(hoursThisWeek._sum.totalHours || 0),
+    hoursThisWeek: Number(hoursThisWeek || 0),
     expiringCerts,
   };
 }
@@ -93,20 +122,35 @@ export async function getCrewDashboardStats() {
 export async function getPendingTimeEntries() {
   const { organizationId } = await getOrgContext();
 
-  const entries = await prisma.crewTimeEntry.findMany({
-    where: { organizationId, status: "SUBMITTED" },
-    include: {
-      crewMember: { select: { firstName: true, lastName: true } },
-      assignment: {
-        include: {
-          project: { select: { name: true, projectNumber: true } },
-          crewRole: { select: { name: true } },
-        },
-      },
-    },
-    orderBy: { date: "desc" },
-    take: 15,
-  });
+  const [timeEntries, memberList, roleMap, assignments, projects] = await Promise.all([
+    getTimeEntriesByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getAssignmentsByOrg(organizationId),
+    projectMap(organizationId),
+  ]);
+  const memberMap = new Map(memberList.map((m) => [m.id, m]));
+  const asgMap = new Map(assignments.map((a) => [a.id, a]));
+
+  const entries = timeEntries
+    .filter((t) => t.status === "SUBMITTED")
+    .sort((a, b) => cmpDateDesc(a.date, b.date))
+    .slice(0, 15)
+    .map((t) => {
+      const m = memberMap.get(t.crewMemberId);
+      const a = t.assignmentId ? asgMap.get(t.assignmentId) : undefined;
+      const proj = a ? projects.get(a.projectId) : undefined;
+      return {
+        ...t,
+        crewMember: m ? { firstName: m.firstName, lastName: m.lastName } : null,
+        assignment: a
+          ? {
+              project: proj ? { name: proj.name, projectNumber: proj.projectNumber } : null,
+              crewRole: a.crewRoleId ? { name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+            }
+          : null,
+      };
+    });
 
   return serialize(entries);
 }
@@ -116,46 +160,63 @@ export async function getActiveAssignmentsSummary() {
 
   const now = new Date();
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: {
-      organizationId,
-      status: { in: ["CONFIRMED", "ACCEPTED"] },
-      OR: [{ endDate: { gte: now } }, { endDate: null }],
-    },
-    include: {
-      crewMember: { select: { id: true, firstName: true, lastName: true } },
-      crewRole: { select: { name: true } },
-      project: {
-        select: { id: true, name: true, projectNumber: true, status: true },
-      },
-    },
-    orderBy: { startDate: "asc" },
-    take: 20,
-  });
+  const [assignments, memberList, roleMap, projects] = await Promise.all([
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    projectMap(organizationId),
+  ]);
+  const memberMap = new Map(memberList.map((m) => [m.id, m]));
 
-  return serialize(assignments);
+  const result = assignments
+    .filter(
+      (a) =>
+        (a.status === "CONFIRMED" || a.status === "ACCEPTED") &&
+        (a.endDate === null || a.endDate.getTime() >= now.getTime()),
+    )
+    .sort((a, b) => cmpDateAsc(a.startDate, b.startDate))
+    .slice(0, 20)
+    .map((a) => {
+      const m = memberMap.get(a.crewMemberId);
+      const proj = projects.get(a.projectId);
+      return {
+        ...a,
+        crewMember: m ? { id: m.id, firstName: m.firstName, lastName: m.lastName } : null,
+        crewRole: a.crewRoleId ? { name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+        project: proj ? { id: proj.id, name: proj.name, projectNumber: proj.projectNumber, status: proj.status } : null,
+      };
+    });
+
+  return serialize(result);
 }
 
 export async function getPendingOffers() {
   const { organizationId } = await getOrgContext();
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: {
-      organizationId,
-      status: { in: ["PENDING", "OFFERED"] },
-    },
-    include: {
-      crewMember: { select: { id: true, firstName: true, lastName: true, email: true } },
-      crewRole: { select: { name: true } },
-      project: {
-        select: { id: true, name: true, projectNumber: true },
-      },
-    },
-    orderBy: { createdAt: "desc" },
-    take: 15,
-  });
+  const [assignments, memberList, roleMap, projects] = await Promise.all([
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    projectMap(organizationId),
+  ]);
+  const memberMap = new Map(memberList.map((m) => [m.id, m]));
 
-  return serialize(assignments);
+  const result = assignments
+    .filter((a) => a.status === "PENDING" || a.status === "OFFERED")
+    .sort((a, b) => cmpDateDesc(a.createdAt, b.createdAt))
+    .slice(0, 15)
+    .map((a) => {
+      const m = memberMap.get(a.crewMemberId);
+      const proj = projects.get(a.projectId);
+      return {
+        ...a,
+        crewMember: m ? { id: m.id, firstName: m.firstName, lastName: m.lastName, email: m.email ?? null } : null,
+        crewRole: a.crewRoleId ? { name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+        project: proj ? { id: proj.id, name: proj.name, projectNumber: proj.projectNumber } : null,
+      };
+    });
+
+  return serialize(result);
 }
 
 export async function getUpcomingShifts() {
@@ -164,24 +225,36 @@ export async function getUpcomingShifts() {
   const now = new Date();
   now.setHours(0, 0, 0, 0);
 
-  const shifts = await prisma.crewShift.findMany({
-    where: {
-      status: "SCHEDULED",
-      date: { gte: now },
-      assignment: { organizationId },
-    },
-    include: {
-      assignment: {
-        include: {
-          crewMember: { select: { firstName: true, lastName: true } },
-          crewRole: { select: { name: true } },
-          project: { select: { name: true, projectNumber: true } },
-        },
-      },
-    },
-    orderBy: { date: "asc" },
-    take: 10,
-  });
+  const [shifts, assignments, memberList, roleMap, projects] = await Promise.all([
+    getShiftsByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    projectMap(organizationId),
+  ]);
+  const memberMap = new Map(memberList.map((m) => [m.id, m]));
+  const asgMap = new Map(assignments.map((a) => [a.id, a]));
 
-  return serialize(shifts);
+  const result = shifts
+    .filter((s) => s.status === "SCHEDULED" && s.date.getTime() >= now.getTime())
+    .sort((a, b) => cmpDateAsc(a.date, b.date))
+    .slice(0, 10)
+    .map((s) => {
+      const a = asgMap.get(s.assignmentId);
+      const m = a ? memberMap.get(a.crewMemberId) : undefined;
+      const proj = a ? projects.get(a.projectId) : undefined;
+      return {
+        ...s,
+        assignment: a
+          ? {
+              id: a.id,
+              crewMember: m ? { firstName: m.firstName, lastName: m.lastName } : null,
+              crewRole: a.crewRoleId ? { name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+              project: proj ? { name: proj.name, projectNumber: proj.projectNumber } : null,
+            }
+          : null,
+      };
+    });
+
+  return serialize(result);
 }


### PR DESCRIPTION
## What

Second **Phase A** leaf surface of the [domain-only Convex decommission](../blob/main/docs/designs/convex-domain-only-decommission.md). The 6 read-only crew dashboard widgets in `src/server/crew-dashboard.ts` (picker list, stat counts, pending timesheets, active assignments, pending offers, upcoming shifts) now read **Convex** instead of Prisma.

> Independent of PR #194 (test-tag reports) — both branch off `main` and touch the same migration docs, so expect a trivial docs merge if #194 lands first.

## Changes

- **`src/lib/crew-scheduling-read.ts`** — fetchers + mappers for the project-coupled scheduling sub-tables (`crewAssignment` / `crewTimeEntry` / `crewShift` / `crewCertification`): epoch-ms → `Date`, absent → `null`, Decimal → `number`.
- Crew members/roles via `crew-read.ts`, projects via `projects-read.ts`. Old Prisma `where`/`orderBy`/`include` → JS filter/sort/attach, with Postgres null-ordering replicated (ASC = NULLS LAST, DESC = NULLS FIRST). The stat counts + `_sum(totalHours)` aggregate are computed in JS over the org-scoped lists. **No Prisma fallback** — a map miss is `null`.
- **`crew_shift` / `crew_certification` have no org column** (parent-scoped), so added `crewShifts.listByOrg` / `crewCertifications.listByOrg` Convex queries that join via `crewAssignments` / `crewMembers`.
- The server actions keep their existing shape (still called via `useServerQuery`) — **no client changes**.
- **`scripts/seed-crew-dev.ts`** + `npm run seed:crew` — idempotent crew dev seed.

## Validation

- `tsc` clean · `npm test` 2285 passing (incl. new `crew-scheduling-read.test.ts`) · `eslint` 0 · `npm run build` ✓
- **Golden-diff vs Prisma** on seeded dev data — stats + all 5 lists matched on the consumed fields (filter + sort + null-ordering + attach + the hours aggregate).

## Reviewer: validate on this preview

Log into **Gearflow Test** and open **Crew** (manager view). The stat cards, Pending Timesheets, Active Assignments, Pending Offers, and Upcoming Shifts should populate from the seeded crew data (4 members, assignments across statuses, time entries, shifts, certs). If empty, the shared dev data was clobbered — re-run `npm run seed:crew` + `convex:backfill:crew` + `:crew-scheduling`.

## ⚠️ Merge gate — prod backfill

Unlike #194 (whose tables were already backfilled in prod), the crew **scheduling** tables (assignment / shift / certification / time entry) are **not confirmed backfilled in prod Convex**. **Before merging, run `convex:backfill:crew-scheduling` (and `:crew`) against prod**, else the dashboard widgets read empty in production. Plus the standard human preview validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)