### PR TITLE
feat(convex): read custom-field definitions from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,33 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **custom field definitions** (`server/custom-fields.ts` →
+  `src/lib/custom-fields-read.ts`). `getCustomFieldDefinitions(entityType)` (settings
+  page, includes inactive) and `getActiveCustomFields(entityType)` (entity create/edit
+  forms, active only) now read the Convex `customFieldDefinitions` table (dual-written
+  + `convex-backfill-custom-fields.ts`). The Convex `list({ orgId })` returns all
+  entity types + active/inactive rows, so the `entityType` (plus `isActive` for the
+  active variant) filter and `[{ sortOrder asc }, { createdAt asc }]` ordering are
+  applied in JS (`mapCustomFieldDefinition` / `sortCustomFieldDefinitions`, pure +
+  unit-tested). Convex stores most columns as optional → coerced back to Prisma
+  defaults (entityType→ASSET, fieldType→TEXT, options→[], required→false, sortOrder→0,
+  isActive→true). The auth gate (`requirePermission` / `getOrgContext`) and all writes
+  stay on Prisma. Deploy gate: `customFieldDefinition` backfilled into prod Convex
+  before this lands.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/custom-fields-read.test.ts
+++ b/src/lib/custom-fields-read.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapCustomFieldDefinition,
+  sortCustomFieldDefinitions,
+  type CustomFieldDefinitionRow,
+} from "@/lib/custom-fields-read";
+
+describe("custom-fields-read mapper", () => {
+  it("converts epoch-ms dates to Date and keeps absent helpText as null", () => {
+    const m = mapCustomFieldDefinition({
+      id: "cf1",
+      organizationId: "org1",
+      entityType: "ASSET",
+      label: "Rig Number",
+      fieldKey: "rigNumber",
+      fieldType: "TEXT",
+      options: [],
+      required: false,
+      sortOrder: 0,
+      isActive: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_005_000,
+      // helpText absent
+    } as never);
+    expect(m.createdAt).toBeInstanceOf(Date);
+    expect(m.createdAt?.getTime()).toBe(1_700_000_000_000);
+    expect(m.updatedAt?.getTime()).toBe(1_700_000_005_000);
+    expect(m.helpText).toBeNull();
+    expect(m.entityType).toBe("ASSET");
+    expect(m.fieldType).toBe("TEXT");
+    expect(m.options).toEqual([]);
+  });
+
+  it("coerces Convex-optional columns to their Prisma defaults when absent", () => {
+    const m = mapCustomFieldDefinition({
+      id: "cf2",
+      organizationId: "org1",
+      label: "Bare",
+      fieldKey: "bare",
+      // entityType, fieldType, options, required, sortOrder, isActive, dates all absent
+    } as never);
+    expect(m.entityType).toBe("ASSET");
+    expect(m.fieldType).toBe("TEXT");
+    expect(m.options).toEqual([]);
+    expect(m.required).toBe(false);
+    expect(m.sortOrder).toBe(0);
+    expect(m.isActive).toBe(true);
+    expect(m.createdAt).toBeNull();
+    expect(m.updatedAt).toBeNull();
+  });
+
+  it("passes through SELECT options + helpText + non-default flags", () => {
+    const m = mapCustomFieldDefinition({
+      id: "cf3",
+      organizationId: "org1",
+      entityType: "PROJECT",
+      label: "Priority",
+      fieldKey: "priority",
+      fieldType: "SELECT",
+      options: ["Low", "High"],
+      required: true,
+      helpText: "pick one",
+      sortOrder: 3,
+      isActive: false,
+      createdAt: 1,
+      updatedAt: 2,
+    } as never);
+    expect(m.entityType).toBe("PROJECT");
+    expect(m.fieldType).toBe("SELECT");
+    expect(m.options).toEqual(["Low", "High"]);
+    expect(m.required).toBe(true);
+    expect(m.helpText).toBe("pick one");
+    expect(m.isActive).toBe(false);
+    expect(m.sortOrder).toBe(3);
+  });
+});
+
+describe("sortCustomFieldDefinitions", () => {
+  const row = (
+    partial: Partial<CustomFieldDefinitionRow> & { id: string },
+  ): CustomFieldDefinitionRow => ({
+    id: partial.id,
+    organizationId: "org",
+    entityType: "ASSET",
+    label: partial.id,
+    fieldKey: partial.id,
+    fieldType: "TEXT",
+    options: [],
+    required: false,
+    helpText: null,
+    sortOrder: partial.sortOrder ?? 0,
+    isActive: partial.isActive ?? true,
+    createdAt: partial.createdAt ?? null,
+    updatedAt: null,
+  });
+
+  it("orders by sortOrder asc, then createdAt asc (matches Prisma orderBy)", () => {
+    const defs = [
+      row({ id: "third", sortOrder: 2 }),
+      row({ id: "first", sortOrder: 0 }),
+      row({ id: "second", sortOrder: 1 }),
+    ];
+    expect(sortCustomFieldDefinitions(defs).map((d) => d.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("breaks sortOrder ties by createdAt ascending", () => {
+    const defs = [
+      row({ id: "newer", sortOrder: 0, createdAt: new Date(2000) }),
+      row({ id: "older", sortOrder: 0, createdAt: new Date(1000) }),
+    ];
+    expect(sortCustomFieldDefinitions(defs).map((d) => d.id)).toEqual([
+      "older",
+      "newer",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const defs = [row({ id: "b", sortOrder: 1 }), row({ id: "a", sortOrder: 0 })];
+    const original = defs.map((d) => d.id);
+    sortCustomFieldDefinitions(defs);
+    expect(defs.map((d) => d.id)).toEqual(original);
+  });
+});

--- a/src/lib/custom-fields-read.ts
+++ b/src/lib/custom-fields-read.ts
@@ -1,0 +1,129 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type { CustomFieldEntity } from "@/lib/validations/custom-field";
+
+/**
+ * Server-side read helpers for the custom-field-definition domain (Phase A
+ * read-rewiring of the Convex domain-only decommission).
+ *
+ * `customFieldDefinition` is dual-written (inline `api.customFieldDefinitions.*`
+ * from src/server/custom-fields.ts) and backfilled
+ * (scripts/convex-backfill-custom-fields.ts). These helpers read the Convex copy
+ * and shape it back into the Prisma-row form the settings page + entity
+ * create/edit forms expect.
+ *
+ * Convex stores most columns as `v.optional(...)` (the generated mirror schema),
+ * but every Prisma row has a value for them (column defaults). The mapper coerces
+ * those back to their Prisma-defaulted, non-null shape (entityType→ASSET,
+ * fieldType→TEXT, options→[], required→false, sortOrder→0, isActive→true) so
+ * consumers see the exact serialize(Prisma row) shape: epoch-ms → Date,
+ * helpText absent → null.
+ *
+ * The Convex `list` query is org-scoped and returns ALL entity types + active and
+ * inactive rows; the entityType / isActive filter + display ordering are applied
+ * here in JS (pure, unit-tested) to match the Prisma `where`/`orderBy`.
+ */
+
+type RawDef = Doc<"customFieldDefinitions">;
+
+const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
+const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+
+/** The mapped row — mirrors serialize(prisma.customFieldDefinition row). */
+export interface CustomFieldDefinitionRow {
+  id: string;
+  organizationId: string;
+  entityType: CustomFieldEntity;
+  label: string;
+  fieldKey: string;
+  fieldType: "TEXT" | "NUMBER" | "DATE" | "SELECT" | "BOOLEAN";
+  options: string[];
+  required: boolean;
+  helpText: string | null;
+  sortOrder: number;
+  isActive: boolean;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+/**
+ * Map a Convex `customFieldDefinitions` doc back to the Prisma row shape.
+ * Coerces every column Convex stores as optional to its Prisma default so the
+ * output is byte-compatible with serialize(prisma row).
+ */
+export function mapCustomFieldDefinition(d: RawDef): CustomFieldDefinitionRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    entityType: (d.entityType ?? "ASSET") as CustomFieldEntity,
+    label: d.label,
+    fieldKey: d.fieldKey,
+    fieldType: (d.fieldType ?? "TEXT") as CustomFieldDefinitionRow["fieldType"],
+    options: d.options ?? [],
+    required: d.required ?? false,
+    helpText: orNull(d.helpText),
+    sortOrder: d.sortOrder ?? 0,
+    isActive: d.isActive ?? true,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+/**
+ * Replicate Prisma `orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]`.
+ * Both columns are non-null in the Prisma row (defaults), so no NULLS handling
+ * is needed. A null createdAt (impossible for a real row) sorts as 0 — stable.
+ */
+export function sortCustomFieldDefinitions(
+  defs: CustomFieldDefinitionRow[],
+): CustomFieldDefinitionRow[] {
+  return [...defs].sort(
+    (a, b) =>
+      a.sortOrder - b.sortOrder ||
+      (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0),
+  );
+}
+
+/**
+ * All definitions for an entity type, ordered for display. Includes inactive
+ * ones — the settings page needs to show + toggle them.
+ *
+ * Replicates `where: { organizationId, entityType }`,
+ * `orderBy: [{ sortOrder }, { createdAt }]`.
+ */
+export async function getCustomFieldDefinitionsForOrg(
+  organizationId: string,
+  entityType: CustomFieldEntity = "ASSET",
+): Promise<CustomFieldDefinitionRow[]> {
+  const rows = (await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.customFieldDefinitions.list, {
+      orgId: organizationId,
+    }),
+  )) as RawDef[];
+  const mapped = rows
+    .map(mapCustomFieldDefinition)
+    .filter((d) => d.entityType === entityType);
+  return sortCustomFieldDefinitions(mapped);
+}
+
+/**
+ * Active definitions only — what the entity create/edit form renders.
+ *
+ * Replicates `where: { organizationId, entityType, isActive: true }`,
+ * `orderBy: [{ sortOrder }, { createdAt }]`.
+ */
+export async function getActiveCustomFieldsForOrg(
+  organizationId: string,
+  entityType: CustomFieldEntity = "ASSET",
+): Promise<CustomFieldDefinitionRow[]> {
+  const rows = (await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.customFieldDefinitions.list, {
+      orgId: organizationId,
+    }),
+  )) as RawDef[];
+  const mapped = rows
+    .map(mapCustomFieldDefinition)
+    .filter((d) => d.entityType === entityType && d.isActive);
+  return sortCustomFieldDefinitions(mapped);
+}

--- a/src/server/custom-fields.ts
+++ b/src/server/custom-fields.ts
@@ -15,6 +15,10 @@
 import { type FunctionArgs } from "convex/server";
 import { prisma } from "@/lib/prisma";
 import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
+import {
+  getActiveCustomFieldsForOrg,
+  getCustomFieldDefinitionsForOrg,
+} from "@/lib/custom-fields-read";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
@@ -56,10 +60,9 @@ async function patchCustomFieldInConvex(id: string, row: Record<string, unknown>
  *  inactive ones — the settings page needs to show + toggle them. */
 export async function getCustomFieldDefinitions(entityType: CustomFieldEntity = "ASSET") {
   const { organizationId } = await requirePermission("orgSettings", "read");
-  const defs = await prisma.customFieldDefinition.findMany({
-    where: { organizationId, entityType },
-    orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
-  });
+  // Convex-only read (Phase A): customFieldDefinition is dual-written + backfilled,
+  // so read the Convex copy and apply the entityType filter + display ordering in JS.
+  const defs = await getCustomFieldDefinitionsForOrg(organizationId, entityType);
   return serialize(defs);
 }
 
@@ -68,10 +71,9 @@ export async function getCustomFieldDefinitions(entityType: CustomFieldEntity = 
  *  who can edit an asset can see its custom-field inputs. */
 export async function getActiveCustomFields(entityType: CustomFieldEntity = "ASSET") {
   const { organizationId } = await getOrgContext();
-  const defs = await prisma.customFieldDefinition.findMany({
-    where: { organizationId, entityType, isActive: true },
-    orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
-  });
+  // Convex-only read (Phase A): active-only definitions, entityType-filtered +
+  // ordered in JS over the dual-written + backfilled Convex copy.
+  const defs = await getActiveCustomFieldsForOrg(organizationId, entityType);
   return serialize(defs);
 }
 


### PR DESCRIPTION
Phase A read-rewiring (Convex domain-only decommission). Moves `getCustomFieldDefinitions` + `getActiveCustomFields` in `server/custom-fields.ts` onto the dual-written + backfilled Convex `customFieldDefinitions` table via new `src/lib/custom-fields-read.ts`. Convex `list({orgId})` returns all entity types + active/inactive, so the `entityType` (+ `isActive` for the active variant) filter and `[{sortOrder asc},{createdAt asc}]` ordering are applied in JS. Optional Convex columns are coerced back to Prisma defaults. The auth gate (`requirePermission`/`getOrgContext`) and all writes stay on Prisma.

**Validation:** tsc clean, 6 unit tests pass, eslint clean (only the pre-existing `_id`-strip warning).

**Deploy gate:** `customFieldDefinition` is dual-written + backfilled — gate satisfied. Merge human-gated on Coolify preview.