### PR TITLE
feat(convex): read brand templates from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,33 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **brand templates** (`server/brand-templates.ts` → `src/lib/brand-templates-read.ts`).
+  `getBrandTemplates` (org list + `_count.documentTemplates`, `[{ isDefault desc },
+  { name asc }]`) and `getBrandTemplate` (cuid + org re-scope) now read the Convex
+  `brandTemplates` table (dual-written + `convex-backfill-brand-templates.ts`). The
+  `_count.documentTemplates` is recomputed in JS by counting the org's
+  `documentTemplates` by `brandTemplateId` (one extra org-scoped query). `getById` is
+  cuid-only in Convex → the Prisma `{ id, organizationId }` org-scope is re-applied in
+  JS (mismatch → null → the action throws "Brand template not found" as before).
+  `headerSettings`/`footerSettings` JSON-string columns pass straight through (the
+  caller `JSON.parse`s them). All writes + the delete-unlink
+  `documentTemplate.updateMany` stay on Prisma. `mapBrandTemplate` /
+  `compareBrandTemplatesForList` / `matchesOrg` are pure + unit-tested. Deploy gate:
+  `brandTemplate` backfilled into prod Convex before this lands.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/brand-templates-read.test.ts
+++ b/src/lib/brand-templates-read.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the brand-template Convex read helpers (Phase A read-rewiring of
+ * the Convex domain-only decommission).
+ *
+ * Covers the correctness guards for the 2 converted reads in
+ * src/server/brand-templates.ts: the mapper (epoch-ms → Date, absent → null,
+ * Prisma-defaulted `isDefault` coercion, non-null createdAt/updatedAt), the pure
+ * [isDefault desc, name asc] sort, and the JS org-scope re-application.
+ */
+import { describe, it, expect } from "vitest";
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  mapBrandTemplate,
+  compareBrandTemplatesForList,
+  matchesOrg,
+  type BrandTemplateRow,
+} from "@/lib/brand-templates-read";
+
+// ─── mapBrandTemplate ─────────────────────────────────────────────────────────
+
+describe("mapBrandTemplate", () => {
+  it("converts a full row: epoch-ms → Date, strips _id/_creationTime", () => {
+    const raw = {
+      _id: "convex-internal-id",
+      _creationTime: 123,
+      id: "bt1",
+      organizationId: "org1",
+      name: "Default Brand",
+      headerSettings: '{"logo":"x"}',
+      footerSettings: '{"text":"y"}',
+      accentColor: "#ff0000",
+      isDefault: true,
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_650_000_000_000,
+    } as unknown as Doc<"brandTemplates">;
+
+    const row = mapBrandTemplate(raw);
+
+    expect(row).toEqual({
+      id: "bt1",
+      organizationId: "org1",
+      name: "Default Brand",
+      headerSettings: '{"logo":"x"}',
+      footerSettings: '{"text":"y"}',
+      accentColor: "#ff0000",
+      isDefault: true,
+      createdAt: new Date(1_600_000_000_000),
+      updatedAt: new Date(1_650_000_000_000),
+    });
+    expect("_id" in row).toBe(false);
+    expect("_creationTime" in row).toBe(false);
+  });
+
+  it("coerces Prisma-defaulted isDefault and nulls absent accentColor", () => {
+    const raw = {
+      _id: "x",
+      _creationTime: 1,
+      id: "bt2",
+      organizationId: "org1",
+      name: "Bare",
+      headerSettings: "{}",
+      footerSettings: "{}",
+      // accentColor absent
+      // isDefault absent
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    } as unknown as Doc<"brandTemplates">;
+
+    const row = mapBrandTemplate(raw);
+
+    expect(row.accentColor).toBeNull();
+    expect(row.isDefault).toBe(false);
+    expect(row.createdAt).toEqual(new Date(1_700_000_000_000));
+    expect(row.updatedAt).toEqual(new Date(1_700_000_000_000));
+  });
+
+  it("passes headerSettings/footerSettings through as raw JSON strings (no parse)", () => {
+    const raw = {
+      id: "bt3",
+      organizationId: "org1",
+      name: "JSON",
+      headerSettings: '{"a":1}',
+      footerSettings: '[1,2,3]',
+      createdAt: 1,
+      updatedAt: 2,
+    } as unknown as Doc<"brandTemplates">;
+
+    const row = mapBrandTemplate(raw);
+    expect(row.headerSettings).toBe('{"a":1}');
+    expect(row.footerSettings).toBe("[1,2,3]");
+  });
+});
+
+// ─── compareBrandTemplatesForList ────────────────────────────────────────────
+
+const mk = (over: Partial<BrandTemplateRow>): BrandTemplateRow => ({
+  id: "id",
+  organizationId: "org1",
+  name: "name",
+  headerSettings: "{}",
+  footerSettings: "{}",
+  accentColor: null,
+  isDefault: false,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  ...over,
+});
+
+describe("compareBrandTemplatesForList", () => {
+  it("sorts [isDefault desc, name asc]", () => {
+    const rows = [
+      mk({ id: "b", name: "Bravo", isDefault: false }),
+      mk({ id: "a", name: "Alpha", isDefault: false }),
+      mk({ id: "d", name: "Delta", isDefault: true }),
+      mk({ id: "c", name: "Charlie", isDefault: true }),
+    ];
+    const sorted = [...rows].sort(compareBrandTemplatesForList).map((r) => r.id);
+    // defaults first (by name asc: Charlie, Delta), then non-defaults (Alpha, Bravo)
+    expect(sorted).toEqual(["c", "d", "a", "b"]);
+  });
+
+  it("default beats non-default regardless of name", () => {
+    const a = mk({ name: "ZZZ", isDefault: true });
+    const b = mk({ name: "AAA", isDefault: false });
+    expect(compareBrandTemplatesForList(a, b)).toBeLessThan(0);
+  });
+
+  it("equal isDefault + equal name → 0", () => {
+    expect(compareBrandTemplatesForList(mk({ name: "x" }), mk({ name: "x" }))).toBe(0);
+  });
+});
+
+// ─── matchesOrg ──────────────────────────────────────────────────────────────
+
+describe("matchesOrg", () => {
+  it("true on matching org, false otherwise", () => {
+    const row = mk({ organizationId: "org1" });
+    expect(matchesOrg(row, "org1")).toBe(true);
+    expect(matchesOrg(row, "org2")).toBe(false);
+  });
+});

--- a/src/lib/brand-templates-read.ts
+++ b/src/lib/brand-templates-read.ts
@@ -1,0 +1,132 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the brand-template domain (Phase A read-rewiring of
+ * the Convex domain-only decommission). `brandTemplate` is dual-written (see
+ * src/server/brand-templates.ts + convex/brandTemplates.ts) and backfilled
+ * (scripts/convex-backfill-brand-templates.ts). These helpers read the Convex copy
+ * and shape it back into the Prisma-row form the branding pages expect (epoch-ms →
+ * Date, absent optionals → null, Prisma-defaulted columns coerced).
+ *
+ * headerSettings/footerSettings are JSON-string columns — passed straight through
+ * (the caller JSON.parses them, exactly as the Prisma path did).
+ *
+ * `getById` is cuid-only in Convex (no org arg) → org-scope is re-applied in JS to
+ * match Prisma `findFirst({ where: { id, organizationId } })`. See FEATUREDOCS/54.
+ */
+
+type RawBrandTemplate = Doc<"brandTemplates">;
+type RawDocumentTemplate = Doc<"documentTemplates">;
+
+const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+const req = <T>(v: T | undefined): T => v as T;
+/** createdAt/updatedAt are non-null Prisma columns → coerce to a non-null Date. */
+const reqDate = (v: number | undefined): Date => new Date(req(v));
+
+/** Prisma-row shape for BrandTemplate (matches prisma.brandTemplate). */
+export interface BrandTemplateRow {
+  id: string;
+  organizationId: string;
+  name: string;
+  headerSettings: string;
+  footerSettings: string;
+  accentColor: string | null;
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function mapBrandTemplate(d: RawBrandTemplate): BrandTemplateRow {
+  return {
+    id: req(d.id),
+    organizationId: req(d.organizationId),
+    name: req(d.name),
+    headerSettings: req(d.headerSettings),
+    footerSettings: req(d.footerSettings),
+    accentColor: orNull(d.accentColor),
+    isDefault: d.isDefault ?? false,
+    createdAt: reqDate(d.createdAt),
+    updatedAt: reqDate(d.updatedAt),
+  };
+}
+
+// ─── Pure sort + filter (replicate Prisma where/orderBy) ─────────────────────
+
+/**
+ * orderBy [{ isDefault: "desc" }, { name: "asc" }].
+ * isDefault desc → defaults (true) first; name asc → plain lexicographic compare
+ * (matches Postgres default text collation for the seeded fixtures here).
+ */
+export function compareBrandTemplatesForList(a: BrandTemplateRow, b: BrandTemplateRow): number {
+  if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+/** Re-apply Prisma `findFirst({ where: { id, organizationId } })` org-scope in JS. */
+export function matchesOrg(row: BrandTemplateRow, organizationId: string): boolean {
+  return row.organizationId === organizationId;
+}
+
+// ─── Convex fetchers ─────────────────────────────────────────────────────────
+
+/** List-view projection row (mirrors the Prisma `select` in getBrandTemplates). */
+export interface BrandTemplateListRow {
+  id: string;
+  name: string;
+  accentColor: string | null;
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  _count: { documentTemplates: number };
+}
+
+/**
+ * List brand templates for an org with per-template document-template counts,
+ * sorted [isDefault desc, name asc]. Replicates getBrandTemplates' Prisma read
+ * (findMany + _count.documentTemplates) by counting the org's documentTemplates
+ * by brandTemplateId in JS (one extra round trip, both reads org-scoped).
+ */
+export async function getBrandTemplateListForOrg(orgId: string): Promise<BrandTemplateListRow[]> {
+  const convex = await getConvexClient();
+  const [brands, docTemplates] = await Promise.all([
+    convex.query(api.brandTemplates.list, { orgId }) as Promise<RawBrandTemplate[]>,
+    convex.query(api.documentTemplates.list, { orgId }) as Promise<RawDocumentTemplate[]>,
+  ]);
+
+  const counts = new Map<string, number>();
+  for (const dt of docTemplates) {
+    if (dt.brandTemplateId == null) continue;
+    counts.set(dt.brandTemplateId, (counts.get(dt.brandTemplateId) ?? 0) + 1);
+  }
+
+  return brands
+    .map(mapBrandTemplate)
+    .sort(compareBrandTemplatesForList)
+    .map((b) => ({
+      id: b.id,
+      name: b.name,
+      accentColor: b.accentColor,
+      isDefault: b.isDefault,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      _count: { documentTemplates: counts.get(b.id) ?? 0 },
+    }));
+}
+
+/**
+ * Single brand template by cuid, org-scoped in JS (returns null on org mismatch or
+ * miss — caller throws). Full row; caller JSON.parses headerSettings/footerSettings.
+ */
+export async function getBrandTemplateForOrg(
+  id: string,
+  organizationId: string,
+): Promise<BrandTemplateRow | null> {
+  const row = (await (await getConvexClient()).query(api.brandTemplates.getById, {
+    id,
+  })) as RawBrandTemplate | null;
+  if (!row) return null;
+  const mapped = mapBrandTemplate(row);
+  return matchesOrg(mapped, organizationId) ? mapped : null;
+}

--- a/src/server/brand-templates.ts
+++ b/src/server/brand-templates.ts
@@ -5,6 +5,10 @@ import { prisma } from "@/lib/prisma";
 import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
+import {
+  getBrandTemplateForOrg,
+  getBrandTemplateListForOrg,
+} from "@/lib/brand-templates-read";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import {
@@ -59,19 +63,7 @@ import type {
 export async function getBrandTemplates() {
   const { organizationId } = await getOrgContext();
 
-  const templates = await prisma.brandTemplate.findMany({
-    where: { organizationId },
-    orderBy: [{ isDefault: "desc" }, { name: "asc" }],
-    select: {
-      id: true,
-      name: true,
-      accentColor: true,
-      isDefault: true,
-      createdAt: true,
-      updatedAt: true,
-      _count: { select: { documentTemplates: true } },
-    },
-  });
+  const templates = await getBrandTemplateListForOrg(organizationId);
 
   return serialize(templates);
 }
@@ -82,9 +74,7 @@ export async function getBrandTemplates() {
 export async function getBrandTemplate(id: string) {
   const { organizationId } = await getOrgContext();
 
-  const template = await prisma.brandTemplate.findFirst({
-    where: { id, organizationId },
-  });
+  const template = await getBrandTemplateForOrg(id, organizationId);
 
   if (!template) throw new Error("Brand template not found");
 


### PR DESCRIPTION
Phase A read-rewiring (Convex domain-only decommission). Moves `getBrandTemplates` + `getBrandTemplate` in `server/brand-templates.ts` onto the dual-written + backfilled Convex `brandTemplates` table via new `src/lib/brand-templates-read.ts`. `_count.documentTemplates` is recomputed in JS by counting the org's `documentTemplates` by `brandTemplateId`. `getById` is cuid-only in Convex so the `{id, organizationId}` org-scope is re-applied in JS. `headerSettings`/`footerSettings` JSON-string columns pass straight through. All writes + the delete-unlink `documentTemplate.updateMany` stay on Prisma.

**Validation:** tsc clean, 7 unit tests pass, eslint clean (only the pre-existing `_id`-strip warning).

**Deploy gate:** `brandTemplate` is dual-written + backfilled — gate satisfied. Merge human-gated on Coolify preview.