### PR TITLE
feat(convex): read test-tag records from Convex (Phase A, stacked on #194)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2677,6 +2677,43 @@ counts — all read-only) moved off Prisma. It read `testTagAsset` / `testTagRec
   sub-test-records, asset-scan-logs, check-records) — added so "the one command"
   is actually complete. (Prod ran them individually, so prod was unaffected.)
 
+### Test & Tag records + auditor partial — DONE (stacked on the reports surface)
+
+`src/server/test-tag-records.ts` (per-asset test history + Quick Pass pre-fill)
+and the dual-written-table reads inside `src/server/test-tag-auditor.ts` moved
+off Prisma, **extending** the same `src/lib/test-tag-read.ts` helper.
+
+- **Reads converted:**
+  - `getTestTagRecords(assetId, {page,pageSize})` — paginated test history.
+    Convex `testTagRecords.listByOrgAndAsset` → JS sort `testDate` desc →
+    JS slice for pagination (`total` from the full set). `testProfile`/
+    `subTestRecords` attached from Convex, `testedBy {id,name}` from Prisma.
+  - `getLatestTestRecord(assetId)` — same fetch, first row after the desc sort.
+  - `getAuditorScopeOptions()` — distinct `applianceType`/`equipmentClass`/
+    `location` facets + the sorted asset picker list, computed in JS over the
+    Convex `isActive` assets (replaces 4 Prisma `distinct`/`orderBy` queries).
+  - `getAuditorPortalData(orgId, scope)` — Convex asset list filtered by the new
+    pure `assetMatchesAuditorScope` predicate (org + `isActive` + scope facets);
+    the `groupBy status` stats are tallied in JS over the same scoped set.
+    `organization.name`/`metadata` stays Prisma (Better Auth table, not domain).
+- **testTagAuditorToken reads stay on Prisma — BLOCKED terminus.** That table is
+  **not dual-written** (no mirror write from `src/`, no backfill script; the
+  `convex/testTagAuditorTokens.ts` module is a generated stub only). So
+  `validateAuditorToken`, `getAuditorTokens`, and the token find/update/revoke
+  reads remain Prisma until the table is dual-written + backfilled.
+- **`testedBy` = Better Auth `User`** — permanent Prisma terminus (via
+  `getUserNameMap`), as in the reports surface; not a violation.
+- **New Convex query:** `testTagRecords.listByOrgAndAsset` (org-scoped per-asset
+  fetch via the `by_organizationId_testTagAssetId` composite index). Added a
+  `cmpStrAsc` codepoint comparator + `sortRecordsByTestDateDesc` /
+  `assetMatchesAuditorScope` to the helper (all pure, unit-tested).
+- **Validation:** pure-function unit tests in `src/lib/test-tag-read.test.ts`
+  (24 total). tsc + eslint + `pnpm run build` all green locally (this PR is
+  **stacked** on the reports branch — stacked PRs only get CI after retarget, so
+  the build was run locally). Convex data-correctness is human-gated on the
+  Coolify PR preview against prod Convex (per the deploy-ordering gate above:
+  testTagRecord/subTestRecord are already backfilled into prod).
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/testTagRecords.ts
+++ b/convex/testTagRecords.ts
@@ -32,6 +32,26 @@ export const getById = query({
   },
 });
 
+/**
+ * Records for one asset within an org, in one round trip. Used by the
+ * per-asset test history (`getTestTagRecords`) and the Quick Pass pre-fill
+ * (`getLatestTestRecord`) reads. Org-scoped via the composite index so a stray
+ * cross-org id can't leak. Caller sorts by `testDate` desc + paginates.
+ * HAND-ADDED for the Phase A read-rewiring of the test-tag records surface.
+ */
+export const listByOrgAndAsset = query({
+  args: { orgId: v.string(), testTagAssetId: v.string() },
+  handler: async (ctx, { orgId, testTagAssetId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("testTagRecords")
+      .withIndex("by_organizationId_testTagAssetId", (q) =>
+        q.eq("organizationId", orgId).eq("testTagAssetId", testTagAssetId),
+      )
+      .collect();
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/lib/test-tag-read.test.ts
+++ b/src/lib/test-tag-read.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   assetMatchesFilters,
   recordMatchesFilters,
+  assetMatchesAuditorScope,
+  sortRecordsByTestDateDesc,
+  cmpStrAsc,
   mapTTAsset,
   mapTTRecord,
   mapSubTest,
@@ -159,6 +162,70 @@ describe("recordMatchesFilters", () => {
 
   it("empty filters match any record", () => {
     expect(recordMatchesFilters(record(), {})).toBe(true);
+  });
+});
+
+// ─── assetMatchesAuditorScope ─────────────────────────────────────────────────
+
+describe("assetMatchesAuditorScope", () => {
+  it("excludes inactive items regardless of scope (where always sets isActive:true)", () => {
+    expect(assetMatchesAuditorScope(asset({ isActive: false }), null)).toBe(false);
+    expect(assetMatchesAuditorScope(asset({ isActive: false }), { categories: ["APPLIANCE"] })).toBe(false);
+  });
+
+  it("null/empty scope matches any active item", () => {
+    expect(assetMatchesAuditorScope(asset(), null)).toBe(true);
+    expect(assetMatchesAuditorScope(asset(), undefined)).toBe(true);
+    expect(assetMatchesAuditorScope(asset(), {})).toBe(true);
+  });
+
+  it("filters by categories (applianceType IN)", () => {
+    expect(assetMatchesAuditorScope(asset({ applianceType: "APPLIANCE" }), { categories: ["APPLIANCE"] })).toBe(true);
+    expect(assetMatchesAuditorScope(asset({ applianceType: "POWER_BOARD" }), { categories: ["APPLIANCE"] })).toBe(false);
+  });
+
+  it("filters by equipmentClasses (IN)", () => {
+    expect(assetMatchesAuditorScope(asset({ equipmentClass: "CLASS_I" }), { equipmentClasses: ["CLASS_I"] })).toBe(true);
+    expect(assetMatchesAuditorScope(asset({ equipmentClass: "CLASS_II" }), { equipmentClasses: ["CLASS_I"] })).toBe(false);
+  });
+
+  it("filters by locations (IN); null location never matches", () => {
+    expect(assetMatchesAuditorScope(asset({ location: "Warehouse A" }), { locations: ["Warehouse A"] })).toBe(true);
+    expect(assetMatchesAuditorScope(asset({ location: "Truck 1" }), { locations: ["Warehouse A"] })).toBe(false);
+    expect(assetMatchesAuditorScope(asset({ location: null }), { locations: ["Warehouse A"] })).toBe(false);
+  });
+
+  it("filters by assetIds (IN over id)", () => {
+    expect(assetMatchesAuditorScope(asset({ id: "tt1" }), { assetIds: ["tt1", "tt2"] })).toBe(true);
+    expect(assetMatchesAuditorScope(asset({ id: "tt9" }), { assetIds: ["tt1", "tt2"] })).toBe(false);
+  });
+
+  it("combines facets with AND", () => {
+    const item = asset({ applianceType: "APPLIANCE", equipmentClass: "CLASS_I", location: "Warehouse A", id: "tt1" });
+    expect(assetMatchesAuditorScope(item, { categories: ["APPLIANCE"], equipmentClasses: ["CLASS_I"], locations: ["Warehouse A"], assetIds: ["tt1"] })).toBe(true);
+    expect(assetMatchesAuditorScope(item, { categories: ["APPLIANCE"], equipmentClasses: ["CLASS_II"] })).toBe(false);
+  });
+});
+
+// ─── sortRecordsByTestDateDesc / cmpStrAsc ────────────────────────────────────
+
+describe("sortRecordsByTestDateDesc", () => {
+  it("orders records newest testDate first and does not mutate the input", () => {
+    const a = record({ id: "a", testDate: new Date("2026-01-01") });
+    const b = record({ id: "b", testDate: new Date("2026-06-01") });
+    const c = record({ id: "c", testDate: new Date("2026-03-01") });
+    const input = [a, b, c];
+    const sorted = sortRecordsByTestDateDesc(input);
+    expect(sorted.map((r) => r.id)).toEqual(["b", "c", "a"]);
+    expect(input.map((r) => r.id)).toEqual(["a", "b", "c"]); // unmutated
+  });
+});
+
+describe("cmpStrAsc", () => {
+  it("codepoint-orders ascending (uppercase before lowercase, unlike localeCompare)", () => {
+    expect(["TT-010", "TT-002", "TT-001"].sort(cmpStrAsc)).toEqual(["TT-001", "TT-002", "TT-010"]);
+    expect(cmpStrAsc("A", "a")).toBe(-1);
+    expect(cmpStrAsc("x", "x")).toBe(0);
   });
 });
 

--- a/src/lib/test-tag-read.ts
+++ b/src/lib/test-tag-read.ts
@@ -225,6 +225,31 @@ export async function getTestTagRecordsByOrg(orgId: string): Promise<TTRecord[]>
   return rows.map(mapTTRecord);
 }
 
+/**
+ * All records for one asset within an org (unsorted — caller sorts by `testDate`).
+ * Backs the per-asset test history (`getTestTagRecords`) and the Quick Pass
+ * pre-fill (`getLatestTestRecord`). Org-scoped at the Convex layer.
+ */
+export async function getTestTagRecordsByAsset(orgId: string, testTagAssetId: string): Promise<TTRecord[]> {
+  const rows = (await (await getConvexClient()).query(api.testTagRecords.listByOrgAndAsset, {
+    orgId,
+    testTagAssetId,
+  })) as RawTTRecord[];
+  return rows.map(mapTTRecord);
+}
+
+/** Sort a record list by `testDate` descending — replicates `orderBy: { testDate: "desc" }`. */
+export function sortRecordsByTestDateDesc(records: TTRecord[]): TTRecord[] {
+  return [...records].sort((a, b) => b.testDate.getTime() - a.testDate.getTime());
+}
+
+/**
+ * Codepoint string compare (ascending) — matches Postgres default `orderBy asc`
+ * byte ordering more faithfully than `localeCompare`. Used for `testTagId asc`
+ * in the auditor reads, consistent with the T&T reports surface.
+ */
+export const cmpStrAsc = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
 /** Sub-test records for a set of test records, in one round trip, sorted by sortOrder. */
 export async function getSubTestRecordsByRecordIds(recordIds: string[]): Promise<SubTestRecord[]> {
   if (recordIds.length === 0) return [];
@@ -291,6 +316,35 @@ export function recordMatchesFilters(record: TTRecord, filters: ReportFilters): 
   }
   if (filters.results?.length && !filters.results.includes(record.result)) return false;
   if (filters.testedBy?.length && !filters.testedBy.includes(record.testedById)) return false;
+  return true;
+}
+
+// ─── Auditor portal scope filter (replicates the Prisma scope `where` AND) ────
+
+/** Auditor token scope (mirror of `AuditorTokenScope` in the server action). */
+export interface AuditorScope {
+  categories?: string[];       // applianceType values
+  equipmentClasses?: string[]; // equipmentClass values
+  locations?: string[];        // location strings
+  assetIds?: string[];         // specific testTagAsset ids
+}
+
+/**
+ * Mirrors the auditor portal's Prisma `where` AND: org + `isActive: true` are
+ * applied at fetch (`getTestTagAssetsByOrg` + `assetMatchesFilters`-style
+ * `isActive` guard here), this covers the optional scope facets. Each present
+ * facet is an `in` over the asset's field; absent facets impose no constraint.
+ * Pure → unit-tested.
+ */
+export function assetMatchesAuditorScope(item: TTAsset, scope: AuditorScope | null | undefined): boolean {
+  if (item.isActive !== true) return false;
+  if (!scope) return true;
+  if (scope.categories?.length && !scope.categories.includes(item.applianceType)) return false;
+  if (scope.equipmentClasses?.length && !scope.equipmentClasses.includes(item.equipmentClass)) return false;
+  if (scope.locations?.length) {
+    if (item.location == null || !scope.locations.includes(item.location)) return false;
+  }
+  if (scope.assetIds?.length && !scope.assetIds.includes(item.id)) return false;
   return true;
 }
 

--- a/src/server/test-tag-auditor.ts
+++ b/src/server/test-tag-auditor.ts
@@ -5,6 +5,11 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
+import {
+  getTestTagAssetsByOrg,
+  assetMatchesAuditorScope,
+  cmpStrAsc,
+} from "@/lib/test-tag-read";
 
 function hashToken(token: string): string {
   return crypto.createHash("sha256").update(token).digest("hex");
@@ -193,34 +198,24 @@ export async function deleteAuditorToken(id: string) {
 export async function getAuditorScopeOptions() {
   const { organizationId } = await getOrgContext();
 
-  const [applianceTypes, equipmentClasses, locations, assets] = await Promise.all([
-    prisma.testTagAsset.findMany({
-      where: { organizationId, isActive: true },
-      select: { applianceType: true },
-      distinct: ["applianceType"],
-    }),
-    prisma.testTagAsset.findMany({
-      where: { organizationId, isActive: true },
-      select: { equipmentClass: true },
-      distinct: ["equipmentClass"],
-    }),
-    prisma.testTagAsset.findMany({
-      where: { organizationId, isActive: true, location: { not: null } },
-      select: { location: true },
-      distinct: ["location"],
-    }),
-    prisma.testTagAsset.findMany({
-      where: { organizationId, isActive: true },
-      select: { id: true, testTagId: true, description: true },
-      orderBy: { testTagId: "asc" },
-    }),
-  ]);
+  // Convex read (testTagAsset is dual-written). Distinct facets + the sorted
+  // asset list are computed in JS — replicating the old Prisma `distinct` /
+  // `orderBy` queries over `isActive: true` assets.
+  const active = (await getTestTagAssetsByOrg(organizationId)).filter((a) => a.isActive === true);
+
+  const applianceTypes = [...new Set(active.map((a) => a.applianceType))];
+  const equipmentClasses = [...new Set(active.map((a) => a.equipmentClass))];
+  const locations = [...new Set(active.map((a) => a.location).filter((l): l is string => Boolean(l)))];
+
+  const assets = active
+    .map((a) => ({ id: a.id, testTagId: a.testTagId, description: a.description }))
+    .sort((x, y) => cmpStrAsc(x.testTagId, y.testTagId));
 
   return serialize({
-    applianceTypes: applianceTypes.map((a) => a.applianceType),
-    equipmentClasses: equipmentClasses.map((e) => e.equipmentClass),
-    locations: locations.map((l) => l.location).filter(Boolean) as string[],
-    assets: assets,
+    applianceTypes,
+    equipmentClasses,
+    locations,
+    assets,
   });
 }
 
@@ -263,62 +258,41 @@ export async function getAuditorPortalData(
   organizationId: string,
   scope?: AuditorTokenScope | null,
 ) {
-  // Build where clause with scope filtering
-  const where: Record<string, unknown> = { organizationId, isActive: true };
-
-  if (scope) {
-    const andConditions: Record<string, unknown>[] = [];
-    if (scope.categories?.length) {
-      andConditions.push({ applianceType: { in: scope.categories } });
-    }
-    if (scope.equipmentClasses?.length) {
-      andConditions.push({ equipmentClass: { in: scope.equipmentClasses } });
-    }
-    if (scope.locations?.length) {
-      andConditions.push({ location: { in: scope.locations } });
-    }
-    if (scope.assetIds?.length) {
-      andConditions.push({ id: { in: scope.assetIds } });
-    }
-    if (andConditions.length > 0) {
-      where.AND = andConditions;
-    }
-  }
-
-  const [org, assets, stats] = await Promise.all([
+  // org/name stays Prisma — Better Auth `Organization` is not a domain table.
+  // testTagAsset is dual-written → read from Convex, then apply the scope `where`
+  // (org + `isActive: true` + the optional scope facets) as a pure JS predicate.
+  const [org, allAssets] = await Promise.all([
     prisma.organization.findUnique({
       where: { id: organizationId },
       select: { name: true, metadata: true },
     }),
-    prisma.testTagAsset.findMany({
-      where,
-      select: {
-        id: true,
-        testTagId: true,
-        description: true,
-        equipmentClass: true,
-        applianceType: true,
-        make: true,
-        modelName: true,
-        serialNumber: true,
-        location: true,
-        status: true,
-        lastTestDate: true,
-        nextDueDate: true,
-        testIntervalMonths: true,
-      },
-      orderBy: { testTagId: "asc" },
-    }),
-    prisma.testTagAsset.groupBy({
-      by: ["status"],
-      where,
-      _count: true,
-    }),
+    getTestTagAssetsByOrg(organizationId),
   ]);
 
+  const scoped = allAssets.filter((a) => assetMatchesAuditorScope(a, scope));
+
+  const assets = scoped
+    .map((a) => ({
+      id: a.id,
+      testTagId: a.testTagId,
+      description: a.description,
+      equipmentClass: a.equipmentClass,
+      applianceType: a.applianceType,
+      make: a.make,
+      modelName: a.modelName,
+      serialNumber: a.serialNumber,
+      location: a.location,
+      status: a.status,
+      lastTestDate: a.lastTestDate,
+      nextDueDate: a.nextDueDate,
+      testIntervalMonths: a.testIntervalMonths,
+    }))
+    .sort((x, y) => cmpStrAsc(x.testTagId, y.testTagId));
+
+  // groupBy status → counts, computed over the same scoped set.
   const statusCounts: Record<string, number> = {};
-  for (const s of stats) {
-    statusCounts[s.status] = s._count;
+  for (const a of scoped) {
+    statusCounts[a.status] = (statusCounts[a.status] ?? 0) + 1;
   }
 
   const total = assets.length;

--- a/src/server/test-tag-records.ts
+++ b/src/server/test-tag-records.ts
@@ -11,6 +11,44 @@ import {
   mirrorSubTestRecordCreate,
   patchTestTagAssetInConvex,
 } from "@/lib/test-tag-mirror";
+import {
+  getTestTagRecordsByAsset,
+  sortRecordsByTestDateDesc,
+  getSubTestRecordsByRecordIds,
+  getTestProfileMap,
+  getUserNameMap,
+  type TTRecord,
+} from "@/lib/test-tag-read";
+
+/**
+ * Re-shape Convex-sourced records into the Prisma `include` form the record-history
+ * consumers expect: `testedBy {id,name}` (Better Auth User — Prisma terminus),
+ * `testProfile {id,name}` (Convex), and `subTestRecords[]` sorted by `sortOrder`
+ * asc (Convex). All cross-domain joins are batched (one round trip each).
+ */
+async function attachRecordRelations(organizationId: string, records: TTRecord[]) {
+  if (records.length === 0) return [];
+
+  const [profileMap, userMap, subTests] = await Promise.all([
+    getTestProfileMap(organizationId),
+    getUserNameMap(records.map((r) => r.testedById)),
+    getSubTestRecordsByRecordIds(records.map((r) => r.id)),
+  ]);
+
+  const subsByRecord = new Map<string, typeof subTests>();
+  for (const s of subTests) {
+    const list = subsByRecord.get(s.testTagRecordId) ?? [];
+    list.push(s);
+    subsByRecord.set(s.testTagRecordId, list);
+  }
+
+  return records.map((r) => ({
+    ...r,
+    testedBy: { id: r.testedById, name: userMap.get(r.testedById) ?? null },
+    testProfile: r.testProfileId ? profileMap.get(r.testProfileId) ?? null : null,
+    subTestRecords: (subsByRecord.get(r.id) ?? []).sort((a, b) => a.sortOrder - b.sortOrder),
+  }));
+}
 
 /**
  * Recalculate and update a TestTagAsset's status based on its latest test record and dates.
@@ -315,22 +353,15 @@ export async function getTestTagRecords(testTagAssetId: string, params?: {
   const { organizationId } = await getOrgContext();
   const { page = 1, pageSize = 20 } = params || {};
 
-  const where = { organizationId, testTagAssetId };
+  // Convex read (testTagRecord is dual-written). Org scoping is enforced by the
+  // composite index; sort + paginate in JS to replicate the old Prisma query.
+  const all = sortRecordsByTestDateDesc(
+    await getTestTagRecordsByAsset(organizationId, testTagAssetId),
+  );
+  const total = all.length;
+  const pageRecords = all.slice((page - 1) * pageSize, (page - 1) * pageSize + pageSize);
 
-  const [records, total] = await Promise.all([
-    prisma.testTagRecord.findMany({
-      where,
-      orderBy: { testDate: "desc" },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-      include: {
-        testedBy: { select: { id: true, name: true } },
-        testProfile: { select: { id: true, name: true } },
-        subTestRecords: { orderBy: { sortOrder: "asc" } },
-      },
-    }),
-    prisma.testTagRecord.count({ where }),
-  ]);
+  const records = await attachRecordRelations(organizationId, pageRecords);
 
   return serialize({
     records,
@@ -347,15 +378,12 @@ export async function getTestTagRecords(testTagAssetId: string, params?: {
 export async function getLatestTestRecord(testTagAssetId: string) {
   const { organizationId } = await getOrgContext();
 
-  const record = await prisma.testTagRecord.findFirst({
-    where: { organizationId, testTagAssetId },
-    orderBy: { testDate: "desc" },
-    include: {
-      testedBy: { select: { id: true, name: true } },
-      testProfile: { select: { id: true, name: true } },
-      subTestRecords: { orderBy: { sortOrder: "asc" } },
-    },
-  });
+  const all = sortRecordsByTestDateDesc(
+    await getTestTagRecordsByAsset(organizationId, testTagAssetId),
+  );
+  const latest = all[0];
+  if (!latest) return null;
 
-  return record ? serialize(record) : null;
+  const [record] = await attachRecordRelations(organizationId, [latest]);
+  return serialize(record);
 }


### PR DESCRIPTION
## What

Phase A read-rewiring of the **test-tag records** surface (+ the auditor partial). Moves the dual-written-table READS off Prisma onto Convex, **extending** `src/lib/test-tag-read.ts` (introduced by #194).

> **STACKED on #194** (`feat/convex-read-test-tag-reports`). Must merge **after** #194 — the read helper this PR extends lives on that branch. Base is `feat/convex-read-test-tag-reports`, not `main`.

## Reads converted (dual-written tables)

- `getTestTagRecords(assetId, {page,pageSize})` — paginated test history. Convex `testTagRecords.listByOrgAndAsset` → JS `testDate` desc sort → JS slice for pagination. `testProfile`/`subTestRecords` attached from Convex; `testedBy {id,name}` from Prisma.
- `getLatestTestRecord(assetId)` — same fetch, first row after the desc sort.
- `getAuditorScopeOptions()` — distinct `applianceType`/`equipmentClass`/`location` facets + sorted asset picker, computed in JS over Convex `isActive` assets (replaces 4 Prisma `distinct`/`orderBy` queries).
- `getAuditorPortalData(orgId, scope)` — Convex asset list filtered by the new pure `assetMatchesAuditorScope` predicate; `groupBy status` tallied in JS. `organization.name`/`metadata` stays Prisma (Better Auth table).

## Stays on Prisma

- **`testTagAuditorToken` reads — BLOCKED terminus.** That table is **not dual-written** (no mirror write from `src/`, no backfill script; `convex/testTagAuditorTokens.ts` is a generated stub only). So `validateAuditorToken` / `getAuditorTokens` / token find+update+revoke reads remain Prisma until the table is dual-written + backfilled.
- `testedBy` = Better Auth `User` — permanent Prisma terminus (via `getUserNameMap`), not a violation.

## New Convex query

`testTagRecords.listByOrgAndAsset` — org-scoped per-asset fetch via the existing `by_organizationId_testTagAssetId` composite index. (Added into the existing module; no new module file, no `_generated` edits.) Helper also gains pure, unit-tested `cmpStrAsc` / `sortRecordsByTestDateDesc` / `assetMatchesAuditorScope`.

## Validation

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/test-tag-read.test.ts` — **24 passed**
- `pnpm exec eslint` on all changed files — clean
- `pnpm run build` — **exit 0** (run locally: stacked PRs only get CI after retarget)

Convex data-correctness is **human-gated on the Coolify PR preview** against prod Convex (testTagRecord/subTestRecord are already backfilled into prod per the deploy-ordering gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)