### PR TITLE
feat(convex): read test-tag profiles from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,33 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **test-tag profiles** (`server/test-tag-profiles.ts` → `src/lib/test-profiles-read.ts`).
+  The two read-only actions `getTestProfiles` (org list + optional isActive[default
+  true]/equipmentClass/applianceType filters, name-asc sort) and `getTestProfile`
+  (cuid lookup) now read the Convex `testProfiles` table (dual-written +
+  `convex-backfill-test-profiles.ts`). `getById` is cuid-only in Convex, so the
+  Prisma `{ id, organizationId }` org-scope is re-applied in JS (mismatch → null →
+  the action throws "Test profile not found" exactly as before). The three Json
+  columns (`visualChecks`/`electricalTests`/`thresholds`) pass straight through from
+  Convex `v.any()`. **All writes + the read-then-write validation `findFirst`s
+  (resolve/create/update/duplicate/seed/delete) stay on Prisma** (dual-write source +
+  durable FK anchor). `filterAndSortTestProfiles` + `mapTestProfile` are pure and
+  unit-tested (`src/lib/test-profiles-read.test.ts`). Deploy gate: `testProfile`
+  backfilled into prod Convex before this lands.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/test-profiles-read.test.ts
+++ b/src/lib/test-profiles-read.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the pure test-profile read helpers (mapper + filter/sort).
+ *
+ * These replace the Prisma reads `getTestProfiles` (findMany where org + optional
+ * isActive/equipmentClass/applianceType, orderBy name asc) and `getTestProfile`
+ * (findFirst { id, organizationId }). The safety property: the mapped Convex doc
+ * matches the Prisma row shape (epoch-ms → Date, absent → null, defaults coerced,
+ * Json passed through) and the JS filter/sort reproduces the Prisma where/orderBy.
+ */
+import { describe, it, expect } from "vitest";
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  mapTestProfile,
+  filterAndSortTestProfiles,
+  type TestProfileRow,
+} from "@/lib/test-profiles-read";
+
+type RawProfile = Doc<"testProfiles">;
+
+function rawProfile(over: Partial<RawProfile> = {}): RawProfile {
+  return {
+    _id: "doc_1" as RawProfile["_id"],
+    _creationTime: 123,
+    id: "tp1",
+    organizationId: "org1",
+    name: "Class I Appliance",
+    equipmentClass: "CLASS_I",
+    applianceType: "APPLIANCE",
+    visualChecks: [{ key: "casing", label: "Casing", enabled: true }],
+    electricalTests: [{ key: "earth", threshold: 1 }],
+    thresholds: { earthMax: 1, insulationMin: 1 },
+    requiresSubTests: false,
+    defaultSubTestCount: 1,
+    subTestLabel: "Outlet",
+    isDefault: false,
+    isActive: true,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_500_000,
+    ...over,
+  };
+}
+
+describe("mapTestProfile", () => {
+  it("maps epoch-ms to Date and passes Json fields through unchanged", () => {
+    const visualChecks = [{ key: "casing", label: "Casing", enabled: true }];
+    const electricalTests = [{ key: "earth", threshold: 1 }];
+    const thresholds = { earthMax: 1, insulationMin: 1 };
+    const row = mapTestProfile(
+      rawProfile({ visualChecks, electricalTests, thresholds }),
+    );
+
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.createdAt?.getTime()).toBe(1_700_000_000_000);
+    expect(row.updatedAt?.getTime()).toBe(1_700_000_500_000);
+    // Json fields pass through by reference, untouched.
+    expect(row.visualChecks).toBe(visualChecks);
+    expect(row.electricalTests).toBe(electricalTests);
+    expect(row.thresholds).toBe(thresholds);
+  });
+
+  it("strips _id/_creationTime and keeps no Convex internals", () => {
+    const row = mapTestProfile(rawProfile()) as unknown as Record<string, unknown>;
+    expect(row._id).toBeUndefined();
+    expect(row._creationTime).toBeUndefined();
+  });
+
+  it("coerces absent Prisma-defaulted columns to their defaults", () => {
+    const row = mapTestProfile(
+      rawProfile({
+        equipmentClass: undefined,
+        applianceType: undefined,
+        requiresSubTests: undefined,
+        defaultSubTestCount: undefined,
+        subTestLabel: undefined,
+        isDefault: undefined,
+        isActive: undefined,
+      }),
+    );
+    expect(row.equipmentClass).toBe("CLASS_I");
+    expect(row.applianceType).toBe("APPLIANCE");
+    expect(row.requiresSubTests).toBe(false);
+    expect(row.defaultSubTestCount).toBe(1);
+    expect(row.subTestLabel).toBe("Outlet");
+    expect(row.isDefault).toBe(false);
+    expect(row.isActive).toBe(true);
+  });
+
+  it("maps absent createdAt/updatedAt to null", () => {
+    const row = mapTestProfile(
+      rawProfile({ createdAt: undefined, updatedAt: undefined }),
+    );
+    expect(row.createdAt).toBeNull();
+    expect(row.updatedAt).toBeNull();
+  });
+
+  it("preserves provided non-default values", () => {
+    const row = mapTestProfile(
+      rawProfile({
+        equipmentClass: "CLASS_II",
+        applianceType: "POWER_BOARD",
+        requiresSubTests: true,
+        defaultSubTestCount: 4,
+        subTestLabel: "Phase",
+        isDefault: true,
+        isActive: false,
+      }),
+    );
+    expect(row.equipmentClass).toBe("CLASS_II");
+    expect(row.applianceType).toBe("POWER_BOARD");
+    expect(row.requiresSubTests).toBe(true);
+    expect(row.defaultSubTestCount).toBe(4);
+    expect(row.subTestLabel).toBe("Phase");
+    expect(row.isDefault).toBe(true);
+    expect(row.isActive).toBe(false);
+  });
+});
+
+function row(over: Partial<TestProfileRow>): TestProfileRow {
+  return mapTestProfile(rawProfile(over as Partial<RawProfile>));
+}
+
+describe("filterAndSortTestProfiles", () => {
+  const profiles = [
+    row({ id: "b", name: "Beta", isActive: true }),
+    row({ id: "a", name: "Alpha", isActive: true }),
+    row({ id: "c", name: "Gamma", isActive: false }),
+  ];
+
+  it("defaults to isActive=true and sorts by name asc", () => {
+    const out = filterAndSortTestProfiles(profiles);
+    expect(out.map((p) => p.name)).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("returns inactive profiles when isActive=false", () => {
+    const out = filterAndSortTestProfiles(profiles, { isActive: false });
+    expect(out.map((p) => p.name)).toEqual(["Gamma"]);
+  });
+
+  it("filters by equipmentClass", () => {
+    const list = [
+      row({ id: "1", name: "One", equipmentClass: "CLASS_I" }),
+      row({ id: "2", name: "Two", equipmentClass: "CLASS_II" }),
+    ];
+    const out = filterAndSortTestProfiles(list, { equipmentClass: "CLASS_II" });
+    expect(out.map((p) => p.id)).toEqual(["2"]);
+  });
+
+  it("filters by applianceType", () => {
+    const list = [
+      row({ id: "1", name: "One", applianceType: "APPLIANCE" }),
+      row({ id: "2", name: "Two", applianceType: "POWER_BOARD" }),
+    ];
+    const out = filterAndSortTestProfiles(list, { applianceType: "POWER_BOARD" });
+    expect(out.map((p) => p.id)).toEqual(["2"]);
+  });
+
+  it("combines all filters (AND) and still sorts", () => {
+    const list = [
+      row({ id: "1", name: "Zed", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", isActive: true }),
+      row({ id: "2", name: "Ann", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", isActive: true }),
+      row({ id: "3", name: "Mid", equipmentClass: "CLASS_II", applianceType: "APPLIANCE", isActive: true }),
+    ];
+    const out = filterAndSortTestProfiles(list, {
+      isActive: true,
+      equipmentClass: "CLASS_I",
+      applianceType: "APPLIANCE",
+    });
+    expect(out.map((p) => p.name)).toEqual(["Ann", "Zed"]);
+  });
+});

--- a/src/lib/test-profiles-read.ts
+++ b/src/lib/test-profiles-read.ts
@@ -1,0 +1,127 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the test-profile domain (Phase A read-rewiring of
+ * the Convex domain-only decommission). `testProfile` is dual-written (inline
+ * `api.testProfiles.*` from src/server/test-tag-profiles.ts) and backfilled
+ * (scripts/convex-backfill-test-profiles.ts). These helpers read the Convex copy
+ * and shape it back into the Prisma-row form the test-profile consumers expect
+ * (epoch-ms → Date, absent optionals → null, Prisma-defaulted columns coerced to
+ * non-null). The visualChecks/electricalTests/thresholds Json fields are stored as
+ * Convex `v.any()` and pass straight through unchanged.
+ *
+ * Filtering/sorting is replicated in JS (pure, unit-tested) to match the original
+ * Prisma `where`/`orderBy`. See FEATUREDOCS/54.
+ */
+
+type RawProfile = Doc<"testProfiles">;
+
+const toDate = (v: number | undefined): Date | null =>
+  typeof v === "number" ? new Date(v) : null;
+
+/**
+ * Prisma-row shape of a TestProfile. Dates are `Date` (serialize() preserves Date),
+ * the three Json columns are `unknown` (passed through from Convex `v.any()`), and
+ * the Prisma-defaulted scalar columns are non-null.
+ */
+export interface TestProfileRow {
+  id: string;
+  organizationId: string;
+  name: string;
+  equipmentClass: string;
+  applianceType: string;
+  visualChecks: unknown;
+  electricalTests: unknown;
+  thresholds: unknown;
+  requiresSubTests: boolean;
+  defaultSubTestCount: number;
+  subTestLabel: string;
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+/** Map a Convex testProfiles doc to the Prisma TestProfile row shape. */
+export function mapTestProfile(d: RawProfile): TestProfileRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    name: d.name,
+    // Prisma defaults: equipmentClass=CLASS_I, applianceType=APPLIANCE.
+    equipmentClass: d.equipmentClass ?? "CLASS_I",
+    applianceType: d.applianceType ?? "APPLIANCE",
+    visualChecks: d.visualChecks,
+    electricalTests: d.electricalTests,
+    thresholds: d.thresholds,
+    // Prisma defaults: false / 1 / "Outlet" / false / true.
+    requiresSubTests: d.requiresSubTests ?? false,
+    defaultSubTestCount: d.defaultSubTestCount ?? 1,
+    subTestLabel: d.subTestLabel ?? "Outlet",
+    isDefault: d.isDefault ?? false,
+    isActive: d.isActive ?? true,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+export interface TestProfileFilters {
+  isActive?: boolean;
+  equipmentClass?: string;
+  applianceType?: string;
+}
+
+/**
+ * Pure replica of the Prisma `getTestProfiles` where + orderBy: filter by
+ * isActive (default true), optional equipmentClass, optional applianceType; sort
+ * by name asc. The org filter is already applied by the Convex `list` query.
+ */
+export function filterAndSortTestProfiles(
+  profiles: TestProfileRow[],
+  params?: TestProfileFilters,
+): TestProfileRow[] {
+  const { isActive = true, equipmentClass, applianceType } = params ?? {};
+  return profiles
+    .filter((p) => {
+      if (isActive !== undefined && p.isActive !== isActive) return false;
+      if (equipmentClass && p.equipmentClass !== equipmentClass) return false;
+      if (applianceType && p.applianceType !== applianceType) return false;
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Read all test profiles for an org, filtered + sorted (replaces Prisma findMany). */
+export async function getTestProfilesFromConvex(
+  orgId: string,
+  params?: TestProfileFilters,
+): Promise<TestProfileRow[]> {
+  const rows = await withConvexReadRetry(
+    async () =>
+      (await (await getConvexClient()).query(api.testProfiles.list, {
+        orgId,
+      })) as RawProfile[],
+  );
+  return filterAndSortTestProfiles(rows.map(mapTestProfile), params);
+}
+
+/**
+ * Read one test profile by cuid, re-applying the Prisma `{ id, organizationId }`
+ * org-scope in JS (Convex `getById` is cuid-only). Returns null when the row is
+ * missing or belongs to another org — caller decides whether to throw.
+ */
+export async function getTestProfileFromConvex(
+  id: string,
+  orgId: string,
+): Promise<TestProfileRow | null> {
+  const row = await withConvexReadRetry(
+    async () =>
+      (await (await getConvexClient()).query(api.testProfiles.getById, {
+        id,
+      })) as RawProfile | null,
+  );
+  if (!row || row.organizationId !== orgId) return null;
+  return mapTestProfile(row);
+}

--- a/src/server/test-tag-profiles.ts
+++ b/src/server/test-tag-profiles.ts
@@ -8,6 +8,10 @@ import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { SEED_PROFILES } from "@/lib/test-profiles/seed-data";
+import {
+  getTestProfilesFromConvex,
+  getTestProfileFromConvex,
+} from "@/lib/test-profiles-read";
 
 // Test profiles are DUAL-WRITTEN: every create/update/duplicate/seed/delete writes
 // the Prisma `test_profile` row (the durable FK anchor — model.defaultTestProfileId,
@@ -40,17 +44,10 @@ export async function getTestProfiles(params?: {
   applianceType?: string;
 }) {
   const { organizationId } = await getOrgContext();
-  const { isActive = true, equipmentClass, applianceType } = params || {};
 
-  const profiles = await prisma.testProfile.findMany({
-    where: {
-      organizationId,
-      ...(isActive !== undefined && { isActive }),
-      ...(equipmentClass && { equipmentClass: equipmentClass as "CLASS_I" | "CLASS_II" | "CLASS_II_DOUBLE_INSULATED" | "LEAD_CORD_ASSEMBLY" }),
-      ...(applianceType && { applianceType: applianceType as "APPLIANCE" | "CORD_SET" | "EXTENSION_LEAD" | "POWER_BOARD" | "RCD_PORTABLE" | "RCD_FIXED" | "THREE_PHASE" | "MICROWAVE" | "OTHER" }),
-    },
-    orderBy: { name: "asc" },
-  });
+  // Read-rewired to Convex (Phase A). testProfile is dual-written; filtering +
+  // orderBy replicated in src/lib/test-profiles-read.ts. See FEATUREDOCS/54.
+  const profiles = await getTestProfilesFromConvex(organizationId, params);
 
   return serialize(profiles);
 }
@@ -58,9 +55,9 @@ export async function getTestProfiles(params?: {
 export async function getTestProfile(id: string) {
   const { organizationId } = await getOrgContext();
 
-  const profile = await prisma.testProfile.findFirst({
-    where: { id, organizationId },
-  });
+  // Read-rewired to Convex (Phase A). getById is cuid-only; org-scope re-applied
+  // in JS to match the Prisma { id, organizationId } scoping. See FEATUREDOCS/54.
+  const profile = await getTestProfileFromConvex(id, organizationId);
   if (!profile) throw new Error("Test profile not found");
 
   return serialize(profile);


### PR DESCRIPTION
Phase A read-rewiring (Convex domain-only decommission). Moves the two read-only test-profile actions in `server/test-tag-profiles.ts` (`getTestProfiles`, `getTestProfile`) onto the dual-written + backfilled Convex `testProfiles` table via new `src/lib/test-profiles-read.ts` (epoch-ms→Date mappers, Json passthrough, pure unit-tested filter/sort). `getById` is cuid-only in Convex so the `{id, organizationId}` org-scope is re-applied in JS. All writes + read-then-write validation `findFirst`s stay on Prisma.

**Validation:** tsc --noEmit clean, 10 unit tests pass, eslint clean (only the pre-existing `_id`-strip warning).

**Deploy gate:** `testProfile` is dual-written + backfilled in prod Convex — gate satisfied. Merge is human-gated on the Coolify PR preview (Convex data-correctness can't be verified in a dev worktree).