### PR TITLE
feat(convex): read kits (primary reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,40 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **kits (primary reads)** (`server/kits.ts` → extends `src/lib/kits-read.ts`).
+  Only `canDeleteKit` moved: its kit-row read (`prisma.kit.findUnique` →
+  `getKitById`) now reads the dual-written Convex `kits` doc, and its decision
+  logic became two pure, unit-tested helpers — `coerceKitDeletabilityRow` (the
+  Convex doc declares `status`/`isActive` as `v.optional`, so coerce to the Prisma
+  `@default(AVAILABLE)` / `@default(true)`) and `computeKitDeletability` (a
+  byte-for-byte port of the archive/hard-delete predicate + reason copy). The
+  `prisma.projectLineItem.count` reference check stays on Prisma — keystone
+  project-line-item tree is not migrated yet — and is passed into the pure helper.
+  Org scoping moved to a `convexKit.organizationId !== organizationId` guard (the
+  Prisma `where` filtered by org; Convex `getById` is keyed by cuid only). **Left
+  on Prisma + why:** `getKit` (detail-page media composite — joins
+  lineItems→project, scanLogs→`scannedBy` Better Auth User, maintenanceRecords,
+  category, location, media→file; documented terminus, stays Prisma forever — the
+  reactive trigger is `convex/kitDetail.ts`'s version vector); `getKitCounts` /
+  `getAvailableAssetsForKit` / `getAvailableBulkAssetsForKit` (handled by sibling
+  PR #237); every kit-composition mutation's leading `prisma.kit.findUnique`
+  status guard + the `kitSerializedItem`/`kitBulkItem` add/remove and
+  `kitCheckItem` cleanup reads (all read-then-write inside the same mutation). No
+  new Convex query (reused `api.kits.getById`); no `convex/_generated` changes.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/kits-read.test.ts
+++ b/src/lib/kits-read.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the pure kit read-rewiring helpers (Phase A).
+ *
+ * `coerceKitDeletabilityRow` reproduces the Prisma column defaults that the
+ * Convex-optional `status`/`isActive` fields lose, and `computeKitDeletability`
+ * is a byte-for-byte port of the decision logic that used to live inline in the
+ * `canDeleteKit` server action (the ProjectLineItem reference count is supplied
+ * by the caller — it stays on Prisma until the keystone tree migrates).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  coerceKitDeletabilityRow,
+  computeKitDeletability,
+  type ConvexKit,
+} from "@/lib/kits-read";
+
+function kit(overrides: Partial<ConvexKit> = {}): ConvexKit {
+  return {
+    _id: "x" as ConvexKit["_id"],
+    _creationTime: 0,
+    id: "k1",
+    organizationId: "org1",
+    assetTag: "K-001",
+    name: "Kit",
+    status: "AVAILABLE",
+    isActive: true,
+    ...overrides,
+  } as ConvexKit;
+}
+
+describe("coerceKitDeletabilityRow", () => {
+  it("passes through explicit status/isActive", () => {
+    expect(coerceKitDeletabilityRow(kit({ status: "CHECKED_OUT", isActive: false }))).toEqual({
+      id: "k1",
+      status: "CHECKED_OUT",
+      isActive: false,
+    });
+  });
+
+  it("coerces absent status to AVAILABLE and absent isActive to true (Prisma defaults)", () => {
+    expect(
+      coerceKitDeletabilityRow(kit({ status: undefined, isActive: undefined })),
+    ).toEqual({ id: "k1", status: "AVAILABLE", isActive: true });
+  });
+
+  it("keeps isActive=false (a falsey value, not absence)", () => {
+    expect(coerceKitDeletabilityRow(kit({ isActive: false })).isActive).toBe(false);
+  });
+});
+
+describe("computeKitDeletability", () => {
+  it("allows archive + hard delete for an AVAILABLE, active, unreferenced kit", () => {
+    expect(
+      computeKitDeletability({ id: "k1", status: "AVAILABLE", isActive: true }, 0),
+    ).toEqual({
+      canArchive: true,
+      canHardDelete: true,
+      referencingLineItems: 0,
+      reason: undefined,
+    });
+  });
+
+  it("allows archive but blocks hard delete when referenced (singular pluralisation)", () => {
+    const r = computeKitDeletability({ id: "k1", status: "AVAILABLE", isActive: true }, 1);
+    expect(r.canArchive).toBe(true);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.referencingLineItems).toBe(1);
+    expect(r.reason).toBe(
+      "Kit is referenced by 1 project line item. Archive it instead, or remove it from those projects first.",
+    );
+  });
+
+  it("blocks hard delete with plural copy for multiple references", () => {
+    const r = computeKitDeletability({ id: "k1", status: "AVAILABLE", isActive: true }, 3);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.reason).toBe(
+      "Kit is referenced by 3 project line items. Archive it instead, or remove it from those projects first.",
+    );
+  });
+
+  it("blocks both when status is not AVAILABLE, naming the status", () => {
+    const r = computeKitDeletability({ id: "k1", status: "CHECKED_OUT", isActive: true }, 0);
+    expect(r.canArchive).toBe(false);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.reason).toBe(
+      "Kit status is CHECKED_OUT — only AVAILABLE kits can be archived or deleted.",
+    );
+  });
+
+  it("reports an already-archived kit when AVAILABLE but inactive", () => {
+    const r = computeKitDeletability({ id: "k1", status: "AVAILABLE", isActive: false }, 0);
+    expect(r.canArchive).toBe(false);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.reason).toBe("Kit is already archived.");
+  });
+
+  it("status-not-AVAILABLE message takes precedence over the reference message", () => {
+    const r = computeKitDeletability({ id: "k1", status: "RETIRED", isActive: true }, 5);
+    expect(r.reason).toBe(
+      "Kit status is RETIRED — only AVAILABLE kits can be archived or deleted.",
+    );
+  });
+});

--- a/src/lib/kits-read.ts
+++ b/src/lib/kits-read.ts
@@ -36,3 +36,66 @@ export async function getKitMap(orgId: string): Promise<Map<string, ConvexKit>> 
 export async function getKitByAssetTag(orgId: string, assetTag: string): Promise<ConvexKit | null> {
   return await (await getConvexClient()).query(api.kits.getByAssetTag, { organizationId: orgId, assetTag });
 }
+
+// ---------------------------------------------------------------------------
+// canDeleteKit predicate (Phase A read-rewiring)
+// ---------------------------------------------------------------------------
+/**
+ * The Convex `kits` doc declares `status`/`isActive` as `v.optional` (a row that
+ * predates the column, or one mirrored before the field was set, reads
+ * `undefined`). Prisma defaults them (`status @default(AVAILABLE)`,
+ * `isActive @default(true)`), so coerce to those defaults to match what the
+ * Prisma read returned.
+ */
+export type KitDeletabilityRow = {
+  id: string;
+  status: ConvexKit["status"];
+  isActive: boolean;
+};
+
+/** Coerce the Convex-optional status/isActive to their Prisma defaults. */
+export function coerceKitDeletabilityRow(kit: ConvexKit): KitDeletabilityRow {
+  return {
+    id: kit.id,
+    status: kit.status ?? "AVAILABLE",
+    isActive: kit.isActive ?? true,
+  };
+}
+
+export type KitDeletability = {
+  canArchive: boolean;
+  canHardDelete: boolean;
+  referencingLineItems: number;
+  reason?: string;
+};
+
+/**
+ * Pure replication of `canDeleteKit`'s decision logic. `referencingLineItems`
+ * is supplied by the caller — it comes from `prisma.projectLineItem.count`,
+ * which stays on Prisma until the keystone project-line-item tree migrates
+ * (see FEATUREDOCS/54). The kit row itself comes from Convex.
+ */
+export function computeKitDeletability(
+  kit: KitDeletabilityRow,
+  referencingLineItems: number,
+): KitDeletability {
+  // Archive is allowed whenever the kit is AVAILABLE (matches archiveKit guard).
+  const canArchive = kit.status === "AVAILABLE" && kit.isActive;
+
+  // Hard delete adds two extra constraints: (a) no ProjectLineItem references,
+  // (b) AVAILABLE status. This prevents losing historical project data.
+  const canHardDelete =
+    kit.status === "AVAILABLE" && kit.isActive && referencingLineItems === 0;
+
+  let reason: string | undefined;
+  if (!canArchive) {
+    reason =
+      kit.status !== "AVAILABLE"
+        ? `Kit status is ${kit.status} — only AVAILABLE kits can be archived or deleted.`
+        : "Kit is already archived.";
+  } else if (!canHardDelete) {
+    reason = `Kit is referenced by ${referencingLineItems} project line item${referencingLineItems === 1 ? "" : "s"}. Archive it instead, or remove it from those projects first.`;
+  }
+
+  return { canArchive, canHardDelete, referencingLineItems, reason };
+}

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -27,6 +27,7 @@ import { removeKitCheckItemFromConvex } from "@/lib/check-item-assignment-mirror
 import { syncMediaForParent } from "@/lib/media-mirror";
 import { getPrimaryPhotoMap } from "@/lib/media-read";
 import { getModelById, getModelMap } from "@/lib/models-read";
+import { getKitById, coerceKitDeletabilityRow, computeKitDeletability } from "@/lib/kits-read";
 
 /**
  * Per-kit member-item counts + primary photo (kitId -> meta).
@@ -297,33 +298,22 @@ export async function archiveKit(id: string) {
 export async function canDeleteKit(id: string) {
   const { organizationId } = await requirePermission("kit", "delete");
 
-  const kit = await prisma.kit.findUnique({
-    where: { id, organizationId },
-    select: { id: true, status: true, isActive: true },
-  });
-  if (!kit) throw new Error("Kit not found");
+  // The kit row comes off Convex (the dual-written reactive mirror); a miss
+  // reads null with no Prisma fallback (a fallback would mask mirror drift).
+  const convexKit = await getKitById(id);
+  if (!convexKit || convexKit.organizationId !== organizationId) {
+    throw new Error("Kit not found");
+  }
 
-  // Archive is allowed whenever the kit is AVAILABLE (matches archiveKit guard).
-  const canArchive = kit.status === "AVAILABLE" && kit.isActive;
-
-  // Hard delete adds two extra constraints: (a) no ProjectLineItem references,
-  // (b) AVAILABLE status. This prevents losing historical project data.
+  // ProjectLineItem references stay on Prisma until the keystone
+  // project-line-item tree migrates (see FEATUREDOCS/54).
   const referencingLineItems = await prisma.projectLineItem.count({
     where: { kitId: id, organizationId },
   });
 
-  const canHardDelete = kit.status === "AVAILABLE" && kit.isActive && referencingLineItems === 0;
-  let reason: string | undefined;
-
-  if (!canArchive) {
-    reason = kit.status !== "AVAILABLE"
-      ? `Kit status is ${kit.status} — only AVAILABLE kits can be archived or deleted.`
-      : "Kit is already archived.";
-  } else if (!canHardDelete) {
-    reason = `Kit is referenced by ${referencingLineItems} project line item${referencingLineItems === 1 ? "" : "s"}. Archive it instead, or remove it from those projects first.`;
-  }
-
-  return serialize({ canArchive, canHardDelete, referencingLineItems, reason });
+  return serialize(
+    computeKitDeletability(coerceKitDeletabilityRow(convexKit), referencingLineItems),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase A read-rewiring for the **kits** surface. `server/kits.ts` turned out to
have only **one** genuine pure read-only action not already handled by sibling
PR #237 and not a documented terminus: **`canDeleteKit`**. Its kit-row read is
rewired from `prisma.kit.findUnique` to the dual-written Convex `kits` doc via
`getKitById`, and its decision logic is extracted into two pure, unit-tested
helpers in `src/lib/kits-read.ts`:

- **`coerceKitDeletabilityRow`** — the Convex doc declares `status`/`isActive` as
  `v.optional`, so coerce absent values to the Prisma column defaults
  (`status @default(AVAILABLE)`, `isActive @default(true)`).
- **`computeKitDeletability`** — a byte-for-byte port of the archive / hard-delete
  predicate and its `reason` copy (including singular/plural line-item wording and
  the status-precedence ordering).

The `prisma.projectLineItem.count` reference check **stays on Prisma** (keystone
project-line-item tree is not migrated yet) and is passed into the pure helper.
Org scoping moves to an explicit `convexKit.organizationId !== organizationId`
guard, since Convex `getById` is keyed by cuid only. **No Prisma fallback** on a
Convex miss.

## Left on Prisma (intentional, documented in FEATUREDOCS/54)

- **`getKit`** — detail-page media composite terminus (joins lineItems→project,
  scanLogs→`scannedBy` Better Auth User, maintenanceRecords, category, location,
  media→file). Stays Prisma forever; reactivity comes from `convex/kitDetail.ts`'s
  version vector.
- **`getKitCounts` / `getAvailableAssetsForKit` / `getAvailableBulkAssetsForKit`** —
  handled by sibling PR #237.
- All kit-composition **read-then-write** paths (each mutation's leading
  `prisma.kit.findUnique` status guard, the `kitSerializedItem`/`kitBulkItem`
  add/remove, `kitCheckItem` cleanup) — feed a write in the same action.

## Changes

- No new Convex query (reuses `api.kits.getById`); **no `convex/_generated`
  changes**.
- New unit tests: `src/lib/kits-read.test.ts` (9 cases covering coercion +
  every predicate/reason branch).
- FEATUREDOCS/54: new "Phase A read-rewiring — leaf surfaces" section + the kits
  bullet.

## Validation

- `pnpm exec tsc --noEmit` — clean (exit 0)
- `pnpm exec vitest run src/lib/kits-read.test.ts` — 9/9 pass
- `pnpm exec eslint <changed files>` — 0 errors (3 pre-existing `_asset`/`_bulkAsset`
  unused-var warnings in untouched mutation code)

## Deploy gate

Merge gate is the standard Phase A deploy-ordering gate: the `kit` table must be
backfilled into **prod Convex** before this read deploys (it is — kits are
dual-written + backfilled). Human-gated on a Coolify PR preview against prod
Convex (Convex data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)