### PR TITLE
feat(convex): read project-managers/tags/scan-lookup from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,24 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **small leaves (project-managers / tags / scan-lookup)** (`server/project-managers.ts`, `server/tags.ts`, `server/scan-lookup.ts`).
+  - `project-managers.ts` — `getProjectManagers` now reads `projectManager` rows from Convex via new `src/lib/project-managers-read.ts` (`getProjectManagerRows` + pure unit-tested `filterAndSortManagers`: org/project scope + `addedAt asc`, epoch-ms→Date, absent `addedAt`→epoch). The `user` join stays a batched `prisma.user.findMany({ id: { in } })` (Better Auth — never moves). `addProjectManager`/`removeProjectManager` stay Prisma (read-then-write: member check + create/delete, still own RBAC/audit/mirror sync). Backfill: `convex-backfill-project-subtables.ts`.
+  - `tags.ts` — `getOrgTags`'s last Prisma read (`maintenanceRecord.findMany({ select: { tags } })`) moved to Convex via new `src/lib/maintenance-read.ts` `getMaintenanceTagsByOrg` (`maintenanceRecords.list` → `{ tags }`, `tags ?? []`); Prisma import dropped. (`tag` has no table — `getOrgTags` aggregates per-domain `tags` arrays, all already Convex-backed.)
+  - `scan-lookup.ts` — the test & tag branch's `testTagAsset.findUnique` moved to Convex via **new query `testTagAssets.getByOrgTestTagId`** (uses existing `by_organizationId_testTagId` index, mirrors the Prisma `organizationId_testTagId` unique). Stale "no Convex mirror" comment corrected; this is a read-only lookup (no read-then-write), so the Prisma import is fully dropped. Backfill: `convex-backfill-test-tag-assets.ts`.
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/convex/testTagAssets.ts
+++ b/convex/testTagAssets.ts
@@ -32,6 +32,19 @@ export const getById = query({
   },
 });
 
+export const getByOrgTestTagId = query({
+  args: { orgId: v.string(), testTagId: v.string() },
+  handler: async (ctx, { orgId, testTagId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("testTagAssets")
+      .withIndex("by_organizationId_testTagId", (q) =>
+        q.eq("organizationId", orgId).eq("testTagId", testTagId),
+      )
+      .unique();
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/lib/maintenance-read.ts
+++ b/src/lib/maintenance-read.ts
@@ -1,0 +1,23 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Server-side read helpers for MaintenanceRecord (Phase A read-rewiring).
+ *
+ * `maintenanceRecord` is dual-written (Prisma anchor + Convex reactive doc — see
+ * src/lib/maintenance-mirror.ts). Reads that only need the Convex copy go through
+ * here. No Prisma fallback on a Convex miss. See FEATUREDOCS/54.
+ */
+
+/**
+ * Distinct-tag aggregation feed: an org's maintenance records normalised to the
+ * `{ tags }` shape `getOrgTags` consumes. `tags` is Prisma-defaulted to `[]`, so a
+ * Convex doc with the field absent coerces to an empty array.
+ */
+export async function getMaintenanceTagsByOrg(
+  organizationId: string,
+): Promise<{ tags: string[] }[]> {
+  const client = await getConvexClient();
+  const docs = await client.query(api.maintenanceRecords.list, { orgId: organizationId });
+  return docs.map((d) => ({ tags: d.tags ?? [] }));
+}

--- a/src/lib/project-managers-read.test.ts
+++ b/src/lib/project-managers-read.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the pure projectManager filter/sort (`filterAndSortManagers`).
+ *
+ * Replaces the Prisma read
+ * `findMany({ where: { projectId, organizationId }, orderBy: { addedAt: "asc" } })`.
+ * Safety property: identical row set + order — org/project-scoped, ascending by
+ * addedAt, with epoch-ms `addedAt` mapped back to a Date.
+ */
+import { describe, it, expect } from "vitest";
+import { filterAndSortManagers, type ConvexProjectManager } from "@/lib/project-managers-read";
+
+function doc(over: Partial<ConvexProjectManager>): ConvexProjectManager {
+  return {
+    _id: "x" as ConvexProjectManager["_id"],
+    _creationTime: 0,
+    id: "pm1",
+    organizationId: "org1",
+    projectId: "proj1",
+    userId: "u1",
+    addedAt: 1000,
+    ...over,
+  } as ConvexProjectManager;
+}
+
+describe("filterAndSortManagers", () => {
+  it("keeps only rows matching both projectId and organizationId", () => {
+    const rows = filterAndSortManagers(
+      [
+        doc({ id: "a", projectId: "proj1", organizationId: "org1" }),
+        doc({ id: "b", projectId: "proj2", organizationId: "org1" }),
+        doc({ id: "c", projectId: "proj1", organizationId: "org2" }),
+      ],
+      "proj1",
+      "org1",
+    );
+    expect(rows.map((r) => r.id)).toEqual(["a"]);
+  });
+
+  it("sorts ascending by addedAt", () => {
+    const rows = filterAndSortManagers(
+      [
+        doc({ id: "late", addedAt: 3000 }),
+        doc({ id: "early", addedAt: 1000 }),
+        doc({ id: "mid", addedAt: 2000 }),
+      ],
+      "proj1",
+      "org1",
+    );
+    expect(rows.map((r) => r.id)).toEqual(["early", "mid", "late"]);
+  });
+
+  it("maps epoch-ms addedAt to a Date and preserves scalar fields", () => {
+    const [row] = filterAndSortManagers(
+      [doc({ id: "pm9", userId: "u42", addedAt: 1700000000000 })],
+      "proj1",
+      "org1",
+    );
+    expect(row).toEqual({
+      id: "pm9",
+      organizationId: "org1",
+      projectId: "proj1",
+      userId: "u42",
+      addedAt: new Date(1700000000000),
+    });
+    expect(row.addedAt).toBeInstanceOf(Date);
+  });
+
+  it("coerces an absent addedAt to the epoch (Prisma @default(now()) column)", () => {
+    const [row] = filterAndSortManagers(
+      [doc({ id: "pm0", addedAt: undefined })],
+      "proj1",
+      "org1",
+    );
+    expect(row.addedAt).toEqual(new Date(0));
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterAndSortManagers([doc({})], "nope", "org1")).toEqual([]);
+  });
+});

--- a/src/lib/project-managers-read.ts
+++ b/src/lib/project-managers-read.ts
@@ -1,0 +1,60 @@
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for ProjectManager (Phase A read-rewiring).
+ *
+ * `projectManager` is dual-written (Prisma FK anchor + Convex reactive doc — see
+ * src/lib/project-subtable-mirror.ts `syncProjectManagersToConvex`, backfilled by
+ * scripts/convex-backfill-project-subtables.ts). Pure reads of projectManager rows
+ * go through these helpers. The `user` half is Better Auth and stays a batched
+ * Prisma lookup in the server action. No Prisma fallback on a Convex miss. See
+ * FEATUREDOCS/54.
+ */
+export type ConvexProjectManager = Doc<"projectManagers">;
+
+/** A projectManager row mapped back to the Prisma `ProjectManager` shape (epoch-ms → Date). */
+export interface ProjectManagerRow {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  userId: string;
+  addedAt: Date;
+}
+
+function mapProjectManager(doc: ConvexProjectManager): ProjectManagerRow {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    projectId: doc.projectId,
+    userId: doc.userId,
+    // addedAt has a Prisma @default(now()); a backfilled/older row may be absent.
+    addedAt: doc.addedAt != null ? new Date(doc.addedAt) : new Date(0),
+  };
+}
+
+/**
+ * Pure: replicate Prisma `where: { projectId, organizationId }` + `orderBy: { addedAt: "asc" }`.
+ * The Convex `list` query returns ALL of an org's managers; we filter + sort in JS.
+ */
+export function filterAndSortManagers(
+  docs: ConvexProjectManager[],
+  projectId: string,
+  organizationId: string,
+): ProjectManagerRow[] {
+  return docs
+    .filter((d) => d.projectId === projectId && d.organizationId === organizationId)
+    .map(mapProjectManager)
+    .sort((a, b) => a.addedAt.getTime() - b.addedAt.getTime());
+}
+
+/** Fetch + filter + sort an org's project managers for one project (Convex-backed). */
+export async function getProjectManagerRows(
+  organizationId: string,
+  projectId: string,
+): Promise<ProjectManagerRow[]> {
+  const client = await getConvexClient();
+  const docs = await client.query(api.projectManagers.list, { orgId: organizationId });
+  return filterAndSortManagers(docs, projectId, organizationId);
+}

--- a/src/server/project-managers.ts
+++ b/src/server/project-managers.ts
@@ -5,19 +5,28 @@ import { requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { syncProjectManagersToConvex } from "@/lib/project-subtable-mirror";
+import { getProjectManagerRows } from "@/lib/project-managers-read";
 
 export async function getProjectManagers(projectId: string) {
   const { organizationId } = await requirePermission("project", "read");
 
-  const managers = await prisma.projectManager.findMany({
-    where: { projectId, organizationId },
-    include: {
-      user: {
+  // projectManager rows come from Convex (dual-written). The `user` half is
+  // Better Auth and stays a batched Prisma lookup.
+  const rows = await getProjectManagerRows(organizationId, projectId);
+
+  const userIds = [...new Set(rows.map((r) => r.userId))];
+  const users = userIds.length
+    ? await prisma.user.findMany({
+        where: { id: { in: userIds } },
         select: { id: true, name: true, email: true, image: true },
-      },
-    },
-    orderBy: { addedAt: "asc" },
-  });
+      })
+    : [];
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  const managers = rows.map((r) => ({
+    ...r,
+    user: userMap.get(r.userId) ?? null,
+  }));
 
   return serialize(managers);
 }

--- a/src/server/scan-lookup.ts
+++ b/src/server/scan-lookup.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
@@ -38,10 +37,10 @@ export async function scanLookup(value: string): Promise<{ url: string | null; l
     return { url: `/assets/registry/${bulk.id}`, label: `Bulk Asset ${bulk.assetTag}` };
   }
 
-  // 4. Check test & tag items (stays Prisma — testTagAsset has no Convex mirror)
-  const ttAsset = await prisma.testTagAsset.findUnique({
-    where: { organizationId_testTagId: { organizationId, testTagId: tag } },
-    select: { id: true, testTagId: true },
+  // 4. Check test & tag items (testTagAsset is dual-written — read from Convex).
+  const ttAsset = await client.query(api.testTagAssets.getByOrgTestTagId, {
+    orgId: organizationId,
+    testTagId: tag,
   });
   if (ttAsset) {
     return { url: `/test-and-tag/${ttAsset.id}`, label: `T&T ${ttAsset.testTagId}` };

--- a/src/server/tags.ts
+++ b/src/server/tags.ts
@@ -8,7 +8,7 @@ import { getKitsByOrg } from "@/lib/kits-read";
 import { getLocationsByOrg } from "@/lib/locations-read";
 import { getCategoriesByOrg } from "@/lib/categories-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
-import { prisma } from "@/lib/prisma";
+import { getMaintenanceTagsByOrg } from "@/lib/maintenance-read";
 
 /**
  * Get all distinct tags used across the organization.
@@ -26,7 +26,8 @@ export async function getOrgTags(): Promise<string[]> {
     getKitsByOrg(organizationId).then((ks) => ks.map((k) => ({ tags: k.tags ?? [] }))),
     getLocationsByOrg(organizationId).then((ls) => ls.map((l) => ({ tags: l.tags ?? [] }))),
     getCategoriesByOrg(organizationId).then((cs) => cs.map((c) => ({ tags: c.tags ?? [] }))),
-    prisma.maintenanceRecord.findMany({ where: { organizationId }, select: { tags: true } }),
+    // Maintenance records live in Convex (dual-written) — normalise to { tags }.
+    getMaintenanceTagsByOrg(organizationId),
     getProjectsByOrg(organizationId).then((ps) => ps.map((p) => ({ tags: p.tags ?? [] }))),
     // Clients live in Convex now — normalise to the same { tags } shape.
     getClientsByOrg(organizationId).then((cs) => cs.map((c) => ({ tags: c.tags ?? [] }))),


### PR DESCRIPTION
Phase A read-rewiring for three small **leaf** surfaces of the "domain data Convex-only" decommission. Each target table is dual-written + backfilled, so reads move to Convex with **no Prisma fallback** on a map miss (a miss reads null, like a join against a deleted row — falling back would hide mirror drift).

## Per-file

**`server/project-managers.ts`** — `getProjectManagers` reads `projectManager` rows from Convex via new `src/lib/project-managers-read.ts` (`getProjectManagerRows` + pure unit-tested `filterAndSortManagers`: org/project scope + `addedAt asc`, epoch-ms→Date, absent `addedAt`→epoch). The `user` half is Better Auth → stays a batched `prisma.user.findMany({ id: { in } })`. `addProjectManager`/`removeProjectManager` **left on Prisma** (read-then-write: member check + create/delete, still own RBAC/audit/mirror sync).
- Dual-write: `syncProjectManagersToConvex` (`project-subtable-mirror.ts`). Backfill: `convex-backfill-project-subtables.ts` (`convex:backfill:project-subtables`).

**`server/tags.ts`** — `getOrgTags`'s last Prisma read (`maintenanceRecord.findMany({ select: { tags } })`) moves to Convex via new `src/lib/maintenance-read.ts` `getMaintenanceTagsByOrg`. Prisma import dropped. (There is no `tag` table — `getOrgTags` aggregates per-domain `tags` arrays, all already Convex-backed.)
- Dual-write: `maintenance-mirror.ts` + `convex/maintenanceRecords.ts`.

**`server/scan-lookup.ts`** — the test & tag branch's `testTagAsset.findUnique` moves to Convex via **new query `testTagAssets.getByOrgTestTagId`** (added to the existing `convex/testTagAssets.ts`, using the existing `by_organizationId_testTagId` index — mirrors the Prisma `organizationId_testTagId` unique). The stale "testTagAsset has no Convex mirror" comment is corrected; this is a read-only lookup (no read-then-write), so the Prisma import is fully dropped.
- Dual-write: `convex/testTagAssets.ts` + mirror. Backfill: `convex-backfill-test-tag-assets.ts` (`convex:backfill:test-tag-assets`).

## New convex query
`testTagAssets.getByOrgTestTagId({ orgId, testTagId })` — service-only, `.unique()` on `by_organizationId_testTagId`. No new module; `_generated/api.d.ts` untouched (whole-module import already covers it). Reverted the `purgeRemovedTables` codegen drift the dev push introduced.

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/project-managers-read.test.ts` — 5/5 pass
- `pnpm exec eslint <changed files>` — clean

Note: `pnpm exec convex dev --once` could not push to the shared dev deployment due to a **pre-existing** schema-vs-data mismatch (an autoplan fixture row in `projects` has a stale `billingDays` field not in the current validator) — unrelated to this change. The new query is correct and tsc-resolves; it deploys via the PR preview / prod path.

## Deploy gate (merge gate)
**`projectManager`, `maintenanceRecord`, and `testTagAsset` must be backfilled into prod Convex BEFORE this merges**, else the rewired reads return empty. Human-gated on the Coolify PR preview against prod Convex (Convex data-correctness can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)