### PR TITLE
feat(convex): read assets + bulk-assets (primary reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,21 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **assets + bulk-assets (primary reads)** (`server/assets.ts`, `server/bulk-assets.ts` → `src/lib/assets-read.ts`). `getAssets` and `getBulkAssets` (the paginated `prisma.asset`/`prisma.bulkAsset` `findMany` + `count`) now read every org row from Convex `assets.list`/`bulkAssets.list` and filter/sort/paginate in JS. New pure helpers in `assets-read.ts`: `mapConvexAssetToPrisma`/`mapConvexBulkAssetToPrisma` (rebuild the Prisma row shape — epoch-ms→Date, number→`Prisma.Decimal`, defaulted `status`/`condition`/`isActive`/`images`/`tags`/quantities coerced non-null, `_id`/`_creationTime` stripped); `filterAssets`/`filterBulkAssets` (replicate the Prisma `where` incl. `categoryId`→model.categoryId, the DataTable enum `in` filters, `tags` `hasSome`, and the `assetTag`/`serialNumber`/`customName`/`model.name` search OR); `sortAssets`/`sortBulkAssets` (model.name / location.name joins, enum columns by DECLARED order via rank maps, Postgres NULLS-LAST-on-asc); `paginate`. Model/category/location names come from `getModelWithCategoryMap`/`getLocationMap` (already Convex). **No new Convex query** — the existing `list({orgId})` returns the full row set. **Stays Prisma (documented terminus / out of scope):** `getAsset` (detail composite — `media`+`file`, `maintenanceLinks`, `scanLogs`, `lineItems`, `childAssets`/`childBulkItems`, `modelMedia`, `modelBulkAccessory` cross-domain joins) and `getBulkAsset` (detail composite — `scanLogs`/`lineItems`/`testTagAssets`); the read-then-write `findUnique`s in `updateAsset`/`updateBulkAsset` (quantity reconcile), `deleteAsset`/`deleteBulkAsset` (`_count` referential guard), and the `testTagAsset` find→retire in `deleteAsset`/`archiveAsset`; `customFieldDefinition.findMany` (custom-field domain, not asset). 19 unit tests in `assets-read.test.ts`.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/assets-read.test.ts
+++ b/src/lib/assets-read.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the pure asset/bulk-asset list helpers in assets-read.ts —
+ * the Convex-backed replacements for prisma.asset.findMany / bulkAsset.findMany
+ * + count (server/assets.ts:getAssets, server/bulk-assets.ts:getBulkAssets).
+ *
+ * Safety property: identical row set + order + page slice to the old Prisma
+ * where/orderBy/skip/take. Mappers rebuild the Prisma row shape (Date,
+ * Decimal, defaulted-non-null columns) from the Convex doc (epoch-ms, number,
+ * absent → undefined).
+ */
+import { describe, it, expect } from "vitest";
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  mapConvexAssetToPrisma,
+  mapConvexBulkAssetToPrisma,
+  filterAssets,
+  filterBulkAssets,
+  sortAssets,
+  sortBulkAssets,
+  paginate,
+} from "@/lib/assets-read";
+
+type AssetDoc = Doc<"assets">;
+type BulkDoc = Doc<"bulkAssets">;
+
+function assetDoc(over: Partial<AssetDoc>): AssetDoc {
+  return {
+    _id: "x" as AssetDoc["_id"],
+    _creationTime: 0,
+    id: "a1",
+    organizationId: "org1",
+    modelId: "m1",
+    assetTag: "AST-001",
+    ...over,
+  } as AssetDoc;
+}
+
+function bulkDoc(over: Partial<BulkDoc>): BulkDoc {
+  return {
+    _id: "x" as BulkDoc["_id"],
+    _creationTime: 0,
+    id: "b1",
+    organizationId: "org1",
+    modelId: "m1",
+    assetTag: "BLK-001",
+    ...over,
+  } as BulkDoc;
+}
+
+// model/category/location lookups injected as plain functions in the helpers.
+const modelNames: Record<string, string> = { m1: "Speaker", m2: "Cable", m3: "Mixer" };
+const modelCategories: Record<string, string> = { m1: "audio", m2: "audio", m3: "mixers" };
+const locationNames: Record<string, string> = { l1: "Warehouse A", l2: "Warehouse B" };
+const modelNameFor = (id: string) => modelNames[id];
+const categoryFor = (id: string) => modelCategories[id];
+const locationNameFor = (id: string | null) => (id ? locationNames[id] : null);
+
+describe("mapConvexAssetToPrisma", () => {
+  it("rebuilds the Prisma row shape, coercing defaults and converting types", () => {
+    const row = mapConvexAssetToPrisma(
+      assetDoc({
+        purchaseDate: 1_700_000_000_000,
+        purchasePrice: 199.99,
+        warrantyExpiry: undefined,
+        createdAt: 1_600_000_000_000,
+        updatedAt: 1_600_000_001_000,
+      }),
+    );
+    expect(row.purchaseDate).toBeInstanceOf(Date);
+    expect((row.purchaseDate as Date).getTime()).toBe(1_700_000_000_000);
+    expect(row.warrantyExpiry).toBeNull();
+    // Decimal — duck-typed by toNumber() (serialize() turns it into a number).
+    expect((row.purchasePrice as unknown as { toNumber(): number }).toNumber()).toBeCloseTo(199.99);
+    // defaulted-non-null columns
+    expect(row.status).toBe("AVAILABLE");
+    expect(row.condition).toBe("NEW");
+    expect(row.isActive).toBe(true);
+    expect(row.images).toEqual([]);
+    expect(row.tags).toEqual([]);
+    // absent → null
+    expect(row.serialNumber).toBeNull();
+    expect(row.supplierId).toBeNull();
+    // no Convex system fields leak through
+    expect("_id" in row).toBe(false);
+    expect("_creationTime" in row).toBe(false);
+  });
+
+  it("preserves explicitly-set non-default scalars", () => {
+    const row = mapConvexAssetToPrisma(
+      assetDoc({ status: "CHECKED_OUT", condition: "FAIR", isActive: false, tags: ["x"], serialNumber: "SN1" }),
+    );
+    expect(row.status).toBe("CHECKED_OUT");
+    expect(row.condition).toBe("FAIR");
+    expect(row.isActive).toBe(false);
+    expect(row.tags).toEqual(["x"]);
+    expect(row.serialNumber).toBe("SN1");
+  });
+});
+
+describe("mapConvexBulkAssetToPrisma", () => {
+  it("rebuilds the Prisma row shape with quantity + status defaults", () => {
+    const row = mapConvexBulkAssetToPrisma(bulkDoc({ purchasePricePerUnit: 5.5 }));
+    expect(row.totalQuantity).toBe(0);
+    expect(row.availableQuantity).toBe(0);
+    expect(row.status).toBe("ACTIVE");
+    expect(row.isActive).toBe(true);
+    expect((row.purchasePricePerUnit as unknown as { toNumber(): number }).toNumber()).toBeCloseTo(5.5);
+    expect(row.purchasePricePerUnit).not.toBeNull();
+    expect("_id" in row).toBe(false);
+  });
+});
+
+describe("filterAssets", () => {
+  const rows = [
+    mapConvexAssetToPrisma(assetDoc({ id: "a1", modelId: "m1", assetTag: "AST-001", status: "AVAILABLE", condition: "NEW", locationId: "l1", isActive: true, tags: ["red"], serialNumber: "SN-AAA" })),
+    mapConvexAssetToPrisma(assetDoc({ id: "a2", modelId: "m2", assetTag: "AST-002", status: "CHECKED_OUT", condition: "GOOD", locationId: "l2", isActive: true, tags: ["blue"] })),
+    mapConvexAssetToPrisma(assetDoc({ id: "a3", modelId: "m3", assetTag: "AST-003", status: "RETIRED", condition: "POOR", isActive: false })),
+  ];
+
+  it("defaults to isActive only", () => {
+    const out = filterAssets(rows, { isActive: true }, modelNameFor, categoryFor);
+    expect(out.map((r) => r.id)).toEqual(["a1", "a2"]);
+  });
+
+  it("filters by isActive: false", () => {
+    const out = filterAssets(rows, { isActive: false }, modelNameFor, categoryFor);
+    expect(out.map((r) => r.id)).toEqual(["a3"]);
+  });
+
+  it("filters by status/condition/locationId/modelId", () => {
+    expect(filterAssets(rows, { isActive: true, status: "AVAILABLE" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1"]);
+    expect(filterAssets(rows, { isActive: true, condition: "GOOD" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a2"]);
+    expect(filterAssets(rows, { isActive: true, locationId: "l1" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1"]);
+    expect(filterAssets(rows, { isActive: true, modelId: "m2" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a2"]);
+  });
+
+  it("filters by categoryId (via the model map)", () => {
+    expect(filterAssets(rows, { isActive: true, categoryId: "audio" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1", "a2"]);
+  });
+
+  it("applies enum `in` filters and tags hasSome", () => {
+    expect(filterAssets(rows, { isActive: true, statusIn: ["CHECKED_OUT"] }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a2"]);
+    expect(filterAssets(rows, { isActive: true, locationIdIn: ["l1", "l2"] }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1", "a2"]);
+    expect(filterAssets(rows, { isActive: true, categoryIdIn: ["mixers"] }, modelNameFor, categoryFor).map((r) => r.id)).toEqual([]);
+    expect(filterAssets(rows, { isActive: true, tagsHasSome: ["red"] }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1"]);
+  });
+
+  it("searches assetTag, serialNumber, and model.name case-insensitively", () => {
+    expect(filterAssets(rows, { isActive: true, search: "ast-001" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1"]);
+    expect(filterAssets(rows, { isActive: true, search: "sn-aaa" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a1"]);
+    expect(filterAssets(rows, { isActive: true, search: "cable" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["a2"]);
+  });
+});
+
+describe("filterBulkAssets", () => {
+  const rows = [
+    mapConvexBulkAssetToPrisma(bulkDoc({ id: "b1", modelId: "m1", assetTag: "BLK-001", status: "ACTIVE", locationId: "l1", isActive: true })),
+    mapConvexBulkAssetToPrisma(bulkDoc({ id: "b2", modelId: "m3", assetTag: "BLK-002", status: "LOW_STOCK", isActive: true })),
+    mapConvexBulkAssetToPrisma(bulkDoc({ id: "b3", modelId: "m2", assetTag: "BLK-003", status: "RETIRED", isActive: false })),
+  ];
+
+  it("defaults to isActive only", () => {
+    expect(filterBulkAssets(rows, { isActive: true }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b1", "b2"]);
+  });
+
+  it("filters by status/location/model/category", () => {
+    expect(filterBulkAssets(rows, { isActive: true, status: "LOW_STOCK" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b2"]);
+    expect(filterBulkAssets(rows, { isActive: true, locationId: "l1" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b1"]);
+    expect(filterBulkAssets(rows, { isActive: true, categoryId: "mixers" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b2"]);
+  });
+
+  it("searches assetTag and model.name", () => {
+    expect(filterBulkAssets(rows, { isActive: true, search: "blk-001" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b1"]);
+    expect(filterBulkAssets(rows, { isActive: true, search: "mixer" }, modelNameFor, categoryFor).map((r) => r.id)).toEqual(["b2"]);
+  });
+});
+
+describe("sortAssets", () => {
+  const rows = [
+    mapConvexAssetToPrisma(assetDoc({ id: "a1", assetTag: "AST-003", modelId: "m3", status: "RETIRED", locationId: "l2" })),
+    mapConvexAssetToPrisma(assetDoc({ id: "a2", assetTag: "AST-001", modelId: "m1", status: "AVAILABLE", locationId: undefined })),
+    mapConvexAssetToPrisma(assetDoc({ id: "a3", assetTag: "AST-002", modelId: "m2", status: "CHECKED_OUT", locationId: "l1" })),
+  ];
+
+  it("sorts by scalar assetTag asc/desc", () => {
+    expect(sortAssets(rows, "assetTag", "asc", modelNameFor, locationNameFor).map((r) => r.assetTag)).toEqual(["AST-001", "AST-002", "AST-003"]);
+    expect(sortAssets(rows, "assetTag", "desc", modelNameFor, locationNameFor).map((r) => r.assetTag)).toEqual(["AST-003", "AST-002", "AST-001"]);
+  });
+
+  it("sorts by model.name", () => {
+    expect(sortAssets(rows, "model", "asc", modelNameFor, locationNameFor).map((r) => r.id)).toEqual(["a3", "a1", "a2"]);
+  });
+
+  it("sorts enum status by DECLARED order, not alphabetical", () => {
+    // declared: AVAILABLE < CHECKED_OUT < RETIRED (alpha would put AVAILABLE, CHECKED_OUT, RETIRED too — use a discriminating case)
+    expect(sortAssets(rows, "status", "asc", modelNameFor, locationNameFor).map((r) => r.status)).toEqual(["AVAILABLE", "CHECKED_OUT", "RETIRED"]);
+  });
+
+  it("sorts location with NULLS LAST on asc, NULLS FIRST on desc", () => {
+    expect(sortAssets(rows, "location", "asc", modelNameFor, locationNameFor).map((r) => r.id)).toEqual(["a3", "a1", "a2"]);
+    expect(sortAssets(rows, "location", "desc", modelNameFor, locationNameFor).map((r) => r.id)).toEqual(["a2", "a1", "a3"]);
+  });
+});
+
+describe("sortBulkAssets", () => {
+  const rows = [
+    mapConvexBulkAssetToPrisma(bulkDoc({ id: "b1", assetTag: "BLK-002", status: "RETIRED" })),
+    mapConvexBulkAssetToPrisma(bulkDoc({ id: "b2", assetTag: "BLK-001", status: "ACTIVE" })),
+  ];
+  it("sorts enum status by declared order", () => {
+    expect(sortBulkAssets(rows, "status", "asc", modelNameFor, locationNameFor).map((r) => r.status)).toEqual(["ACTIVE", "RETIRED"]);
+  });
+  it("sorts by assetTag", () => {
+    expect(sortBulkAssets(rows, "assetTag", "asc", modelNameFor, locationNameFor).map((r) => r.assetTag)).toEqual(["BLK-001", "BLK-002"]);
+  });
+});
+
+describe("paginate", () => {
+  const rows = [1, 2, 3, 4, 5];
+  it("slices 1-based page/pageSize", () => {
+    expect(paginate(rows, 1, 2)).toEqual([1, 2]);
+    expect(paginate(rows, 2, 2)).toEqual([3, 4]);
+    expect(paginate(rows, 3, 2)).toEqual([5]);
+    expect(paginate(rows, 4, 2)).toEqual([]);
+  });
+});

--- a/src/lib/assets-read.ts
+++ b/src/lib/assets-read.ts
@@ -1,6 +1,8 @@
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
+import type { Asset, BulkAsset } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 
 /**
  * Server-side read helpers for the Asset + BulkAsset domains (Phase 3 cutover).
@@ -46,4 +48,254 @@ export async function getActiveAssetsByModel(modelId: string, orgId: string): Pr
 export async function getActiveBulkAssetsByModel(modelId: string, orgId: string): Promise<ConvexBulkAsset[]> {
   const all = (await (await getConvexClient()).query(api.bulkAssets.listByModel, { modelId, orgId })) as ConvexBulkAsset[];
   return all.filter((ba) => ba.isActive !== false);
+}
+
+/* ------------------------------------------------------------------ *
+ * Primary list reads (server/assets.ts:getAssets, server/bulk-assets.ts:
+ * getBulkAssets) — Convex-backed replacements for the paginated
+ * prisma.asset.findMany / prisma.bulkAsset.findMany + count.
+ *
+ * Convex `list({orgId})` returns ALL rows for the org → filter/sort/paginate
+ * in JS, replicating the old Prisma where/orderBy. Convex docs carry numeric
+ * epoch-ms dates and plain-number Decimals (absent → undefined); the mappers
+ * rebuild the Prisma row shape (Date, Decimal, defaulted-non-null columns) so
+ * the existing `AssetWithRelations` / `BulkAssetWithRelations` consumers (the
+ * T&T new-record form) read the same field names as before. No Prisma fallback
+ * on a miss — a missing Convex row reads as absent (the mirror is the source of
+ * truth post-cutover). See FEATUREDOCS/54.
+ * ------------------------------------------------------------------ */
+
+function msToDate(ms: number | null | undefined): Date | null {
+  return ms == null ? null : new Date(ms);
+}
+
+// Postgres enum columns sort by DECLARED order, not alphabetical. Rank maps
+// replicate prisma/schema.prisma declaration order for orderBy on enum fields.
+const ASSET_STATUS_RANK: Record<string, number> = {
+  AVAILABLE: 0, CHECKED_OUT: 1, IN_MAINTENANCE: 2, RETIRED: 3, LOST: 4, RESERVED: 5,
+};
+const ASSET_CONDITION_RANK: Record<string, number> = {
+  NEW: 0, GOOD: 1, FAIR: 2, POOR: 3, DAMAGED: 4,
+};
+const BULK_ASSET_STATUS_RANK: Record<string, number> = {
+  ACTIVE: 0, LOW_STOCK: 1, OUT_OF_STOCK: 2, RETIRED: 3,
+};
+
+/**
+ * Map a Convex `assets` doc to the Prisma `Asset` scalar row shape. Strips
+ * `_id`/`_creationTime`; coerces Prisma-defaulted columns non-null
+ * (status/condition/isActive/images/tags); epoch-ms → Date; number → Decimal.
+ */
+export function mapConvexAssetToPrisma(doc: ConvexAsset): Asset {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    modelId: doc.modelId,
+    assetTag: doc.assetTag,
+    serialNumber: doc.serialNumber ?? null,
+    customName: doc.customName ?? null,
+    status: (doc.status ?? "AVAILABLE") as Asset["status"],
+    condition: (doc.condition ?? "NEW") as Asset["condition"],
+    purchaseDate: msToDate(doc.purchaseDate),
+    purchasePrice:
+      doc.purchasePrice == null ? null : new Prisma.Decimal(doc.purchasePrice),
+    purchaseSupplier: doc.purchaseSupplier ?? null,
+    supplierId: doc.supplierId ?? null,
+    purchaseOrderNumber: doc.purchaseOrderNumber ?? null,
+    supplierOrderId: doc.supplierOrderId ?? null,
+    warrantyExpiry: msToDate(doc.warrantyExpiry),
+    notes: doc.notes ?? null,
+    locationId: doc.locationId ?? null,
+    customFieldValues: (doc.customFieldValues ?? null) as Asset["customFieldValues"],
+    lastTestAndTagDate: msToDate(doc.lastTestAndTagDate),
+    nextTestAndTagDate: msToDate(doc.nextTestAndTagDate),
+    barcode: doc.barcode ?? null,
+    qrCode: doc.qrCode ?? null,
+    images: doc.images ?? [],
+    tags: doc.tags ?? [],
+    isActive: doc.isActive ?? true,
+    createdAt: msToDate(doc.createdAt) ?? new Date(0),
+    updatedAt: msToDate(doc.updatedAt) ?? new Date(0),
+    kitId: doc.kitId ?? null,
+    parentAssetId: doc.parentAssetId ?? null,
+  };
+}
+
+/**
+ * Map a Convex `bulkAssets` doc to the Prisma `BulkAsset` scalar row shape.
+ */
+export function mapConvexBulkAssetToPrisma(doc: ConvexBulkAsset): BulkAsset {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    modelId: doc.modelId,
+    assetTag: doc.assetTag,
+    totalQuantity: doc.totalQuantity ?? 0,
+    availableQuantity: doc.availableQuantity ?? 0,
+    purchasePricePerUnit:
+      doc.purchasePricePerUnit == null ? null : new Prisma.Decimal(doc.purchasePricePerUnit),
+    locationId: doc.locationId ?? null,
+    status: (doc.status ?? "ACTIVE") as BulkAsset["status"],
+    notes: doc.notes ?? null,
+    tags: doc.tags ?? [],
+    isActive: doc.isActive ?? true,
+    createdAt: msToDate(doc.createdAt) ?? new Date(0),
+    updatedAt: msToDate(doc.updatedAt) ?? new Date(0),
+  };
+}
+
+export interface AssetListFilter {
+  search?: string;
+  categoryId?: string;
+  status?: string;
+  condition?: string;
+  locationId?: string;
+  modelId?: string;
+  isActive: boolean;
+  /** enum `in` filters from the DataTable: status/condition/locationId/categoryId. */
+  statusIn?: string[];
+  conditionIn?: string[];
+  locationIdIn?: string[];
+  categoryIdIn?: string[];
+  /** tags `hasSome`. */
+  tagsHasSome?: string[];
+}
+
+export interface BulkAssetListFilter {
+  search?: string;
+  categoryId?: string;
+  status?: string;
+  locationId?: string;
+  modelId?: string;
+  isActive: boolean;
+}
+
+function matchesSearch(haystacks: (string | null | undefined)[], search: string): boolean {
+  const needle = search.toLowerCase();
+  return haystacks.some((h) => (h ?? "").toLowerCase().includes(needle));
+}
+
+/**
+ * Replicates the Prisma `where` for getAssets. `categoryFor(modelId)` resolves a
+ * model's categoryId (the Convex model map), `modelNameFor(modelId)` its name —
+ * used by the categoryId filter and the model.name search OR-branch.
+ */
+export function filterAssets(
+  rows: Asset[],
+  f: AssetListFilter,
+  modelNameFor: (modelId: string) => string | null | undefined,
+  categoryFor: (modelId: string) => string | null | undefined,
+): Asset[] {
+  return rows.filter((a) => {
+    if (a.isActive !== f.isActive) return false;
+    if (f.status && a.status !== f.status) return false;
+    if (f.condition && a.condition !== f.condition) return false;
+    if (f.locationId && a.locationId !== f.locationId) return false;
+    if (f.modelId && a.modelId !== f.modelId) return false;
+    if (f.categoryId && categoryFor(a.modelId) !== f.categoryId) return false;
+    if (f.statusIn && f.statusIn.length > 0 && !f.statusIn.includes(a.status)) return false;
+    if (f.conditionIn && f.conditionIn.length > 0 && !f.conditionIn.includes(a.condition)) return false;
+    if (f.locationIdIn && f.locationIdIn.length > 0 && !(a.locationId != null && f.locationIdIn.includes(a.locationId))) return false;
+    if (f.categoryIdIn && f.categoryIdIn.length > 0) {
+      const cat = categoryFor(a.modelId);
+      if (!(cat != null && f.categoryIdIn.includes(cat))) return false;
+    }
+    if (f.tagsHasSome && f.tagsHasSome.length > 0 && !a.tags.some((t) => f.tagsHasSome!.includes(t))) return false;
+    if (f.search && !matchesSearch([a.assetTag, a.serialNumber, a.customName, modelNameFor(a.modelId)], f.search)) return false;
+    return true;
+  });
+}
+
+/** Replicates the Prisma `where` for getBulkAssets. */
+export function filterBulkAssets(
+  rows: BulkAsset[],
+  f: BulkAssetListFilter,
+  modelNameFor: (modelId: string) => string | null | undefined,
+  categoryFor: (modelId: string) => string | null | undefined,
+): BulkAsset[] {
+  return rows.filter((b) => {
+    if (b.isActive !== f.isActive) return false;
+    if (f.status && b.status !== f.status) return false;
+    if (f.locationId && b.locationId !== f.locationId) return false;
+    if (f.modelId && b.modelId !== f.modelId) return false;
+    if (f.categoryId && categoryFor(b.modelId) !== f.categoryId) return false;
+    if (f.search && !matchesSearch([b.assetTag, modelNameFor(b.modelId)], f.search)) return false;
+    return true;
+  });
+}
+
+function compareValues(av: unknown, bv: unknown, dir: 1 | -1): number {
+  // Postgres default NULLS LAST for ASC, NULLS FIRST for DESC.
+  const aNull = av == null;
+  const bNull = bv == null;
+  if (aNull && bNull) return 0;
+  if (aNull) return dir === 1 ? 1 : -1;
+  if (bNull) return dir === 1 ? -1 : 1;
+  if (av instanceof Date && bv instanceof Date) return (av.getTime() - bv.getTime()) * dir;
+  if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+  if (typeof av === "boolean" && typeof bv === "boolean") {
+    return ((av ? 1 : 0) - (bv ? 1 : 0)) * dir;
+  }
+  return String(av).localeCompare(String(bv)) * dir;
+}
+
+/**
+ * Replicates the Prisma `orderBy` for getAssets. `model` sorts on model.name,
+ * `location` on location.name, enum fields by declared order, else the scalar.
+ */
+export function sortAssets(
+  rows: Asset[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+  modelNameFor: (modelId: string) => string | null | undefined,
+  locationNameFor: (locationId: string | null) => string | null | undefined,
+): Asset[] {
+  const dir: 1 | -1 = sortOrder === "desc" ? -1 : 1;
+  const keyFn = (a: Asset): unknown => {
+    if (sortBy === "model") return modelNameFor(a.modelId);
+    if (sortBy === "location") return locationNameFor(a.locationId);
+    if (sortBy === "status") return ASSET_STATUS_RANK[a.status];
+    if (sortBy === "condition") return ASSET_CONDITION_RANK[a.condition];
+    return (a as unknown as Record<string, unknown>)[sortBy];
+  };
+  return [...rows].sort((a, b) => compareValues(keyFn(a), keyFn(b), dir));
+}
+
+/** Replicates the Prisma `orderBy` for getBulkAssets. */
+export function sortBulkAssets(
+  rows: BulkAsset[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+  modelNameFor: (modelId: string) => string | null | undefined,
+  locationNameFor: (locationId: string | null) => string | null | undefined,
+): BulkAsset[] {
+  const dir: 1 | -1 = sortOrder === "desc" ? -1 : 1;
+  const keyFn = (b: BulkAsset): unknown => {
+    if (sortBy === "model") return modelNameFor(b.modelId);
+    if (sortBy === "location") return locationNameFor(b.locationId);
+    if (sortBy === "status") return BULK_ASSET_STATUS_RANK[b.status];
+    return (b as unknown as Record<string, unknown>)[sortBy];
+  };
+  return [...rows].sort((a, b) => compareValues(keyFn(a), keyFn(b), dir));
+}
+
+/** skip/take pagination (1-based page). */
+export function paginate<T>(rows: T[], page: number, pageSize: number): T[] {
+  return rows.slice((page - 1) * pageSize, (page - 1) * pageSize + pageSize);
+}
+
+/** Fetch + map every org asset to the Prisma row shape (pre-filter). */
+export async function getMappedAssetsByOrg(orgId: string): Promise<Asset[]> {
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.assets.list, { orgId }),
+  );
+  return (docs as ConvexAsset[]).map(mapConvexAssetToPrisma);
+}
+
+/** Fetch + map every org bulk asset to the Prisma row shape (pre-filter). */
+export async function getMappedBulkAssetsByOrg(orgId: string): Promise<BulkAsset[]> {
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.bulkAssets.list, { orgId }),
+  );
+  return (docs as ConvexBulkAsset[]).map(mapConvexBulkAssetToPrisma);
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -22,7 +22,13 @@ import { getSupplierById } from "@/lib/suppliers-read";
 import { getModelById, getModelWithCategoryMap, type ModelWithCategory } from "@/lib/models-read";
 import { getLocationMap, type ConvexLocation } from "@/lib/locations-read";
 import { getPrimaryPhotoMaps } from "@/lib/media-read";
-import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/table-utils";
+import { type FilterValue } from "@/lib/table-utils";
+import {
+  getMappedAssetsByOrg,
+  filterAssets,
+  sortAssets,
+  paginate,
+} from "@/lib/assets-read";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { validateCustomFieldValues } from "@/lib/validations/custom-field";
 
@@ -50,14 +56,6 @@ async function resolveAssetCustomFields(
     });
   }
 }
-
-const assetFilterColumns: FilterColumnDef[] = [
-  { id: "status", filterType: "enum" },
-  { id: "condition", filterType: "enum" },
-  { id: "locationId", filterType: "enum" },
-  { id: "categoryId", filterType: "enum", filterKey: "model.categoryId" },
-  { id: "tags", filterType: "enum" },
-];
 
 // model (+ nested equipment category) + location live in Convex (dual-written) —
 // attached from the maps, not Prisma joins. Sorts/filters on model.name /
@@ -89,57 +87,41 @@ export async function getAssets(params?: {
     filters,
   } = params || {};
 
-  // Build filter where from DataTable filters
-  const filterWhere = buildFilterWhere(filters, assetFilterColumns);
+  // Extract the DataTable enum `in` filters (status/condition/locationId/
+  // categoryId) and the tags hasSome filter from the raw filter map.
+  const asArr = (v: FilterValue | undefined): string[] | undefined =>
+    Array.isArray(v) && v.length > 0 ? (v as string[]) : undefined;
 
-  // Handle tags filter specially (hasSome)
-  let tagsFilter: Prisma.AssetWhereInput | undefined;
-  if (filters?.tags && Array.isArray(filters.tags) && filters.tags.length > 0) {
-    tagsFilter = { tags: { hasSome: filters.tags as string[] } };
-    delete (filterWhere as Record<string, unknown>).tags;
-  }
-
-  const where: Prisma.AssetWhereInput = {
-    organizationId,
-    isActive,
-    ...(status && { status: status as Prisma.EnumAssetStatusFilter }),
-    ...(condition && { condition: condition as Prisma.EnumAssetConditionFilter }),
-    ...(locationId && { locationId }),
-    ...(modelId && { modelId }),
-    ...(categoryId && { model: { categoryId } }),
-    ...filterWhere,
-    ...tagsFilter,
-    ...(search && {
-      OR: [
-        { assetTag: { contains: search, mode: "insensitive" } },
-        { serialNumber: { contains: search, mode: "insensitive" } },
-        { customName: { contains: search, mode: "insensitive" } },
-        { model: { name: { contains: search, mode: "insensitive" } } },
-      ],
-    }),
-  };
-
-  const [assets, total] = await Promise.all([
-    prisma.asset.findMany({
-      where,
-      // model (+ category) + location attached from Convex below. The sole
-      // consumer (test-tag form) reads model scalars only, so the old primary-photo
-      // media joins are dropped (the reactive registry table gets photos from
-      // getAssetRegistryPhotos, not this query). Sort stays on the Prisma mirror.
-      orderBy: sortBy === "model" ? { model: { name: sortOrder } }
-        : sortBy === "location" ? { location: { name: sortOrder } }
-        : { [sortBy]: sortOrder },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.asset.count({ where }),
-  ]);
-
-  const [modelMap, locationMap] = await Promise.all([
+  // Asset rows + model/location maps all come from Convex (dual-written). The
+  // org's full row set is fetched then filtered/sorted/paginated in JS,
+  // replicating the old Prisma where/orderBy. See src/lib/assets-read.ts.
+  const [allAssets, modelMap, locationMap] = await Promise.all([
+    getMappedAssetsByOrg(organizationId),
     getModelWithCategoryMap(organizationId),
     getLocationMap(organizationId),
   ]);
-  const withRelations = assets.map((a) => ({
+  const modelNameFor = (id: string) => modelMap.get(id)?.name;
+  const categoryFor = (id: string) => modelMap.get(id)?.categoryId;
+  const locationNameFor = (id: string | null) => (id ? locationMap.get(id)?.name : null);
+
+  const filtered = filterAssets(
+    allAssets,
+    {
+      search, categoryId, status, condition, locationId, modelId, isActive,
+      statusIn: asArr(filters?.status),
+      conditionIn: asArr(filters?.condition),
+      locationIdIn: asArr(filters?.locationId),
+      categoryIdIn: asArr(filters?.categoryId),
+      tagsHasSome: asArr(filters?.tags),
+    },
+    modelNameFor,
+    categoryFor,
+  );
+  const total = filtered.length;
+  const sorted = sortAssets(filtered, sortBy, sortOrder, modelNameFor, locationNameFor);
+  const pageRows = paginate(sorted, page, pageSize);
+
+  const withRelations = pageRows.map((a) => ({
     ...a,
     model: a.modelId ? modelMap.get(a.modelId) ?? null : null,
     location: a.locationId ? locationMap.get(a.locationId) ?? null : null,

--- a/src/server/bulk-assets.ts
+++ b/src/server/bulk-assets.ts
@@ -14,6 +14,12 @@ import {
   patchBulkAssetInConvex,
   removeBulkAssetFromConvex,
 } from "@/lib/asset-mirror";
+import {
+  getMappedBulkAssetsByOrg,
+  filterBulkAssets,
+  sortBulkAssets,
+  paginate,
+} from "@/lib/assets-read";
 
 // model (+ nested equipment category) + location live in Convex (dual-written) —
 // attached from the maps below, not Prisma joins. Sorts/filters on model.name /
@@ -42,39 +48,29 @@ export async function getBulkAssets(params?: {
     sortBy = "assetTag", sortOrder = "asc",
   } = params || {};
 
-  const where: Prisma.BulkAssetWhereInput = {
-    organizationId,
-    isActive,
-    ...(status && { status: status as Prisma.EnumBulkAssetStatusFilter }),
-    ...(locationId && { locationId }),
-    ...(modelId && { modelId }),
-    ...(categoryId && { model: { categoryId } }),
-    ...(search && {
-      OR: [
-        { assetTag: { contains: search, mode: "insensitive" } },
-        { model: { name: { contains: search, mode: "insensitive" } } },
-      ],
-    }),
-  };
-
-  const [bulkAssets, total] = await Promise.all([
-    prisma.bulkAsset.findMany({
-      where,
-      // model + location attached from Convex below; sort stays on the Prisma mirror.
-      orderBy: sortBy === "model" ? { model: { name: sortOrder } }
-        : sortBy === "location" ? { location: { name: sortOrder } }
-        : { [sortBy]: sortOrder },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.bulkAsset.count({ where }),
-  ]);
-
-  const [modelMap, locationMap] = await Promise.all([
+  // Bulk-asset rows + model/location maps all come from Convex (dual-written).
+  // The org's full row set is fetched then filtered/sorted/paginated in JS,
+  // replicating the old Prisma where/orderBy. See src/lib/assets-read.ts.
+  const [allBulk, modelMap, locationMap] = await Promise.all([
+    getMappedBulkAssetsByOrg(organizationId),
     getModelWithCategoryMap(organizationId),
     getLocationMap(organizationId),
   ]);
-  const withRelations = bulkAssets.map((b) => ({
+  const modelNameFor = (id: string) => modelMap.get(id)?.name;
+  const categoryFor = (id: string) => modelMap.get(id)?.categoryId;
+  const locationNameFor = (id: string | null) => (id ? locationMap.get(id)?.name : null);
+
+  const filtered = filterBulkAssets(
+    allBulk,
+    { search, categoryId, status, locationId, modelId, isActive },
+    modelNameFor,
+    categoryFor,
+  );
+  const total = filtered.length;
+  const sorted = sortBulkAssets(filtered, sortBy, sortOrder, modelNameFor, locationNameFor);
+  const pageRows = paginate(sorted, page, pageSize);
+
+  const withRelations = pageRows.map((b) => ({
     ...b,
     model: b.modelId ? modelMap.get(b.modelId) ?? null : null,
     location: b.locationId ? locationMap.get(b.locationId) ?? null : null,


### PR DESCRIPTION
## Summary

Phase A read-rewiring, one leaf surface: the paginated list reads for the
**asset** + **bulkAsset** domains. `server/assets.ts:getAssets` and
`server/bulk-assets.ts:getBulkAssets` now read every org row from Convex
(`assets.list` / `bulkAssets.list`) and filter/sort/paginate in JS, replacing
`prisma.asset.findMany`/`prisma.bulkAsset.findMany` + `count`. Both domains are
dual-written + backfilled. Combined into one PR because they share
`src/lib/assets-read.ts`.

### Converted (pure reads → Convex)
- `getAssets` — list/filter/sort/paginate + total count
- `getBulkAssets` — list/filter/sort/paginate + total count

### New pure helpers in `src/lib/assets-read.ts` (unit-tested)
- `mapConvexAssetToPrisma` / `mapConvexBulkAssetToPrisma` — rebuild the Prisma
  row shape: epoch-ms→`Date`, number→`Prisma.Decimal`, `status`/`condition`/
  `isActive`/`images`/`tags`/quantities coerced to their Prisma defaults,
  `_id`/`_creationTime` stripped, JSON passed through.
- `filterAssets` / `filterBulkAssets` — replicate the Prisma `where`
  (`categoryId`→model.categoryId via the Convex model map, DataTable enum `in`
  filters, `tags` `hasSome`, the `assetTag`/`serialNumber`/`customName`/
  `model.name` case-insensitive search OR).
- `sortAssets` / `sortBulkAssets` — model.name / location.name joins, enum
  columns by **DECLARED order** (rank maps from prisma/schema.prisma), Postgres
  NULLS-LAST-on-asc / NULLS-FIRST-on-desc.
- `paginate` — 1-based skip/take.

Model/category/location names come from the existing Convex read libs
(`getModelWithCategoryMap`, `getLocationMap`). **No new Convex query** — the
existing `list({orgId})` returns the full row set. **No Prisma fallback on a
map miss** (a miss reads null, matching a join against a deleted row).

### Left on Prisma (documented terminus / out of scope)
- `getAsset` / `getBulkAsset` — detail composites with cross-domain joins
  (media+file, maintenanceLinks, scanLogs, lineItems, childAssets/childBulkItems,
  modelMedia, modelBulkAccessory, testTagAssets).
- Read-then-write `findUnique`s: `updateAsset`/`updateBulkAsset` (quantity
  reconcile), `deleteAsset`/`deleteBulkAsset` (`_count` referential guard).
- `testTagAsset` find→retire in `deleteAsset`/`archiveAsset` (cross-domain +
  read-then-write).
- `customFieldDefinition.findMany` (custom-field domain, not asset).

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/assets-read.test.ts` — 19 passed
- `pnpm exec eslint` on changed files — clean (only a pre-existing unused-`before`
  warning in `updateAsset`, present on origin/main)

## Deploy gate
Merge gate = the deploy-ordering gate: the `assets` + `bulkAssets` tables must be
backfilled into **prod** Convex before this read deploys, else rows read empty.
Human-validated on the Coolify PR preview against prod Convex (Convex
data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)