### PR TITLE
feat(convex): read categories + locations (primary reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,50 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **categories + locations (primary reads)** (`server/categories.ts`,
+  `server/locations.ts` → `src/lib/categories-read.ts` + `locations-read.ts`).
+  **categories.ts converted:** `getCategories` (list + parent self-join + `_count`
+  {models, kits, children}), `getCategoryCounts` (categoryId→{models, kits}),
+  `getCategoryTree` (roots-first forest + `_count.models`), and the category-tree
+  walk in `getCaseCategoryIds` (`getMappedCategoriesByOrg` + pure
+  `collectDescendantCategoryIds` BFS). The parent/children hierarchy is rebuilt
+  client-side from the flat Convex list via a Map; model + kit counts aggregate in
+  JS from the dual-written Convex model/kit lists (replacing the old `kit` Prisma
+  `groupBy`). **Left Prisma (documented):** `getCategory` (detail-page composite —
+  pulls kit serializedItems/bulkItems counts and per-model asset counts + primary
+  model media, cross-domain aggregations with no Convex read helper, analogous to
+  the intentional detail-page-media-gallery Prisma terminus); the `org.metadata`
+  read in `getCaseCategoryIds` (the `organization` table is Better-Auth-owned, not
+  in the domain dual-write set); `searchContainerAssets` (skipped — covered by
+  sibling PR #237). **locations.ts converted:** `getLocations` (filter/sort/
+  paginate + parent `{name}` self-join + `_count` {assets, bulkAssets, kits,
+  children, projects}) via pure `filterLocations`/`sortLocations`/
+  `buildLocationCounts` + `listLocations`; counts aggregate from the dual-written
+  Convex asset/bulk-asset/kit/project lists (the `_count.projects` stays faithful —
+  it counts ALL projects including templates, matching the original's lack of an
+  `isTemplate` filter); the parent-name sort replicates Postgres NULLS-LAST(asc)/
+  FIRST(desc) and the `isDefault desc` primary key. **Left Prisma (documented):**
+  `getLocation` (detail-page composite — active assets/bulk/kits with model joins,
+  projects with client, media + file gallery; cross-domain heavy + media-gallery
+  terminus); `getLocationCounts` (already Convex, no Prisma); all mutations and
+  `unsetDefaultsInConvex` (read-then-write — the single-default toggle reads
+  prior-defaults to unset them in the same action). **No new Convex queries** — all
+  reuse existing `*.list`/`getById` module queries. New pure helpers + unit tests
+  in the two read libs (23 tests).
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/categories-read.test.ts
+++ b/src/lib/categories-read.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the pure category read-rewiring helpers (Phase A).
+ *
+ * These replace the Prisma list/tree/count/case-walk reads in
+ * server/categories.ts. The safety property for each: identical output shape +
+ * ordering to the Prisma query it replaces — parent/children hierarchy rebuilt
+ * from the flat Convex list, model/kit counts aggregated in JS, dates as Date.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapCategory,
+  sortCategories,
+  buildChildCountMap,
+  buildModelKitCounts,
+  buildCategoriesWithCounts,
+  buildCategoryTree,
+  collectDescendantCategoryIds,
+  type MappedCategory,
+} from "@/lib/categories-read";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+type CatDoc = Doc<"categories">;
+
+function doc(over: Partial<CatDoc>): CatDoc {
+  return {
+    _id: "x" as CatDoc["_id"],
+    _creationTime: 1,
+    id: "c1",
+    organizationId: "org1",
+    name: "Cat",
+    ...over,
+  } as CatDoc;
+}
+
+describe("mapCategory", () => {
+  it("converts epoch-ms → Date, coerces defaults, strips _id/_creationTime", () => {
+    const m = mapCategory(
+      doc({ id: "c1", name: "Audio", createdAt: 1000, updatedAt: 2000 }),
+    );
+    expect(m).toEqual<MappedCategory>({
+      id: "c1",
+      organizationId: "org1",
+      name: "Audio",
+      parentId: null,
+      description: null,
+      icon: null,
+      sortOrder: 0,
+      tags: [],
+      suggestedCrewRoles: [],
+      createdAt: new Date(1000),
+      updatedAt: new Date(2000),
+    });
+    expect((m as unknown as Record<string, unknown>)._id).toBeUndefined();
+    expect((m as unknown as Record<string, unknown>)._creationTime).toBeUndefined();
+  });
+
+  it("preserves provided optional fields", () => {
+    const m = mapCategory(
+      doc({
+        parentId: "p1",
+        description: "d",
+        icon: "🎛",
+        sortOrder: 5,
+        tags: ["t"],
+        suggestedCrewRoles: ["r"],
+      }),
+    );
+    expect(m.parentId).toBe("p1");
+    expect(m.description).toBe("d");
+    expect(m.icon).toBe("🎛");
+    expect(m.sortOrder).toBe(5);
+    expect(m.tags).toEqual(["t"]);
+    expect(m.suggestedCrewRoles).toEqual(["r"]);
+  });
+});
+
+const cat = (over: Partial<MappedCategory>): MappedCategory => ({
+  id: "c",
+  organizationId: "org1",
+  name: "n",
+  parentId: null,
+  description: null,
+  icon: null,
+  sortOrder: 0,
+  tags: [],
+  suggestedCrewRoles: [],
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  ...over,
+});
+
+describe("sortCategories", () => {
+  it("orders by sortOrder asc, then name asc", () => {
+    const rows = [
+      cat({ id: "a", name: "Zebra", sortOrder: 1 }),
+      cat({ id: "b", name: "Apple", sortOrder: 1 }),
+      cat({ id: "c", name: "Mid", sortOrder: 0 }),
+    ];
+    expect(sortCategories(rows).map((r) => r.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("does not mutate the input", () => {
+    const rows = [cat({ id: "a", sortOrder: 2 }), cat({ id: "b", sortOrder: 1 })];
+    const copy = [...rows];
+    sortCategories(rows);
+    expect(rows).toEqual(copy);
+  });
+});
+
+describe("buildChildCountMap", () => {
+  it("counts categories per parentId", () => {
+    const m = buildChildCountMap([
+      { id: "p", parentId: null },
+      { id: "a", parentId: "p" },
+      { id: "b", parentId: "p" },
+      { id: "c", parentId: "a" },
+    ]);
+    expect(m.get("p")).toBe(2);
+    expect(m.get("a")).toBe(1);
+    expect(m.get("b")).toBeUndefined();
+  });
+});
+
+describe("buildModelKitCounts", () => {
+  it("aggregates model + kit counts per categoryId, ignoring null", () => {
+    const m = buildModelKitCounts(
+      [{ categoryId: "c1" }, { categoryId: "c1" }, { categoryId: null }, {}],
+      [{ categoryId: "c1" }, { categoryId: "c2" }],
+    );
+    expect(m.get("c1")).toEqual({ models: 2, kits: 1 });
+    expect(m.get("c2")).toEqual({ models: 0, kits: 1 });
+    expect(m.has("null")).toBe(false);
+  });
+});
+
+describe("buildCategoriesWithCounts", () => {
+  it("attaches parent row + _count{models,kits,children}, sorted", () => {
+    const cats = [
+      cat({ id: "child", name: "Child", parentId: "root", sortOrder: 0 }),
+      cat({ id: "root", name: "Root", sortOrder: 0 }),
+    ];
+    const counts = new Map([["root", { models: 3, kits: 1 }]]);
+    const out = buildCategoriesWithCounts(cats, counts);
+    // sorted by sortOrder then name: "Child" < "Root"
+    expect(out.map((c) => c.id)).toEqual(["child", "root"]);
+    const child = out.find((c) => c.id === "child")!;
+    expect(child.parent?.name).toBe("Root");
+    expect(child._count).toEqual({ models: 0, kits: 0, children: 0 });
+    const root = out.find((c) => c.id === "root")!;
+    expect(root.parent).toBeNull();
+    expect(root._count).toEqual({ models: 3, kits: 1, children: 1 });
+  });
+
+  it("parent is null when the parent row is absent (e.g. cross-org/deleted)", () => {
+    const out = buildCategoriesWithCounts([cat({ id: "x", parentId: "missing" })], new Map());
+    expect(out[0].parent).toBeNull();
+  });
+});
+
+describe("buildCategoryTree", () => {
+  it("builds a roots-first forest with nested sorted children + _count.models", () => {
+    const cats = [
+      cat({ id: "root", name: "Root", sortOrder: 0 }),
+      cat({ id: "b", name: "Beta", parentId: "root", sortOrder: 1 }),
+      cat({ id: "a", name: "Alpha", parentId: "root", sortOrder: 1 }),
+      cat({ id: "orphan", name: "Orphan", parentId: "gone" }),
+    ];
+    const modelCounts = new Map([["root", 4]]);
+    const tree = buildCategoryTree(cats, modelCounts);
+    // roots: "Orphan" (parent missing → root) and "Root", sorted by name
+    expect(tree.map((n) => n.id)).toEqual(["orphan", "root"]);
+    const root = tree.find((n) => n.id === "root")!;
+    expect(root._count.models).toBe(4);
+    // children sorted by sortOrder then name → Alpha before Beta
+    expect(root.children.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("collectDescendantCategoryIds", () => {
+  const cats = [
+    { id: "root", parentId: null },
+    { id: "a", parentId: "root" },
+    { id: "b", parentId: "root" },
+    { id: "a1", parentId: "a" },
+    { id: "other", parentId: null },
+  ];
+
+  it("BFS-collects the root and all descendants", () => {
+    expect(collectDescendantCategoryIds(cats, "root").sort()).toEqual(
+      ["a", "a1", "b", "root"].sort(),
+    );
+  });
+
+  it("returns just the leaf when it has no children", () => {
+    expect(collectDescendantCategoryIds(cats, "a1")).toEqual(["a1"]);
+  });
+
+  it("returns [] for a falsy root", () => {
+    expect(collectDescendantCategoryIds(cats, null)).toEqual([]);
+    expect(collectDescendantCategoryIds(cats, undefined)).toEqual([]);
+    expect(collectDescendantCategoryIds(cats, "")).toEqual([]);
+  });
+});

--- a/src/lib/categories-read.ts
+++ b/src/lib/categories-read.ts
@@ -1,6 +1,8 @@
 import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
+import { getModelsByOrg } from "@/lib/models-read";
+import { getKitsByOrg } from "@/lib/kits-read";
 
 /**
  * Server-side read helpers for the Categories domain (Phase 3 cutover).
@@ -32,4 +34,219 @@ export async function getCategoriesByOrg(orgId: string): Promise<ConvexCategory[
 export async function getCategoryMap(orgId: string): Promise<Map<string, ConvexCategory>> {
   const all = await getCategoriesByOrg(orgId);
   return new Map(all.map((c) => [c.id, c]));
+}
+
+// ---------------------------------------------------------------------------
+// Primary reads — list / tree / counts / case-category walk (Phase A)
+//
+// These replace the pure Prisma list/tree/filter reads in server/categories.ts.
+// Categories are dual-written, so the Convex list is the read source. The
+// self-referential parent/children hierarchy is rebuilt CLIENT-side in JS from
+// the flat Convex list via a Map, and the cross-domain model/kit counts are
+// aggregated in JS from the (also-dual-written) Convex model/kit lists.
+//
+// MAPPING: a Convex doc carries the same business fields as the Prisma row plus
+// `_id`/`_creationTime` and numeric `createdAt`/`updatedAt`. `serialize()` keeps
+// Date objects intact, so the old server action returned Dates — we MUST convert
+// epoch-ms → Date here. Prisma-defaulted columns (sortOrder=0, tags=[],
+// suggestedCrewRoles=[]) are coerced non-null. The cuid `id` is preserved; `_id`
+// and `_creationTime` are stripped.
+// ---------------------------------------------------------------------------
+
+/** A category mapped from its flat Convex doc to the Prisma-row business shape. */
+export interface MappedCategory {
+  id: string;
+  organizationId: string;
+  name: string;
+  parentId: string | null;
+  description: string | null;
+  icon: string | null;
+  sortOrder: number;
+  tags: string[];
+  suggestedCrewRoles: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Pure: Convex category doc → Prisma-row business shape (epoch-ms→Date, defaults coerced, `_id`/`_creationTime` stripped). */
+export function mapCategory(doc: ConvexCategory): MappedCategory {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    name: doc.name,
+    parentId: doc.parentId ?? null,
+    description: doc.description ?? null,
+    icon: doc.icon ?? null,
+    sortOrder: doc.sortOrder ?? 0,
+    tags: doc.tags ?? [],
+    suggestedCrewRoles: doc.suggestedCrewRoles ?? [],
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
+/**
+ * Pure: replicate Prisma's `orderBy: [{ sortOrder: "asc" }, { name: "asc" }]`.
+ * Postgres has no nulls to consider here (both columns are non-null). Returns a
+ * NEW sorted array (does not mutate the input).
+ */
+export function sortCategories<T extends { sortOrder: number; name: string }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+}
+
+/**
+ * Pure: count children per parentId from the flat category list. A category's
+ * children count = number of categories whose `parentId` === its `id`.
+ */
+export function buildChildCountMap(cats: Array<{ id: string; parentId: string | null }>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const c of cats) {
+    if (c.parentId) counts.set(c.parentId, (counts.get(c.parentId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Pure: per-category {models, kits} counts from the flat model/kit lists
+ * (each carries an optional `categoryId`). Replaces the Prisma `_count.models`
+ * relation + the `kit` groupBy.
+ */
+export function buildModelKitCounts(
+  models: Array<{ categoryId?: string | null }>,
+  kits: Array<{ categoryId?: string | null }>,
+): Map<string, { models: number; kits: number }> {
+  const counts = new Map<string, { models: number; kits: number }>();
+  const ensure = (id: string) => {
+    let e = counts.get(id);
+    if (!e) counts.set(id, (e = { models: 0, kits: 0 }));
+    return e;
+  };
+  for (const m of models) if (m.categoryId) ensure(m.categoryId).models++;
+  for (const k of kits) if (k.categoryId) ensure(k.categoryId).kits++;
+  return counts;
+}
+
+/** A mapped category with its parent (full row) and relation counts — the `getCategories` row shape. */
+export type CategoryWithCounts = MappedCategory & {
+  parent: MappedCategory | null;
+  _count: { models: number; kits: number; children: number };
+};
+
+/**
+ * Pure: build the `getCategories` list — each category with its parent row and
+ * `_count {models, kits, children}`, sorted by sortOrder then name. Replicates
+ * `findMany({ include: { parent, _count }, orderBy: [sortOrder, name] })`.
+ */
+export function buildCategoriesWithCounts(
+  cats: MappedCategory[],
+  modelKitCounts: Map<string, { models: number; kits: number }>,
+): CategoryWithCounts[] {
+  const byId = new Map(cats.map((c) => [c.id, c]));
+  const childCounts = buildChildCountMap(cats);
+  return sortCategories(cats).map((c) => ({
+    ...c,
+    parent: c.parentId ? byId.get(c.parentId) ?? null : null,
+    _count: {
+      models: modelKitCounts.get(c.id)?.models ?? 0,
+      kits: modelKitCounts.get(c.id)?.kits ?? 0,
+      children: childCounts.get(c.id) ?? 0,
+    },
+  }));
+}
+
+/** A tree node: a mapped category with `_count.models` and recursively-nested children. */
+export type CategoryTreeNode = MappedCategory & {
+  _count: { models: number };
+  children: CategoryTreeNode[];
+};
+
+/**
+ * Pure: build the `getCategoryTree` forest — roots-first, each node carrying
+ * `_count.models` and its nested `children`. Replicates the original two-pass
+ * Map build (a node whose parentId is missing from the set becomes a root). Both
+ * the roots and each children array are sorted by sortOrder then name.
+ */
+export function buildCategoryTree(
+  cats: MappedCategory[],
+  modelCounts: Map<string, number>,
+): CategoryTreeNode[] {
+  const nodes = new Map<string, CategoryTreeNode>();
+  for (const c of cats) {
+    nodes.set(c.id, { ...c, _count: { models: modelCounts.get(c.id) ?? 0 }, children: [] });
+  }
+  const roots: CategoryTreeNode[] = [];
+  for (const c of cats) {
+    const node = nodes.get(c.id)!;
+    if (c.parentId && nodes.has(c.parentId)) {
+      nodes.get(c.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  for (const node of nodes.values()) node.children = sortCategories(node.children);
+  return sortCategories(roots);
+}
+
+/**
+ * Pure: BFS the category tree from `rootCatId`, returning that id plus all
+ * descendant ids. Replicates the `getCaseCategoryIds` walk over a flat
+ * {id, parentId} list. Returns `[]` if `rootCatId` is falsy.
+ */
+export function collectDescendantCategoryIds(
+  cats: Array<{ id: string; parentId: string | null }>,
+  rootCatId: string | null | undefined,
+): string[] {
+  if (!rootCatId) return [];
+  const childrenMap = new Map<string, string[]>();
+  for (const c of cats) {
+    if (c.parentId) {
+      const list = childrenMap.get(c.parentId);
+      if (list) list.push(c.id);
+      else childrenMap.set(c.parentId, [c.id]);
+    }
+  }
+  const result: string[] = [];
+  const queue = [rootCatId];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    result.push(id);
+    const kids = childrenMap.get(id);
+    if (kids) queue.push(...kids);
+  }
+  return result;
+}
+
+/** All of an org's categories mapped to the Prisma-row business shape. */
+export async function getMappedCategoriesByOrg(orgId: string): Promise<MappedCategory[]> {
+  const docs = await getCategoriesByOrg(orgId);
+  return docs.map(mapCategory);
+}
+
+/** `getCategories` from Convex: each category + parent + `_count {models, kits, children}`. */
+export async function listCategoriesWithCounts(orgId: string): Promise<CategoryWithCounts[]> {
+  const [cats, models, kits] = await Promise.all([
+    getMappedCategoriesByOrg(orgId),
+    getModelsByOrg(orgId),
+    getKitsByOrg(orgId),
+  ]);
+  return buildCategoriesWithCounts(cats, buildModelKitCounts(models, kits));
+}
+
+/** `getCategoryCounts` from Convex: categoryId → {models, kits}, as a plain record. */
+export async function getCategoryModelKitCounts(
+  orgId: string,
+): Promise<Record<string, { models: number; kits: number }>> {
+  const [models, kits] = await Promise.all([getModelsByOrg(orgId), getKitsByOrg(orgId)]);
+  const counts = buildModelKitCounts(models, kits);
+  const out: Record<string, { models: number; kits: number }> = {};
+  for (const [id, v] of counts) out[id] = v;
+  return out;
+}
+
+/** `getCategoryTree` from Convex: roots-first forest with `_count.models` + nested children. */
+export async function listCategoryTree(orgId: string): Promise<CategoryTreeNode[]> {
+  const [cats, models] = await Promise.all([getMappedCategoriesByOrg(orgId), getModelsByOrg(orgId)]);
+  const modelCounts = new Map<string, number>();
+  for (const m of models) if (m.categoryId) modelCounts.set(m.categoryId, (modelCounts.get(m.categoryId) ?? 0) + 1);
+  return buildCategoryTree(cats, modelCounts);
 }

--- a/src/lib/locations-read.test.ts
+++ b/src/lib/locations-read.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the pure location read-rewiring helpers (Phase A).
+ *
+ * These replace the Prisma `getLocations` list read in server/locations.ts. The
+ * safety property: identical filter/sort/paginate semantics + relation counts +
+ * parent-name shape to the Prisma query — including Postgres NULLS ordering for
+ * the parent-name sort and the `isDefault desc` primary sort key.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapLocation,
+  buildLocationCounts,
+  filterLocations,
+  sortLocations,
+  type MappedLocation,
+} from "@/lib/locations-read";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+type LocDoc = Doc<"locations">;
+
+function doc(over: Partial<LocDoc>): LocDoc {
+  return {
+    _id: "x" as LocDoc["_id"],
+    _creationTime: 1,
+    id: "l1",
+    organizationId: "org1",
+    name: "Loc",
+    ...over,
+  } as LocDoc;
+}
+
+describe("mapLocation", () => {
+  it("converts epoch-ms → Date, coerces defaults, strips _id/_creationTime", () => {
+    const m = mapLocation(doc({ id: "l1", name: "Main", createdAt: 10, updatedAt: 20 }));
+    expect(m).toEqual<MappedLocation>({
+      id: "l1",
+      organizationId: "org1",
+      name: "Main",
+      address: null,
+      latitude: null,
+      longitude: null,
+      type: "WAREHOUSE",
+      isDefault: false,
+      parentId: null,
+      notes: null,
+      tags: [],
+      createdAt: new Date(10),
+      updatedAt: new Date(20),
+    });
+    expect((m as unknown as Record<string, unknown>)._id).toBeUndefined();
+  });
+
+  it("preserves provided fields", () => {
+    const m = mapLocation(
+      doc({ address: "1 St", latitude: -33, longitude: 151, type: "VEHICLE", isDefault: true, parentId: "p", notes: "n", tags: ["t"] }),
+    );
+    expect(m).toMatchObject({ address: "1 St", latitude: -33, longitude: 151, type: "VEHICLE", isDefault: true, parentId: "p", notes: "n", tags: ["t"] });
+  });
+});
+
+const loc = (over: Partial<MappedLocation>): MappedLocation => ({
+  id: "l",
+  organizationId: "org1",
+  name: "n",
+  address: null,
+  latitude: null,
+  longitude: null,
+  type: "WAREHOUSE",
+  isDefault: false,
+  parentId: null,
+  notes: null,
+  tags: [],
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  ...over,
+});
+
+describe("buildLocationCounts", () => {
+  it("counts assets/bulk/kits/projects per locationId and children per parentId", () => {
+    const locations = [
+      { id: "root", parentId: null },
+      { id: "child", parentId: "root" },
+    ];
+    const counts = buildLocationCounts(
+      locations,
+      [{ locationId: "root" }, { locationId: "root" }, { locationId: null }],
+      [{ locationId: "child" }],
+      [{ locationId: "root" }],
+      [{ locationId: "root" }, { locationId: "child" }],
+    );
+    expect(counts.get("root")).toEqual({ assets: 2, bulkAssets: 0, kits: 1, children: 1, projects: 1 });
+    expect(counts.get("child")).toEqual({ assets: 0, bulkAssets: 1, kits: 0, children: 0, projects: 1 });
+  });
+});
+
+describe("filterLocations", () => {
+  const rows = [
+    loc({ id: "a", name: "Sydney Depot", address: "1 George St", type: "WAREHOUSE" }),
+    loc({ id: "b", name: "Truck 1", address: null, type: "VEHICLE" }),
+    loc({ id: "c", name: "Melbourne", address: "Bourke St", type: "WAREHOUSE" }),
+  ];
+
+  it("filters by exact type", () => {
+    expect(filterLocations(rows, { type: "VEHICLE" }).map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("filters by typeIn (enum in)", () => {
+    expect(filterLocations(rows, { typeIn: ["VEHICLE", "WAREHOUSE"] }).map((r) => r.id)).toEqual(["a", "b", "c"]);
+    expect(filterLocations(rows, { typeIn: [] }).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("case-insensitive search across name OR address", () => {
+    expect(filterLocations(rows, { search: "george" }).map((r) => r.id)).toEqual(["a"]);
+    expect(filterLocations(rows, { search: "truck" }).map((r) => r.id)).toEqual(["b"]);
+    expect(filterLocations(rows, { search: "zzz" })).toEqual([]);
+  });
+});
+
+describe("sortLocations", () => {
+  it("default sort: isDefault desc then the chosen column asc", () => {
+    const rows = [
+      loc({ id: "a", name: "Alpha", isDefault: false }),
+      loc({ id: "b", name: "Bravo", isDefault: true }),
+      loc({ id: "c", name: "Charlie", isDefault: false }),
+    ];
+    expect(sortLocations(rows, "name", "asc", new Map()).map((r) => r.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("default sort respects desc direction within the column", () => {
+    const rows = [loc({ id: "a", name: "Alpha" }), loc({ id: "c", name: "Charlie" })];
+    expect(sortLocations(rows, "name", "desc", new Map()).map((r) => r.id)).toEqual(["c", "a"]);
+  });
+
+  it("parent sort: NULLS LAST for asc", () => {
+    const rows = [
+      loc({ id: "noparent", parentId: null }),
+      loc({ id: "underZ", parentId: "z" }),
+      loc({ id: "underA", parentId: "a" }),
+    ];
+    const parentName = new Map<string, string | null>([
+      ["noparent", null],
+      ["underZ", "Zone"],
+      ["underA", "Acme"],
+    ]);
+    expect(sortLocations(rows, "parent", "asc", parentName).map((r) => r.id)).toEqual([
+      "underA",
+      "underZ",
+      "noparent",
+    ]);
+  });
+
+  it("parent sort: NULLS FIRST for desc", () => {
+    const rows = [
+      loc({ id: "noparent", parentId: null }),
+      loc({ id: "underZ", parentId: "z" }),
+      loc({ id: "underA", parentId: "a" }),
+    ];
+    const parentName = new Map<string, string | null>([
+      ["noparent", null],
+      ["underZ", "Zone"],
+      ["underA", "Acme"],
+    ]);
+    expect(sortLocations(rows, "parent", "desc", parentName).map((r) => r.id)).toEqual([
+      "noparent",
+      "underZ",
+      "underA",
+    ]);
+  });
+
+  it("sorts by a Date column", () => {
+    const rows = [
+      loc({ id: "old", createdAt: new Date(1000) }),
+      loc({ id: "new", createdAt: new Date(3000) }),
+    ];
+    expect(sortLocations(rows, "createdAt", "desc", new Map()).map((r) => r.id)).toEqual(["new", "old"]);
+  });
+});

--- a/src/lib/locations-read.ts
+++ b/src/lib/locations-read.ts
@@ -1,6 +1,9 @@
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
+import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
+import { getKitsByOrg } from "@/lib/kits-read";
+import { getProjectsByOrg } from "@/lib/projects-read";
 
 /**
  * Server-side read helpers for the Locations domain (Phase 3 cutover).
@@ -56,4 +59,230 @@ export async function attachLocation<T extends { locationId: string | null }>(
     ...r,
     location: r.locationId ? map.get(r.locationId) ?? null : null,
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Primary reads — paginated/filtered/sorted list (Phase A)
+//
+// Replaces the pure Prisma list read in server/locations.ts (`getLocations`).
+// Locations are dual-written, so the Convex list is the read source. The
+// self-referential parent (name only) and the per-location relation counts
+// (assets, bulkAssets, kits, projects from their dual-written Convex lists;
+// children from this list) are computed CLIENT-side in JS; filter/sort/paginate
+// replicate the Prisma `where`/`orderBy`/`skip`/`take` exactly.
+//
+// MAPPING: `serialize()` keeps Date intact, so the old action returned Dates —
+// we convert epoch-ms → Date. Prisma-defaulted columns (type=WAREHOUSE,
+// isDefault=false, tags=[]) are coerced non-null. cuid `id` preserved; `_id`/
+// `_creationTime` stripped. The `_count.projects` is faithful to the original:
+// it counts ALL projects on the location (templates included — the original had
+// no isTemplate filter).
+// ---------------------------------------------------------------------------
+
+/** A location mapped from its flat Convex doc to the Prisma-row business shape. */
+export interface MappedLocation {
+  id: string;
+  organizationId: string;
+  name: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  type: string;
+  isDefault: boolean;
+  parentId: string | null;
+  notes: string | null;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Pure: Convex location doc → Prisma-row business shape (epoch-ms→Date, defaults coerced, `_id`/`_creationTime` stripped). */
+export function mapLocation(doc: ConvexLocation): MappedLocation {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    name: doc.name,
+    address: doc.address ?? null,
+    latitude: doc.latitude ?? null,
+    longitude: doc.longitude ?? null,
+    type: doc.type ?? "WAREHOUSE",
+    isDefault: doc.isDefault ?? false,
+    parentId: doc.parentId ?? null,
+    notes: doc.notes ?? null,
+    tags: doc.tags ?? [],
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
+/** Per-location relation counts (assets, bulkAssets, kits, children, projects). */
+export interface LocationRelCounts {
+  assets: number;
+  bulkAssets: number;
+  kits: number;
+  children: number;
+  projects: number;
+}
+
+/**
+ * Pure: per-location relation counts from the flat domain lists. `children` is
+ * derived from the location list's own parentId; the other four from their
+ * respective lists' `locationId`.
+ */
+export function buildLocationCounts(
+  locations: Array<{ id: string; parentId: string | null }>,
+  assets: Array<{ locationId?: string | null }>,
+  bulkAssets: Array<{ locationId?: string | null }>,
+  kits: Array<{ locationId?: string | null }>,
+  projects: Array<{ locationId?: string | null }>,
+): Map<string, LocationRelCounts> {
+  const counts = new Map<string, LocationRelCounts>();
+  const ensure = (id: string) => {
+    let e = counts.get(id);
+    if (!e) counts.set(id, (e = { assets: 0, bulkAssets: 0, kits: 0, children: 0, projects: 0 }));
+    return e;
+  };
+  for (const l of locations) if (l.parentId) ensure(l.parentId).children++;
+  for (const a of assets) if (a.locationId) ensure(a.locationId).assets++;
+  for (const b of bulkAssets) if (b.locationId) ensure(b.locationId).bulkAssets++;
+  for (const k of kits) if (k.locationId) ensure(k.locationId).kits++;
+  for (const p of projects) if (p.locationId) ensure(p.locationId).projects++;
+  return counts;
+}
+
+/**
+ * Pure: replicate the `getLocations` Prisma `where` filter — org scope is already
+ * applied by the Convex query, so this covers `type` (exact), `search` (case-
+ * insensitive substring on name OR address), and the `filters.type` enum (`in`).
+ */
+export function filterLocations<T extends { name: string; address: string | null; type: string }>(
+  rows: T[],
+  opts: { search?: string; type?: string; typeIn?: string[] },
+): T[] {
+  const search = opts.search?.toLowerCase();
+  return rows.filter((r) => {
+    if (opts.type && r.type !== opts.type) return false;
+    if (opts.typeIn && opts.typeIn.length > 0 && !opts.typeIn.includes(r.type)) return false;
+    if (search) {
+      const inName = r.name.toLowerCase().includes(search);
+      const inAddr = (r.address ?? "").toLowerCase().includes(search);
+      if (!inName && !inAddr) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Pure: replicate the `getLocations` Prisma `orderBy`. Two shapes:
+ *  - sortBy === "parent" → order by the parent location's name (Postgres sorts
+ *    NULLs LAST for ASC, FIRST for DESC — rows with no parent have a null key).
+ *  - otherwise → `[{ isDefault: "desc" }, { [sortBy]: sortOrder }]` (default
+ *    locations float to the top, then the chosen column).
+ * Returns a NEW sorted array. `parentNameById` resolves a location's parent name.
+ */
+export function sortLocations<T extends MappedLocation>(
+  rows: T[],
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+  parentNameById: Map<string, string | null>,
+): T[] {
+  const dir = sortOrder === "asc" ? 1 : -1;
+  const cmpStr = (a: string | null | undefined, b: string | null | undefined) => {
+    // Postgres NULLS LAST for ASC, NULLS FIRST for DESC.
+    const an = a == null || a === "";
+    const bn = b == null || b === "";
+    if (an && bn) return 0;
+    if (an) return sortOrder === "asc" ? 1 : -1;
+    if (bn) return sortOrder === "asc" ? -1 : 1;
+    return (a as string).localeCompare(b as string) * dir;
+  };
+  const out = [...rows];
+  if (sortBy === "parent") {
+    out.sort((a, b) => cmpStr(parentNameById.get(a.id) ?? null, parentNameById.get(b.id) ?? null));
+    return out;
+  }
+  out.sort((a, b) => {
+    // isDefault desc first (true before false).
+    if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+    const av = (a as Record<string, unknown>)[sortBy];
+    const bv = (b as Record<string, unknown>)[sortBy];
+    if (typeof av === "string" || typeof bv === "string" || av == null || bv == null) {
+      return cmpStr(av as string | null, bv as string | null);
+    }
+    if (av instanceof Date && bv instanceof Date) return (av.getTime() - bv.getTime()) * dir;
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    if (typeof av === "boolean" && typeof bv === "boolean") return ((av ? 1 : 0) - (bv ? 1 : 0)) * dir;
+    return 0;
+  });
+  return out;
+}
+
+/** A mapped location with `parent {name}` and `_count` — the `getLocations` row shape. */
+export type LocationListRow = MappedLocation & {
+  parent: { name: string } | null;
+  _count: LocationRelCounts;
+};
+
+/** All of an org's locations mapped to the Prisma-row business shape. */
+export async function getMappedLocationsByOrg(orgId: string): Promise<MappedLocation[]> {
+  const docs = await getLocationsByOrg(orgId);
+  return docs.map(mapLocation);
+}
+
+/**
+ * `getLocations` from Convex: filter → sort → paginate, each row carrying
+ * `parent {name}` and `_count {assets, bulkAssets, kits, children, projects}`.
+ */
+export async function listLocations(
+  orgId: string,
+  params: {
+    search?: string;
+    type?: string;
+    typeIn?: string[];
+    page: number;
+    pageSize: number;
+    sortBy: string;
+    sortOrder: "asc" | "desc";
+  },
+): Promise<{ locations: LocationListRow[]; total: number; page: number; pageSize: number; totalPages: number }> {
+  const [locations, assets, bulkAssets, kits, projects] = await Promise.all([
+    getMappedLocationsByOrg(orgId),
+    getAssetsByOrg(orgId),
+    getBulkAssetsByOrg(orgId),
+    getKitsByOrg(orgId),
+    getProjectsByOrg(orgId),
+  ]);
+
+  const byId = new Map(locations.map((l) => [l.id, l]));
+  const parentNameById = new Map<string, string | null>(
+    locations.map((l) => [l.id, l.parentId ? byId.get(l.parentId)?.name ?? null : null]),
+  );
+  const counts = buildLocationCounts(locations, assets, bulkAssets, kits, projects);
+
+  const filtered = filterLocations(locations, {
+    search: params.search,
+    type: params.type,
+    typeIn: params.typeIn,
+  });
+  const total = filtered.length;
+  const sorted = sortLocations(filtered, params.sortBy, params.sortOrder, parentNameById);
+  const start = (params.page - 1) * params.pageSize;
+  const pageRows = sorted.slice(start, start + params.pageSize);
+
+  const rows: LocationListRow[] = pageRows.map((l) => {
+    const parentRow = l.parentId ? byId.get(l.parentId) : undefined;
+    return {
+      ...l,
+      parent: parentRow ? { name: parentRow.name } : null,
+      _count: counts.get(l.id) ?? { assets: 0, bulkAssets: 0, kits: 0, children: 0, projects: 0 },
+    };
+  });
+
+  return {
+    locations: rows,
+    total,
+    page: params.page,
+    pageSize: params.pageSize,
+    totalPages: Math.ceil(total / params.pageSize),
+  };
 }

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -5,7 +5,14 @@ import { prisma } from "@/lib/prisma";
 import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
-import { getModelMap, getModelsByOrg } from "@/lib/models-read";
+import { getModelMap } from "@/lib/models-read";
+import {
+  listCategoriesWithCounts,
+  getCategoryModelKitCounts,
+  listCategoryTree,
+  collectDescendantCategoryIds,
+  getMappedCategoriesByOrg,
+} from "@/lib/categories-read";
 import { serialize } from "@/lib/serialize";
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
 import { logActivity } from "@/lib/activity-log";
@@ -35,15 +42,12 @@ async function patchCategoryInConvex(id: string, row: Record<string, unknown>) {
   });
 }
 
+// Categories list — READ FROM CONVEX (Phase A). The parent/children hierarchy is
+// rebuilt client-side from the flat Convex list; model + kit counts aggregate
+// from the (dual-written) Convex model/kit lists. See src/lib/categories-read.ts.
 export async function getCategories() {
   const { organizationId } = await getOrgContext();
-  return serialize(
-    await prisma.category.findMany({
-      where: { organizationId },
-      include: { parent: true, _count: { select: { models: true, kits: true, children: true } } },
-      orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
-    })
-  );
+  return serialize(await listCategoriesWithCounts(organizationId));
 }
 
 export async function getCategory(id: string) {
@@ -91,42 +95,15 @@ export async function getCategory(id: string) {
  */
 export async function getCategoryCounts(): Promise<Record<string, { models: number; kits: number }>> {
   const { organizationId } = await getOrgContext();
-  // Models live in Convex — count by categoryId in JS instead of a Prisma groupBy.
-  const [allModels, kitGroups] = await Promise.all([
-    getModelsByOrg(organizationId),
-    prisma.kit.groupBy({ by: ["categoryId"], where: { organizationId, categoryId: { not: null } }, _count: { _all: true } }),
-  ]);
-  const counts: Record<string, { models: number; kits: number }> = {};
-  const ensure = (id: string) => (counts[id] ??= { models: 0, kits: 0 });
-  for (const m of allModels) if (m.categoryId) ensure(m.categoryId).models++;
-  for (const g of kitGroups) if (g.categoryId) ensure(g.categoryId).kits = g._count._all;
-  return serialize(counts);
+  // Models AND kits live in Convex — count by categoryId in JS from both lists.
+  return serialize(await getCategoryModelKitCounts(organizationId));
 }
 
+// Category tree — READ FROM CONVEX (Phase A). Tree rebuilt client-side from the
+// flat Convex list; `_count.models` from the Convex model list.
 export async function getCategoryTree() {
   const { organizationId } = await getOrgContext();
-  const categories = await prisma.category.findMany({
-    where: { organizationId },
-    include: { _count: { select: { models: true } } },
-    orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
-  });
-
-  // Build tree structure
-  const map = new Map<string, typeof categories[0] & { children: typeof categories }>();
-  const roots: (typeof categories[0] & { children: typeof categories })[] = [];
-
-  for (const cat of categories) {
-    map.set(cat.id, { ...cat, children: [] });
-  }
-  for (const cat of categories) {
-    const node = map.get(cat.id)!;
-    if (cat.parentId && map.has(cat.parentId)) {
-      map.get(cat.parentId)!.children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-  return serialize(roots);
+  return serialize(await listCategoryTree(organizationId));
 }
 
 // Get category + all descendant IDs for container cases.
@@ -142,32 +119,11 @@ export async function getCaseCategoryIds(): Promise<string[]> {
   const rootCatId = settings.prepKitCategoryId;
   if (!rootCatId) return [];
 
-  // Fetch all categories and walk the tree
-  const allCats = await prisma.category.findMany({
-    where: { organizationId },
-    select: { id: true, parentId: true },
-  });
-
-  const childrenMap = new Map<string, string[]>();
-  for (const cat of allCats) {
-    if (cat.parentId) {
-      const list = childrenMap.get(cat.parentId) || [];
-      list.push(cat.id);
-      childrenMap.set(cat.parentId, list);
-    }
-  }
-
-  // BFS from root
-  const result: string[] = [];
-  const queue = [rootCatId];
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    result.push(id);
-    const kids = childrenMap.get(id);
-    if (kids) queue.push(...kids);
-  }
-
-  return result;
+  // The category tree walk reads from Convex (categories are dual-written). The
+  // org.metadata read above stays Prisma: the `organization` table is owned by
+  // Better Auth, not part of the domain-data dual-write set.
+  const allCats = await getMappedCategoriesByOrg(organizationId);
+  return collectDescendantCategoryIds(allCats, rootCatId);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/locations.ts
+++ b/src/server/locations.ts
@@ -11,10 +11,10 @@ import { getModelMap } from "@/lib/models-read";
 import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
 import { getKitsByOrg } from "@/lib/kits-read";
 import { locationSchema, type LocationFormValues } from "@/lib/validations/asset";
-import type { Prisma } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
-import { buildFilterWhere, type FilterValue, type FilterColumnDef } from "@/lib/table-utils";
+import { type FilterValue } from "@/lib/table-utils";
+import { listLocations } from "@/lib/locations-read";
 
 // Locations are DUAL-WRITTEN: every create/update/delete writes the Prisma
 // `location` row (the durable FK anchor — asset/bulk_asset/kit/project/
@@ -60,10 +60,11 @@ async function unsetDefaultsInConvex(organizationId: string, exceptId?: string) 
   }
 }
 
-const locationFilterColumns: FilterColumnDef[] = [
-  { id: "type", filterType: "enum", filterKey: "type" },
-];
-
+// Locations list — READ FROM CONVEX (Phase A). Filter/sort/paginate + the parent
+// name self-join + per-location relation counts are all computed client-side from
+// the dual-written Convex location/asset/bulk-asset/kit/project lists. The enum
+// `filters.type` is pulled out as a plain string[] for the JS filter (no Prisma
+// `where` is built any more). See src/lib/locations-read.ts.
 export async function getLocations(params?: {
   search?: string;
   type?: string;
@@ -84,42 +85,20 @@ export async function getLocations(params?: {
     sortOrder = "asc",
   } = params || {};
 
-  const filterWhere = buildFilterWhere(filters, locationFilterColumns);
+  const rawTypeFilter = filters?.type;
+  const typeIn = Array.isArray(rawTypeFilter) ? (rawTypeFilter as string[]) : undefined;
 
-  const where: Prisma.LocationWhereInput = {
-    organizationId,
-    ...(type && { type: type as Prisma.EnumLocationTypeFilter }),
-    ...(search && {
-      OR: [
-        { name: { contains: search, mode: "insensitive" } },
-        { address: { contains: search, mode: "insensitive" } },
-      ],
+  return serialize(
+    await listLocations(organizationId, {
+      search,
+      type,
+      typeIn,
+      page,
+      pageSize,
+      sortBy,
+      sortOrder,
     }),
-    ...filterWhere,
-  };
-
-  const [locations, total] = await Promise.all([
-    prisma.location.findMany({
-      where,
-      include: {
-        parent: { select: { name: true } },
-        _count: { select: { assets: true, bulkAssets: true, kits: true, children: true, projects: true } },
-      },
-      orderBy: sortBy === "parent" ? { parent: { name: sortOrder } }
-        : [{ isDefault: "desc" }, { [sortBy]: sortOrder }],
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.location.count({ where }),
-  ]);
-
-  return serialize({
-    locations,
-    total,
-    page,
-    pageSize,
-    totalPages: Math.ceil(total / pageSize),
-  });
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase A read-rewiring for two **leaf** surfaces of the "domain data Convex-only" decommission. `category` + `location` are both dual-written + backfilled, so the Convex list becomes the read source for the pure list/tree/count/filter reads. The self-referential parent/children hierarchy is rebuilt **client-side** from the flat Convex list via a Map; cross-domain relation counts aggregate in JS from the dual-written model/kit/asset/project lists. **No new Convex queries** — all reuse existing `*.list`/`getById` module queries. **No `convex/_generated` edits.**

### `server/categories.ts`
**Converted → Convex** (`src/lib/categories-read.ts`):
- `getCategories` — list + `parent` self-join + `_count {models, kits, children}`
- `getCategoryCounts` — `categoryId → {models, kits}` (replaces the `kit` Prisma `groupBy`)
- `getCategoryTree` — roots-first forest + `_count.models`, nested + sorted
- `getCaseCategoryIds` — the category-tree BFS walk (pure `collectDescendantCategoryIds`)

**Left Prisma (documented):**
- `getCategory` — detail-page composite (kit serializedItems/bulkItems counts, per-model asset counts, primary model media — cross-domain aggregations with no Convex read helper; analogous to the intentional detail-page-media-gallery terminus)
- the `org.metadata` read inside `getCaseCategoryIds` — the `organization` table is Better-Auth-owned, not in the domain dual-write set
- `searchContainerAssets` — **skipped**, covered by sibling PR #237

### `server/locations.ts`
**Converted → Convex** (`src/lib/locations-read.ts`):
- `getLocations` — filter/sort/paginate + `parent {name}` self-join + `_count {assets, bulkAssets, kits, children, projects}` via pure `filterLocations` / `sortLocations` / `buildLocationCounts` + `listLocations`. Faithful to Postgres NULLS-LAST(asc)/FIRST(desc) for the parent-name sort and the `isDefault desc` primary key. `_count.projects` counts **all** projects (incl. templates) — matches the original's lack of an `isTemplate` filter.

**Left Prisma (documented):**
- `getLocation` — detail-page composite (active assets/bulk/kits + model joins, projects + client, media + file gallery)
- `getLocationCounts` — already Convex, no Prisma
- all mutations + `unsetDefaultsInConvex` — **read-then-write** (the single-default toggle reads prior-defaults to unset them in the same action)

## Pattern fidelity
Mappers convert epoch-ms → Date (`serialize()` keeps Date, so the old actions returned Dates), absent → null, Prisma-defaulted columns (`sortOrder=0`, `tags=[]`, `type=WAREHOUSE`, `isDefault=false`) coerced non-null, `_id`/`_creationTime` stripped. **No Prisma fallback on a Convex map miss** (a miss reads null, like a join against a deleted row).

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/categories-read.test.ts src/lib/locations-read.test.ts` — **23 passed** (every new pure fn covered: mappers, sort, child/model-kit counts, tree build, BFS walk; location filter, NULLS ordering, isDefault sort, Date sort)
- `pnpm exec eslint` on changed files — only pre-existing/acceptable warnings (`_id`-strip ×2; `resolveLocationInheritance` already unused on origin/main)

## Deploy gate
**Merge-gated:** `category` + `location` must be backfilled into **prod Convex** before this read deploys (else existing rows read empty). Human-gated on **Coolify PR preview** validation against prod Convex — Convex data-correctness can't be verified in a dev worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)