### PR TITLE
feat(convex): read check items from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,34 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **check items** (`server/check-items.ts` → `src/lib/check-items-read.ts`). Moved all
+  five pure-read actions: `getCheckItems` (list + `_count`), `getCheckItemCounts`,
+  `getCheckItem` (single + its model assignments), `getModelCheckItems`, and
+  `getKitCheckItems`. Tables: `checkItem`, `modelCheckItem`, `kitCheckItem` are all
+  dual-written + backfilled (`convex-backfill-check-items.ts`,
+  `convex-backfill-check-item-assignments.ts`); the `_count` halves come from the
+  dual-written `modelCheckItem` and `checkRecord` (`convex-backfill-check-records.ts`)
+  lists, computed in JS. New Convex queries added to the existing modules:
+  `modelCheckItems.listByModelId`, `modelCheckItems.listByCheckItemId`, and
+  `kitCheckItems.listByKitId` (org-scoped FK-index reads). Stayed on their own
+  sources: the cross-domain `model` name join in `getCheckItem` (Model is read from
+  Convex via `getModelById`); all writes (create/update/delete + the model/kit
+  assignment mutations and their read-then-write `aggregate`/`groupBy`/`findFirst`
+  guards) stay Prisma-anchored as before.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/convex/kitCheckItems.ts
+++ b/convex/kitCheckItems.ts
@@ -32,6 +32,19 @@ export const getById = query({
   },
 });
 
+/** Assignments for one kit, org-scoped. Replaces a Prisma findMany by kitId. */
+export const listByKitId = query({
+  args: { orgId: v.string(), kitId: v.string() },
+  handler: async (ctx, { orgId, kitId }) => {
+    await requireOrgRead(ctx, orgId);
+    const rows = await ctx.db
+      .query("kitCheckItems")
+      .withIndex("by_kitId", (q) => q.eq("kitId", kitId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/modelCheckItems.ts
+++ b/convex/modelCheckItems.ts
@@ -32,6 +32,33 @@ export const getById = query({
   },
 });
 
+/** Assignments for one model, org-scoped. Replaces a Prisma findMany by modelId. */
+export const listByModelId = query({
+  args: { orgId: v.string(), modelId: v.string() },
+  handler: async (ctx, { orgId, modelId }) => {
+    await requireOrgRead(ctx, orgId);
+    const rows = await ctx.db
+      .query("modelCheckItems")
+      .withIndex("by_modelId", (q) => q.eq("modelId", modelId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
+/** Assignments for one check item, org-scoped. Replaces a Prisma findMany by
+ *  checkItemId (the `modelCheckItems` include on a single check item). */
+export const listByCheckItemId = query({
+  args: { orgId: v.string(), checkItemId: v.string() },
+  handler: async (ctx, { orgId, checkItemId }) => {
+    await requireOrgRead(ctx, orgId);
+    const rows = await ctx.db
+      .query("modelCheckItems")
+      .withIndex("by_checkItemId", (q) => q.eq("checkItemId", checkItemId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/lib/check-items-read.test.ts
+++ b/src/lib/check-items-read.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the pure filter/sort predicates in check-items-read.
+ *
+ * These replicate the Prisma `orderBy` clauses the Convex reads replace:
+ *  - the check-item library: `orderBy: [{ category: "asc" }, { label: "asc" }]`
+ *    (Postgres ASC ⇒ NULLS LAST on the nullable `category`).
+ *  - the model/kit assignment lists: `orderBy: { sortOrder: "asc" }`.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  sortCheckItemsForLibrary,
+  sortAssignmentsBySortOrder,
+  type CheckItemRow,
+} from "@/lib/check-items-read";
+
+function ci(partial: Partial<CheckItemRow> & { id: string }): CheckItemRow {
+  return {
+    organizationId: "org1",
+    label: partial.label ?? "Label",
+    description: null,
+    type: "PASS_FAIL",
+    category: null,
+    measurementUnit: null,
+    measurementMin: null,
+    measurementMax: null,
+    dropdownOptions: null,
+    createdById: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...partial,
+  };
+}
+
+describe("sortCheckItemsForLibrary", () => {
+  it("sorts by category ASC then label ASC", () => {
+    const sorted = sortCheckItemsForLibrary([
+      ci({ id: "b", category: "Electrical", label: "Beta" }),
+      ci({ id: "a", category: "Electrical", label: "Alpha" }),
+      ci({ id: "c", category: "Audio", label: "Gamma" }),
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("places null category LAST (Postgres ASC NULLS LAST)", () => {
+    const sorted = sortCheckItemsForLibrary([
+      ci({ id: "uncat", category: null, label: "Aaa" }),
+      ci({ id: "cat", category: "Zzz", label: "Zzz" }),
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual(["cat", "uncat"]);
+  });
+
+  it("breaks category ties on label ASC", () => {
+    const sorted = sortCheckItemsForLibrary([
+      ci({ id: "y", category: null, label: "Yankee" }),
+      ci({ id: "x", category: null, label: "Xray" }),
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual(["x", "y"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [ci({ id: "b", label: "B" }), ci({ id: "a", label: "A" })];
+    const before = input.map((i) => i.id);
+    sortCheckItemsForLibrary(input);
+    expect(input.map((i) => i.id)).toEqual(before);
+  });
+});
+
+describe("sortAssignmentsBySortOrder", () => {
+  it("sorts ascending by sortOrder", () => {
+    const sorted = sortAssignmentsBySortOrder([
+      { id: "c", sortOrder: 2 },
+      { id: "a", sortOrder: 0 },
+      { id: "b", sortOrder: 1 },
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      { id: "b", sortOrder: 1 },
+      { id: "a", sortOrder: 0 },
+    ];
+    sortAssignmentsBySortOrder(input);
+    expect(input.map((r) => r.id)).toEqual(["b", "a"]);
+  });
+});

--- a/src/lib/check-items-read.ts
+++ b/src/lib/check-items-read.ts
@@ -1,0 +1,256 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the Check Items domain (Phase A read-rewiring).
+ *
+ * CheckItem, ModelCheckItem and KitCheckItem are all dual-written: every
+ * create/update/delete writes BOTH the Prisma row (the durable FK anchor —
+ * `model_check_item`, `kit_check_item` and `check_record` carry a required +
+ * Cascade FK to `check_item`) AND the Convex doc (the reactive read source). These
+ * helpers read the pure-read server actions (`getCheckItems`, `getCheckItem`,
+ * `getModelCheckItems`, `getKitCheckItems`) from Convex instead of Prisma.
+ *
+ * Mappers reverse `toConvexDoc`: epoch-ms → Date, absent → null, and
+ * Prisma-defaulted columns (`type` default PASS_FAIL, `sortOrder` default 0) are
+ * coerced back to their non-null defaults. `dropdownOptions` is a JSON column
+ * (`v.any()`) and passes straight through. No Prisma fallback on a Convex miss — a
+ * miss reads null/empty, like a join against a deleted row. Cross-domain joins to
+ * the auth `User` (createdBy) and to the `Model` table stay on their own sources.
+ * See FEATUREDOCS/54.
+ */
+
+type ConvexCheckItem = Doc<"checkItems">;
+type ConvexModelCheckItem = Doc<"modelCheckItems">;
+type ConvexKitCheckItem = Doc<"kitCheckItems">;
+
+/** Public shape of a check item, matching the old Prisma `serialize`d row. */
+export interface CheckItemRow {
+  id: string;
+  organizationId: string;
+  label: string;
+  description: string | null;
+  type: "PASS_FAIL" | "NOTES" | "MEASUREMENT" | "DROPDOWN";
+  category: string | null;
+  measurementUnit: string | null;
+  measurementMin: number | null;
+  measurementMax: number | null;
+  dropdownOptions: unknown;
+  createdById: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** A model/kit assignment row with its nested `checkItem`, matching the old
+ *  Prisma `include: { checkItem: true }` shape. */
+export interface CheckItemAssignmentRow {
+  id: string;
+  organizationId: string;
+  modelId?: string;
+  kitId?: string;
+  checkItemId: string;
+  sortOrder: number;
+  createdAt: Date;
+  checkItem: CheckItemRow;
+}
+
+/** Map a Convex checkItems doc back to the Prisma-shaped row. */
+function mapCheckItem(doc: ConvexCheckItem): CheckItemRow {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    label: doc.label,
+    description: doc.description ?? null,
+    // Prisma column default is PASS_FAIL; toConvexDoc drops the field if it ever
+    // equalled the default and was somehow absent, so coerce defensively.
+    type: doc.type ?? "PASS_FAIL",
+    category: doc.category ?? null,
+    measurementUnit: doc.measurementUnit ?? null,
+    measurementMin: doc.measurementMin ?? null,
+    measurementMax: doc.measurementMax ?? null,
+    // JSON column — pass straight through (absent → null).
+    dropdownOptions: doc.dropdownOptions ?? null,
+    createdById: doc.createdById ?? null,
+    createdAt: doc.createdAt != null ? new Date(doc.createdAt) : new Date(0),
+    updatedAt: doc.updatedAt != null ? new Date(doc.updatedAt) : new Date(0),
+  };
+}
+
+// ─── Pure filter/sort predicates (unit-tested) ──────────────────────────────
+
+/**
+ * Replicate Prisma `orderBy: [{ category: "asc" }, { label: "asc" }]`. Postgres
+ * ASC sorts NULLS LAST, so a null `category` sorts after any present value; ties
+ * break on `label` (a required column, never null).
+ */
+export function sortCheckItemsForLibrary(items: CheckItemRow[]): CheckItemRow[] {
+  return [...items].sort((a, b) => {
+    const ca = nullsLastAsc(a.category, b.category);
+    if (ca !== 0) return ca;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/** ASC comparator with NULLS LAST (Postgres default for ASC). */
+function nullsLastAsc(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return a.localeCompare(b);
+}
+
+/** Replicate Prisma `orderBy: { sortOrder: "asc" }` on assignment rows. */
+export function sortAssignmentsBySortOrder<T extends { sortOrder: number }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => a.sortOrder - b.sortOrder);
+}
+
+// ─── Fetchers ───────────────────────────────────────────────────────────────
+
+/** All check items for an org, sorted like the Prisma library query. */
+export async function getCheckItemsForOrg(orgId: string): Promise<CheckItemRow[]> {
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.checkItems.list, { orgId }),
+  );
+  return sortCheckItemsForLibrary(docs.map(mapCheckItem));
+}
+
+/** A single check item by id, org-scoped (null when absent or wrong org). */
+export async function getCheckItemById(
+  orgId: string,
+  id: string,
+): Promise<CheckItemRow | null> {
+  const doc = await (await getConvexClient()).query(api.checkItems.getById, { id });
+  if (!doc || doc.organizationId !== orgId) return null;
+  return mapCheckItem(doc);
+}
+
+/**
+ * Per-check-item usage counts (checkItemId → { modelCheckItems, checkRecords })
+ * computed in JS over the org's modelCheckItems and checkRecords lists. Both join
+ * tables are dual-written, so the whole groupBy/_count moves to Convex. Replaces
+ * two Prisma `groupBy({ by: ["checkItemId"], _count })` aggregates.
+ */
+export async function getCheckItemUsageCounts(
+  orgId: string,
+): Promise<Record<string, { modelCheckItems: number; checkRecords: number }>> {
+  const [modelRows, recordRows] = await Promise.all([
+    withConvexReadRetry(async () =>
+      (await getConvexClient()).query(api.modelCheckItems.list, { orgId }),
+    ),
+    withConvexReadRetry(async () =>
+      (await getConvexClient()).query(api.checkRecords.list, { orgId }),
+    ),
+  ]);
+  const counts: Record<string, { modelCheckItems: number; checkRecords: number }> = {};
+  const ensure = (id: string) => (counts[id] ??= { modelCheckItems: 0, checkRecords: 0 });
+  for (const r of modelRows) if (r.checkItemId) ensure(r.checkItemId).modelCheckItems += 1;
+  for (const r of recordRows) if (r.checkItemId) ensure(r.checkItemId).checkRecords += 1;
+  return counts;
+}
+
+/**
+ * Model check-item assignments for one model, sorted by sortOrder, each with its
+ * nested `checkItem` attached from the org's Convex checkItems list. Replaces
+ * Prisma `findMany({ where: { modelId }, include: { checkItem: true } })`.
+ */
+export async function getModelCheckItemsForModel(
+  orgId: string,
+  modelId: string,
+): Promise<CheckItemAssignmentRow[]> {
+  const [assignments, checkItems] = await Promise.all([
+    withConvexReadRetry(async () =>
+      (await getConvexClient()).query(api.modelCheckItems.listByModelId, { orgId, modelId }),
+    ),
+    getCheckItemMap(orgId),
+  ]);
+  return attachCheckItems(assignments, checkItems);
+}
+
+/**
+ * Kit check-item assignments for one kit, sorted by sortOrder, each with its
+ * nested `checkItem`. Replaces Prisma `findMany({ where: { kitId }, include: {
+ * checkItem: true } })`.
+ */
+export async function getKitCheckItemsForKit(
+  orgId: string,
+  kitId: string,
+): Promise<CheckItemAssignmentRow[]> {
+  const [assignments, checkItems] = await Promise.all([
+    withConvexReadRetry(async () =>
+      (await getConvexClient()).query(api.kitCheckItems.listByKitId, { orgId, kitId }),
+    ),
+    getCheckItemMap(orgId),
+  ]);
+  return attachCheckItems(assignments, checkItems);
+}
+
+/** A raw model assignment row (no nested checkItem), matching the Prisma
+ *  `modelCheckItems: true` include on a single check item. */
+export interface ModelAssignmentRow {
+  id: string;
+  organizationId: string;
+  modelId: string;
+  checkItemId: string;
+  sortOrder: number;
+  createdAt: Date;
+}
+
+/**
+ * Raw model assignments for one check item (by checkItemId), no nested checkItem.
+ * Replaces the `modelCheckItems: true` include in the Prisma getCheckItem query.
+ * No orderBy — the caller re-sorts by resolved model name.
+ */
+export async function getModelAssignmentsForCheckItem(
+  orgId: string,
+  checkItemId: string,
+): Promise<ModelAssignmentRow[]> {
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.modelCheckItems.listByCheckItemId, { orgId, checkItemId }),
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    organizationId: r.organizationId,
+    modelId: r.modelId,
+    checkItemId: r.checkItemId,
+    sortOrder: r.sortOrder ?? 0,
+    createdAt: r.createdAt != null ? new Date(r.createdAt) : new Date(0),
+  }));
+}
+
+// ─── Attach helper ───────────────────────────────────────────────────────────
+
+/** Org check items keyed by cuid `id`, for attaching to assignment rows. */
+async function getCheckItemMap(orgId: string): Promise<Map<string, CheckItemRow>> {
+  const items = await getCheckItemsForOrg(orgId);
+  return new Map(items.map((i) => [i.id, i]));
+}
+
+/**
+ * Attach the nested `checkItem` to assignment rows and sort by sortOrder. An
+ * assignment whose `checkItem` is absent from the map (a join against a deleted
+ * row) is dropped — Prisma's required FK + Cascade delete means such a row can't
+ * exist, but we never invent one.
+ */
+function attachCheckItems(
+  assignments: Array<ConvexModelCheckItem | ConvexKitCheckItem>,
+  checkItems: Map<string, CheckItemRow>,
+): CheckItemAssignmentRow[] {
+  const rows: CheckItemAssignmentRow[] = [];
+  for (const a of assignments) {
+    const checkItem = checkItems.get(a.checkItemId);
+    if (!checkItem) continue;
+    rows.push({
+      id: a.id,
+      organizationId: a.organizationId,
+      ...("modelId" in a ? { modelId: a.modelId } : {}),
+      ...("kitId" in a ? { kitId: a.kitId } : {}),
+      checkItemId: a.checkItemId,
+      // Prisma column default is 0.
+      sortOrder: a.sortOrder ?? 0,
+      createdAt: a.createdAt != null ? new Date(a.createdAt) : new Date(0),
+      checkItem,
+    });
+  }
+  return sortAssignmentsBySortOrder(rows);
+}

--- a/src/server/check-items.ts
+++ b/src/server/check-items.ts
@@ -6,6 +6,14 @@ import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getModelById, getModelMap } from "@/lib/models-read";
+import {
+  getCheckItemsForOrg,
+  getCheckItemById,
+  getCheckItemUsageCounts,
+  getModelCheckItemsForModel,
+  getKitCheckItemsForKit,
+  getModelAssignmentsForCheckItem,
+} from "@/lib/check-items-read";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import {
@@ -53,56 +61,53 @@ async function patchCheckItemInConvex(id: string, row: Record<string, unknown>) 
 export async function getCheckItems() {
   const { organizationId } = await requirePermission("checkItem", "read");
 
+  // Convex reads: the check-item list + the usage counts (both join tables are
+  // dual-written) replace the Prisma findMany + `_count` aggregate.
+  const [items, counts] = await Promise.all([
+    getCheckItemsForOrg(organizationId),
+    getCheckItemUsageCounts(organizationId),
+  ]);
   return serialize(
-    await prisma.checkItem.findMany({
-      where: { organizationId },
-      include: {
-        _count: { select: { modelCheckItems: true, checkRecords: true } },
-      },
-      orderBy: [{ category: "asc" }, { label: "asc" }],
-    })
+    items.map((item) => ({
+      ...item,
+      _count: counts[item.id] ?? { modelCheckItems: 0, checkRecords: 0 },
+    }))
   );
 }
 
 /**
  * Per-check-item usage counts (checkItemId -> { modelCheckItems, checkRecords }).
- * Cross-domain: the assignment + record join tables stay in Prisma, so this can't
- * come from Convex. Used by the reactive check-item library, which subscribes to
- * the list via Convex and merges these (non-reactive) counts in.
+ * Both the modelCheckItem and checkRecord join tables are dual-written, so the
+ * counts come from Convex. Used by the reactive check-item library, which
+ * subscribes to the list via Convex and merges these (non-reactive) counts in.
  */
 export async function getCheckItemCounts(): Promise<Record<string, { modelCheckItems: number; checkRecords: number }>> {
   const { organizationId } = await getOrgContext();
-  const [modelGroups, recordGroups] = await Promise.all([
-    prisma.modelCheckItem.groupBy({ by: ["checkItemId"], where: { organizationId }, _count: { _all: true } }),
-    prisma.checkRecord.groupBy({ by: ["checkItemId"], where: { organizationId }, _count: { _all: true } }),
-  ]);
-  const counts: Record<string, { modelCheckItems: number; checkRecords: number }> = {};
-  const ensure = (id: string) => (counts[id] ??= { modelCheckItems: 0, checkRecords: 0 });
-  for (const g of modelGroups) if (g.checkItemId) ensure(g.checkItemId).modelCheckItems = g._count._all;
-  for (const g of recordGroups) if (g.checkItemId) ensure(g.checkItemId).checkRecords = g._count._all;
-  return serialize(counts);
+  return serialize(await getCheckItemUsageCounts(organizationId));
 }
 
 export async function getCheckItem(id: string) {
   const { organizationId } = await requirePermission("checkItem", "read");
 
-  const item = await prisma.checkItem.findFirst({
-    where: { id, organizationId },
-    include: {
-      _count: { select: { modelCheckItems: true, checkRecords: true } },
-      modelCheckItems: true,
-    },
-  });
+  // Convex reads: the check item itself + its model assignments (replacing the
+  // Prisma findFirst with `_count` + `modelCheckItems` include).
+  const [item, assignments, counts] = await Promise.all([
+    getCheckItemById(organizationId, id),
+    getModelAssignmentsForCheckItem(organizationId, id),
+    getCheckItemUsageCounts(organizationId),
+  ]);
   if (!item) {
     throw new Error("Check item not found");
   }
 
-  const models = await Promise.all(item.modelCheckItems.map((m) => getModelById(m.modelId)));
+  // Model name is a cross-domain join — Model lives in Convex too.
+  const models = await Promise.all(assignments.map((m) => getModelById(m.modelId)));
   const modelNameMap = new Map<string, { id: string; name: string }>();
   for (const m of models) if (m) modelNameMap.set(m.id, { id: m.id, name: m.name });
   const enriched = {
     ...item,
-    modelCheckItems: item.modelCheckItems
+    _count: counts[item.id] ?? { modelCheckItems: 0, checkRecords: 0 },
+    modelCheckItems: assignments
       .map((m) => ({ ...m, model: modelNameMap.get(m.modelId) ?? null }))
       .sort((a, b) => (a.model?.name ?? "").localeCompare(b.model?.name ?? "")),
   };
@@ -220,13 +225,7 @@ export async function deleteCheckItem(id: string) {
 export async function getModelCheckItems(modelId: string) {
   const { organizationId } = await requirePermission("checkItem", "read");
 
-  return serialize(
-    await prisma.modelCheckItem.findMany({
-      where: { modelId, organizationId },
-      include: { checkItem: true },
-      orderBy: { sortOrder: "asc" },
-    })
-  );
+  return serialize(await getModelCheckItemsForModel(organizationId, modelId));
 }
 
 export async function addCheckItemToModel(
@@ -419,13 +418,7 @@ export async function bulkAddCheckItemsToModels(
 export async function getKitCheckItems(kitId: string) {
   const { organizationId } = await requirePermission("checkItem", "read");
 
-  return serialize(
-    await prisma.kitCheckItem.findMany({
-      where: { kitId, organizationId },
-      include: { checkItem: true },
-      orderBy: { sortOrder: "asc" },
-    })
-  );
+  return serialize(await getKitCheckItemsForKit(organizationId, kitId));
 }
 
 export async function addCheckItemToKit(


### PR DESCRIPTION
## Summary

Phase A read-rewiring for the **check-items** surface. Moves the five pure-read
server actions in `src/server/check-items.ts` off Prisma and onto Convex:

- `getCheckItems` — org check-item list + `_count: { modelCheckItems, checkRecords }`
- `getCheckItemCounts` — per-check-item usage counts
- `getCheckItem` — single check item + its model assignments (model names joined from Convex)
- `getModelCheckItems` — model assignments with nested `checkItem`
- `getKitCheckItems` — kit assignments with nested `checkItem`

New `src/lib/check-items-read.ts` holds the fetchers + mappers (epoch-ms→Date,
absent→null, Prisma-defaulted `type`/`sortOrder` coerced to their non-null
defaults, `dropdownOptions` JSON passed straight through) and pure, unit-tested
sort predicates replicating the Prisma `orderBy` (`category` ASC NULLS LAST then
`label`; `sortOrder` ASC). **No Prisma fallback on a Convex miss.**

### New Convex queries (added to existing modules, no `_generated` edits)
- `modelCheckItems.listByModelId(orgId, modelId)`
- `modelCheckItems.listByCheckItemId(orgId, checkItemId)`
- `kitCheckItems.listByKitId(orgId, kitId)`

All org-scoped FK-index reads using the neighboring auth pattern (`requireOrgRead`).

### Stayed on Prisma (by design)
All writes (create/update/delete + model/kit assignment mutations) and their
read-then-write guards (`aggregate`/`groupBy`/`findFirst` whose result feeds a
mutation) remain Prisma-anchored. The `model` name join in `getCheckItem` reads
Model from Convex via `getModelById` (already a Convex domain).

## Deploy gate (tables dual-written + backfilled in prod Convex)
- `checkItem` — dual-written; backfill `convex-backfill-check-items.ts`
- `modelCheckItem` / `kitCheckItem` — dual-written; backfill `convex-backfill-check-item-assignments.ts`
- `checkRecord` (for the `_count` half) — dual-written; backfill `convex-backfill-check-records.ts`

All must be backfilled into prod Convex **before** this read deploys, else the
reads return empty.

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/check-items-read.test.ts` — 6 passed
- `pnpm exec eslint` on touched files — 0 errors (only the accepted `_id`-strip unused-var warning)

**Human-gated on a Coolify PR preview** against prod Convex (data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)