### PR TITLE
feat(convex): read-rewire document-templates reads to Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -440,6 +440,42 @@ this is **infra-only**.
 - Backfill `pnpm convex:backfill:templates` (0/0). Verified: tsc clean, 2185 tests,
   0 new lint errors, `pnpm build` exit 0.
 
+#### Phase A read-rewire — `server/document-templates.ts` (DONE, surface shrank to 3)
+
+**Surface shrank after the PDF template-builder removal (#227).** That feature
+removal gutted `server/document-templates.ts` from 826 → **147 lines**, deleting the
+entire write surface (the "all 15 write paths" inventory above is now historical —
+`create`/`duplicate*`/`import`/`save*`/section+block tx saves/`setDefaultTemplate`/
+`delete` are gone, along with `getTemplateForEditor` and `exportTemplate`). Only **3
+read functions survive**: `getDocumentTemplates`, `getPublishedTemplatesForDropdown`,
+`getDocumentTemplate`. Document templates are therefore now **read-only from the app's
+perspective** — but still **dual-written infra** (mirror helpers in
+`src/lib/template-mirror.ts`, the brand-delete unlink in `brand-templates.ts`, the
+Convex modules `documentTemplates`/`brandTemplates`, and the re-runnable backfill heal
+path `scripts/convex-backfill-templates.ts` all remain). Gate satisfied → safe to read
+from Convex.
+
+- New read-lib `src/lib/document-template-read.ts` (+ unit tests
+  `document-template-read.test.ts`): `mapDocumentTemplate`/`mapBrandTemplate`
+  (epoch-ms→Date, absent→null, Prisma-defaults coerced `isDefault/isDraft ?? false`,
+  `version ?? 1`, non-null Prisma columns→non-null Date, strip `_id`/`_creationTime`),
+  two pure sort comparators (`type` is a plain String column → lexicographic, NOT enum
+  rank), and four fetchers over `api.documentTemplates.list/getById` +
+  `api.brandTemplates.list/getById` (no new Convex queries needed).
+- `getDocumentTemplates` → `documentTemplates.list` + `brandTemplates.list` for the
+  `{id,name}` FK join + pure `[type ASC, isDefault DESC, updatedAt DESC]` sort; the
+  virtual `system-` synthesis is untouched and runs over the mapped rows.
+  `getPublishedTemplatesForDropdown` → same list, JS `isDraft===false` filter + `[type,
+  isDefault DESC, name ASC]` sort. `getDocumentTemplate` → `system-` branch unchanged;
+  real-read branch is `documentTemplates.getById` + JS org re-check (same "Template not
+  found" throw) + `brandTemplates.getById` for the full `brandTemplate` FK. No Prisma
+  fallback on a miss.
+- **Deploy gate:** templates backfill must have run against prod Convex before this
+  deploys, else existing rows read empty (re-runnable: `pnpm convex:backfill:templates`).
+- PR `feat/convex-read-document-templates` (reworked onto new main, force-pushed over
+  the stale #207 whose diff was mostly against now-deleted code). Verified: tsc clean,
+  `vitest run document-template-read.test.ts` green, eslint clean, `pnpm build` exit 0.
+
 ### Central graph — analysis & recommended sequencing (NOT yet migrated)
 
 The remaining domains (`asset`, `bulk_asset`, `kit`, `project`, `project_line_item`,

--- a/src/lib/document-template-read.test.ts
+++ b/src/lib/document-template-read.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Unit tests for the document-template Convex read helpers
+ * (Phase A read-rewiring of the Convex domain-only decommission).
+ *
+ * Covers the correctness guards for the 3 converted reads in
+ * src/server/document-templates.ts: the mappers (epoch-ms → Date, absent → null,
+ * Prisma-defaulted coercion), the 3 pure sort comparators, the isDraft filter, and
+ * — the gnarly part — the virtual system-default `isDefault` override composition
+ * fed by mapped rows.
+ */
+import { describe, it, expect } from "vitest";
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  mapDocumentTemplate,
+  mapBrandTemplate,
+  compareDocumentTemplatesForList,
+  compareDocumentTemplatesForDropdown,
+  type DocumentTemplateRow,
+} from "@/lib/document-template-read";
+import { DOCUMENT_TYPES, DOCUMENT_TYPE_LABELS } from "@/lib/validations/document-template";
+
+// ─── mapDocumentTemplate ──────────────────────────────────────────────────────
+
+describe("mapDocumentTemplate", () => {
+  it("converts a full row: epoch-ms → Date, all optionals present", () => {
+    const raw = {
+      _id: "convex-internal-id",
+      _creationTime: 123,
+      id: "dt1",
+      organizationId: "org1",
+      name: "Quote A",
+      type: "quote",
+      basePdf: "{base}",
+      schemas: "[schema]",
+      settings: "{settings}",
+      sections: "[sections]",
+      brandTemplateId: "bt1",
+      thumbnailData: "data:image/png;base64,xxx",
+      isDefault: true,
+      isDraft: false,
+      version: 4,
+      thumbnailUrl: "https://x/thumb.png",
+      publishedAt: 1_700_000_000_000,
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_650_000_000_000,
+    } as unknown as Doc<"documentTemplates">;
+
+    const row = mapDocumentTemplate(raw);
+
+    expect(row).toEqual({
+      id: "dt1",
+      organizationId: "org1",
+      name: "Quote A",
+      type: "quote",
+      basePdf: "{base}",
+      schemas: "[schema]",
+      settings: "{settings}",
+      sections: "[sections]",
+      brandTemplateId: "bt1",
+      thumbnailData: "data:image/png;base64,xxx",
+      isDefault: true,
+      isDraft: false,
+      version: 4,
+      thumbnailUrl: "https://x/thumb.png",
+      publishedAt: new Date(1_700_000_000_000),
+      createdAt: new Date(1_600_000_000_000),
+      updatedAt: new Date(1_650_000_000_000),
+    });
+    // _id / _creationTime stripped
+    expect("_id" in row).toBe(false);
+    expect("_creationTime" in row).toBe(false);
+  });
+
+  it("coerces Prisma-defaulted columns and nulls absent optionals", () => {
+    const raw = {
+      _id: "x",
+      _creationTime: 1,
+      id: "dt2",
+      organizationId: "org1",
+      name: "Bare",
+      type: "invoice",
+      // isDefault / isDraft / version absent → defaults
+      // all string optionals absent → null
+      // publishedAt absent → null
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_600_000_000_000,
+    } as unknown as Doc<"documentTemplates">;
+
+    const row = mapDocumentTemplate(raw);
+
+    expect(row.isDefault).toBe(false);
+    expect(row.isDraft).toBe(false);
+    expect(row.version).toBe(1);
+    expect(row.basePdf).toBeNull();
+    expect(row.schemas).toBeNull();
+    expect(row.settings).toBeNull();
+    expect(row.sections).toBeNull();
+    expect(row.brandTemplateId).toBeNull();
+    expect(row.thumbnailData).toBeNull();
+    expect(row.thumbnailUrl).toBeNull();
+    expect(row.publishedAt).toBeNull();
+    expect(row.createdAt).toEqual(new Date(1_600_000_000_000));
+    expect(row.updatedAt).toEqual(new Date(1_600_000_000_000));
+  });
+});
+
+// ─── mapBrandTemplate ─────────────────────────────────────────────────────────
+
+describe("mapBrandTemplate", () => {
+  it("converts a full row with accentColor present", () => {
+    const raw = {
+      _id: "x",
+      _creationTime: 1,
+      id: "bt1",
+      organizationId: "org1",
+      name: "Brand A",
+      headerSettings: "{header}",
+      footerSettings: "{footer}",
+      accentColor: "#ff0000",
+      isDefault: true,
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_650_000_000_000,
+    } as unknown as Doc<"brandTemplates">;
+
+    expect(mapBrandTemplate(raw)).toEqual({
+      id: "bt1",
+      organizationId: "org1",
+      name: "Brand A",
+      headerSettings: "{header}",
+      footerSettings: "{footer}",
+      accentColor: "#ff0000",
+      isDefault: true,
+      createdAt: new Date(1_600_000_000_000),
+      updatedAt: new Date(1_650_000_000_000),
+    });
+  });
+
+  it("nulls absent accentColor and defaults isDefault", () => {
+    const raw = {
+      _id: "x",
+      _creationTime: 1,
+      id: "bt2",
+      organizationId: "org1",
+      name: "Brand B",
+      headerSettings: "{}",
+      footerSettings: "{}",
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_600_000_000_000,
+    } as unknown as Doc<"brandTemplates">;
+
+    const row = mapBrandTemplate(raw);
+    expect(row.accentColor).toBeNull();
+    expect(row.isDefault).toBe(false);
+  });
+});
+
+// ─── helpers for comparator/composition tests ─────────────────────────────────
+
+function row(over: Partial<DocumentTemplateRow>): DocumentTemplateRow {
+  return {
+    id: "id",
+    organizationId: "org1",
+    name: "name",
+    type: "quote",
+    basePdf: null,
+    schemas: null,
+    settings: null,
+    sections: null,
+    brandTemplateId: null,
+    thumbnailData: null,
+    isDefault: false,
+    isDraft: false,
+    version: 1,
+    thumbnailUrl: null,
+    publishedAt: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...over,
+  };
+}
+
+// ─── compareDocumentTemplatesForList ──────────────────────────────────────────
+
+describe("compareDocumentTemplatesForList", () => {
+  it("sorts by type asc (lexicographic), then isDefault desc, then updatedAt desc", () => {
+    const a = row({ id: "a", type: "invoice", isDefault: false, updatedAt: new Date(10) });
+    const b = row({ id: "b", type: "quote", isDefault: false, updatedAt: new Date(100) });
+    const c = row({ id: "c", type: "invoice", isDefault: true, updatedAt: new Date(1) });
+    const d = row({ id: "d", type: "invoice", isDefault: false, updatedAt: new Date(50) });
+
+    const sorted = [a, b, c, d].sort(compareDocumentTemplatesForList).map((r) => r.id);
+    // invoice (< quote) first: within invoice, default first, then updatedAt desc
+    expect(sorted).toEqual(["c", "d", "a", "b"]);
+  });
+
+  it("uses plain string compare for type (not enum rank)", () => {
+    // lexicographic: "call-sheet" < "delivery-docket" < "quote"
+    const a = row({ id: "a", type: "quote" });
+    const b = row({ id: "b", type: "call-sheet" });
+    const c = row({ id: "c", type: "delivery-docket" });
+    expect([a, b, c].sort(compareDocumentTemplatesForList).map((r) => r.type)).toEqual([
+      "call-sheet",
+      "delivery-docket",
+      "quote",
+    ]);
+  });
+});
+
+// ─── compareDocumentTemplatesForDropdown ──────────────────────────────────────
+
+describe("compareDocumentTemplatesForDropdown", () => {
+  it("sorts by type asc, then isDefault desc, then name asc", () => {
+    const a = { type: "quote", isDefault: false, name: "Bravo" };
+    const b = { type: "quote", isDefault: false, name: "Alpha" };
+    const c = { type: "quote", isDefault: true, name: "Zeta" };
+    const d = { type: "invoice", isDefault: false, name: "Mike" };
+
+    const sorted = [a, b, c, d]
+      .sort(compareDocumentTemplatesForDropdown)
+      .map((r) => `${r.type}/${r.isDefault}/${r.name}`);
+    expect(sorted).toEqual([
+      "invoice/false/Mike",
+      "quote/true/Zeta",
+      "quote/false/Alpha",
+      "quote/false/Bravo",
+    ]);
+  });
+});
+
+// ─── isDraft filter (getPublishedTemplatesForDropdown) ────────────────────────
+
+describe("getPublishedTemplatesForDropdown filter", () => {
+  it("keeps only isDraft === false rows", () => {
+    const rows = [
+      row({ id: "published", isDraft: false }),
+      row({ id: "draft", isDraft: true }),
+    ];
+    const published = rows.filter((t) => t.isDraft === false).map((r) => r.id);
+    expect(published).toEqual(["published"]);
+  });
+});
+
+// ─── virtual system-default composition over mapped rows ──────────────────────
+//
+// Replicates the synthesis logic in getDocumentTemplates byte-for-byte, fed by
+// mapped rows — the load-bearing, gnarly part. A system default for a type is
+// active (isDefault: true) iff NO custom template of that type is marked default.
+
+function composeSystemDefaults(templates: DocumentTemplateRow[], organizationId: string) {
+  const systemDefaults = DOCUMENT_TYPES.map((type) => ({
+    id: `system-${type}`,
+    organizationId,
+    name: `${DOCUMENT_TYPE_LABELS[type]} — System Default`,
+    type,
+    isDefault: false,
+    isSystemDefault: true,
+  }));
+
+  const customByType = new Map<string, DocumentTemplateRow[]>();
+  for (const t of templates) {
+    if (!customByType.has(t.type)) customByType.set(t.type, []);
+    customByType.get(t.type)!.push(t);
+  }
+
+  return systemDefaults.map((sd) => {
+    const customs = customByType.get(sd.type) || [];
+    const hasCustomDefault = customs.some((c) => c.isDefault);
+    return { ...sd, isDefault: !hasCustomDefault };
+  });
+}
+
+describe("virtual system-default isDefault override (over mapped rows)", () => {
+  it("system default is active when no custom of that type is default", () => {
+    const mapped = [
+      mapDocumentTemplate({
+        _id: "x",
+        _creationTime: 1,
+        id: "dt-quote",
+        organizationId: "org1",
+        name: "Quote custom",
+        type: "quote",
+        isDefault: false, // not default → system default stays active
+        createdAt: 1,
+        updatedAt: 1,
+      } as unknown as Doc<"documentTemplates">),
+    ];
+
+    const result = composeSystemDefaults(mapped, "org1");
+    const quoteSd = result.find((r) => r.type === "quote")!;
+    const invoiceSd = result.find((r) => r.type === "invoice")!;
+    expect(quoteSd.isDefault).toBe(true); // no custom default for quote
+    expect(invoiceSd.isDefault).toBe(true); // no custom at all for invoice
+  });
+
+  it("system default is overridden (inactive) when a custom of that type is default", () => {
+    const mapped = [
+      mapDocumentTemplate({
+        _id: "x",
+        _creationTime: 1,
+        id: "dt-quote",
+        organizationId: "org1",
+        name: "Quote custom",
+        type: "quote",
+        isDefault: true, // custom default → system default becomes inactive
+        createdAt: 1,
+        updatedAt: 1,
+      } as unknown as Doc<"documentTemplates">),
+    ];
+
+    const result = composeSystemDefaults(mapped, "org1");
+    const quoteSd = result.find((r) => r.type === "quote")!;
+    const invoiceSd = result.find((r) => r.type === "invoice")!;
+    expect(quoteSd.isDefault).toBe(false); // overridden by custom default
+    expect(invoiceSd.isDefault).toBe(true); // unaffected
+  });
+});

--- a/src/lib/document-template-read.ts
+++ b/src/lib/document-template-read.ts
@@ -1,0 +1,174 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the document-template domain (Phase A read-rewiring
+ * of the Convex domain-only decommission). `documentTemplate` and `brandTemplate`
+ * are dual-written infra (mirror helpers in src/lib/template-mirror.ts +
+ * src/server/brand-templates.ts, backfill heal path in
+ * scripts/convex-backfill-templates.ts, Convex modules convex/documentTemplates.ts
+ * + convex/brandTemplates.ts). After the PDF template-builder removal (#227) the
+ * document-template *write* surface is gone — these rows are now read-only from the
+ * app's perspective, served out of the dual-written Convex copy. These helpers read
+ * the Convex copy and shape it back into the Prisma-row form the document-template
+ * server actions expect (epoch-ms → Date, absent optionals → null, Prisma-defaulted
+ * columns coerced).
+ *
+ * ONLY the real-DB-row reads convert. The "virtual system-default template"
+ * synthesis (ids starting with "system-") stays byte-for-byte in the server actions
+ * and simply operates on the converted rows.
+ */
+
+type RawDocumentTemplate = Doc<"documentTemplates">;
+type RawBrandTemplate = Doc<"brandTemplates">;
+
+const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
+const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+const req = <T>(v: T | undefined): T => v as T;
+/**
+ * createdAt/updatedAt are non-null Prisma columns (@default(now()) / @updatedAt) —
+ * the Prisma reads always handed consumers a Date. Coerce the (always-present)
+ * epoch-ms to a non-null Date so the row shape matches the original.
+ */
+const reqDate = (v: number | undefined): Date => new Date(req(v));
+
+/** Prisma-row shape for DocumentTemplate (matches prisma.documentTemplate). */
+export interface DocumentTemplateRow {
+  id: string;
+  organizationId: string;
+  name: string;
+  type: string;
+  basePdf: string | null;
+  schemas: string | null;
+  settings: string | null;
+  sections: string | null;
+  brandTemplateId: string | null;
+  thumbnailData: string | null;
+  isDefault: boolean;
+  isDraft: boolean;
+  version: number;
+  thumbnailUrl: string | null;
+  publishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Prisma-row shape for BrandTemplate (matches prisma.brandTemplate). */
+export interface BrandTemplateRow {
+  id: string;
+  organizationId: string;
+  name: string;
+  headerSettings: string;
+  footerSettings: string;
+  accentColor: string | null;
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function mapDocumentTemplate(d: RawDocumentTemplate): DocumentTemplateRow {
+  return {
+    id: req(d.id),
+    organizationId: req(d.organizationId),
+    name: req(d.name),
+    type: req(d.type),
+    isDefault: d.isDefault ?? false,
+    isDraft: d.isDraft ?? false,
+    version: d.version ?? 1,
+    sections: orNull(d.sections),
+    basePdf: orNull(d.basePdf),
+    schemas: orNull(d.schemas),
+    settings: orNull(d.settings),
+    thumbnailData: orNull(d.thumbnailData),
+    thumbnailUrl: orNull(d.thumbnailUrl),
+    brandTemplateId: orNull(d.brandTemplateId),
+    publishedAt: toDate(d.publishedAt),
+    createdAt: reqDate(d.createdAt),
+    updatedAt: reqDate(d.updatedAt),
+  };
+}
+
+export function mapBrandTemplate(d: RawBrandTemplate): BrandTemplateRow {
+  return {
+    id: req(d.id),
+    organizationId: req(d.organizationId),
+    name: req(d.name),
+    headerSettings: req(d.headerSettings),
+    footerSettings: req(d.footerSettings),
+    accentColor: orNull(d.accentColor),
+    isDefault: d.isDefault ?? false,
+    createdAt: reqDate(d.createdAt),
+    updatedAt: reqDate(d.updatedAt),
+  };
+}
+
+// ─── Pure sort comparators (replicate Prisma orderBy) ────────────────────────
+
+/**
+ * orderBy [{ type: "asc" }, { isDefault: "desc" }, { updatedAt: "desc" }].
+ * `type` is a free String column (NOT an enum) → plain lexicographic compare.
+ * Mirrors getDocumentTemplates.
+ */
+export function compareDocumentTemplatesForList(
+  a: DocumentTemplateRow,
+  b: DocumentTemplateRow,
+): number {
+  if (a.type !== b.type) return a.type < b.type ? -1 : 1;
+  const byDefault = (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0);
+  if (byDefault !== 0) return byDefault;
+  return b.updatedAt.getTime() - a.updatedAt.getTime();
+}
+
+/**
+ * orderBy [{ type: "asc" }, { isDefault: "desc" }, { name: "asc" }].
+ * `type` + `name` are plain String columns → lexicographic compare.
+ * Mirrors getPublishedTemplatesForDropdown.
+ */
+export function compareDocumentTemplatesForDropdown(
+  a: Pick<DocumentTemplateRow, "type" | "isDefault" | "name">,
+  b: Pick<DocumentTemplateRow, "type" | "isDefault" | "name">,
+): number {
+  if (a.type !== b.type) return a.type < b.type ? -1 : 1;
+  const byDefault = (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0);
+  if (byDefault !== 0) return byDefault;
+  if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+  return 0;
+}
+
+// ─── Fetchers ────────────────────────────────────────────────────────────────
+
+/** All document templates for an org, mapped (unsorted). */
+export async function listDocumentTemplates(orgId: string): Promise<DocumentTemplateRow[]> {
+  const rows = (await (await getConvexClient()).query(api.documentTemplates.list, {
+    orgId,
+  })) as RawDocumentTemplate[];
+  return rows.map(mapDocumentTemplate);
+}
+
+/**
+ * Single document template by cuid, mapped. NOT org-scoped on the Convex side —
+ * the caller MUST re-check organizationId.
+ */
+export async function getDocumentTemplateById(id: string): Promise<DocumentTemplateRow | null> {
+  const row = (await (await getConvexClient()).query(api.documentTemplates.getById, {
+    id,
+  })) as RawDocumentTemplate | null;
+  return row ? mapDocumentTemplate(row) : null;
+}
+
+/** All brand templates for an org, mapped. */
+export async function listBrandTemplates(orgId: string): Promise<BrandTemplateRow[]> {
+  const rows = (await (await getConvexClient()).query(api.brandTemplates.list, {
+    orgId,
+  })) as RawBrandTemplate[];
+  return rows.map(mapBrandTemplate);
+}
+
+/** Single brand template by cuid, mapped. */
+export async function getBrandTemplateById(id: string): Promise<BrandTemplateRow | null> {
+  const row = (await (await getConvexClient()).query(api.brandTemplates.getById, {
+    id,
+  })) as RawBrandTemplate | null;
+  return row ? mapBrandTemplate(row) : null;
+}

--- a/src/server/document-templates.ts
+++ b/src/server/document-templates.ts
@@ -1,8 +1,15 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
+import {
+  listDocumentTemplates,
+  getDocumentTemplateById,
+  listBrandTemplates,
+  getBrandTemplateById,
+  compareDocumentTemplatesForList,
+  compareDocumentTemplatesForDropdown,
+} from "@/lib/document-template-read";
 import {
   DOCUMENT_TYPES,
   DOCUMENT_TYPE_LABELS,
@@ -17,11 +24,18 @@ import type { DocumentType } from "@/lib/pdfme/types";
 export async function getDocumentTemplates() {
   const { organizationId } = await getOrgContext();
 
-  const templates = await prisma.documentTemplate.findMany({
-    where: { organizationId },
-    orderBy: [{ type: "asc" }, { isDefault: "desc" }, { updatedAt: "desc" }],
-    include: { brandTemplate: { select: { id: true, name: true } } },
-  });
+  const [rows, brandRows] = await Promise.all([
+    listDocumentTemplates(organizationId),
+    listBrandTemplates(organizationId),
+  ]);
+  const brandMap = new Map(brandRows.map((b) => [b.id, { id: b.id, name: b.name }]));
+  const templates = rows
+    .slice()
+    .sort(compareDocumentTemplatesForList)
+    .map((t) => ({
+      ...t,
+      brandTemplate: t.brandTemplateId ? brandMap.get(t.brandTemplateId) ?? null : null,
+    }));
 
   // Build virtual system default entries for each doc type
   const systemDefaults = DOCUMENT_TYPES.map((type) => ({
@@ -85,19 +99,16 @@ export async function getDocumentTemplates() {
 export async function getPublishedTemplatesForDropdown() {
   const { organizationId } = await getOrgContext();
 
-  const templates = await prisma.documentTemplate.findMany({
-    where: {
-      organizationId,
-      isDraft: false,
-    },
-    select: {
-      id: true,
-      name: true,
-      type: true,
-      isDefault: true,
-    },
-    orderBy: [{ type: "asc" }, { isDefault: "desc" }, { name: "asc" }],
-  });
+  const rows = await listDocumentTemplates(organizationId);
+  const templates = rows
+    .filter((t) => t.isDraft === false)
+    .sort(compareDocumentTemplatesForDropdown)
+    .map((t) => ({
+      id: t.id,
+      name: t.name,
+      type: t.type,
+      isDefault: t.isDefault,
+    }));
 
   return serialize(templates);
 }
@@ -134,14 +145,15 @@ export async function getDocumentTemplate(id: string) {
     });
   }
 
-  const template = await prisma.documentTemplate.findFirst({
-    where: { id, organizationId },
-    include: { brandTemplate: true },
-  });
-
-  if (!template) {
+  const row = await getDocumentTemplateById(id);
+  if (!row || row.organizationId !== organizationId) {
     throw new Error("Template not found");
   }
+
+  const brandTemplate = row.brandTemplateId
+    ? await getBrandTemplateById(row.brandTemplateId)
+    : null;
+  const template = { ...row, brandTemplate };
 
   return serialize(template);
 }


### PR DESCRIPTION
## Reworked onto new main after the PDF template-builder removal (#227)

This PR was rebuilt from scratch on top of current `main`. PR #227
("all-feature-removals") removed the PDF template **builder** (kept PDF
**generation**), gutting `src/server/document-templates.ts` from 826 →
**147 lines**. The original #207 diff was mostly against now-deleted code,
so the branch was reset to `origin/main` and force-pushed.

### Gate check — still safe to read from Convex
`documentTemplate` (and the `brandTemplate` join) remain **dual-written
infra**: the mirror helpers (`src/lib/template-mirror.ts`), the
brand-delete unlink (`src/server/brand-templates.ts`), the Convex modules
(`documentTemplates` / `brandTemplates`), and the re-runnable backfill heal
path (`scripts/convex-backfill-templates.ts`) all survive the removal.
After the builder removal there are no longer any document-template *write*
calls in the app — the rows are read-only from the app's perspective — but
the dual-write infrastructure + backfill exist, so reading the Convex copy
is safe.

### What this converts
Only the **3 surviving read functions**:
- `getDocumentTemplates` → `documentTemplates.list` + `brandTemplates.list`
  for the `{id,name}` FK join + pure `[type ASC, isDefault DESC, updatedAt DESC]`
  sort. Virtual `system-` synthesis untouched, runs over mapped rows.
- `getPublishedTemplatesForDropdown` → same list, JS `isDraft===false` filter
  + `[type, isDefault DESC, name ASC]` sort.
- `getDocumentTemplate` → `system-` branch unchanged; real-read branch is
  `documentTemplates.getById` + JS org re-check (same "Template not found"
  throw) + `brandTemplates.getById` for the full `brandTemplate` FK.

New read-lib `src/lib/document-template-read.ts` (+ unit tests): mappers
(epoch-ms→Date, absent→null, Prisma defaults coerced, strip `_id`/`_creationTime`),
two pure sort comparators (`type` is a plain String column → lexicographic,
not enum rank), four fetchers. No new Convex queries needed. No Prisma
fallback on a miss.

### Deploy gate
The templates backfill must have run against prod Convex before this deploys
(re-runnable: `pnpm convex:backfill:templates`), else existing rows read empty.

### Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/document-template-read.test.ts` — 10 passed
- `pnpm exec eslint <changed files>` — clean
- `pnpm run build` — exit 0

Base: `main`. CI re-runs on the force-push.