### PR TITLE
feat(convex): read crew roster from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,39 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **crew roster** (`server/crew.ts` → extends `src/lib/crew-read.ts`). Moved to
+  Convex: `getCrewMembers` (list/count/filter/search/sort/paginate in JS; crewRole
+  resolved from the Convex role map; `skills` m2m + Better Auth user batched from
+  Prisma over the page), `getCrewMemberById` (member row + crewRole from Convex;
+  `skills`/`user`/`assignments` stay Prisma — assignments are a sibling-PR
+  scheduling table; org isolation enforced in the action since the Convex `getById`
+  arg isn't org-scoped), `getMyCrewMemberId`, `getCrewRoles` (`_count.crewMembers`
+  derived from members' `crewRoleId` in JS), `getCrewRoleOptions`,
+  `getCrewSkillOptions`, `getCrewDepartments` (distinct over the member list).
+  Hybrid: `getCrewSkills` reads skill rows from Convex but keeps the
+  `_count.crewMembers` (the `_CrewMemberToCrewSkill` m2m has NO Convex
+  representation) as a batched Prisma read.
+  `getOrgUsersForCrewLink` — the `member` rows stay Prisma (Better Auth auth
+  terminus); only the crew-member→user linkage set comes from the Convex roster.
+  Left on Prisma: `getCrewMemberExtras` (every field is a cross-domain User/skill
+  m2m join — nothing to read from Convex) and all writes/read-then-writes. No new
+  Convex query (served by the existing `crewMembers`/`crewRoles`/`crewSkills`
+  `list`/`getById`). Deploy-gated on the crew backfill (`convex:backfill:crew`)
+  having run in prod.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/crew-read.test.ts
+++ b/src/lib/crew-read.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for the pure crew-roster read primitives (Phase A read-rewiring).
+ *
+ * These replace the Prisma `where`/`orderBy`/`distinct`/`_count` of
+ * src/server/crew.ts. The safety property for each: identical output to the
+ * Prisma query it stands in for, given the same rows. Mappers reverse
+ * convex-client.ts `toConvexDoc` (epoch-ms → Date, absent → null, defaults
+ * coerced non-null).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapCrewMember,
+  mapCrewRole,
+  mapCrewSkill,
+  applyCrewMemberFilters,
+  applyCrewMemberSearch,
+  sortCrewMembers,
+  paginate,
+  distinctDepartments,
+  activeRolesSorted,
+  skillsSorted,
+  countMembersByRole,
+  type ConvexCrewMember,
+  type ConvexCrewRole,
+  type ConvexCrewSkill,
+  type CrewMemberRow,
+} from "@/lib/crew-read";
+
+// ─── Mappers ──────────────────────────────────────────────────────────────
+
+describe("mapCrewMember", () => {
+  it("converts epoch-ms → Date, absent → null, coerces defaults non-null", () => {
+    const doc = {
+      _id: "convex_internal" as unknown,
+      _creationTime: 1000,
+      id: "m1",
+      organizationId: "org1",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      // email/phone/etc absent
+      defaultDayRate: 500.5,
+      dateOfBirth: 631152000000, // 1990-01-01
+      createdAt: 1700000000000,
+      updatedAt: 1700000001000,
+    } as unknown as ConvexCrewMember;
+    const row = mapCrewMember(doc);
+    expect(row).toMatchObject({
+      id: "m1",
+      organizationId: "org1",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: null,
+      phone: null,
+      type: "FREELANCER", // schema default
+      status: "ACTIVE", // schema default
+      tags: [], // schema default
+      icalEnabled: false, // schema default
+      isActive: true, // schema default
+      defaultDayRate: 500.5,
+      crewRoleId: null,
+    });
+    expect(row.dateOfBirth).toEqual(new Date(631152000000));
+    expect(row.createdAt).toEqual(new Date(1700000000000));
+    expect(row.updatedAt).toEqual(new Date(1700000001000));
+    // _id / _creationTime stripped
+    expect("_id" in row).toBe(false);
+    expect("_creationTime" in row).toBe(false);
+  });
+
+  it("falls back createdAt/updatedAt to _creationTime when absent", () => {
+    const doc = {
+      _creationTime: 42,
+      id: "m2",
+      organizationId: "org1",
+      firstName: "B",
+      lastName: "C",
+    } as unknown as ConvexCrewMember;
+    const row = mapCrewMember(doc);
+    expect(row.createdAt).toEqual(new Date(42));
+    expect(row.updatedAt).toEqual(new Date(42));
+    expect(row.dateOfBirth).toBeNull();
+  });
+});
+
+describe("mapCrewRole", () => {
+  it("coerces sortOrder/isActive defaults and absent → null", () => {
+    const doc = {
+      _creationTime: 1,
+      id: "r1",
+      organizationId: "org1",
+      name: "Lighting Tech",
+    } as unknown as ConvexCrewRole;
+    expect(mapCrewRole(doc)).toEqual({
+      id: "r1",
+      organizationId: "org1",
+      name: "Lighting Tech",
+      description: null,
+      department: null,
+      color: null,
+      defaultRate: null,
+      rateType: null,
+      sortOrder: 0,
+      isActive: true,
+    });
+  });
+});
+
+describe("mapCrewSkill", () => {
+  it("coerces category absent → null", () => {
+    const doc = {
+      _creationTime: 1,
+      id: "s1",
+      organizationId: "org1",
+      name: "Rigging",
+    } as unknown as ConvexCrewSkill;
+    expect(mapCrewSkill(doc)).toEqual({
+      id: "s1",
+      organizationId: "org1",
+      name: "Rigging",
+      category: null,
+    });
+  });
+});
+
+// ─── Filters / search ─────────────────────────────────────────────────────
+
+const member = (over: Partial<CrewMemberRow>): CrewMemberRow => ({
+  id: "x",
+  organizationId: "org1",
+  firstName: "F",
+  lastName: "L",
+  email: null,
+  phone: null,
+  image: null,
+  userId: null,
+  type: "FREELANCER",
+  status: "ACTIVE",
+  department: null,
+  defaultDayRate: null,
+  defaultHourlyRate: null,
+  overtimeMultiplier: null,
+  currency: null,
+  address: null,
+  addressLatitude: null,
+  addressLongitude: null,
+  emergencyContactName: null,
+  emergencyContactPhone: null,
+  dateOfBirth: null,
+  abnOrGst: null,
+  notes: null,
+  tags: [],
+  icalEnabled: false,
+  icalToken: null,
+  crewRoleId: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  isActive: true,
+  ...over,
+});
+
+describe("applyCrewMemberFilters", () => {
+  const rows = [
+    member({ id: "a", type: "EMPLOYEE", status: "ACTIVE", department: "Audio" }),
+    member({ id: "b", type: "FREELANCER", status: "INACTIVE", department: "Video" }),
+    member({ id: "c", type: "EMPLOYEE", status: "ON_LEAVE", department: null }),
+  ];
+
+  it("returns all rows when no filters", () => {
+    expect(applyCrewMemberFilters(rows, undefined).map((r) => r.id)).toEqual(["a", "b", "c"]);
+    expect(applyCrewMemberFilters(rows, {}).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters by enum `in` for type", () => {
+    expect(applyCrewMemberFilters(rows, { type: ["EMPLOYEE"] }).map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("combines multiple enum filters (AND)", () => {
+    expect(
+      applyCrewMemberFilters(rows, { type: ["EMPLOYEE"], status: ["ACTIVE"] }).map((r) => r.id),
+    ).toEqual(["a"]);
+  });
+
+  it("filters by department and excludes null departments", () => {
+    expect(applyCrewMemberFilters(rows, { department: ["Audio"] }).map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("ignores empty filter arrays", () => {
+    expect(applyCrewMemberFilters(rows, { type: [] }).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("applyCrewMemberSearch", () => {
+  const rows = [
+    member({ id: "a", firstName: "Ada", lastName: "Smith", email: "ada@x.com" }),
+    member({ id: "b", firstName: "Bob", phone: "555-1234", department: "Audio" }),
+    member({ id: "c", firstName: "Cara", tags: ["rigging", "audio"] }),
+  ];
+
+  it("returns all rows when no search", () => {
+    expect(applyCrewMemberSearch(rows, undefined).length).toBe(3);
+  });
+
+  it("matches firstName case-insensitively", () => {
+    expect(applyCrewMemberSearch(rows, "ada").map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("matches across phone/department", () => {
+    expect(applyCrewMemberSearch(rows, "555").map((r) => r.id)).toEqual(["b"]);
+    // "audio" matches b's department (contains) AND c's exact tag token (hasSome)
+    expect(applyCrewMemberSearch(rows, "AUDIO").map((r) => r.id)).toEqual(["b", "c"]);
+  });
+
+  it("matches tags only on exact lowercased token (hasSome)", () => {
+    // "rig" is a substring of the tag "rigging" but hasSome is exact-equality
+    expect(applyCrewMemberSearch(rows, "rig").map((r) => r.id)).toEqual([]);
+    expect(applyCrewMemberSearch(rows, "rigging").map((r) => r.id)).toEqual(["c"]);
+  });
+});
+
+// ─── Sort / paginate ──────────────────────────────────────────────────────
+
+describe("sortCrewMembers", () => {
+  it("sorts by lastName asc (default)", () => {
+    const rows = [
+      member({ id: "a", lastName: "Charlie" }),
+      member({ id: "b", lastName: "alpha" }),
+      member({ id: "c", lastName: "Bravo" }),
+    ];
+    expect(sortCrewMembers(rows, "lastName", "asc").map((r) => r.id)).toEqual(["b", "c", "a"]);
+    expect(sortCrewMembers(rows, "lastName", "desc").map((r) => r.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("puts nulls last on asc, first on desc (Postgres semantics)", () => {
+    const rows = [
+      member({ id: "a", department: "Audio" }),
+      member({ id: "b", department: null }),
+      member({ id: "c", department: "Video" }),
+    ];
+    expect(sortCrewMembers(rows, "department", "asc").map((r) => r.id)).toEqual(["a", "c", "b"]);
+    expect(sortCrewMembers(rows, "department", "desc").map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("sorts dates and numbers numerically", () => {
+    const rows = [
+      member({ id: "a", defaultDayRate: 300 }),
+      member({ id: "b", defaultDayRate: 100 }),
+      member({ id: "c", defaultDayRate: 200 }),
+    ];
+    expect(sortCrewMembers(rows, "defaultDayRate", "asc").map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+});
+
+describe("paginate", () => {
+  const rows = [1, 2, 3, 4, 5];
+  it("slices 1-based pages", () => {
+    expect(paginate(rows, 1, 2)).toEqual([1, 2]);
+    expect(paginate(rows, 2, 2)).toEqual([3, 4]);
+    expect(paginate(rows, 3, 2)).toEqual([5]);
+    expect(paginate(rows, 4, 2)).toEqual([]);
+  });
+});
+
+// ─── Departments / roles / skills / counts ────────────────────────────────
+
+describe("distinctDepartments", () => {
+  it("returns distinct non-null departments sorted asc", () => {
+    const rows = [
+      member({ department: "Video" }),
+      member({ department: "Audio" }),
+      member({ department: "Video" }),
+      member({ department: null }),
+    ];
+    expect(distinctDepartments(rows)).toEqual(["Audio", "Video"]);
+  });
+});
+
+describe("activeRolesSorted", () => {
+  it("keeps only active roles, ordered by [sortOrder asc, name asc]", () => {
+    const roles = [
+      mapCrewRole({ _creationTime: 1, id: "r1", organizationId: "o", name: "Zeta", sortOrder: 0, isActive: true } as unknown as ConvexCrewRole),
+      mapCrewRole({ _creationTime: 1, id: "r2", organizationId: "o", name: "Alpha", sortOrder: 0, isActive: true } as unknown as ConvexCrewRole),
+      mapCrewRole({ _creationTime: 1, id: "r3", organizationId: "o", name: "Beta", sortOrder: 1, isActive: true } as unknown as ConvexCrewRole),
+      mapCrewRole({ _creationTime: 1, id: "r4", organizationId: "o", name: "Gone", sortOrder: 0, isActive: false } as unknown as ConvexCrewRole),
+    ];
+    expect(activeRolesSorted(roles).map((r) => r.id)).toEqual(["r2", "r1", "r3"]);
+  });
+});
+
+describe("skillsSorted", () => {
+  it("orders by name asc", () => {
+    const skills = [
+      mapCrewSkill({ _creationTime: 1, id: "s1", organizationId: "o", name: "Welding" } as unknown as ConvexCrewSkill),
+      mapCrewSkill({ _creationTime: 1, id: "s2", organizationId: "o", name: "Audio" } as unknown as ConvexCrewSkill),
+    ];
+    expect(skillsSorted(skills).map((s) => s.name)).toEqual(["Audio", "Welding"]);
+  });
+});
+
+describe("countMembersByRole", () => {
+  it("counts members per crewRoleId, ignoring null", () => {
+    const rows = [
+      member({ crewRoleId: "r1" }),
+      member({ crewRoleId: "r1" }),
+      member({ crewRoleId: "r2" }),
+      member({ crewRoleId: null }),
+    ];
+    expect(countMembersByRole(rows)).toEqual({ r1: 2, r2: 1 });
+  });
+});

--- a/src/lib/crew-read.ts
+++ b/src/lib/crew-read.ts
@@ -1,19 +1,37 @@
 import { getConvexClient } from "@/lib/convex-client";
+import type { FilterValue } from "@/lib/table-utils";
+import type {
+  CrewMemberType,
+  CrewMemberStatus,
+  CrewRateType,
+} from "@/generated/prisma/enums";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 
 /**
- * Server-side read helpers for the crew roster (Phase 3 cutover).
+ * Server-side read helpers for the crew roster (Phase 3 cutover + Phase A
+ * read-rewiring).
  *
  * crew_member / crew_role / crew_skill are dual-written (Prisma FK anchor + Convex
  * reactive doc — see src/lib/crew-mirror.ts). Reads that want the Convex copy go
  * through these helpers; cross-domain joins onto crew (e.g. assignment → member,
  * which still live in Prisma) attach via the maps. The project-coupled crew
- * sub-tables stay Prisma-only for now. See FEATUREDOCS/54.
+ * sub-tables (assignment / availability / time entry) stay Prisma-only for now,
+ * as does the implicit `_CrewMemberToCrewSkill` m2m and the Better Auth member /
+ * User join. See FEATUREDOCS/54.
+ *
+ * Mappers below reverse src/lib/convex-client.ts `toConvexDoc`: it stores
+ * Date → epoch-ms, Decimal → number, and OMITS null/undefined Prisma fields.
+ * So mappers convert epoch-ms → Date, coerce absent → null, and coerce
+ * Prisma-defaulted columns (type/status/tags/icalEnabled/isActive/sortOrder/
+ * createdAt/updatedAt) to their schema defaults. The output shape matches
+ * `serialize(<prisma row>)` (which keeps Date instances).
  */
 export type ConvexCrewMember = Doc<"crewMembers">;
 export type ConvexCrewRole = Doc<"crewRoles">;
 export type ConvexCrewSkill = Doc<"crewSkills">;
+
+// ─── Fetchers (raw Convex docs) ──────────────────────────────────────────────
 
 export async function getCrewMemberById(id: string): Promise<ConvexCrewMember | null> {
   return await (await getConvexClient()).query(api.crewMembers.getById, { id });
@@ -41,4 +59,238 @@ export async function getCrewMemberMap(orgId: string): Promise<Map<string, Conve
 export async function getCrewRoleMap(orgId: string): Promise<Map<string, ConvexCrewRole>> {
   const all = await getCrewRolesByOrg(orgId);
   return new Map(all.map((r) => [r.id, r]));
+}
+
+// ─── Mapped row shapes (match serialize(<prisma row>)) ───────────────────────
+
+const epochToDate = (ms: number | undefined, fallback: Date): Date =>
+  ms == null ? fallback : new Date(ms);
+
+export type CrewMemberRow = {
+  id: string;
+  organizationId: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phone: string | null;
+  image: string | null;
+  userId: string | null;
+  type: CrewMemberType;
+  status: CrewMemberStatus;
+  department: string | null;
+  defaultDayRate: number | null;
+  defaultHourlyRate: number | null;
+  overtimeMultiplier: number | null;
+  currency: string | null;
+  address: string | null;
+  addressLatitude: number | null;
+  addressLongitude: number | null;
+  emergencyContactName: string | null;
+  emergencyContactPhone: string | null;
+  dateOfBirth: Date | null;
+  abnOrGst: string | null;
+  notes: string | null;
+  tags: string[];
+  icalEnabled: boolean;
+  icalToken: string | null;
+  crewRoleId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  isActive: boolean;
+};
+
+export type CrewRoleRow = {
+  id: string;
+  organizationId: string;
+  name: string;
+  description: string | null;
+  department: string | null;
+  color: string | null;
+  defaultRate: number | null;
+  rateType: CrewRateType | null;
+  sortOrder: number;
+  isActive: boolean;
+};
+
+export type CrewSkillRow = {
+  id: string;
+  organizationId: string;
+  name: string;
+  category: string | null;
+};
+
+/**
+ * Map a raw Convex crewMembers doc to the Prisma-shaped row. Strips `_id` /
+ * `_creationTime`; epoch-ms → Date; absent → null; Prisma-defaulted columns
+ * (type/status/tags/icalEnabled/isActive/createdAt/updatedAt) coerced non-null.
+ */
+export function mapCrewMember(d: ConvexCrewMember): CrewMemberRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    firstName: d.firstName,
+    lastName: d.lastName,
+    email: d.email ?? null,
+    phone: d.phone ?? null,
+    image: d.image ?? null,
+    userId: d.userId ?? null,
+    type: d.type ?? "FREELANCER",
+    status: d.status ?? "ACTIVE",
+    department: d.department ?? null,
+    defaultDayRate: d.defaultDayRate ?? null,
+    defaultHourlyRate: d.defaultHourlyRate ?? null,
+    overtimeMultiplier: d.overtimeMultiplier ?? null,
+    currency: d.currency ?? null,
+    address: d.address ?? null,
+    addressLatitude: d.addressLatitude ?? null,
+    addressLongitude: d.addressLongitude ?? null,
+    emergencyContactName: d.emergencyContactName ?? null,
+    emergencyContactPhone: d.emergencyContactPhone ?? null,
+    dateOfBirth: d.dateOfBirth == null ? null : new Date(d.dateOfBirth),
+    abnOrGst: d.abnOrGst ?? null,
+    notes: d.notes ?? null,
+    tags: d.tags ?? [],
+    icalEnabled: d.icalEnabled ?? false,
+    icalToken: d.icalToken ?? null,
+    crewRoleId: d.crewRoleId ?? null,
+    createdAt: epochToDate(d.createdAt, new Date(d._creationTime)),
+    updatedAt: epochToDate(d.updatedAt, new Date(d._creationTime)),
+    isActive: d.isActive ?? true,
+  };
+}
+
+export function mapCrewRole(d: ConvexCrewRole): CrewRoleRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    name: d.name,
+    description: d.description ?? null,
+    department: d.department ?? null,
+    color: d.color ?? null,
+    defaultRate: d.defaultRate ?? null,
+    rateType: d.rateType ?? null,
+    sortOrder: d.sortOrder ?? 0,
+    isActive: d.isActive ?? true,
+  };
+}
+
+export function mapCrewSkill(d: ConvexCrewSkill): CrewSkillRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    name: d.name,
+    category: d.category ?? null,
+  };
+}
+
+// ─── Pure filter / sort / paginate (replicate Prisma where/orderBy) ──────────
+
+/**
+ * CrewMemberStatus / CrewMemberType / CrewRateType have no inherent JS ordering;
+ * the roster sorts/filters on plain string columns only (lastName etc.), so no
+ * enum rank map is needed here. (Departments are free-text strings.)
+ */
+
+/** Enum `{ field: { in: [...] } }` filter, replicating buildFilterWhere for the
+ *  roster's three enum columns (type / status / department). */
+export function applyCrewMemberFilters(
+  rows: CrewMemberRow[],
+  filters: Record<string, FilterValue> | undefined,
+): CrewMemberRow[] {
+  if (!filters) return rows;
+  const enumCols: Array<keyof CrewMemberRow> = ["type", "status", "department"];
+  let out = rows;
+  for (const col of enumCols) {
+    const value = filters[col as string];
+    if (Array.isArray(value) && value.length > 0) {
+      const allowed = new Set(value as string[]);
+      out = out.filter((r) => {
+        const fv = r[col];
+        return typeof fv === "string" && allowed.has(fv);
+      });
+    }
+  }
+  return out;
+}
+
+/** Case-insensitive `contains` OR across firstName/lastName/email/phone/
+ *  department + `tags hasSome [search.toLowerCase()]`, replicating getCrewMembers. */
+export function applyCrewMemberSearch(rows: CrewMemberRow[], search: string | undefined): CrewMemberRow[] {
+  if (!search) return rows;
+  const needle = search.toLowerCase();
+  const inField = (v: string | null) => v != null && v.toLowerCase().includes(needle);
+  return rows.filter(
+    (r) =>
+      inField(r.firstName) ||
+      inField(r.lastName) ||
+      inField(r.email) ||
+      inField(r.phone) ||
+      inField(r.department) ||
+      r.tags.some((t) => t === needle),
+  );
+}
+
+/**
+ * Sort by a string/Date/number column. Postgres default ASC = NULLS LAST,
+ * DESC = NULLS FIRST. The roster only ever sorts on `lastName` (string) but we
+ * support the generic shape the action exposes.
+ */
+export function sortCrewMembers(
+  rows: CrewMemberRow[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+): CrewMemberRow[] {
+  const dir = sortOrder === "desc" ? -1 : 1;
+  const key = sortBy as keyof CrewMemberRow;
+  return [...rows].sort((a, b) => {
+    const av = a[key] as unknown;
+    const bv = b[key] as unknown;
+    const aNull = av == null;
+    const bNull = bv == null;
+    if (aNull && bNull) return 0;
+    // ASC → nulls last; DESC → nulls first.
+    if (aNull) return sortOrder === "desc" ? -1 : 1;
+    if (bNull) return sortOrder === "desc" ? 1 : -1;
+    let cmp: number;
+    if (av instanceof Date && bv instanceof Date) cmp = av.getTime() - bv.getTime();
+    else if (typeof av === "number" && typeof bv === "number") cmp = av - bv;
+    else cmp = String(av).localeCompare(String(bv));
+    return cmp * dir;
+  });
+}
+
+/** Slice for 1-based pagination (page/pageSize), matching Prisma skip/take. */
+export function paginate<T>(rows: T[], page: number, pageSize: number): T[] {
+  const start = (page - 1) * pageSize;
+  return rows.slice(start, start + pageSize);
+}
+
+/** Distinct non-null departments, ASC (case-sensitive, matching Postgres text
+ *  collation closely enough for filter options). */
+export function distinctDepartments(rows: CrewMemberRow[]): string[] {
+  const set = new Set<string>();
+  for (const r of rows) if (r.department) set.add(r.department);
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+/** Active roles, ordered by [sortOrder asc, name asc] — replicates getCrewRoles /
+ *  getCrewRoleOptions orderBy. */
+export function activeRolesSorted(rows: CrewRoleRow[]): CrewRoleRow[] {
+  return rows
+    .filter((r) => r.isActive)
+    .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+}
+
+/** Skills ordered by name asc — replicates getCrewSkills / getCrewSkillOptions. */
+export function skillsSorted(rows: CrewSkillRow[]): CrewSkillRow[] {
+  return [...rows].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Count of members per crewRoleId, replicating crewRole._count.crewMembers. */
+export function countMembersByRole(members: CrewMemberRow[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const m of members) {
+    if (m.crewRoleId) counts[m.crewRoleId] = (counts[m.crewRoleId] ?? 0) + 1;
+  }
+  return counts;
 }

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -17,16 +17,24 @@ import {
   snapshotCrewMemberCascade,
   removeCrewMemberCascadeFromConvex,
 } from "@/lib/crew-scheduling-mirror";
-import { buildFilterWhere, type FilterValue } from "@/lib/table-utils";
-import type { ColumnDef } from "@/components/ui/data-table";
-
-// ─── Column defs for server-side filter building ─────────────────────────────
-
-const filterColumnDefs: ColumnDef<unknown>[] = [
-  { id: "type", header: "Type", accessorKey: "type", filterable: true, filterType: "enum" },
-  { id: "status", header: "Status", accessorKey: "status", filterable: true, filterType: "enum" },
-  { id: "department", header: "Department", accessorKey: "department", filterable: true, filterType: "enum" },
-];
+import { type FilterValue } from "@/lib/table-utils";
+import {
+  getCrewMembersByOrg,
+  getCrewMemberById as getConvexCrewMemberById,
+  getCrewRolesByOrg,
+  getCrewSkillsByOrg,
+  mapCrewMember,
+  mapCrewRole,
+  mapCrewSkill,
+  applyCrewMemberFilters,
+  applyCrewMemberSearch,
+  sortCrewMembers,
+  paginate,
+  distinctDepartments,
+  activeRolesSorted,
+  skillsSorted,
+  countMembersByRole,
+} from "@/lib/crew-read";
 
 // ─── Crew Members ────────────────────────────────────────────────────────────
 
@@ -41,63 +49,94 @@ export async function getCrewMembers(params: {
   const { organizationId } = await requirePermission("crew", "read");
   const { search, filters, page = 1, pageSize = 25, sortBy = "lastName", sortOrder = "asc" } = params;
 
-  const filterWhere = filters ? buildFilterWhere(filters, filterColumnDefs) : {};
+  // Base member rows come from Convex (the reactive mirror). Filter/search/sort/
+  // paginate in JS, replicating the Prisma where/orderBy/skip/take.
+  const all = (await getCrewMembersByOrg(organizationId)).map(mapCrewMember);
+  const filtered = applyCrewMemberSearch(applyCrewMemberFilters(all, filters), search);
+  const sorted = sortCrewMembers(filtered, sortBy, sortOrder);
+  const total = sorted.length;
+  const pageRows = paginate(sorted, page, pageSize);
 
-  const where = {
-    organizationId,
-    ...filterWhere,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" as const } },
-            { lastName: { contains: search, mode: "insensitive" as const } },
-            { email: { contains: search, mode: "insensitive" as const } },
-            { phone: { contains: search, mode: "insensitive" as const } },
-            { department: { contains: search, mode: "insensitive" as const } },
-            { tags: { hasSome: [search.toLowerCase()] } },
-          ],
-        }
-      : {}),
-  };
+  // crewRole (id/name/color) resolves from the Convex role map.
+  const roleMap = new Map(
+    (await getCrewRolesByOrg(organizationId)).map(mapCrewRole).map((r) => [r.id, r] as const),
+  );
 
-  const [crewMembers, total] = await Promise.all([
-    prisma.crewMember.findMany({
-      where,
-      include: {
-        crewRole: { select: { id: true, name: true, color: true } },
-        skills: { select: { id: true, name: true, category: true } },
-        user: { select: { id: true, name: true, image: true } },
-      },
-      orderBy: { [sortBy]: sortOrder },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.crewMember.count({ where }),
+  // skills (implicit m2m, Prisma-only) and the linked Better Auth user join stay
+  // Prisma — batched over just the page's members.
+  const pageIds = pageRows.map((m) => m.id);
+  const userIds = pageRows.map((m) => m.userId).filter((u): u is string => u != null);
+  const [withSkills, users] = await Promise.all([
+    pageIds.length
+      ? prisma.crewMember.findMany({
+          where: { id: { in: pageIds } },
+          select: { id: true, skills: { select: { id: true, name: true, category: true } } },
+        })
+      : Promise.resolve([]),
+    userIds.length
+      ? prisma.user.findMany({
+          where: { id: { in: userIds } },
+          select: { id: true, name: true, image: true },
+        })
+      : Promise.resolve([]),
   ]);
+  const skillsByMember = new Map(withSkills.map((m) => [m.id, m.skills]));
+  const userById = new Map(users.map((u) => [u.id, u]));
+
+  const crewMembers = pageRows.map((m) => {
+    const role = m.crewRoleId ? roleMap.get(m.crewRoleId) : null;
+    return {
+      ...m,
+      crewRole: role ? { id: role.id, name: role.name, color: role.color } : null,
+      skills: skillsByMember.get(m.id) ?? [],
+      user: m.userId ? userById.get(m.userId) ?? null : null,
+    };
+  });
 
   return serialize({ crewMembers, total });
 }
 
 export async function getCrewMemberById(id: string) {
   const { organizationId, userId } = await requirePermission("crew", "read");
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id, organizationId },
-    include: {
-      crewRole: true,
-      skills: true,
-      user: { select: { id: true, name: true, email: true, image: true } },
-      assignments: {
-        include: {
-          project: { select: { id: true, name: true, projectNumber: true, status: true } },
-          crewRole: { select: { id: true, name: true, color: true } },
+  const doc = await getConvexCrewMemberById(id);
+  // Convex getById is not org-scoped in the query args — enforce org isolation
+  // here (matches the Prisma `where: { id, organizationId }`).
+  if (!doc || doc.organizationId !== organizationId) throw new Error("Crew member not found");
+  const crewMember = mapCrewMember(doc);
+
+  // crewRole (full row) from the Convex role map; skills (m2m), the linked
+  // Better Auth user, and project assignments (scheduling sub-table) stay Prisma.
+  const [role, prismaExtras] = await Promise.all([
+    crewMember.crewRoleId
+      ? getCrewRolesByOrg(organizationId).then(
+          (roles) => roles.map(mapCrewRole).find((r) => r.id === crewMember.crewRoleId) ?? null,
+        )
+      : Promise.resolve(null),
+    prisma.crewMember.findUnique({
+      where: { id, organizationId },
+      select: {
+        skills: true,
+        user: { select: { id: true, name: true, email: true, image: true } },
+        assignments: {
+          include: {
+            project: { select: { id: true, name: true, projectNumber: true, status: true } },
+            crewRole: { select: { id: true, name: true, color: true } },
+          },
+          orderBy: { startDate: "desc" },
         },
-        orderBy: { startDate: "desc" },
       },
-    },
+    }),
+  ]);
+
+  return serialize({
+    ...crewMember,
+    crewRole: role,
+    skills: prismaExtras?.skills ?? [],
+    user: prismaExtras?.user ?? null,
+    assignments: prismaExtras?.assignments ?? [],
+    // Include whether this is the current user's own crew profile
+    isOwnProfile: crewMember.userId === userId,
   });
-  if (!crewMember) throw new Error("Crew member not found");
-  // Include whether this is the current user's own crew profile
-  return serialize({ ...crewMember, isOwnProfile: crewMember.userId === userId });
 }
 
 /**
@@ -107,7 +146,10 @@ export async function getCrewMemberById(id: string) {
  * Prisma-only) are NOT in Convex — they come from this (non-reactive) server query
  * and are merged into the reactive list client-side. crewRole name/color is
  * resolved client-side from the reactive `crewRoles` list instead (it IS in
- * Convex). See FEATUREDOCS/54.
+ * Convex). This action is INTENTIONALLY still Prisma-only: every field it returns
+ * is a cross-domain join (Better Auth User + the `_CrewMemberToCrewSkill` m2m)
+ * that has no Convex representation — there is nothing here to read from Convex.
+ * See FEATUREDOCS/54.
  */
 export async function getCrewMemberExtras(): Promise<
   Record<string, { userName: string | null; userImage: string | null; skills: { id: string; name: string }[] }>
@@ -135,11 +177,12 @@ export async function getCrewMemberExtras(): Promise<
 /** Get the current user's crew member ID (if they have a linked crew profile) */
 export async function getMyCrewMemberId() {
   const { organizationId, userId } = await getOrgContext();
-  const crewMember = await prisma.crewMember.findFirst({
-    where: { organizationId, userId },
-    select: { id: true },
-  });
-  return crewMember?.id ?? null;
+  if (!userId) return null;
+  const all = await getCrewMembersByOrg(organizationId);
+  // Replicates findFirst({ where: { organizationId, userId } }) — list is already
+  // org-scoped, so match on userId only.
+  const match = all.find((m) => m.userId === userId);
+  return match?.id ?? null;
 }
 
 export async function createCrewMember(data: CrewMemberFormValues) {
@@ -293,12 +336,17 @@ export async function deleteCrewMember(id: string) {
 
 export async function getCrewRoles() {
   const { organizationId } = await requirePermission("crew", "read");
+  const [roles, members] = await Promise.all([
+    getCrewRolesByOrg(organizationId).then((r) => r.map(mapCrewRole)),
+    getCrewMembersByOrg(organizationId).then((m) => m.map(mapCrewMember)),
+  ]);
+  // _count.crewMembers is derivable from Convex: members carry crewRoleId.
+  const counts = countMembersByRole(members);
   return serialize(
-    await prisma.crewRole.findMany({
-      where: { organizationId, isActive: true },
-      orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
-      include: { _count: { select: { crewMembers: true } } },
-    })
+    activeRolesSorted(roles).map((r) => ({
+      ...r,
+      _count: { crewMembers: counts[r.id] ?? 0 },
+    })),
   );
 }
 
@@ -306,12 +354,22 @@ export async function getCrewRoles() {
 
 export async function getCrewSkills() {
   const { organizationId } = await requirePermission("crew", "read");
-  return serialize(
-    await prisma.crewSkill.findMany({
+  // Skill rows come from Convex; but _count.crewMembers is the implicit
+  // `_CrewMemberToCrewSkill` m2m, which has NO Convex representation — it stays a
+  // batched Prisma read (a legit cross-domain terminus, like the User joins).
+  const [skills, counted] = await Promise.all([
+    getCrewSkillsByOrg(organizationId).then((s) => s.map(mapCrewSkill)),
+    prisma.crewSkill.findMany({
       where: { organizationId },
-      orderBy: { name: "asc" },
-      include: { _count: { select: { crewMembers: true } } },
-    })
+      select: { id: true, _count: { select: { crewMembers: true } } },
+    }),
+  ]);
+  const countById = new Map(counted.map((s) => [s.id, s._count.crewMembers]));
+  return serialize(
+    skillsSorted(skills).map((s) => ({
+      ...s,
+      _count: { crewMembers: countById.get(s.id) ?? 0 },
+    })),
   );
 }
 
@@ -320,24 +378,23 @@ export async function getCrewSkills() {
 /** Get all crew roles for dropdown options */
 export async function getCrewRoleOptions() {
   const { organizationId } = await requirePermission("crew", "read");
+  const roles = (await getCrewRolesByOrg(organizationId)).map(mapCrewRole);
   return serialize(
-    await prisma.crewRole.findMany({
-      where: { organizationId, isActive: true },
-      select: { id: true, name: true, department: true, color: true },
-      orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
-    })
+    activeRolesSorted(roles).map((r) => ({
+      id: r.id,
+      name: r.name,
+      department: r.department,
+      color: r.color,
+    })),
   );
 }
 
 /** Get all crew skills for multi-select */
 export async function getCrewSkillOptions() {
   const { organizationId } = await requirePermission("crew", "read");
+  const skills = (await getCrewSkillsByOrg(organizationId)).map(mapCrewSkill);
   return serialize(
-    await prisma.crewSkill.findMany({
-      where: { organizationId },
-      select: { id: true, name: true, category: true },
-      orderBy: { name: "asc" },
-    })
+    skillsSorted(skills).map((s) => ({ id: s.id, name: s.name, category: s.category })),
   );
 }
 
@@ -357,12 +414,14 @@ export async function getOrgUsersForCrewLink() {
     },
   });
 
-  // Get already-linked user IDs in this org
-  const linked = await prisma.crewMember.findMany({
-    where: { organizationId, userId: { not: null } },
-    select: { userId: true },
-  });
-  const linkedIds = new Set(linked.map((c) => c.userId));
+  // Get already-linked user IDs in this org. The `member` rows above are Better
+  // Auth (auth terminus, stays Prisma); only the crew-member→user linkage comes
+  // from the Convex roster mirror.
+  const linkedIds = new Set(
+    (await getCrewMembersByOrg(organizationId))
+      .map((c) => c.userId)
+      .filter((u): u is string => u != null),
+  );
 
   return serialize(
     members.map((m) => ({
@@ -440,11 +499,6 @@ export async function linkCrewMemberToUser(id: string, userId: string | null) {
 /** Get distinct departments for filter options */
 export async function getCrewDepartments() {
   const { organizationId } = await requirePermission("crew", "read");
-  const results = await prisma.crewMember.findMany({
-    where: { organizationId, department: { not: null } },
-    select: { department: true },
-    distinct: ["department"],
-    orderBy: { department: "asc" },
-  });
-  return results.map((r) => r.department).filter(Boolean) as string[];
+  const members = (await getCrewMembersByOrg(organizationId)).map(mapCrewMember);
+  return distinctDepartments(members);
 }


### PR DESCRIPTION
## What

Phase A read-rewiring for the **crew roster** surface: move the pure read-only actions in `src/server/crew.ts` off Prisma and onto the Convex crew mirror, extending `src/lib/crew-read.ts` with mappers + pure unit-tested filter/sort/count primitives. No certification references touched (table dropped in #227).

## Converted to Convex
- `getCrewMembers` — list/count/filter/search/sort/paginate in JS replicating the Prisma where/orderBy/skip/take; `crewRole` resolved from the Convex role map; `skills` (m2m) + Better Auth `user` batched from Prisma over just the page.
- `getCrewMemberById` — member row + crewRole from Convex; `skills`/`user`/`assignments` stay Prisma (assignments = sibling-PR scheduling table). Org isolation enforced in the action (the Convex `getById` arg isn't org-scoped).
- `getMyCrewMemberId`, `getCrewRoles` (`_count.crewMembers` derived from members' `crewRoleId`), `getCrewRoleOptions`, `getCrewSkillOptions`, `getCrewDepartments` (distinct over members).
- `getOrgUsersForCrewLink` — **partial**: `member` rows stay Prisma (Better Auth auth terminus); only the crew-member→user linkage set comes from Convex.

## Hybrid / left on Prisma (with reasons)
- `getCrewSkills` — skill rows from Convex, but `_count.crewMembers` is the `_CrewMemberToCrewSkill` m2m which has **no Convex representation**, so the count stays a batched Prisma read.
- `getCrewMemberExtras` — every field is a cross-domain User/skill-m2m join; nothing to read from Convex. Intentionally Prisma-only.
- All writes + read-then-writes untouched.

## New Convex query
None — the existing `list`/`getById` on `crewMembers`/`crewRoles`/`crewSkills` suffice. No `convex/_generated` edits.

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` — 2027 passed (79 files); new `crew-read.test.ts` = 21 tests (mappers, enum filters, search incl. tag `hasSome` exact-match, NULLS-LAST/FIRST sort, pagination, distinct departments, active-role + skill ordering, role member-count)
- `pnpm exec eslint` on all changed files — clean

## ⚠️ DEPLOY GATE
The crew backfill (`npm run convex:backfill:crew`) **must run against prod Convex before this merges**, else the rewired reads come back empty. Merge gate = human validation on the Coolify PR preview. **Do not merge** until both are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)