### PR TITLE
feat(convex): read maintenance records from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,38 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **maintenance records** (`server/maintenance.ts` → `src/lib/maintenance-read.ts`).
+  `getMaintenanceRecords` (list + paginate) and `getMaintenanceRecord` (detail) now
+  source the `maintenanceRecord` row from Convex (`maintenanceRecords.list` /
+  `.getById`, both pre-existing) via `getMaintenanceRecordsByOrg` /
+  `getMaintenanceRecordById`. The `maintenanceRecordAssets` join table is the
+  intentional Prisma terminus (NOT mirrored — the record's `updatedAt` is the
+  reactive signal), so the asset/model join is attached from Prisma exactly as the
+  old `include` did, and the Auth-`User` joins (`reportedBy` / `assignedTo`) stay
+  Prisma via a batched `prisma.user.findMany`. The model doc is grafted from Convex
+  (`getModelMap`). Filtering (status / type / assetId / search-across-tag+model-name)
+  and sorting (default `[status asc, scheduledDate asc]` or explicit scalar `sortBy`,
+  with declared-enum-order rank maps + Postgres NULLS-LAST/FIRST) are pure
+  unit-tested predicates in `maintenance-read.ts`; pagination is a JS `slice` over
+  the org's records (mirrors the old `skip`/`take`). All writes
+  (`create`/`update`/`delete` + the asset state-machine) and `getAssetsForMaintenanceSelect`
+  stay Prisma. Org-scope on the by-cuid `getById` is enforced in the action
+  (`record.organizationId !== organizationId → null`), matching the old
+  `where: { id, organizationId }`. No new convex query needed.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/maintenance-read.test.ts
+++ b/src/lib/maintenance-read.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapMaintenanceRecord,
+  filterMaintenanceRecords,
+  sortMaintenanceRecords,
+  type MaintenanceJoinData,
+  type MaintenanceRecordRow,
+} from "./maintenance-read";
+
+// Minimal Convex-doc factory (only the fields the mapper reads).
+function doc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "convex_internal_id" as never,
+    _creationTime: 1_700_000_000_000,
+    id: "rec_1",
+    organizationId: "org_1",
+    type: "REPAIR",
+    status: "IN_PROGRESS",
+    title: "Fix amp",
+    createdAt: 1_700_000_100_000,
+    updatedAt: 1_700_000_200_000,
+    ...overrides,
+  } as never;
+}
+
+describe("mapMaintenanceRecord", () => {
+  it("converts epoch-ms date fields to Date and strips Convex internals", () => {
+    const r = mapMaintenanceRecord(
+      doc({
+        scheduledDate: 1_700_000_300_000,
+        completedDate: 1_700_000_400_000,
+        nextDueDate: 1_700_000_500_000,
+      }),
+    );
+    expect(r.scheduledDate).toBeInstanceOf(Date);
+    expect(r.scheduledDate?.getTime()).toBe(1_700_000_300_000);
+    expect(r.completedDate?.getTime()).toBe(1_700_000_400_000);
+    expect(r.nextDueDate?.getTime()).toBe(1_700_000_500_000);
+    expect(r.createdAt.getTime()).toBe(1_700_000_100_000);
+    expect(r.updatedAt.getTime()).toBe(1_700_000_200_000);
+    // _id / _creationTime are not on the typed result shape.
+    expect((r as unknown as Record<string, unknown>)._id).toBeUndefined();
+    expect((r as unknown as Record<string, unknown>)._creationTime).toBeUndefined();
+  });
+
+  it("normalises absent optionals to null", () => {
+    const r = mapMaintenanceRecord(doc());
+    expect(r.kitId).toBeNull();
+    expect(r.projectId).toBeNull();
+    expect(r.description).toBeNull();
+    expect(r.reportedById).toBeNull();
+    expect(r.assignedToId).toBeNull();
+    expect(r.scheduledDate).toBeNull();
+    expect(r.completedDate).toBeNull();
+    expect(r.nextDueDate).toBeNull();
+    expect(r.cost).toBeNull();
+    expect(r.partsUsed).toBeNull();
+    expect(r.result).toBeNull();
+  });
+
+  it("coerces Prisma-defaulted columns non-null (status / arrays)", () => {
+    const r = mapMaintenanceRecord(doc({ status: undefined }));
+    expect(r.status).toBe("SCHEDULED");
+    expect(r.attachments).toEqual([]);
+    expect(r.photos).toEqual([]);
+    expect(r.tags).toEqual([]);
+  });
+
+  it("keeps cost as a number (Convex stores it numeric)", () => {
+    const r = mapMaintenanceRecord(doc({ cost: 123.45 }));
+    expect(r.cost).toBe(123.45);
+  });
+
+  it("falls back to _creationTime when createdAt/updatedAt are absent", () => {
+    const r = mapMaintenanceRecord(doc({ createdAt: undefined, updatedAt: undefined }));
+    expect(r.createdAt.getTime()).toBe(1_700_000_000_000);
+    expect(r.updatedAt.getTime()).toBe(1_700_000_000_000);
+  });
+});
+
+// ─── filter ──────────────────────────────────────────────────────────────────
+
+function row(overrides: Partial<MaintenanceRecordRow> = {}): MaintenanceRecordRow {
+  return {
+    id: "r1",
+    organizationId: "org_1",
+    kitId: null,
+    projectId: null,
+    type: "REPAIR",
+    status: "SCHEDULED",
+    title: "Generic title",
+    description: null,
+    reportedById: null,
+    assignedToId: null,
+    scheduledDate: null,
+    completedDate: null,
+    cost: null,
+    partsUsed: null,
+    attachments: [],
+    photos: [],
+    result: null,
+    nextDueDate: null,
+    tags: [],
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+const emptyJoin: MaintenanceJoinData = { assetIds: [], assetTags: [], modelNames: [] };
+
+function joinMap(entries: Record<string, MaintenanceJoinData>): Map<string, MaintenanceJoinData> {
+  return new Map(Object.entries(entries));
+}
+
+describe("filterMaintenanceRecords", () => {
+  it("filters by status and type", () => {
+    const records = [
+      row({ id: "a", status: "SCHEDULED", type: "REPAIR" }),
+      row({ id: "b", status: "COMPLETED", type: "REPAIR" }),
+      row({ id: "c", status: "SCHEDULED", type: "CLEANING" }),
+    ];
+    const jm = joinMap({ a: emptyJoin, b: emptyJoin, c: emptyJoin });
+    expect(filterMaintenanceRecords(records, jm, { status: "SCHEDULED" }).map((r) => r.id)).toEqual([
+      "a",
+      "c",
+    ]);
+    expect(
+      filterMaintenanceRecords(records, jm, { status: "SCHEDULED", type: "REPAIR" }).map((r) => r.id),
+    ).toEqual(["a"]);
+  });
+
+  it("filters by assetId via the join data", () => {
+    const records = [row({ id: "a" }), row({ id: "b" })];
+    const jm = joinMap({
+      a: { assetIds: ["asset_x"], assetTags: [], modelNames: [] },
+      b: { assetIds: ["asset_y"], assetTags: [], modelNames: [] },
+    });
+    expect(filterMaintenanceRecords(records, jm, { assetId: "asset_x" }).map((r) => r.id)).toEqual([
+      "a",
+    ]);
+  });
+
+  it("search matches title, description, asset tag, and model name (case-insensitive)", () => {
+    const records = [
+      row({ id: "title", title: "Replace XLR cable" }),
+      row({ id: "desc", description: "Loose XLR connector" }),
+      row({ id: "tag" }),
+      row({ id: "model" }),
+      row({ id: "none", title: "unrelated" }),
+    ];
+    const jm = joinMap({
+      title: emptyJoin,
+      desc: emptyJoin,
+      tag: { assetIds: [], assetTags: ["XLR-001"], modelNames: [] },
+      model: { assetIds: [], assetTags: [], modelNames: ["XLR Snake"] },
+      none: emptyJoin,
+    });
+    const hits = filterMaintenanceRecords(records, jm, { search: "xlr" }).map((r) => r.id);
+    expect(hits.sort()).toEqual(["desc", "model", "tag", "title"]);
+  });
+});
+
+// ─── sort ──────────────────────────────────────────────────────────────────
+
+describe("sortMaintenanceRecords", () => {
+  it("default order: status (declared rank) then scheduledDate asc (NULLS LAST)", () => {
+    const records = [
+      row({ id: "completed", status: "COMPLETED", scheduledDate: new Date(100) }),
+      row({ id: "sched-null", status: "SCHEDULED", scheduledDate: null }),
+      row({ id: "sched-early", status: "SCHEDULED", scheduledDate: new Date(50) }),
+      row({ id: "inprog", status: "IN_PROGRESS", scheduledDate: new Date(10) }),
+    ];
+    expect(sortMaintenanceRecords(records).map((r) => r.id)).toEqual([
+      "sched-early", // SCHEDULED rank 0, earliest date
+      "sched-null", // SCHEDULED rank 0, null date last
+      "inprog", // IN_PROGRESS rank 2
+      "completed", // COMPLETED rank 4
+    ]);
+  });
+
+  it("explicit sortBy=type asc uses declared enum order, not alphabetical", () => {
+    const records = [
+      row({ id: "cleaning", type: "CLEANING" }),
+      row({ id: "repair", type: "REPAIR" }),
+      row({ id: "inspection", type: "INSPECTION" }),
+    ];
+    // Declared order: REPAIR(0) < INSPECTION(3) < CLEANING(4) — NOT alphabetical.
+    expect(sortMaintenanceRecords(records, "type", "asc").map((r) => r.id)).toEqual([
+      "repair",
+      "inspection",
+      "cleaning",
+    ]);
+  });
+
+  it("explicit sortBy with desc reverses and puts NULLS FIRST", () => {
+    const records = [
+      row({ id: "has", scheduledDate: new Date(50) }),
+      row({ id: "null", scheduledDate: null }),
+      row({ id: "later", scheduledDate: new Date(100) }),
+    ];
+    expect(sortMaintenanceRecords(records, "scheduledDate", "desc").map((r) => r.id)).toEqual([
+      "null", // NULLS FIRST on desc
+      "later",
+      "has",
+    ]);
+  });
+
+  it("sortBy=title is a plain string compare", () => {
+    const records = [row({ id: "b", title: "Beta" }), row({ id: "a", title: "Alpha" })];
+    expect(sortMaintenanceRecords(records, "title", "asc").map((r) => r.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/maintenance-read.ts
+++ b/src/lib/maintenance-read.ts
@@ -1,0 +1,274 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type {
+  MaintenanceStatus,
+  MaintenanceType,
+  MaintenanceResult,
+} from "@/generated/prisma/client";
+
+/**
+ * Server-side read helpers for the Maintenance domain (Phase A read-rewiring).
+ *
+ * `maintenanceRecord` is dual-written (Prisma FK anchor + Convex reactive doc —
+ * see src/lib/maintenance-mirror.ts) and backfilled
+ * (scripts/convex-backfill-maintenance.ts). The read-only server actions
+ * `getMaintenanceRecords` / `getMaintenanceRecord` source the record row from
+ * Convex via these helpers.
+ *
+ * The `maintenanceRecordAssets` join table is the intentional Prisma terminus —
+ * it is NOT mirrored to Convex (the record's `updatedAt` bumps on any link
+ * change, which is a sufficient reactive signal). So the asset/model join AND
+ * the Auth-`User` joins (reportedBy / assignedTo) are attached from Prisma in
+ * the server action, exactly as the old `include` did. This module only owns
+ * the Convex record fetch + the Prisma→Convex shape mapping + the pure
+ * filter/sort predicates replicating the old Prisma `where`/`orderBy`.
+ *
+ * No Prisma fallback on a Convex map miss (a miss reads as "absent", like a join
+ * against a deleted row — falling back would hide mirror drift). See
+ * FEATUREDOCS/54.
+ */
+
+type ConvexMaintenanceDoc = Doc<"maintenanceRecords">;
+
+/**
+ * A maintenance record in the Prisma-row shape the existing consumers expect:
+ * Date fields are `Date` (Convex stores epoch-ms), `cost` is `number | null`,
+ * Prisma-defaulted columns are coerced non-null, absent optionals are `null`.
+ * Relations (assets / reportedBy / assignedTo) are attached separately from
+ * Prisma in the server action.
+ */
+export interface MaintenanceRecordRow {
+  id: string;
+  organizationId: string;
+  kitId: string | null;
+  projectId: string | null;
+  type: MaintenanceType;
+  status: MaintenanceStatus;
+  title: string;
+  description: string | null;
+  reportedById: string | null;
+  assignedToId: string | null;
+  scheduledDate: Date | null;
+  completedDate: Date | null;
+  cost: number | null;
+  partsUsed: string | null;
+  attachments: string[];
+  photos: string[];
+  result: MaintenanceResult | null;
+  nextDueDate: Date | null;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** epoch-ms → Date, treating absent/null as null. */
+function toDate(ms: number | null | undefined): Date | null {
+  return ms === null || ms === undefined ? null : new Date(ms);
+}
+
+/**
+ * Map a Convex `maintenanceRecords` doc to the Prisma-row shape. Strips
+ * `_id`/`_creationTime`, converts epoch-ms→Date, coerces Prisma-defaulted
+ * columns (`status` default SCHEDULED; `attachments`/`photos`/`tags` default
+ * `[]`; `createdAt`/`updatedAt` are `@default(now())`/`@updatedAt` so always
+ * present in practice but fall back to the doc's `_creationTime`), and
+ * normalises absent optionals to `null`.
+ */
+export function mapMaintenanceRecord(doc: ConvexMaintenanceDoc): MaintenanceRecordRow {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    kitId: doc.kitId ?? null,
+    projectId: doc.projectId ?? null,
+    type: doc.type as MaintenanceType,
+    status: (doc.status ?? "SCHEDULED") as MaintenanceStatus,
+    title: doc.title,
+    description: doc.description ?? null,
+    reportedById: doc.reportedById ?? null,
+    assignedToId: doc.assignedToId ?? null,
+    scheduledDate: toDate(doc.scheduledDate),
+    completedDate: toDate(doc.completedDate),
+    cost: doc.cost ?? null,
+    partsUsed: doc.partsUsed ?? null,
+    attachments: doc.attachments ?? [],
+    photos: doc.photos ?? [],
+    result: (doc.result ?? null) as MaintenanceResult | null,
+    nextDueDate: toDate(doc.nextDueDate),
+    tags: doc.tags ?? [],
+    createdAt: toDate(doc.createdAt) ?? new Date(doc._creationTime),
+    updatedAt: toDate(doc.updatedAt) ?? new Date(doc._creationTime),
+  };
+}
+
+export async function getMaintenanceRecordsByOrg(orgId: string): Promise<MaintenanceRecordRow[]> {
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.maintenanceRecords.list, { orgId }),
+  );
+  return docs.map(mapMaintenanceRecord);
+}
+
+export async function getMaintenanceRecordById(id: string): Promise<MaintenanceRecordRow | null> {
+  const doc = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.maintenanceRecords.getById, { id }),
+  );
+  return doc ? mapMaintenanceRecord(doc) : null;
+}
+
+// ─── Pure filter/sort (replicates the old Prisma where/orderBy) ──────────────
+
+/**
+ * Per-record cross-domain join data the `where`/`orderBy` reference. The
+ * search OR matches asset tags and the asset model name, so the filter needs
+ * the Prisma-attached asset/model strings; orderBy by a User name isn't
+ * supported by the old action (sortBy is a scalar column), so users aren't
+ * needed here.
+ */
+export interface MaintenanceJoinData {
+  /** assetIds linked to this record (for the `assetId` filter). */
+  assetIds: string[];
+  /** asset tags linked to this record (for the search OR). */
+  assetTags: string[];
+  /** model names of the linked assets (for the search OR). */
+  modelNames: string[];
+}
+
+export interface MaintenanceFilter {
+  status?: string;
+  type?: string;
+  assetId?: string;
+  search?: string;
+}
+
+function matchesSearch(
+  record: MaintenanceRecordRow,
+  join: MaintenanceJoinData,
+  search: string,
+): boolean {
+  const needle = search.toLowerCase();
+  // Postgres `contains` mode:"insensitive" → case-insensitive substring.
+  if (record.title.toLowerCase().includes(needle)) return true;
+  if (record.description && record.description.toLowerCase().includes(needle)) return true;
+  if (join.assetTags.some((t) => t.toLowerCase().includes(needle))) return true;
+  if (join.modelNames.some((n) => n.toLowerCase().includes(needle))) return true;
+  return false;
+}
+
+/**
+ * Replicates the old `getMaintenanceRecords` Prisma `where`: org scope is
+ * already applied by the org-scoped Convex query, so this only applies the
+ * optional status / type / assetId / search predicates.
+ */
+export function filterMaintenanceRecords(
+  records: MaintenanceRecordRow[],
+  joinByRecordId: Map<string, MaintenanceJoinData>,
+  filter: MaintenanceFilter,
+): MaintenanceRecordRow[] {
+  const { status, type, assetId, search } = filter;
+  return records.filter((r) => {
+    if (status && r.status !== status) return false;
+    if (type && r.type !== type) return false;
+    const join = joinByRecordId.get(r.id) ?? { assetIds: [], assetTags: [], modelNames: [] };
+    if (assetId && !join.assetIds.includes(assetId)) return false;
+    if (search && !matchesSearch(r, join, search)) return false;
+    return true;
+  });
+}
+
+// Enum sort ranks follow the DECLARED order in prisma/schema.prisma (Postgres
+// enum columns sort by declared order, NOT alphabetically).
+const STATUS_RANK: Record<string, number> = {
+  SCHEDULED: 0,
+  AWAITING_PARTS: 1,
+  IN_PROGRESS: 2,
+  QA: 3,
+  COMPLETED: 4,
+  CANCELLED: 5,
+};
+const TYPE_RANK: Record<string, number> = {
+  REPAIR: 0,
+  PREVENTATIVE: 1,
+  TEST_AND_TAG: 2,
+  INSPECTION: 3,
+  CLEANING: 4,
+  FIRMWARE_UPDATE: 5,
+};
+const RESULT_RANK: Record<string, number> = {
+  PASS: 0,
+  FAIL: 1,
+  CONDITIONAL: 2,
+};
+
+type SortDir = "asc" | "desc";
+
+/** -1 / 0 / 1, with Postgres NULL ordering (ASC → NULLS LAST, DESC → NULLS FIRST). */
+function cmpNullable(
+  a: number | string | null,
+  b: number | string | null,
+  dir: SortDir,
+): number {
+  if (a === null && b === null) return 0;
+  // NULLS LAST on asc, NULLS FIRST on desc.
+  if (a === null) return dir === "asc" ? 1 : -1;
+  if (b === null) return dir === "asc" ? -1 : 1;
+  let base: number;
+  if (typeof a === "string" && typeof b === "string") base = a < b ? -1 : a > b ? 1 : 0;
+  else base = (a as number) - (b as number);
+  return dir === "asc" ? base : -base;
+}
+
+function sortKeyValue(r: MaintenanceRecordRow, key: string): number | string | null {
+  switch (key) {
+    case "status":
+      return STATUS_RANK[r.status] ?? Number.MAX_SAFE_INTEGER;
+    case "type":
+      return TYPE_RANK[r.type] ?? Number.MAX_SAFE_INTEGER;
+    case "result":
+      return r.result === null ? null : RESULT_RANK[r.result] ?? Number.MAX_SAFE_INTEGER;
+    case "title":
+      return r.title;
+    case "scheduledDate":
+      return r.scheduledDate ? r.scheduledDate.getTime() : null;
+    case "completedDate":
+      return r.completedDate ? r.completedDate.getTime() : null;
+    case "nextDueDate":
+      return r.nextDueDate ? r.nextDueDate.getTime() : null;
+    case "createdAt":
+      return r.createdAt.getTime();
+    case "updatedAt":
+      return r.updatedAt.getTime();
+    case "cost":
+      return r.cost;
+    default:
+      // Unknown sortBy column: fall back to a stable scalar (createdAt) so we
+      // never throw. The old action passed the column straight to Prisma; an
+      // invalid column would have errored there, but the UI only ever sends a
+      // known scalar sortKey.
+      return r.createdAt.getTime();
+  }
+}
+
+/**
+ * Replicates the old `getMaintenanceRecords` `orderBy`:
+ *   - explicit `sortBy` → single scalar column, given direction (default asc)
+ *   - default → [{ status: asc }, { scheduledDate: asc }]
+ */
+export function sortMaintenanceRecords(
+  records: MaintenanceRecordRow[],
+  sortBy?: string,
+  sortOrder: SortDir = "asc",
+): MaintenanceRecordRow[] {
+  const out = [...records];
+  if (sortBy) {
+    out.sort((a, b) =>
+      cmpNullable(sortKeyValue(a, sortBy), sortKeyValue(b, sortBy), sortOrder),
+    );
+  } else {
+    out.sort((a, b) => {
+      const byStatus = cmpNullable(sortKeyValue(a, "status"), sortKeyValue(b, "status"), "asc");
+      if (byStatus !== 0) return byStatus;
+      return cmpNullable(sortKeyValue(a, "scheduledDate"), sortKeyValue(b, "scheduledDate"), "asc");
+    });
+  }
+  return out;
+}

--- a/src/server/maintenance.ts
+++ b/src/server/maintenance.ts
@@ -15,12 +15,20 @@ import {
   patchMaintenanceInConvex,
   removeMaintenanceFromConvex,
 } from "@/lib/maintenance-mirror";
-import { UserFacingError } from "@/lib/errors";
 import { getModelMap } from "@/lib/models-read";
 import { getAssetsByOrg } from "@/lib/assets-read";
+import {
+  getMaintenanceRecordsByOrg,
+  getMaintenanceRecordById,
+  filterMaintenanceRecords,
+  sortMaintenanceRecords,
+  type MaintenanceRecordRow,
+  type MaintenanceJoinData,
+} from "@/lib/maintenance-read";
 
-// asset.model lives in Convex — `asset: true` keeps the asset scalars (incl.
-// modelId); the model doc is grafted onto each record's assets[].asset below.
+// Write paths (create/update) build the record with its asset links so the
+// mirror payload carries fresh scalars. `asset: true` keeps the asset scalars
+// (incl. modelId) — reads source the record from Convex instead (see below).
 const assetInclude = {
   assets: {
     include: { asset: true },
@@ -28,20 +36,88 @@ const assetInclude = {
   },
 };
 
-/** Graft the Convex model doc onto every maintenance record's assets[].asset. */
-async function attachAssetModels<T>(organizationId: string, records: T[]): Promise<T[]> {
+/**
+ * Attach the cross-domain joins the maintenance reads need onto Convex-sourced
+ * record rows:
+ *
+ *   - `assets[]` — the `maintenanceRecordAssets` join table (the intentional
+ *     Prisma terminus — NOT mirrored to Convex), each carrying its `asset`
+ *     scalars + the Convex `model` doc grafted on, ordered by asset tag asc
+ *     (matches the old `orderBy: { asset: { assetTag: "asc" } }`).
+ *   - `reportedBy` / `assignedTo` — Auth `User` rows (stay Prisma forever),
+ *     batched in one findMany.
+ *
+ * Returns the records enriched in the same nested shape the old Prisma
+ * `include` produced, plus a per-record `MaintenanceJoinData` map the
+ * filter/sort predicates use (assetIds / tags / model names for the search).
+ */
+async function attachJoins(
+  organizationId: string,
+  records: MaintenanceRecordRow[],
+): Promise<{
+  enriched: Record<string, unknown>[];
+  joinByRecordId: Map<string, MaintenanceJoinData>;
+}> {
+  const recordIds = records.map((r) => r.id);
+
+  // The Prisma-only join table + the linked asset scalars.
+  const links = recordIds.length
+    ? await prisma.maintenanceRecordAsset.findMany({
+        where: { maintenanceRecordId: { in: recordIds } },
+        include: { asset: true },
+      })
+    : [];
+
   const modelMap = await getModelMap(organizationId);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return records.map((r: any) => ({
-    ...r,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    assets: r.assets?.map((ra: any) => ({
-      ...ra,
-      asset: ra.asset
-        ? { ...ra.asset, model: ra.asset.modelId ? modelMap.get(ra.asset.modelId) ?? null : null }
-        : ra.asset,
-    })),
-  }));
+
+  // Auth Users for reportedBy / assignedTo (Prisma terminus).
+  const userIds = Array.from(
+    new Set(
+      records
+        .flatMap((r) => [r.reportedById, r.assignedToId])
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const users = userIds.length
+    ? await prisma.user.findMany({ where: { id: { in: userIds } } })
+    : [];
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  // Group links by record, graft the Convex model onto each asset, and sort by
+  // asset tag asc to mirror the old include orderBy.
+  const linksByRecord = new Map<string, Record<string, unknown>[]>();
+  const joinByRecordId = new Map<string, MaintenanceJoinData>();
+  for (const id of recordIds) {
+    linksByRecord.set(id, []);
+    joinByRecordId.set(id, { assetIds: [], assetTags: [], modelNames: [] });
+  }
+  for (const link of links) {
+    const model = link.asset?.modelId ? modelMap.get(link.asset.modelId) ?? null : null;
+    const graftedAsset = link.asset ? { ...link.asset, model } : link.asset;
+    linksByRecord.get(link.maintenanceRecordId)?.push({ ...link, asset: graftedAsset });
+    const join = joinByRecordId.get(link.maintenanceRecordId);
+    if (join) {
+      join.assetIds.push(link.assetId);
+      if (link.asset?.assetTag) join.assetTags.push(link.asset.assetTag);
+      if (model?.name) join.modelNames.push(model.name);
+    }
+  }
+
+  const enriched = records.map((r) => {
+    const recordLinks = (linksByRecord.get(r.id) ?? []).sort((a, b) => {
+      const ta = (a.asset as { assetTag?: string } | null)?.assetTag ?? "";
+      const tb = (b.asset as { assetTag?: string } | null)?.assetTag ?? "";
+      return ta < tb ? -1 : ta > tb ? 1 : 0;
+    });
+    return {
+      ...r,
+      assets: recordLinks,
+      reportedBy: r.reportedById ? userMap.get(r.reportedById) ?? null : null,
+      assignedTo: r.assignedToId ? userMap.get(r.assignedToId) ?? null : null,
+    };
+  });
+
+  return { enriched, joinByRecordId };
 }
 
 export async function getMaintenanceRecords(params?: {
@@ -57,40 +133,29 @@ export async function getMaintenanceRecords(params?: {
   const { organizationId } = await getOrgContext();
   const { search, status, type, assetId, page = 1, pageSize = 25, sortBy, sortOrder } = params || {};
 
-  const where: Prisma.MaintenanceRecordWhereInput = {
-    organizationId,
-    ...(status && { status: status as Prisma.EnumMaintenanceStatusFilter }),
-    ...(type && { type: type as Prisma.EnumMaintenanceTypeFilter }),
-    ...(assetId && { assets: { some: { assetId } } }),
-    ...(search && {
-      OR: [
-        { title: { contains: search, mode: "insensitive" } },
-        { description: { contains: search, mode: "insensitive" } },
-        { assets: { some: { asset: { assetTag: { contains: search, mode: "insensitive" } } } } },
-        { assets: { some: { asset: { model: { name: { contains: search, mode: "insensitive" } } } } } },
-      ],
-    }),
-  };
+  // Record rows from Convex (org-scoped); the assets/model + User joins stay
+  // Prisma. The search OR matches asset tags + model names, so the join data is
+  // needed to filter — attach for the whole org, then filter/sort/paginate in
+  // JS (mirrors the old Prisma where/orderBy/skip/take). No Prisma fallback.
+  const allRecords = await getMaintenanceRecordsByOrg(organizationId);
+  const { joinByRecordId } = await attachJoins(organizationId, allRecords);
 
-  const [records, total] = await Promise.all([
-    prisma.maintenanceRecord.findMany({
-      where,
-      include: {
-        ...assetInclude,
-        assignedTo: true,
-        reportedBy: true,
-      },
-      orderBy: sortBy
-        ? { [sortBy]: sortOrder || "asc" }
-        : [{ status: "asc" }, { scheduledDate: "asc" }],
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.maintenanceRecord.count({ where }),
-  ]);
+  const filtered = filterMaintenanceRecords(allRecords, joinByRecordId, {
+    search,
+    status,
+    type,
+    assetId,
+  });
+  const sorted = sortMaintenanceRecords(filtered, sortBy, sortOrder || "asc");
+  const total = sorted.length;
+  const pageRows = sorted.slice((page - 1) * pageSize, page * pageSize);
+
+  // Re-attach joins for just the page slice (cheap; avoids serialising the
+  // whole org's asset/user graph when only a page is rendered).
+  const { enriched } = await attachJoins(organizationId, pageRows);
 
   return serialize({
-    records: await attachAssetModels(organizationId, records),
+    records: enriched,
     total,
     page,
     pageSize,
@@ -101,17 +166,13 @@ export async function getMaintenanceRecords(params?: {
 export async function getMaintenanceRecord(id: string) {
   const { organizationId } = await getOrgContext();
 
-  const record = await prisma.maintenanceRecord.findUnique({
-    where: { id, organizationId },
-    include: {
-      ...assetInclude,
-      assignedTo: true,
-      reportedBy: true,
-    },
-  });
-  if (!record) return serialize(null);
-  const [grafted] = await attachAssetModels(organizationId, [record]);
-  return serialize(grafted);
+  const record = await getMaintenanceRecordById(id);
+  // getById isn't org-scoped at the index level (lookup is by cuid), so enforce
+  // the org boundary here exactly as the old `where: { id, organizationId }` did.
+  if (!record || record.organizationId !== organizationId) return serialize(null);
+
+  const { enriched } = await attachJoins(organizationId, [record]);
+  return serialize(enriched[0]);
 }
 
 /**


### PR DESCRIPTION
## What

Phase A read-rewiring for the **maintenance** surface: the read-only server actions now source the `maintenanceRecord` row from Convex (the dual-written + backfilled mirror) instead of Prisma.

- **`getMaintenanceRecords`** (list + paginate) and **`getMaintenanceRecord`** (detail) → new `src/lib/maintenance-read.ts` via `getMaintenanceRecordsByOrg` / `getMaintenanceRecordById`, over the **pre-existing** `maintenanceRecords.list` / `.getById` Convex queries. **No new convex query needed.**
- `maintenance-read.ts`: Convex→Prisma-row mapper (epoch-ms→Date, absent→null, Prisma-defaulted columns — `status`/`attachments`/`photos`/`tags`/`createdAt`/`updatedAt` — coerced non-null, `cost` number passthrough, `_id`/`_creationTime` stripped) + **pure unit-tested** filter (status / type / assetId / search-across-asset-tag+model-name) and sort (default `[status asc, scheduledDate asc]` or explicit scalar `sortBy`; **declared-enum-order** rank maps for status/type/result; Postgres ASC=NULLS-LAST / DESC=NULLS-FIRST). Pagination is a JS `slice` mirroring the old `skip`/`take`.

## What stays Prisma (intentional)

- **`maintenanceRecordAssets`** join table — the intentional Prisma terminus (NOT mirrored; the record's `updatedAt` bumps on any link change, which is the reactive signal). The asset/model join is attached from Prisma exactly as the old `include` did, with the Convex `model` doc grafted on via `getModelMap`.
- **Auth `User` joins** (`reportedBy` / `assignedTo`) — batched `prisma.user.findMany` (stay Prisma forever).
- **All writes** (`create`/`update`/`delete` + the asset state-machine) and `getAssetsForMaintenanceSelect`.

Org-scope on the by-cuid `getById` is enforced in the action (`record.organizationId !== organizationId → null`), matching the old `where: { id, organizationId }`. **No Prisma fallback** on a Convex map miss. Removed a now-dead `UserFacingError` import (its only consumer, `setMaintenanceStatus`, was removed with the workshop kanban in #227).

## Validation

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/maintenance-read.test.ts` — **12 passed**
- `pnpm exec eslint` on `maintenance-read.ts` / `.test.ts` / `server/maintenance.ts` — clean

## Deploy gate (merge blocker)

`maintenanceRecord` must be backfilled into **prod Convex** (`scripts/convex-backfill-maintenance.ts`) **before** this read deploys, else existing rows read empty. Human-gated on the Coolify PR preview against prod Convex (Convex data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)