### PR TITLE
feat(convex): read projects (non-line-item reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,45 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **projects (non-line-item reads)** (`server/projects.ts` → extends `src/lib/projects-read.ts`).
+  Only **`getCallSheetDates`** was moved to Convex — it reads the project's scalar
+  milestone dates (`loadInDate`/`eventStartDate`/`eventEndDate`/`loadOutDate`) plus its
+  non-cancelled, dated `projectService` rows with a per-service `_count.crewAssignments`,
+  none of which touch the line-item tree. New helper `getCallSheetData` (+ pure,
+  unit-tested `mapCallSheetMilestoneDates` and `buildCallSheetServiceDates`) reads via the
+  existing `api.projects.getById`, `api.projectServices.listByProject`, and
+  `api.crewAssignments.listByProject` queries (no new Convex query added). `crewCount` is
+  computed in JS by counting assignments whose `serviceId` matches the service (replacing
+  Prisma's relation `_count`); services are filtered `status != CANCELLED` + `date != null`
+  and ordered `date` asc, exactly mirroring the old query. **Everything else in
+  `server/projects.ts` stays on Prisma:**
+  - `getProject` — the KEYSTONE equipment-tree read (handled separately by the unmerged
+    keystone tree reader); pulls `categories`/`groups`/`lineItems`/`units`/`media`.
+  - `getProjectIssueFlags` — KEYSTONE-blocked (reads `projectLineItem` for overbooked/
+    reduced-stock status).
+  - `getTemplates` — KEYSTONE-blocked (`_count: { lineItems }`).
+  - `getProjects` — KEYSTONE-coupled: its `includeLineItems: true` branch (used by the
+    warehouse page) selects `lineItems`, plus a `location.name` relation-filter on search
+    and arbitrary-field sort/pagination; left on Prisma until the keystone lands.
+  - `peekNextProjectNumber` / `generateTemplateCode` — read-then-write number-allocation
+    logic; `projectNumberSequence` and `organization` are not dual-written.
+  - `createProject` / `updateProject` / `updateProjectStatus` / `updateProjectNotes` /
+    `archiveProject` / `duplicateProject` / `saveAsTemplate` / `deleteTemplate` /
+    `deleteProject` — all read-then-write (status/before-image reads feeding a mutation).
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/projects-read.test.ts
+++ b/src/lib/projects-read.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapCallSheetMilestoneDates,
+  buildCallSheetServiceDates,
+  type ConvexProject,
+  type ConvexProjectService,
+  type ConvexCrewAssignment,
+} from "@/lib/projects-read";
+
+/**
+ * Tests for the pure call-sheet read helpers extracted from the (now
+ * Convex-backed) `getCallSheetDates` server action. These replicate the old
+ * Prisma `where`/`orderBy`/`_count` semantics in JS.
+ */
+
+function project(overrides: Partial<ConvexProject> = {}): ConvexProject {
+  return {
+    _id: "x" as ConvexProject["_id"],
+    _creationTime: 0,
+    id: "p1",
+    organizationId: "org1",
+    projectNumber: "P-001",
+    name: "Test",
+    ...overrides,
+  } as ConvexProject;
+}
+
+function service(overrides: Partial<ConvexProjectService> = {}): ConvexProjectService {
+  return {
+    _id: "s" as ConvexProjectService["_id"],
+    _creationTime: 0,
+    id: "svc",
+    organizationId: "org1",
+    projectId: "p1",
+    type: "LABOUR",
+    title: "Svc",
+    ...overrides,
+  } as ConvexProjectService;
+}
+
+function assignment(overrides: Partial<ConvexCrewAssignment> = {}): ConvexCrewAssignment {
+  return {
+    _id: "a" as ConvexCrewAssignment["_id"],
+    _creationTime: 0,
+    id: "asn",
+    organizationId: "org1",
+    projectId: "p1",
+    ...overrides,
+  } as ConvexCrewAssignment;
+}
+
+describe("mapCallSheetMilestoneDates", () => {
+  it("converts epoch-ms milestone fields to Date", () => {
+    const t = Date.UTC(2026, 5, 1);
+    const result = mapCallSheetMilestoneDates(
+      project({ loadInDate: t, eventStartDate: t + 1, eventEndDate: t + 2, loadOutDate: t + 3 }),
+    );
+    expect(result.loadInDate).toEqual(new Date(t));
+    expect(result.eventStartDate).toEqual(new Date(t + 1));
+    expect(result.eventEndDate).toEqual(new Date(t + 2));
+    expect(result.loadOutDate).toEqual(new Date(t + 3));
+  });
+
+  it("maps absent milestone fields to null", () => {
+    const result = mapCallSheetMilestoneDates(project());
+    expect(result.loadInDate).toBeNull();
+    expect(result.eventStartDate).toBeNull();
+    expect(result.eventEndDate).toBeNull();
+    expect(result.loadOutDate).toBeNull();
+  });
+});
+
+describe("buildCallSheetServiceDates", () => {
+  it("drops CANCELLED services (Prisma where status != CANCELLED)", () => {
+    const t = Date.UTC(2026, 0, 1);
+    const result = buildCallSheetServiceDates(
+      [
+        service({ id: "ok", date: t, status: "CONFIRMED" }),
+        service({ id: "cancelled", date: t + 1, status: "CANCELLED" }),
+      ],
+      [],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toEqual(new Date(t));
+  });
+
+  it("drops services with no date (call-site .filter(date != null))", () => {
+    const t = Date.UTC(2026, 0, 1);
+    const result = buildCallSheetServiceDates(
+      [service({ id: "dated", date: t }), service({ id: "undated", date: undefined })],
+      [],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toEqual(new Date(t));
+  });
+
+  it("counts crew assignments per service via serviceId (_count crewAssignments)", () => {
+    const t = Date.UTC(2026, 0, 1);
+    const result = buildCallSheetServiceDates(
+      [service({ id: "svc1", date: t }), service({ id: "svc2", date: t + 1 })],
+      [
+        assignment({ id: "a1", serviceId: "svc1" }),
+        assignment({ id: "a2", serviceId: "svc1" }),
+        assignment({ id: "a3", serviceId: "svc2" }),
+        assignment({ id: "a4", serviceId: undefined }), // unlinked — not counted
+        assignment({ id: "a5", serviceId: "other" }), // other service — not counted
+      ],
+    );
+    expect(result.find((r) => r.date.getTime() === t)?.crewCount).toBe(2);
+    expect(result.find((r) => r.date.getTime() === t + 1)?.crewCount).toBe(1);
+  });
+
+  it("returns crewCount 0 for a service with no assignments", () => {
+    const t = Date.UTC(2026, 0, 1);
+    const result = buildCallSheetServiceDates([service({ id: "svc1", date: t })], []);
+    expect(result[0].crewCount).toBe(0);
+  });
+
+  it("orders ascending by date (Prisma orderBy date asc)", () => {
+    const a = Date.UTC(2026, 0, 3);
+    const b = Date.UTC(2026, 0, 1);
+    const c = Date.UTC(2026, 0, 2);
+    const result = buildCallSheetServiceDates(
+      [service({ id: "a", date: a }), service({ id: "b", date: b }), service({ id: "c", date: c })],
+      [],
+    );
+    expect(result.map((r) => r.date.getTime())).toEqual([b, c, a]);
+  });
+
+  it("converts epoch-ms service date to Date", () => {
+    const t = Date.UTC(2026, 5, 15);
+    const result = buildCallSheetServiceDates([service({ date: t })], []);
+    expect(result[0].date).toEqual(new Date(t));
+    expect(result[0].date).toBeInstanceOf(Date);
+  });
+});

--- a/src/lib/projects-read.ts
+++ b/src/lib/projects-read.ts
@@ -3,6 +3,8 @@ import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 
 export type ConvexProject = Doc<"projects">;
+export type ConvexProjectService = Doc<"projectServices">;
+export type ConvexCrewAssignment = Doc<"crewAssignments">;
 
 export async function getProjectsByOrg(orgId: string): Promise<ConvexProject[]> {
   return await (await getConvexClient()).query(api.projects.list, { orgId });
@@ -17,4 +19,86 @@ export async function getProjectIdsForManager(orgId: string, userId: string): Pr
   const client = await getConvexClient();
   const entries = await client.query(api.projectManagers.list, { orgId });
   return new Set(entries.filter((e) => e.userId === userId).map((e) => e.projectId));
+}
+
+/** Convert an optional epoch-ms field to a Date (serialize keeps Date), else null. */
+function epochToDate(ms: number | undefined | null): Date | null {
+  return ms == null ? null : new Date(ms);
+}
+
+/**
+ * Project milestone dates used by the call-sheet date picker. Replaces the
+ * scalar-only `prisma.project.findUnique(... select dates ...)` read — the
+ * `project` row is dual-written to Convex, so these come from the Convex doc.
+ * Epoch-ms is converted back to `Date` because `serialize()` round-trips Dates.
+ */
+export type CallSheetMilestoneDates = {
+  loadInDate: Date | null;
+  eventStartDate: Date | null;
+  eventEndDate: Date | null;
+  loadOutDate: Date | null;
+};
+
+export function mapCallSheetMilestoneDates(project: ConvexProject): CallSheetMilestoneDates {
+  return {
+    loadInDate: epochToDate(project.loadInDate),
+    eventStartDate: epochToDate(project.eventStartDate),
+    eventEndDate: epochToDate(project.eventEndDate),
+    loadOutDate: epochToDate(project.loadOutDate),
+  };
+}
+
+export type CallSheetServiceDate = { date: Date; crewCount: number };
+
+/**
+ * Pure replacement for the Prisma `projectService.findMany({ where: status !=
+ * CANCELLED, select: { date, _count: { crewAssignments } }, orderBy: date asc })`
+ * read, plus its dropped-null filter at the call site. Replicates exactly:
+ *   - drop services whose `status === "CANCELLED"` (Prisma `where`)
+ *   - drop services with no `date` (the call site's `.filter(s => s.date != null)`)
+ *   - `crewCount` = number of crew assignments whose `serviceId` matches the
+ *     service (Prisma `_count: { crewAssignments }`, the per-service relation count)
+ *   - order ascending by `date` (Prisma `orderBy: { date: "asc" }`)
+ * Epoch-ms `date` is converted back to a `Date`.
+ */
+export function buildCallSheetServiceDates(
+  services: ConvexProjectService[],
+  assignments: ConvexCrewAssignment[],
+): CallSheetServiceDate[] {
+  const countByServiceId = new Map<string, number>();
+  for (const a of assignments) {
+    if (a.serviceId == null) continue;
+    countByServiceId.set(a.serviceId, (countByServiceId.get(a.serviceId) ?? 0) + 1);
+  }
+  return services
+    .filter((s) => s.status !== "CANCELLED" && s.date != null)
+    .sort((a, b) => (a.date ?? 0) - (b.date ?? 0))
+    .map((s) => ({
+      date: new Date(s.date as number),
+      crewCount: countByServiceId.get(s.id) ?? 0,
+    }));
+}
+
+/**
+ * Convex fetchers for the call-sheet date picker: the project milestone dates +
+ * its (non-cancelled, dated) services with per-service crew counts. Mirrors the
+ * old `getCallSheetDates` Prisma reads. Returns `null` when the project is
+ * missing (no Prisma fallback — a miss means the row isn't mirrored / was
+ * deleted, exactly like a join against a deleted row).
+ */
+export async function getCallSheetData(
+  orgId: string,
+  projectId: string,
+): Promise<{ milestones: CallSheetMilestoneDates; serviceDates: CallSheetServiceDate[] } | null> {
+  const client = await getConvexClient();
+  const [project, services, assignments] = await Promise.all([
+    client.query(api.projects.getById, { id: projectId }),
+    client.query(api.projectServices.listByProject, { projectId, orgId }),
+    client.query(api.crewAssignments.listByProject, { projectId, orgId }),
+  ]);
+  if (!project || project.organizationId !== orgId) return null;
+  return {
+    milestones: mapCallSheetMilestoneDates(project),
+    serviceDates: buildCallSheetServiceDates(services, assignments),
+  };
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getClientById, getClientMap, attachClient } from "@/lib/clients-read";
+import { getCallSheetData } from "@/lib/projects-read";
 import {
   buildLineItemAttachMaps,
   attachLineItemTree,
@@ -1292,26 +1293,12 @@ export async function deleteProject(id: string) {
 /** Get project milestone dates for call sheet dialog */
 export async function getCallSheetDates(projectId: string) {
   const { organizationId } = await getOrgContext();
-  const [project, services] = await Promise.all([
-    prisma.project.findUnique({
-      where: { id: projectId, organizationId },
-      select: {
-        loadInDate: true,
-        eventStartDate: true,
-        eventEndDate: true,
-        loadOutDate: true,
-      },
-    }),
-    prisma.projectService.findMany({
-      where: { projectId, organizationId, status: { not: "CANCELLED" } },
-      select: {
-        date: true,
-        _count: { select: { crewAssignments: true } },
-      },
-      orderBy: { date: "asc" },
-    }),
-  ]);
-  if (!project) {
+  // project (scalar milestone dates), projectService (date + per-service crew
+  // count) and crewAssignment are all dual-written to Convex — read from there
+  // instead of Prisma. No line-item/group/category data is touched, so this is
+  // safe ahead of the keystone tree reader. See src/lib/projects-read.ts.
+  const data = await getCallSheetData(organizationId, projectId);
+  if (!data) {
     throw new UserFacingError({
       code: "NOT_FOUND",
       title: "Project not found",
@@ -1319,9 +1306,7 @@ export async function getCallSheetDates(projectId: string) {
     });
   }
   return serialize({
-    ...project,
-    serviceDates: services
-      .filter((s) => s.date != null)
-      .map((s) => ({ date: s.date, crewCount: s._count.crewAssignments })),
+    ...data.milestones,
+    serviceDates: data.serviceDates,
   });
 }


### PR DESCRIPTION
## Summary

Phase A read-rewiring for the **projects** surface. After classifying every Prisma read in `src/server/projects.ts`, exactly **one** action qualifies as a pure, non-line-item, read-only read: **`getCallSheetDates`**. It is moved off Prisma onto the dual-written Convex rows.

`getCallSheetDates` reads:
- the project's scalar milestone dates (`loadInDate`/`eventStartDate`/`eventEndDate`/`loadOutDate`)
- its `projectService` rows (filtered `status != CANCELLED` + `date != null`, ordered `date` asc)
- a per-service crew-assignment count (Prisma `_count: { crewAssignments }`)

None of this touches the line-item / group / category tree, so it is safe to ship ahead of the unmerged keystone tree reader.

### What changed
- Extends `src/lib/projects-read.ts` with `getCallSheetData` (Convex fetcher) and two pure, unit-tested helpers:
  - `mapCallSheetMilestoneDates` — epoch-ms → `Date` (serialize round-trips Dates), absent → null
  - `buildCallSheetServiceDates` — replicates the Prisma `where`/`orderBy`/`_count`: drops CANCELLED + undated services, counts assignments by `serviceId` (replacing the relation `_count`), orders by date asc, converts date epoch-ms → `Date`
- Reads via **existing** Convex queries `projects.getById`, `projectServices.listByProject`, `crewAssignments.listByProject` — **no new Convex query** added, no `convex/_generated` edits.
- **No Prisma fallback** on a Convex miss (a miss reads null, like a join against a deleted row).

### Stays on Prisma (keystone-blocked / read-then-write)
- `getProject` — KEYSTONE equipment-tree read (handled by the separate unmerged keystone tree reader)
- `getProjectIssueFlags` — keystone-blocked (`projectLineItem` overbooked/reduced-stock)
- `getTemplates` — keystone-blocked (`_count: { lineItems }`)
- `getProjects` — keystone-coupled (`includeLineItems: true` branch used by warehouse, plus `location.name` relation-filter search + arbitrary sort)
- `peekNextProjectNumber` / `generateTemplateCode` — read-then-write number allocation (`projectNumberSequence`/`organization` not dual-written)
- `createProject` / `updateProject` / `updateProjectStatus` / `updateProjectNotes` / `archiveProject` / `duplicateProject` / `saveAsTemplate` / `deleteTemplate` / `deleteProject` — read-then-write

### Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/projects-read.test.ts` — 8 passed
- `pnpm exec eslint` on changed files — clean

### Deploy gate
Merge-gated on the standard Phase A deploy-ordering gate: `project`, `projectService`, and `crewAssignment` must be backfilled into **prod Convex** before this read deploys (else the call-sheet picker reads empty). **Human-gated on a Coolify PR preview** validated against prod Convex — Convex data-correctness can't be verified in a dev worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)