### PR TITLE
Phase C Stage 1: drop domain↔domain FK constraints

### DIFF
--- a/docs/designs/convex-domain-only-decommission.md
+++ b/docs/designs/convex-domain-only-decommission.md
@@ -250,14 +250,64 @@ and only then drop the mirror for that surface.
 
 ---
 
-## Phase C — Drop Prisma domain tables (task #6, blocked by B)
+## Phase C — Invert FK-anchor mirrors + drop Prisma domain tables (task #6)
 
-- Remove the domain models from `prisma/schema.prisma` (keep the auth/RBAC/audit
-  subset).
-- Delete the backfill scripts + parity check + dual-write infra.
-- Migrate the DB to drop the now-unused domain tables.
-- Result: a small Postgres for Better Auth + `customRole` + `activityLog`;
-  everything else lives in Convex.
+> **Scope reconciliation (2026-06-18).** The original Phase C above assumed Phase B
+> inverted *all* writes. It did not: Phase B inverted only the **safely-invertible**
+> (leaf / no-inbound-FK) tables. The **12 remaining mirror clusters still dual-write
+> Prisma-first** because they are **FK anchors** — other still-Prisma domain rows hold
+> FK constraints pointing into them, so their Prisma row must exist. Inverting them
+> (with the transactional-invariant re-implementation the Phase B section describes)
+> therefore belongs to Phase C, gated behind dropping those FK constraints first.
+>
+> Remaining mirrors: `asset` (+bulk, bulk-child, scan-log), `kit` (+items),
+> `project`, `line-item`, `line-item-unit`, `crew` (member/role/skill),
+> `crew-scheduling` (assignment/shift/availability/time-entry), `file-upload`,
+> `media` (7 `*_media`), `sub-hire` (+item/group, supplier-order),
+> `warehouse-close`, `project-subtable` (service/task/manager).
+
+**FK boundary is clean (verified):** no kept table (auth / `customRole` /
+`activityLog`) has an FK into any domain table — `activityLog.{projectId,assetId,
+kitId}` are plain soft-string columns, `customRole` references only `organization`.
+So dropping domain tables can never violate a constraint on a kept table; the only
+schema edits on kept models are deleting Prisma back-relation array fields.
+
+### Sequenced stages (one surface per PR, preview-validated)
+
+- **Stage 1 — drop domain↔domain FK constraints** *(IN PROGRESS — branch
+  `phase-c/stage-1-drop-domain-fk`, migration
+  `20260618110000_drop_domain_domain_fk_constraints`)*. One self-discovering
+  migration drops every FK where **both** endpoints are domain tables, preserving
+  domain→`user`/`organization` (those vanish with the table drop in Stage 4).
+  Unblocks order-independent write-inversion. Non-destructive (constraints, not
+  data). Validated locally in a rolled-back txn: matches the domain↔domain FK set,
+  preserves the domain→auth set.
+- **Stage 2 — invert the 12 mirrors to Convex-only** (~8–12 PRs, leaf→root). Each
+  PR builds the real Convex mutation with re-implemented invariants (cascade
+  deletes, `maxSort`-then-insert ordering races, kit composition, sub-hire
+  regeneration, warehouse checkout/checkin), removes the Prisma write + mirror
+  call, deletes the `*-mirror.ts` file, and is preview-validated before the mirror
+  is dropped. Order: **warehouse-close** → file-upload+media → crew → crew-scheduling
+  → project-subtable → asset → kit → sub-hire → **project+line-item (keystone, last;
+  full-pipeline PDF integration test)**.
+- **Stage 3 — schema removal** (1 PR): delete the 71 domain models + orphaned
+  `User`/`Organization` back-relation arrays from `schema.prisma`; `prisma validate`
+  + `generate` clean; grep-gate zero `prisma.<domainModel>.` remaining.
+- **Stage 4 — drop tables** (1 PR, irreversible): hand-authored migration via
+  `migrate deploy`, single `DROP TABLE IF EXISTS … CASCADE` over the 71 domain
+  tables + implicit `_CrewMemberToCrewSkill`. Pre-drop `pg_dump` is the only data
+  rollback.
+- **Stage 5 — infra cleanup** (1 PR): delete backfill scripts (44), parity-check,
+  resync/purge/roundtrip scripts + their `package.json` entries; **keep**
+  `convex-client.ts`, `convex-auth*.ts`, all `*-read.ts`. Update docs.
+
+**Also in Phase C (independent of the FK web):** migrate `SiteSettings`
+(`site_settings`) to Convex — the `siteSettings` Convex table/CRUD exists but the
+app still reads/writes `prisma.siteSettings` (`platform.ts`, `auth.ts`,
+`site-admin.ts`, two route handlers). Its own small PR (relation-isolated singleton).
+
+**Result:** a small Postgres for Better Auth + `customRole` + `activityLog`;
+everything else lives in Convex.
 
 ---
 

--- a/prisma/migrations/20260618110000_drop_domain_domain_fk_constraints/migration.sql
+++ b/prisma/migrations/20260618110000_drop_domain_domain_fk_constraints/migration.sql
@@ -1,0 +1,63 @@
+-- Phase C, Stage 1: drop every FOREIGN KEY constraint whose BOTH endpoints are
+-- domain tables (the tables being decommissioned to Convex-only).
+--
+-- WHY: the 12 remaining mirror clusters (asset, kit, project, line-item,
+-- line-item-unit, crew, crew-scheduling, file-upload, media, sub-hire,
+-- warehouse-close, project-subtable) still dual-write Prisma-first because they
+-- are FK anchors: other still-Prisma domain rows hold FK constraints pointing
+-- into them. To invert each cluster's write to Convex-only (Stage 2) we must
+-- stop writing the parent's Prisma row, which would violate any surviving child
+-- FK. Dropping all domain<->domain FKs up front makes the inversions
+-- order-independent. Referential integrity for these tables already lives in
+-- application code + Convex (reads are 100% Convex since Phase A).
+--
+-- This deliberately PRESERVES domain->user and domain->organization FKs: those
+-- constraints live on the domain (child) side and are removed automatically when
+-- the domain tables are dropped in Stage 4. Keeping them now changes nothing.
+--
+-- Self-discovering by design: rather than hand-list ~40 constraint names (a typo
+-- would be silently swallowed by IF EXISTS and leave a live FK to block a later
+-- inversion), we drop every FK where conrelid AND confrelid are both in the
+-- domain-table set. Idempotent and drift-safe — re-running drops nothing new,
+-- and constraints already dropped by Phase B simply do not match.
+--
+-- Pure DDL on constraints (no row data touched) -> no ANALYZE required.
+
+DO $$
+DECLARE
+  r record;
+  domain_tables text[] := ARRAY[
+    'asset','asset_bulk_child','asset_media','asset_scan_log','brand_template',
+    'bulk_asset','category','category_slot','check_item','check_record','client',
+    'client_media','crew_assignment','crew_availability','crew_member','crew_role',
+    'crew_shift','crew_skill','crew_time_entry','custom_field_definition',
+    'document_template','file_upload','group_template','group_template_item','kit',
+    'kit_bulk_item','kit_check_item','kit_media','kit_serialized_item',
+    'line_item_merge_map','location','location_media','maintenance_record',
+    'maintenance_record_asset','model','model_bulk_accessory','model_check_item',
+    'model_media','notification_dismissal','notification_email_log','project',
+    'project_category','project_group','project_line_item','project_line_item_unit',
+    'project_manager','project_media','project_number_sequence','project_service',
+    'project_task','saved_table_view','section_preset','service_template','sub_hire',
+    'sub_hire_group','sub_hire_item','sub_hire_media','sub_test_record','supplier',
+    'supplier_model_rate','supplier_order','supplier_order_item','test_profile',
+    'test_tag_asset','test_tag_auditor_token','test_tag_record',
+    'user_notification_preference','warehouse_close','warehouse_dashboard_token',
+    'woocommerce_integration','woocommerce_order_log'
+  ];
+BEGIN
+  FOR r IN
+    SELECT con.conname,
+           con.conrelid::regclass::text AS child_table
+    FROM pg_constraint con
+    JOIN pg_class child  ON child.oid  = con.conrelid
+    JOIN pg_namespace ns ON ns.oid     = child.relnamespace
+    WHERE con.contype = 'f'
+      AND ns.nspname = 'public'
+      AND child.relname = ANY(domain_tables)
+      AND (con.confrelid::regclass::text) = ANY(domain_tables)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I',
+                   r.child_table, r.conname);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Phase C — Stage 1 of 5

Drops every FK constraint whose **both** endpoints are domain tables, unblocking order-independent write-inversion of the 12 remaining FK-anchor mirror clusters (Stage 2).

### Why
The 12 remaining mirrors (asset, kit, project, line-item, line-item-unit, crew, crew-scheduling, file-upload, media, sub-hire, warehouse-close, project-subtable) still dual-write Prisma-first because they are **FK anchors** — other still-Prisma domain rows hold FK constraints pointing into them. To invert each to Convex-only we must stop writing the parent's Prisma row, which would violate surviving child FKs. Dropping all domain↔domain FKs up front makes the inversions order-independent. Referential integrity already lives in app code + Convex (reads are 100% Convex since Phase A).

### What it does / doesn't touch
- **Drops:** every FK where `conrelid` AND `confrelid` are both domain tables.
- **Preserves:** domain→`user` and domain→`organization` FKs — those live on the domain (child) side and are removed automatically when the domain tables drop in Stage 4.
- **Self-discovering:** a `pg_constraint` scan, not hand-listed names — a typo can't be silently swallowed by `IF EXISTS` and leave a live FK. Idempotent + drift-safe (constraints already dropped by Phase B simply don't match).
- Pure constraint DDL, no row data touched → no `ANALYZE`.

### Validation
Ran the migration against a real Postgres inside a **rolled-back transaction**: parses + executes (exit 0), matches the domain↔domain FK set (93 in the local dev DB; prod fewer since Phase B already dropped several groups), and confirmed domain→auth FKs are **not** matched (preserved).

### Risk
Non-destructive — drops constraints, not data. The follow-on Stage 2 inversions are where data-integrity risk lives and are gated one-cluster-per-PR behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)