### PR TITLE
feat(convex): read saved table views from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,28 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **saved table views** (`server/saved-views.ts` → `src/lib/saved-views-read.ts`).
+  The read-only `getSavedViews(tableId)` now reads the Convex `savedTableViews` table
+  (dual-written via `saved-views-mirror.ts` + `convex-backfill-saved-views.ts`). The
+  Convex `list({ orgId })` returns every view for the org, so the per-user + per-table
+  scope and `[{ isDefault desc }, { name asc }]` ordering are re-applied in JS
+  (`filterAndSortSavedViews`, pure + unit-tested). The `config` JSON column passes
+  straight through. All write paths (create/update/delete/set-default) stay on Prisma.
+  Deploy gate: `savedTableView` backfilled into prod Convex before this lands.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/saved-views-read.test.ts
+++ b/src/lib/saved-views-read.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapSavedView,
+  filterAndSortSavedViews,
+  type SavedTableViewRow,
+} from "@/lib/saved-views-read";
+
+describe("saved-views-read mapper", () => {
+  it("converts epoch-ms timestamps to Date and passes config through", () => {
+    const m = mapSavedView({
+      id: "v1",
+      organizationId: "org",
+      userId: "u1",
+      tableId: "assets",
+      name: "Overdue",
+      config: { filters: { status: ["OVERDUE"] }, pageSize: 25 },
+      isDefault: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_500_000,
+    } as never);
+
+    expect(m.createdAt).toBeInstanceOf(Date);
+    expect(m.createdAt?.getTime()).toBe(1_700_000_000_000);
+    expect(m.updatedAt?.getTime()).toBe(1_700_000_500_000);
+    expect(m.isDefault).toBe(true);
+    // JSON column passes through untouched.
+    expect(m.config).toEqual({ filters: { status: ["OVERDUE"] }, pageSize: 25 });
+  });
+
+  it("coerces absent Prisma-defaulted/optional fields", () => {
+    const m = mapSavedView({
+      id: "v2",
+      organizationId: "org",
+      userId: "u1",
+      tableId: "projects",
+      name: "Active",
+      config: undefined,
+      // isDefault / createdAt / updatedAt absent
+    } as never);
+
+    expect(m.isDefault).toBe(false);
+    expect(m.config).toEqual({});
+    expect(m.createdAt).toBeNull();
+    expect(m.updatedAt).toBeNull();
+  });
+});
+
+describe("saved-views-read filterAndSortSavedViews", () => {
+  const make = (over: Partial<SavedTableViewRow>): SavedTableViewRow => ({
+    id: Math.random().toString(36).slice(2),
+    organizationId: "org",
+    userId: "u1",
+    tableId: "assets",
+    name: "x",
+    config: {},
+    isDefault: false,
+    createdAt: null,
+    updatedAt: null,
+    ...over,
+  });
+
+  it("filters to the given user + table", () => {
+    const rows = [
+      make({ userId: "u1", tableId: "assets", name: "Mine" }),
+      make({ userId: "u2", tableId: "assets", name: "Theirs" }),
+      make({ userId: "u1", tableId: "projects", name: "OtherTable" }),
+    ];
+    const out = filterAndSortSavedViews(rows, "u1", "assets");
+    expect(out.map((v) => v.name)).toEqual(["Mine"]);
+  });
+
+  it("orders default-first then name ascending", () => {
+    const rows = [
+      make({ name: "Bravo", isDefault: false }),
+      make({ name: "Alpha", isDefault: false }),
+      make({ name: "Zulu", isDefault: true }),
+    ];
+    const out = filterAndSortSavedViews(rows, "u1", "assets");
+    expect(out.map((v) => v.name)).toEqual(["Zulu", "Alpha", "Bravo"]);
+    expect(out[0].isDefault).toBe(true);
+  });
+
+  it("returns an empty array when nothing matches (no Prisma fallback)", () => {
+    const rows = [make({ userId: "u9", tableId: "clients" })];
+    expect(filterAndSortSavedViews(rows, "u1", "assets")).toEqual([]);
+  });
+});

--- a/src/lib/saved-views-read.ts
+++ b/src/lib/saved-views-read.ts
@@ -1,0 +1,96 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type { SavedViewConfig } from "@/lib/saved-views";
+
+/**
+ * Server-side read helpers for the saved-table-view domain (Phase A read-rewiring
+ * of the Convex domain-only decommission). `savedTableView` is dual-written (see
+ * src/lib/saved-views-mirror.ts) and backfilled (scripts/convex-backfill-saved-views.ts).
+ *
+ * These helpers read the Convex copy and shape it back into the Prisma-row form the
+ * saved-view server actions return (epoch-ms → Date, absent optionals → null,
+ * Prisma-defaulted columns coerced to non-null). The `config` JSON column passes
+ * through untouched.
+ *
+ * `api.savedTableViews.list({ orgId })` returns EVERY view for the org; the
+ * entityType (tableId) + per-user scope + ordering that the old Prisma query
+ * applied is reproduced here in pure JS (filterAndSortSavedViews) so it stays
+ * unit-testable with no Prisma fallback on a miss.
+ */
+
+type RawSavedView = Doc<"savedTableViews">;
+
+const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
+
+export interface SavedTableViewRow {
+  id: string;
+  organizationId: string;
+  userId: string;
+  tableId: string;
+  name: string;
+  config: SavedViewConfig;
+  isDefault: boolean;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export function mapSavedView(d: RawSavedView): SavedTableViewRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    userId: d.userId,
+    tableId: d.tableId,
+    name: d.name,
+    // `config` is a passthrough JSON column (SavedViewConfig).
+    config: (d.config ?? {}) as SavedViewConfig,
+    // Prisma column has @default(false); Convex stores it as an optional, so an
+    // absent value means false.
+    isDefault: d.isDefault ?? false,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+/**
+ * Reproduce the old Prisma query:
+ *   where:   { organizationId, userId, tableId }
+ *   orderBy: [{ isDefault: "desc" }, { name: "asc" }]
+ *
+ * `organizationId` is already satisfied by the Convex `list({ orgId })` query, so
+ * this filters the remaining `userId` + `tableId` scope and sorts. Default views
+ * sort first; within each group, by name ascending (locale-naive, matching
+ * Postgres default text collation closely enough for view names).
+ */
+export function filterAndSortSavedViews(
+  rows: SavedTableViewRow[],
+  userId: string,
+  tableId: string,
+): SavedTableViewRow[] {
+  return rows
+    .filter((v) => v.userId === userId && v.tableId === tableId)
+    .sort((a, b) => {
+      // isDefault desc: true (1) before false (0).
+      if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+      // name asc.
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    });
+}
+
+/**
+ * The user's saved views for one table, scoped to org + user, default-first then
+ * name-ascending — the Convex-read replacement for the Prisma `findMany` in
+ * `getSavedViews`.
+ */
+export async function getSavedViewsForUser(
+  organizationId: string,
+  userId: string,
+  tableId: string,
+): Promise<SavedTableViewRow[]> {
+  const rows = (await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.savedTableViews.list, { orgId: organizationId }),
+  )) as RawSavedView[];
+  return filterAndSortSavedViews(rows.map(mapSavedView), userId, tableId);
+}

--- a/src/server/saved-views.ts
+++ b/src/server/saved-views.ts
@@ -11,6 +11,7 @@ import {
   removeSavedViewFromConvex,
   syncUserTableViewsToConvex,
 } from "@/lib/saved-views-mirror";
+import { getSavedViewsForUser } from "@/lib/saved-views-read";
 
 /**
  * Saved table views are personal: each is owned by the user who created it and
@@ -23,10 +24,9 @@ import {
 export async function getSavedViews(tableId: string) {
   const { organizationId, userId } = await getOrgContext();
 
-  const views = await prisma.savedTableView.findMany({
-    where: { organizationId, userId, tableId },
-    orderBy: [{ isDefault: "desc" }, { name: "asc" }],
-  });
+  // Convex-only read (Phase A): savedTableView is dual-written + backfilled, so we
+  // read the Convex copy and apply the user + table scope and ordering in JS.
+  const views = await getSavedViewsForUser(organizationId, userId, tableId);
 
   return serialize(views);
 }


### PR DESCRIPTION
Phase A read-rewiring (Convex domain-only decommission). Moves `getSavedViews` in `server/saved-views.ts` onto the dual-written + backfilled Convex `savedTableViews` table via new `src/lib/saved-views-read.ts`. Convex `list({orgId})` returns every view for the org, so the per-user + per-table scope and `[{isDefault desc},{name asc}]` ordering are re-applied in JS (`filterAndSortSavedViews`, pure + unit-tested). The `config` JSON column passes straight through. All write paths stay on Prisma.

**Validation:** tsc clean, 5 unit tests pass, eslint clean.

**Deploy gate:** `savedTableView` is dual-written (`saved-views-mirror.ts`) + backfilled — gate satisfied. Merge human-gated on Coolify preview.