### PR TITLE
feat(convex): read-rewire project crew tab to Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2688,6 +2688,18 @@ auth stays Prisma). The write/status-transition actions (create/update/delete/
 submit/approve/dispute) stay Prisma-first + mirror (read-then-write). Same crew
 deploy gate as the dashboard.
 
+### Crew assignments (project crew tab) — DONE
+
+`src/server/crew-assignments.ts`: `getProjectCrew` (the project Crew tab — full
+assignment rows + crewMember/crewRole/service/shifts/confirmedBy) and
+`getProjectLabourCost` (sum estimatedCost + count) → Convex. `CrewAssignmentRow`
++ `CrewShiftRow` extended to full rows; added `getAssignmentsByProject` +
+`getProjectServiceMap`. `confirmedBy` (User) via `users-read`. **`phase: "asc"`
+replicates Postgres enum ordering** (declared order, not alphabetical) via a
+`PHASE_ORDER` rank map. `getCrewMembersForAssignment` (cross-project conflict +
+availability scan) is **deferred** — stays on Prisma until the availability
+surface converts. Writes stay Prisma-first + mirror. Same crew deploy gate.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/docs/designs/convex-domain-only-decommission.md
+++ b/docs/designs/convex-domain-only-decommission.md
@@ -163,6 +163,12 @@ integration test, not just plugin-level tests.
   member/project lists + CSV export) → Convex via `crew-scheduling-read.ts`
   (time-entry row extended to full) + new `src/lib/users-read.ts` for `approvedBy`.
   Same crew deploy gate. Writes stay Prisma-first + mirror.
+- **`crew-assignments.ts` — DONE (getProjectCrew + getProjectLabourCost).** Full
+  assignment rows + crewMember/crewRole/service/shifts/confirmedBy via
+  `crew-scheduling-read.ts` (+ `getAssignmentsByProject` / `getProjectServiceMap`).
+  `phase: "asc"` replicates Postgres enum (declared-order) sort. Deferred:
+  `getCrewMembersForAssignment` (cross-project conflict + availability) stays
+  Prisma. Same crew deploy gate.
 
 **Env note for validators.** The dev worktree *can* run live Convex reads/backfills
 against the shared dev deployment by overriding the service-token issuer to match

--- a/src/lib/crew-scheduling-read.test.ts
+++ b/src/lib/crew-scheduling-read.test.ts
@@ -15,6 +15,19 @@ describe("crew-scheduling-read mappers", () => {
     expect(m.phase).toBeNull();
     expect(m.isProjectManager).toBe(true);
     expect(m.status).toBe("CONFIRMED");
+    expect(m.estimatedCost).toBeNull();
+    expect(m.serviceId).toBeNull();
+    expect(m.confirmedAt).toBeNull();
+  });
+
+  it("mapAssignment keeps Decimal estimatedCost as number and confirmedAt as Date", () => {
+    const m = mapAssignment({
+      id: "a", organizationId: "o", projectId: "p", crewMemberId: "m", status: "CONFIRMED",
+      isProjectManager: false, estimatedCost: 1234.5, confirmedAt: 1_700_000_000_000, confirmedById: "u",
+    } as never);
+    expect(m.estimatedCost).toBe(1234.5);
+    expect(m.confirmedAt?.getTime()).toBe(1_700_000_000_000);
+    expect(m.confirmedById).toBe("u");
   });
 
   it("mapAssignment defaults isProjectManager to false when absent", () => {

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -33,12 +33,28 @@ export interface CrewAssignmentRow {
   projectId: string;
   crewMemberId: string;
   crewRoleId: string | null;
+  serviceId: string | null;
   status: string;
   phase: string | null;
   isProjectManager: boolean;
   startDate: Date | null;
+  startTime: string | null;
   endDate: Date | null;
+  endTime: string | null;
+  rateOverride: number | null;
+  rateType: string | null;
+  estimatedHours: number | null;
+  estimatedCost: number | null;
+  notes: string | null;
+  internalNotes: string | null;
+  responseToken: string | null;
+  offeredAt: Date | null;
+  respondedAt: Date | null;
+  responseNote: string | null;
+  confirmedAt: Date | null;
+  confirmedById: string | null;
   createdAt: Date | null;
+  updatedAt: Date | null;
 }
 
 export interface CrewTimeEntryRow {
@@ -66,6 +82,9 @@ export interface CrewShiftRow {
   date: Date;
   callTime: string | null;
   endTime: string | null;
+  breakMinutes: number | null;
+  location: string | null;
+  notes: string | null;
   status: string;
 }
 
@@ -82,12 +101,28 @@ export function mapAssignment(d: RawAssignment): CrewAssignmentRow {
     projectId: req(d.projectId),
     crewMemberId: req(d.crewMemberId),
     crewRoleId: orNull(d.crewRoleId),
+    serviceId: orNull(d.serviceId),
     status: req(d.status),
     phase: orNull(d.phase),
     isProjectManager: d.isProjectManager ?? false,
     startDate: toDate(d.startDate),
+    startTime: orNull(d.startTime),
     endDate: toDate(d.endDate),
+    endTime: orNull(d.endTime),
+    rateOverride: orNull(d.rateOverride),
+    rateType: orNull(d.rateType),
+    estimatedHours: orNull(d.estimatedHours),
+    estimatedCost: orNull(d.estimatedCost),
+    notes: orNull(d.notes),
+    internalNotes: orNull(d.internalNotes),
+    responseToken: orNull(d.responseToken),
+    offeredAt: toDate(d.offeredAt),
+    respondedAt: toDate(d.respondedAt),
+    responseNote: orNull(d.responseNote),
+    confirmedAt: toDate(d.confirmedAt),
+    confirmedById: orNull(d.confirmedById),
     createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
   };
 }
 
@@ -119,6 +154,9 @@ export function mapShift(d: RawShift): CrewShiftRow {
     date: new Date(req(d.date)),
     callTime: orNull(d.callTime),
     endTime: orNull(d.endTime),
+    breakMinutes: orNull(d.breakMinutes),
+    location: orNull(d.location),
+    notes: orNull(d.notes),
     status: req(d.status),
   };
 }
@@ -147,4 +185,22 @@ export async function getShiftsByOrg(orgId: string): Promise<CrewShiftRow[]> {
 export async function getCertificationsByOrg(orgId: string): Promise<CrewCertificationRow[]> {
   const rows = (await (await getConvexClient()).query(api.crewCertifications.listByOrg, { orgId })) as RawCertification[];
   return rows.map(mapCertification);
+}
+
+export async function getAssignmentsByProject(projectId: string, orgId: string): Promise<CrewAssignmentRow[]> {
+  const rows = (await (await getConvexClient()).query(api.crewAssignments.listByProject, {
+    projectId,
+    orgId,
+  })) as RawAssignment[];
+  return rows.map(mapAssignment);
+}
+
+/** Project services keyed by cuid, reduced to `{ id, title, type }` for attach. */
+export async function getProjectServiceMap(orgId: string): Promise<Map<string, { id: string; title: string; type: string }>> {
+  const rows = (await (await getConvexClient()).query(api.projectServices.list, { orgId })) as Array<{
+    id: string;
+    title: string;
+    type: string;
+  }>;
+  return new Map(rows.map((s) => [s.id, { id: s.id, title: s.title, type: s.type }]));
 }

--- a/src/server/crew-assignments.ts
+++ b/src/server/crew-assignments.ts
@@ -3,6 +3,14 @@
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getProjectById } from "@/lib/projects-read";
+import { getCrewMembersByOrg, getCrewRolesByOrg } from "@/lib/crew-read";
+import { getUserMap } from "@/lib/users-read";
+import {
+  getAssignmentsByProject,
+  getProjectServiceMap,
+  getShiftsByOrg,
+  type CrewShiftRow,
+} from "@/lib/crew-scheduling-read";
 import { serialize } from "@/lib/serialize";
 import {
   crewAssignmentSchema,
@@ -66,6 +74,13 @@ function calculateEstimatedCost(
 
 // ─── Assignments ─────────────────────────────────────────────────────────────
 
+// ProjectPhase enum declaration order — Postgres sorts enum columns by declared
+// order, not alphabetically, so replicate the order for the `phase: "asc"` sort.
+const PHASE_ORDER: Record<string, number> = {
+  BUMP_IN: 0, EVENT: 1, BUMP_OUT: 2, DELIVERY: 3, PICKUP: 4, SETUP: 5, REHEARSAL: 6, FULL_DURATION: 7,
+};
+const phaseRank = (p: string | null) => (p == null ? Number.POSITIVE_INFINITY : PHASE_ORDER[p] ?? Number.POSITIVE_INFINITY);
+
 export async function getProjectCrew(projectId: string) {
   const { organizationId } = await getOrgContext();
 
@@ -73,33 +88,61 @@ export async function getProjectCrew(projectId: string) {
   const project = await getProjectById(projectId);
   if (!project || project.organizationId !== organizationId) throw new Error("Project not found");
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: { projectId, organizationId },
-    include: {
-      crewMember: {
-        select: {
-          id: true, firstName: true, lastName: true,
-          email: true, phone: true, image: true,
-          defaultDayRate: true, defaultHourlyRate: true,
-        },
-      },
-      crewRole: {
-        select: { id: true, name: true, color: true, defaultRate: true, rateType: true },
-      },
-      service: {
-        select: { id: true, title: true, type: true },
-      },
-      shifts: { orderBy: { date: "asc" } },
-      confirmedBy: { select: { id: true, name: true } },
-    },
-    orderBy: [
-      { isProjectManager: "desc" },
-      { phase: "asc" },
-      { crewMember: { lastName: "asc" } },
-    ],
+  // Project crew read moved off Prisma to Convex (Phase A). Assignments + shifts
+  // from Convex; members/roles from crew-read; service from projectServices;
+  // confirmedBy (User) from users-read (auth stays Prisma).
+  const [assignments, members, roles, serviceMap, shifts] = await Promise.all([
+    getAssignmentsByProject(projectId, organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRolesByOrg(organizationId),
+    getProjectServiceMap(organizationId),
+    getShiftsByOrg(organizationId),
+  ]);
+  const memberMap = new Map(members.map((m) => [m.id, m]));
+  const roleMap = new Map(roles.map((r) => [r.id, r]));
+  const userMap = await getUserMap(assignments.map((a) => a.confirmedById));
+
+  const shiftsByAssignment = new Map<string, CrewShiftRow[]>();
+  for (const s of shifts) {
+    const arr = shiftsByAssignment.get(s.assignmentId);
+    if (arr) arr.push(s);
+    else shiftsByAssignment.set(s.assignmentId, [s]);
+  }
+  for (const arr of shiftsByAssignment.values()) arr.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  const sorted = [...assignments].sort((a, b) => {
+    if (a.isProjectManager !== b.isProjectManager) return a.isProjectManager ? -1 : 1; // desc
+    const pr = phaseRank(a.phase) - phaseRank(b.phase); // phase asc (enum order, nulls last)
+    if (pr !== 0) return pr;
+    const al = memberMap.get(a.crewMemberId)?.lastName ?? "";
+    const bl = memberMap.get(b.crewMemberId)?.lastName ?? "";
+    return al.localeCompare(bl);
   });
 
-  return serialize(assignments);
+  const result = sorted
+    // crewMember is a required relation (Prisma inner-joined it); a missing member
+    // means mirror drift, not a real row — drop it (don't fabricate / crash).
+    .filter((a) => memberMap.has(a.crewMemberId))
+    .map((a) => {
+    const m = memberMap.get(a.crewMemberId)!;
+    const r = a.crewRoleId ? roleMap.get(a.crewRoleId) : undefined;
+    return {
+      ...a,
+      crewMember: {
+        id: m.id, firstName: m.firstName, lastName: m.lastName,
+        email: m.email ?? null, phone: m.phone ?? null, image: m.image ?? null,
+        defaultDayRate: m.defaultDayRate ?? null, defaultHourlyRate: m.defaultHourlyRate ?? null,
+      },
+      crewRole: r
+        ? { id: r.id, name: r.name, color: r.color ?? null, defaultRate: r.defaultRate ?? null, rateType: r.rateType ?? null }
+        : null,
+      service: a.serviceId ? serviceMap.get(a.serviceId) ?? null : null,
+      shifts: shiftsByAssignment.get(a.id) ?? [],
+      confirmedBy: a.confirmedById ? userMap.get(a.confirmedById) ?? null : null,
+    };
+  });
+
+  return serialize(result);
 }
 
 export async function createAssignment(projectId: string, data: CrewAssignmentFormValues) {
@@ -483,24 +526,26 @@ export async function deleteShift(shiftId: string) {
 export async function getProjectLabourCost(projectId: string) {
   const { organizationId } = await getOrgContext();
 
-  const result = await prisma.crewAssignment.aggregate({
-    where: {
-      projectId,
-      organizationId,
-      status: { notIn: ["CANCELLED", "DECLINED"] },
-    },
-    _sum: { estimatedCost: true },
-    _count: true,
-  });
+  // Labour cost read moved to Convex (Phase A): sum estimatedCost + count of
+  // non-cancelled/declined assignments, in JS over the Convex rows.
+  const assignments = await getAssignmentsByProject(projectId, organizationId);
+  const active = assignments.filter((a) => a.status !== "CANCELLED" && a.status !== "DECLINED");
+  const totalLabourCost = active.reduce((sum, a) => sum + (a.estimatedCost ?? 0), 0);
 
   return serialize({
-    totalLabourCost: result._sum.estimatedCost || 0,
-    assignmentCount: result._count,
+    totalLabourCost,
+    assignmentCount: active.length,
   });
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+/**
+ * DEFERRED (Phase A): this assignment-picker read stays on Prisma for now. It does
+ * a cross-project date-overlap conflict scan + crew-availability check that is
+ * more intricate than the leaf reads converted in this pass; convert it with the
+ * rest of the crew availability surface. The dual-write mirror keeps it fresh.
+ */
 export async function getCrewMembersForAssignment(
   projectId: string,
   search?: string,


### PR DESCRIPTION
## What

Crew-cluster continuation (Phase A). In `src/server/crew-assignments.ts`: **`getProjectCrew`** (the project Crew tab) and **`getProjectLabourCost`** now read **Convex**.

> **Stacked on #196** (base = `feat/convex-read-crew-time`). Chain: #195 → #196 → this. Merge in order after the crew prod backfill.

## Changes

- `crew-scheduling-read.ts`: `CrewAssignmentRow` + `CrewShiftRow` extended to the full Prisma scalar set; added `getAssignmentsByProject` + `getProjectServiceMap`.
- `getProjectCrew` attaches crewMember (incl. rate fields), crewRole (color/defaultRate/rateType), `service` (projectServices), `shifts` (grouped per assignment, date asc), and `confirmedBy` (User via `users-read`).
- **`phase: "asc"` replicates Postgres enum ordering** (declared order, not alphabetical) via a `PHASE_ORDER` rank map; then `isProjectManager` desc + `crewMember.lastName` asc. crewMember filtered to resolvable members so the required relation stays non-null (matches the old inner join).
- `getProjectLabourCost`: sum `estimatedCost` + count of non-cancelled/declined, in JS.
- **Deferred:** `getCrewMembersForAssignment` (cross-project date-overlap conflict + crew-availability scan) stays on Prisma — convert with the availability surface. Writes stay Prisma-first + mirror.

## Validation

- `tsc` clean · `npm test` 2286 passing · `eslint` 0 · `npm run build` ✓
- **Full-output golden-diff vs Prisma** on seeded data — `getProjectCrew` (all assignment scalars + every relation + the enum-order sort) and `getProjectLabourCost` matched exactly.

## Merge gate

Same crew **scheduling** prod-backfill gate as #195/#196, plus human preview validation (a project's **Crew** tab + labour-cost summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)