### PR TITLE
feat(convex): read dashboard/notifications non-blocked reads from Convex (Phase A)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2371,6 +2371,45 @@ status }` relation-filter on its `projectLineItem.findFirst` (line ~65) — a le
 cross-domain read from the model-only batch. Low priority (single point read, fresh
 Prisma mirror) but tracked for a future pass.
 
+## Phase A read-rewiring — leaf surfaces (in progress, preview-gated)
+
+The "domain data Convex-only" decommission's Phase A (read-rewiring) ships
+**per-surface, each as its own PR**, validated on a Coolify PR preview against prod
+Convex (Convex data-correctness can't be verified in a dev worktree). Each surface
+follows the proven pattern: a thin `src/lib/<x>-read.ts` (mappers epoch-ms→Date,
+Decimal→number, absent→null, JSON `v.any()` passed through, Prisma-defaulted
+columns coerced non-null) + pure unit-tested filter/sort predicates replicating the
+Prisma `where`/`orderBy` + JS attach for cross-domain joins. **No Prisma fallback on
+a Convex map miss** (a miss reads null, like a join against a deleted row — falling
+back would hide mirror drift). The merge gate for each PR is the deploy-ordering gate
+above: the table must be backfilled into prod Convex before the read deploys.
+
+- **dashboard / notifications / project-costs (non-blocked reads)** (`server/dashboard.ts`,
+  `server/notifications.ts`, `lib/project-costs.ts`). Converted the pure counts/aggregates
+  over dual-written tables to Convex via new pure helpers (all unit-tested in
+  `src/lib/dashboard-notifications-read.test.ts`):
+  - `getDashboardStats` — `maintenanceDue` (→ `maintenance-read.countDueMaintenance`),
+    `activeCrew` (→ `crew-read.countActiveCrew`), `pendingCrewOffers`
+    (→ `crew-scheduling-read.countAssignmentsByStatus`).
+  - `getNotifications` — `pendingOffers` (crewAssignment count) + `submittedTimesheets`
+    (crewTimeEntry count) via `crew-scheduling-read`.
+  - `computeProjectOperationalCosts` — `serviceRevenue` (→ `project-services-read.sumProjectServiceRevenue`)
+    + maintenance cost/count (→ `maintenance-read.aggregateMaintenanceForProject`).
+    `lib/project-costs.ts` no longer imports Prisma.
+  - New read libs: `maintenance-read.ts`, `crew-scheduling-read.ts`, `project-services-read.ts`;
+    `countActiveCrew` added to existing `crew-read.ts`. No new Convex queries needed (reused each
+    module's existing org-scoped `list`).
+  - **Left KEYSTONE-BLOCKED (stay Prisma):** `getDashboardStats.overdueReturns` and the
+    `getMyHomeData`/`getUpcomingProjects` line-item group-bys and `getNotifications` flagged-asset
+    `projectLineItem.findMany` (all touch `projectLineItem` + a project relation filter);
+    `getNotifications` overdue-maintenance/overdue-return line-item counts likewise.
+  - **Left DUAL-WRITE-BLOCKED (stay Prisma):** `notifications.getDismissedKeys`/`dismissNotification`/
+    `pruneStaleDismissals` (`notificationDismissal` has a Convex module but NO mirror write from `src/`,
+    so it is not dual-written); `getRecentActivity` (assetScanLog/testTagRecord/maintenanceRecord
+    list reads — the maintenance list needs the un-mirrored `maintenanceRecordAssets` join, and the
+    set is a join-heavy composite deferred as a unit); `getNotifications` pending-invitations + user
+    lookup (Better Auth `invitation`/`organization`/`user`).
+
 ## Remaining work & session sizing (post-central-graph)
 
 The central graph is fully dual-written. What's left, with honest per-item effort

--- a/src/lib/crew-read.ts
+++ b/src/lib/crew-read.ts
@@ -42,3 +42,11 @@ export async function getCrewRoleMap(orgId: string): Promise<Map<string, ConvexC
   const all = await getCrewRolesByOrg(orgId);
   return new Map(all.map((r) => [r.id, r]));
 }
+
+/**
+ * Count of ACTIVE crew members. Replicates Prisma
+ * `count({ status: "ACTIVE" })`. A row with no status never matches.
+ */
+export function countActiveCrew(members: ConvexCrewMember[]): number {
+  return members.filter((m) => m.status === "ACTIVE").length;
+}

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -1,0 +1,55 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for crew scheduling counts (Phase A read-rewiring).
+ *
+ * `crewAssignment` and `crewTimeEntry` are dual-written (Prisma FK anchor + Convex
+ * reactive doc — see src/lib/crew-scheduling-mirror.ts). Pure counts over their
+ * `status` scalar go through these helpers. Reads that join assignment/time-entry
+ * back onto crew members, projects, or Better Auth users stay heavier composites
+ * for later. See FEATUREDOCS/54.
+ */
+export type ConvexCrewAssignment = Doc<"crewAssignments">;
+export type ConvexCrewTimeEntry = Doc<"crewTimeEntries">;
+
+export async function getCrewAssignmentsByOrg(
+  orgId: string,
+): Promise<ConvexCrewAssignment[]> {
+  return await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewAssignments.list, { orgId }),
+  );
+}
+
+export async function getCrewTimeEntriesByOrg(
+  orgId: string,
+): Promise<ConvexCrewTimeEntry[]> {
+  return await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.crewTimeEntries.list, { orgId }),
+  );
+}
+
+/**
+ * Count of crew assignments whose status is in `statuses`. Replicates Prisma
+ * `count({ status: { in: statuses } })`. A row with no status never matches.
+ */
+export function countAssignmentsByStatus(
+  assignments: ConvexCrewAssignment[],
+  statuses: readonly string[],
+): number {
+  const set = new Set(statuses);
+  return assignments.filter((a) => a.status != null && set.has(a.status)).length;
+}
+
+/**
+ * Count of crew time entries whose status is in `statuses`. Replicates Prisma
+ * `count({ status: { in: statuses } })`. A row with no status never matches.
+ */
+export function countTimeEntriesByStatus(
+  entries: ConvexCrewTimeEntry[],
+  statuses: readonly string[],
+): number {
+  const set = new Set(statuses);
+  return entries.filter((e) => e.status != null && set.has(e.status)).length;
+}

--- a/src/lib/dashboard-notifications-read.test.ts
+++ b/src/lib/dashboard-notifications-read.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  countDueMaintenance,
+  aggregateMaintenanceForProject,
+  type ConvexMaintenanceRecord,
+} from "@/lib/maintenance-read";
+import {
+  countAssignmentsByStatus,
+  countTimeEntriesByStatus,
+  type ConvexCrewAssignment,
+  type ConvexCrewTimeEntry,
+} from "@/lib/crew-scheduling-read";
+import { countActiveCrew, type ConvexCrewMember } from "@/lib/crew-read";
+import {
+  sumProjectServiceRevenue,
+  type ConvexProjectService,
+} from "@/lib/project-services-read";
+
+// Minimal builders — the pure functions only touch the scalar fields under test.
+function maint(p: Partial<ConvexMaintenanceRecord>): ConvexMaintenanceRecord {
+  return { id: "m", organizationId: "org" /* + Convex sys fields */, ...p } as ConvexMaintenanceRecord;
+}
+function asn(p: Partial<ConvexCrewAssignment>): ConvexCrewAssignment {
+  return { id: "a", organizationId: "org", projectId: "p", crewMemberId: "c", ...p } as ConvexCrewAssignment;
+}
+function te(p: Partial<ConvexCrewTimeEntry>): ConvexCrewTimeEntry {
+  return { id: "t", organizationId: "org", crewMemberId: "c", ...p } as ConvexCrewTimeEntry;
+}
+function member(p: Partial<ConvexCrewMember>): ConvexCrewMember {
+  return { id: "cm", organizationId: "org", firstName: "A", lastName: "B", ...p } as ConvexCrewMember;
+}
+function svc(p: Partial<ConvexProjectService>): ConvexProjectService {
+  return { id: "s", organizationId: "org", projectId: "p", title: "T", ...p } as ConvexProjectService;
+}
+
+const NOW = 1_000_000;
+
+describe("countDueMaintenance", () => {
+  it("counts SCHEDULED/IN_PROGRESS with scheduledDate <= cutoff", () => {
+    const records = [
+      maint({ status: "SCHEDULED", scheduledDate: NOW - 1 }), // due
+      maint({ status: "IN_PROGRESS", scheduledDate: NOW }), // due (boundary inclusive)
+      maint({ status: "SCHEDULED", scheduledDate: NOW + 1 }), // not yet due
+      maint({ status: "COMPLETED", scheduledDate: NOW - 1 }), // wrong status
+      maint({ status: "CANCELLED", scheduledDate: NOW - 1 }), // wrong status
+      maint({ status: "SCHEDULED", scheduledDate: undefined }), // no date → excluded (Prisma lte skips NULL)
+      maint({ status: undefined, scheduledDate: NOW - 1 }), // no status → excluded
+    ];
+    expect(countDueMaintenance(records, NOW)).toBe(2);
+  });
+
+  it("returns 0 for empty input", () => {
+    expect(countDueMaintenance([], NOW)).toBe(0);
+  });
+});
+
+describe("aggregateMaintenanceForProject", () => {
+  it("sums cost and counts non-CANCELLED records for the project", () => {
+    const records = [
+      maint({ projectId: "p1", status: "COMPLETED", cost: 100 }),
+      maint({ projectId: "p1", status: "SCHEDULED", cost: 50 }),
+      maint({ projectId: "p1", status: "CANCELLED", cost: 999 }), // excluded
+      maint({ projectId: "p1", status: "SCHEDULED", cost: undefined }), // null cost → 0
+      maint({ projectId: "p2", status: "COMPLETED", cost: 7 }), // other project
+    ];
+    expect(aggregateMaintenanceForProject(records, "p1")).toEqual({ costTotal: 150, count: 3 });
+  });
+
+  it("returns zeroed aggregate when no records match", () => {
+    expect(aggregateMaintenanceForProject([], "p1")).toEqual({ costTotal: 0, count: 0 });
+  });
+});
+
+describe("countAssignmentsByStatus", () => {
+  it("counts assignments whose status is in the set", () => {
+    const rows = [
+      asn({ status: "OFFERED" }),
+      asn({ status: "PENDING" }),
+      asn({ status: "OFFERED" }),
+      asn({ status: "CONFIRMED" }),
+      asn({ status: undefined }),
+    ];
+    expect(countAssignmentsByStatus(rows, ["OFFERED", "PENDING"])).toBe(3);
+    expect(countAssignmentsByStatus(rows, ["OFFERED"])).toBe(2);
+  });
+});
+
+describe("countTimeEntriesByStatus", () => {
+  it("counts SUBMITTED time entries", () => {
+    const rows = [
+      te({ status: "SUBMITTED" }),
+      te({ status: "APPROVED" }),
+      te({ status: "SUBMITTED" }),
+      te({ status: undefined }),
+    ];
+    expect(countTimeEntriesByStatus(rows, ["SUBMITTED"])).toBe(2);
+  });
+});
+
+describe("countActiveCrew", () => {
+  it("counts only ACTIVE members", () => {
+    const rows = [
+      member({ status: "ACTIVE" }),
+      member({ status: "INACTIVE" }),
+      member({ status: "ACTIVE" }),
+      member({ status: "ARCHIVED" }),
+      member({ status: undefined }),
+    ];
+    expect(countActiveCrew(rows)).toBe(2);
+  });
+});
+
+describe("sumProjectServiceRevenue", () => {
+  it("sums lineTotal for non-CANCELLED, showOnDocuments services of the project", () => {
+    const rows = [
+      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: true, lineTotal: 100 }),
+      svc({ projectId: "p1", status: "PLANNED", showOnDocuments: true, lineTotal: 50 }),
+      svc({ projectId: "p1", status: "CANCELLED", showOnDocuments: true, lineTotal: 999 }), // excluded
+      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: false, lineTotal: 999 }), // excluded
+      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: undefined, lineTotal: 999 }), // absent → excluded
+      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: true, lineTotal: undefined }), // null total → 0
+      svc({ projectId: "p2", status: "CONFIRMED", showOnDocuments: true, lineTotal: 7 }), // other project
+    ];
+    expect(sumProjectServiceRevenue(rows, "p1")).toBe(150);
+  });
+
+  it("returns 0 when nothing matches", () => {
+    expect(sumProjectServiceRevenue([], "p1")).toBe(0);
+  });
+});

--- a/src/lib/maintenance-read.ts
+++ b/src/lib/maintenance-read.ts
@@ -1,0 +1,78 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the Maintenance domain (Phase A read-rewiring).
+ *
+ * `maintenanceRecord` is dual-written: every create/update/delete in the server
+ * actions writes BOTH the Prisma row (the durable FK anchor — `project`, `kit`,
+ * `maintenance_record_asset` carry FKs to it) AND the Convex `maintenanceRecords`
+ * doc (see src/lib/maintenance-mirror.ts). Pure counts/aggregates over the record
+ * scalars (status, scheduledDate, cost) go through this helper. The
+ * `maintenanceRecordAssets` join table is NOT mirrored — any read that needs the
+ * record→asset join (e.g. the dashboard "recent maintenance" list, the overdue
+ * notification card) stays on Prisma for now. See FEATUREDOCS/54.
+ *
+ * Convex stores epoch-ms numbers; the pure predicates below operate on those
+ * numbers directly so callers never need to round-trip through Date.
+ */
+export type ConvexMaintenanceRecord = Doc<"maintenanceRecords">;
+
+export async function getMaintenanceRecordsByOrg(
+  orgId: string,
+): Promise<ConvexMaintenanceRecord[]> {
+  return await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.maintenanceRecords.list, { orgId }),
+  );
+}
+
+/** Statuses that count as "open" maintenance work. */
+const OPEN_MAINTENANCE_STATUSES = new Set(["SCHEDULED", "IN_PROGRESS"]);
+
+/**
+ * Count of open maintenance whose scheduled date has arrived (<= cutoffMs).
+ * Replicates Prisma `count({ status: { in: [SCHEDULED, IN_PROGRESS] },
+ * scheduledDate: { lte: now } })`. A record with no scheduledDate is excluded
+ * (Prisma `lte` never matches NULL).
+ */
+export function countDueMaintenance(
+  records: ConvexMaintenanceRecord[],
+  cutoffMs: number,
+): number {
+  return records.filter(
+    (m) =>
+      m.status != null &&
+      OPEN_MAINTENANCE_STATUSES.has(m.status) &&
+      m.scheduledDate != null &&
+      m.scheduledDate <= cutoffMs,
+  ).length;
+}
+
+export interface MaintenanceProjectAggregate {
+  /** Sum of `cost` over non-CANCELLED records for the project (null cost = 0). */
+  costTotal: number;
+  /** Count of non-CANCELLED records for the project. */
+  count: number;
+}
+
+/**
+ * Per-project maintenance aggregate. Replicates Prisma
+ * `aggregate({ where: { projectId, organizationId, status: { notIn: [CANCELLED] } },
+ * _sum: { cost }, _count: true })`. Records carrying the org's rows are filtered to
+ * the project here (Convex `list` is org-scoped).
+ */
+export function aggregateMaintenanceForProject(
+  records: ConvexMaintenanceRecord[],
+  projectId: string,
+): MaintenanceProjectAggregate {
+  let costTotal = 0;
+  let count = 0;
+  for (const m of records) {
+    if (m.projectId !== projectId) continue;
+    if (m.status === "CANCELLED") continue;
+    count += 1;
+    costTotal += m.cost ?? 0;
+  }
+  return { costTotal, count };
+}

--- a/src/lib/project-costs.ts
+++ b/src/lib/project-costs.ts
@@ -5,8 +5,9 @@
  * `organizationId` via the session and delegates here.
  */
 
-import { prisma } from "@/lib/prisma";
 import { getProjectById } from "@/lib/projects-read";
+import { getProjectServicesByOrg, sumProjectServiceRevenue } from "@/lib/project-services-read";
+import { getMaintenanceRecordsByOrg, aggregateMaintenanceForProject } from "@/lib/maintenance-read";
 
 export interface ProjectOperationalCosts {
   equipmentRevenue: number;
@@ -30,24 +31,21 @@ export async function computeProjectOperationalCosts(
   const project = await getProjectById(projectId);
   if (!project || project.organizationId !== organizationId) return emptyResult();
 
-  const serviceRevenueAgg = await prisma.projectService.aggregate({
-    where: { projectId, organizationId, status: { not: "CANCELLED" }, showOnDocuments: true },
-    _sum: { lineTotal: true },
-  });
-
-  const maintenanceAgg = await prisma.maintenanceRecord.aggregate({
-    where: { projectId, organizationId, status: { notIn: ["CANCELLED"] } },
-    _sum: { cost: true },
-    _count: true,
-  });
+  // projectService + maintenanceRecord are dual-written — aggregate from Convex.
+  const [orgServices, orgMaintenance] = await Promise.all([
+    getProjectServicesByOrg(organizationId),
+    getMaintenanceRecordsByOrg(organizationId),
+  ]);
+  const serviceRevenueTotal = sumProjectServiceRevenue(orgServices, projectId);
+  const maintenanceAgg = aggregateMaintenanceForProject(orgMaintenance, projectId);
 
   const equipmentRevenue = Number(project.equipmentRevenue ?? 0);
-  const serviceRevenue = Number(serviceRevenueAgg._sum.lineTotal ?? 0);
+  const serviceRevenue = serviceRevenueTotal;
   const total = Number(project.total ?? 0);
   const serviceCostTotal = Number(project.serviceCostTotal ?? 0);
   const labourCostTotal = Number(project.labourCostTotal ?? 0);
   const subHireCostTotal = Number(project.subHireCostTotal ?? 0);
-  const maintenanceCostTotal = Number(maintenanceAgg._sum.cost ?? 0);
+  const maintenanceCostTotal = maintenanceAgg.costTotal;
 
   const allCosts =
     serviceCostTotal + labourCostTotal + subHireCostTotal + maintenanceCostTotal;
@@ -66,7 +64,7 @@ export async function computeProjectOperationalCosts(
     netMargin,
     marginPercent,
     counts: {
-      maintenanceRecords: maintenanceAgg._count,
+      maintenanceRecords: maintenanceAgg.count,
     },
   };
 }

--- a/src/lib/project-services-read.ts
+++ b/src/lib/project-services-read.ts
@@ -1,0 +1,45 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helpers for the Project Services domain (Phase A read-rewiring).
+ *
+ * `projectService` is dual-written (Prisma row + Convex `projectServices` doc — see
+ * src/lib/project-subtable-mirror.ts). The operational-P&L revenue aggregate (sum of
+ * billable `lineTotal`) goes through the pure helper below. `lineTotal` is stored as a
+ * plain number in Convex (Prisma `Decimal` → number on mirror). See FEATUREDOCS/54.
+ */
+export type ConvexProjectService = Doc<"projectServices">;
+
+export async function getProjectServicesByOrg(
+  orgId: string,
+): Promise<ConvexProjectService[]> {
+  return await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.projectServices.list, { orgId }),
+  );
+}
+
+/**
+ * Sum of `lineTotal` over a project's non-CANCELLED, document-visible services.
+ * Replicates Prisma `aggregate({ where: { projectId, status: { not: CANCELLED },
+ * showOnDocuments: true }, _sum: { lineTotal } })`. Org-scoped Convex `list` is
+ * filtered to the project here; null `lineTotal` contributes 0.
+ *
+ * NOTE on `showOnDocuments`: Prisma's `showOnDocuments: true` matches only rows
+ * whose column is exactly `true`. The Convex field is optional, so a row with the
+ * value absent reads `undefined` and is correctly excluded by the strict `=== true`.
+ */
+export function sumProjectServiceRevenue(
+  services: ConvexProjectService[],
+  projectId: string,
+): number {
+  let total = 0;
+  for (const s of services) {
+    if (s.projectId !== projectId) continue;
+    if (s.status === "CANCELLED") continue;
+    if (s.showOnDocuments !== true) continue;
+    total += s.lineTotal ?? 0;
+  }
+  return total;
+}

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -8,24 +8,23 @@ import { listOpenBlockingThreads } from "@/lib/blocking-comments-read";
 import { getModelMap } from "@/lib/models-read";
 import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
 import { getProjectsByOrg, getProjectIdsForManager } from "@/lib/projects-read";
+import { getMaintenanceRecordsByOrg, countDueMaintenance } from "@/lib/maintenance-read";
+import { getCrewMembersByOrg, countActiveCrew } from "@/lib/crew-read";
+import { getCrewAssignmentsByOrg, countAssignmentsByStatus } from "@/lib/crew-scheduling-read";
 
 export async function getDashboardStats() {
   const { organizationId } = await getOrgContext();
 
   const now = new Date();
 
-  const [allAssets, allBulkAssets, allProjects, maintenanceDue, overdueReturns, activeCrew, pendingCrewOffers] =
+  const [allAssets, allBulkAssets, allProjects, maintenanceRecords, overdueReturns, crewMembers, crewAssignments] =
     await Promise.all([
       getAssetsByOrg(organizationId),
       getBulkAssetsByOrg(organizationId),
       getProjectsByOrg(organizationId),
-      prisma.maintenanceRecord.count({
-        where: {
-          organizationId,
-          status: { in: ["SCHEDULED", "IN_PROGRESS"] },
-          scheduledDate: { lte: now },
-        },
-      }),
+      // Maintenance is dual-written — count due records (status + scheduledDate) from Convex.
+      getMaintenanceRecordsByOrg(organizationId),
+      // overdueReturns aggregates projectLineItem joined to a project filter → KEYSTONE-BLOCKED, stays Prisma.
       prisma.projectLineItem.count({
         where: {
           organizationId,
@@ -37,13 +36,14 @@ export async function getDashboardStats() {
           },
         },
       }),
-      prisma.crewMember.count({
-        where: { organizationId, status: "ACTIVE" },
-      }),
-      prisma.crewAssignment.count({
-        where: { organizationId, status: { in: ["OFFERED", "PENDING"] } },
-      }),
+      // Crew roster + assignments are dual-written — count from Convex.
+      getCrewMembersByOrg(organizationId),
+      getCrewAssignmentsByOrg(organizationId),
     ]);
+
+  const maintenanceDue = countDueMaintenance(maintenanceRecords, now.getTime());
+  const activeCrew = countActiveCrew(crewMembers);
+  const pendingCrewOffers = countAssignmentsByStatus(crewAssignments, ["OFFERED", "PENDING"]);
 
   const activeAssets = allAssets.filter((a) => a.isActive !== false);
   const activeBulkAssets = allBulkAssets.filter((ba) => ba.isActive !== false);

--- a/src/server/notifications.ts
+++ b/src/server/notifications.ts
@@ -5,6 +5,12 @@ import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { getModelMap } from "@/lib/models-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
+import {
+  getCrewAssignmentsByOrg,
+  countAssignmentsByStatus,
+  getCrewTimeEntriesByOrg,
+  countTimeEntriesByStatus,
+} from "@/lib/crew-scheduling-read";
 
 export interface AppNotification {
   id: string;
@@ -216,9 +222,11 @@ export async function getNotifications(): Promise<AppNotification[]> {
   }
 
   // 6. Pending crew offers (assignments in OFFERED status)
-  const pendingOffers = await prisma.crewAssignment.count({
-    where: { organizationId, status: "OFFERED" },
-  });
+  // crewAssignment is dual-written — count from Convex.
+  const pendingOffers = countAssignmentsByStatus(
+    await getCrewAssignmentsByOrg(organizationId),
+    ["OFFERED"],
+  );
   if (pendingOffers > 0) {
     notifications.push({
       id: "crew-pending-offers",
@@ -232,9 +240,11 @@ export async function getNotifications(): Promise<AppNotification[]> {
   }
 
   // 8. Submitted timesheets awaiting approval
-  const submittedTimesheets = await prisma.crewTimeEntry.count({
-    where: { organizationId, status: "SUBMITTED" },
-  });
+  // crewTimeEntry is dual-written — count from Convex.
+  const submittedTimesheets = countTimeEntriesByStatus(
+    await getCrewTimeEntriesByOrg(organizationId),
+    ["SUBMITTED"],
+  );
   if (submittedTimesheets > 0) {
     notifications.push({
       id: "crew-pending-timesheets",


### PR DESCRIPTION
## Summary

Phase A read-rewiring of the **non-line-item, non-blocked** reads across three
composite surfaces. Each converted read is a pure count/aggregate over a
**dual-written** domain table, served from Convex via new unit-tested pure helpers.

### Converted to Convex
- **`server/dashboard.ts` `getDashboardStats`** — `maintenanceDue`
  (`maintenance-read.countDueMaintenance`), `activeCrew`
  (`crew-read.countActiveCrew`), `pendingCrewOffers`
  (`crew-scheduling-read.countAssignmentsByStatus`).
- **`server/notifications.ts` `getNotifications`** — `pendingOffers` (crewAssignment)
  + `submittedTimesheets` (crewTimeEntry) via `crew-scheduling-read`.
- **`lib/project-costs.ts` `computeProjectOperationalCosts`** — `serviceRevenue`
  (`project-services-read.sumProjectServiceRevenue`) + maintenance cost/count
  (`maintenance-read.aggregateMaintenanceForProject`). File no longer imports Prisma.

New read libs `maintenance-read.ts`, `crew-scheduling-read.ts`,
`project-services-read.ts` (+ `countActiveCrew` in `crew-read.ts`). **No new Convex
queries** — each reuses its module's existing org-scoped `list`.

### Left on Prisma (intentional)
- **KEYSTONE-BLOCKED** (touch `projectLineItem` + a project relation filter):
  `getDashboardStats.overdueReturns`; `getMyHomeData` / `getUpcomingProjects`
  line-item group-bys; `getNotifications` overdue-return/overdue-maintenance
  line-item counts + flagged-asset `projectLineItem.findMany`.
- **DUAL-WRITE-BLOCKED:** `notificationDismissal` (Convex module exists but **no
  mirror write from `src/`** → not dual-written) — `getDismissedKeys` /
  `dismissNotification` / `pruneStaleDismissals` stay Prisma; `getRecentActivity`
  (the maintenance list needs the **un-mirrored `maintenanceRecordAssets`** join,
  and the asset-scan/test-tag/maintenance list set is a join-heavy composite
  deferred as a unit); pending-invitations + user lookup (Better Auth
  `invitation`/`organization`/`user`).

### Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/lib/dashboard-notifications-read.test.ts` — 9/9 pass
- `pnpm exec eslint <changed files>` — clean
- No `convex/_generated` drift.

### Deploy gate
Merge gate = the deploy-ordering gate in FEATUREDOCS/54: `maintenanceRecord`,
`crewMember`, `crewAssignment`, `crewTimeEntry`, `projectService` must be
backfilled into **prod Convex** before this read deploys (all confirmed
dual-written; verify backfills are run in prod). Convex data-correctness is
**human-gated on the Coolify PR preview** (can't be verified in a dev worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)