### PR TITLE
chore(convex): purge tool for removed-table orphans

### DIFF
--- a/convex/purgeRemovedTables.ts
+++ b/convex/purgeRemovedTables.ts
@@ -1,0 +1,71 @@
+import { v, ConvexError } from "convex/values";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+/**
+ * One-off cleanup for the June-2026 feature-removal effort.
+ *
+ * When a table is removed from the Convex schema, its existing documents are
+ * NOT deleted — they orphan (still on disk, no longer typed/queryable through
+ * the schema). These helpers delete those orphaned documents.
+ *
+ * Only the tables that were FULLY removed are listed. Tables kept by decision
+ * (crewRoles / crewSkills — D1; documentTemplates — D4) are intentionally
+ * absent, and the allowlist guard refuses anything not in this set.
+ *
+ * Best run while the tables are still in the schema (i.e. before the removal
+ * PRs' Convex deploy) for fully-typed access; the `as any` cast also lets it
+ * work afterwards against orphaned tables. Idempotent + re-runnable.
+ */
+export const REMOVED_TABLES = [
+  "stocktakes",
+  "stocktakeItems",
+  "savedReports",
+  "crewCertifications",
+  "discordIntegrations",
+  "discordAccountLinks",
+  "discordLinkTokens",
+  "discordOutboxes",
+  "damageEvents",
+] as const;
+
+const ALLOWED = new Set<string>(REMOVED_TABLES);
+
+/**
+ * Delete one bounded batch from an allowlisted removed table.
+ * Returns { table, deleted, done }. Drive in a loop until done === true.
+ */
+export const purgeBatch = internalMutation({
+  args: { table: v.string(), batchSize: v.optional(v.number()) },
+  handler: async (ctx, { table, batchSize }) => {
+    if (!ALLOWED.has(table)) {
+      throw new ConvexError(
+        `purge refused: "${table}" is not an allowlisted removed table`,
+      );
+    }
+    const limit = Math.min(batchSize ?? 500, 2000);
+    // `as any`: the table may already have left the schema (orphaned), so it is
+    // not in the typed TableNames union — but the documents still exist on disk.
+    const docs = await ctx.db
+      .query(table as never)
+      .take(limit);
+    for (const doc of docs) {
+      await ctx.db.delete((doc as { _id: never })._id);
+    }
+    return { table, deleted: docs.length, done: docs.length < limit };
+  },
+});
+
+/** Per-table remaining document counts (capped scan) — to verify the purge. */
+export const pendingCounts = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const out: Record<string, number> = {};
+    for (const table of REMOVED_TABLES) {
+      // Cap the scan so a huge orphaned table can't blow the read limit; any
+      // value >= cap means "still has data, keep purging".
+      const rows = await ctx.db.query(table as never).take(2001);
+      out[table] = rows.length;
+    }
+    return out;
+  },
+});

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "convex:backfill:all": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-all.ts",
     "convex:parity": "tsx --env-file=.env --env-file=.env.local scripts/convex-parity-check.ts",
     "convex:resync:line-items": "tsx --env-file=.env --env-file=.env.local scripts/convex-resync-line-items.ts",
-    "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts"
+    "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts",
+    "convex:purge:removed": "tsx scripts/convex-purge-removed-tables.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",

--- a/scripts/convex-purge-removed-tables.ts
+++ b/scripts/convex-purge-removed-tables.ts
@@ -1,0 +1,95 @@
+/**
+ * Purge orphaned Convex documents from the tables removed by the June-2026
+ * feature-removal effort (stocktake, reports, discord, crew certifications,
+ * damage capture). Drives `convex/purgeRemovedTables:purgeBatch` in a loop
+ * per table until each is empty, then verifies with `pendingCounts`.
+ *
+ * Uses the Convex deployment from the environment (CONVEX_DEPLOYMENT / deploy
+ * key), same as the existing backfill scripts.
+ *
+ *   pnpm exec tsx scripts/convex-purge-removed-tables.ts           # dev deployment
+ *   pnpm exec tsx scripts/convex-purge-removed-tables.ts --prod    # prod deployment
+ *   pnpm exec tsx scripts/convex-purge-removed-tables.ts --dry     # counts only, no deletes
+ *
+ * On Coolify/prod, run inside the app container (env vars injected) exactly
+ * like the backfill scripts. Ideal timing: run it AROUND the removal deploy —
+ * before is fully typed; after still works (orphan cleanup via `as any`).
+ */
+import { execFileSync } from "node:child_process";
+
+const REMOVED_TABLES = [
+  "stocktakes",
+  "stocktakeItems",
+  "savedReports",
+  "crewCertifications",
+  "discordIntegrations",
+  "discordAccountLinks",
+  "discordLinkTokens",
+  "discordOutboxes",
+  "damageEvents",
+];
+
+const PROD = process.argv.includes("--prod");
+const DRY = process.argv.includes("--dry");
+const TARGET = PROD ? ["--prod"] : [];
+
+/** Run a Convex function via the CLI and parse its returned JSON value. */
+function convexRun(fn: string, args?: Record<string, unknown>): unknown {
+  const argv = ["exec", "convex", "run", ...TARGET, fn];
+  if (args) argv.push(JSON.stringify(args));
+  const raw = execFileSync("pnpm", argv, { encoding: "utf8" });
+  // `convex run` prints the return value; grab the last JSON object/value.
+  const match = raw.match(/(\{[\s\S]*\}|\[[\s\S]*\]|\d+)\s*$/);
+  if (!match) {
+    throw new Error(`could not parse output of \`convex run ${fn}\`:\n${raw}`);
+  }
+  return JSON.parse(match[1]);
+}
+
+function main() {
+  console.log(
+    `Convex purge — target: ${PROD ? "PROD" : "dev"}${DRY ? " (dry run)" : ""}`,
+  );
+
+  const before = convexRun("purgeRemovedTables:pendingCounts") as Record<
+    string,
+    number
+  >;
+  console.log("Before:", JSON.stringify(before));
+
+  if (DRY) {
+    const total = Object.values(before).reduce((a, b) => a + b, 0);
+    console.log(`Dry run: ${total}+ documents across ${REMOVED_TABLES.length} tables would be purged.`);
+    return;
+  }
+
+  let grand = 0;
+  for (const table of REMOVED_TABLES) {
+    let total = 0;
+    for (let guard = 0; guard < 100000; guard++) {
+      const res = convexRun("purgeRemovedTables:purgeBatch", { table }) as {
+        deleted: number;
+        done: boolean;
+      };
+      total += res.deleted;
+      if (res.done) break;
+    }
+    grand += total;
+    console.log(`  ${table}: purged ${total}`);
+  }
+
+  const after = convexRun("purgeRemovedTables:pendingCounts") as Record<
+    string,
+    number
+  >;
+  const remaining = Object.values(after).reduce((a, b) => a + b, 0);
+  console.log(
+    `\nDone. Purged ${grand} documents. Remaining (should be 0): ${remaining}`,
+  );
+  if (remaining > 0) {
+    console.error("WARNING: some documents remain:", JSON.stringify(after));
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
A one-off cleanup tool to delete orphaned Convex documents from the tables fully removed by the June-2026 feature removals. When a table leaves the Convex schema, its documents aren't deleted — they orphan (on disk, untyped). This purges them.

**Targets (9 tables):** `stocktakes`, `stocktakeItems`, `savedReports`, `crewCertifications`, `discordIntegrations`, `discordAccountLinks`, `discordLinkTokens`, `discordOutboxes`, `damageEvents`.

**Allowlist-guarded** — kept-by-decision tables (`crewRoles`/`crewSkills` per D1, `documentTemplates` per D4) are excluded and the mutation refuses anything off the list.

**Usage:**
```
pnpm exec tsx scripts/convex-purge-removed-tables.ts --dry    # counts only
pnpm exec tsx scripts/convex-purge-removed-tables.ts          # dev deployment
pnpm exec tsx scripts/convex-purge-removed-tables.ts --prod   # prod deployment
```
On Coolify/prod, run inside the app container like the existing backfill scripts.

**Timing:** ideal to run *around* the removal Convex deploy — before it (tables still in schema → fully typed) or after (orphan cleanup via an `as`-cast). Idempotent + re-runnable; verifies 0 remaining at the end.

> Not yet executed against a live deployment — it deploys with the next Convex deploy, then `npm run convex:purge:removed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)