### PR TITLE
feat(convex): read suppliers (primary reads) from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,38 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **suppliers (primary reads)** (`server/suppliers.ts` → extends `src/lib/suppliers-read.ts`).
+  `getSuppliers`, `getSuppliersPaginated`, and `getSupplierById` moved off
+  `prisma.supplier` to Convex via new `getMappedSuppliersByOrg` + `mapSupplier`
+  (epoch-ms→Date so `serialize` hands the client the same Date shape; tags `[]` /
+  isActive `true` coerced; absent optionals → null; `_id`/`_creationTime` stripped)
+  and pure unit-tested predicates `supplierMatchesSearch` (name/contact/email/
+  account#/tags, tag arm is exact-membership matching Prisma `hasSome`) +
+  `compareSuppliers` (string/Date/boolean, nulls-last). Per-supplier `_count.assets`
+  and `_count.orders` now come from Convex (`getAssetsByOrg` + `api.supplierOrders.list`
+  via the new private `getOrgSupplierCounts`); `getSupplierById` drops its embedded
+  `orders` array (the detail page fetches orders via `getSupplierOrders`, never reads
+  `supplier.orders`). **`getSupplierCounts` (sibling PR #237) and `getSupplierOrders`/
+  `getSupplierOrderById` (sibling PR #198) left untouched.** **Left on Prisma + why:**
+  `_count.lineItems` and `getSupplierSubhires` read `projectLineItem` (the keystone
+  line-item tree, read-rewired later as one unit) — the count stays a scalar Prisma
+  `count` (NOT a tree read); `getSupplierAssets` was already Convex (`getAssetsByOrg`
+  + `attachModel`). No new Convex query added (reused the existing
+  `suppliers.list` / `supplierOrders.list` / asset read helpers).
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/suppliers-read.test.ts
+++ b/src/lib/suppliers-read.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapSupplier,
+  supplierMatchesSearch,
+  compareSuppliers,
+  type ConvexSupplier,
+  type MappedSupplier,
+} from "./suppliers-read";
+
+/** Build a raw Convex supplier doc with sensible defaults; override per-test. */
+function doc(over: Partial<ConvexSupplier> = {}): ConvexSupplier {
+  return {
+    _id: "convex_id" as ConvexSupplier["_id"],
+    _creationTime: 123,
+    id: "sup_1",
+    organizationId: "org_1",
+    name: "Acme",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_500_000,
+    ...over,
+  } as ConvexSupplier;
+}
+
+function mapped(over: Partial<ConvexSupplier> = {}): MappedSupplier {
+  return mapSupplier(doc(over));
+}
+
+describe("mapSupplier", () => {
+  it("converts epoch-ms createdAt/updatedAt to Date", () => {
+    const m = mapSupplier(doc({ createdAt: 1_700_000_000_000, updatedAt: 1_700_000_500_000 }));
+    expect(m.createdAt).toBeInstanceOf(Date);
+    expect(m.createdAt.getTime()).toBe(1_700_000_000_000);
+    expect(m.updatedAt.getTime()).toBe(1_700_000_500_000);
+  });
+
+  it("coerces missing timestamps to epoch 0 Dates", () => {
+    const m = mapSupplier(doc({ createdAt: undefined, updatedAt: undefined }));
+    expect(m.createdAt.getTime()).toBe(0);
+    expect(m.updatedAt.getTime()).toBe(0);
+  });
+
+  it("coerces absent optional strings to null", () => {
+    const m = mapSupplier(doc());
+    expect(m.contactName).toBeNull();
+    expect(m.email).toBeNull();
+    expect(m.phone).toBeNull();
+    expect(m.website).toBeNull();
+    expect(m.address).toBeNull();
+    expect(m.notes).toBeNull();
+    expect(m.accountNumber).toBeNull();
+    expect(m.paymentTerms).toBeNull();
+    expect(m.defaultLeadTime).toBeNull();
+    expect(m.latitude).toBeNull();
+    expect(m.longitude).toBeNull();
+  });
+
+  it("coerces Prisma-defaulted columns: tags -> [], isActive -> true", () => {
+    const m = mapSupplier(doc({ tags: undefined, isActive: undefined }));
+    expect(m.tags).toEqual([]);
+    expect(m.isActive).toBe(true);
+  });
+
+  it("preserves provided values including isActive: false", () => {
+    const m = mapSupplier(
+      doc({
+        contactName: "Jane",
+        email: "j@acme.test",
+        tags: ["lighting", "rigging"],
+        isActive: false,
+        latitude: -33.8,
+        longitude: 151.2,
+      }),
+    );
+    expect(m.contactName).toBe("Jane");
+    expect(m.email).toBe("j@acme.test");
+    expect(m.tags).toEqual(["lighting", "rigging"]);
+    expect(m.isActive).toBe(false);
+    expect(m.latitude).toBe(-33.8);
+    expect(m.longitude).toBe(151.2);
+  });
+
+  it("strips Convex system fields", () => {
+    const m = mapSupplier(doc()) as unknown as Record<string, unknown>;
+    expect(m._id).toBeUndefined();
+    expect(m._creationTime).toBeUndefined();
+  });
+});
+
+describe("supplierMatchesSearch", () => {
+  const s = mapped({
+    name: "Acme Lighting",
+    contactName: "Jane Doe",
+    email: "jane@acme.test",
+    accountNumber: "ACC-9001",
+    tags: ["lighting", "rigging"],
+  });
+
+  it("matches everything when search is blank", () => {
+    expect(supplierMatchesSearch(s, "")).toBe(true);
+    expect(supplierMatchesSearch(s, "   ")).toBe(true);
+  });
+
+  it("matches name case-insensitively (substring)", () => {
+    expect(supplierMatchesSearch(s, "acme")).toBe(true);
+    expect(supplierMatchesSearch(s, "LIGHT")).toBe(true);
+  });
+
+  it("matches contactName, email, accountNumber", () => {
+    expect(supplierMatchesSearch(s, "jane")).toBe(true);
+    expect(supplierMatchesSearch(s, "@acme.test")).toBe(true);
+    expect(supplierMatchesSearch(s, "acc-9001")).toBe(true);
+  });
+
+  it("matches a tag exactly (lowercased), like Prisma hasSome [search.toLowerCase()]", () => {
+    expect(supplierMatchesSearch(s, "rigging")).toBe(true);
+    expect(supplierMatchesSearch(s, "RIGGING")).toBe(true);
+    // hasSome is exact membership, not substring — partial tag should not match via the tag arm
+    expect(supplierMatchesSearch(mapped({ name: "X", tags: ["rigging"] }), "rig")).toBe(false);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(supplierMatchesSearch(s, "zzz-nope")).toBe(false);
+  });
+
+  it("tolerates null optional fields", () => {
+    const bare = mapped({ name: "Bare", contactName: undefined, email: undefined, accountNumber: undefined, tags: [] });
+    expect(supplierMatchesSearch(bare, "bare")).toBe(true);
+    expect(supplierMatchesSearch(bare, "anything")).toBe(false);
+  });
+});
+
+describe("compareSuppliers", () => {
+  it("sorts by name ascending, case-insensitively", () => {
+    const rows = [mapped({ name: "beta" }), mapped({ name: "Alpha" }), mapped({ name: "Gamma" })];
+    const sorted = [...rows].sort(compareSuppliers("name", "asc")).map((r) => r.name);
+    expect(sorted).toEqual(["Alpha", "beta", "Gamma"]);
+  });
+
+  it("sorts by name descending", () => {
+    const rows = [mapped({ name: "Alpha" }), mapped({ name: "beta" }), mapped({ name: "Gamma" })];
+    const sorted = [...rows].sort(compareSuppliers("name", "desc")).map((r) => r.name);
+    expect(sorted).toEqual(["Gamma", "beta", "Alpha"]);
+  });
+
+  it("sorts by Date field (createdAt)", () => {
+    const a = mapped({ name: "A", createdAt: 1_000 });
+    const b = mapped({ name: "B", createdAt: 3_000 });
+    const c = mapped({ name: "C", createdAt: 2_000 });
+    const asc = [a, b, c].sort(compareSuppliers("createdAt", "asc")).map((r) => r.name);
+    expect(asc).toEqual(["A", "C", "B"]);
+    const desc = [a, b, c].sort(compareSuppliers("createdAt", "desc")).map((r) => r.name);
+    expect(desc).toEqual(["B", "C", "A"]);
+  });
+
+  it("sorts by boolean field (isActive)", () => {
+    const t = mapped({ name: "T", isActive: true });
+    const f = mapped({ name: "F", isActive: false });
+    const asc = [t, f].sort(compareSuppliers("isActive", "asc")).map((r) => r.name);
+    expect(asc).toEqual(["F", "T"]);
+  });
+
+  it("sorts nulls last regardless of direction", () => {
+    const withVal = mapped({ name: "Z", accountNumber: "A1" });
+    const noVal = mapped({ name: "A", accountNumber: undefined });
+    expect(
+      [noVal, withVal].sort(compareSuppliers("accountNumber", "asc")).map((r) => r.name),
+    ).toEqual(["Z", "A"]);
+    expect(
+      [withVal, noVal].sort(compareSuppliers("accountNumber", "desc")).map((r) => r.name),
+    ).toEqual(["Z", "A"]);
+  });
+});

--- a/src/lib/suppliers-read.ts
+++ b/src/lib/suppliers-read.ts
@@ -24,8 +24,114 @@ import type { Doc } from "../../convex/_generated/dataModel";
  */
 export type ConvexSupplier = Doc<"suppliers">;
 
+/**
+ * A Convex supplier doc mapped back to the *Prisma-row shape* the server actions
+ * (`getSuppliers` / `getSuppliersPaginated` / `getSupplierById`) used to return:
+ * `createdAt`/`updatedAt` as `Date` (because `serialize` preserves `Date`, so the
+ * client receives the same shape it always has), Prisma-defaulted columns coerced
+ * non-null (`tags: []`, `isActive: true`), and absent optionals as `null`. The
+ * Convex system fields (`_id`/`_creationTime`) are stripped.
+ */
+export interface MappedSupplier {
+  id: string;
+  organizationId: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  website: string | null;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  notes: string | null;
+  accountNumber: string | null;
+  paymentTerms: string | null;
+  defaultLeadTime: string | null;
+  tags: string[];
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Map a raw Convex supplier doc back to the Prisma-row shape (see MappedSupplier). */
+export function mapSupplier(doc: ConvexSupplier): MappedSupplier {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    name: doc.name,
+    contactName: doc.contactName ?? null,
+    email: doc.email ?? null,
+    phone: doc.phone ?? null,
+    website: doc.website ?? null,
+    address: doc.address ?? null,
+    latitude: doc.latitude ?? null,
+    longitude: doc.longitude ?? null,
+    notes: doc.notes ?? null,
+    accountNumber: doc.accountNumber ?? null,
+    paymentTerms: doc.paymentTerms ?? null,
+    defaultLeadTime: doc.defaultLeadTime ?? null,
+    tags: doc.tags ?? [],
+    isActive: doc.isActive ?? true,
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
 export async function getSupplierById(id: string): Promise<ConvexSupplier | null> {
   return await (await getConvexClient()).query(api.suppliers.getById, { id });
+}
+
+/** All of an org's suppliers, mapped to the Prisma-row shape (Date/null/defaults). */
+export async function getMappedSuppliersByOrg(orgId: string): Promise<MappedSupplier[]> {
+  return (await getSuppliersByOrg(orgId)).map(mapSupplier);
+}
+
+/**
+ * Pure predicate replicating the old `getSuppliersPaginated` Prisma `where`:
+ * the case-insensitive `search` OR across name/contactName/email/accountNumber
+ * (+ `tags hasSome [search.toLowerCase()]`). `organizationId` and the `isActive`
+ * enum filter are applied separately by the caller (they map to dedicated
+ * narrowings). An empty/blank `search` matches everything.
+ */
+export function supplierMatchesSearch(s: MappedSupplier, search: string): boolean {
+  const q = search.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    s.name.toLowerCase().includes(q) ||
+    (s.contactName?.toLowerCase().includes(q) ?? false) ||
+    (s.email?.toLowerCase().includes(q) ?? false) ||
+    (s.accountNumber?.toLowerCase().includes(q) ?? false) ||
+    s.tags.includes(q)
+  );
+}
+
+/**
+ * Comparator replicating Prisma `orderBy: { [sortBy]: sortOrder }` for the supplier
+ * columns the table sorts by (string fields like `name`, plus the `Date`/`boolean`
+ * columns). Nulls sort LAST regardless of direction, matching Postgres' default
+ * `NULLS LAST` for ascending and replicating it for descending too (the supplier
+ * table never sorts on a nullable column, but we keep the rule explicit). Strings
+ * use locale-aware, case-insensitive comparison (Prisma `name` ordering is
+ * collation-driven; this matches the ASCII supplier names this app uses).
+ */
+export function compareSuppliers(
+  sortBy: string,
+  sortOrder: "asc" | "desc",
+): (a: MappedSupplier, b: MappedSupplier) => number {
+  const dir = sortOrder === "desc" ? -1 : 1;
+  return (a, b) => {
+    const av = (a as unknown as Record<string, unknown>)[sortBy];
+    const bv = (b as unknown as Record<string, unknown>)[sortBy];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av instanceof Date && bv instanceof Date) return (av.getTime() - bv.getTime()) * dir;
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    if (typeof av === "boolean" && typeof bv === "boolean") {
+      return (Number(av) - Number(bv)) * dir;
+    }
+    return String(av).localeCompare(String(bv), undefined, { sensitivity: "base" }) * dir;
+  };
 }
 
 export async function getSuppliersByOrg(orgId: string): Promise<ConvexSupplier[]> {

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -9,10 +9,16 @@ import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { supplierSchema, type SupplierFormValues } from "@/lib/validations/supplier";
 import { logActivity, buildChanges } from "@/lib/activity-log";
-import { buildFilterWhere, type FilterValue } from "@/lib/table-utils";
-import type { ColumnDef } from "@/components/ui/data-table";
+import { type FilterValue } from "@/lib/table-utils";
 import { attachModel } from "@/lib/models-read";
 import { getAssetsByOrg } from "@/lib/assets-read";
+import {
+  getSupplierById as getConvexSupplierById,
+  getMappedSuppliersByOrg,
+  mapSupplier,
+  supplierMatchesSearch,
+  compareSuppliers,
+} from "@/lib/suppliers-read";
 
 // Suppliers are DUAL-WRITTEN: every create/update/delete writes the Prisma
 // `supplier` row (the durable FK anchor — asset/bulk_asset/project_line_item/
@@ -41,20 +47,57 @@ async function patchSupplierInConvex(id: string, row: Record<string, unknown>) {
   });
 }
 
-// Column defs for server-side filter building
-const filterColumnDefs: ColumnDef<unknown>[] = [
-  { id: "isActive", header: "Status", accessorKey: "isActive", filterable: true, filterType: "enum" },
-];
+/**
+ * Per-supplier `{ assets, orders }` counts for an org, both from Convex (assets via
+ * the asset read helper, orders via the supplierOrders list). `projectLineItem`
+ * stays in Prisma (keystone tree, not yet cut over), so `lineItems` is counted
+ * separately by `getLineItemCount` when a consumer needs it.
+ */
+async function getOrgSupplierCounts(
+  organizationId: string,
+): Promise<Map<string, { assets: number; orders: number }>> {
+  const [allAssets, allOrders] = await Promise.all([
+    getAssetsByOrg(organizationId),
+    (await getConvexClient()).query(api.supplierOrders.list, { orgId: organizationId }),
+  ]);
+  const counts = new Map<string, { assets: number; orders: number }>();
+  const bump = (id: string) => {
+    let c = counts.get(id);
+    if (!c) counts.set(id, (c = { assets: 0, orders: 0 }));
+    return c;
+  };
+  for (const a of allAssets) if (a.supplierId) bump(a.supplierId).assets++;
+  for (const o of allOrders) if (o.supplierId) bump(o.supplierId).orders++;
+  return counts;
+}
+
+/**
+ * Count of sub-hire / supplier line items for a supplier. KEYSTONE-BLOCKED:
+ * `projectLineItem` is the project line-item tree, which is read-rewired as a
+ * single keystone unit later — until then this stays a Prisma count (a scalar
+ * cross-domain count, NOT a tree read). Same rationale as `getSupplierSubhires`.
+ */
+async function getLineItemCount(organizationId: string, supplierId: string): Promise<number> {
+  return prisma.projectLineItem.count({ where: { organizationId, supplierId } });
+}
 
 export async function getSuppliers() {
   const { organizationId } = await getOrgContext();
-  return serialize(
-    await prisma.supplier.findMany({
-      where: { organizationId, isActive: true },
-      include: { _count: { select: { assets: true, orders: true } } },
-      orderBy: { name: "asc" },
-    })
-  );
+  const [suppliers, counts] = await Promise.all([
+    getMappedSuppliersByOrg(organizationId),
+    getOrgSupplierCounts(organizationId),
+  ]);
+  const active = suppliers
+    .filter((s) => s.isActive)
+    .sort(compareSuppliers("name", "asc"))
+    .map((s) => ({
+      ...s,
+      _count: {
+        assets: counts.get(s.id)?.assets ?? 0,
+        orders: counts.get(s.id)?.orders ?? 0,
+      },
+    }));
+  return serialize(active);
 }
 
 export async function getSuppliersPaginated(params: {
@@ -68,36 +111,37 @@ export async function getSuppliersPaginated(params: {
   const { organizationId } = await getOrgContext();
   const { search, filters, page = 1, pageSize = 25, sortBy = "name", sortOrder = "asc" } = params;
 
-  const filterWhere = filters ? buildFilterWhere(filters, filterColumnDefs) : {};
-
-  const where = {
-    organizationId,
-    ...filterWhere,
-    ...(search
-      ? {
-          OR: [
-            { name: { contains: search, mode: "insensitive" as const } },
-            { contactName: { contains: search, mode: "insensitive" as const } },
-            { email: { contains: search, mode: "insensitive" as const } },
-            { accountNumber: { contains: search, mode: "insensitive" as const } },
-            { tags: { hasSome: [search.toLowerCase()] } },
-          ],
-        }
-      : {}),
-  };
-
-  const [suppliers, total] = await Promise.all([
-    prisma.supplier.findMany({
-      where,
-      include: {
-        _count: { select: { assets: true, orders: true, lineItems: true } },
-      },
-      orderBy: { [sortBy]: sortOrder },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.supplier.count({ where }),
+  const [all, counts] = await Promise.all([
+    getMappedSuppliersByOrg(organizationId),
+    getOrgSupplierCounts(organizationId),
   ]);
+
+  // Replicates the old Prisma `where`: the `isActive` enum filter + the
+  // case-insensitive search OR across name/contact/email/account#/tags.
+  const activeFilter = filters?.isActive as string | undefined;
+  const filtered = all.filter((s) => {
+    if (activeFilter === "true" && s.isActive !== true) return false;
+    if (activeFilter === "false" && s.isActive !== false) return false;
+    return search ? supplierMatchesSearch(s, search) : true;
+  });
+
+  const total = filtered.length;
+  const sorted = filtered.sort(compareSuppliers(sortBy, sortOrder));
+  const pageItems = sorted.slice((page - 1) * pageSize, page * pageSize);
+
+  // lineItems count is keystone-blocked (projectLineItem), so it's a per-page
+  // Prisma count; assets/orders come from Convex.
+  const lineItemCounts = await Promise.all(
+    pageItems.map((s) => getLineItemCount(organizationId, s.id)),
+  );
+  const suppliers = pageItems.map((s, i) => ({
+    ...s,
+    _count: {
+      assets: counts.get(s.id)?.assets ?? 0,
+      orders: counts.get(s.id)?.orders ?? 0,
+      lineItems: lineItemCounts[i],
+    },
+  }));
 
   return serialize({ suppliers, total });
 }
@@ -130,22 +174,25 @@ export async function getSupplierCounts(): Promise<Record<string, { assets: numb
 
 export async function getSupplierById(id: string) {
   const { organizationId } = await getOrgContext();
-  const supplier = await prisma.supplier.findUnique({
-    where: { id, organizationId },
-    include: {
-      _count: { select: { assets: true, orders: true, lineItems: true } },
-      orders: {
-        orderBy: { createdAt: "desc" },
-        take: 10,
-        include: {
-          _count: { select: { items: true } },
-          project: { select: { id: true, name: true, projectNumber: true } },
-        },
-      },
+  const doc = await getConvexSupplierById(id);
+  if (!doc || doc.organizationId !== organizationId) throw new Error("Supplier not found");
+
+  // assets/orders counts from Convex; lineItems keystone-blocked (Prisma count).
+  // The embedded `orders` array the old shape carried is dropped — the detail page
+  // fetches its order list via getSupplierOrders, never reads `supplier.orders`.
+  const [counts, lineItems] = await Promise.all([
+    getOrgSupplierCounts(organizationId),
+    getLineItemCount(organizationId, id),
+  ]);
+
+  return serialize({
+    ...mapSupplier(doc),
+    _count: {
+      assets: counts.get(id)?.assets ?? 0,
+      orders: counts.get(id)?.orders ?? 0,
+      lineItems,
     },
   });
-  if (!supplier) throw new Error("Supplier not found");
-  return serialize(supplier);
 }
 
 export async function getSupplierAssets(supplierId: string, params: {


### PR DESCRIPTION
## Summary

Phase A read-rewiring of the **suppliers** surface: the pure read-only supplier
actions in `src/server/suppliers.ts` move off `prisma.supplier` to Convex,
extending `src/lib/suppliers-read.ts`.

**Converted (now read Convex):**
- `getSuppliers` — org supplier list, active-only, name-sorted.
- `getSuppliersPaginated` — search/`isActive`-filter/sort/paginate (all JS,
  replicating the Prisma `where`/`orderBy`).
- `getSupplierById` — supplier doc + counts. Drops the embedded `orders` array
  (the detail page fetches orders via `getSupplierOrders`, never reads
  `supplier.orders`).

New in `suppliers-read.ts`:
- `mapSupplier` / `getMappedSuppliersByOrg` — Convex doc → Prisma-row shape
  (epoch-ms→`Date` since `serialize` preserves `Date`; `tags []` / `isActive true`
  coerced; absent optionals → `null`; `_id`/`_creationTime` stripped).
- `supplierMatchesSearch` — name/contact/email/account#/tags; the tag arm is
  exact-membership, matching Prisma `tags hasSome [search.toLowerCase()]`.
- `compareSuppliers` — string/Date/boolean comparator, nulls-last.

Per-supplier `_count.assets` / `_count.orders` now come from Convex
(`getAssetsByOrg` + `api.supplierOrders.list`, via a new private
`getOrgSupplierCounts`). **No new Convex query added** — reused existing
`suppliers.list` / `supplierOrders.list` / asset read helpers.

**Left on Prisma (intentional, documented):**
- `_count.lineItems` and `getSupplierSubhires` read `projectLineItem` — the
  keystone line-item tree, read-rewired later as one unit. The count stays a
  scalar Prisma `count` (NOT a tree read).
- `getSupplierAssets` was already Convex (`getAssetsByOrg` + `attachModel`).

**Skipped (sibling PRs):** `getSupplierCounts` (#237), `getSupplierOrders` /
`getSupplierOrderById` (#198) — untouched.

## Validation
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec vitest run src/lib/suppliers-read.test.ts` — 17/17 pass (every new pure fn).
- `pnpm exec eslint <changed files>` — 0 errors (1 pre-existing `_id`-strip warning).
- No `convex/_generated` drift.

## Deploy gate
Merge gate = the deploy-ordering gate: the `supplier` (+ `asset`, `supplierOrder`)
tables must be backfilled into **prod Convex** before this read deploys, else the
list/dropdown reads empty. **Human-gated on a Coolify PR preview** against prod
Convex (Convex data-correctness can't be verified in a dev worktree). Do not merge
until validated on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)