### PR TITLE
feat(convex): read media galleries from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,42 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **media galleries** (`src/server/{asset,model,kit,project}-media.ts` →
+  `src/lib/media-read.ts`). The four standalone gallery getters — `getAssetMedia`,
+  `getModelMedia`, `getKitMedia`, `getProjectMedia` — moved off the Prisma
+  `*_media` + `file_upload` join to the Convex mirror via new
+  `get{Asset,Model,Kit,Project}MediaFromConvex` helpers. Each reconstructs the
+  EXACT prior serialized shape: media rows sorted by `sortOrder` asc (Prisma
+  `orderBy`), each with a nested `file` object, all timestamps converted epoch-ms→`Date`
+  (the old read ran `serialize()`, which keeps `Date`), and the optional Convex
+  columns `type`/`isPrimary`/`sortOrder`/`createdAt` coerced to the Prisma defaults
+  (PHOTO·OTHER / false / 0 / epoch). Project media carries no `isPrimary` and uses
+  `ProjectMediaType` (default OTHER). The org filter is reapplied in the server
+  action for parity with the old `where: { <fk>, organizationId }`.
+  **Dual-write status:** all four tables (`asset_media`/`model_media`/`kit_media`/`project_media`)
+  are dual-written via `media-mirror.ts`, backfilled via `scripts/convex-backfill-media.ts`,
+  and have Convex modules (`convex/{asset,model,kit,project}Media.ts`) — pre-flight gate satisfied.
+  **No new Convex query** — the existing per-table `listByParent` (added for the
+  mirror reconcile) is reused for the gallery read; `file` resolution uses the
+  existing `fileUploads.getById`. **Stays on Prisma (documented terminus):** the
+  detail-page composites `assets.ts:getAsset`, `kits.ts:getKit`, `models.ts:getModel`
+  compose their `*_media` galleries inside large cross-domain Prisma detail queries —
+  splitting a `media` include out is gratuitous risk. Pure mappers/sort unit-tested in
+  `src/lib/media-read.test.ts`.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/media-read.test.ts
+++ b/src/lib/media-read.test.ts
@@ -9,7 +9,12 @@
  * the file row (missing file → nulls), keyed by the parent fk.
  */
 import { describe, it, expect } from "vitest";
-import { buildPrimaryPhotoMap } from "@/lib/media-read";
+import {
+  buildPrimaryPhotoMap,
+  mapGalleryFile,
+  sortGalleryBySortOrder,
+} from "@/lib/media-read";
+import type { Doc } from "../../convex/_generated/dataModel";
 
 const files = [
   { id: "f1", url: "https://x/1.jpg", thumbnailUrl: "https://x/1_t.jpg" },
@@ -54,5 +59,83 @@ describe("buildPrimaryPhotoMap", () => {
       files,
     );
     expect(Object.keys(map)).toHaveLength(0);
+  });
+});
+
+/**
+ * Pure-core tests for the standalone gallery getters (Phase A read-rewiring).
+ * The getters themselves need a live Convex backend; these cover the
+ * deterministic mapping/sorting that reconstructs the old serialized Prisma
+ * shape from the Convex mirror.
+ */
+describe("mapGalleryFile", () => {
+  const baseFile: Doc<"fileUploads"> = {
+    _id: "internal" as Doc<"fileUploads">["_id"],
+    _creationTime: 0,
+    id: "f1",
+    organizationId: "org1",
+    fileName: "a.jpg",
+    fileSize: 123,
+    mimeType: "image/jpeg",
+    storageKey: "key/a.jpg",
+    url: "https://x/a.jpg",
+    thumbnailUrl: "https://x/a_t.jpg",
+    width: 800,
+    height: 600,
+    uploadedById: "u1",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_500_000,
+  };
+
+  it("returns null for a missing file (no Prisma fallback)", () => {
+    expect(mapGalleryFile(null)).toBeNull();
+  });
+
+  it("maps epoch-ms timestamps to Date and preserves business fields", () => {
+    const f = mapGalleryFile(baseFile)!;
+    expect(f.createdAt).toBeInstanceOf(Date);
+    expect(f.createdAt.getTime()).toBe(1_700_000_000_000);
+    expect(f.updatedAt.getTime()).toBe(1_700_000_500_000);
+    expect(f.url).toBe("https://x/a.jpg");
+    expect(f.thumbnailUrl).toBe("https://x/a_t.jpg");
+    expect(f.width).toBe(800);
+    expect(f.height).toBe(600);
+  });
+
+  it("coerces absent optional columns to null", () => {
+    const f = mapGalleryFile({
+      ...baseFile,
+      thumbnailUrl: undefined,
+      width: undefined,
+      height: undefined,
+    })!;
+    expect(f.thumbnailUrl).toBeNull();
+    expect(f.width).toBeNull();
+    expect(f.height).toBeNull();
+  });
+
+  it("coerces absent timestamps to the epoch (never NaN/Invalid Date)", () => {
+    const f = mapGalleryFile({ ...baseFile, createdAt: undefined, updatedAt: undefined })!;
+    expect(f.createdAt.getTime()).toBe(0);
+    expect(f.updatedAt.getTime()).toBe(0);
+  });
+});
+
+describe("sortGalleryBySortOrder", () => {
+  it("orders ascending by sortOrder (Prisma orderBy parity)", () => {
+    const rows = [{ id: "c", sortOrder: 2 }, { id: "a", sortOrder: 0 }, { id: "b", sortOrder: 1 }];
+    expect(sortGalleryBySortOrder(rows).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("treats an absent sortOrder as 0 (the Prisma default)", () => {
+    const rows = [{ id: "x", sortOrder: 1 }, { id: "y" }];
+    expect(sortGalleryBySortOrder(rows).map((r) => r.id)).toEqual(["y", "x"]);
+  });
+
+  it("is stable for ties and does not mutate the input", () => {
+    const rows = [{ id: "p", sortOrder: 5 }, { id: "q", sortOrder: 5 }];
+    const sorted = sortGalleryBySortOrder(rows);
+    expect(sorted.map((r) => r.id)).toEqual(["p", "q"]);
+    expect(rows[0].id).toBe("p");
   });
 });

--- a/src/lib/media-read.ts
+++ b/src/lib/media-read.ts
@@ -1,6 +1,8 @@
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { MEDIA_SPECS, type MediaKind } from "@/lib/media-mirror";
 import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type { MediaType, ProjectMediaType } from "@/generated/prisma/client";
 
 /**
  * Server-side read helpers for the `*_media` domains (Phase 6 decommission).
@@ -94,4 +96,186 @@ export async function getPrimaryPhotoMap(
   orgId: string,
 ): Promise<Record<string, PhotoMeta>> {
   return (await getPrimaryPhotoMaps([kind], orgId))[kind];
+}
+
+/* ------------------------------------------------------------------------- *
+ * Standalone gallery getters (Phase A read-rewiring)
+ *
+ * The dead-no-longer standalone gallery server actions — getAssetMedia /
+ * getModelMedia / getKitMedia / getProjectMedia — now read the Convex mirror
+ * instead of a Prisma `*_media` + `file_upload` join. They reconstruct the EXACT
+ * prior serialized shape: an array of media rows (ordered by sortOrder asc, the
+ * Prisma `orderBy`), each with a nested `file` object, and `Date` values for
+ * every timestamp (the old read ran `serialize()`, which preserves `Date`; the
+ * Convex mirror stores epoch-ms, so we convert back to `Date` here).
+ *
+ * The Convex `*_media` columns `type` / `isPrimary` / `sortOrder` / `createdAt`
+ * are stored `v.optional()` (they're Prisma-defaulted), so we coerce them to the
+ * Prisma defaults (PHOTO / OTHER, false, 0, epoch) — never null — to match the
+ * non-null Prisma row.
+ *
+ * The detail-page composites (`assets.ts:getAsset`, `kits.ts:getKit`,
+ * `models.ts:getModel`) compose their galleries inside large cross-domain Prisma
+ * detail queries and STAY on Prisma — documented terminus, see media-mirror.ts.
+ * Only these four standalone getters move.
+ *
+ * NO Prisma fallback on a Convex miss — a missing file id reads `file: null`,
+ * the same as a Prisma join against a deleted row.
+ * ------------------------------------------------------------------------- */
+
+/** The nested `file` shape the old `include: { file: true }` produced, with the
+ * mirror's epoch-ms timestamps converted back to `Date`. */
+export type GalleryFile = {
+  id: string;
+  organizationId: string;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  storageKey: string;
+  url: string;
+  thumbnailUrl: string | null;
+  width: number | null;
+  height: number | null;
+  uploadedById: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type GalleryMediaBase = {
+  id: string;
+  organizationId: string;
+  fileId: string;
+  displayName: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  file: GalleryFile | null;
+};
+
+export type AssetGalleryMedia = GalleryMediaBase & { assetId: string; type: MediaType; isPrimary: boolean };
+export type ModelGalleryMedia = GalleryMediaBase & { modelId: string; type: MediaType; isPrimary: boolean };
+export type KitGalleryMedia = GalleryMediaBase & { kitId: string; type: MediaType; isPrimary: boolean };
+export type ProjectGalleryMedia = GalleryMediaBase & { projectId: string; type: ProjectMediaType };
+
+/** Map a Convex `fileUploads` doc to the nested `file` shape (epoch-ms → Date,
+ * absent → null for the nullable columns). */
+export function mapGalleryFile(doc: Doc<"fileUploads"> | null): GalleryFile | null {
+  if (!doc) return null;
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    fileName: doc.fileName,
+    fileSize: doc.fileSize,
+    mimeType: doc.mimeType,
+    storageKey: doc.storageKey,
+    url: doc.url,
+    thumbnailUrl: doc.thumbnailUrl ?? null,
+    width: doc.width ?? null,
+    height: doc.height ?? null,
+    uploadedById: doc.uploadedById,
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
+/** Shared media-row fields (everything but the parent FK + photo `type`/`isPrimary`). */
+function mapGalleryBase(
+  m: { id: string; organizationId: string; fileId: string; displayName?: string | null; sortOrder?: number | null; createdAt?: number | null },
+  file: GalleryFile | null,
+): GalleryMediaBase {
+  return {
+    id: m.id,
+    organizationId: m.organizationId,
+    fileId: m.fileId,
+    displayName: m.displayName ?? null,
+    sortOrder: m.sortOrder ?? 0,
+    createdAt: new Date(m.createdAt ?? 0),
+    file,
+  };
+}
+
+/** Pure sort replicating Prisma `orderBy: { sortOrder: "asc" }` (coercing the
+ * Prisma-defaulted `sortOrder` to 0). Stable so ties keep input order. */
+export function sortGalleryBySortOrder<T extends { sortOrder?: number | null }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+}
+
+/**
+ * Resolve the nested `file` for a set of media rows from the Convex mirror.
+ * Fetches each distinct `fileId` once via `fileUploads.getById` (per-parent
+ * media sets are small; a per-parent gallery has at most a handful of files, so
+ * a few targeted lookups beat pulling the whole org file list).
+ */
+async function fetchGalleryFiles(fileIds: string[]): Promise<Map<string, GalleryFile>> {
+  const unique = [...new Set(fileIds)];
+  if (unique.length === 0) return new Map();
+  const convex = await getConvexClient();
+  const docs = await Promise.all(unique.map((id) => convex.query(api.fileUploads.getById, { id })));
+  const out = new Map<string, GalleryFile>();
+  unique.forEach((id, i) => {
+    const mapped = mapGalleryFile(docs[i]);
+    if (mapped) out.set(id, mapped);
+  });
+  return out;
+}
+
+async function getGalleryRows<K extends MediaKind>(
+  kind: K,
+  parentId: string,
+): Promise<Array<Doc<"assetMedia"> | Doc<"modelMedia"> | Doc<"kitMedia"> | Doc<"projectMedia">>> {
+  const convex = await getConvexClient();
+  return withConvexReadRetry(
+    async () =>
+      (await convex.query(MEDIA_SPECS[kind].convex.listByParent, { parentId })) as Array<
+        Doc<"assetMedia"> | Doc<"modelMedia"> | Doc<"kitMedia"> | Doc<"projectMedia">
+      >,
+  );
+}
+
+/** Asset gallery — replaces `prisma.assetMedia.findMany({ where: { assetId },
+ * include: { file }, orderBy: { sortOrder: "asc" } })`. */
+export async function getAssetMediaFromConvex(assetId: string): Promise<AssetGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("asset", assetId)) as Doc<"assetMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    assetId: m.assetId,
+    type: (m.type ?? "PHOTO") as MediaType,
+    isPrimary: m.isPrimary ?? false,
+  }));
+}
+
+/** Model gallery — Convex equivalent of the old `prisma.modelMedia` getter. */
+export async function getModelMediaFromConvex(modelId: string): Promise<ModelGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("model", modelId)) as Doc<"modelMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    modelId: m.modelId,
+    type: (m.type ?? "PHOTO") as MediaType,
+    isPrimary: m.isPrimary ?? false,
+  }));
+}
+
+/** Kit gallery — Convex equivalent of the old `prisma.kitMedia` getter. */
+export async function getKitMediaFromConvex(kitId: string): Promise<KitGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("kit", kitId)) as Doc<"kitMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    kitId: m.kitId,
+    type: (m.type ?? "PHOTO") as MediaType,
+    isPrimary: m.isPrimary ?? false,
+  }));
+}
+
+/** Project gallery — Convex equivalent of the old `prisma.projectMedia` getter.
+ * Project media has NO `isPrimary` and uses `ProjectMediaType` (default OTHER). */
+export async function getProjectMediaFromConvex(projectId: string): Promise<ProjectGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("project", projectId)) as Doc<"projectMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    projectId: m.projectId,
+    type: (m.type ?? "OTHER") as ProjectMediaType,
+  }));
 }

--- a/src/server/asset-media.ts
+++ b/src/server/asset-media.ts
@@ -5,6 +5,7 @@ import { mirrorFileUploadDelete } from "@/lib/file-upload-mirror";
 import { mirrorMediaCreate, syncMediaForParent } from "@/lib/media-mirror";
 import { getOrgContext } from "@/lib/org-context";
 import { getAssetById } from "@/lib/assets-read";
+import { getAssetMediaFromConvex } from "@/lib/media-read";
 import { serialize } from "@/lib/serialize";
 import { deleteFromS3 } from "@/lib/storage";
 import type { MediaType } from "@/generated/prisma/client";
@@ -125,11 +126,12 @@ export async function setAssetPrimaryPhoto(assetId: string, mediaId: string) {
 export async function getAssetMedia(assetId: string) {
   const { organizationId } = await getOrgContext();
 
-  const media = await prisma.assetMedia.findMany({
-    where: { assetId, organizationId },
-    include: { file: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // Read the gallery from the Convex mirror (dual-written, backfilled). The
+  // parent asset is org-unique, but keep the org filter for parity with the
+  // old Prisma `where: { assetId, organizationId }`. See media-read.ts.
+  const media = (await getAssetMediaFromConvex(assetId)).filter(
+    (m) => m.organizationId === organizationId,
+  );
 
   return serialize(media);
 }

--- a/src/server/kit-media.ts
+++ b/src/server/kit-media.ts
@@ -5,6 +5,7 @@ import { mirrorFileUploadDelete } from "@/lib/file-upload-mirror";
 import { mirrorMediaCreate, syncMediaForParent } from "@/lib/media-mirror";
 import { getOrgContext } from "@/lib/org-context";
 import { getKitById } from "@/lib/kits-read";
+import { getKitMediaFromConvex } from "@/lib/media-read";
 import { serialize } from "@/lib/serialize";
 import { deleteFromS3 } from "@/lib/storage";
 import type { MediaType } from "@/generated/prisma/client";
@@ -125,11 +126,12 @@ export async function setKitPrimaryPhoto(kitId: string, mediaId: string) {
 export async function getKitMedia(kitId: string) {
   const { organizationId } = await getOrgContext();
 
-  const media = await prisma.kitMedia.findMany({
-    where: { kitId, organizationId },
-    include: { file: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // Read the gallery from the Convex mirror (dual-written, backfilled). The
+  // parent kit is org-unique, but keep the org filter for parity with the old
+  // Prisma `where: { kitId, organizationId }`. See media-read.ts.
+  const media = (await getKitMediaFromConvex(kitId)).filter(
+    (m) => m.organizationId === organizationId,
+  );
 
   return serialize(media);
 }

--- a/src/server/model-media.ts
+++ b/src/server/model-media.ts
@@ -8,6 +8,7 @@ import { serialize } from "@/lib/serialize";
 import { deleteFromS3 } from "@/lib/storage";
 import type { MediaType } from "@/generated/prisma/client";
 import { getModelById } from "@/lib/models-read";
+import { getModelMediaFromConvex } from "@/lib/media-read";
 
 export async function addModelMedia(data: {
   modelId: string;
@@ -153,11 +154,12 @@ export async function reorderModelMedia(modelId: string, orderedIds: string[]) {
 export async function getModelMedia(modelId: string) {
   const { organizationId } = await getOrgContext();
 
-  const media = await prisma.modelMedia.findMany({
-    where: { modelId, organizationId },
-    include: { file: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // Read the gallery from the Convex mirror (dual-written, backfilled). The
+  // parent model is org-unique, but keep the org filter for parity with the
+  // old Prisma `where: { modelId, organizationId }`. See media-read.ts.
+  const media = (await getModelMediaFromConvex(modelId)).filter(
+    (m) => m.organizationId === organizationId,
+  );
 
   return serialize(media);
 }

--- a/src/server/project-media.ts
+++ b/src/server/project-media.ts
@@ -5,6 +5,7 @@ import { mirrorFileUploadDelete } from "@/lib/file-upload-mirror";
 import { mirrorMediaCreate, syncMediaForParent } from "@/lib/media-mirror";
 import { getOrgContext } from "@/lib/org-context";
 import { getProjectById } from "@/lib/projects-read";
+import { getProjectMediaFromConvex } from "@/lib/media-read";
 import { serialize } from "@/lib/serialize";
 import { deleteFromS3 } from "@/lib/storage";
 import type { ProjectMediaType } from "@/generated/prisma/client";
@@ -76,11 +77,12 @@ export async function removeProjectMedia(mediaId: string) {
 export async function getProjectMedia(projectId: string) {
   const { organizationId } = await getOrgContext();
 
-  const media = await prisma.projectMedia.findMany({
-    where: { projectId, organizationId },
-    include: { file: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // Read the gallery from the Convex mirror (dual-written, backfilled). The
+  // parent project is org-unique, but keep the org filter for parity with the
+  // old Prisma `where: { projectId, organizationId }`. See media-read.ts.
+  const media = (await getProjectMediaFromConvex(projectId)).filter(
+    (m) => m.organizationId === organizationId,
+  );
 
   return serialize(media);
 }


### PR DESCRIPTION
## Summary

Phase A read-rewiring, one leaf surface: the four **standalone media gallery getters** move off the Prisma `*_media` + `file_upload` join to the Convex mirror.

- `getAssetMedia`, `getModelMedia`, `getKitMedia`, `getProjectMedia` (`src/server/{asset,model,kit,project}-media.ts`) now read via new `get{Asset,Model,Kit,Project}MediaFromConvex` helpers in `src/lib/media-read.ts`.
- Each helper reconstructs the **exact prior serialized shape**: media rows sorted by `sortOrder` asc (Prisma `orderBy`), each with a nested `file` object, all timestamps converted epoch-ms→`Date` (the old read ran `serialize()`, which keeps `Date`), and the optional Convex columns `type`/`isPrimary`/`sortOrder`/`createdAt` coerced to the Prisma defaults (PHOTO·OTHER / false / 0 / epoch). Project media carries no `isPrimary` and uses `ProjectMediaType` (default OTHER).
- Org filter reapplied in the server action for parity with the old `where: { <fk>, organizationId }`.
- **Reuses the existing per-table `listByParent` query + `fileUploads.getById`** — no new Convex function, **no `convex/*.ts` changes**.
- **No Prisma fallback** on a Convex miss (a missing file id reads `file: null`, same as a Prisma join against a deleted row).

### Stays on Prisma (documented terminus)
The detail-page composites `assets.ts:getAsset`, `kits.ts:getKit`, `models.ts:getModel` compose their galleries inside large cross-domain Prisma detail queries — not touched.

## Pre-flight gate (satisfied)
All four tables (`asset_media`/`model_media`/`kit_media`/`project_media`) are dual-written (`src/lib/media-mirror.ts`), backfilled (`scripts/convex-backfill-media.ts`), and have Convex modules (`convex/{asset,model,kit,project}Media.ts`).

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/media-read.test.ts` — **10/10 pass** (6 new pure mapper/sort tests added: `mapGalleryFile`, `sortGalleryBySortOrder`)
- `pnpm exec eslint` on all modified files — clean (no warnings)

## Deploy gate / merge gate
The media tables must be backfilled into **prod Convex** before this read deploys (they are — backfilled with the media family). Merge is **human-gated on the Coolify PR preview** — Convex data-correctness can't be verified in a dev worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)