### PR TITLE
feat(convex): read group templates from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,29 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **group templates** (`src/server/group-templates.ts` → `src/lib/group-templates-read.ts`).
+  `getGroupTemplates` is now a HYBRID read: parent rows come from Convex
+  (`api.groupTemplates.list`, mapped epoch-ms→Date + absent description→null,
+  name-asc sorted in JS via `sortGroupTemplatesByName`) and the child `items` are
+  attached from Prisma (`groupTemplateItem.findMany` with the same `model`/`kit`
+  selects and `sortOrder: "asc"`). The `group_template_item` children stay Prisma —
+  the mirror strips `items` before writing, so they are the Prisma terminus for this
+  surface (correct + expected). No new convex query (existing `groupTemplates.list`
+  reused). All writes + read-then-write stay Prisma.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/group-templates-read.test.ts
+++ b/src/lib/group-templates-read.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the pure group-template parent mappers/sorters.
+ *
+ * These cover the Convex→Prisma parent-shape mapping and the `orderBy:
+ * { name: "asc" }` replication that back `getGroupTemplates` (Phase A
+ * read-rewiring). The child `items` come from Prisma and aren't exercised here —
+ * the safety property tested is the PARENT shape: epoch-ms→Date, absent
+ * description→null, system fields stripped, deterministic name-asc ordering.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapGroupTemplate,
+  sortGroupTemplatesByName,
+  type ConvexGroupTemplate,
+} from "@/lib/group-templates-read";
+
+function doc(over: Partial<ConvexGroupTemplate>): ConvexGroupTemplate {
+  return {
+    _id: "convex_id" as ConvexGroupTemplate["_id"],
+    _creationTime: 123,
+    id: "gt1",
+    organizationId: "org1",
+    name: "Template",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_500_000,
+    ...over,
+  } as ConvexGroupTemplate;
+}
+
+describe("mapGroupTemplate", () => {
+  it("strips _id/_creationTime and converts epoch-ms timestamps to Date", () => {
+    const m = mapGroupTemplate(doc({}));
+    expect(m).not.toHaveProperty("_id");
+    expect(m).not.toHaveProperty("_creationTime");
+    expect(m.createdAt).toBeInstanceOf(Date);
+    expect(m.updatedAt).toBeInstanceOf(Date);
+    expect(m.createdAt.getTime()).toBe(1_700_000_000_000);
+    expect(m.updatedAt.getTime()).toBe(1_700_000_500_000);
+  });
+
+  it("coerces absent description to null", () => {
+    expect(mapGroupTemplate(doc({ description: undefined })).description).toBeNull();
+    expect(mapGroupTemplate(doc({ description: "x" })).description).toBe("x");
+  });
+
+  it("falls back to epoch 0 when timestamps are absent (legacy mirrored rows)", () => {
+    const m = mapGroupTemplate(doc({ createdAt: undefined, updatedAt: undefined }));
+    expect(m.createdAt.getTime()).toBe(0);
+    expect(m.updatedAt.getTime()).toBe(0);
+  });
+
+  it("preserves required scalars", () => {
+    const m = mapGroupTemplate(doc({ id: "abc", organizationId: "o9", name: "Rig" }));
+    expect(m).toMatchObject({ id: "abc", organizationId: "o9", name: "Rig" });
+  });
+});
+
+describe("sortGroupTemplatesByName", () => {
+  const make = (id: string, name: string) =>
+    mapGroupTemplate(doc({ id, name }));
+
+  it("sorts by name ascending", () => {
+    const sorted = sortGroupTemplatesByName([
+      make("a", "Zulu"),
+      make("b", "Alpha"),
+      make("c", "Mike"),
+    ]);
+    expect(sorted.map((t) => t.name)).toEqual(["Alpha", "Mike", "Zulu"]);
+  });
+
+  it("is a stable total order — ties broken by id", () => {
+    const sorted = sortGroupTemplatesByName([
+      make("z", "Same"),
+      make("a", "Same"),
+    ]);
+    expect(sorted.map((t) => t.id)).toEqual(["a", "z"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [make("a", "B"), make("b", "A")];
+    const copy = [...input];
+    sortGroupTemplatesByName(input);
+    expect(input).toEqual(copy);
+  });
+});

--- a/src/lib/group-templates-read.ts
+++ b/src/lib/group-templates-read.ts
@@ -1,0 +1,81 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the Group Templates domain (Phase A read-rewiring).
+ *
+ * Group templates are dual-written: every create/update/delete writes BOTH the
+ * Prisma `group_template` row (the durable FK anchor — `group_template_item`
+ * carries a required + Cascade FK to it) AND the Convex `groupTemplates` doc.
+ * **Only the PARENT scalar fields live in Convex** — the mirror strips the nested
+ * `items` relation before writing (see `src/server/group-templates.ts`). The child
+ * `group_template_item` rows (with their `model`/`kit` joins) stay in Prisma and
+ * are the Prisma terminus for this surface.
+ *
+ * `getGroupTemplates` is therefore a HYBRID read: the parent rows come from Convex
+ * (filtered/sorted in JS, mappers below), and the `items` are attached from Prisma
+ * exactly as the old `include` did. No Prisma fallback on a Convex parent miss — a
+ * miss reads as an absent template (like a join against a deleted row); falling back
+ * would hide mirror drift. See FEATUREDOCS/54.
+ */
+
+export type ConvexGroupTemplate = Doc<"groupTemplates">;
+
+/** The parent group-template shape as the old Prisma read returned it (post-`serialize`):
+ *  required scalars, `description` nullable, `createdAt`/`updatedAt` as `Date`. */
+export type MappedGroupTemplate = {
+  id: string;
+  organizationId: string;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * Map a Convex `groupTemplates` doc to the Prisma parent shape: strip the Convex
+ * system fields (`_id`/`_creationTime`), coerce the optional `description` to
+ * `null` when absent, and convert epoch-ms timestamps to `Date` (Prisma's
+ * `serialize` keeps `Date` instances, so consumers expect `Date`, not numbers).
+ */
+export function mapGroupTemplate(doc: ConvexGroupTemplate): MappedGroupTemplate {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _id, _creationTime, ...rest } = doc;
+  return {
+    id: rest.id,
+    organizationId: rest.organizationId,
+    name: rest.name,
+    description: rest.description ?? null,
+    // createdAt/updatedAt are non-null in Prisma (@default(now()) / @updatedAt);
+    // they are optional in Convex only because old mirrored rows may predate them.
+    createdAt: rest.createdAt != null ? new Date(rest.createdAt) : new Date(0),
+    updatedAt: rest.updatedAt != null ? new Date(rest.updatedAt) : new Date(0),
+  };
+}
+
+/**
+ * Replicates Prisma `orderBy: { name: "asc" }` over the mapped parent rows.
+ * Pure + total-ordered: primary key is `name` (codepoint compare), tie-broken by
+ * `id` so the result is deterministic even when two templates share a name (the
+ * settings page re-sorts by `name.localeCompare` for display regardless).
+ */
+export function sortGroupTemplatesByName(
+  rows: MappedGroupTemplate[],
+): MappedGroupTemplate[] {
+  return [...rows].sort((a, b) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/** All of an org's group-template PARENT rows from Convex, mapped + name-sorted. */
+export async function getGroupTemplateParents(
+  orgId: string,
+): Promise<MappedGroupTemplate[]> {
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.groupTemplates.list, { orgId }),
+  );
+  return sortGroupTemplatesByName(docs.map(mapGroupTemplate));
+}

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -7,6 +7,7 @@ import { api } from "../../convex/_generated/api";
 import { requirePermission } from "@/lib/org-context";
 import { getModelMap } from "@/lib/models-read";
 import { getProjectById } from "@/lib/projects-read";
+import { getGroupTemplateParents } from "@/lib/group-templates-read";
 import {
   groupTemplateSchema,
   applyGroupTemplateSchema,
@@ -49,32 +50,41 @@ async function patchGroupTemplateInConvex(id: string, row: Record<string, unknow
 export async function getGroupTemplates() {
   const { organizationId } = await requirePermission("project", "read");
 
-  const templates = await prisma.groupTemplate.findMany({
-    where: { organizationId },
+  // HYBRID read (Phase A): parent rows from Convex (the dual-write source of
+  // truth for group-template scalars), child `items` attached from Prisma — the
+  // mirror strips `items` before writing, so the children are the Prisma
+  // terminus for this surface. No Prisma fallback on a parent miss. See
+  // src/lib/group-templates-read.ts + FEATUREDOCS/54.
+  const parents = await getGroupTemplateParents(organizationId);
+  if (parents.length === 0) return serialize([]);
+
+  // One Prisma round-trip for ALL templates' items, then group by templateId —
+  // reproduces the per-template `include: { items: { include: { model, kit } } }`
+  // with the same selects and `orderBy: { sortOrder: "asc" }`.
+  const items = await prisma.groupTemplateItem.findMany({
+    where: { organizationId, templateId: { in: parents.map((p) => p.id) } },
     include: {
-      items: {
-        include: {
-          model: {
-            select: {
-              id: true,
-              name: true,
-              dailyRate: true,
-              weeklyRate: true,
-            },
-          },
-          kit: {
-            select: {
-              id: true,
-              name: true,
-              assetTag: true,
-            },
-          },
-        },
-        orderBy: { sortOrder: "asc" },
+      model: {
+        select: { id: true, name: true, dailyRate: true, weeklyRate: true },
+      },
+      kit: {
+        select: { id: true, name: true, assetTag: true },
       },
     },
-    orderBy: { name: "asc" },
+    orderBy: { sortOrder: "asc" },
   });
+
+  const itemsByTemplate = new Map<string, typeof items>();
+  for (const item of items) {
+    const list = itemsByTemplate.get(item.templateId);
+    if (list) list.push(item);
+    else itemsByTemplate.set(item.templateId, [item]);
+  }
+
+  const templates = parents.map((p) => ({
+    ...p,
+    items: itemsByTemplate.get(p.id) ?? [],
+  }));
 
   return serialize(templates);
 }


### PR DESCRIPTION
## Summary

Phase A read-rewiring for the **group-templates** surface. `getGroupTemplates` is converted to a **hybrid read**:

- **Parent rows** now come from Convex (`api.groupTemplates.list`) via the new `src/lib/group-templates-read.ts` — pure mappers (`mapGroupTemplate`: strip `_id`/`_creationTime`, epoch-ms→`Date`, absent `description`→`null`, legacy-row timestamp fallback) + pure name-asc sorter (`sortGroupTemplatesByName`, total order tie-broken by id).
- **Child `items`** are attached from Prisma (`groupTemplateItem.findMany` with the same `model`/`kit` selects and `orderBy: { sortOrder: "asc" }`), grouped by `templateId`. This is the **expected hybrid**: the dual-write mirror strips the nested `items` before writing, so `group_template_item` is the Prisma terminus for this surface.

No Prisma fallback on a Convex parent miss. All writes + read-then-write paths (`create`/`saveGroupAs`/`apply`/`update`/`delete`) stay Prisma. No new convex query — reuses the existing `groupTemplates.list`.

## Converted vs left on Prisma

- Converted: `getGroupTemplates` (read-only).
- Left on Prisma (intentional): the `items` child rows + their `model`/`kit` joins (terminus, not in Convex); all group-template writes.

## Validation (worktree, local)

- `pnpm exec tsc --noEmit` — clean (exit 0)
- `pnpm exec vitest run src/lib/group-templates-read.test.ts` — 7/7 passing
- `pnpm exec eslint` on changed files — 0 errors (only the accepted pre-existing `_id`/`_items`-strip unused-var warnings in the existing mirror helpers)

## Deploy gate

`groupTemplates` (parent) is dual-written and has a backfill script (`scripts/convex-backfill-group-templates.ts`). **Merge gate:** that table must be backfilled into prod Convex *before* this read deploys, else existing templates read empty. Convex data-correctness can't be verified in a dev worktree — **human-gated on the Coolify PR preview** against prod Convex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)