### PR TITLE
fix(auth): same-origin browser auth client (fixes flow.rvlt.app CORS)

### DIFF
--- a/FEATUREDOCS/04-auth-permissions.md
+++ b/FEATUREDOCS/04-auth-permissions.md
@@ -27,6 +27,13 @@ This instance runs in **single-org mode**: exactly one `Organization` row exists
 - Session stored in PostgreSQL `Session` table
 - Passkey RP ID configurable via `PASSKEY_RP_ID` env var (defaults to `localhost`)
 
+## Auth Client Base URL & CORS (`src/lib/auth-client.ts`)
+The browser auth client resolves its `baseURL` from `window.location.origin` — **never** from `NEXT_PUBLIC_APP_URL`. The `/api/auth` handler is co-located with the app, so auth calls are always same-origin; there is no CORS preflight and no `Access-Control-Allow-Origin` requirement.
+
+**Why not `NEXT_PUBLIC_APP_URL`?** `NEXT_PUBLIC_*` vars are *inlined into the client bundle at `next build`* (baked via the Dockerfile `ARG` + the `vars.NEXT_PUBLIC_APP_URL` GitHub Actions variable in `build-image.yml`). A baked URL keeps pointing at the *old* domain after a move, even after you update Coolify's runtime env — the compiled JS can't change. That caused a `get-session` CORS failure when the app moved to `flow.rvlt.app` while the bundle still called `gearflow.prod.rvlt.app`. Using `window.location.origin` means **moving domains never requires a rebuild**; only SSR (no `window`) falls back to `NEXT_PUBLIC_APP_URL`.
+
+Server-side origin allow-listing still uses env (`trustedOrigins` in `src/lib/auth.ts` reads `env.NEXT_PUBLIC_APP_URL` + `env.SSO_TRUSTED_ORIGINS`), and these are read at *runtime*, so a Coolify env change is enough for the server. After any domain move, set runtime `BETTER_AUTH_URL` + `NEXT_PUBLIC_APP_URL` (Coolify) and `CONVEX_AUTH_ISSUER` + `CONVEX_AUTH_JWKS_URL` (Convex deployment) to the new origin.
+
 ## Middleware (`src/middleware.ts`)
 - Checks cookies: `better-auth.session_token` or `__Secure-better-auth.session_token` (HTTPS)
 - Public routes exempted: `/login`, `/register`, `/api/auth`, `/invite`, `/two-factor`, `/onboarding`, `/api/platform-name`, `/api/registration-policy`, `/pending-approval`

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -5,7 +5,17 @@ import { passkeyClient } from "@better-auth/passkey/client";
 import { ssoClient } from "@better-auth/sso/client";
 
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+  // In the browser, always talk to the origin that actually served the page.
+  // The /api/auth handler is co-located with the app, so this is same-origin by
+  // definition — no CORS, and moving domains never requires a rebuild. We
+  // deliberately do NOT use NEXT_PUBLIC_APP_URL here: it's inlined into the JS
+  // bundle at build time, so a baked value would keep pointing at the old domain
+  // after a move (this caused a CORS failure when the app moved to flow.rvlt.app).
+  // Only SSR (no window) falls back to the env value.
+  baseURL:
+    typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
   plugins: [
     organizationClient(),
     twoFactorClient({


### PR DESCRIPTION
## Problem

After moving the app to `https://flow.rvlt.app`, the browser failed every auth call with:

> Access to fetch at `https://gearflow.prod.rvlt.app/api/auth/get-session` from origin `https://flow.rvlt.app` has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present.

## Root cause

The browser auth client (`src/lib/auth-client.ts`) set its `baseURL` from `NEXT_PUBLIC_APP_URL`. `NEXT_PUBLIC_*` vars are **inlined into the client bundle at `next build`** (Dockerfile `ARG` ← `vars.NEXT_PUBLIC_APP_URL` in `build-image.yml`). The baked value was still `gearflow.prod.rvlt.app`, so the bundle served from `flow.rvlt.app` kept calling the old domain cross-origin. Updating Coolify's *runtime* env can't change already-compiled JS.

There is **no hardcoded CORS header or domain string** anywhere — the only coupling was this build-time inlining.

## Fix

Resolve the browser auth client `baseURL` from `window.location.origin`. Auth calls become same-origin by definition (no CORS), and **moving domains never requires a rebuild again**. SSR (no `window`) falls back to `NEXT_PUBLIC_APP_URL`.

Server-side `trustedOrigins` already reads env at runtime, so a Coolify env change suffices there.

## Post-merge config (runtime, not code)

- Coolify: `BETTER_AUTH_URL` + `NEXT_PUBLIC_APP_URL` = `https://flow.rvlt.app`
- Convex prod deployment: `CONVEX_AUTH_ISSUER` = `https://flow.rvlt.app`, `CONVEX_AUTH_JWKS_URL` = `https://flow.rvlt.app/api/auth/jwks`
- Optional: GitHub Actions `vars.NEXT_PUBLIC_APP_URL` → `https://flow.rvlt.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)