### PR TITLE
feat(convex): read crew scheduling from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,21 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **crew scheduling** (`server/crew-dashboard.ts`, `crew-time.ts`, `crew-assignments.ts`, `crew-availability.ts`, `crew-calendar.ts` → `src/lib/crew-scheduling-read.ts`). **Converted (pure reads):** crew-dashboard — `getCrewPickerList`, `getCrewDashboardStats`, `getPendingTimeEntries`, `getActiveAssignmentsSummary`, `getPendingOffers`, `getUpcomingShifts`; crew-time — `getAllTimeEntries` (JS filter/search/sort/paginate + count), `getTimeEntriesForMember`, `getTimeEntriesForProject`; crew-assignments — `getProjectCrew`, `getProjectLabourCost` (JS sum/count aggregate), `getCrewMembersForAssignment` (members + JS date-overlap conflicts + UNAVAILABLE set — converted, stayed clean); crew-availability — `getCrewAvailability`, `getCrewPlannerData`, `getCrewAvailabilityStatus`; crew-calendar — `getIcalSettings` (crewMember icalEnabled/icalToken), `getAssignmentIcsData` (assignment + member + role + project + location + shifts). Joins reuse `crew-read.ts` (member/role maps), `projects-read.ts` (project name/number/status), `locations-read.ts` (ics location). **Stayed Prisma:** all writes (clock/approve/dispute, create/update/delete assignment+shift+availability, ical token writes), all read-then-write (`createTimeEntry`/`updateTimeEntry` in-action verify reads, `checkCrewConflicts` overlap-check, `exportTimesheetCSV` is a `requirePermission("crew","read")` read but left Prisma with the write-adjacent CRUD), and Better Auth `User` joins (`approvedBy`/`confirmedBy` — batched `prisma.user`). **New convex queries:** `crewShifts.listByAssignmentIds` (shifts have no org column — scoped by the org-fetched assignment ids; service-only) and `crewAvailabilities.listByCrewMemberIds` (org is OPTIONAL on availability → by-member access path, per the gate note). **DEPLOY-GATED:** `convex:backfill:crew-scheduling` (+ `convex-backfill-crew-availability-org`) must run in prod Convex before merge, else existing rows read empty.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/convex/crewAvailabilities.ts
+++ b/convex/crewAvailabilities.ts
@@ -33,6 +33,30 @@ export const getById = query({
   },
 });
 
+/**
+ * Availability rows for a set of crew members (read-rewiring for crew scheduling
+ * reads). `organizationId` is OPTIONAL on this table (older rows may lack the
+ * denormalized org), so a by-member fetch must use the `by_crewMemberId` index,
+ * not the org index — the caller has already org-scoped the crew member ids.
+ * Service-only (server actions own authorization). One indexed query per member
+ * id, flattened.
+ */
+export const listByCrewMemberIds = query({
+  args: { crewMemberIds: v.array(v.string()) },
+  handler: async (ctx, { crewMemberIds }) => {
+    await requireService(ctx);
+    const groups = await Promise.all(
+      crewMemberIds.map((crewMemberId) =>
+        ctx.db
+          .query("crewAvailabilities")
+          .withIndex("by_crewMemberId", (q) => q.eq("crewMemberId", crewMemberId))
+          .collect(),
+      ),
+    );
+    return groups.flat();
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/crewShifts.ts
+++ b/convex/crewShifts.ts
@@ -32,6 +32,28 @@ export const getById = query({
   },
 });
 
+/**
+ * Shifts for a set of assignments (read-rewiring for crew scheduling reads).
+ * crewShifts has no organizationId — the org scope is the assignment list the
+ * server already fetched (org-scoped via crewAssignments). Service-only, like
+ * the other shift reads. One indexed query per assignment id, flattened.
+ */
+export const listByAssignmentIds = query({
+  args: { assignmentIds: v.array(v.string()) },
+  handler: async (ctx, { assignmentIds }) => {
+    await requireService(ctx);
+    const groups = await Promise.all(
+      assignmentIds.map((assignmentId) =>
+        ctx.db
+          .query("crewShifts")
+          .withIndex("by_assignmentId", (q) => q.eq("assignmentId", assignmentId))
+          .collect(),
+      ),
+    );
+    return groups.flat();
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/lib/crew-scheduling-read.test.ts
+++ b/src/lib/crew-scheduling-read.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapAssignment,
+  mapShift,
+  mapAvailability,
+  mapTimeEntry,
+  compareAscNullsLast,
+  compareDescNullsFirst,
+  countActiveConfirmedAssignments,
+  countPendingOffers,
+  countSubmittedTimeEntries,
+  sumHoursThisWeek,
+  selectActiveAssignmentsSummary,
+  selectPendingOffers,
+  selectPendingTimeEntries,
+  selectMemberPickerAssignments,
+  selectUpcomingShifts,
+  sortProjectCrew,
+  aggregateProjectLabourCost,
+  shiftsForAssignmentSortedAsc,
+  sortTimeEntries,
+  filterTimeEntries,
+  paginate,
+  sortTimeEntriesDateThenStartDesc,
+  overlapsRange,
+  assignmentOverlapsRange,
+  selectMemberAvailability,
+  computeAvailabilityStatus,
+  selectPlannerAssignments,
+  selectPlannerAvailability,
+  selectMemberConflicts,
+  selectUnavailableMemberIds,
+  PROJECT_PHASE_RANK,
+  type ConvexCrewAssignment,
+  type ConvexCrewShift,
+  type ConvexCrewAvailability,
+  type ConvexCrewTimeEntry,
+  type MappedCrewAssignment,
+  type MappedCrewTimeEntry,
+} from "./crew-scheduling-read";
+
+const ms = (iso: string) => new Date(iso).getTime();
+
+// ─── Factory helpers ──────────────────────────────────────────────────────────
+function rawAssignment(over: Partial<ConvexCrewAssignment> = {}): ConvexCrewAssignment {
+  return {
+    _id: "x" as never,
+    _creationTime: 0,
+    id: "a1",
+    organizationId: "org",
+    projectId: "p1",
+    crewMemberId: "m1",
+    ...over,
+  } as ConvexCrewAssignment;
+}
+function mAssign(over: Partial<MappedCrewAssignment> = {}): MappedCrewAssignment {
+  return { ...mapAssignment(rawAssignment()), ...over };
+}
+function mTime(over: Partial<MappedCrewTimeEntry> = {}): MappedCrewTimeEntry {
+  return {
+    id: "t1",
+    organizationId: "org",
+    assignmentId: null,
+    crewMemberId: "m1",
+    description: null,
+    date: new Date("2026-06-10T00:00:00Z"),
+    startTime: "09:00",
+    endTime: "17:00",
+    breakMinutes: 0,
+    totalHours: 8,
+    status: "DRAFT",
+    approvedById: null,
+    approvedAt: null,
+    notes: null,
+    createdAt: null,
+    updatedAt: null,
+    ...over,
+  };
+}
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+describe("mappers", () => {
+  it("mapAssignment: epoch->Date, absent->null, defaults coerced, _id stripped", () => {
+    const d = mapAssignment(
+      rawAssignment({
+        status: "CONFIRMED",
+        startDate: ms("2026-06-01T00:00:00Z"),
+        estimatedCost: 1200,
+        isProjectManager: true,
+      }),
+    );
+    expect(d.startDate).toBeInstanceOf(Date);
+    expect(d.startDate?.getTime()).toBe(ms("2026-06-01T00:00:00Z"));
+    expect(d.endDate).toBeNull();
+    expect(d.crewRoleId).toBeNull();
+    expect(d.estimatedCost).toBe(1200);
+    expect(d.isProjectManager).toBe(true);
+    expect((d as unknown as Record<string, unknown>)._id).toBeUndefined();
+    expect((d as unknown as Record<string, unknown>)._creationTime).toBeUndefined();
+  });
+
+  it("mapAssignment: missing status defaults to PENDING, missing isProjectManager false", () => {
+    const d = mapAssignment(rawAssignment());
+    expect(d.status).toBe("PENDING");
+    expect(d.isProjectManager).toBe(false);
+  });
+
+  it("mapShift: date required->Date, status default SCHEDULED, breakMinutes absent->null", () => {
+    const s = mapShift({
+      _id: "x" as never,
+      _creationTime: 0,
+      id: "s1",
+      assignmentId: "a1",
+      date: ms("2026-06-05T00:00:00Z"),
+    } as ConvexCrewShift);
+    expect(s.date.getTime()).toBe(ms("2026-06-05T00:00:00Z"));
+    expect(s.status).toBe("SCHEDULED");
+    expect(s.breakMinutes).toBeNull();
+  });
+
+  it("mapAvailability: org optional->null, type default UNAVAILABLE, isAllDay default true", () => {
+    const av = mapAvailability({
+      _id: "x" as never,
+      _creationTime: 0,
+      id: "av1",
+      crewMemberId: "m1",
+      startDate: ms("2026-06-01T00:00:00Z"),
+      endDate: ms("2026-06-02T00:00:00Z"),
+    } as ConvexCrewAvailability);
+    expect(av.organizationId).toBeNull();
+    expect(av.type).toBe("UNAVAILABLE");
+    expect(av.isAllDay).toBe(true);
+    expect(av.startDate).toBeInstanceOf(Date);
+  });
+
+  it("mapTimeEntry: breakMinutes default 0, status default DRAFT, totalHours absent->null", () => {
+    const e = mapTimeEntry({
+      _id: "x" as never,
+      _creationTime: 0,
+      id: "t1",
+      organizationId: "org",
+      crewMemberId: "m1",
+      date: ms("2026-06-10T00:00:00Z"),
+      startTime: "09:00",
+      endTime: "17:00",
+    } as ConvexCrewTimeEntry);
+    expect(e.breakMinutes).toBe(0);
+    expect(e.status).toBe("DRAFT");
+    expect(e.totalHours).toBeNull();
+    expect(e.assignmentId).toBeNull();
+  });
+});
+
+// ─── Comparators ───────────────────────────────────────────────────────────────
+describe("comparators", () => {
+  it("compareAscNullsLast puts nulls last", () => {
+    const arr = [3, null, 1, undefined, 2].sort(compareAscNullsLast);
+    expect(arr).toEqual([1, 2, 3, null, undefined]);
+  });
+  it("compareDescNullsFirst puts nulls first", () => {
+    const arr = [3, null, 1, 2].sort(compareDescNullsFirst);
+    expect(arr).toEqual([null, 3, 2, 1]);
+  });
+});
+
+// ─── Dashboard ─────────────────────────────────────────────────────────────────
+describe("dashboard stats", () => {
+  const now = new Date("2026-06-15T00:00:00Z");
+  it("countActiveConfirmedAssignments: CONFIRMED + (endDate>=now OR null)", () => {
+    const list = [
+      mAssign({ status: "CONFIRMED", endDate: new Date("2026-06-20T00:00:00Z") }),
+      mAssign({ status: "CONFIRMED", endDate: null }),
+      mAssign({ status: "CONFIRMED", endDate: new Date("2026-06-01T00:00:00Z") }), // past
+      mAssign({ status: "PENDING", endDate: null }),
+    ];
+    expect(countActiveConfirmedAssignments(list, now)).toBe(2);
+  });
+
+  it("countPendingOffers counts PENDING + OFFERED", () => {
+    const list = [
+      mAssign({ status: "PENDING" }),
+      mAssign({ status: "OFFERED" }),
+      mAssign({ status: "CONFIRMED" }),
+    ];
+    expect(countPendingOffers(list)).toBe(2);
+  });
+
+  it("countSubmittedTimeEntries counts SUBMITTED only", () => {
+    expect(
+      countSubmittedTimeEntries([mTime({ status: "SUBMITTED" }), mTime({ status: "APPROVED" })]),
+    ).toBe(1);
+  });
+
+  it("sumHoursThisWeek: APPROVED|EXPORTED, date>=weekAgo", () => {
+    const weekAgo = new Date("2026-06-08T00:00:00Z");
+    const list = [
+      mTime({ status: "APPROVED", totalHours: 5, date: new Date("2026-06-10T00:00:00Z") }),
+      mTime({ status: "EXPORTED", totalHours: 3, date: new Date("2026-06-09T00:00:00Z") }),
+      mTime({ status: "APPROVED", totalHours: 9, date: new Date("2026-06-01T00:00:00Z") }), // before weekAgo
+      mTime({ status: "SUBMITTED", totalHours: 4, date: new Date("2026-06-10T00:00:00Z") }), // wrong status
+      mTime({ status: "APPROVED", totalHours: null, date: new Date("2026-06-10T00:00:00Z") }), // null hours
+    ];
+    expect(sumHoursThisWeek(list, weekAgo)).toBe(8);
+  });
+
+  it("selectActiveAssignmentsSummary: status CONFIRMED|ACCEPTED, running, sorted startDate asc, cap 20", () => {
+    const list = [
+      mAssign({ status: "ACCEPTED", startDate: new Date("2026-06-20T00:00:00Z"), endDate: null }),
+      mAssign({ status: "CONFIRMED", startDate: new Date("2026-06-16T00:00:00Z"), endDate: null }),
+      mAssign({ status: "DECLINED", startDate: new Date("2026-06-10T00:00:00Z"), endDate: null }),
+    ];
+    const out = selectActiveAssignmentsSummary(list, now);
+    expect(out.map((a) => a.startDate?.getTime())).toEqual([
+      ms("2026-06-16T00:00:00Z"),
+      ms("2026-06-20T00:00:00Z"),
+    ]);
+  });
+
+  it("selectPendingOffers: createdAt desc, cap 15", () => {
+    const list = [
+      mAssign({ status: "PENDING", createdAt: new Date("2026-06-01T00:00:00Z") }),
+      mAssign({ status: "OFFERED", createdAt: new Date("2026-06-05T00:00:00Z") }),
+    ];
+    const out = selectPendingOffers(list);
+    expect(out.map((a) => a.createdAt?.getTime())).toEqual([
+      ms("2026-06-05T00:00:00Z"),
+      ms("2026-06-01T00:00:00Z"),
+    ]);
+  });
+
+  it("selectPendingTimeEntries: SUBMITTED, date desc, cap 15", () => {
+    const list = [
+      mTime({ status: "SUBMITTED", date: new Date("2026-06-01T00:00:00Z") }),
+      mTime({ status: "SUBMITTED", date: new Date("2026-06-09T00:00:00Z") }),
+      mTime({ status: "DRAFT", date: new Date("2026-06-10T00:00:00Z") }),
+    ];
+    const out = selectPendingTimeEntries(list);
+    expect(out).toHaveLength(2);
+    expect(out[0].date.getTime()).toBe(ms("2026-06-09T00:00:00Z"));
+  });
+
+  it("selectMemberPickerAssignments: exclude CANCELLED|DECLINED, startDate desc", () => {
+    const list = [
+      mAssign({ status: "CONFIRMED", startDate: new Date("2026-06-01T00:00:00Z") }),
+      mAssign({ status: "CANCELLED", startDate: new Date("2026-06-09T00:00:00Z") }),
+      mAssign({ status: "PENDING", startDate: new Date("2026-06-05T00:00:00Z") }),
+    ];
+    const out = selectMemberPickerAssignments(list);
+    expect(out.map((a) => a.status)).toEqual(["PENDING", "CONFIRMED"]);
+  });
+
+  it("selectUpcomingShifts: SCHEDULED, date>=today, assignment in org, date asc, cap 10", () => {
+    const orgIds = new Set(["a1", "a2"]);
+    const today = new Date("2026-06-15T00:00:00Z");
+    const shifts = [
+      mapShift({ id: "s1", assignmentId: "a1", date: ms("2026-06-16T00:00:00Z"), status: "SCHEDULED" } as ConvexCrewShift),
+      mapShift({ id: "s2", assignmentId: "a2", date: ms("2026-06-15T00:00:00Z"), status: "SCHEDULED" } as ConvexCrewShift),
+      mapShift({ id: "s3", assignmentId: "a1", date: ms("2026-06-14T00:00:00Z"), status: "SCHEDULED" } as ConvexCrewShift), // past
+      mapShift({ id: "s4", assignmentId: "a3", date: ms("2026-06-20T00:00:00Z"), status: "SCHEDULED" } as ConvexCrewShift), // not in org
+      mapShift({ id: "s5", assignmentId: "a1", date: ms("2026-06-18T00:00:00Z"), status: "CANCELLED" } as ConvexCrewShift), // wrong status
+    ];
+    const out = selectUpcomingShifts(shifts, orgIds, today);
+    expect(out.map((s) => s.id)).toEqual(["s2", "s1"]);
+  });
+});
+
+// ─── Project crew ────────────────────────────────────────────────────────────
+describe("project crew", () => {
+  it("sortProjectCrew: PM first, then phase declared order, then lastName asc", () => {
+    expect(PROJECT_PHASE_RANK.BUMP_IN).toBeLessThan(PROJECT_PHASE_RANK.EVENT);
+    const rows = [
+      { id: "1", isProjectManager: false, phase: "EVENT", lastName: "Adams" },
+      { id: "2", isProjectManager: true, phase: "EVENT", lastName: "Zed" },
+      { id: "3", isProjectManager: false, phase: "BUMP_IN", lastName: "Brown" },
+      { id: "4", isProjectManager: false, phase: null, lastName: "Carter" },
+    ];
+    const out = sortProjectCrew(rows, (r) => r.lastName);
+    expect(out.map((r) => r.id)).toEqual(["2", "3", "1", "4"]);
+  });
+
+  it("aggregateProjectLabourCost: sum estimatedCost + count, excl CANCELLED|DECLINED", () => {
+    const list = [
+      mAssign({ status: "CONFIRMED", estimatedCost: 100 }),
+      mAssign({ status: "PENDING", estimatedCost: 50 }),
+      mAssign({ status: "CANCELLED", estimatedCost: 999 }),
+      mAssign({ status: "CONFIRMED", estimatedCost: null }),
+    ];
+    expect(aggregateProjectLabourCost(list)).toEqual({ totalLabourCost: 150, assignmentCount: 3 });
+  });
+
+  it("shiftsForAssignmentSortedAsc filters by assignment and sorts date asc", () => {
+    const shifts = [
+      mapShift({ id: "s1", assignmentId: "a1", date: ms("2026-06-09T00:00:00Z") } as ConvexCrewShift),
+      mapShift({ id: "s2", assignmentId: "a2", date: ms("2026-06-01T00:00:00Z") } as ConvexCrewShift),
+      mapShift({ id: "s3", assignmentId: "a1", date: ms("2026-06-01T00:00:00Z") } as ConvexCrewShift),
+    ];
+    expect(shiftsForAssignmentSortedAsc(shifts, "a1").map((s) => s.id)).toEqual(["s3", "s1"]);
+  });
+});
+
+// ─── Time entries list ─────────────────────────────────────────────────────────
+describe("time entry list filter/sort/paginate", () => {
+  const nameMap: Record<string, { firstName: string; lastName: string }> = {
+    m1: { firstName: "Alice", lastName: "Zephyr" },
+    m2: { firstName: "Bob", lastName: "Anders" },
+  };
+  const projMap: Record<string, { name: string; projectNumber: string }> = {
+    a1: { name: "Gala Night", projectNumber: "P-0007" },
+  };
+  const ctxFilter = {
+    nameOf: (e: MappedCrewTimeEntry) => nameMap[e.crewMemberId] ?? { firstName: "", lastName: "" },
+    projectOf: (e: MappedCrewTimeEntry) => (e.assignmentId ? projMap[e.assignmentId] ?? null : null),
+  };
+
+  it("search matches member name, description, project name/number (case-insensitive)", () => {
+    const entries = [
+      mTime({ id: "t1", crewMemberId: "m1" }),
+      mTime({ id: "t2", crewMemberId: "m2", description: "overnight" }),
+      mTime({ id: "t3", crewMemberId: "m2", assignmentId: "a1" }),
+    ];
+    expect(filterTimeEntries(entries, { search: "alice" }, ctxFilter).map((e) => e.id)).toEqual(["t1"]);
+    expect(filterTimeEntries(entries, { search: "OVERNIGHT" }, ctxFilter).map((e) => e.id)).toEqual(["t2"]);
+    expect(filterTimeEntries(entries, { search: "p-0007" }, ctxFilter).map((e) => e.id)).toEqual(["t3"]);
+  });
+
+  it("status + crewMemberId filters use IN semantics", () => {
+    const entries = [
+      mTime({ id: "t1", crewMemberId: "m1", status: "DRAFT" }),
+      mTime({ id: "t2", crewMemberId: "m2", status: "APPROVED" }),
+    ];
+    expect(
+      filterTimeEntries(entries, { filters: { status: ["APPROVED"] } }, ctxFilter).map((e) => e.id),
+    ).toEqual(["t2"]);
+    expect(
+      filterTimeEntries(entries, { filters: { crewMemberId: ["m1"] } }, ctxFilter).map((e) => e.id),
+    ).toEqual(["t1"]);
+  });
+
+  it("sortTimeEntries by date desc adds startTime desc tie-break", () => {
+    const d = new Date("2026-06-10T00:00:00Z");
+    const entries = [
+      mTime({ id: "t1", date: d, startTime: "08:00" }),
+      mTime({ id: "t2", date: d, startTime: "12:00" }),
+    ];
+    const out = sortTimeEntries(entries, "date", "desc", { lastNameOf: (e) => nameMap[e.crewMemberId]?.lastName });
+    expect(out.map((e) => e.id)).toEqual(["t2", "t1"]);
+  });
+
+  it("sortTimeEntries by crewMember uses lastName", () => {
+    const entries = [mTime({ id: "t1", crewMemberId: "m1" }), mTime({ id: "t2", crewMemberId: "m2" })];
+    const out = sortTimeEntries(entries, "crewMember", "asc", {
+      lastNameOf: (e) => nameMap[e.crewMemberId]?.lastName,
+    });
+    expect(out.map((e) => e.id)).toEqual(["t2", "t1"]); // Anders before Zephyr
+  });
+
+  it("paginate slices 1-based pages", () => {
+    const rows = [1, 2, 3, 4, 5];
+    expect(paginate(rows, 1, 2)).toEqual([1, 2]);
+    expect(paginate(rows, 2, 2)).toEqual([3, 4]);
+    expect(paginate(rows, 3, 2)).toEqual([5]);
+  });
+
+  it("sortTimeEntriesDateThenStartDesc orders date desc then startTime desc", () => {
+    const entries = [
+      mTime({ id: "t1", date: new Date("2026-06-01T00:00:00Z"), startTime: "09:00" }),
+      mTime({ id: "t2", date: new Date("2026-06-09T00:00:00Z"), startTime: "08:00" }),
+      mTime({ id: "t3", date: new Date("2026-06-09T00:00:00Z"), startTime: "15:00" }),
+    ];
+    expect(sortTimeEntriesDateThenStartDesc(entries).map((e) => e.id)).toEqual(["t3", "t2", "t1"]);
+  });
+});
+
+// ─── Overlap + availability ─────────────────────────────────────────────────────
+describe("overlap + availability", () => {
+  const range = { start: new Date("2026-06-10T00:00:00Z"), end: new Date("2026-06-12T00:00:00Z") };
+
+  it("overlapsRange: rowStart<=end AND rowEnd>=start", () => {
+    expect(
+      overlapsRange(new Date("2026-06-11"), new Date("2026-06-15"), range.start, range.end),
+    ).toBe(true);
+    expect(
+      overlapsRange(new Date("2026-06-01"), new Date("2026-06-05"), range.start, range.end),
+    ).toBe(false);
+    expect(
+      overlapsRange(new Date("2026-06-13"), new Date("2026-06-20"), range.start, range.end),
+    ).toBe(false);
+  });
+
+  it("assignmentOverlapsRange: null start/end never overlaps", () => {
+    expect(assignmentOverlapsRange(mAssign({ startDate: null, endDate: null }), range.start, range.end)).toBe(false);
+    expect(
+      assignmentOverlapsRange(
+        mAssign({ startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }),
+        range.start,
+        range.end,
+      ),
+    ).toBe(true);
+  });
+
+  it("selectMemberAvailability: filter by member + optional overlap, sorted startDate asc", () => {
+    const rows = [
+      mapAvailability({ id: "av1", crewMemberId: "m1", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+      mapAvailability({ id: "av2", crewMemberId: "m1", startDate: ms("2026-06-01"), endDate: ms("2026-06-02") } as ConvexCrewAvailability),
+      mapAvailability({ id: "av3", crewMemberId: "m2", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+    ];
+    expect(selectMemberAvailability(rows, "m1", null).map((r) => r.id)).toEqual(["av2", "av1"]);
+    expect(selectMemberAvailability(rows, "m1", range).map((r) => r.id)).toEqual(["av1"]);
+  });
+
+  it("computeAvailabilityStatus: UNAVAILABLE > TENTATIVE > busy > available", () => {
+    const blocks = [
+      mapAvailability({ id: "b1", crewMemberId: "m1", type: "UNAVAILABLE", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+      mapAvailability({ id: "b2", crewMemberId: "m2", type: "TENTATIVE", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+    ];
+    const assignments = [
+      mAssign({ crewMemberId: "m3", status: "CONFIRMED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }),
+      mAssign({ crewMemberId: "m1", status: "CONFIRMED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }), // should NOT override unavailable
+      mAssign({ crewMemberId: "m4", status: "CANCELLED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }),
+    ];
+    const out = computeAvailabilityStatus(["m1", "m2", "m3", "m4"], blocks, assignments, range);
+    expect(out).toEqual({ m1: "unavailable", m2: "tentative", m3: "busy", m4: "available" });
+  });
+});
+
+// ─── Planner + form helper ───────────────────────────────────────────────────
+describe("planner + getCrewMembersForAssignment helpers", () => {
+  const range = { start: new Date("2026-06-10T00:00:00Z"), end: new Date("2026-06-12T00:00:00Z") };
+
+  it("selectPlannerAssignments: exclude CANCELLED|DECLINED; keep null-start OR overlap", () => {
+    const list = [
+      mAssign({ id: "1", status: "CONFIRMED", startDate: null, endDate: null }),
+      mAssign({ id: "2", status: "CONFIRMED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }),
+      mAssign({ id: "3", status: "CONFIRMED", startDate: new Date("2026-06-01"), endDate: new Date("2026-06-02") }),
+      mAssign({ id: "4", status: "DECLINED", startDate: null, endDate: null }),
+    ];
+    expect(selectPlannerAssignments(list, range).map((a) => a.id)).toEqual(["1", "2"]);
+  });
+
+  it("selectPlannerAvailability: only overlapping rows", () => {
+    const rows = [
+      mapAvailability({ id: "av1", crewMemberId: "m1", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+      mapAvailability({ id: "av2", crewMemberId: "m1", startDate: ms("2026-06-01"), endDate: ms("2026-06-02") } as ConvexCrewAvailability),
+    ];
+    expect(selectPlannerAvailability(rows, range).map((r) => r.id)).toEqual(["av1"]);
+  });
+
+  it("selectMemberConflicts: other-project, non-excluded, overlapping", () => {
+    const list = [
+      mAssign({ id: "c1", crewMemberId: "m1", projectId: "p2", status: "CONFIRMED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }),
+      mAssign({ id: "c2", crewMemberId: "m1", projectId: "p1", status: "CONFIRMED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }), // same project
+      mAssign({ id: "c3", crewMemberId: "m1", projectId: "p3", status: "DECLINED", startDate: new Date("2026-06-11"), endDate: new Date("2026-06-11") }), // declined
+      mAssign({ id: "c4", crewMemberId: "m1", projectId: "p4", status: "CONFIRMED", startDate: new Date("2026-06-01"), endDate: new Date("2026-06-02") }), // no overlap
+    ];
+    const out = selectMemberConflicts(list, "m1", "p1", range);
+    expect(out.map((a) => a.id)).toEqual(["c1"]);
+  });
+
+  it("selectUnavailableMemberIds: UNAVAILABLE blocks overlapping range", () => {
+    const blocks = [
+      mapAvailability({ id: "b1", crewMemberId: "m1", type: "UNAVAILABLE", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+      mapAvailability({ id: "b2", crewMemberId: "m2", type: "TENTATIVE", startDate: ms("2026-06-11"), endDate: ms("2026-06-11") } as ConvexCrewAvailability),
+      mapAvailability({ id: "b3", crewMemberId: "m3", type: "UNAVAILABLE", startDate: ms("2026-06-01"), endDate: ms("2026-06-02") } as ConvexCrewAvailability),
+    ];
+    const out = selectUnavailableMemberIds(blocks, range);
+    expect([...out]).toEqual(["m1"]);
+  });
+});

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -1,0 +1,703 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the crew SCHEDULING tables (Phase A read-rewiring).
+ *
+ * crewAssignment / crewShift / crewAvailability / crewTimeEntry are dual-written
+ * (Prisma FK anchor + Convex reactive doc — see src/lib/crew-scheduling-mirror.ts)
+ * and backfilled (scripts/convex-backfill-crew-scheduling.ts +
+ * convex-backfill-crew-availability-org.ts). The pure read-only server actions in
+ * server/crew-dashboard.ts, crew-time.ts, crew-assignments.ts, crew-availability.ts
+ * and crew-calendar.ts read the Convex copy through these helpers; cross-domain
+ * joins onto crew members / roles reuse src/lib/crew-read.ts maps, onto projects
+ * reuse src/lib/projects-read.ts, onto locations reuse src/lib/locations-read.ts,
+ * and onto Better Auth User (approvedBy / confirmedBy) stay Prisma (batched by the
+ * caller). DEPLOY-GATED: the crew-scheduling tables must be backfilled into prod
+ * Convex before these reads deploy, else existing rows read empty. See FEATUREDOCS/54.
+ *
+ * Mapping conventions (Convex doc -> old Prisma row shape, so consumers and the
+ * `serialize()` boundary behave identically): epoch-ms numbers -> Date (serialize
+ * keeps Date), numeric money/hours stay numbers (Convex has no Decimal), absent
+ * optional fields -> null, Prisma-defaulted columns coerced non-null, `_id` /
+ * `_creationTime` stripped. NO Prisma fallback on a Convex map miss — a miss reads
+ * null, like a join against a deleted row.
+ */
+
+// ─── Raw Convex doc types ────────────────────────────────────────────────────
+export type ConvexCrewAssignment = Doc<"crewAssignments">;
+export type ConvexCrewShift = Doc<"crewShifts">;
+export type ConvexCrewAvailability = Doc<"crewAvailabilities">;
+export type ConvexCrewTimeEntry = Doc<"crewTimeEntries">;
+
+// ─── Mapped (Prisma-shaped) types ────────────────────────────────────────────
+export interface MappedCrewAssignment {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  crewMemberId: string;
+  crewRoleId: string | null;
+  status: string;
+  phase: string | null;
+  isProjectManager: boolean;
+  startDate: Date | null;
+  startTime: string | null;
+  endDate: Date | null;
+  endTime: string | null;
+  rateOverride: number | null;
+  rateType: string | null;
+  estimatedHours: number | null;
+  estimatedCost: number | null;
+  notes: string | null;
+  internalNotes: string | null;
+  responseToken: string | null;
+  offeredAt: Date | null;
+  respondedAt: Date | null;
+  responseNote: string | null;
+  confirmedAt: Date | null;
+  confirmedById: string | null;
+  serviceId: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export interface MappedCrewShift {
+  id: string;
+  assignmentId: string;
+  date: Date;
+  callTime: string | null;
+  endTime: string | null;
+  breakMinutes: number | null;
+  location: string | null;
+  notes: string | null;
+  status: string;
+}
+
+export interface MappedCrewAvailability {
+  id: string;
+  crewMemberId: string;
+  organizationId: string | null;
+  startDate: Date;
+  endDate: Date;
+  type: string;
+  reason: string | null;
+  isAllDay: boolean;
+  startTime: string | null;
+  endTime: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export interface MappedCrewTimeEntry {
+  id: string;
+  organizationId: string;
+  assignmentId: string | null;
+  crewMemberId: string;
+  description: string | null;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  breakMinutes: number;
+  totalHours: number | null;
+  status: string;
+  approvedById: string | null;
+  approvedAt: Date | null;
+  notes: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+// ─── Map helpers (epoch -> Date, absent -> null, defaulted -> non-null) ───────
+const toDate = (ms: number | null | undefined): Date | null =>
+  ms == null ? null : new Date(ms);
+
+export function mapAssignment(d: ConvexCrewAssignment): MappedCrewAssignment {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    projectId: d.projectId,
+    crewMemberId: d.crewMemberId,
+    crewRoleId: d.crewRoleId ?? null,
+    status: d.status ?? "PENDING",
+    phase: d.phase ?? null,
+    isProjectManager: d.isProjectManager ?? false,
+    startDate: toDate(d.startDate),
+    startTime: d.startTime ?? null,
+    endDate: toDate(d.endDate),
+    endTime: d.endTime ?? null,
+    rateOverride: d.rateOverride ?? null,
+    rateType: d.rateType ?? null,
+    estimatedHours: d.estimatedHours ?? null,
+    estimatedCost: d.estimatedCost ?? null,
+    notes: d.notes ?? null,
+    internalNotes: d.internalNotes ?? null,
+    responseToken: d.responseToken ?? null,
+    offeredAt: toDate(d.offeredAt),
+    respondedAt: toDate(d.respondedAt),
+    responseNote: d.responseNote ?? null,
+    confirmedAt: toDate(d.confirmedAt),
+    confirmedById: d.confirmedById ?? null,
+    serviceId: d.serviceId ?? null,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+export function mapShift(d: ConvexCrewShift): MappedCrewShift {
+  return {
+    id: d.id,
+    assignmentId: d.assignmentId,
+    date: new Date(d.date),
+    callTime: d.callTime ?? null,
+    endTime: d.endTime ?? null,
+    breakMinutes: d.breakMinutes ?? null,
+    location: d.location ?? null,
+    notes: d.notes ?? null,
+    status: d.status ?? "SCHEDULED",
+  };
+}
+
+export function mapAvailability(d: ConvexCrewAvailability): MappedCrewAvailability {
+  return {
+    id: d.id,
+    crewMemberId: d.crewMemberId,
+    organizationId: d.organizationId ?? null,
+    startDate: new Date(d.startDate),
+    endDate: new Date(d.endDate),
+    type: d.type ?? "UNAVAILABLE",
+    reason: d.reason ?? null,
+    isAllDay: d.isAllDay ?? true,
+    startTime: d.startTime ?? null,
+    endTime: d.endTime ?? null,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+export function mapTimeEntry(d: ConvexCrewTimeEntry): MappedCrewTimeEntry {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    assignmentId: d.assignmentId ?? null,
+    crewMemberId: d.crewMemberId,
+    description: d.description ?? null,
+    date: new Date(d.date),
+    startTime: d.startTime,
+    endTime: d.endTime,
+    breakMinutes: d.breakMinutes ?? 0,
+    totalHours: d.totalHours ?? null,
+    status: d.status ?? "DRAFT",
+    approvedById: d.approvedById ?? null,
+    approvedAt: toDate(d.approvedAt),
+    notes: d.notes ?? null,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+// ─── Fetchers ────────────────────────────────────────────────────────────────
+export async function getAssignmentsByOrg(orgId: string): Promise<MappedCrewAssignment[]> {
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewAssignments.list, { orgId }),
+  );
+  return rows.map(mapAssignment);
+}
+
+export async function getAssignmentsByProject(
+  projectId: string,
+  orgId: string,
+): Promise<MappedCrewAssignment[]> {
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewAssignments.listByProject, { projectId, orgId }),
+  );
+  return rows.map(mapAssignment);
+}
+
+export async function getAssignmentById(id: string): Promise<MappedCrewAssignment | null> {
+  const row = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewAssignments.getById, { id }),
+  );
+  return row ? mapAssignment(row) : null;
+}
+
+export async function getTimeEntriesByOrg(orgId: string): Promise<MappedCrewTimeEntry[]> {
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewTimeEntries.list, { orgId }),
+  );
+  return rows.map(mapTimeEntry);
+}
+
+export async function getShiftsByAssignmentIds(
+  assignmentIds: string[],
+): Promise<MappedCrewShift[]> {
+  if (assignmentIds.length === 0) return [];
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewShifts.listByAssignmentIds, { assignmentIds }),
+  );
+  return rows.map(mapShift);
+}
+
+/**
+ * Availability for a set of crew members. `organizationId` is OPTIONAL on the
+ * crewAvailabilities table, so this uses the by_crewMemberId access path (the
+ * caller has already org-scoped the member ids), per the gate note.
+ */
+export async function getAvailabilityByCrewMemberIds(
+  crewMemberIds: string[],
+): Promise<MappedCrewAvailability[]> {
+  if (crewMemberIds.length === 0) return [];
+  const rows = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewAvailabilities.listByCrewMemberIds, { crewMemberIds }),
+  );
+  return rows.map(mapAvailability);
+}
+
+// ─── Pure filter / sort / aggregate functions (unit-tested) ───────────────────
+
+/**
+ * Postgres enum columns sort by DECLARED order (not alphabetical). Rank maps
+ * replicate `orderBy: { <enum>: "asc" }`. Declared order from prisma/schema.prisma.
+ */
+export const PROJECT_PHASE_RANK: Record<string, number> = {
+  BUMP_IN: 0,
+  EVENT: 1,
+  BUMP_OUT: 2,
+  DELIVERY: 3,
+  PICKUP: 4,
+  SETUP: 5,
+  REHEARSAL: 6,
+  FULL_DURATION: 7,
+};
+
+const ACTIVE_ASSIGNMENT_STATUSES = new Set(["CONFIRMED", "ACCEPTED"]);
+const PENDING_OFFER_STATUSES = new Set(["PENDING", "OFFERED"]);
+const EXCLUDED_ASSIGNMENT_STATUSES = new Set(["CANCELLED", "DECLINED"]);
+
+/** Generic ascending compare, Postgres ASC = NULLS LAST. */
+export function compareAscNullsLast<T>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1; // nulls last
+  if (b == null) return -1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Descending compare, Postgres DESC = NULLS FIRST. */
+export function compareDescNullsFirst<T>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1; // nulls first
+  if (b == null) return 1;
+  return a < b ? 1 : a > b ? -1 : 0;
+}
+
+// ── crew-dashboard ──
+
+/** getCrewDashboardStats: confirmed assignments still running (endDate >= now OR null). */
+export function countActiveConfirmedAssignments(
+  assignments: MappedCrewAssignment[],
+  now: Date,
+): number {
+  return assignments.filter(
+    (a) =>
+      a.status === "CONFIRMED" && (a.endDate == null || a.endDate.getTime() >= now.getTime()),
+  ).length;
+}
+
+/** getCrewDashboardStats / getPendingOffers count: status in PENDING|OFFERED. */
+export function countPendingOffers(assignments: MappedCrewAssignment[]): number {
+  return assignments.filter((a) => PENDING_OFFER_STATUSES.has(a.status)).length;
+}
+
+/** getCrewDashboardStats: time entries with status SUBMITTED. */
+export function countSubmittedTimeEntries(entries: MappedCrewTimeEntry[]): number {
+  return entries.filter((e) => e.status === "SUBMITTED").length;
+}
+
+/** getCrewDashboardStats: sum totalHours of APPROVED|EXPORTED entries since weekAgo. */
+export function sumHoursThisWeek(
+  entries: MappedCrewTimeEntry[],
+  weekAgo: Date,
+): number {
+  return entries
+    .filter(
+      (e) =>
+        (e.status === "APPROVED" || e.status === "EXPORTED") &&
+        e.date.getTime() >= weekAgo.getTime(),
+    )
+    .reduce((sum, e) => sum + (e.totalHours ?? 0), 0);
+}
+
+/** getActiveAssignmentsSummary filter: status in CONFIRMED|ACCEPTED, running, sorted startDate asc, take 20. */
+export function selectActiveAssignmentsSummary(
+  assignments: MappedCrewAssignment[],
+  now: Date,
+): MappedCrewAssignment[] {
+  return assignments
+    .filter(
+      (a) =>
+        ACTIVE_ASSIGNMENT_STATUSES.has(a.status) &&
+        (a.endDate == null || a.endDate.getTime() >= now.getTime()),
+    )
+    .sort((a, b) => compareAscNullsLast(a.startDate?.getTime(), b.startDate?.getTime()))
+    .slice(0, 20);
+}
+
+/** getPendingOffers filter: status in PENDING|OFFERED, sorted createdAt desc, take 15. */
+export function selectPendingOffers(
+  assignments: MappedCrewAssignment[],
+): MappedCrewAssignment[] {
+  return assignments
+    .filter((a) => PENDING_OFFER_STATUSES.has(a.status))
+    .sort((a, b) => compareDescNullsFirst(a.createdAt?.getTime(), b.createdAt?.getTime()))
+    .slice(0, 15);
+}
+
+/** getPendingTimeEntries filter: status SUBMITTED, sorted date desc, take 15. */
+export function selectPendingTimeEntries(
+  entries: MappedCrewTimeEntry[],
+): MappedCrewTimeEntry[] {
+  return entries
+    .filter((e) => e.status === "SUBMITTED")
+    .sort((a, b) => compareDescNullsFirst(a.date.getTime(), b.date.getTime()))
+    .slice(0, 15);
+}
+
+/**
+ * getCrewPickerList sub-list: a member's assignments excluding CANCELLED|DECLINED,
+ * sorted startDate desc. (The member-level fetch/sort is done in the action.)
+ */
+export function selectMemberPickerAssignments(
+  assignments: MappedCrewAssignment[],
+): MappedCrewAssignment[] {
+  return assignments
+    .filter((a) => !EXCLUDED_ASSIGNMENT_STATUSES.has(a.status))
+    .sort((a, b) => compareDescNullsFirst(a.startDate?.getTime(), b.startDate?.getTime()));
+}
+
+/**
+ * getUpcomingShifts filter: shift status SCHEDULED, date >= startOfToday, and the
+ * shift's assignment is in the org (caller passes the org assignment-id set).
+ * Sorted date asc, take 10.
+ */
+export function selectUpcomingShifts(
+  shifts: MappedCrewShift[],
+  orgAssignmentIds: Set<string>,
+  startOfToday: Date,
+): MappedCrewShift[] {
+  return shifts
+    .filter(
+      (s) =>
+        s.status === "SCHEDULED" &&
+        s.date.getTime() >= startOfToday.getTime() &&
+        orgAssignmentIds.has(s.assignmentId),
+    )
+    .sort((a, b) => compareAscNullsLast(a.date.getTime(), b.date.getTime()))
+    .slice(0, 10);
+}
+
+// ── crew-assignments ──
+
+/** getProjectCrew sort: isProjectManager desc, phase asc (declared order, null last), member lastName asc. */
+export function sortProjectCrew<
+  T extends { isProjectManager: boolean; phase: string | null },
+>(rows: T[], lastNameOf: (row: T) => string | null | undefined): T[] {
+  return [...rows].sort((a, b) => {
+    // isProjectManager desc (true before false)
+    if (a.isProjectManager !== b.isProjectManager) return a.isProjectManager ? -1 : 1;
+    // phase asc by declared rank, nulls last
+    const ar = a.phase == null ? Number.POSITIVE_INFINITY : PROJECT_PHASE_RANK[a.phase] ?? Number.POSITIVE_INFINITY;
+    const br = b.phase == null ? Number.POSITIVE_INFINITY : PROJECT_PHASE_RANK[b.phase] ?? Number.POSITIVE_INFINITY;
+    if (ar !== br) return ar - br;
+    // crewMember.lastName asc, nulls last
+    return compareAscNullsLast(lastNameOf(a), lastNameOf(b));
+  });
+}
+
+/** getProjectLabourCost aggregate: sum estimatedCost + count, over status not in CANCELLED|DECLINED. */
+export function aggregateProjectLabourCost(assignments: MappedCrewAssignment[]): {
+  totalLabourCost: number;
+  assignmentCount: number;
+} {
+  const eligible = assignments.filter((a) => !EXCLUDED_ASSIGNMENT_STATUSES.has(a.status));
+  return {
+    totalLabourCost: eligible.reduce((sum, a) => sum + (a.estimatedCost ?? 0), 0),
+    assignmentCount: eligible.length,
+  };
+}
+
+/** Shifts for one assignment, sorted date asc (getProjectCrew shifts include). */
+export function shiftsForAssignmentSortedAsc(
+  shifts: MappedCrewShift[],
+  assignmentId: string,
+): MappedCrewShift[] {
+  return shifts
+    .filter((s) => s.assignmentId === assignmentId)
+    .sort((a, b) => compareAscNullsLast(a.date.getTime(), b.date.getTime()));
+}
+
+// ── crew-time ──
+
+const TIME_ENTRY_SORT_KEYS = new Set(["date", "crewMember", "startTime", "totalHours", "status"]);
+
+export interface TimeEntrySortContext {
+  /** crewMember lastName, for the "crewMember" sort key. */
+  lastNameOf: (entry: MappedCrewTimeEntry) => string | null | undefined;
+}
+
+/**
+ * getAllTimeEntries ordering. Mirrors the Prisma orderByMap: by chosen key, with a
+ * secondary `startTime` desc tie-break ONLY when sorting by date (matches Prisma).
+ */
+export function sortTimeEntries(
+  entries: MappedCrewTimeEntry[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+  ctx: TimeEntrySortContext,
+): MappedCrewTimeEntry[] {
+  const key = TIME_ENTRY_SORT_KEYS.has(sortBy) ? sortBy : "date";
+  const cmp = sortOrder === "asc" ? compareAscNullsLast : compareDescNullsFirst;
+  const valueOf = (e: MappedCrewTimeEntry): string | number | null | undefined => {
+    switch (key) {
+      case "crewMember":
+        return ctx.lastNameOf(e);
+      case "startTime":
+        return e.startTime;
+      case "totalHours":
+        return e.totalHours;
+      case "status":
+        return e.status;
+      case "date":
+      default:
+        return e.date.getTime();
+    }
+  };
+  return [...entries].sort((a, b) => {
+    const primary = cmp(valueOf(a), valueOf(b));
+    if (primary !== 0) return primary;
+    if (key === "date") {
+      // secondary startTime desc (NULLS FIRST)
+      return compareDescNullsFirst(a.startTime, b.startTime);
+    }
+    return 0;
+  });
+}
+
+export interface TimeEntryFilterContext {
+  /** crewMember first/last name + email, for search. */
+  nameOf: (entry: MappedCrewTimeEntry) => { firstName: string; lastName: string };
+  /** project name + number for the entry's assignment, for search. */
+  projectOf: (entry: MappedCrewTimeEntry) => { name: string; projectNumber: string } | null;
+}
+
+/**
+ * getAllTimeEntries where-clause. organizationId scoping is done by the fetcher
+ * (org list). Applies the optional case-insensitive search and the status /
+ * crewMemberId `in` filters.
+ */
+export function filterTimeEntries(
+  entries: MappedCrewTimeEntry[],
+  params:
+    | {
+        search?: string;
+        filters?: Record<string, unknown>;
+      }
+    | undefined,
+  ctx: TimeEntryFilterContext,
+): MappedCrewTimeEntry[] {
+  let out = entries;
+
+  const search = params?.search?.trim();
+  if (search) {
+    const needle = search.toLowerCase();
+    out = out.filter((e) => {
+      const { firstName, lastName } = ctx.nameOf(e);
+      const project = ctx.projectOf(e);
+      return (
+        firstName.toLowerCase().includes(needle) ||
+        lastName.toLowerCase().includes(needle) ||
+        (e.description ?? "").toLowerCase().includes(needle) ||
+        (project?.name ?? "").toLowerCase().includes(needle) ||
+        (project?.projectNumber ?? "").toLowerCase().includes(needle)
+      );
+    });
+  }
+
+  if (params?.filters) {
+    const f = params.filters as Record<string, string[]>;
+    if (f.status?.length) {
+      const set = new Set(f.status);
+      out = out.filter((e) => set.has(e.status));
+    }
+    if (f.crewMemberId?.length) {
+      const set = new Set(f.crewMemberId);
+      out = out.filter((e) => set.has(e.crewMemberId));
+    }
+  }
+
+  return out;
+}
+
+/** Slice a page out of an already-filtered+sorted list (1-based page). */
+export function paginate<T>(rows: T[], page: number, pageSize: number): T[] {
+  const p = page > 0 ? page : 1;
+  return rows.slice((p - 1) * pageSize, (p - 1) * pageSize + pageSize);
+}
+
+/** getTimeEntriesForMember / getTimeEntriesForProject sort: date desc, then startTime desc. */
+export function sortTimeEntriesDateThenStartDesc(
+  entries: MappedCrewTimeEntry[],
+): MappedCrewTimeEntry[] {
+  return [...entries].sort((a, b) => {
+    const byDate = compareDescNullsFirst(a.date.getTime(), b.date.getTime());
+    if (byDate !== 0) return byDate;
+    return compareDescNullsFirst(a.startTime, b.startTime);
+  });
+}
+
+// ── crew-availability ──
+
+/** Date-overlap test: row overlaps [start, end] when row.startDate <= end AND row.endDate >= start. */
+export function overlapsRange(
+  rowStart: Date,
+  rowEnd: Date,
+  rangeStart: Date,
+  rangeEnd: Date,
+): boolean {
+  return (
+    rowStart.getTime() <= rangeEnd.getTime() && rowEnd.getTime() >= rangeStart.getTime()
+  );
+}
+
+/** Assignment overlaps a range (treats null start/end as open-ended on that side? — no: Prisma uses lte/gte so null dates do NOT match a range). */
+export function assignmentOverlapsRange(
+  a: MappedCrewAssignment,
+  rangeStart: Date,
+  rangeEnd: Date,
+): boolean {
+  if (a.startDate == null || a.endDate == null) return false;
+  return overlapsRange(a.startDate, a.endDate, rangeStart, rangeEnd);
+}
+
+/**
+ * getCrewAvailability filter: a member's availability, optionally overlapping a
+ * range, sorted startDate asc.
+ */
+export function selectMemberAvailability(
+  rows: MappedCrewAvailability[],
+  crewMemberId: string,
+  range: { start: Date; end: Date } | null,
+): MappedCrewAvailability[] {
+  return rows
+    .filter((r) => r.crewMemberId === crewMemberId)
+    .filter((r) => (range ? overlapsRange(r.startDate, r.endDate, range.start, range.end) : true))
+    .sort((a, b) => compareAscNullsLast(a.startDate.getTime(), b.startDate.getTime()));
+}
+
+/**
+ * getCrewAvailabilityStatus: per-member status from availability blocks + active
+ * assignments overlapping [start, end]. UNAVAILABLE wins, then TENTATIVE, then
+ * busy (an overlapping non-cancelled/declined assignment), default available.
+ */
+export function computeAvailabilityStatus(
+  crewMemberIds: string[],
+  blocks: MappedCrewAvailability[],
+  assignments: MappedCrewAssignment[],
+  range: { start: Date; end: Date },
+): Record<string, "available" | "tentative" | "unavailable" | "busy"> {
+  const statusMap: Record<string, "available" | "tentative" | "unavailable" | "busy"> = {};
+  const memberSet = new Set(crewMemberIds);
+  for (const id of crewMemberIds) statusMap[id] = "available";
+
+  for (const b of blocks) {
+    if (!memberSet.has(b.crewMemberId)) continue;
+    if (!overlapsRange(b.startDate, b.endDate, range.start, range.end)) continue;
+    if (b.type === "UNAVAILABLE") {
+      statusMap[b.crewMemberId] = "unavailable";
+    } else if (b.type === "TENTATIVE" && statusMap[b.crewMemberId] === "available") {
+      statusMap[b.crewMemberId] = "tentative";
+    }
+  }
+
+  for (const a of assignments) {
+    if (!memberSet.has(a.crewMemberId)) continue;
+    if (EXCLUDED_ASSIGNMENT_STATUSES.has(a.status)) continue;
+    if (!assignmentOverlapsRange(a, range.start, range.end)) continue;
+    if (statusMap[a.crewMemberId] === "available") {
+      statusMap[a.crewMemberId] = "busy";
+    }
+  }
+
+  return statusMap;
+}
+
+/**
+ * getCrewPlannerData: a member's planner assignments — exclude CANCELLED|DECLINED,
+ * and (overlap [start,end]) OR (startDate == null). Replicates the nested
+ * `assignments.where` (no orderBy in the Prisma include → preserve input order).
+ */
+export function selectPlannerAssignments(
+  assignments: MappedCrewAssignment[],
+  range: { start: Date; end: Date },
+): MappedCrewAssignment[] {
+  return assignments.filter((a) => {
+    if (EXCLUDED_ASSIGNMENT_STATUSES.has(a.status)) return false;
+    if (a.startDate == null) return true;
+    // matches { startDate: { lte: end }, endDate: { gte: start } }
+    return assignmentOverlapsRange(a, range.start, range.end);
+  });
+}
+
+/** getCrewPlannerData: a member's planner availability overlapping [start,end]. */
+export function selectPlannerAvailability(
+  rows: MappedCrewAvailability[],
+  range: { start: Date; end: Date },
+): MappedCrewAvailability[] {
+  return rows.filter((r) => overlapsRange(r.startDate, r.endDate, range.start, range.end));
+}
+
+// ── crew-assignments: getCrewMembersForAssignment helpers ──
+
+/**
+ * Cross-project conflicts for a member over [start,end]: other-project,
+ * non-cancelled/declined assignments whose date window overlaps. Mirrors the
+ * Prisma `crewAssignment.findMany({ crewMemberId in, projectId not, status notIn,
+ * startDate lte end, endDate gte start })`.
+ */
+export function selectMemberConflicts(
+  assignments: MappedCrewAssignment[],
+  crewMemberId: string,
+  currentProjectId: string,
+  range: { start: Date; end: Date },
+): MappedCrewAssignment[] {
+  return assignments.filter(
+    (a) =>
+      a.crewMemberId === crewMemberId &&
+      a.projectId !== currentProjectId &&
+      !EXCLUDED_ASSIGNMENT_STATUSES.has(a.status) &&
+      assignmentOverlapsRange(a, range.start, range.end),
+  );
+}
+
+/**
+ * The set of crew member ids that are UNAVAILABLE over [start,end]: availability
+ * blocks of type UNAVAILABLE whose window overlaps the range.
+ */
+export function selectUnavailableMemberIds(
+  blocks: MappedCrewAvailability[],
+  range: { start: Date; end: Date },
+): Set<string> {
+  const out = new Set<string>();
+  for (const b of blocks) {
+    if (b.type !== "UNAVAILABLE") continue;
+    if (overlapsRange(b.startDate, b.endDate, range.start, range.end)) out.add(b.crewMemberId);
+  }
+  return out;
+}
+
+export { EXCLUDED_ASSIGNMENT_STATUSES };

--- a/src/server/crew-assignments.ts
+++ b/src/server/crew-assignments.ts
@@ -2,7 +2,10 @@
 
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
-import { getProjectById } from "@/lib/projects-read";
+import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
+import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 import { serialize } from "@/lib/serialize";
 import {
   crewAssignmentSchema,
@@ -19,6 +22,19 @@ import {
   patchCrewShiftInConvex,
   removeCrewShiftFromConvex,
 } from "@/lib/crew-scheduling-mirror";
+import {
+  getAssignmentsByProject,
+  getAssignmentsByOrg,
+  getShiftsByAssignmentIds,
+  getAvailabilityByCrewMemberIds,
+  sortProjectCrew,
+  aggregateProjectLabourCost,
+  shiftsForAssignmentSortedAsc,
+  selectMemberConflicts,
+  selectUnavailableMemberIds,
+  compareAscNullsLast,
+  type MappedCrewAssignment,
+} from "@/lib/crew-scheduling-read";
 
 // ─── Rate Cascade ────────────────────────────────────────────────────────────
 
@@ -72,33 +88,74 @@ export async function getProjectCrew(projectId: string) {
   const project = await getProjectById(projectId);
   if (!project || project.organizationId !== organizationId) throw new Error("Project not found");
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: { projectId, organizationId },
-    include: {
+  const [assignments, members, roleMap] = await Promise.all([
+    getAssignmentsByProject(projectId, organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+  ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+
+  // Shifts for these assignments (one indexed query per assignment id).
+  const shifts = await getShiftsByAssignmentIds(assignments.map((a) => a.id));
+
+  // Service join (ProjectService) — read the project's services from Convex.
+  const services = await (await getConvexClient()).query(api.projectServices.listByProject, {
+    projectId,
+    orgId: organizationId,
+  });
+  const serviceById = new Map(services.map((s) => [s.id, s]));
+
+  // confirmedBy is a Better Auth User — stays Prisma, batched.
+  const confirmerIds = [
+    ...new Set(assignments.map((a) => a.confirmedById).filter((id): id is string => !!id)),
+  ];
+  const confirmers = confirmerIds.length
+    ? await prisma.user.findMany({ where: { id: { in: confirmerIds } }, select: { id: true, name: true } })
+    : [];
+  const confirmerById = new Map(confirmers.map((u) => [u.id, u]));
+
+  // crewMember is a required Prisma relation (cascade-deleted with the member), so
+  // an assignment always has a present member — a Convex map miss means the member
+  // row is gone, which is equivalent to the assignment not existing. Drop those
+  // (no Prisma fallback) so the join stays non-null for consumers.
+  const sorted = sortProjectCrew(
+    assignments.filter((a) => memberById.has(a.crewMemberId)),
+    (a) => memberById.get(a.crewMemberId)?.lastName,
+  );
+
+  const result = sorted.map((a) => {
+    const m = memberById.get(a.crewMemberId)!;
+    const role = a.crewRoleId ? roleMap.get(a.crewRoleId) ?? null : null;
+    const service = a.serviceId ? serviceById.get(a.serviceId) ?? null : null;
+    const confirmer = a.confirmedById ? confirmerById.get(a.confirmedById) ?? null : null;
+    return {
+      ...a,
       crewMember: {
-        select: {
-          id: true, firstName: true, lastName: true,
-          email: true, phone: true, image: true,
-          defaultDayRate: true, defaultHourlyRate: true,
-        },
+        id: m.id,
+        firstName: m.firstName,
+        lastName: m.lastName,
+        email: m.email ?? null,
+        phone: m.phone ?? null,
+        image: m.image ?? null,
+        defaultDayRate: m.defaultDayRate ?? null,
+        defaultHourlyRate: m.defaultHourlyRate ?? null,
       },
-      crewRole: {
-        select: { id: true, name: true, color: true, defaultRate: true, rateType: true },
-      },
-      service: {
-        select: { id: true, title: true, type: true },
-      },
-      shifts: { orderBy: { date: "asc" } },
-      confirmedBy: { select: { id: true, name: true } },
-    },
-    orderBy: [
-      { isProjectManager: "desc" },
-      { phase: "asc" },
-      { crewMember: { lastName: "asc" } },
-    ],
+      crewRole: role
+        ? {
+            id: role.id,
+            name: role.name,
+            color: role.color ?? null,
+            defaultRate: role.defaultRate ?? null,
+            rateType: role.rateType ?? null,
+          }
+        : null,
+      service: service ? { id: service.id, title: service.title, type: service.type } : null,
+      shifts: shiftsForAssignmentSortedAsc(shifts, a.id),
+      confirmedBy: confirmer ? { id: confirmer.id, name: confirmer.name ?? null } : null,
+    };
   });
 
-  return serialize(assignments);
+  return serialize(result);
 }
 
 export async function createAssignment(projectId: string, data: CrewAssignmentFormValues) {
@@ -455,20 +512,8 @@ export async function deleteShift(shiftId: string) {
 export async function getProjectLabourCost(projectId: string) {
   const { organizationId } = await getOrgContext();
 
-  const result = await prisma.crewAssignment.aggregate({
-    where: {
-      projectId,
-      organizationId,
-      status: { notIn: ["CANCELLED", "DECLINED"] },
-    },
-    _sum: { estimatedCost: true },
-    _count: true,
-  });
-
-  return serialize({
-    totalLabourCost: result._sum.estimatedCost || 0,
-    assignmentCount: result._count,
-  });
+  const assignments = await getAssignmentsByProject(projectId, organizationId);
+  return serialize(aggregateProjectLabourCost(assignments));
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -480,102 +525,95 @@ export async function getCrewMembersForAssignment(
 ) {
   const { organizationId } = await getOrgContext();
 
-  const where = {
-    organizationId,
-    isActive: true,
-    status: "ACTIVE" as const,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" as const } },
-            { lastName: { contains: search, mode: "insensitive" as const } },
-            { email: { contains: search, mode: "insensitive" as const } },
-            { department: { contains: search, mode: "insensitive" as const } },
-          ],
-        }
-      : {}),
-  };
+  const [allMembers, allAssignments, roleMap, projects] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
 
-  const members = await prisma.crewMember.findMany({
-    where,
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      email: true,
-      phone: true,
-      image: true,
-      department: true,
-      defaultDayRate: true,
-      defaultHourlyRate: true,
-      crewRole: { select: { id: true, name: true } },
-      // Assignments on this project
-      assignments: {
-        where: { projectId },
-        select: { id: true, phase: true, status: true, serviceId: true },
-      },
-    },
-    orderBy: { lastName: "asc" },
-    take: 50,
-  });
+  const needle = search?.trim().toLowerCase();
+  const members = allMembers
+    .filter((m) => (m.isActive ?? true) && (m.status ?? "ACTIVE") === "ACTIVE")
+    .filter((m) => {
+      if (!needle) return true;
+      return (
+        m.firstName.toLowerCase().includes(needle) ||
+        m.lastName.toLowerCase().includes(needle) ||
+        (m.email ?? "").toLowerCase().includes(needle) ||
+        (m.department ?? "").toLowerCase().includes(needle)
+      );
+    })
+    .sort((a, b) => compareAscNullsLast(a.lastName, b.lastName))
+    .slice(0, 50);
+
+  // Assignments on THIS project, grouped by member (the nested `assignments` sublist).
+  const projectAssignmentsByMember = new Map<string, MappedCrewAssignment[]>();
+  for (const a of allAssignments) {
+    if (a.projectId !== projectId) continue;
+    const list = projectAssignmentsByMember.get(a.crewMemberId) ?? [];
+    list.push(a);
+    projectAssignmentsByMember.set(a.crewMemberId, list);
+  }
+
+  const baseShape = (m: (typeof members)[number]) => {
+    const role = m.crewRoleId ? roleMap.get(m.crewRoleId) ?? null : null;
+    return {
+      id: m.id,
+      firstName: m.firstName,
+      lastName: m.lastName,
+      email: m.email ?? null,
+      phone: m.phone ?? null,
+      image: m.image ?? null,
+      department: m.department ?? null,
+      defaultDayRate: m.defaultDayRate ?? null,
+      defaultHourlyRate: m.defaultHourlyRate ?? null,
+      crewRole: role ? { id: role.id, name: role.name } : null,
+      assignments: (projectAssignmentsByMember.get(m.id) ?? []).map((a) => ({
+        id: a.id,
+        phase: a.phase,
+        status: a.status,
+        serviceId: a.serviceId,
+      })),
+    };
+  };
 
   // Cross-project availability check (Arch fix #2)
   if (dateRange) {
     const rangeStart = new Date(dateRange.start);
     const rangeEnd = new Date(dateRange.end);
+    const range = { start: rangeStart, end: rangeEnd };
     const memberIds = members.map((m) => m.id);
 
-    // Single query for all overlapping assignments across all projects
-    const conflicts = await prisma.crewAssignment.findMany({
-      where: {
-        crewMemberId: { in: memberIds },
-        projectId: { not: projectId }, // Other projects only
-        status: { notIn: ["CANCELLED", "DECLINED"] },
-        startDate: { lte: rangeEnd },
-        endDate: { gte: rangeStart },
-      },
-      select: {
-        crewMemberId: true,
-        projectId: true,
-        project: { select: { projectNumber: true, name: true } },
-        startDate: true,
-        endDate: true,
-      },
-    });
-
-    // Build conflict map
-    const conflictMap = new Map<string, typeof conflicts>();
-    for (const c of conflicts) {
-      const existing = conflictMap.get(c.crewMemberId) || [];
-      existing.push(c);
-      conflictMap.set(c.crewMemberId, existing);
-    }
-
-    // Also check crew availability blocks
-    const unavailable = await prisma.crewAvailability.findMany({
-      where: {
-        crewMemberId: { in: memberIds },
-        type: "UNAVAILABLE",
-        startDate: { lte: rangeEnd },
-        endDate: { gte: rangeStart },
-      },
-      select: { crewMemberId: true },
-    });
-    const unavailableSet = new Set(unavailable.map((u) => u.crewMemberId));
+    const availability = await getAvailabilityByCrewMemberIds(memberIds);
+    const unavailableSet = selectUnavailableMemberIds(availability, range);
 
     return serialize(
-      members.map((m) => ({
-        ...m,
-        conflicts: conflictMap.get(m.id) || [],
-        isUnavailable: unavailableSet.has(m.id),
-      })),
+      members.map((m) => {
+        const conflicts = selectMemberConflicts(allAssignments, m.id, projectId, range).map((c) => {
+          const p = projectsById.get(c.projectId) ?? null;
+          return {
+            crewMemberId: c.crewMemberId,
+            projectId: c.projectId,
+            project: p ? { projectNumber: p.projectNumber, name: p.name } : null,
+            startDate: c.startDate,
+            endDate: c.endDate,
+          };
+        });
+        return {
+          ...baseShape(m),
+          conflicts,
+          isUnavailable: unavailableSet.has(m.id),
+        };
+      }),
     );
   }
 
   return serialize(
     members.map((m) => ({
-      ...m,
-      conflicts: [],
+      ...baseShape(m),
+      conflicts: [] as never[],
       isUnavailable: false,
     })),
   );

--- a/src/server/crew-availability.ts
+++ b/src/server/crew-availability.ts
@@ -12,6 +12,18 @@ import {
   mirrorCrewAvailabilityCreate,
   removeCrewAvailabilityFromConvex,
 } from "@/lib/crew-scheduling-mirror";
+import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getProjectsByOrg } from "@/lib/projects-read";
+import {
+  getAvailabilityByCrewMemberIds,
+  getAssignmentsByOrg,
+  selectMemberAvailability,
+  selectPlannerAssignments,
+  selectPlannerAvailability,
+  computeAvailabilityStatus,
+  compareAscNullsLast,
+  type MappedCrewAssignment,
+} from "@/lib/crew-scheduling-read";
 
 // ─── Availability CRUD ──────────────────────────────────────────────────────
 
@@ -22,23 +34,14 @@ export async function getCrewAvailability(
 ) {
   const { organizationId } = await getOrgContext();
 
-  const member = await prisma.crewMember.findUnique({
-    where: { id: crewMemberId, organizationId },
-    select: { id: true },
-  });
-  if (!member) throw new Error("Crew member not found");
+  const members = await getCrewMembersByOrg(organizationId);
+  if (!members.some((m) => m.id === crewMemberId)) throw new Error("Crew member not found");
 
-  const where: Record<string, unknown> = { crewMemberId };
-  if (startDate && endDate) {
-    // Overlapping range: availability.startDate <= endDate AND availability.endDate >= startDate
-    where.startDate = { lte: new Date(endDate) };
-    where.endDate = { gte: new Date(startDate) };
-  }
+  const rows = await getAvailabilityByCrewMemberIds([crewMemberId]);
+  const range =
+    startDate && endDate ? { start: new Date(startDate), end: new Date(endDate) } : null;
 
-  const records = await prisma.crewAvailability.findMany({
-    where,
-    orderBy: { startDate: "asc" },
-  });
+  const records = selectMemberAvailability(rows, crewMemberId, range);
 
   return serialize(records);
 }
@@ -189,47 +192,67 @@ export async function getCrewPlannerData(startDate: string, endDate: string) {
 
   const start = new Date(startDate);
   const end = new Date(endDate);
+  const range = { start, end };
 
-  // Get all active crew members with their assignments and availability in range
-  const members = await prisma.crewMember.findMany({
-    where: { organizationId, isActive: true, status: "ACTIVE" },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      department: true,
-      crewRole: { select: { id: true, name: true, color: true } },
-      assignments: {
-        where: {
-          status: { notIn: ["CANCELLED", "DECLINED"] },
-          OR: [
-            { startDate: { lte: end }, endDate: { gte: start } },
-            { startDate: null },
-          ],
-        },
-        include: {
-          project: {
-            select: {
-              id: true,
-              name: true,
-              projectNumber: true,
-              status: true,
-            },
-          },
-          crewRole: { select: { name: true, color: true } },
-        },
+  const [allMembers, allAssignments, roleMap, projects] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const members = allMembers
+    .filter((m) => (m.isActive ?? true) && (m.status ?? "ACTIVE") === "ACTIVE")
+    .sort(
+      (a, b) =>
+        compareAscNullsLast(a.lastName, b.lastName) || compareAscNullsLast(a.firstName, b.firstName),
+    );
+
+  const assignmentsByMember = new Map<string, MappedCrewAssignment[]>();
+  for (const a of allAssignments) {
+    const list = assignmentsByMember.get(a.crewMemberId) ?? [];
+    list.push(a);
+    assignmentsByMember.set(a.crewMemberId, list);
+  }
+
+  // Availability for all displayed members, grouped.
+  const availabilityRows = await getAvailabilityByCrewMemberIds(members.map((m) => m.id));
+  const availabilityByMember = new Map<string, typeof availabilityRows>();
+  for (const r of availabilityRows) {
+    const list = availabilityByMember.get(r.crewMemberId) ?? [];
+    list.push(r);
+    availabilityByMember.set(r.crewMemberId, list);
+  }
+
+  const result = members.map((m) => {
+    const role = m.crewRoleId ? roleMap.get(m.crewRoleId) ?? null : null;
+    const assignments = selectPlannerAssignments(assignmentsByMember.get(m.id) ?? [], range).map(
+      (a) => {
+        const p = projectsById.get(a.projectId) ?? null;
+        const aRole = a.crewRoleId ? roleMap.get(a.crewRoleId) ?? null : null;
+        return {
+          ...a,
+          project: p
+            ? { id: p.id, name: p.name, projectNumber: p.projectNumber, status: p.status ?? null }
+            : null,
+          crewRole: aRole ? { name: aRole.name, color: aRole.color ?? null } : null,
+        };
       },
-      availability: {
-        where: {
-          startDate: { lte: end },
-          endDate: { gte: start },
-        },
-      },
-    },
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    );
+    const availability = selectPlannerAvailability(availabilityByMember.get(m.id) ?? [], range);
+    return {
+      id: m.id,
+      firstName: m.firstName,
+      lastName: m.lastName,
+      department: m.department ?? null,
+      crewRole: role ? { id: role.id, name: role.name, color: role.color ?? null } : null,
+      assignments,
+      availability,
+    };
   });
 
-  return serialize(members);
+  return serialize(result);
 }
 
 // ─── Availability Status for Crew List ──────────────────────────────────────
@@ -243,58 +266,17 @@ export async function getCrewAvailabilityStatus(
 
   const start = new Date(startDate);
   const end = new Date(endDate);
+  const range = { start, end };
 
-  // Get availability blocks for all requested members
-  const blocks = await prisma.crewAvailability.findMany({
-    where: {
-      crewMemberId: { in: crewMemberIds },
-      startDate: { lte: end },
-      endDate: { gte: start },
-      crewMember: { organizationId },
-    },
-    select: { crewMemberId: true, type: true },
-  });
+  const [blocks, allAssignments, members] = await Promise.all([
+    getAvailabilityByCrewMemberIds(crewMemberIds),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+  ]);
 
-  // Get overlapping assignments
-  const assignments = await prisma.crewAssignment.findMany({
-    where: {
-      crewMemberId: { in: crewMemberIds },
-      organizationId,
-      status: { notIn: ["CANCELLED", "DECLINED"] },
-      startDate: { lte: end },
-      endDate: { gte: start },
-    },
-    select: { crewMemberId: true },
-  });
+  // Scope availability blocks to members in this org (crewMember.organizationId).
+  const orgMemberIds = new Set(members.map((m) => m.id));
+  const orgBlocks = blocks.filter((b) => orgMemberIds.has(b.crewMemberId));
 
-  // Build status map: "available" | "tentative" | "unavailable" | "busy"
-  const statusMap: Record<
-    string,
-    "available" | "tentative" | "unavailable" | "busy"
-  > = {};
-
-  for (const id of crewMemberIds) {
-    statusMap[id] = "available";
-  }
-
-  // Check blocks
-  for (const b of blocks) {
-    if (b.type === "UNAVAILABLE") {
-      statusMap[b.crewMemberId] = "unavailable";
-    } else if (
-      b.type === "TENTATIVE" &&
-      statusMap[b.crewMemberId] === "available"
-    ) {
-      statusMap[b.crewMemberId] = "tentative";
-    }
-  }
-
-  // Check assignments (don't override unavailable)
-  for (const a of assignments) {
-    if (statusMap[a.crewMemberId] === "available") {
-      statusMap[a.crewMemberId] = "busy";
-    }
-  }
-
-  return statusMap;
+  return computeAvailabilityStatus(crewMemberIds, orgBlocks, allAssignments, range);
 }

--- a/src/server/crew-calendar.ts
+++ b/src/server/crew-calendar.ts
@@ -6,6 +6,13 @@ import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { patchCrewMemberInConvex } from "@/lib/crew-mirror";
+import { getCrewMemberById, getCrewRoleMap } from "@/lib/crew-read";
+import { getProjectById } from "@/lib/projects-read";
+import { getLocationById } from "@/lib/locations-read";
+import {
+  getAssignmentById,
+  getShiftsByAssignmentIds,
+} from "@/lib/crew-scheduling-read";
 
 // ─── Token Management ────────────────────────────────────────────────────────
 
@@ -118,13 +125,13 @@ export async function regenerateIcalToken(crewMemberId: string) {
 export async function getIcalSettings(crewMemberId: string) {
   const { organizationId } = await getOrgContext();
 
-  const member = await prisma.crewMember.findUnique({
-    where: { id: crewMemberId, organizationId },
-    select: { icalEnabled: true, icalToken: true },
-  });
-  if (!member) throw new Error("Crew member not found");
+  const member = await getCrewMemberById(crewMemberId);
+  if (!member || member.organizationId !== organizationId) throw new Error("Crew member not found");
 
-  return serialize(member);
+  return serialize({
+    icalEnabled: member.icalEnabled ?? false,
+    icalToken: member.icalToken ?? null,
+  });
 }
 
 // ─── Assignment .ics Download ────────────────────────────────────────────────
@@ -132,27 +139,40 @@ export async function getIcalSettings(crewMemberId: string) {
 export async function getAssignmentIcsData(assignmentId: string) {
   const { organizationId } = await getOrgContext();
 
-  const assignment = await prisma.crewAssignment.findUnique({
-    where: { id: assignmentId, organizationId },
-    include: {
-      crewMember: { select: { firstName: true, lastName: true, email: true } },
-      crewRole: { select: { name: true } },
-      project: {
-        select: {
-          name: true,
-          projectNumber: true,
-          location: { select: { name: true, address: true } },
-          siteContactName: true,
-          siteContactPhone: true,
-        },
-      },
-      shifts: {
-        where: { status: { not: "CANCELLED" } },
-        orderBy: { date: "asc" },
-      },
-    },
-  });
+  const assignment = await getAssignmentById(assignmentId);
+  if (!assignment || assignment.organizationId !== organizationId) {
+    throw new Error("Assignment not found");
+  }
 
-  if (!assignment) throw new Error("Assignment not found");
-  return serialize(assignment);
+  const [member, roleMap, project, shifts] = await Promise.all([
+    getCrewMemberById(assignment.crewMemberId),
+    getCrewRoleMap(organizationId),
+    getProjectById(assignment.projectId),
+    getShiftsByAssignmentIds([assignmentId]),
+  ]);
+
+  const role = assignment.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+  const location = project?.locationId ? await getLocationById(project.locationId) : null;
+
+  const filteredShifts = shifts
+    .filter((s) => s.status !== "CANCELLED")
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  return serialize({
+    ...assignment,
+    crewMember: member
+      ? { firstName: member.firstName, lastName: member.lastName, email: member.email ?? null }
+      : null,
+    crewRole: role ? { name: role.name } : null,
+    project: project
+      ? {
+          name: project.name,
+          projectNumber: project.projectNumber,
+          location: location ? { name: location.name, address: location.address ?? null } : null,
+          siteContactName: project.siteContactName ?? null,
+          siteContactPhone: project.siteContactPhone ?? null,
+        }
+      : null,
+    shifts: filteredShifts,
+  });
 }

--- a/src/server/crew-dashboard.ts
+++ b/src/server/crew-dashboard.ts
@@ -1,33 +1,89 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
+import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getProjectsByOrg } from "@/lib/projects-read";
+import {
+  getAssignmentsByOrg,
+  getTimeEntriesByOrg,
+  getShiftsByAssignmentIds,
+  countActiveConfirmedAssignments,
+  countPendingOffers,
+  countSubmittedTimeEntries,
+  sumHoursThisWeek,
+  selectActiveAssignmentsSummary,
+  selectPendingOffers,
+  selectPendingTimeEntries,
+  selectMemberPickerAssignments,
+  selectUpcomingShifts,
+  compareAscNullsLast,
+  type MappedCrewAssignment,
+} from "@/lib/crew-scheduling-read";
+
+/** Project mini-shape used for the dashboard joins (replaces Prisma `include: { project }`). */
+function projectMini(
+  projectsById: Map<string, { id: string; name: string; projectNumber: string; status?: string }>,
+  projectId: string,
+) {
+  const p = projectsById.get(projectId);
+  return p ? { id: p.id, name: p.name, projectNumber: p.projectNumber, status: p.status ?? null } : null;
+}
+
+/** Attach project + crewRole onto an assignment, matching the old include shape. */
+function attachAssignmentJoins(
+  a: MappedCrewAssignment,
+  projectsById: Map<string, { id: string; name: string; projectNumber: string; status?: string }>,
+  roleMap: Map<string, { id: string; name: string }>,
+) {
+  const project = projectMini(projectsById, a.projectId);
+  const crewRole = a.crewRoleId ? roleMap.get(a.crewRoleId) ?? null : null;
+  return {
+    ...a,
+    project: project ? { id: project.id, name: project.name, projectNumber: project.projectNumber } : null,
+    crewRole: crewRole ? { id: crewRole.id, name: crewRole.name } : null,
+  };
+}
 
 export async function getCrewPickerList() {
   const { organizationId } = await getOrgContext();
 
-  const members = await prisma.crewMember.findMany({
-    where: { organizationId, isActive: true, status: "ACTIVE" },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      department: true,
-      crewRole: { select: { name: true } },
-      assignments: {
-        where: { status: { notIn: ["CANCELLED", "DECLINED"] } },
-        include: {
-          project: { select: { id: true, name: true, projectNumber: true } },
-          crewRole: { select: { id: true, name: true } },
-        },
-        orderBy: { startDate: "desc" },
-      },
-    },
-    orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+  const [members, assignments, roleMap, projects] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const activeMembers = members
+    .filter((m) => (m.isActive ?? true) && (m.status ?? "ACTIVE") === "ACTIVE")
+    .sort(
+      (a, b) =>
+        compareAscNullsLast(a.firstName, b.firstName) || compareAscNullsLast(a.lastName, b.lastName),
+    );
+
+  const assignmentsByMember = new Map<string, MappedCrewAssignment[]>();
+  for (const a of assignments) {
+    const list = assignmentsByMember.get(a.crewMemberId) ?? [];
+    list.push(a);
+    assignmentsByMember.set(a.crewMemberId, list);
+  }
+
+  const result = activeMembers.map((m) => {
+    const role = m.crewRoleId ? roleMap.get(m.crewRoleId) ?? null : null;
+    const memberAssignments = selectMemberPickerAssignments(assignmentsByMember.get(m.id) ?? []);
+    return {
+      id: m.id,
+      firstName: m.firstName,
+      lastName: m.lastName,
+      department: m.department ?? null,
+      crewRole: role ? { name: role.name } : null,
+      assignments: memberAssignments.map((a) => attachAssignmentJoins(a, projectsById, roleMap)),
+    };
   });
 
-  return serialize(members);
+  return serialize(result);
 }
 
 export async function getCrewDashboardStats() {
@@ -37,70 +93,60 @@ export async function getCrewDashboardStats() {
   const weekAgo = new Date(now);
   weekAgo.setDate(weekAgo.getDate() - 7);
 
-  const [
-    totalActive,
-    activeAssignments,
-    pendingOffers,
-    submittedTime,
-    hoursThisWeek,
-  ] = await Promise.all([
-    prisma.crewMember.count({
-      where: { organizationId, isActive: true, status: "ACTIVE" },
-    }),
-    prisma.crewAssignment.count({
-      where: {
-        organizationId,
-        status: "CONFIRMED",
-        OR: [{ endDate: { gte: now } }, { endDate: null }],
-      },
-    }),
-    prisma.crewAssignment.count({
-      where: {
-        organizationId,
-        status: { in: ["PENDING", "OFFERED"] },
-      },
-    }),
-    prisma.crewTimeEntry.count({
-      where: { organizationId, status: "SUBMITTED" },
-    }),
-    prisma.crewTimeEntry.aggregate({
-      where: {
-        organizationId,
-        status: { in: ["APPROVED", "EXPORTED"] },
-        date: { gte: weekAgo },
-      },
-      _sum: { totalHours: true },
-    }),
+  const [members, assignments, timeEntries] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getTimeEntriesByOrg(organizationId),
   ]);
+
+  const totalActive = members.filter(
+    (m) => (m.isActive ?? true) && (m.status ?? "ACTIVE") === "ACTIVE",
+  ).length;
 
   return {
     totalActive,
-    activeAssignments,
-    pendingOffers,
-    submittedTime,
-    hoursThisWeek: Number(hoursThisWeek._sum.totalHours || 0),
+    activeAssignments: countActiveConfirmedAssignments(assignments, now),
+    pendingOffers: countPendingOffers(assignments),
+    submittedTime: countSubmittedTimeEntries(timeEntries),
+    hoursThisWeek: sumHoursThisWeek(timeEntries, weekAgo),
   };
 }
 
 export async function getPendingTimeEntries() {
   const { organizationId } = await getOrgContext();
 
-  const entries = await prisma.crewTimeEntry.findMany({
-    where: { organizationId, status: "SUBMITTED" },
-    include: {
-      crewMember: { select: { firstName: true, lastName: true } },
-      assignment: {
-        include: {
-          project: { select: { name: true, projectNumber: true } },
-          crewRole: { select: { name: true } },
-        },
-      },
-    },
-    orderBy: { date: "desc" },
-    take: 15,
+  const [timeEntries, assignments, members, roleMap, projects] = await Promise.all([
+    getTimeEntriesByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const assignmentById = new Map(assignments.map((a) => [a.id, a]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const selected = selectPendingTimeEntries(timeEntries);
+
+  const result = selected.map((e) => {
+    const member = memberById.get(e.crewMemberId) ?? null;
+    const assignment = e.assignmentId ? assignmentById.get(e.assignmentId) ?? null : null;
+    const project = assignment ? projectMini(projectsById, assignment.projectId) : null;
+    const role = assignment?.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+    return {
+      ...e,
+      crewMember: member ? { firstName: member.firstName, lastName: member.lastName } : null,
+      assignment: assignment
+        ? {
+            ...assignment,
+            project: project ? { name: project.name, projectNumber: project.projectNumber } : null,
+            crewRole: role ? { name: role.name } : null,
+          }
+        : null,
+    };
   });
 
-  return serialize(entries);
+  return serialize(result);
 }
 
 export async function getActiveAssignmentsSummary() {
@@ -108,46 +154,63 @@ export async function getActiveAssignmentsSummary() {
 
   const now = new Date();
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: {
-      organizationId,
-      status: { in: ["CONFIRMED", "ACCEPTED"] },
-      OR: [{ endDate: { gte: now } }, { endDate: null }],
-    },
-    include: {
-      crewMember: { select: { id: true, firstName: true, lastName: true } },
-      crewRole: { select: { name: true } },
-      project: {
-        select: { id: true, name: true, projectNumber: true, status: true },
-      },
-    },
-    orderBy: { startDate: "asc" },
-    take: 20,
+  const [assignments, members, roleMap, projects] = await Promise.all([
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const selected = selectActiveAssignmentsSummary(assignments, now);
+
+  const result = selected.map((a) => {
+    const member = memberById.get(a.crewMemberId) ?? null;
+    const role = a.crewRoleId ? roleMap.get(a.crewRoleId) ?? null : null;
+    const project = projectMini(projectsById, a.projectId);
+    return {
+      ...a,
+      crewMember: member ? { id: member.id, firstName: member.firstName, lastName: member.lastName } : null,
+      crewRole: role ? { name: role.name } : null,
+      project: project
+        ? { id: project.id, name: project.name, projectNumber: project.projectNumber, status: project.status }
+        : null,
+    };
   });
 
-  return serialize(assignments);
+  return serialize(result);
 }
 
 export async function getPendingOffers() {
   const { organizationId } = await getOrgContext();
 
-  const assignments = await prisma.crewAssignment.findMany({
-    where: {
-      organizationId,
-      status: { in: ["PENDING", "OFFERED"] },
-    },
-    include: {
-      crewMember: { select: { id: true, firstName: true, lastName: true, email: true } },
-      crewRole: { select: { name: true } },
-      project: {
-        select: { id: true, name: true, projectNumber: true },
-      },
-    },
-    orderBy: { createdAt: "desc" },
-    take: 15,
+  const [assignments, members, roleMap, projects] = await Promise.all([
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const selected = selectPendingOffers(assignments);
+
+  const result = selected.map((a) => {
+    const member = memberById.get(a.crewMemberId) ?? null;
+    const role = a.crewRoleId ? roleMap.get(a.crewRoleId) ?? null : null;
+    const project = projectMini(projectsById, a.projectId);
+    return {
+      ...a,
+      crewMember: member
+        ? { id: member.id, firstName: member.firstName, lastName: member.lastName, email: member.email ?? null }
+        : null,
+      crewRole: role ? { name: role.name } : null,
+      project: project ? { id: project.id, name: project.name, projectNumber: project.projectNumber } : null,
+    };
   });
 
-  return serialize(assignments);
+  return serialize(result);
 }
 
 export async function getUpcomingShifts() {
@@ -156,24 +219,37 @@ export async function getUpcomingShifts() {
   const now = new Date();
   now.setHours(0, 0, 0, 0);
 
-  const shifts = await prisma.crewShift.findMany({
-    where: {
-      status: "SCHEDULED",
-      date: { gte: now },
-      assignment: { organizationId },
-    },
-    include: {
-      assignment: {
-        include: {
-          crewMember: { select: { firstName: true, lastName: true } },
-          crewRole: { select: { name: true } },
-          project: { select: { name: true, projectNumber: true } },
-        },
-      },
-    },
-    orderBy: { date: "asc" },
-    take: 10,
+  const [assignments, members, roleMap, projects] = await Promise.all([
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const orgAssignmentIds = new Set(assignments.map((a) => a.id));
+  const assignmentById = new Map(assignments.map((a) => [a.id, a]));
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const shifts = await getShiftsByAssignmentIds([...orgAssignmentIds]);
+  const selected = selectUpcomingShifts(shifts, orgAssignmentIds, now);
+
+  const result = selected.map((s) => {
+    const assignment = assignmentById.get(s.assignmentId) ?? null;
+    const member = assignment ? memberById.get(assignment.crewMemberId) ?? null : null;
+    const role = assignment?.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+    const project = assignment ? projectMini(projectsById, assignment.projectId) : null;
+    return {
+      ...s,
+      assignment: assignment
+        ? {
+            ...assignment,
+            crewMember: member ? { firstName: member.firstName, lastName: member.lastName } : null,
+            crewRole: role ? { name: role.name } : null,
+            project: project ? { name: project.name, projectNumber: project.projectNumber } : null,
+          }
+        : null,
+    };
   });
 
-  return serialize(shifts);
+  return serialize(result);
 }

--- a/src/server/crew-time.ts
+++ b/src/server/crew-time.ts
@@ -14,6 +14,17 @@ import {
   removeCrewTimeEntryFromConvex,
   syncCrewTimeEntriesToConvex,
 } from "@/lib/crew-scheduling-mirror";
+import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getProjectsByOrg } from "@/lib/projects-read";
+import {
+  getTimeEntriesByOrg,
+  getAssignmentsByOrg,
+  filterTimeEntries,
+  sortTimeEntries,
+  paginate,
+  sortTimeEntriesDateThenStartDesc,
+  type MappedCrewTimeEntry,
+} from "@/lib/crew-scheduling-read";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -28,6 +39,24 @@ function calculateTotalHours(
   const endMins = eh * 60 + em;
   const worked = endMins - startMins - breakMinutes;
   return Math.max(0, Math.round(worked * 100 / 60) / 100);
+}
+
+// ─── Read-side join helpers (Convex reads + batched auth-User join) ───────────
+
+/**
+ * Batched Better Auth `User.name` lookup for the `approvedBy` join — User stays in
+ * Postgres (auth is not migrated to Convex). One query for all approver ids.
+ */
+async function getApproverNameMap(
+  entries: MappedCrewTimeEntry[],
+): Promise<Map<string, string | null>> {
+  const ids = [...new Set(entries.map((e) => e.approvedById).filter((id): id is string => !!id))];
+  if (ids.length === 0) return new Map();
+  const users = await prisma.user.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, name: true },
+  });
+  return new Map(users.map((u) => [u.id, u.name ?? null]));
 }
 
 // ─── Queries ────────────────────────────────────────────────────────────────
@@ -47,55 +76,54 @@ export async function getAllTimeEntries(params?: {
   const sortBy = params?.sortBy || "date";
   const sortOrder = params?.sortOrder || "desc";
 
-  const where: Record<string, unknown> = { organizationId };
-
-  // Search
-  if (params?.search) {
-    where.OR = [
-      { crewMember: { firstName: { contains: params.search, mode: "insensitive" } } },
-      { crewMember: { lastName: { contains: params.search, mode: "insensitive" } } },
-      { description: { contains: params.search, mode: "insensitive" } },
-      { assignment: { project: { name: { contains: params.search, mode: "insensitive" } } } },
-      { assignment: { project: { projectNumber: { contains: params.search, mode: "insensitive" } } } },
-    ];
-  }
-
-  // Filters
-  if (params?.filters) {
-    const f = params.filters as Record<string, string[]>;
-    if (f.status?.length) where.status = { in: f.status };
-    if (f.crewMemberId?.length) where.crewMemberId = { in: f.crewMemberId };
-  }
-
-  // Sort mapping
-  const orderByMap: Record<string, unknown> = {
-    date: { date: sortOrder },
-    crewMember: { crewMember: { lastName: sortOrder } },
-    startTime: { startTime: sortOrder },
-    totalHours: { totalHours: sortOrder },
-    status: { status: sortOrder },
-  };
-  const orderBy = orderByMap[sortBy] || { date: sortOrder };
-
-  const [entries, total] = await Promise.all([
-    prisma.crewTimeEntry.findMany({
-      where,
-      include: {
-        crewMember: { select: { id: true, firstName: true, lastName: true } },
-        assignment: {
-          include: {
-            project: { select: { id: true, name: true, projectNumber: true } },
-            crewRole: { select: { name: true } },
-          },
-        },
-        approvedBy: { select: { name: true } },
-      },
-      orderBy: sortBy === "date" ? [orderBy as Record<string, string>, { startTime: "desc" }] : [orderBy as Record<string, string>],
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.crewTimeEntry.count({ where }),
+  const [allEntries, assignments, members, roleMap, projects] = await Promise.all([
+    getTimeEntriesByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
   ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const assignmentById = new Map(assignments.map((a) => [a.id, a]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const nameOf = (e: MappedCrewTimeEntry) => {
+    const m = memberById.get(e.crewMemberId);
+    return { firstName: m?.firstName ?? "", lastName: m?.lastName ?? "" };
+  };
+  const projectOf = (e: MappedCrewTimeEntry) => {
+    const a = e.assignmentId ? assignmentById.get(e.assignmentId) : null;
+    const p = a ? projectsById.get(a.projectId) : null;
+    return p ? { name: p.name, projectNumber: p.projectNumber } : null;
+  };
+
+  const filtered = filterTimeEntries(allEntries, params, { nameOf, projectOf });
+  const sorted = sortTimeEntries(filtered, sortBy, sortOrder, {
+    lastNameOf: (e) => memberById.get(e.crewMemberId)?.lastName,
+  });
+  const total = filtered.length;
+  const pageEntries = paginate(sorted, page, pageSize);
+
+  const approverNames = await getApproverNameMap(pageEntries);
+
+  const entries = pageEntries.map((e) => {
+    const member = memberById.get(e.crewMemberId) ?? null;
+    const assignment = e.assignmentId ? assignmentById.get(e.assignmentId) ?? null : null;
+    const project = assignment ? projectsById.get(assignment.projectId) ?? null : null;
+    const role = assignment?.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+    return {
+      ...e,
+      crewMember: member ? { id: member.id, firstName: member.firstName, lastName: member.lastName } : null,
+      assignment: assignment
+        ? {
+            ...assignment,
+            project: project ? { id: project.id, name: project.name, projectNumber: project.projectNumber } : null,
+            crewRole: role ? { name: role.name } : null,
+          }
+        : null,
+      approvedBy: e.approvedById ? { name: approverNames.get(e.approvedById) ?? null } : null,
+    };
+  });
 
   return serialize({ entries, total });
 }
@@ -103,24 +131,39 @@ export async function getAllTimeEntries(params?: {
 export async function getTimeEntriesForMember(crewMemberId: string) {
   const { organizationId } = await getOrgContext();
 
-  const member = await prisma.crewMember.findUnique({
-    where: { id: crewMemberId, organizationId },
-    select: { id: true },
-  });
+  const [allEntries, assignments, members, roleMap, projects] = await Promise.all([
+    getTimeEntriesByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+    getProjectsByOrg(organizationId),
+  ]);
+  const member = members.find((m) => m.id === crewMemberId);
   if (!member) throw new Error("Crew member not found");
 
-  const entries = await prisma.crewTimeEntry.findMany({
-    where: { crewMemberId, organizationId },
-    include: {
-      assignment: {
-        include: {
-          project: { select: { name: true, projectNumber: true } },
-          crewRole: { select: { name: true } },
-        },
-      },
-      approvedBy: { select: { name: true } },
-    },
-    orderBy: [{ date: "desc" }, { startTime: "desc" }],
+  const assignmentById = new Map(assignments.map((a) => [a.id, a]));
+  const projectsById = new Map(projects.map((p) => [p.id, p]));
+
+  const sorted = sortTimeEntriesDateThenStartDesc(
+    allEntries.filter((e) => e.crewMemberId === crewMemberId),
+  );
+  const approverNames = await getApproverNameMap(sorted);
+
+  const entries = sorted.map((e) => {
+    const assignment = e.assignmentId ? assignmentById.get(e.assignmentId) ?? null : null;
+    const project = assignment ? projectsById.get(assignment.projectId) ?? null : null;
+    const role = assignment?.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+    return {
+      ...e,
+      assignment: assignment
+        ? {
+            ...assignment,
+            project: project ? { name: project.name, projectNumber: project.projectNumber } : null,
+            crewRole: role ? { name: role.name } : null,
+          }
+        : null,
+      approvedBy: e.approvedById ? { name: approverNames.get(e.approvedById) ?? null } : null,
+    };
   });
 
   return serialize(entries);
@@ -129,21 +172,38 @@ export async function getTimeEntriesForMember(crewMemberId: string) {
 export async function getTimeEntriesForProject(projectId: string) {
   const { organizationId } = await getOrgContext();
 
-  const entries = await prisma.crewTimeEntry.findMany({
-    where: {
-      organizationId,
-      assignment: { projectId },
-    },
-    include: {
-      crewMember: { select: { firstName: true, lastName: true } },
-      assignment: {
-        include: {
-          crewRole: { select: { name: true } },
-        },
-      },
-      approvedBy: { select: { name: true } },
-    },
-    orderBy: [{ date: "desc" }, { startTime: "desc" }],
+  const [allEntries, assignments, members, roleMap] = await Promise.all([
+    getTimeEntriesByOrg(organizationId),
+    getAssignmentsByOrg(organizationId),
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+  ]);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const assignmentById = new Map(assignments.map((a) => [a.id, a]));
+  const projectAssignmentIds = new Set(
+    assignments.filter((a) => a.projectId === projectId).map((a) => a.id),
+  );
+
+  const sorted = sortTimeEntriesDateThenStartDesc(
+    allEntries.filter((e) => e.assignmentId != null && projectAssignmentIds.has(e.assignmentId)),
+  );
+  const approverNames = await getApproverNameMap(sorted);
+
+  const entries = sorted.map((e) => {
+    const member = memberById.get(e.crewMemberId) ?? null;
+    const assignment = e.assignmentId ? assignmentById.get(e.assignmentId) ?? null : null;
+    const role = assignment?.crewRoleId ? roleMap.get(assignment.crewRoleId) ?? null : null;
+    return {
+      ...e,
+      crewMember: member ? { firstName: member.firstName, lastName: member.lastName } : null,
+      assignment: assignment
+        ? {
+            ...assignment,
+            crewRole: role ? { name: role.name } : null,
+          }
+        : null,
+      approvedBy: e.approvedById ? { name: approverNames.get(e.approvedById) ?? null } : null,
+    };
   });
 
   return serialize(entries);


### PR DESCRIPTION
Phase A read-rewiring for the **crew scheduling** surface: the pure read-only server actions now read `crewAssignment` / `crewShift` / `crewAvailability` / `crewTimeEntry` from **Convex** instead of Prisma, via a new `src/lib/crew-scheduling-read.ts`.

## Pattern
Thin Convex fetchers + mappers (epoch-ms→Date — `serialize()` keeps Date, so this preserves the old Prisma-row shape; absent→null; Prisma-defaulted columns coerced non-null; `_id`/`_creationTime` stripped; money/hours stay numbers — Convex has no Decimal) + **pure unit-tested** filter/sort/aggregate/overlap functions replicating each Prisma `where`/`orderBy`/`aggregate`. Postgres enum columns sort by DECLARED order (rank map); ASC = NULLS LAST, DESC = NULLS FIRST. **No Prisma fallback on a Convex map miss** (a miss reads null, like a join against a deleted row).

## Converted (per file)
- **crew-dashboard.ts:** `getCrewPickerList`, `getCrewDashboardStats` (counts/aggregate over member+assignment+timeEntry, computed in JS), `getPendingTimeEntries`, `getActiveAssignmentsSummary`, `getPendingOffers`, `getUpcomingShifts`
- **crew-time.ts:** `getAllTimeEntries` (JS search/status+crewMember filter/sort/paginate + count), `getTimeEntriesForMember`, `getTimeEntriesForProject`
- **crew-assignments.ts:** `getProjectCrew` (assignment + shift + member + role + ProjectService + confirmedBy), `getProjectLabourCost` (JS sum+count aggregate), `getCrewMembersForAssignment` (members from Convex + JS date-overlap cross-project conflicts + UNAVAILABLE availability set — **converted; stayed clean**)
- **crew-availability.ts:** `getCrewAvailability`, `getCrewPlannerData`, `getCrewAvailabilityStatus`
- **crew-calendar.ts:** `getIcalSettings` (crewMember icalEnabled/icalToken), `getAssignmentIcsData` (assignment + member + role + project + location + shifts)

Cross-domain joins reuse `crew-read.ts` (member/role maps), `projects-read.ts` (project name/number/status), `locations-read.ts` (ics location).

## Stayed on Prisma (intentional)
All writes (clock/approve/dispute, create/update/delete assignment+shift+availability, ical token writes); all read-then-write (`createTimeEntry`/`updateTimeEntry` in-action verify reads, `checkCrewConflicts` overlap-check-before-create, `exportTimesheetCSV` read sitting among the write CRUD); Better Auth `User` joins (`approvedBy` / `confirmedBy` — batched `prisma.user`); `crew-communication.ts` (out of scope).

## New Convex queries
- `crewShifts.listByAssignmentIds` — shifts have no org column; scoped by the org-fetched assignment id set (service-only, like the other shift reads).
- `crewAvailabilities.listByCrewMemberIds` — `organizationId` is OPTIONAL on availability, so this uses the `by_crewMemberId` access path (caller has already org-scoped the member ids), per the gate note.

(No `convex/_generated` edits — both auto-type via `typeof import`.)

## DEPLOY GATE (do NOT merge until satisfied)
`convex:backfill:crew-scheduling` **and** `convex-backfill-crew-availability-org` must run against **prod Convex** before this read deploys, else existing rows read empty. Human-gated on the Coolify PR preview (Convex data-correctness can't be verified in a dev worktree).

## Validation
- `tsc --noEmit`: exit 0
- `vitest run` (full suite): 2039 passed (incl. 33 new pure-function tests in `crew-scheduling-read.test.ts`)
- `eslint` (all changed files): exit 0
- `pnpm run build`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)