### PR TITLE
fix(backfill): skip --env-file flags when .env files don't exist (Coolify)

### DIFF
--- a/scripts/convex-backfill-all.ts
+++ b/scripts/convex-backfill-all.ts
@@ -17,6 +17,7 @@
  */
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
+import { existsSync } from "node:fs";
 
 // Backfill script basenames (under scripts/), in run order.
 const ORDER: string[] = [
@@ -70,13 +71,20 @@ function main() {
   const scriptsDir = path.dirname(new URL(import.meta.url).pathname);
   const results: Array<{ name: string; ok: boolean; ms: number }> = [];
 
+  // Only pass --env-file flags for files that actually exist (Coolify injects
+  // env vars directly and has no .env file — the flag causes node to exit 9).
+  const cwd = process.cwd();
+  const envFileArgs = [".env", ".env.local"]
+    .filter((f) => existsSync(path.join(cwd, f)))
+    .flatMap((f) => [`--env-file=${f}`]);
+
   for (const name of ORDER) {
     const file = path.join(scriptsDir, `convex-backfill-${name}.ts`);
     console.log(`\n── backfill: ${name} ──`);
     const started = Date.now();
     const res = spawnSync(
       "npx",
-      ["tsx", "--env-file=.env", "--env-file=.env.local", file],
+      ["tsx", ...envFileArgs, file],
       { stdio: "inherit", env: process.env },
     );
     const ms = Date.now() - started;


### PR DESCRIPTION
The `convex-backfill-all.ts` orchestrator hard-codes `--env-file=.env` and `--env-file=.env.local` on every child process. In Coolify, env vars are injected directly — no `.env` file exists, so Node exits 9 immediately. Now checks file existence before adding the flag.