### PR TITLE
feat(convex): read-rewire stocktake reads to Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2635,6 +2635,26 @@ re-introduce a Prisma fallback: a *map miss* still yields `null` (mirror-freshne
 invariant preserved); only a *thrown* transient error is retried. Regression tests:
 `src/lib/convex-client.test.ts`, `src/lib/convex-auth-guards.test.ts`.
 
+## Phase A — read-rewiring: Stocktake reads (DONE)
+
+> Full Phase A plan + the keystone line-item-tree work:
+> [`docs/designs/convex-domain-only-decommission.md`](../docs/designs/convex-domain-only-decommission.md).
+
+`server/stocktake.ts` read functions (`getStocktakes` / `getStocktakeById` /
+`getStocktakeProgress` / `getRecentScans` / `searchStocktakeAssets`) now read the
+`stocktake` + `stocktakeItem` rows from Convex via
+[`src/lib/stocktake-read.ts`](../src/lib/stocktake-read.ts) instead of Prisma.
+`asset` / `bulkAsset` (+ each one's `model`) attach from the Convex mirrors;
+`location` from the location map; `startedBy` / `reviewedBy` are Better Auth Users
+and stay Prisma (batched `prisma.user.findMany` in the server action — auth
+terminus, not a violation). List filter/sort/paginate + the search OR (asset tag /
+serial / customName / model name; bulk tag / model name) run in JS; the `result`
+ordering replicates the Postgres enum DECLARED order (MATCH → MISSING → UNEXPECTED
+→ QUANTITY_MISMATCH → WRONG_LOCATION) via a rank map. The write paths
+(`markStocktakeItemFound`, bulk count, resolve) keep `attachStocktakeModels` over
+their freshly-written Prisma rows (read-then-write — Phase B). Golden-diffed at the
+lib level vs the old Prisma reads on a created stocktake + items.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/src/lib/stocktake-read.ts
+++ b/src/lib/stocktake-read.ts
@@ -1,0 +1,163 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  type ConvexAsset,
+  type ConvexBulkAsset,
+  getAssetsByOrg,
+  getBulkAssetsByOrg,
+} from "@/lib/assets-read";
+import { getModelMap, type ConvexModel } from "@/lib/models-read";
+
+/**
+ * Convex read layer for the Stocktake domain (Phase A read-rewiring). The
+ * `stocktake` + `stocktakeItem` rows are dual-written to Convex; this replaces the
+ * `prisma.stocktake.findMany/findUnique` reads behind the stocktake list / detail /
+ * progress / recent-scans / search server actions. `asset` / `bulkAsset` (+ their
+ * `model`) are attached from the Convex mirrors; `location` is attached by the
+ * caller from its location map; `startedBy` / `reviewedBy` are Better Auth Users
+ * and stay Prisma (attached by the caller — not a violation).
+ *
+ * Convex dates are epoch-ms → mapped to `Date`. No Prisma fallback on a miss.
+ */
+
+type StocktakeDoc = Doc<"stocktakes">;
+type StocktakeItemDoc = Doc<"stocktakeItems">;
+
+function msToDate(n: number | null | undefined): Date | null {
+  return n == null ? null : new Date(n);
+}
+
+export interface MappedStocktake {
+  id: string;
+  organizationId: string;
+  name: string;
+  locationId: string;
+  scope: string;
+  categoryId: string | null;
+  status: string;
+  startedAt: Date | null;
+  startedById: string | null;
+  completedAt: Date | null;
+  reviewedById: string | null;
+  expectedCount: number;
+  foundCount: number;
+  missingCount: number;
+  unexpectedCount: number;
+  discrepancyCount: number;
+  notes: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export function mapStocktake(d: StocktakeDoc): MappedStocktake {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    name: d.name,
+    locationId: d.locationId,
+    scope: d.scope,
+    categoryId: d.categoryId ?? null,
+    status: d.status ?? "DRAFT",
+    startedAt: msToDate(d.startedAt),
+    startedById: d.startedById ?? null,
+    completedAt: msToDate(d.completedAt),
+    reviewedById: d.reviewedById ?? null,
+    expectedCount: d.expectedCount ?? 0,
+    foundCount: d.foundCount ?? 0,
+    missingCount: d.missingCount ?? 0,
+    unexpectedCount: d.unexpectedCount ?? 0,
+    discrepancyCount: d.discrepancyCount ?? 0,
+    notes: d.notes ?? null,
+    createdAt: msToDate(d.createdAt),
+    updatedAt: msToDate(d.updatedAt),
+  };
+}
+
+export interface MappedStocktakeItem {
+  id: string;
+  stocktakeId: string;
+  assetId: string | null;
+  bulkAssetId: string | null;
+  expectedAtLocation: boolean;
+  expectedQuantity: number;
+  found: boolean;
+  foundQuantity: number;
+  scannedAt: Date | null;
+  scannedById: string | null;
+  result: string;
+  conditionNote: string | null;
+  actionTaken: string | null;
+}
+
+export function mapStocktakeItem(d: StocktakeItemDoc): MappedStocktakeItem {
+  return {
+    id: d.id,
+    stocktakeId: d.stocktakeId,
+    assetId: d.assetId ?? null,
+    bulkAssetId: d.bulkAssetId ?? null,
+    expectedAtLocation: d.expectedAtLocation ?? true,
+    expectedQuantity: d.expectedQuantity ?? 1,
+    found: d.found ?? false,
+    foundQuantity: d.foundQuantity ?? 0,
+    scannedAt: msToDate(d.scannedAt),
+    scannedById: d.scannedById ?? null,
+    result: d.result ?? "MATCH",
+    conditionNote: d.conditionNote ?? null,
+    actionTaken: d.actionTaken ?? null,
+  };
+}
+
+/** Fetch + map all stocktakes for an org (caller filters/sorts/paginates in JS). */
+export async function getStocktakesByOrg(orgId: string): Promise<MappedStocktake[]> {
+  const docs = await (await getConvexClient()).query(api.stocktakes.list, { orgId });
+  return docs.map(mapStocktake);
+}
+
+/** Fetch + map a single stocktake by cuid (org-checked by the caller). */
+export async function getStocktakeByIdConvex(id: string): Promise<MappedStocktake | null> {
+  const doc = await (await getConvexClient()).query(api.stocktakes.getById, { id });
+  return doc ? mapStocktake(doc) : null;
+}
+
+/** Fetch + map a stocktake's items by stocktakeId. */
+export async function getStocktakeItemsConvex(stocktakeId: string): Promise<MappedStocktakeItem[]> {
+  const docs = await (await getConvexClient()).query(api.stocktakeItems.list, { stocktakeId });
+  return docs.map(mapStocktakeItem);
+}
+
+/** An asset/bulk-asset doc with its `model` resolved (matches the old
+ *  `asset: { include: { model } }` shape the stocktake UI reads). */
+type AssetWithModel = (ConvexAsset | ConvexBulkAsset) & { model: ConvexModel | null };
+
+/** A stocktake item with `asset` / `bulkAsset` (+ each one's `model`) attached. */
+export type StocktakeItemWithAssets = MappedStocktakeItem & {
+  asset: AssetWithModel | null;
+  bulkAsset: AssetWithModel | null;
+};
+
+/**
+ * Attach `asset` / `bulkAsset` (+ nested `model`) from the Convex mirrors onto a
+ * batch of stocktake items. One round-trip per org. A miss yields `null` (no
+ * Prisma fallback). Replaces the Prisma `asset`/`bulkAsset` joins + the old
+ * `attachStocktakeModels` model graft.
+ */
+export async function attachStocktakeItemAssets(
+  orgId: string,
+  items: MappedStocktakeItem[],
+): Promise<StocktakeItemWithAssets[]> {
+  const [assetArr, bulkArr, modelMap] = await Promise.all([
+    getAssetsByOrg(orgId),
+    getBulkAssetsByOrg(orgId),
+    getModelMap(orgId),
+  ]);
+  const assetMap = new Map(assetArr.map((a) => [a.id, a]));
+  const bulkAssetMap = new Map(bulkArr.map((b) => [b.id, b]));
+  const withModel = (a: ConvexAsset | ConvexBulkAsset | undefined): AssetWithModel | null =>
+    a ? { ...a, model: a.modelId ? modelMap.get(a.modelId) ?? null : null } : null;
+  return items.map((it) => ({
+    ...it,
+    asset: it.assetId ? withModel(assetMap.get(it.assetId)) : null,
+    bulkAsset: it.bulkAssetId ? withModel(bulkAssetMap.get(it.bulkAssetId)) : null,
+  }));
+}

--- a/src/server/stocktake.ts
+++ b/src/server/stocktake.ts
@@ -10,6 +10,13 @@ import { getModelMap, type ConvexModel } from "@/lib/models-read";
 import { getLocationMap, getLocationById } from "@/lib/locations-read";
 import { getAssetsByOrg, getBulkAssetsByOrg, getAssetByAssetTag, getBulkAssetByAssetTag } from "@/lib/assets-read";
 import {
+  getStocktakesByOrg,
+  getStocktakeByIdConvex,
+  getStocktakeItemsConvex,
+  attachStocktakeItemAssets,
+  type MappedStocktake,
+} from "@/lib/stocktake-read";
+import {
   createStocktakeSchema,
   type CreateStocktakeValues,
   updateStocktakeSchema,
@@ -52,6 +59,40 @@ async function attachStocktakeModels<T extends { asset?: unknown; bulkAsset?: un
 // (or a lib module) invoked from an already-authenticated server action that
 // derives organizationId from the session, never from caller input.
 
+/** Batch-load Better Auth Users by id. `startedBy` / `reviewedBy` are auth rows
+ *  and stay Prisma (not a domain-read violation). */
+async function getStocktakeUserMap(ids: Array<string | null | undefined>) {
+  const unique = [...new Set(ids.filter((x): x is string => !!x))];
+  if (unique.length === 0) return new Map<string, Awaited<ReturnType<typeof prisma.user.findFirst>>>();
+  const users = await prisma.user.findMany({ where: { id: { in: unique } } });
+  return new Map(users.map((u) => [u.id, u]));
+}
+
+/** Comparator for a mapped-stocktake sort field — Date/number/string aware,
+ *  nulls last (mirrors Postgres `ORDER BY ... ASC NULLS LAST`). */
+function compareStocktake(field: string, dir: "asc" | "desc") {
+  const sign = dir === "asc" ? 1 : -1;
+  return (ra: MappedStocktake, rb: MappedStocktake) => {
+    const av = (ra as unknown as Record<string, unknown>)[field];
+    const bv = (rb as unknown as Record<string, unknown>)[field];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av instanceof Date && bv instanceof Date) return (av.getTime() - bv.getTime()) * sign;
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * sign;
+    return String(av).localeCompare(String(bv)) * sign;
+  };
+}
+
+// StocktakeItemResult sorts by Postgres DECLARED order (not alphabetical).
+const STOCKTAKE_RESULT_RANK: Record<string, number> = {
+  MATCH: 0,
+  MISSING: 1,
+  UNEXPECTED: 2,
+  QUANTITY_MISMATCH: 3,
+  WRONG_LOCATION: 4,
+};
+
 export async function getStocktakes(params?: {
   page?: number;
   pageSize?: number;
@@ -66,35 +107,28 @@ export async function getStocktakes(params?: {
   const pageSize = params?.pageSize ?? 25;
   const skip = (page - 1) * pageSize;
 
-  const where: Record<string, unknown> = { organizationId };
-  if (params?.status) where.status = params.status;
+  // stocktake rows come from Convex; filter / sort / paginate in JS.
+  let items = await getStocktakesByOrg(organizationId);
+  if (params?.status) items = items.filter((s) => s.status === params.status);
   if (params?.search) {
-    where.name = { contains: params.search, mode: "insensitive" };
+    const q = params.search.toLowerCase();
+    items = items.filter((s) => s.name.toLowerCase().includes(q));
   }
+  const sortField = params?.sortField ?? "createdAt";
+  const sortDir = params?.sortField ? params.sortDirection ?? "desc" : "desc";
+  items = [...items].sort(compareStocktake(sortField, sortDir));
 
-  const orderBy: Record<string, string> = {};
-  if (params?.sortField) {
-    orderBy[params.sortField] = params.sortDirection ?? "desc";
-  } else {
-    orderBy.createdAt = "desc";
-  }
+  const total = items.length;
+  const pageItems = items.slice(skip, skip + pageSize);
 
-  const [items, total] = await Promise.all([
-    prisma.stocktake.findMany({
-      where,
-      // location lives in Convex — attached below, not joined.
-      include: { startedBy: true },
-      orderBy,
-      skip,
-      take: pageSize,
-    }),
-    prisma.stocktake.count({ where }),
+  const [locationMap, userMap] = await Promise.all([
+    getLocationMap(organizationId),
+    getStocktakeUserMap(pageItems.map((s) => s.startedById)),
   ]);
-
-  const locationMap = await getLocationMap(organizationId);
-  const withLocation = items.map((s) => ({
+  const withLocation = pageItems.map((s) => ({
     ...s,
     location: s.locationId ? locationMap.get(s.locationId) ?? null : null,
+    startedBy: s.startedById ? userMap.get(s.startedById) ?? null : null,
   }));
 
   return serialize({ items: withLocation, total, page, pageSize });
@@ -103,49 +137,39 @@ export async function getStocktakes(params?: {
 export async function getStocktakeById(id: string) {
   const { organizationId } = await requirePermission("stocktake", "read");
 
-  const stocktake = await prisma.stocktake.findUnique({
-    where: { id, organizationId },
-    include: {
-      // location + items[].asset.model + items[].bulkAsset.model live in Convex.
-      startedBy: true,
-      reviewedBy: true,
-      items: {
-        include: {
-          asset: true,
-          bulkAsset: true,
-        },
-        orderBy: { result: "asc" },
-      },
-    },
-  });
+  // stocktake + items come from Convex; asset/bulkAsset (+ model) attached from
+  // the mirrors; location + startedBy/reviewedBy attached below.
+  const stocktake = await getStocktakeByIdConvex(id);
+  if (!stocktake || stocktake.organizationId !== organizationId) throw new Error("Stocktake not found");
 
-  if (!stocktake) throw new Error("Stocktake not found");
-  const locationMap = await getLocationMap(organizationId);
+  const rawItems = await getStocktakeItemsConvex(id);
+  const items = (await attachStocktakeItemAssets(organizationId, rawItems)).sort(
+    (a, b) => (STOCKTAKE_RESULT_RANK[a.result] ?? 99) - (STOCKTAKE_RESULT_RANK[b.result] ?? 99),
+  );
+
+  const [locationMap, userMap] = await Promise.all([
+    getLocationMap(organizationId),
+    getStocktakeUserMap([stocktake.startedById, stocktake.reviewedById]),
+  ]);
   return serialize({
     ...stocktake,
     location: stocktake.locationId ? locationMap.get(stocktake.locationId) ?? null : null,
-    items: await attachStocktakeModels(organizationId, stocktake.items),
+    startedBy: stocktake.startedById ? userMap.get(stocktake.startedById) ?? null : null,
+    reviewedBy: stocktake.reviewedById ? userMap.get(stocktake.reviewedById) ?? null : null,
+    items,
   });
 }
 
 export async function getStocktakeProgress(id: string) {
   const { organizationId } = await requirePermission("stocktake", "read");
 
-  const stocktake = await prisma.stocktake.findUnique({
-    where: { id, organizationId },
-    select: {
-      id: true,
-      status: true,
-      expectedCount: true,
-      _count: { select: { items: { where: { found: true } } } },
-    },
-  });
-
-  if (!stocktake) throw new Error("Stocktake not found");
+  const stocktake = await getStocktakeByIdConvex(id);
+  if (!stocktake || stocktake.organizationId !== organizationId) throw new Error("Stocktake not found");
+  const items = await getStocktakeItemsConvex(id);
 
   return serialize({
     expectedCount: stocktake.expectedCount,
-    foundCount: stocktake._count.items,
+    foundCount: items.filter((i) => i.found).length,
     status: stocktake.status,
   });
 }
@@ -973,27 +997,15 @@ export async function cancelStocktake(id: string) {
 export async function getRecentScans(stocktakeId: string, limit = 10) {
   const { organizationId } = await requirePermission("stocktake", "read");
 
-  const stocktake = await prisma.stocktake.findUnique({
-    where: { id: stocktakeId, organizationId },
-    select: { id: true },
-  });
-  if (!stocktake) throw new Error("Stocktake not found");
+  const stocktake = await getStocktakeByIdConvex(stocktakeId);
+  if (!stocktake || stocktake.organizationId !== organizationId) throw new Error("Stocktake not found");
 
-  const items = await prisma.stocktakeItem.findMany({
-    where: {
-      stocktakeId,
-      found: true,
-      scannedAt: { not: null },
-    },
-    include: {
-      asset: true,
-      bulkAsset: true,
-    },
-    orderBy: { scannedAt: "desc" },
-    take: limit,
-  });
+  const found = (await getStocktakeItemsConvex(stocktakeId))
+    .filter((i) => i.found && i.scannedAt != null)
+    .sort((a, b) => (b.scannedAt?.getTime() ?? 0) - (a.scannedAt?.getTime() ?? 0))
+    .slice(0, limit);
 
-  return serialize(await attachStocktakeModels(organizationId, items));
+  return serialize(await attachStocktakeItemAssets(organizationId, found));
 }
 
 export async function searchStocktakeAssets(
@@ -1002,56 +1014,30 @@ export async function searchStocktakeAssets(
 ) {
   const { organizationId } = await requirePermission("stocktake", "read");
 
-  const stocktake = await prisma.stocktake.findUnique({
-    where: { id: stocktakeId, organizationId },
-    select: { id: true },
-  });
-  if (!stocktake) throw new Error("Stocktake not found");
+  const stocktake = await getStocktakeByIdConvex(stocktakeId);
+  if (!stocktake || stocktake.organizationId !== organizationId) throw new Error("Stocktake not found");
 
   const search = query.trim();
   if (!search) return serialize([]);
+  const q = search.toLowerCase();
 
-  // Search stocktake items where asset tag or model name matches
-  const items = await prisma.stocktakeItem.findMany({
-    where: {
-      stocktakeId,
-      OR: [
-        { asset: { assetTag: { contains: search, mode: "insensitive" } } },
-        {
-          asset: {
-            model: { name: { contains: search, mode: "insensitive" } },
-          },
-        },
-        {
-          asset: {
-            serialNumber: { contains: search, mode: "insensitive" },
-          },
-        },
-        {
-          asset: {
-            customName: { contains: search, mode: "insensitive" },
-          },
-        },
-        {
-          bulkAsset: {
-            assetTag: { contains: search, mode: "insensitive" },
-          },
-        },
-        {
-          bulkAsset: {
-            model: { name: { contains: search, mode: "insensitive" } },
-          },
-        },
-      ],
-    },
-    include: {
-      asset: true,
-      bulkAsset: true,
-    },
-    take: 30,
-  });
+  // Attach asset/bulkAsset (+ model) from Convex, then filter in JS — replicating
+  // the old relational OR (asset tag / serial / customName / model name, bulk tag /
+  // model name), case-insensitive.
+  const all = await attachStocktakeItemAssets(organizationId, await getStocktakeItemsConvex(stocktakeId));
+  const has = (v: string | null | undefined) => !!v && v.toLowerCase().includes(q);
+  const items = all
+    .filter((it) =>
+      has(it.asset?.assetTag) ||
+      has(it.asset?.model?.name) ||
+      has((it.asset as { serialNumber?: string | null } | null)?.serialNumber) ||
+      has((it.asset as { customName?: string | null } | null)?.customName) ||
+      has(it.bulkAsset?.assetTag) ||
+      has(it.bulkAsset?.model?.name),
+    )
+    .slice(0, 30);
 
-  return serialize(await attachStocktakeModels(organizationId, items));
+  return serialize(items);
 }
 
 export async function markStocktakeItemFound(itemId: string) {


### PR DESCRIPTION
Phase A read-rewiring — **independent surface (off main)**. Moves the stocktake
read functions off Prisma onto the dual-written Convex `stocktake` + `stocktakeItem`
tables.

## What changed
- **`src/lib/stocktake-read.ts`** (new) — mappers (epoch-ms→Date, absent→null) +
  Convex fetchers (`getStocktakesByOrg`, `getStocktakeByIdConvex`,
  `getStocktakeItemsConvex`) + `attachStocktakeItemAssets` (asset/bulkAsset + model).
- **`server/stocktake.ts`** — `getStocktakes` / `getStocktakeById` /
  `getStocktakeProgress` / `getRecentScans` / `searchStocktakeAssets` now read from
  Convex. List filter/sort/paginate + the search OR run in JS; `result` ordering
  uses the Postgres enum declared-order rank map. `startedBy`/`reviewedBy` Users
  via a batched `prisma.user` lookup (auth terminus — not a violation). Write-path
  `attachStocktakeModels` (read-then-write) unchanged.

## Validation
- Lib-level golden-diff vs the old Prisma reads on a created stocktake + items
  (asset + bulk, mixed results, found/scanned): detail / list / progress /
  recent-scans all match.
- `tsc` clean · full vitest 2280 green · eslint clean · `npm run build` green.

## Notes
- Deploy gate satisfied: `stocktake` is in the central-graph backfill, run in prod.
- Design-doc Phase A progress is consolidated on the keystone PR chain (#199–#203)
  + the final-sweep PR to avoid 3-way doc merge conflicts; this PR updates
  FEATUREDOCS/54.
- Independent of the keystone chain — mergeable in any order relative to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)