### PR TITLE
feat(convex): read project tasks from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,34 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **project tasks** (`server/project-tasks.ts` → `src/lib/project-tasks-read.ts`).
+  Moved the three read-only actions: `getProjectTasks` (project task list, sortOrder
+  asc → createdAt asc), `getMyOpenTasks` (cross-project "my open work": assignee=me,
+  status≠DONE, project not template; dueDate asc NULLS LAST → priority desc by
+  DECLARED order → createdAt asc), and the **crewMember half** of `getTaskAssignees`
+  (org crew, status≠ARCHIVED, firstName asc → lastName asc). The `projectTask` rows
+  come from Convex (`projectTasks.listByProject` / `projectTasks.list` — both already
+  existed, no new query); `assigneeCrew` is grafted from the dual-written Convex
+  `crewMembers` docs; the `project` name/number join (getMyOpenTasks) from Convex
+  `projects.list`. **`assigneeUser` + `createdBy` + the member/User half of
+  getTaskAssignees STAY on Prisma** — those are Better Auth `User`/`member` rows (auth
+  terminus, never moves), resolved via a single batched `prisma.user.findMany` +
+  `prisma.member.findMany`. All writes (create/update/delete/reorder) + assignee
+  org-validation stay Prisma (read-then-write). No new Convex query added.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/project-tasks-read.test.ts
+++ b/src/lib/project-tasks-read.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the project-tasks Convex read layer (Phase A read-rewiring).
+ *
+ * Covers the mapper (epoch-ms→Date, absent→null, Prisma-default coercion) and the
+ * pure filter/sort predicates that replicate the Prisma where/orderBy for
+ * getProjectTasks (sortOrder asc, createdAt asc) and getMyOpenTasks (dueDate asc
+ * NULLS LAST, priority desc by DECLARED order, createdAt asc) plus the
+ * getTaskAssignees crew half (status != ARCHIVED, firstName asc, lastName asc).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapProjectTask,
+  sortProjectTasks,
+  filterTasksForProject,
+  filterMyOpenTasks,
+  sortMyOpenTasks,
+  selectCrewAssignees,
+  type ConvexProjectTask,
+} from "@/lib/project-tasks-read";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+function makeDoc(overrides: Partial<ConvexProjectTask>): ConvexProjectTask {
+  return {
+    _id: "cx",
+    _creationTime: 0,
+    id: "t1",
+    organizationId: "org-1",
+    projectId: "p1",
+    title: "Task",
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  } as ConvexProjectTask;
+}
+
+function makeCrew(overrides: Partial<Doc<"crewMembers">>): Doc<"crewMembers"> {
+  return {
+    _id: "cx",
+    _creationTime: 0,
+    id: "c1",
+    organizationId: "org-1",
+    firstName: "A",
+    lastName: "Z",
+    ...overrides,
+  } as Doc<"crewMembers">;
+}
+
+describe("mapProjectTask", () => {
+  it("converts epoch-ms date fields to Date and strips convex internals", () => {
+    const m = mapProjectTask(
+      makeDoc({ dueDate: 50000, completedAt: 60000, createdAt: 1000, updatedAt: 2000 }),
+    );
+    expect(m.dueDate).toEqual(new Date(50000));
+    expect(m.completedAt).toEqual(new Date(60000));
+    expect(m.createdAt).toEqual(new Date(1000));
+    expect(m.updatedAt).toEqual(new Date(2000));
+    expect(m).not.toHaveProperty("_id");
+    expect(m).not.toHaveProperty("_creationTime");
+  });
+
+  it("maps absent optional fields to null", () => {
+    const m = mapProjectTask(makeDoc({}));
+    expect(m.description).toBeNull();
+    expect(m.dueDate).toBeNull();
+    expect(m.completedAt).toBeNull();
+    expect(m.assigneeUserId).toBeNull();
+    expect(m.assigneeCrewId).toBeNull();
+    expect(m.createdById).toBeNull();
+    expect(m.checklist).toBeNull();
+  });
+
+  it("coerces Prisma-defaulted columns non-null", () => {
+    const m = mapProjectTask(makeDoc({}));
+    expect(m.status).toBe("TODO");
+    expect(m.priority).toBe("NORMAL");
+    expect(m.sortOrder).toBe(0);
+  });
+
+  it("passes status/priority/sortOrder/checklist through when present", () => {
+    const m = mapProjectTask(
+      makeDoc({
+        status: "DONE",
+        priority: "HIGH",
+        sortOrder: 7,
+        checklist: [{ id: "x", text: "step", done: true }],
+      }),
+    );
+    expect(m.status).toBe("DONE");
+    expect(m.priority).toBe("HIGH");
+    expect(m.sortOrder).toBe(7);
+    expect(m.checklist).toEqual([{ id: "x", text: "step", done: true }]);
+  });
+});
+
+describe("getProjectTasks filter + sort", () => {
+  it("filters by project + org", () => {
+    const rows = [
+      mapProjectTask(makeDoc({ id: "a", projectId: "p1" })),
+      mapProjectTask(makeDoc({ id: "b", projectId: "p2" })),
+      mapProjectTask(makeDoc({ id: "c", projectId: "p1", organizationId: "org-2" })),
+    ];
+    const out = filterTasksForProject(rows, "p1", "org-1");
+    expect(out.map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("orders by sortOrder asc then createdAt asc", () => {
+    const rows = [
+      mapProjectTask(makeDoc({ id: "a", sortOrder: 2, createdAt: 100 })),
+      mapProjectTask(makeDoc({ id: "b", sortOrder: 1, createdAt: 500 })),
+      mapProjectTask(makeDoc({ id: "c", sortOrder: 1, createdAt: 100 })),
+    ];
+    expect(sortProjectTasks(rows).map((t) => t.id)).toEqual(["c", "b", "a"]);
+  });
+});
+
+describe("getMyOpenTasks filter", () => {
+  const nonTemplate = new Set(["p1", "p2"]);
+  const base = [
+    mapProjectTask(makeDoc({ id: "mine-open", assigneeUserId: "u1", status: "TODO", projectId: "p1" })),
+    mapProjectTask(makeDoc({ id: "mine-done", assigneeUserId: "u1", status: "DONE", projectId: "p1" })),
+    mapProjectTask(makeDoc({ id: "other", assigneeUserId: "u2", status: "TODO", projectId: "p1" })),
+    mapProjectTask(makeDoc({ id: "template", assigneeUserId: "u1", status: "TODO", projectId: "p-template" })),
+    mapProjectTask(makeDoc({ id: "wrong-org", assigneeUserId: "u1", status: "TODO", projectId: "p2", organizationId: "org-2" })),
+  ];
+
+  it("keeps only my non-done tasks in non-template projects of my org", () => {
+    const out = filterMyOpenTasks(base, "org-1", "u1", nonTemplate);
+    expect(out.map((t) => t.id)).toEqual(["mine-open"]);
+  });
+});
+
+describe("getMyOpenTasks sort", () => {
+  it("orders dueDate asc NULLS LAST, then priority desc, then createdAt asc", () => {
+    const rows = [
+      mapProjectTask(makeDoc({ id: "nodue-high", priority: "HIGH", createdAt: 100 })),
+      mapProjectTask(makeDoc({ id: "nodue-low", priority: "LOW", createdAt: 50 })),
+      mapProjectTask(makeDoc({ id: "due-late", dueDate: 9000, priority: "NORMAL", createdAt: 100 })),
+      mapProjectTask(makeDoc({ id: "due-early", dueDate: 1000, priority: "LOW", createdAt: 100 })),
+    ];
+    // dated first (early before late), then undated by priority desc.
+    expect(sortMyOpenTasks(rows).map((t) => t.id)).toEqual([
+      "due-early",
+      "due-late",
+      "nodue-high",
+      "nodue-low",
+    ]);
+  });
+
+  it("breaks priority ties by createdAt asc", () => {
+    const rows = [
+      mapProjectTask(makeDoc({ id: "newer", priority: "HIGH", createdAt: 500 })),
+      mapProjectTask(makeDoc({ id: "older", priority: "HIGH", createdAt: 100 })),
+    ];
+    expect(sortMyOpenTasks(rows).map((t) => t.id)).toEqual(["older", "newer"]);
+  });
+});
+
+describe("getTaskAssignees crew half", () => {
+  it("excludes ARCHIVED crew and orders by firstName asc then lastName asc", () => {
+    const crew = [
+      makeCrew({ id: "c1", firstName: "Bob", lastName: "Y" }),
+      makeCrew({ id: "c2", firstName: "Amy", lastName: "Z" }),
+      makeCrew({ id: "c3", firstName: "Amy", lastName: "A" }),
+      makeCrew({ id: "c4", firstName: "Zed", lastName: "Q", status: "ARCHIVED" }),
+    ];
+    const out = selectCrewAssignees(crew);
+    expect(out.map((c) => c.id)).toEqual(["c3", "c2", "c1"]);
+    expect(out[0]).toEqual({ id: "c3", firstName: "Amy", lastName: "A" });
+  });
+});

--- a/src/lib/project-tasks-read.ts
+++ b/src/lib/project-tasks-read.ts
@@ -1,0 +1,203 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type { ChecklistItem, ProjectTaskStatus, ProjectTaskPriority } from "@/lib/project-tasks";
+
+/**
+ * Server-side read helpers for project tasks (Phase A read-rewiring).
+ *
+ * `projectTask` is dual-written (Prisma FK anchor + Convex doc — see
+ * src/lib/project-subtable-mirror.ts `syncProjectTasksToConvex`) and backfilled
+ * (scripts/convex-backfill-project-subtables.ts). The read-only actions
+ * (getProjectTasks, getMyOpenTasks, and the crew half of getTaskAssignees) read
+ * the Convex copy through these helpers.
+ *
+ * CROSS-DOMAIN JOINS:
+ * - assigneeCrew → CrewMember is a dual-written DOMAIN table, so it is attached
+ *   from Convex (crew-read.ts).
+ * - assigneeUser / createdBy → User is a Better Auth table (AUTH TERMINUS) that
+ *   stays in Prisma forever; those halves are attached via a batched
+ *   prisma.user.findMany in the server action.
+ * - project (name/number for getMyOpenTasks) is a dual-written domain table,
+ *   attached from Convex (projects-read.ts).
+ *
+ * NO Prisma fallback on a Convex map miss — a miss reads as the join against a
+ * deleted row would (assignee/project null), which is the same behaviour Prisma's
+ * `SetNull`/left-join relations produce. Falling back would hide mirror drift.
+ *
+ * Mappers convert epoch-ms → Date (serialize() keeps Date and Next serializes it
+ * to an ISO string on the wire, matching the previous Prisma shape), absent →
+ * null, and coerce Prisma-defaulted columns (status/priority/sortOrder) non-null.
+ * See FEATUREDOCS/54.
+ */
+
+export type ConvexProjectTask = Doc<"projectTasks">;
+
+/** The mapped shape mirrors `prisma.projectTask` rows (before include attach). */
+export interface MappedProjectTask {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  title: string;
+  description: string | null;
+  status: ProjectTaskStatus;
+  priority: ProjectTaskPriority;
+  dueDate: Date | null;
+  sortOrder: number;
+  checklist: ChecklistItem[] | null;
+  assigneeUserId: string | null;
+  assigneeCrewId: string | null;
+  createdById: string | null;
+  completedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const toDate = (ms: number | null | undefined): Date | null =>
+  ms === null || ms === undefined ? null : new Date(ms);
+
+/**
+ * Map a Convex projectTask doc to the Prisma-row shape. Strips _id/_creationTime,
+ * coerces the Prisma-defaulted columns non-null, and turns epoch-ms back into Date.
+ */
+export function mapProjectTask(doc: ConvexProjectTask): MappedProjectTask {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    projectId: doc.projectId,
+    title: doc.title,
+    description: doc.description ?? null,
+    status: (doc.status ?? "TODO") as ProjectTaskStatus,
+    priority: (doc.priority ?? "NORMAL") as ProjectTaskPriority,
+    dueDate: toDate(doc.dueDate),
+    sortOrder: doc.sortOrder ?? 0,
+    // checklist is stored as inline JSON (v.any()) — passed through unchanged.
+    checklist: (doc.checklist ?? null) as ChecklistItem[] | null,
+    assigneeUserId: doc.assigneeUserId ?? null,
+    assigneeCrewId: doc.assigneeCrewId ?? null,
+    createdById: doc.createdById ?? null,
+    completedAt: toDate(doc.completedAt),
+    // createdAt/updatedAt are @default(now())/@updatedAt — never absent for a real
+    // row, but coerce defensively so the non-null Date contract holds.
+    createdAt: toDate(doc.createdAt) ?? new Date(0),
+    updatedAt: toDate(doc.updatedAt) ?? new Date(0),
+  };
+}
+
+// ── Fetchers ────────────────────────────────────────────────────────────────
+
+/** All projectTask rows for a project (Convex), mapped to Prisma-row shape. */
+export async function getProjectTaskRowsByProject(
+  projectId: string,
+  orgId: string,
+): Promise<MappedProjectTask[]> {
+  const rows = await (await getConvexClient()).query(api.projectTasks.listByProject, {
+    projectId,
+    orgId,
+  });
+  return rows.map(mapProjectTask);
+}
+
+/** All projectTask rows for an org (Convex), mapped to Prisma-row shape. */
+export async function getProjectTaskRowsByOrg(orgId: string): Promise<MappedProjectTask[]> {
+  const rows = await (await getConvexClient()).query(api.projectTasks.list, { orgId });
+  return rows.map(mapProjectTask);
+}
+
+// ── Pure filters / sorts (replicate Prisma where/orderBy) ─────────────────────
+
+/**
+ * getProjectTasks ordering: `[{ sortOrder: "asc" }, { createdAt: "asc" }]`.
+ * Both columns are non-null, so no nulls handling needed.
+ */
+export function sortProjectTasks(tasks: MappedProjectTask[]): MappedProjectTask[] {
+  return [...tasks].sort(
+    (a, b) =>
+      a.sortOrder - b.sortOrder ||
+      a.createdAt.getTime() - b.createdAt.getTime(),
+  );
+}
+
+/** Filter to a single project (Convex listByProject already filters projectId; the
+ * org guard matches the Prisma `where: { organizationId, projectId }`). */
+export function filterTasksForProject(
+  tasks: MappedProjectTask[],
+  projectId: string,
+  orgId: string,
+): MappedProjectTask[] {
+  return tasks.filter((t) => t.projectId === projectId && t.organizationId === orgId);
+}
+
+// Postgres enum columns sort by DECLARED order, not alphabetical. ProjectTaskPriority
+// is declared LOW, NORMAL, HIGH — so `priority: "desc"` orders HIGH > NORMAL > LOW.
+const PRIORITY_RANK: Record<ProjectTaskPriority, number> = {
+  LOW: 0,
+  NORMAL: 1,
+  HIGH: 2,
+};
+
+/**
+ * getMyOpenTasks where: `{ organizationId, assigneeUserId: userId, status != DONE,
+ * project.isTemplate: false }`. The project-template predicate is applied here via
+ * the supplied non-template projectId set (templates excluded by the caller).
+ */
+export function filterMyOpenTasks(
+  tasks: MappedProjectTask[],
+  orgId: string,
+  userId: string,
+  nonTemplateProjectIds: Set<string>,
+): MappedProjectTask[] {
+  return tasks.filter(
+    (t) =>
+      t.organizationId === orgId &&
+      t.assigneeUserId === userId &&
+      t.status !== "DONE" &&
+      nonTemplateProjectIds.has(t.projectId),
+  );
+}
+
+/**
+ * getMyOpenTasks ordering:
+ *   [{ dueDate: { sort: "asc", nulls: "last" } }, { priority: "desc" }, { createdAt: "asc" }]
+ * Postgres ASC defaults NULLS LAST; this query makes it explicit. Dated tasks
+ * surface first; ties break by priority HIGH→LOW then oldest createdAt first.
+ */
+export function sortMyOpenTasks(tasks: MappedProjectTask[]): MappedProjectTask[] {
+  return [...tasks].sort((a, b) => {
+    // dueDate asc, NULLS LAST.
+    const ad = a.dueDate?.getTime() ?? null;
+    const bd = b.dueDate?.getTime() ?? null;
+    if (ad !== bd) {
+      if (ad === null) return 1;
+      if (bd === null) return -1;
+      return ad - bd;
+    }
+    // priority desc (declared-order rank).
+    const pr = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
+    if (pr !== 0) return pr;
+    // createdAt asc.
+    return a.createdAt.getTime() - b.createdAt.getTime();
+  });
+}
+
+// ── Crew assignee picker (getTaskAssignees crew half) ─────────────────────────
+
+export interface AssigneeCrew {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+/**
+ * The crew half of getTaskAssignees: org crew members excluding ARCHIVED, ordered
+ * by firstName asc then lastName asc. Reads the dual-written Convex crewMember docs.
+ */
+export function selectCrewAssignees(crew: Doc<"crewMembers">[]): AssigneeCrew[] {
+  return crew
+    .filter((c) => c.status !== "ARCHIVED")
+    .map((c) => ({ id: c.id, firstName: c.firstName, lastName: c.lastName }))
+    .sort(
+      (a, b) =>
+        a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName),
+    );
+}

--- a/src/server/project-tasks.ts
+++ b/src/server/project-tasks.ts
@@ -2,12 +2,71 @@
 
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/org-context";
-import { getProjectById } from "@/lib/projects-read";
+import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
+import { getCrewMembersByOrg } from "@/lib/crew-read";
+import {
+  getProjectTaskRowsByProject,
+  getProjectTaskRowsByOrg,
+  filterTasksForProject,
+  sortProjectTasks,
+  filterMyOpenTasks,
+  sortMyOpenTasks,
+  selectCrewAssignees,
+  type MappedProjectTask,
+} from "@/lib/project-tasks-read";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { syncProjectTasksToConvex } from "@/lib/project-subtable-mirror";
 import type { Prisma } from "@/generated/prisma/client";
 import type { ChecklistItem, ProjectTaskStatus, ProjectTaskPriority } from "@/lib/project-tasks";
+
+/**
+ * Attach the include relations onto Convex-sourced projectTask rows, replicating
+ * `taskInclude`:
+ *   - assigneeUser ({ id, name, image }) + createdBy ({ id, name }) → Better Auth
+ *     User (AUTH TERMINUS, stays Prisma) via one batched findMany.
+ *   - assigneeCrew ({ id, firstName, lastName }) → CrewMember (dual-written domain)
+ *     attached from the Convex crew docs.
+ * No fallback on a map miss: a missing assignee/creator reads null, exactly as a
+ * Prisma `SetNull` relation would after the referenced row is deleted.
+ */
+async function attachTaskRelations<T extends MappedProjectTask>(
+  organizationId: string,
+  tasks: T[],
+) {
+  const userIds = new Set<string>();
+  const crewIds = new Set<string>();
+  for (const t of tasks) {
+    if (t.assigneeUserId) userIds.add(t.assigneeUserId);
+    if (t.createdById) userIds.add(t.createdById);
+    if (t.assigneeCrewId) crewIds.add(t.assigneeCrewId);
+  }
+
+  const [users, crew] = await Promise.all([
+    userIds.size
+      ? prisma.user.findMany({
+          where: { id: { in: [...userIds] } },
+          select: { id: true, name: true, image: true },
+        })
+      : Promise.resolve([] as { id: string; name: string; image: string | null }[]),
+    crewIds.size ? getCrewMembersByOrg(organizationId) : Promise.resolve([]),
+  ]);
+
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const crewMap = new Map(crew.map((c) => [c.id, c]));
+
+  return tasks.map((t) => {
+    const u = t.assigneeUserId ? userMap.get(t.assigneeUserId) : undefined;
+    const creator = t.createdById ? userMap.get(t.createdById) : undefined;
+    const c = t.assigneeCrewId ? crewMap.get(t.assigneeCrewId) : undefined;
+    return {
+      ...t,
+      assigneeUser: u ? { id: u.id, name: u.name, image: u.image } : null,
+      assigneeCrew: c ? { id: c.id, firstName: c.firstName, lastName: c.lastName } : null,
+      createdBy: creator ? { id: creator.id, name: creator.name } : null,
+    };
+  });
+}
 
 const taskInclude = {
   assigneeUser: { select: { id: true, name: true, image: true } },
@@ -57,33 +116,32 @@ function normaliseChecklist(checklist?: ChecklistItem[] | null): Prisma.InputJso
 export async function getTaskAssignees() {
   const { organizationId } = await requirePermission("project", "read");
 
-  const [members, crew] = await Promise.all([
+  // Auth half (org members → Better Auth User) STAYS on Prisma — auth terminus.
+  // Crew half moves to the dual-written Convex crewMember docs (filter/sort in the
+  // pure helper, replicating `status != ARCHIVED` + firstName asc, lastName asc).
+  const [members, crewDocs] = await Promise.all([
     prisma.member.findMany({
       where: { organizationId },
       select: { user: { select: { id: true, name: true, image: true } } },
       orderBy: { createdAt: "asc" },
     }),
-    prisma.crewMember.findMany({
-      where: { organizationId, status: { not: "ARCHIVED" } },
-      select: { id: true, firstName: true, lastName: true },
-      orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
-    }),
+    getCrewMembersByOrg(organizationId),
   ]);
 
   return serialize({
     users: members.map((m) => m.user).filter(Boolean),
-    crew,
+    crew: selectCrewAssignees(crewDocs),
   });
 }
 
 export async function getProjectTasks(projectId: string) {
   const { organizationId } = await requirePermission("project", "read");
 
-  const tasks = await prisma.projectTask.findMany({
-    where: { organizationId, projectId },
-    include: taskInclude,
-    orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
-  });
+  // projectTask rows from Convex (dual-written); assignee/creator joins attached
+  // below (crew from Convex, User from Prisma — auth terminus).
+  const rows = await getProjectTaskRowsByProject(projectId, organizationId);
+  const sorted = sortProjectTasks(filterTasksForProject(rows, projectId, organizationId));
+  const tasks = await attachTaskRelations(organizationId, sorted);
 
   return serialize(tasks);
 }
@@ -273,24 +331,32 @@ export async function getMyOpenTasks(limit = 25) {
   // the same { organizationId, userId } shape as getOrgContext.
   const { organizationId, userId } = await requirePermission("project", "read");
 
-  const tasks = await prisma.projectTask.findMany({
-    where: {
-      organizationId,
-      assigneeUserId: userId,
-      status: { not: "DONE" },
-      project: { isTemplate: false },
-    },
-    include: {
-      ...taskInclude,
-      project: { select: { id: true, name: true, projectNumber: true } },
-    },
-    orderBy: [
-      // Nulls last on dueDate so dated tasks surface first.
-      { dueDate: { sort: "asc", nulls: "last" } },
-      { priority: "desc" },
-      { createdAt: "asc" },
-    ],
-    take: limit,
+  // org projectTask rows + org projects from Convex (both dual-written). The
+  // `project.isTemplate: false` relation-filter becomes a non-template projectId
+  // set; the `project` include ({ id, name, projectNumber }) is attached from the
+  // same project docs. assignee/creator joins attached below.
+  const [rows, projects] = await Promise.all([
+    getProjectTaskRowsByOrg(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+
+  const nonTemplateProjectIds = new Set(
+    projects.filter((p) => !p.isTemplate).map((p) => p.id),
+  );
+  const projectMap = new Map(projects.map((p) => [p.id, p]));
+
+  const matched = sortMyOpenTasks(
+    filterMyOpenTasks(rows, organizationId, userId, nonTemplateProjectIds),
+  ).slice(0, limit);
+
+  const withRelations = await attachTaskRelations(organizationId, matched);
+
+  const tasks = withRelations.map((t) => {
+    const p = projectMap.get(t.projectId);
+    return {
+      ...t,
+      project: p ? { id: p.id, name: p.name, projectNumber: p.projectNumber } : null,
+    };
   });
 
   return serialize(tasks);


### PR DESCRIPTION
## Summary

Phase A read-rewiring of the **project-tasks** surface — moves the three read-only
actions in `src/server/project-tasks.ts` off Prisma onto the dual-written Convex copy.

**Converted to Convex:**
- `getProjectTasks` — `projectTasks.listByProject`; order sortOrder asc → createdAt asc.
- `getMyOpenTasks` — `projectTasks.list`; where assignee=me, status≠DONE, project not template; order dueDate asc **NULLS LAST** → priority **desc (declared order: HIGH>NORMAL>LOW)** → createdAt asc; take limit.
- `getTaskAssignees` **crew half** — Convex `crewMembers`, status≠ARCHIVED, firstName asc → lastName asc.

**Stays on Prisma (intentional):**
- `assigneeUser`, `createdBy`, and the **member/User half** of `getTaskAssignees` — these are Better Auth `User`/`member` rows (**auth terminus, never moves**). Resolved via one batched `prisma.user.findMany` + `prisma.member.findMany`.
- All writes (`create`/`update`/`delete`/`reorder`) + assignee org-validation (read-then-write).

**Cross-domain joins from Convex:** `assigneeCrew` (dual-written CrewMember) grafted from `crewMembers` docs; `project` name/number (getMyOpenTasks) from `projects.list`.

New `src/lib/project-tasks-read.ts`: Convex fetchers + a mapper (epoch-ms→Date so `serialize`'s Date-passthrough reproduces the prior Prisma wire shape; absent→null; Prisma-defaulted status/priority/sortOrder coerced non-null; checklist JSON passed through) + pure unit-tested filter/sort predicates. **No Prisma fallback on a Convex map miss** (a miss reads null, like a join against a deleted `SetNull` row). **No new Convex query** — `projectTasks.listByProject`/`.list` already existed.

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/project-tasks-read.test.ts` — 10/10 pass (mapper, both filter/sort predicates, crew selector)
- `pnpm exec eslint` on all three changed files — clean

## Pre-flight gate (confirmed)
- `projectTask` dual-written (`syncProjectTasksToConvex`) + backfilled (`convex-backfill-project-subtables.ts`).
- `crewMember` dual-written (crew roster cutover done).
- Assignee is a direct FK column on the projectTask row (no join table) — moves with the Convex row.

## Deploy gate
The `projectTask` and `crewMember` backfills must be run against **prod Convex before this read deploys**, else existing rows read empty. `projectTask` ships in the project-subtables backfill; `crewMember` in the crew roster cutover (already done).

**Human-gated:** Convex data-correctness can't be verified in a dev worktree — merge only after validating on the Coolify PR preview against prod Convex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)