### PR TITLE
Phase C: media cluster read-rewire to Convex (1/2)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2939,6 +2939,7 @@ off Prisma, **extending** the same `src/lib/test-tag-read.ts` helper.
   Coolify PR preview against prod Convex (per the deploy-ordering gate above:
   testTagRecord/subTestRecord are already backfilled into prod).
 
+<<<<<<< HEAD
 ## Phase C — FK-anchor mirror inversion + domain-table drop
 
 Phase B inverted only safely-invertible (leaf / no-inbound-FK) tables; the 12
@@ -3016,6 +3017,43 @@ hard-cutover: backfill the one row, then flip all reads + the write.
 - **Validation:** tsc + 2433 tests + `npm run build` green. Preview-gated; the
   backfill must run in prod (`npx tsx scripts/convex-backfill-site-settings.ts`)
   so the existing policies carry over — until then reads fall back to defaults.
+
+### Phase C — file-upload + media cluster (keystone-class)
+
+`fileUpload` + the 7 `*_media` tables are referenced by detail-page composites
+across **six domains** (getAsset, getKit, getProject, getSubHire, getClient, the
+model/kit count grafts) — the same cross-cutting risk as the line-item keystone.
+So it's split, like the keystone: **read-rewire first, write-invert second.**
+
+#### Read-rewire — DONE (PR #258)
+
+Every remaining Prisma `*_media` / `file_upload` READ moves to the Convex mirror.
+**Pure read swap — media is still dual-written, so Convex data is identical; no FK
+or write change; fully reversible; doesn't depend on the FK-drop (#254).**
+
+- **New Convex gallery getters** `getClientMediaFromConvex` / `getSubHireMediaFromConvex`
+  added to `media-read.ts` (the asset/model/kit/project ones already existed from
+  Phase A). `getGalleryRows` broadened to the client/subHire media docs.
+- **`withResolvedFile`** helper narrows a gallery to rows whose `file` resolved
+  (non-null) — matching the old `include: { file }` on a REQUIRED FK (every row
+  always had a file). Applied at every detail-composite injection so the consumer's
+  non-null-`file` contract holds; an unresolvable mirror row is dropped (same as a
+  Prisma join against a since-deleted row).
+- **Rewired composites:** `assets.getAsset` (own `media` + `model.media`),
+  `kits.getKit`, `projects.getProject`, `sub-hires.getSubHire` (dropped the
+  `media: { include: { file } }` relational include, attach from Convex),
+  `clients.getClient`, `models.getModel`, and the standalone `sub-hires.getSubHireMedia`.
+  `clients.ts` no longer imports `prisma` (removed).
+- Validation: tsc + lint (0 errors) + 2433 tests + `npm run build` green.
+
+#### Write-inversion — DONE (PR #259)
+
+Invert the 7 media write paths + the upload route's `fileUpload.create` to
+Convex-only; re-implement the invariants (sortOrder, single-primary +
+promote-next, set-primary/reorder atomically via custom Convex mutations,
+fileUpload cascade w/ the sub-hire ref-count); rewire the parent-delete media
+cleanups (kit/location); extract `MEDIA_SPECS` out of `media-mirror.ts`; delete
+`file-upload-mirror.ts` + `media-mirror.ts`. Needs #254 (FK drops) deployed.
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/src/lib/media-read.ts
+++ b/src/lib/media-read.ts
@@ -155,6 +155,8 @@ export type AssetGalleryMedia = GalleryMediaBase & { assetId: string; type: Medi
 export type ModelGalleryMedia = GalleryMediaBase & { modelId: string; type: MediaType; isPrimary: boolean };
 export type KitGalleryMedia = GalleryMediaBase & { kitId: string; type: MediaType; isPrimary: boolean };
 export type ProjectGalleryMedia = GalleryMediaBase & { projectId: string; type: ProjectMediaType };
+export type ClientGalleryMedia = GalleryMediaBase & { clientId: string; type: ProjectMediaType };
+export type SubHireGalleryMedia = GalleryMediaBase & { subHireId: string; type: ProjectMediaType };
 
 /** Map a Convex `fileUploads` doc to the nested `file` shape (epoch-ms → Date,
  * absent → null for the nullable columns). */
@@ -193,6 +195,19 @@ function mapGalleryBase(
   };
 }
 
+/**
+ * Narrow a gallery list to rows whose `file` resolved (non-null), matching the
+ * old Prisma `include: { file }` on a REQUIRED FK (every row always had a file).
+ * Detail-page composites consume `media` with a non-null `file`; a mirror row
+ * whose file id doesn't resolve is unrenderable, so drop it (same as a Prisma
+ * join against a since-deleted row would have excluded it).
+ */
+export function withResolvedFile<T extends { file: GalleryFile | null }>(
+  rows: T[],
+): Array<T & { file: GalleryFile }> {
+  return rows.filter((m): m is T & { file: GalleryFile } => m.file !== null);
+}
+
 /** Pure sort replicating Prisma `orderBy: { sortOrder: "asc" }` (coercing the
  * Prisma-defaulted `sortOrder` to 0). Stable so ties keep input order. */
 export function sortGalleryBySortOrder<T extends { sortOrder?: number | null }>(rows: T[]): T[] {
@@ -218,16 +233,22 @@ async function fetchGalleryFiles(fileIds: string[]): Promise<Map<string, Gallery
   return out;
 }
 
+type AnyMediaDoc =
+  | Doc<"assetMedia">
+  | Doc<"modelMedia">
+  | Doc<"kitMedia">
+  | Doc<"projectMedia">
+  | Doc<"clientMedia">
+  | Doc<"subHireMedia">;
+
 async function getGalleryRows<K extends MediaKind>(
   kind: K,
   parentId: string,
-): Promise<Array<Doc<"assetMedia"> | Doc<"modelMedia"> | Doc<"kitMedia"> | Doc<"projectMedia">>> {
+): Promise<AnyMediaDoc[]> {
   const convex = await getConvexClient();
   return withConvexReadRetry(
     async () =>
-      (await convex.query(MEDIA_SPECS[kind].convex.listByParent, { parentId })) as Array<
-        Doc<"assetMedia"> | Doc<"modelMedia"> | Doc<"kitMedia"> | Doc<"projectMedia">
-      >,
+      (await convex.query(MEDIA_SPECS[kind].convex.listByParent, { parentId })) as AnyMediaDoc[],
   );
 }
 
@@ -276,6 +297,30 @@ export async function getProjectMediaFromConvex(projectId: string): Promise<Proj
   return rows.map((m) => ({
     ...mapGalleryBase(m, files.get(m.fileId) ?? null),
     projectId: m.projectId,
+    type: (m.type ?? "OTHER") as ProjectMediaType,
+  }));
+}
+
+/** Client gallery — Convex equivalent of the old `prisma.clientMedia` getter.
+ * Like project media, no `isPrimary`. */
+export async function getClientMediaFromConvex(clientId: string): Promise<ClientGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("client", clientId)) as Doc<"clientMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    clientId: m.clientId,
+    type: (m.type ?? "OTHER") as ProjectMediaType,
+  }));
+}
+
+/** Sub-hire gallery — Convex equivalent of the old `prisma.subHireMedia` getter.
+ * Like project media, no `isPrimary`. */
+export async function getSubHireMediaFromConvex(subHireId: string): Promise<SubHireGalleryMedia[]> {
+  const rows = sortGalleryBySortOrder((await getGalleryRows("subHire", subHireId)) as Doc<"subHireMedia">[]);
+  const files = await fetchGalleryFiles(rows.map((r) => r.fileId));
+  return rows.map((m) => ({
+    ...mapGalleryBase(m, files.get(m.fileId) ?? null),
+    subHireId: m.subHireId,
     type: (m.type ?? "OTHER") as ProjectMediaType,
   }));
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -18,7 +18,7 @@ import {
 import { getSupplierById } from "@/lib/suppliers-read";
 import { getModelById, getModelWithCategoryMap, type ModelWithCategory } from "@/lib/models-read";
 import { getLocationMap, type ConvexLocation } from "@/lib/locations-read";
-import { getPrimaryPhotoMaps } from "@/lib/media-read";
+import { getPrimaryPhotoMaps, getAssetMediaFromConvex, getModelMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { type FilterValue } from "@/lib/table-utils";
 import {
   getMappedAssetsByOrg,
@@ -134,10 +134,6 @@ export async function getAsset(id: string) {
   const asset = await prisma.asset.findUnique({
     where: { id, organizationId },
     include: {
-      media: {
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      },
       maintenanceLinks: {
         include: { maintenanceRecord: true },
         orderBy: { maintenanceRecord: { createdAt: "desc" } },
@@ -176,13 +172,10 @@ export async function getAsset(id: string) {
   if (!asset) return serialize(asset);
 
   // Model (+ category) + supplier live in Convex — attach instead of Prisma joins.
-  // Model media stays a Prisma read (gallery terminus); bulkAccessories now from Convex.
-  const modelMediaPromise: Promise<Prisma.ModelMediaGetPayload<{ include: { file: true } }>[]> = asset.modelId
-    ? prisma.modelMedia.findMany({
-        where: { modelId: asset.modelId },
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      })
+  // Asset + model media galleries now read from the Convex mirror (dual-written →
+  // identical data); bulkAccessories from Convex. See media-read.ts.
+  const modelMediaPromise = asset.modelId
+    ? getModelMediaFromConvex(asset.modelId)
     : Promise.resolve([]);
 
   const convex = await getConvexClient();
@@ -193,9 +186,10 @@ export async function getAsset(id: string) {
       })
     : Promise.resolve([]);
 
-  const [modelMap, modelMediaRows, supplier] = await Promise.all([
+  const [modelMap, modelMediaRows, assetMediaRows, supplier] = await Promise.all([
     getModelWithCategoryMap(organizationId),
     modelMediaPromise,
+    getAssetMediaFromConvex(id),
     asset.supplierId ? getSupplierById(asset.supplierId) : null,
   ]);
   const modelBulkAccessoriesRaw = await modelBulkAccessoriesPromise;
@@ -240,9 +234,10 @@ export async function getAsset(id: string) {
 
   return serialize({
     ...asset,
+    media: withResolvedFile(assetMediaRows),
     location,
     model: assetModel
-      ? { ...assetModel, media: modelMediaRows, bulkAccessories: bulkAccessoriesWithModel }
+      ? { ...assetModel, media: withResolvedFile(modelMediaRows), bulkAccessories: bulkAccessoriesWithModel }
       : null,
     childAssets: childAssetsWithModel,
     childBulkItems: childBulkItemsWithModel,

--- a/src/server/clients.ts
+++ b/src/server/clients.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
+import { getClientMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { getClientById, getClientsByOrg, type ConvexClient } from "@/lib/clients-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
 import {
@@ -130,11 +130,9 @@ export async function getClient(id: string) {
 
   const [allOrgProjects, media] = await Promise.all([
     getProjectsByOrg(organizationId),
-    prisma.clientMedia.findMany({
-      where: { clientId: id },
-      include: { file: true },
-      orderBy: { sortOrder: "asc" },
-    }),
+    // clientMedia gallery now read from the Convex mirror (was a Prisma
+    // clientMedia + file join). Dual-written, so identical data. See media-read.ts.
+    getClientMediaFromConvex(id),
   ]);
 
   const clientProjects = allOrgProjects
@@ -155,7 +153,7 @@ export async function getClient(id: string) {
     _count: { lineItems: lineItemCountMap.get(p.id) ?? 0 },
   }));
 
-  return serialize({ ...client, projects, media });
+  return serialize({ ...client, projects, media: withResolvedFile(media) });
 }
 
 export async function createClient(data: ClientFormValues) {

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -26,7 +26,7 @@ import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { syncAssetsToConvex, syncBulkAssetsToConvex } from "@/lib/asset-mirror";
 import { syncMediaForParent } from "@/lib/media-mirror";
-import { getPrimaryPhotoMap } from "@/lib/media-read";
+import { getPrimaryPhotoMap, getKitMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { getModelById, getModelMap } from "@/lib/models-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { getCategoryMap } from "@/lib/categories-read";
@@ -94,13 +94,11 @@ export async function getKit(id: string) {
         take: 20,
         orderBy: { createdAt: "desc" },
       },
-      media: {
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      },
     },
   });
   if (!kit) return serialize(null);
+  // kit media gallery now from the Convex mirror (dual-written → identical data).
+  const media = withResolvedFile(await getKitMediaFromConvex(id));
   const modelMap = await getModelMap(organizationId);
   // Location + Category FKs were dropped (Phase B); attach both from the Convex mirror.
   const location = kit.locationId
@@ -111,6 +109,7 @@ export async function getKit(id: string) {
     : null;
   return serialize({
     ...kit,
+    media,
     location,
     category,
     serializedItems: kit.serializedItems.map((si) => ({

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -4,7 +4,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { removeAssetFromConvex, removeBulkAssetFromConvex } from "@/lib/asset-mirror";
-import { getPrimaryPhotoMap } from "@/lib/media-read";
+import { getPrimaryPhotoMap, getModelMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import {
   getModelById,
   getModelMap,
@@ -232,11 +232,11 @@ export async function getModel(id: string) {
       getCategoryMap(organizationId),
       getActiveAssetsByModel(id, organizationId),
       getActiveBulkAssetsByModel(id, organizationId),
-      prisma.modelMedia.findMany({
-        where: { modelId: id, organizationId },
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      }),
+      // modelMedia gallery from the Convex mirror (was a Prisma modelMedia + file
+      // join). Dual-written → identical data. See media-read.ts.
+      getModelMediaFromConvex(id).then((rows) =>
+        rows.filter((m) => m.organizationId === organizationId),
+      ),
       convex.query(api.modelBulkAccessories.listByModelId, { modelId: id, organizationId }),
       getModelMap(organizationId),
     ]);
@@ -271,7 +271,7 @@ export async function getModel(id: string) {
     category: model.categoryId ? categoryMap.get(model.categoryId) ?? null : null,
     assets: assetsWithLoc,
     bulkAssets: bulkWithLoc,
-    media: mediaRows,
+    media: withResolvedFile(mediaRows),
     bulkAccessories: bulkAccessoriesRaw.map((ba) => ({
       id: ba.id,
       organizationId: ba.organizationId,

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -23,6 +23,7 @@ import { logActivity } from "@/lib/activity-log";
 import { syncKitsToConvex } from "@/lib/kit-mirror";
 import { syncAssetsToConvex } from "@/lib/asset-mirror";
 import { getConvexClient } from "@/lib/convex-client";
+import { getProjectMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { api } from "../../convex/_generated/api";
 import { upsertProjectLineItemsToConvex, removeLineItemFromConvex } from "@/lib/line-item-mirror";
 import { mirrorProjectCreate, patchProjectInConvex, removeProjectFromConvex } from "@/lib/project-mirror";
@@ -395,13 +396,13 @@ export async function getProject(id: string) {
         },
         orderBy: { addedAt: "asc" },
       },
-      media: {
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      },
     },
   });
   if (!projectRow) return null;
+
+  // project media gallery now from the Convex mirror (dual-written → identical
+  // data); was a Prisma projectMedia + file join. See media-read.ts.
+  const media = withResolvedFile(await getProjectMediaFromConvex(projectRow.id));
 
   // Location FK was dropped (Phase B) — reconstruct `location` (with its parent)
   // from the Convex mirror, replacing the old `include: { location: { include:
@@ -421,7 +422,7 @@ export async function getProject(id: string) {
       location = { ...loc, parent: parentDoc ? mapLocation(parentDoc) : null };
     }
   }
-  const project = { ...projectRow, location };
+  const project = { ...projectRow, media, location };
 
   // Inherit address/coordinates from parent location if child has none
   if (project.location?.parentId) {

--- a/src/server/sub-hires.ts
+++ b/src/server/sub-hires.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/sub-hire-mirror";
 import { upsertProjectLineItemsToConvex, removeLineItemFromConvex } from "@/lib/line-item-mirror";
 import { getConvexClient } from "@/lib/convex-client";
+import { getSubHireMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { api } from "../../convex/_generated/api";
 import { createId } from "@paralleldrive/cuid2";
 import {
@@ -221,19 +222,17 @@ export async function getSubHire(id: string) {
         },
         orderBy: { sortOrder: "asc" },
       },
-      media: {
-        include: { file: true },
-        orderBy: { sortOrder: "asc" },
-      },
     },
   });
 
   if (!subHire) throw new Error("Sub-hire not found");
-  // Model + supplier + project live in Convex — enrich after query.
-  const [modelMap, supplier, convexProject] = await Promise.all([
+  // Model + supplier + project live in Convex — enrich after query. subHire media
+  // gallery from the Convex mirror (dual-written → identical data).
+  const [modelMap, supplier, convexProject, media] = await Promise.all([
     getModelMap(organizationId),
     getSupplierById(subHire.supplierId),
     subHire.projectId ? getProjectById(subHire.projectId) : Promise.resolve(null),
+    getSubHireMediaFromConvex(subHire.id),
   ]);
   const project = convexProject
     ? { id: convexProject.id, name: convexProject.name, projectNumber: convexProject.projectNumber }
@@ -249,7 +248,7 @@ export async function getSubHire(id: string) {
     ...item,
     model: item.modelId ? (modelMap.get(item.modelId) ?? null) : null,
   }));
-  return serialize({ ...subHire, groups: enrichedGroups, items: enrichedItems, supplier, project });
+  return serialize({ ...subHire, media: withResolvedFile(media), groups: enrichedGroups, items: enrichedItems, supplier, project });
 }
 
 export async function createSubHire(input: unknown) {
@@ -1837,11 +1836,11 @@ export async function updateSubHirePaymentStatus(id: string, paymentStatus: SubH
 export async function getSubHireMedia(subHireId: string) {
   const { organizationId } = await requirePermission("subHire", "read");
 
-  const media = await prisma.subHireMedia.findMany({
-    where: { subHireId, organizationId },
-    include: { file: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // subHireMedia gallery from the Convex mirror (was a Prisma subHireMedia + file
+  // join). Dual-written → identical data. See media-read.ts.
+  const media = (await getSubHireMediaFromConvex(subHireId)).filter(
+    (m) => m.organizationId === organizationId,
+  );
 
   return serialize(media);
 }


### PR DESCRIPTION
## Phase C — file-upload + media cluster, **read-rewire (1 of 2)**

`fileUpload` + the 7 `*_media` tables turned out to be **keystone-class**: their media is read by detail-page composites across **six domains** (`getAsset`, `getKit`, `getProject`, `getSubHire`, `getClient`, `getModel`) — the same cross-cutting risk as the line-item keystone. So it's split exactly like the keystone: **read-rewire first (this PR), write-invert second.**

### Why this is low-risk
**Pure read swap.** Media is still dual-written (mirrors untouched), so the Convex data is byte-identical to Prisma. No FK change, no write change, fully reversible, and it doesn't even depend on #254. This is the well-proven Phase A read-rewiring pattern.

### Changes
- **New Convex gallery getters** `getClientMediaFromConvex` / `getSubHireMediaFromConvex` in `media-read.ts` (asset/model/kit/project already existed from Phase A); `getGalleryRows` broadened to the client/subHire docs.
- **`withResolvedFile`** narrows a gallery to rows whose `file` resolved (non-null) — matching the old `include: { file }` on a REQUIRED FK (every row always had a file). Applied at each composite injection so the consumers' non-null-`file` contract holds; an unresolvable mirror row is dropped (same as a Prisma join against a since-deleted row).
- **Rewired** (dropped the `media: { include: { file } }` relational include / standalone Prisma read, attach from Convex): `assets.getAsset` (own `media` + `model.media`), `kits.getKit`, `projects.getProject`, `sub-hires.getSubHire` + `getSubHireMedia`, `clients.getClient`, `models.getModel`. `clients.ts` no longer imports `prisma`.

### Out of scope (follow-up PR)
The write inversion: invert the 7 media write paths + the upload route's `fileUpload.create` to Convex-only, re-implement the invariants (sortOrder, single-primary + promote-next, atomic set-primary/reorder, fileUpload cascade + sub-hire ref-count), rewire parent-delete media cleanups, extract `MEDIA_SPECS`, delete the two mirror files. That one needs #254 (now live on main).

### Validation
tsc + lint (0 errors) + **2433** tests + `npm run build` exit 0. Preview check: open an asset / kit / project / sub-hire / client detail page and the model detail page — galleries + primary photos render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)