### PR TITLE
feat(convex): read leftover kit/supplier/category trims from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,48 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **domain read-trims (kits / suppliers / categories)** (`server/kits.ts`,
+  `server/suppliers.ts`, `server/categories.ts`). Leftover Prisma reads in
+  otherwise-converted domains, all pure (counts / dropdown availability lists /
+  search — none feed a same-action mutation). Moved:
+  - `getKitCounts` — the two `kitSerializedItem`/`kitBulkItem` `groupBy`s →
+    `kits-read.ts` `getKitSerializedItemsByOrg`/`getKitBulkItemsByOrg` +
+    pure `countKitMembers`. (Primary photo already came from Convex.)
+  - `getAvailableAssetsForKit` / `getAvailableBulkAssetsForKit` →
+    `assets-read.ts` `getAssetsByOrg`/`getBulkAssetsByOrg` + pure
+    `filterAvailableAssetsForKit`/`filterAvailableBulkAssetsForKit` +
+    `sortByAssetTagAsc`. Prisma defaults coerced (`status` AVAILABLE/ACTIVE,
+    `isActive` true, `availableQuantity` 0) since the Convex doc leaves them absent.
+  - `getSupplierCounts` — the `supplierOrder.groupBy` → `suppliers-read.ts`
+    `getSupplierOrdersByOrg` + pure `countSupplierAssetsAndOrders` (the asset
+    count already came off `getAssetsByOrg`).
+  - `searchContainerAssets` — the `asset` findMany with a `model.categoryId in`
+    relational filter + OR text filter → `assets-read.ts` `getAssetsByOrg` + pure
+    `filterContainerAssets` (resolves the joined model category/name from the
+    Convex model map) + `sortByAssetTagAsc` + `slice(0, 20)`.
+
+  No new Convex queries (reused `assets.list`, `bulkAssets.list`,
+  `kitSerializedItems.list`, `kitBulkItems.list`, `supplierOrders.list`).
+  `getCaseCategoryIds` stays Prisma (out of scope — reads Better Auth
+  `organization.metadata` for `prepKitCategoryId` plus the category tree; the org
+  table is Better Auth and never moves). Model joins already ran through Convex via
+  `getModelMap`. **Deploy gate:** `assets`/`bulkAssets`/`suppliers`/`supplierOrders`/
+  `kitSerializedItems`/`kitBulkItems` must be backfilled in prod Convex before this
+  deploys (per memory all are).
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/assets-read.test.ts
+++ b/src/lib/assets-read.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the pure asset filter/sort predicates that replicate the Prisma
+ * `where`/`orderBy` of the kit-availability and container-search reads now that
+ * the asset rows come off Convex (Phase A read-rewiring).
+ *
+ * Safety property: identical eligibility + ordering to the Prisma queries,
+ * including the defaulted-column coercions (status/isActive/availableQuantity are
+ * left absent on the Convex doc but default non-null in Postgres).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  sortByAssetTagAsc,
+  filterAvailableAssetsForKit,
+  filterAvailableBulkAssetsForKit,
+  filterContainerAssets,
+  type ConvexAsset,
+  type ConvexBulkAsset,
+} from "@/lib/assets-read";
+
+function asset(p: Partial<ConvexAsset>): ConvexAsset {
+  return {
+    _id: "x" as ConvexAsset["_id"],
+    _creationTime: 0,
+    id: p.id ?? "a",
+    organizationId: "org",
+    modelId: p.modelId ?? "m1",
+    assetTag: p.assetTag ?? "A-001",
+    ...p,
+  } as ConvexAsset;
+}
+
+function bulk(p: Partial<ConvexBulkAsset>): ConvexBulkAsset {
+  return {
+    _id: "x" as ConvexBulkAsset["_id"],
+    _creationTime: 0,
+    id: p.id ?? "b",
+    organizationId: "org",
+    modelId: p.modelId ?? "m1",
+    assetTag: p.assetTag ?? "B-001",
+    ...p,
+  } as ConvexBulkAsset;
+}
+
+describe("sortByAssetTagAsc", () => {
+  it("sorts ascending by assetTag without mutating the input", () => {
+    const input = [asset({ assetTag: "C" }), asset({ assetTag: "A" }), asset({ assetTag: "B" })];
+    const out = sortByAssetTagAsc(input);
+    expect(out.map((a) => a.assetTag)).toEqual(["A", "B", "C"]);
+    expect(input.map((a) => a.assetTag)).toEqual(["C", "A", "B"]);
+  });
+});
+
+describe("filterAvailableAssetsForKit", () => {
+  it("keeps active + AVAILABLE + un-kitted assets", () => {
+    const rows = [
+      asset({ id: "ok", status: "AVAILABLE", isActive: true, kitId: undefined }),
+      asset({ id: "checked-out", status: "CHECKED_OUT", isActive: true }),
+      asset({ id: "inactive", status: "AVAILABLE", isActive: false }),
+      asset({ id: "in-kit", status: "AVAILABLE", isActive: true, kitId: "k1" }),
+    ];
+    expect(filterAvailableAssetsForKit(rows).map((a) => a.id)).toEqual(["ok"]);
+  });
+
+  it("coerces absent status/isActive to the Prisma defaults (AVAILABLE/true)", () => {
+    const rows = [asset({ id: "defaulted", status: undefined, isActive: undefined, kitId: undefined })];
+    expect(filterAvailableAssetsForKit(rows).map((a) => a.id)).toEqual(["defaulted"]);
+  });
+
+  it("filters to one model when modelId is passed", () => {
+    const rows = [
+      asset({ id: "m1a", modelId: "m1", status: "AVAILABLE", isActive: true }),
+      asset({ id: "m2a", modelId: "m2", status: "AVAILABLE", isActive: true }),
+    ];
+    expect(filterAvailableAssetsForKit(rows, "m2").map((a) => a.id)).toEqual(["m2a"]);
+  });
+});
+
+describe("filterAvailableBulkAssetsForKit", () => {
+  it("keeps active + ACTIVE + quantity>0 bulk assets", () => {
+    const rows = [
+      bulk({ id: "ok", status: "ACTIVE", isActive: true, availableQuantity: 3 }),
+      bulk({ id: "zero", status: "ACTIVE", isActive: true, availableQuantity: 0 }),
+      bulk({ id: "retired", status: "RETIRED", isActive: true, availableQuantity: 5 }),
+      bulk({ id: "inactive", status: "ACTIVE", isActive: false, availableQuantity: 5 }),
+    ];
+    expect(filterAvailableBulkAssetsForKit(rows).map((b) => b.id)).toEqual(["ok"]);
+  });
+
+  it("coerces absent status/isActive/availableQuantity defaults (ACTIVE/true/0)", () => {
+    const rows = [
+      bulk({ id: "defaulted-qty-absent", status: undefined, isActive: undefined, availableQuantity: undefined }),
+      bulk({ id: "defaulted-status-only", status: undefined, isActive: undefined, availableQuantity: 2 }),
+    ];
+    // availableQuantity absent → 0 → excluded; the one with qty 2 passes.
+    expect(filterAvailableBulkAssetsForKit(rows).map((b) => b.id)).toEqual(["defaulted-status-only"]);
+  });
+});
+
+describe("filterContainerAssets", () => {
+  const cats = new Set(["c1", "c2"]);
+  const modelCat = (id: string | null | undefined) =>
+    ({ m1: "c1", m2: "c9", m3: "c2" } as Record<string, string>)[id ?? ""] ?? null;
+  const modelName = (id: string | null | undefined) =>
+    ({ m1: "Pelican Tote", m2: "Speaker", m3: "Road Box" } as Record<string, string>)[id ?? ""] ?? null;
+
+  it("keeps only assets whose model category is in the set (empty query)", () => {
+    const rows = [
+      asset({ id: "in", modelId: "m1" }),
+      asset({ id: "out-cat", modelId: "m2" }),
+      asset({ id: "no-model", modelId: undefined }),
+    ];
+    expect(filterContainerAssets(rows, cats, "", modelCat, modelName).map((a) => a.id)).toEqual(["in"]);
+  });
+
+  it("matches query against assetTag, customName, or model name (case-insensitive)", () => {
+    const rows = [
+      asset({ id: "by-tag", modelId: "m1", assetTag: "CASE-42", customName: undefined }),
+      asset({ id: "by-name", modelId: "m1", assetTag: "X-1", customName: "Big Box" }),
+      asset({ id: "by-model", modelId: "m3", assetTag: "Y-1", customName: undefined }),
+      asset({ id: "no-match", modelId: "m1", assetTag: "Z-9", customName: undefined }),
+    ];
+    expect(filterContainerAssets(rows, cats, "case", modelCat, modelName).map((a) => a.id)).toEqual(["by-tag"]);
+    expect(filterContainerAssets(rows, cats, "big box", modelCat, modelName).map((a) => a.id)).toEqual(["by-name"]);
+    expect(filterContainerAssets(rows, cats, "road", modelCat, modelName).map((a) => a.id)).toEqual(["by-model"]);
+  });
+
+  it("excludes an out-of-category asset even if its text matches", () => {
+    const rows = [asset({ id: "wrong-cat", modelId: "m2", assetTag: "CASE-1" })];
+    expect(filterContainerAssets(rows, cats, "case", modelCat, modelName)).toEqual([]);
+  });
+});

--- a/src/lib/assets-read.ts
+++ b/src/lib/assets-read.ts
@@ -47,3 +47,77 @@ export async function getActiveBulkAssetsByModel(modelId: string, orgId: string)
   const all = (await (await getConvexClient()).query(api.bulkAssets.listByModel, { modelId, orgId })) as ConvexBulkAsset[];
   return all.filter((ba) => ba.isActive !== false);
 }
+
+// ---------------------------------------------------------------------------
+// Pure filter/sort predicates (unit-tested) replicating the Prisma `where` /
+// `orderBy` clauses of the kit-availability and container-search reads now that
+// the asset rows come off Convex. Prisma defaults are coerced because the Convex
+// doc leaves defaulted columns absent: `status` (Asset default AVAILABLE /
+// BulkAsset default ACTIVE), `isActive` (default true), `availableQuantity`
+// (default 0). `assetTag` is a required non-null column, so the ASC sort never
+// hits NULLS-LAST.
+// ---------------------------------------------------------------------------
+
+/** Stable ASC sort by `assetTag` (Prisma `orderBy: { assetTag: "asc" }`). */
+export function sortByAssetTagAsc<T extends { assetTag: string }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => (a.assetTag < b.assetTag ? -1 : a.assetTag > b.assetTag ? 1 : 0));
+}
+
+/**
+ * Serialized assets eligible to be added to a kit: active, AVAILABLE, not already
+ * in a kit, optionally filtered to one model. Replicates
+ * `where: { isActive: true, status: "AVAILABLE", kitId: null, ...(modelId && { modelId }) }`.
+ */
+export function filterAvailableAssetsForKit(assets: ConvexAsset[], modelId?: string): ConvexAsset[] {
+  return assets.filter(
+    (a) =>
+      a.isActive !== false &&
+      (a.status ?? "AVAILABLE") === "AVAILABLE" &&
+      (a.kitId ?? null) === null &&
+      (!modelId || a.modelId === modelId),
+  );
+}
+
+/**
+ * Bulk assets eligible to be added to a kit: active, ACTIVE status, with spare
+ * quantity. Replicates
+ * `where: { isActive: true, status: "ACTIVE", availableQuantity: { gt: 0 } }`.
+ */
+export function filterAvailableBulkAssetsForKit(bulkAssets: ConvexBulkAsset[]): ConvexBulkAsset[] {
+  return bulkAssets.filter(
+    (b) =>
+      b.isActive !== false &&
+      (b.status ?? "ACTIVE") === "ACTIVE" &&
+      (b.availableQuantity ?? 0) > 0,
+  );
+}
+
+/**
+ * Container-search match predicate: assets whose model's category is in
+ * `categoryIds`, optionally matching `query` (case-insensitive substring)
+ * against `assetTag`, `customName`, or the model name. Replicates the
+ * `searchContainerAssets` Prisma `where` — the `model: { categoryId: { in } }`
+ * relational filter plus the OR text filter. `modelCategoryId` / `modelName`
+ * resolve the joined model fields from the Convex model map; an asset whose model
+ * can't be resolved fails the category gate (a join against a deleted/absent row,
+ * same as Prisma's inner relational filter).
+ */
+export function filterContainerAssets(
+  assets: ConvexAsset[],
+  categoryIds: Set<string>,
+  query: string,
+  modelCategoryId: (modelId: string | null | undefined) => string | null,
+  modelName: (modelId: string | null | undefined) => string | null,
+): ConvexAsset[] {
+  const needle = query.toLowerCase();
+  return assets.filter((a) => {
+    const catId = modelCategoryId(a.modelId);
+    if (!catId || !categoryIds.has(catId)) return false;
+    if (!needle) return true;
+    return (
+      a.assetTag.toLowerCase().includes(needle) ||
+      (a.customName?.toLowerCase().includes(needle) ?? false) ||
+      (modelName(a.modelId)?.toLowerCase().includes(needle) ?? false)
+    );
+  });
+}

--- a/src/lib/kits-read.test.ts
+++ b/src/lib/kits-read.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit test for countKitMembers — the JS per-kit member counter that replaces the
+ * two Prisma `groupBy({ by: ["kitId"] })` calls in getKitCounts (Phase A).
+ */
+import { describe, it, expect } from "vitest";
+import { countKitMembers } from "@/lib/kits-read";
+
+describe("countKitMembers", () => {
+  it("counts serialized + bulk members per kit", () => {
+    const serialized = [{ kitId: "k1" }, { kitId: "k1" }, { kitId: "k2" }];
+    const bulk = [{ kitId: "k1" }, { kitId: "k3" }];
+    expect(countKitMembers(serialized, bulk)).toEqual({
+      k1: { serializedItems: 2, bulkItems: 1 },
+      k2: { serializedItems: 1, bulkItems: 0 },
+      k3: { serializedItems: 0, bulkItems: 1 },
+    });
+  });
+
+  it("skips rows with a null kitId", () => {
+    expect(
+      countKitMembers([{ kitId: null }, { kitId: "k1" }], [{ kitId: null }]),
+    ).toEqual({ k1: { serializedItems: 1, bulkItems: 0 } });
+  });
+
+  it("returns an empty record for empty inputs", () => {
+    expect(countKitMembers([], [])).toEqual({});
+  });
+});

--- a/src/lib/kits-read.ts
+++ b/src/lib/kits-read.ts
@@ -36,3 +36,33 @@ export async function getKitMap(orgId: string): Promise<Map<string, ConvexKit>> 
 export async function getKitByAssetTag(orgId: string, assetTag: string): Promise<ConvexKit | null> {
   return await (await getConvexClient()).query(api.kits.getByAssetTag, { organizationId: orgId, assetTag });
 }
+
+export type ConvexKitSerializedItem = Doc<"kitSerializedItems">;
+export type ConvexKitBulkItem = Doc<"kitBulkItems">;
+
+/** All of an org's kit serialized-member rows (kit_serialized_item), for counts. */
+export async function getKitSerializedItemsByOrg(orgId: string): Promise<ConvexKitSerializedItem[]> {
+  return await (await getConvexClient()).query(api.kitSerializedItems.list, { orgId });
+}
+
+/** All of an org's kit bulk-member rows (kit_bulk_item), for counts. */
+export async function getKitBulkItemsByOrg(orgId: string): Promise<ConvexKitBulkItem[]> {
+  return await (await getConvexClient()).query(api.kitBulkItems.list, { orgId });
+}
+
+/**
+ * Per-kit member counts (kitId -> { serializedItems, bulkItems }) computed in JS
+ * over the two member lists, replacing the two Prisma `groupBy({ by: ["kitId"] })`
+ * calls in `getKitCounts`. A `null`/absent `kitId` is skipped (matches the Prisma
+ * loop that only counts grouped rows carrying a kitId). Pure + unit-tested.
+ */
+export function countKitMembers(
+  serializedItems: Array<{ kitId?: string | null }>,
+  bulkItems: Array<{ kitId?: string | null }>,
+): Record<string, { serializedItems: number; bulkItems: number }> {
+  const out: Record<string, { serializedItems: number; bulkItems: number }> = {};
+  const ensure = (id: string) => (out[id] ??= { serializedItems: 0, bulkItems: 0 });
+  for (const s of serializedItems) if (s.kitId) ensure(s.kitId).serializedItems++;
+  for (const b of bulkItems) if (b.kitId) ensure(b.kitId).bulkItems++;
+  return out;
+}

--- a/src/lib/suppliers-read.test.ts
+++ b/src/lib/suppliers-read.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Unit test for countSupplierAssetsAndOrders — the JS per-supplier counter that
+ * replaces the Prisma `supplierOrder.groupBy({ by: ["supplierId"] })` in
+ * getSupplierCounts (Phase A). Asset counts already came from Convex.
+ */
+import { describe, it, expect } from "vitest";
+import { countSupplierAssetsAndOrders } from "@/lib/suppliers-read";
+
+describe("countSupplierAssetsAndOrders", () => {
+  it("counts assets + orders per supplier", () => {
+    const assets = [{ supplierId: "s1" }, { supplierId: "s1" }, { supplierId: "s2" }];
+    const orders = [{ supplierId: "s1" }, { supplierId: "s3" }];
+    expect(countSupplierAssetsAndOrders(assets, orders)).toEqual({
+      s1: { assets: 2, orders: 1 },
+      s2: { assets: 1, orders: 0 },
+      s3: { assets: 0, orders: 1 },
+    });
+  });
+
+  it("skips null supplierIds on both sides", () => {
+    expect(
+      countSupplierAssetsAndOrders([{ supplierId: null }, { supplierId: "s1" }], [{ supplierId: null }]),
+    ).toEqual({ s1: { assets: 1, orders: 0 } });
+  });
+
+  it("returns an empty record for empty inputs", () => {
+    expect(countSupplierAssetsAndOrders([], [])).toEqual({});
+  });
+});

--- a/src/lib/suppliers-read.ts
+++ b/src/lib/suppliers-read.ts
@@ -71,3 +71,28 @@ export async function getMatchingSupplierIds(orgId: string, term: string): Promi
   const all = await getSuppliersByOrg(orgId);
   return all.filter((s) => s.name.toLowerCase().includes(needle)).map((s) => s.id);
 }
+
+export type ConvexSupplierOrder = Doc<"supplierOrders">;
+
+/** All of an org's supplier orders (supplier_order), for per-supplier counts. */
+export async function getSupplierOrdersByOrg(orgId: string): Promise<ConvexSupplierOrder[]> {
+  return await (await getConvexClient()).query(api.supplierOrders.list, { orgId });
+}
+
+/**
+ * Per-supplier asset + order counts (supplierId -> { assets, orders }) computed in
+ * JS over the org's assets + supplier orders, replacing the Prisma
+ * `supplierOrder.groupBy({ by: ["supplierId"] })` in `getSupplierCounts`. A
+ * `null`/absent `supplierId` is skipped (matches the Prisma loops, which only
+ * count rows carrying a supplierId). Pure + unit-tested.
+ */
+export function countSupplierAssetsAndOrders(
+  assets: Array<{ supplierId?: string | null }>,
+  orders: Array<{ supplierId?: string | null }>,
+): Record<string, { assets: number; orders: number }> {
+  const counts: Record<string, { assets: number; orders: number }> = {};
+  const ensure = (id: string) => (counts[id] ??= { assets: 0, orders: 0 });
+  for (const a of assets) if (a.supplierId) ensure(a.supplierId).assets++;
+  for (const o of orders) if (o.supplierId) ensure(o.supplierId).orders++;
+  return counts;
+}

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -6,6 +6,7 @@ import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getModelMap, getModelsByOrg } from "@/lib/models-read";
+import { getAssetsByOrg, filterContainerAssets, sortByAssetTagAsc } from "@/lib/assets-read";
 import { serialize } from "@/lib/serialize";
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
 import { logActivity } from "@/lib/activity-log";
@@ -178,34 +179,26 @@ export async function searchContainerAssets(query: string = "") {
   const categoryIds = await getCaseCategoryIds();
   if (categoryIds.length === 0) return serialize([]);
 
-  const assets = await prisma.asset.findMany({
-    where: {
-      organizationId,
-      model: { categoryId: { in: categoryIds } },
-      ...(query
-        ? {
-            OR: [
-              { assetTag: { contains: query, mode: "insensitive" } },
-              { customName: { contains: query, mode: "insensitive" } },
-              { model: { name: { contains: query, mode: "insensitive" } } },
-            ],
-          }
-        : {}),
-    },
-    select: {
-      id: true,
-      assetTag: true,
-      customName: true,
-      modelId: true,
-    },
-    orderBy: { assetTag: "asc" },
-    take: 20,
-  });
-
-  const modelMap = await getModelMap(organizationId);
+  // Assets come off the dual-written Convex `assets` list; the `model.categoryId`
+  // relational filter + OR text filter are replicated by filterContainerAssets,
+  // resolving the joined model fields from the Convex model map (Phase A).
+  const [allAssets, modelMap] = await Promise.all([
+    getAssetsByOrg(organizationId),
+    getModelMap(organizationId),
+  ]);
+  const categoryIdSet = new Set(categoryIds);
+  const matched = sortByAssetTagAsc(
+    filterContainerAssets(
+      allAssets,
+      categoryIdSet,
+      query,
+      (modelId) => (modelId ? modelMap.get(modelId)?.categoryId ?? null : null),
+      (modelId) => (modelId ? modelMap.get(modelId)?.name ?? null : null),
+    ),
+  ).slice(0, 20);
 
   return serialize(
-    assets.map((a) => ({
+    matched.map((a) => ({
       value: a.customName || a.assetTag,
       label: a.customName
         ? `${a.customName} (${a.assetTag})`

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -27,6 +27,8 @@ import { removeKitCheckItemFromConvex } from "@/lib/check-item-assignment-mirror
 import { syncMediaForParent } from "@/lib/media-mirror";
 import { getPrimaryPhotoMap } from "@/lib/media-read";
 import { getModelById, getModelMap } from "@/lib/models-read";
+import { getAssetsByOrg, getBulkAssetsByOrg, filterAvailableAssetsForKit, filterAvailableBulkAssetsForKit, sortByAssetTagAsc } from "@/lib/assets-read";
+import { getKitSerializedItemsByOrg, getKitBulkItemsByOrg, countKitMembers } from "@/lib/kits-read";
 
 /**
  * Per-kit member-item counts + primary photo (kitId -> meta).
@@ -36,20 +38,28 @@ import { getModelById, getModelMap } from "@/lib/models-read";
  * dual-written). Used by the reactive kit table, which subscribes to the kit
  * list via Convex and merges these (non-reactive) values in. Excludes prep-kits
  * (isPrep) to match the kit list.
+ *
+ * Phase A: the member counts now come off the dual-written Convex
+ * `kitSerializedItems` / `kitBulkItems` lists (counted in JS by countKitMembers)
+ * instead of two Prisma `groupBy`s; the primary photo already came from Convex.
  */
 export async function getKitCounts(): Promise<
   Record<string, { serializedItems: number; bulkItems: number; media: { url: string | null; thumbnailUrl: string | null } | null }>
 > {
   const { organizationId } = await getOrgContext();
-  const [serializedGroups, bulkGroups, photoMap] = await Promise.all([
-    prisma.kitSerializedItem.groupBy({ by: ["kitId"], where: { organizationId }, _count: { _all: true } }),
-    prisma.kitBulkItem.groupBy({ by: ["kitId"], where: { organizationId }, _count: { _all: true } }),
+  const [serializedItems, bulkItems, photoMap] = await Promise.all([
+    getKitSerializedItemsByOrg(organizationId),
+    getKitBulkItemsByOrg(organizationId),
     getPrimaryPhotoMap("kit", organizationId),
   ]);
+  const memberCounts = countKitMembers(serializedItems, bulkItems);
   const out: Record<string, { serializedItems: number; bulkItems: number; media: { url: string | null; thumbnailUrl: string | null } | null }> = {};
   const ensure = (id: string) => (out[id] ??= { serializedItems: 0, bulkItems: 0, media: null });
-  for (const g of serializedGroups) if (g.kitId) ensure(g.kitId).serializedItems = g._count._all;
-  for (const g of bulkGroups) if (g.kitId) ensure(g.kitId).bulkItems = g._count._all;
+  for (const [kitId, c] of Object.entries(memberCounts)) {
+    const e = ensure(kitId);
+    e.serializedItems = c.serializedItems;
+    e.bulkItems = c.bulkItems;
+  }
   for (const [kitId, meta] of Object.entries(photoMap)) ensure(kitId).media = meta;
   return serialize(out);
 }
@@ -685,41 +695,33 @@ export async function removeBulkItemFromKit(
   return serialize({ success: true });
 }
 
-// Serialized assets not in any kit.
+// Serialized assets not in any kit. Reads off the dual-written Convex `assets`
+// list; the eligibility where + assetTag sort are replicated by the pure
+// filterAvailableAssetsForKit / sortByAssetTagAsc helpers (Phase A).
 export async function getAvailableAssetsForKit(modelId?: string) {
   const { organizationId } = await getOrgContext();
 
-  const assets = await prisma.asset.findMany({
-    where: {
-      organizationId,
-      isActive: true,
-      status: "AVAILABLE",
-      kitId: null,
-      ...(modelId && { modelId }),
-    },
-    orderBy: { assetTag: "asc" },
-  });
-  const modelMap = await getModelMap(organizationId);
+  const [allAssets, modelMap] = await Promise.all([
+    getAssetsByOrg(organizationId),
+    getModelMap(organizationId),
+  ]);
+  const assets = sortByAssetTagAsc(filterAvailableAssetsForKit(allAssets, modelId));
   return serialize(assets.map((a) => ({
     ...a,
     model: a.modelId ? modelMap.get(a.modelId) ?? null : null,
   })));
 }
 
-// Bulk assets with available quantity.
+// Bulk assets with available quantity. Reads off the dual-written Convex
+// `bulkAssets` list; eligibility + sort via the pure helpers (Phase A).
 export async function getAvailableBulkAssetsForKit() {
   const { organizationId } = await getOrgContext();
 
-  const bulkAssets = await prisma.bulkAsset.findMany({
-    where: {
-      organizationId,
-      isActive: true,
-      status: "ACTIVE",
-      availableQuantity: { gt: 0 },
-    },
-    orderBy: { assetTag: "asc" },
-  });
-  const modelMap = await getModelMap(organizationId);
+  const [allBulkAssets, modelMap] = await Promise.all([
+    getBulkAssetsByOrg(organizationId),
+    getModelMap(organizationId),
+  ]);
+  const bulkAssets = sortByAssetTagAsc(filterAvailableBulkAssetsForKit(allBulkAssets));
   return serialize(bulkAssets.map((b) => ({
     ...b,
     model: b.modelId ? modelMap.get(b.modelId) ?? null : null,

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -13,6 +13,7 @@ import { buildFilterWhere, type FilterValue } from "@/lib/table-utils";
 import type { ColumnDef } from "@/components/ui/data-table";
 import { attachModel } from "@/lib/models-read";
 import { getAssetsByOrg } from "@/lib/assets-read";
+import { getSupplierOrdersByOrg, countSupplierAssetsAndOrders } from "@/lib/suppliers-read";
 
 // Suppliers are DUAL-WRITTEN: every create/update/delete writes the Prisma
 // `supplier` row (the durable FK anchor — asset/bulk_asset/project_line_item/
@@ -104,28 +105,19 @@ export async function getSuppliersPaginated(params: {
 
 /**
  * Asset + order counts per supplier (supplierId -> { assets, orders }).
- * Cross-domain: assets and supplier orders still live in Prisma, so this can't
- * come from Convex. Used by the reactive supplier table, which subscribes to the
- * supplier list via Convex and merges these (non-reactive) counts.
+ * Both inputs now come off Convex — assets via getAssetsByOrg and supplier orders
+ * via getSupplierOrdersByOrg (both dual-written) — counted in JS by
+ * countSupplierAssetsAndOrders, replacing the Prisma `supplierOrder.groupBy`
+ * (Phase A). Used by the reactive supplier table, which subscribes to the supplier
+ * list via Convex and merges these (non-reactive) counts.
  */
 export async function getSupplierCounts(): Promise<Record<string, { assets: number; orders: number }>> {
   const { organizationId } = await getOrgContext();
-  const [allAssets, orderGroups] = await Promise.all([
+  const [allAssets, orders] = await Promise.all([
     getAssetsByOrg(organizationId),
-    prisma.supplierOrder.groupBy({
-      by: ["supplierId"],
-      where: { organizationId },
-      _count: { _all: true },
-    }),
+    getSupplierOrdersByOrg(organizationId),
   ]);
-  const counts: Record<string, { assets: number; orders: number }> = {};
-  for (const a of allAssets) {
-    if (a.supplierId) (counts[a.supplierId] ??= { assets: 0, orders: 0 }).assets++;
-  }
-  for (const g of orderGroups) {
-    if (g.supplierId) (counts[g.supplierId] ??= { assets: 0, orders: 0 }).orders = g._count._all;
-  }
-  return serialize(counts);
+  return serialize(countSupplierAssetsAndOrders(allAssets, orders));
 }
 
 export async function getSupplierById(id: string) {


### PR DESCRIPTION
## What

Phase A read-rewiring "trims": move the last few leftover Prisma domain READs in three otherwise-converted domains (kits / suppliers / categories) to the dual-written Convex mirror. All five actions are **pure reads** (counts / dropdown availability lists / search) — verified none feeds a mutation in the same action.

### Actions converted
- **`getKitCounts`** (`server/kits.ts`) — the two `kitSerializedItem`/`kitBulkItem` `groupBy`s → `kits-read.ts` `getKitSerializedItemsByOrg`/`getKitBulkItemsByOrg` + pure `countKitMembers`. Primary photo already came from Convex.
- **`getAvailableAssetsForKit`** / **`getAvailableBulkAssetsForKit`** (`server/kits.ts`) → `assets-read.ts` `getAssetsByOrg`/`getBulkAssetsByOrg` + pure `filterAvailableAssetsForKit`/`filterAvailableBulkAssetsForKit` + `sortByAssetTagAsc`. Prisma defaults coerced (`status` AVAILABLE/ACTIVE, `isActive` true, `availableQuantity` 0) since the Convex doc leaves defaulted columns absent.
- **`getSupplierCounts`** (`server/suppliers.ts`) — the `supplierOrder.groupBy` → `suppliers-read.ts` `getSupplierOrdersByOrg` + pure `countSupplierAssetsAndOrders`. The asset count already came off `getAssetsByOrg`.
- **`searchContainerAssets`** (`server/categories.ts`) — the `asset` findMany with a `model.categoryId in` relational filter + OR text filter → `assets-read.ts` `getAssetsByOrg` + pure `filterContainerAssets` (resolves joined model category/name from the Convex model map) + `sortByAssetTagAsc` + `slice(0, 20)`.

### Left on Prisma (by design)
- **`getCaseCategoryIds`** (helper used by `searchContainerAssets`) — out of scope: reads Better Auth `organization.metadata` (for `prepKitCategoryId`) plus the category tree. The org table is Better Auth and never moves.
- Model joins already ran through Convex via `getModelMap`.

### New Convex queries
None — reused existing `assets.list`, `bulkAssets.list`, `kitSerializedItems.list`, `kitBulkItems.list`, `supplierOrders.list`.

## Pre-flight gate
All dependent tables have a Convex module, are dual-written, and have a prod backfill: `assets`/`bulkAssets` (`convex-backfill-asset.ts`), `suppliers` (`convex-backfill-suppliers.ts`), `supplierOrders` (`convex-backfill-sub-hires.ts`), `kitSerializedItems`/`kitBulkItems` (`convex-backfill-kit.ts`).

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` (3 new test files) — 15/15 pass
- `pnpm exec eslint` (all changed files) — 0 errors (only pre-existing `_id`/`_asset` destructure-strip warnings in untouched code)

Unit tests cover every new pure function: `countKitMembers`, `countSupplierAssetsAndOrders`, `filterAvailableAssetsForKit`/`filterAvailableBulkAssetsForKit`, `sortByAssetTagAsc`, `filterContainerAssets` (incl. the defaulted-column coercions).

## Deploy gate
Merge gate is the deploy-ordering gate: the above tables must be backfilled in **prod** Convex before this deploys (per project memory, all are). **Human-gated on a Coolify PR preview** — Convex data-correctness can't be verified in a dev worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)