### PR TITLE
feat(convex): read-rewire getCrewMembersForAssignment (crew availability) to Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2696,9 +2696,37 @@ assignment rows + crewMember/crewRole/service/shifts/confirmedBy) and
 + `CrewShiftRow` extended to full rows; added `getAssignmentsByProject` +
 `getProjectServiceMap`. `confirmedBy` (User) via `users-read`. **`phase: "asc"`
 replicates Postgres enum ordering** (declared order, not alphabetical) via a
-`PHASE_ORDER` rank map. `getCrewMembersForAssignment` (cross-project conflict +
-availability scan) is **deferred** — stays on Prisma until the availability
-surface converts. Writes stay Prisma-first + mirror. Same crew deploy gate.
+`PHASE_ORDER` rank map. Writes stay Prisma-first + mirror. Same crew deploy gate.
+
+### Crew availability / assignment picker — DONE
+
+`src/server/crew-assignments.ts`: `getCrewMembersForAssignment(projectId, search?,
+dateRange?)` — the assignment-dialog crew picker — read-rewired to Convex (this was
+the **last deferred crew read**). Three pure read-only reads, no read-then-write:
+
+- **Read A (members + on-project assignments):** `getCrewMembersByOrg` +
+  `getCrewRoleMap` + `getAssignmentsByProject`; member `where`/search/sort/`take 50`
+  reproduced by pure predicates in **`src/lib/crew-assignment-availability.ts`**
+  (`isAssignableMember` — `isActive ?? true && status==="ACTIVE"` + case-insensitive
+  search over firstName/lastName/email/department with null guards; `compareByLastName`
+  localeCompare; `.slice(0,50)` after filter+sort). On-project assignments attached by
+  `crewMemberId` equality.
+- **Read B (cross-project conflicts):** `getAssignmentsByOrg` filtered by
+  `isConflictingAssignment` (other-project, status ∉ {CANCELLED,DECLINED}, inclusive
+  date overlap, null start/end excluded — Prisma lte/gte over NULL is false); project
+  names joined via `getProjectsByOrg`.
+- **Read C (UNAVAILABLE blocks):** new convex query
+  **`crewAvailabilities.listByCrewMemberIds({crewMemberIds, orgId})`** — fans out over
+  the `by_crewMemberId` membership index (orgId gates auth ONLY; `organizationId` is an
+  optional late-addition column on `crewAvailabilities`, so an org-index scan would
+  silently drop un-backfilled rows → false "available"). `getAvailabilitiesByCrewMemberIds`
+  + `mapAvailability` added to crew-scheduling-read.ts (`type` absent → `UNAVAILABLE`,
+  the Prisma default); `isUnavailableBlock` predicate applies the type+overlap filter.
+
+Reads B and C only run when `dateRange` is provided — **both call sites currently pass
+only `projectId`, so those paths are dead today** (converted for signature parity).
+Writes stay Prisma-first + mirror. Same crew deploy gate (assignment/shift/cert/
+timeEntry **and availability** backfilled in prod Convex before merge).
 
 ## Conventions
 

--- a/convex/crewAvailabilities.ts
+++ b/convex/crewAvailabilities.ts
@@ -33,6 +33,29 @@ export const getById = query({
   },
 });
 
+/**
+ * Availability blocks for a set of crew members. `orgId` ONLY gates auth — we do
+ * NOT filter rows by `organizationId`: that column is OPTIONAL on this table (late
+ * addition) and the original Prisma read never org-scoped availability, so an
+ * org-index scan would silently drop un-backfilled rows and yield a false
+ * "available". We fan out over the by_crewMemberId membership index instead.
+ */
+export const listByCrewMemberIds = query({
+  args: { crewMemberIds: v.array(v.string()), orgId: v.string() },
+  handler: async (ctx, { crewMemberIds, orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const out = [];
+    for (const crewMemberId of crewMemberIds) {
+      const rows = await ctx.db
+        .query("crewAvailabilities")
+        .withIndex("by_crewMemberId", (q) => q.eq("crewMemberId", crewMemberId))
+        .collect();
+      out.push(...rows);
+    }
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/lib/crew-assignment-availability.test.ts
+++ b/src/lib/crew-assignment-availability.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAssignableMember,
+  compareByLastName,
+  isConflictingAssignment,
+  isUnavailableBlock,
+  type AssignableMemberLike,
+  type ConflictAssignmentLike,
+  type AvailabilityBlockLike,
+} from "@/lib/crew-assignment-availability";
+import { mapAvailability } from "@/lib/crew-scheduling-read";
+
+const member = (over: Partial<AssignableMemberLike>): AssignableMemberLike => ({
+  isActive: true,
+  status: "ACTIVE",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  department: "Lighting",
+  ...over,
+});
+
+describe("isAssignableMember — member where + search", () => {
+  it("accepts an active ACTIVE member with no search", () => {
+    expect(isAssignableMember(member({}))).toBe(true);
+  });
+
+  it("treats absent isActive as true (Convex optional)", () => {
+    expect(isAssignableMember(member({ isActive: undefined }))).toBe(true);
+  });
+
+  it("rejects isActive=false", () => {
+    expect(isAssignableMember(member({ isActive: false }))).toBe(false);
+  });
+
+  it("rejects non-ACTIVE status", () => {
+    expect(isAssignableMember(member({ status: "INACTIVE" }))).toBe(false);
+    expect(isAssignableMember(member({ status: undefined }))).toBe(false);
+  });
+
+  it("search matches case-insensitively across firstName/lastName/email/department", () => {
+    expect(isAssignableMember(member({ firstName: "Alice" }), "ali")).toBe(true);
+    expect(isAssignableMember(member({ lastName: "Smith" }), "SMI")).toBe(true);
+    expect(isAssignableMember(member({ email: "bob@acme.io" }), "ACME")).toBe(true);
+    expect(isAssignableMember(member({ department: "Audio" }), "aud")).toBe(true);
+  });
+
+  it("search excludes members with no field match", () => {
+    expect(isAssignableMember(member({}), "zzzz")).toBe(false);
+  });
+
+  it("guards null email/department during search (no throw, no false match)", () => {
+    const m = member({ email: null, department: null, firstName: "X", lastName: "Y" });
+    expect(isAssignableMember(m, "lighting")).toBe(false);
+    expect(isAssignableMember(m, "x")).toBe(true);
+  });
+});
+
+describe("compareByLastName + take semantics", () => {
+  it("sorts ascending by lastName and slice(0,50) takes the first 50", () => {
+    const names = Array.from({ length: 60 }, (_, i) => ({
+      lastName: String(60 - i).padStart(3, "0"),
+    }));
+    const sorted = [...names].sort(compareByLastName).slice(0, 50);
+    expect(sorted).toHaveLength(50);
+    expect(sorted[0].lastName).toBe("001");
+    expect(sorted[49].lastName).toBe("050");
+  });
+});
+
+const RANGE_START = new Date("2026-06-10T00:00:00.000Z");
+const RANGE_END = new Date("2026-06-20T00:00:00.000Z");
+
+const assignment = (over: Partial<ConflictAssignmentLike>): ConflictAssignmentLike => ({
+  crewMemberId: "m1",
+  projectId: "other",
+  status: "CONFIRMED",
+  startDate: new Date("2026-06-12T00:00:00.000Z"),
+  endDate: new Date("2026-06-15T00:00:00.000Z"),
+  ...over,
+});
+
+describe("isConflictingAssignment — cross-project overlap", () => {
+  const current = "current-project";
+
+  it("flags an overlapping assignment on another project", () => {
+    expect(isConflictingAssignment(assignment({}), current, RANGE_START, RANGE_END)).toBe(true);
+  });
+
+  it("excludes assignments on the current project", () => {
+    expect(
+      isConflictingAssignment(assignment({ projectId: current }), current, RANGE_START, RANGE_END),
+    ).toBe(false);
+  });
+
+  it("excludes CANCELLED and DECLINED statuses", () => {
+    expect(
+      isConflictingAssignment(assignment({ status: "CANCELLED" }), current, RANGE_START, RANGE_END),
+    ).toBe(false);
+    expect(
+      isConflictingAssignment(assignment({ status: "DECLINED" }), current, RANGE_START, RANGE_END),
+    ).toBe(false);
+  });
+
+  it("excludes rows with null start or end date (Prisma lte/gte over NULL is false)", () => {
+    expect(
+      isConflictingAssignment(assignment({ startDate: null }), current, RANGE_START, RANGE_END),
+    ).toBe(false);
+    expect(
+      isConflictingAssignment(assignment({ endDate: null }), current, RANGE_START, RANGE_END),
+    ).toBe(false);
+  });
+
+  it("excludes non-overlapping ranges (entirely before / entirely after)", () => {
+    const before = assignment({
+      startDate: new Date("2026-06-01T00:00:00.000Z"),
+      endDate: new Date("2026-06-05T00:00:00.000Z"),
+    });
+    const after = assignment({
+      startDate: new Date("2026-06-25T00:00:00.000Z"),
+      endDate: new Date("2026-06-30T00:00:00.000Z"),
+    });
+    expect(isConflictingAssignment(before, current, RANGE_START, RANGE_END)).toBe(false);
+    expect(isConflictingAssignment(after, current, RANGE_START, RANGE_END)).toBe(false);
+  });
+
+  it("includes boundary-touching ranges (inclusive lte/gte)", () => {
+    const touchesEnd = assignment({
+      startDate: RANGE_END,
+      endDate: new Date("2026-06-22T00:00:00.000Z"),
+    });
+    const touchesStart = assignment({
+      startDate: new Date("2026-06-05T00:00:00.000Z"),
+      endDate: RANGE_START,
+    });
+    expect(isConflictingAssignment(touchesEnd, current, RANGE_START, RANGE_END)).toBe(true);
+    expect(isConflictingAssignment(touchesStart, current, RANGE_START, RANGE_END)).toBe(true);
+  });
+});
+
+const block = (over: Partial<AvailabilityBlockLike>): AvailabilityBlockLike => ({
+  crewMemberId: "m1",
+  type: "UNAVAILABLE",
+  startDate: new Date("2026-06-12T00:00:00.000Z"),
+  endDate: new Date("2026-06-15T00:00:00.000Z"),
+  ...over,
+});
+
+describe("isUnavailableBlock — availability overlap", () => {
+  it("flags an overlapping UNAVAILABLE block", () => {
+    expect(isUnavailableBlock(block({}), RANGE_START, RANGE_END)).toBe(true);
+  });
+
+  it("ignores non-UNAVAILABLE types", () => {
+    expect(isUnavailableBlock(block({ type: "AVAILABLE" }), RANGE_START, RANGE_END)).toBe(false);
+  });
+
+  it("ignores non-overlapping UNAVAILABLE blocks", () => {
+    const before = block({
+      startDate: new Date("2026-06-01T00:00:00.000Z"),
+      endDate: new Date("2026-06-05T00:00:00.000Z"),
+    });
+    expect(isUnavailableBlock(before, RANGE_START, RANGE_END)).toBe(false);
+  });
+
+  it("includes boundary-touching blocks", () => {
+    const touches = block({
+      startDate: RANGE_END,
+      endDate: new Date("2026-06-22T00:00:00.000Z"),
+    });
+    expect(isUnavailableBlock(touches, RANGE_START, RANGE_END)).toBe(true);
+  });
+});
+
+describe("mapAvailability — absent type defaults to UNAVAILABLE", () => {
+  it("defaults absent Convex type to UNAVAILABLE (Prisma default)", () => {
+    const m = mapAvailability({
+      id: "av1",
+      crewMemberId: "m1",
+      startDate: 1_700_000_000_000,
+      endDate: 1_700_086_400_000,
+      // type absent
+    } as never);
+    expect(m.type).toBe("UNAVAILABLE");
+    expect(m.startDate.getTime()).toBe(1_700_000_000_000);
+    expect(m.endDate.getTime()).toBe(1_700_086_400_000);
+  });
+
+  it("preserves an explicit type", () => {
+    const m = mapAvailability({
+      id: "av2",
+      crewMemberId: "m1",
+      startDate: 1,
+      endDate: 2,
+      type: "AVAILABLE",
+    } as never);
+    expect(m.type).toBe("AVAILABLE");
+  });
+});

--- a/src/lib/crew-assignment-availability.ts
+++ b/src/lib/crew-assignment-availability.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure filter / sort / overlap predicates backing `getCrewMembersForAssignment`
+ * (src/server/crew-assignments.ts) after its Phase A read-rewire to Convex.
+ *
+ * The server action fetches FLAT Convex rows (all org crew members, all org
+ * assignments, availability blocks per member) and composes these pure helpers to
+ * reproduce the old Prisma `where` / `orderBy` / `take` and the cross-project
+ * conflict + availability-block logic. Kept side-effect-free so they're unit
+ * tested directly. See FEATUREDOCS/54.
+ */
+
+/** Minimal crew-member shape this module reads (structural — Convex Doc satisfies it). */
+export interface AssignableMemberLike {
+  isActive?: boolean;
+  status?: string;
+  firstName: string;
+  lastName: string;
+  email?: string | null;
+  department?: string | null;
+}
+
+/** Minimal assignment shape for cross-project conflict detection. */
+export interface ConflictAssignmentLike {
+  crewMemberId: string;
+  projectId: string;
+  status: string;
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+/** Minimal availability-block shape. */
+export interface AvailabilityBlockLike {
+  crewMemberId: string;
+  type: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+const CONFLICT_EXCLUDED_STATUSES = ["CANCELLED", "DECLINED"];
+
+/**
+ * Replicates the Prisma `where` for the member roster:
+ *   { isActive: true, status: "ACTIVE", ...(search ? OR contains over
+ *     firstName/lastName/email/department insensitive) }
+ * `isActive` defaults to true when absent (Convex optional column).
+ */
+export function isAssignableMember(m: AssignableMemberLike, search?: string): boolean {
+  if ((m.isActive ?? true) !== true) return false;
+  if (m.status !== "ACTIVE") return false;
+  if (!search) return true;
+  const needle = search.toLowerCase();
+  const haystacks = [m.firstName, m.lastName, m.email ?? "", m.department ?? ""];
+  return haystacks.some((h) => h.toLowerCase().includes(needle));
+}
+
+/** orderBy { lastName: "asc" } using locale-aware comparison. */
+export function compareByLastName(a: { lastName: string }, b: { lastName: string }): number {
+  return a.lastName.localeCompare(b.lastName);
+}
+
+/**
+ * Does an assignment count as a cross-project conflict for [rangeStart, rangeEnd]?
+ * Mirrors Prisma: projectId != currentProjectId, status NOT IN
+ * (CANCELLED, DECLINED), startDate <= rangeEnd, endDate >= rangeStart. Rows with a
+ * null start/end never overlap (Prisma's lte/gte over NULL is false).
+ */
+export function isConflictingAssignment(
+  a: ConflictAssignmentLike,
+  currentProjectId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+): boolean {
+  if (a.projectId === currentProjectId) return false;
+  if (CONFLICT_EXCLUDED_STATUSES.includes(a.status)) return false;
+  if (a.startDate === null || a.endDate === null) return false;
+  return a.startDate.getTime() <= rangeEnd.getTime() && a.endDate.getTime() >= rangeStart.getTime();
+}
+
+/** Does an UNAVAILABLE block overlap [rangeStart, rangeEnd]? Non-UNAVAILABLE types ignored. */
+export function isUnavailableBlock(b: AvailabilityBlockLike, rangeStart: Date, rangeEnd: Date): boolean {
+  if (b.type !== "UNAVAILABLE") return false;
+  return b.startDate.getTime() <= rangeEnd.getTime() && b.endDate.getTime() >= rangeStart.getTime();
+}

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -22,6 +22,7 @@ type RawAssignment = Doc<"crewAssignments">;
 type RawTimeEntry = Doc<"crewTimeEntries">;
 type RawShift = Doc<"crewShifts">;
 type RawCertification = Doc<"crewCertifications">;
+type RawAvailability = Doc<"crewAvailabilities">;
 
 const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
 const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
@@ -92,6 +93,14 @@ export interface CrewCertificationRow {
   id: string;
   crewMemberId: string;
   status: string;
+}
+
+export interface CrewAvailabilityRow {
+  id: string;
+  crewMemberId: string;
+  type: string;
+  startDate: Date;
+  endDate: Date;
 }
 
 export function mapAssignment(d: RawAssignment): CrewAssignmentRow {
@@ -165,6 +174,18 @@ export function mapCertification(d: RawCertification): CrewCertificationRow {
   return { id: d.id, crewMemberId: req(d.crewMemberId), status: req(d.status) };
 }
 
+export function mapAvailability(d: RawAvailability): CrewAvailabilityRow {
+  return {
+    id: d.id,
+    crewMemberId: req(d.crewMemberId),
+    // `type` is optional in Convex; Prisma defaults it to UNAVAILABLE, so an
+    // absent value means UNAVAILABLE (don't drop it — the filter compares on it).
+    type: d.type ?? "UNAVAILABLE",
+    startDate: new Date(req(d.startDate)),
+    endDate: new Date(req(d.endDate)),
+  };
+}
+
 // ─── Fetchers ─────────────────────────────────────────────────────────────────
 
 export async function getAssignmentsByOrg(orgId: string): Promise<CrewAssignmentRow[]> {
@@ -185,6 +206,23 @@ export async function getShiftsByOrg(orgId: string): Promise<CrewShiftRow[]> {
 export async function getCertificationsByOrg(orgId: string): Promise<CrewCertificationRow[]> {
   const rows = (await (await getConvexClient()).query(api.crewCertifications.listByOrg, { orgId })) as RawCertification[];
   return rows.map(mapCertification);
+}
+
+/**
+ * Availability blocks for a set of crew members. `orgId` only gates Convex auth;
+ * rows are NOT org-filtered (organizationId is optional on the table — see the
+ * `crewAvailabilities.listByCrewMemberIds` query). Empty input short-circuits.
+ */
+export async function getAvailabilitiesByCrewMemberIds(
+  crewMemberIds: string[],
+  orgId: string,
+): Promise<CrewAvailabilityRow[]> {
+  if (crewMemberIds.length === 0) return [];
+  const rows = (await (await getConvexClient()).query(api.crewAvailabilities.listByCrewMemberIds, {
+    crewMemberIds,
+    orgId,
+  })) as RawAvailability[];
+  return rows.map(mapAvailability);
 }
 
 export async function getAssignmentsByProject(projectId: string, orgId: string): Promise<CrewAssignmentRow[]> {

--- a/src/server/crew-assignments.ts
+++ b/src/server/crew-assignments.ts
@@ -2,15 +2,23 @@
 
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
-import { getProjectById } from "@/lib/projects-read";
-import { getCrewMembersByOrg, getCrewRolesByOrg } from "@/lib/crew-read";
+import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
+import { getCrewMembersByOrg, getCrewRolesByOrg, getCrewRoleMap } from "@/lib/crew-read";
 import { getUserMap } from "@/lib/users-read";
 import {
   getAssignmentsByProject,
+  getAssignmentsByOrg,
+  getAvailabilitiesByCrewMemberIds,
   getProjectServiceMap,
   getShiftsByOrg,
   type CrewShiftRow,
 } from "@/lib/crew-scheduling-read";
+import {
+  isAssignableMember,
+  compareByLastName,
+  isConflictingAssignment,
+  isUnavailableBlock,
+} from "@/lib/crew-assignment-availability";
 import { serialize } from "@/lib/serialize";
 import {
   crewAssignmentSchema,
@@ -546,6 +554,14 @@ export async function getProjectLabourCost(projectId: string) {
  * more intricate than the leaf reads converted in this pass; convert it with the
  * rest of the crew availability surface. The dual-write mirror keeps it fresh.
  */
+type AssignmentConflict = {
+  crewMemberId: string;
+  projectId: string;
+  project: { projectNumber: string; name: string } | null;
+  startDate: Date | null;
+  endDate: Date | null;
+};
+
 export async function getCrewMembersForAssignment(
   projectId: string,
   search?: string,
@@ -553,93 +569,80 @@ export async function getCrewMembersForAssignment(
 ) {
   const { organizationId } = await getOrgContext();
 
-  const where = {
-    organizationId,
-    isActive: true,
-    status: "ACTIVE" as const,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" as const } },
-            { lastName: { contains: search, mode: "insensitive" as const } },
-            { email: { contains: search, mode: "insensitive" as const } },
-            { department: { contains: search, mode: "insensitive" as const } },
-          ],
-        }
-      : {}),
-  };
+  // Read A — members + on-project assignments (Convex).
+  const [allMembers, roleMap, projectAssignments] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getAssignmentsByProject(projectId, organizationId),
+  ]);
 
-  const members = await prisma.crewMember.findMany({
-    where,
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      email: true,
-      phone: true,
-      image: true,
-      department: true,
-      defaultDayRate: true,
-      defaultHourlyRate: true,
-      crewRole: { select: { id: true, name: true } },
-      // Assignments on this project
-      assignments: {
-        where: { projectId },
-        select: { id: true, phase: true, status: true, serviceId: true },
-      },
-    },
-    orderBy: { lastName: "asc" },
-    take: 50,
-  });
+  const members = allMembers
+    .filter((m) => isAssignableMember(m, search))
+    .sort(compareByLastName)
+    .slice(0, 50)
+    .map((m) => {
+      const role = m.crewRoleId ? roleMap.get(m.crewRoleId) : undefined;
+      return {
+        id: m.id,
+        firstName: m.firstName,
+        lastName: m.lastName,
+        email: m.email ?? null,
+        phone: m.phone ?? null,
+        image: m.image ?? null,
+        department: m.department ?? null,
+        defaultDayRate: m.defaultDayRate ?? null,
+        defaultHourlyRate: m.defaultHourlyRate ?? null,
+        crewRole: role ? { id: role.id, name: role.name } : null,
+        assignments: projectAssignments
+          .filter((a) => a.crewMemberId === m.id)
+          .map((a) => ({ id: a.id, phase: a.phase, status: a.status, serviceId: a.serviceId })),
+      };
+    });
 
-  // Cross-project availability check (Arch fix #2)
+  // Cross-project availability check (Arch fix #2). Both call sites pass only
+  // projectId today, so this branch is currently dead — converted for parity.
   if (dateRange) {
     const rangeStart = new Date(dateRange.start);
     const rangeEnd = new Date(dateRange.end);
-    const memberIds = members.map((m) => m.id);
+    const memberIds = new Set(members.map((m) => m.id));
 
-    // Single query for all overlapping assignments across all projects
-    const conflicts = await prisma.crewAssignment.findMany({
-      where: {
-        crewMemberId: { in: memberIds },
-        projectId: { not: projectId }, // Other projects only
-        status: { notIn: ["CANCELLED", "DECLINED"] },
-        startDate: { lte: rangeEnd },
-        endDate: { gte: rangeStart },
-      },
-      select: {
-        crewMemberId: true,
-        projectId: true,
-        project: { select: { projectNumber: true, name: true } },
-        startDate: true,
-        endDate: true,
-      },
-    });
+    // Read B — cross-project conflicts (Convex).
+    const [orgAssignments, orgProjects, availabilities] = await Promise.all([
+      getAssignmentsByOrg(organizationId),
+      getProjectsByOrg(organizationId),
+      getAvailabilitiesByCrewMemberIds([...memberIds], organizationId),
+    ]);
 
-    // Build conflict map
-    const conflictMap = new Map<string, typeof conflicts>();
-    for (const c of conflicts) {
-      const existing = conflictMap.get(c.crewMemberId) || [];
-      existing.push(c);
-      conflictMap.set(c.crewMemberId, existing);
+    const projMap = new Map(
+      orgProjects.map((p) => [p.id, { projectNumber: p.projectNumber, name: p.name }]),
+    );
+
+    const conflictMap = new Map<string, AssignmentConflict[]>();
+    for (const a of orgAssignments) {
+      if (!memberIds.has(a.crewMemberId)) continue;
+      if (!isConflictingAssignment(a, projectId, rangeStart, rangeEnd)) continue;
+      const existing = conflictMap.get(a.crewMemberId) ?? [];
+      existing.push({
+        crewMemberId: a.crewMemberId,
+        projectId: a.projectId,
+        project: projMap.get(a.projectId) ?? null,
+        startDate: a.startDate,
+        endDate: a.endDate,
+      });
+      conflictMap.set(a.crewMemberId, existing);
     }
 
-    // Also check crew availability blocks
-    const unavailable = await prisma.crewAvailability.findMany({
-      where: {
-        crewMemberId: { in: memberIds },
-        type: "UNAVAILABLE",
-        startDate: { lte: rangeEnd },
-        endDate: { gte: rangeStart },
-      },
-      select: { crewMemberId: true },
-    });
-    const unavailableSet = new Set(unavailable.map((u) => u.crewMemberId));
+    // Read C — UNAVAILABLE blocks overlapping the range (Convex).
+    const unavailableSet = new Set(
+      availabilities
+        .filter((b) => isUnavailableBlock(b, rangeStart, rangeEnd))
+        .map((b) => b.crewMemberId),
+    );
 
     return serialize(
       members.map((m) => ({
         ...m,
-        conflicts: conflictMap.get(m.id) || [],
+        conflicts: conflictMap.get(m.id) ?? [],
         isUnavailable: unavailableSet.has(m.id),
       })),
     );
@@ -648,7 +651,7 @@ export async function getCrewMembersForAssignment(
   return serialize(
     members.map((m) => ({
       ...m,
-      conflicts: [],
+      conflicts: [] as AssignmentConflict[],
       isUnavailable: false,
     })),
   );


### PR DESCRIPTION
## Summary

Read-rewires `getCrewMembersForAssignment(projectId, search?, dateRange?)` in `src/server/crew-assignments.ts` to Convex — **the last deferred crew read** of Phase A. All three reads are pure read-only (no read-then-write). Signature + final `serialize(...)` and `getOrgContext()` are unchanged.

- **Read A — members + on-project assignments:** `getCrewMembersByOrg` + `getCrewRoleMap` + `getAssignmentsByProject`. Member `where`/search/sort/`take 50` reproduced by pure, unit-tested predicates in new `src/lib/crew-assignment-availability.ts` (`isAssignableMember`, `compareByLastName`, `.slice(0,50)`).
- **Read B — cross-project conflicts:** `getAssignmentsByOrg` filtered by `isConflictingAssignment` (other-project, status ∉ {CANCELLED,DECLINED}, inclusive date overlap, null start/end excluded); project names via `getProjectsByOrg`.
- **Read C — UNAVAILABLE blocks:** new convex query `crewAvailabilities.listByCrewMemberIds`; `getAvailabilitiesByCrewMemberIds` + `mapAvailability` + `isUnavailableBlock`.

Reads B/C only run when `dateRange` is supplied — **both call sites pass only `projectId` today, so those paths are dead** (converted for signature parity).

## New convex query

`crewAvailabilities.listByCrewMemberIds({ crewMemberIds, orgId })` — fans out over the `by_crewMemberId` index. **`orgId` gates auth ONLY; rows are NOT org-filtered** because `organizationId` is an optional late-addition column on `crewAvailabilities` — an org-index scan would silently drop un-backfilled rows → false "available". (No convex dev/codegen run; the generated api types via `typeof crewAvailabilities`.)

## Converted vs kept

- Converted: all of `getCrewMembersForAssignment` (Reads A/B/C).
- Kept: writes stay Prisma-first + mirror; `getOrgContext()` stays; `testedBy`-style User joins remain Prisma (none here).

## Validation

- `pnpm exec tsc --noEmit` ✅
- `pnpm exec vitest run` on the new test + existing crew tests ✅ (167 passed)
- `pnpm exec eslint <changed files>` ✅
- No `next build`, no live golden-diff (correctness guard = unit tests: member where/search/sort/take, conflict overlap incl. null start/end guard + other-project + status exclusion, availability overlap, mapper default).

## ⚠️ DEPLOY-GATED

The crew-scheduling tables (**assignment / shift / cert / timeEntry / AVAILABILITY**) are **NOT confirmed backfilled in prod Convex**. Run `convex:backfill:crew-scheduling` **and** `convex:backfill:crew` (which together must cover availability) in **prod BEFORE merging this stack** — otherwise the assignment dialog reads an empty crew list and shows zero conflicts / everyone "available".

## Stacking & gating

- **STACKED on #197** (`feat/convex-read-crew-assignments`) — reuses `crew-read.ts` + `crew-scheduling-read.ts`. CI only runs after #197 merges + this retargets to `main`.
- Human-gated on preview validation; golden-diff deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)