### PR TITLE
fix(migration): guard damage_event ALTER TABLE in remove_discord migration

### DIFF
--- a/prisma/migrations/20260617000000_remove_discord/migration.sql
+++ b/prisma/migrations/20260617000000_remove_discord/migration.sql
@@ -17,4 +17,9 @@ DROP TYPE IF EXISTS "DiscordBotDesiredState";
 -- Drop the Discord columns on retained tables. Dropping the column also drops
 -- its unique index (project_discordChannelId_key / damage_event_discordIdempotencyKey_key).
 ALTER TABLE "project" DROP COLUMN IF EXISTS "discordChannelId";
-ALTER TABLE "damage_event" DROP COLUMN IF EXISTS "discordIdempotencyKey";
+-- damage_event may already be gone (removed by chore/remove-damage-capture); guard the table existence.
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'damage_event') THEN
+    ALTER TABLE "damage_event" DROP COLUMN IF EXISTS "discordIdempotencyKey";
+  END IF;
+END $$;


### PR DESCRIPTION
The `20260617000000_remove_discord` migration crashes with `relation "damage_event" does not exist` because that table was already dropped by the damage-capture removal. Wraps the `ALTER TABLE damage_event` in a `DO` block that checks table existence first. Unblocks prod deployment.