### PR TITLE
feat(convex): read models (primary reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,39 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **models (primary reads)** (`server/models.ts` → extends `src/lib/models-read.ts`).
+  `getModels` (the paginated list/filter/sort surface) moved off
+  `prisma.model.findMany`+`count` to the Convex `models.list` mirror: new pure,
+  unit-tested helpers `mapConvexModelToRow` (strips `_id`/`_creationTime`,
+  epoch-ms→Date, coerces defaulted `images`/`manuals`/`tags`/`assetType`/
+  `requiresTestAndTag`/`isActive`), `filterModels` (isActive/categoryId/assetType +
+  case-insensitive name/manufacturer/modelNumber/sku search), `sortModels`
+  (Postgres NULLS-LAST asc / NULLS-FIRST desc; `assetType` by DECLARED enum order
+  via rank map; `category` by resolved category name), `paginateModels`. Nested
+  `category` attached from the Convex category map; per-model `_count.assets/bulkAssets`
+  off the asset/bulkAsset mirror and primary photo off the modelMedia mirror (same
+  sources as `getModelCounts`). No new Convex query — reuses the existing
+  `api.models.list`. `getModelCounts` was already Convex-only (no change). **Left on
+  Prisma:** `getModel` (detail-page media composite — assets+location / bulkAssets+
+  location / media+file / bulkAccessories+bulkAsset cross-domain query: documented
+  terminus); and the read-then-write reads inside `createModel`/`updateModel`/
+  `archiveModel`/`bulkUpdateRates` (`asset.findMany`, `bulkAsset.findMany`,
+  `model.findMany`, `testTagAsset.findMany` whose results feed a same-action
+  mutation). Better Auth joins: none in this surface.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/models-read.test.ts
+++ b/src/lib/models-read.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapConvexModelToRow,
+  filterModels,
+  sortModels,
+  paginateModels,
+  type ConvexModel,
+  type ModelRow,
+} from "./models-read";
+
+/** Minimal Convex `models` doc factory for tests. */
+function convexModel(overrides: Partial<ConvexModel> = {}): ConvexModel {
+  return {
+    _id: "convex_id" as ConvexModel["_id"],
+    _creationTime: 1_700_000_000_000,
+    id: "m1",
+    organizationId: "org1",
+    name: "Model 1",
+    assetType: "SERIALIZED",
+    isActive: true,
+    requiresTestAndTag: false,
+    images: ["a.jpg"],
+    manuals: [],
+    tags: ["x"],
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_001_000,
+    ...overrides,
+  } as ConvexModel;
+}
+
+function row(overrides: Partial<ModelRow> = {}): ModelRow {
+  return mapConvexModelToRow(convexModel(overrides as Partial<ConvexModel>));
+}
+
+describe("mapConvexModelToRow", () => {
+  it("strips Convex system fields and converts epoch-ms to Date", () => {
+    const r = mapConvexModelToRow(convexModel());
+    expect((r as Record<string, unknown>)._id).toBeUndefined();
+    expect((r as Record<string, unknown>)._creationTime).toBeUndefined();
+    expect(r.createdAt).toBeInstanceOf(Date);
+    expect(r.createdAt.getTime()).toBe(1_700_000_000_000);
+    expect(r.updatedAt.getTime()).toBe(1_700_000_001_000);
+  });
+
+  it("coerces Prisma-defaulted columns when absent", () => {
+    const r = mapConvexModelToRow(
+      convexModel({
+        images: undefined,
+        manuals: undefined,
+        tags: undefined,
+        assetType: undefined,
+        requiresTestAndTag: undefined,
+        isActive: undefined,
+      }),
+    );
+    expect(r.images).toEqual([]);
+    expect(r.manuals).toEqual([]);
+    expect(r.tags).toEqual([]);
+    expect(r.assetType).toBe("SERIALIZED");
+    expect(r.requiresTestAndTag).toBe(false);
+    expect(r.isActive).toBe(true);
+  });
+
+  it("preserves provided values", () => {
+    const r = mapConvexModelToRow(
+      convexModel({ assetType: "BULK", isActive: false, tags: ["t1", "t2"] }),
+    );
+    expect(r.assetType).toBe("BULK");
+    expect(r.isActive).toBe(false);
+    expect(r.tags).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("filterModels", () => {
+  const models = [
+    row({ id: "a", name: "Sony FX3", manufacturer: "Sony", categoryId: "cam", assetType: "SERIALIZED", isActive: true }),
+    row({ id: "b", name: "Cable XLR", manufacturer: "Neutrik", categoryId: "cbl", assetType: "BULK", isActive: true }),
+    row({ id: "c", name: "Old Light", manufacturer: "Arri", categoryId: "lig", assetType: "SERIALIZED", isActive: false }),
+    row({ id: "d", name: "Sony A7", manufacturer: "Sony", sku: "SONY-A7", categoryId: "cam", assetType: "SERIALIZED", isActive: true }),
+  ];
+
+  it("defaults to isActive=true", () => {
+    const out = filterModels(models, {});
+    expect(out.map((m) => m.id)).toEqual(["a", "b", "d"]);
+  });
+
+  it("filters by isActive=false", () => {
+    const out = filterModels(models, { isActive: false });
+    expect(out.map((m) => m.id)).toEqual(["c"]);
+  });
+
+  it("filters by categoryId", () => {
+    const out = filterModels(models, { categoryId: "cam" });
+    expect(out.map((m) => m.id)).toEqual(["a", "d"]);
+  });
+
+  it("filters by assetType", () => {
+    const out = filterModels(models, { assetType: "BULK" });
+    expect(out.map((m) => m.id)).toEqual(["b"]);
+  });
+
+  it("case-insensitive search across name/manufacturer/modelNumber/sku", () => {
+    expect(filterModels(models, { search: "sony" }).map((m) => m.id)).toEqual(["a", "d"]);
+    expect(filterModels(models, { search: "NEUTRIK" }).map((m) => m.id)).toEqual(["b"]);
+    expect(filterModels(models, { search: "sony-a7" }).map((m) => m.id)).toEqual(["d"]);
+  });
+
+  it("combines filters with AND semantics", () => {
+    const out = filterModels(models, { categoryId: "cam", search: "a7" });
+    expect(out.map((m) => m.id)).toEqual(["d"]);
+  });
+});
+
+describe("sortModels", () => {
+  it("sorts by name asc (default) case-insensitively", () => {
+    const models = [row({ id: "1", name: "banana" }), row({ id: "2", name: "Apple" }), row({ id: "3", name: "cherry" })];
+    expect(sortModels(models, "name", "asc").map((m) => m.name)).toEqual(["Apple", "banana", "cherry"]);
+  });
+
+  it("sorts by name desc", () => {
+    const models = [row({ id: "1", name: "banana" }), row({ id: "2", name: "apple" })];
+    expect(sortModels(models, "name", "desc").map((m) => m.name)).toEqual(["banana", "apple"]);
+  });
+
+  it("numeric columns compare numerically with NULLS LAST asc", () => {
+    const models = [
+      row({ id: "1", dailyRate: 100 }),
+      row({ id: "2", dailyRate: undefined }),
+      row({ id: "3", dailyRate: 20 }),
+    ];
+    expect(sortModels(models, "dailyRate", "asc").map((m) => m.id)).toEqual(["3", "1", "2"]);
+  });
+
+  it("numeric columns put NULLS FIRST on desc", () => {
+    const models = [
+      row({ id: "1", dailyRate: 100 }),
+      row({ id: "2", dailyRate: undefined }),
+      row({ id: "3", dailyRate: 20 }),
+    ];
+    expect(sortModels(models, "dailyRate", "desc").map((m) => m.id)).toEqual(["2", "1", "3"]);
+  });
+
+  it("assetType sorts by declared enum order (SERIALIZED < BULK), not alphabetical", () => {
+    const models = [row({ id: "1", assetType: "BULK" }), row({ id: "2", assetType: "SERIALIZED" })];
+    expect(sortModels(models, "assetType", "asc").map((m) => m.id)).toEqual(["2", "1"]);
+  });
+
+  it("category sorts by resolved category name with NULLS LAST asc", () => {
+    const models = [
+      row({ id: "1", categoryId: "z" }),
+      row({ id: "2", categoryId: undefined }),
+      row({ id: "3", categoryId: "a" }),
+    ];
+    const names: Record<string, string> = { z: "Zoom", a: "Audio" };
+    const out = sortModels(models, "category", "asc", (m) => (m.categoryId ? names[m.categoryId] ?? null : null));
+    expect(out.map((m) => m.id)).toEqual(["3", "1", "2"]);
+  });
+});
+
+describe("paginateModels", () => {
+  const rows = [1, 2, 3, 4, 5];
+  it("returns the requested 1-based page", () => {
+    expect(paginateModels(rows, 1, 2)).toEqual([1, 2]);
+    expect(paginateModels(rows, 2, 2)).toEqual([3, 4]);
+    expect(paginateModels(rows, 3, 2)).toEqual([5]);
+  });
+  it("returns empty past the end", () => {
+    expect(paginateModels(rows, 4, 2)).toEqual([]);
+  });
+});

--- a/src/lib/models-read.ts
+++ b/src/lib/models-read.ts
@@ -77,3 +77,157 @@ export async function attachModel<T extends { modelId: string | null }>(
     model: r.modelId ? map.get(r.modelId) ?? null : null,
   }));
 }
+
+/* ------------------------------------------------------------------------- *
+ * getModels list read — pure filter/sort/paginate over the Convex model list
+ *
+ * Replaces the Prisma `model.findMany` + `model.count` in
+ * `server/models.ts#getModels`. The Convex `models.list({orgId})` query returns
+ * ALL of an org's models (active + archived), so the Prisma `where`
+ * (isActive / categoryId / assetType / search) and `orderBy` are re-applied in
+ * JS here. Cross-domain `category` (dual-written) is attached via
+ * getModelWithCategoryMap; per-model asset/bulk counts + primary photo come off
+ * the already-Convex getModelCounts (assets/bulkAssets mirror + modelMedia
+ * mirror). No Prisma fallback on a Convex map miss.
+ * ------------------------------------------------------------------------- */
+
+/** A Convex model row reshaped to the Prisma `Model` row shape consumers expect:
+ *  epoch-ms timestamps → Date; Prisma-defaulted columns coerced non-null. */
+export type ModelRow = Omit<ConvexModel, "_id" | "_creationTime" | "createdAt" | "updatedAt"> & {
+  images: string[];
+  manuals: string[];
+  tags: string[];
+  assetType: "SERIALIZED" | "BULK";
+  requiresTestAndTag: boolean;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** Map a Convex `models` doc to the Prisma-row shape: strip Convex system fields,
+ *  convert epoch-ms → Date (serialize keeps Date), coerce Prisma-defaulted
+ *  columns (`images`/`manuals`/`tags`/`assetType`/`requiresTestAndTag`/
+ *  `isActive`) to their non-null defaults. */
+export function mapConvexModelToRow(m: ConvexModel): ModelRow {
+  const {
+    _id: _convexId,
+    _creationTime: _convexCreated,
+    createdAt,
+    updatedAt,
+    images,
+    manuals,
+    tags,
+    assetType,
+    requiresTestAndTag,
+    isActive,
+    ...rest
+  } = m;
+  void _convexId;
+  void _convexCreated;
+  return {
+    ...rest,
+    images: images ?? [],
+    manuals: manuals ?? [],
+    tags: tags ?? [],
+    assetType: assetType ?? "SERIALIZED",
+    requiresTestAndTag: requiresTestAndTag ?? false,
+    isActive: isActive ?? true,
+    createdAt: createdAt != null ? new Date(createdAt) : new Date(0),
+    updatedAt: updatedAt != null ? new Date(updatedAt) : new Date(0),
+  };
+}
+
+export interface ModelListFilter {
+  isActive?: boolean;
+  categoryId?: string;
+  assetType?: "SERIALIZED" | "BULK";
+  search?: string;
+}
+
+/** Replicate the Prisma `where` of getModels in JS: isActive (defaulted true),
+ *  optional categoryId / assetType, and the OR case-insensitive `contains`
+ *  search over name / manufacturer / modelNumber / sku. */
+export function filterModels(models: ModelRow[], filter: ModelListFilter): ModelRow[] {
+  const isActive = filter.isActive ?? true;
+  const search = filter.search?.toLowerCase().trim();
+  return models.filter((m) => {
+    if (m.isActive !== isActive) return false;
+    if (filter.categoryId && m.categoryId !== filter.categoryId) return false;
+    if (filter.assetType && m.assetType !== filter.assetType) return false;
+    if (search) {
+      const hay = [m.name, m.manufacturer, m.modelNumber, m.sku]
+        .filter((s): s is string => typeof s === "string")
+        .map((s) => s.toLowerCase());
+      if (!hay.some((s) => s.includes(search))) return false;
+    }
+    return true;
+  });
+}
+
+// Declared-order rank for the AssetType Postgres enum (sorts by DECLARED order,
+// not alphabetical). Keep in sync with prisma/schema.prisma `enum AssetType`.
+const ASSET_TYPE_RANK: Record<string, number> = { SERIALIZED: 0, BULK: 1 };
+
+/** Final (direction-applied) comparison of two possibly-null values with
+ *  Postgres null ordering: ASC = NULLS LAST, DESC = NULLS FIRST. The null
+ *  branches return their final sign directly (not direction-flipped by the
+ *  caller); only the non-null `cmp` result is oriented by `dir`. */
+function compareNullable(
+  av: unknown,
+  bv: unknown,
+  dir: "asc" | "desc",
+  cmp: (a: NonNullable<unknown>, b: NonNullable<unknown>) => number,
+): number {
+  const an = av == null;
+  const bn = bv == null;
+  if (an && bn) return 0;
+  // ASC → nulls last (null after non-null); DESC → nulls first (null before).
+  if (an) return dir === "asc" ? 1 : -1;
+  if (bn) return dir === "asc" ? -1 : 1;
+  return (dir === "desc" ? -1 : 1) * cmp(av as NonNullable<unknown>, bv as NonNullable<unknown>);
+}
+
+/** Replicate the Prisma `orderBy` of getModels. `sortBy === "category"` sorts by
+ *  the attached category name (provided via categoryNameOf); enum columns use a
+ *  declared-order rank; numeric columns compare numerically; everything else
+ *  compares as a case-insensitive string. Stable (Array.prototype.sort is). */
+export function sortModels(
+  models: ModelRow[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+  categoryNameOf?: (m: ModelRow) => string | null,
+): ModelRow[] {
+  const numericFields = new Set([
+    "defaultRentalPrice",
+    "dailyRate",
+    "weeklyRate",
+    "monthlyRate",
+    "defaultPurchasePrice",
+    "replacementCost",
+    "weight",
+    "powerDraw",
+    "maintenanceIntervalDays",
+    "testAndTagIntervalDays",
+  ]);
+  const valueOf = (m: ModelRow): unknown => {
+    if (sortBy === "category") return categoryNameOf ? categoryNameOf(m) : null;
+    if (sortBy === "assetType") return ASSET_TYPE_RANK[m.assetType] ?? null;
+    return (m as unknown as Record<string, unknown>)[sortBy];
+  };
+  const isNumeric = numericFields.has(sortBy) || sortBy === "assetType";
+  return [...models].sort((a, b) => {
+    const av = valueOf(a);
+    const bv = valueOf(b);
+    return compareNullable(av, bv, sortOrder, (x, y) =>
+      isNumeric
+        ? Number(x) - Number(y)
+        : String(x).localeCompare(String(y), undefined, { sensitivity: "base" }),
+    );
+  });
+}
+
+/** Slice a page (1-based) out of the sorted list. */
+export function paginateModels<T>(rows: T[], page: number, pageSize: number): T[] {
+  const start = (page - 1) * pageSize;
+  return rows.slice(start, start + pageSize);
+}

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -5,7 +5,15 @@ import { prisma } from "@/lib/prisma";
 import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { removeAssetFromConvex, removeBulkAssetFromConvex } from "@/lib/asset-mirror";
 import { getPrimaryPhotoMap } from "@/lib/media-read";
-import { getModelMap } from "@/lib/models-read";
+import {
+  getModelMap,
+  getModelsByOrg,
+  mapConvexModelToRow,
+  filterModels,
+  sortModels,
+  paginateModels,
+} from "@/lib/models-read";
+import { getCategoryMap } from "@/lib/categories-read";
 import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
 import { api } from "../../convex/_generated/api";
 import { serialize } from "@/lib/serialize";
@@ -16,7 +24,7 @@ import { backfillTestTagAssets } from "@/server/test-tag-assets";
 import { patchTestTagAssetInConvex } from "@/lib/test-tag-mirror";
 import { getOrgTestTagSettings } from "@/server/settings";
 import { logActivity } from "@/lib/activity-log";
-import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/table-utils";
+import type { FilterValue } from "@/lib/table-utils";
 
 // Models are DUAL-WRITTEN: every create/update/archive writes the Prisma `model`
 // row (the durable FK anchor — asset/bulk_asset hold a required + Restrict FK;
@@ -44,11 +52,6 @@ async function patchModelInConvex(id: string, row: Record<string, unknown>) {
   });
 }
 
-const modelFilterColumns: FilterColumnDef[] = [
-  { id: "categoryId", filterType: "enum" },
-  { id: "assetType", filterType: "enum" },
-];
-
 export type ModelWithRelations = Prisma.ModelGetPayload<{
   include: {
     category: true;
@@ -56,6 +59,17 @@ export type ModelWithRelations = Prisma.ModelGetPayload<{
   };
 }>;
 
+/**
+ * Paginated model list — read from the reactive Convex `models` mirror.
+ *
+ * Convex `models.list({orgId})` returns ALL of the org's models, so the Prisma
+ * `where` (isActive / categoryId / assetType / search) and `orderBy` are
+ * re-applied in JS via the pure helpers in `src/lib/models-read.ts`. The nested
+ * `category` (dual-written) is attached from the Convex category map; per-model
+ * asset/bulk `_count` come off the Convex asset/bulkAsset mirror and the primary
+ * photo off the Convex modelMedia mirror (same sources as getModelCounts). No
+ * Prisma fallback on a Convex map miss. See FEATUREDOCS/54.
+ */
 export async function getModels(params?: {
   search?: string;
   categoryId?: string;
@@ -70,43 +84,50 @@ export async function getModels(params?: {
   const { organizationId } = await getOrgContext();
   const { search, categoryId, assetType, isActive = true, page = 1, pageSize = 25, sortBy = "name", sortOrder = "asc", filters } = params || {};
 
-  const filterWhere = buildFilterWhere(filters, modelFilterColumns);
+  // The DataTable `filters` for this surface only carries the categoryId /
+  // assetType enum columns (see the column defs); fold the first selected value
+  // of each into the explicit filter (mirrors buildFilterWhere's enum `in`,
+  // which with a single value behaves like equality for these single-value cols).
+  const filterCategoryIds = Array.isArray(filters?.categoryId) ? (filters!.categoryId as string[]) : [];
+  const filterAssetTypes = Array.isArray(filters?.assetType) ? (filters!.assetType as string[]) : [];
 
-  const where: Prisma.ModelWhereInput = {
-    organizationId,
-    isActive,
-    ...(categoryId && { categoryId }),
-    ...(assetType && { assetType }),
-    ...filterWhere,
-    ...(search && {
-      OR: [
-        { name: { contains: search, mode: "insensitive" } },
-        { manufacturer: { contains: search, mode: "insensitive" } },
-        { modelNumber: { contains: search, mode: "insensitive" } },
-        { sku: { contains: search, mode: "insensitive" } },
-      ],
-    }),
-  };
-
-  const [models, total] = await Promise.all([
-    prisma.model.findMany({
-      where,
-      include: {
-        category: true,
-        _count: { select: { assets: true, bulkAssets: true } },
-        media: {
-          where: { type: "PHOTO", isPrimary: true },
-          include: { file: true },
-          take: 1,
-        },
-      },
-      orderBy: sortBy === "category" ? { category: { name: sortOrder } }
-        : { [sortBy]: sortOrder },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.model.count({ where }),
+  const [convexModels, categoryMap, allAssets, allBulkAssets, photoMap] = await Promise.all([
+    getModelsByOrg(organizationId),
+    getCategoryMap(organizationId),
+    getAssetsByOrg(organizationId),
+    getBulkAssetsByOrg(organizationId),
+    getPrimaryPhotoMap("model", organizationId),
   ]);
+
+  const rows = convexModels.map(mapConvexModelToRow);
+  const categoryNameOf = (m: { categoryId?: string | null }) =>
+    m.categoryId ? categoryMap.get(m.categoryId)?.name ?? null : null;
+
+  let filtered = filterModels(rows, { isActive, categoryId, assetType, search });
+  if (filterCategoryIds.length > 0) filtered = filtered.filter((m) => filterCategoryIds.includes(m.categoryId ?? ""));
+  if (filterAssetTypes.length > 0) filtered = filtered.filter((m) => filterAssetTypes.includes(m.assetType));
+
+  const total = filtered.length;
+  const sorted = sortModels(filtered, sortBy, sortOrder, categoryNameOf);
+  const pageRows = paginateModels(sorted, page, pageSize);
+
+  // Per-model asset/bulk counts (active only) off the Convex mirror.
+  const assetCount = new Map<string, number>();
+  const bulkCount = new Map<string, number>();
+  for (const a of allAssets) if (a.isActive !== false) assetCount.set(a.modelId, (assetCount.get(a.modelId) ?? 0) + 1);
+  for (const b of allBulkAssets) if (b.isActive !== false) bulkCount.set(b.modelId, (bulkCount.get(b.modelId) ?? 0) + 1);
+
+  const models = pageRows.map((m) => {
+    const photo = photoMap[m.id];
+    return {
+      ...m,
+      category: m.categoryId ? categoryMap.get(m.categoryId) ?? null : null,
+      _count: { assets: assetCount.get(m.id) ?? 0, bulkAssets: bulkCount.get(m.id) ?? 0 },
+      // Primary photo as a single-element media array (mirrors the Prisma
+      // `media: { where: { isPrimary }, take: 1 }` include shape used here).
+      media: photo ? [{ url: photo.url, thumbnailUrl: photo.thumbnailUrl }] : [],
+    };
+  });
 
   return serialize({ models, total, page, pageSize, totalPages: Math.ceil(total / pageSize) });
 }


### PR DESCRIPTION
## Summary

Phase A read-rewiring for the **models** surface. Moves `getModels` (the paginated model list/filter/sort/paginate server action) off `prisma.model.findMany`+`count` to the reactive Convex `models.list` mirror, extending `src/lib/models-read.ts` with pure, unit-tested helpers:

- `mapConvexModelToRow` — strips `_id`/`_creationTime`, epoch-ms→Date, coerces Prisma-defaulted columns (`images`/`manuals`/`tags`/`assetType`/`requiresTestAndTag`/`isActive`) non-null.
- `filterModels` — replicates the Prisma `where`: `isActive` (default true), `categoryId`, `assetType`, and the case-insensitive OR `contains` search over name/manufacturer/modelNumber/sku.
- `sortModels` — replicates `orderBy`: Postgres NULLS-LAST asc / NULLS-FIRST desc; `assetType` by **declared enum order** via a rank map; `category` by resolved category name.
- `paginateModels` — 1-based page slice.

Nested `category` attached from the Convex category map; per-model `_count.assets/bulkAssets` and primary photo come off the asset/bulkAsset + modelMedia mirrors (same sources as `getModelCounts`). **No new Convex query** — reuses the existing `api.models.list`. **No Prisma fallback** on a Convex map miss.

### Actions converted vs left on Prisma
| Action | Disposition |
|---|---|
| `getModels` | **Converted** → Convex `models.list` + pure JS filter/sort/paginate |
| `getModelCounts` | Already Convex-only (assets/bulkAssets/modelMedia mirrors) — no change |
| `getModel` | **Stays Prisma** — detail-page media composite (assets+location / bulkAssets+location / media+file / bulkAccessories+bulkAsset): documented terminus |
| `createModel` / `updateModel` / `archiveModel` / `bulkUpdateRates` | **Stay Prisma** — writes + read-then-write reads (`asset.findMany`, `bulkAsset.findMany`, `model.findMany`, `testTagAsset.findMany`) whose results feed a same-action mutation |

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/models-read.test.ts` — **17 passed** (mapper, filter, sort incl. NULLS ordering + enum declared-order + category-name, paginate)
- `pnpm exec eslint` on changed files — 0 errors (1 pre-existing `_id`-strip warning in `patchModelInConvex`, expected)

## Deploy gate
`model` is dual-written + backfilled into prod Convex. Merge gate = human validation on the Coolify PR preview against prod Convex (Convex data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)