### PR TITLE
Phase C core step 1: grouping cluster → atomic Convex mutations

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -712,29 +712,41 @@ asset_bulk_child / model_bulk_accessory) plus many nullable refs → dual-write.
 - **Backfill**: `pnpm convex:backfill:asset` (134 rows; counts verified P==C).
   Live patch round-trip verified against the running backend.
 
-### Project grouping substructure — DONE (central-graph step 3, infra-only)
+### Project grouping substructure — CONVEX-ONLY (Phase C core step 1, DONE)
 
-`project_category` (12 rows) + `project_group` (17 rows) are **dual-written
-infra-only** — there is **no Phase 4**. They are composed only inside the
-cross-domain equipment editor (project ↔ line_item ↔ category ↔ group ↔
-category_slot ↔ sub_hire_group, read as the equipment tab's mixed-ordered list),
-which stays on Prisma reads. The mirror keeps the Convex graph complete for the
-eventual decommission. `category_slot` (the cross-type ordering layer) stays
-Prisma-only.
+`projectCategory` + `projectGroup` + `categorySlot` are **Convex-only** (reads
+since Phase A, writes inverted in Phase B `e625763a`, no mirror). They compose
+the equipment editor's mixed-ordered list (project ↔ line_item ↔ category ↔
+group ↔ category_slot ↔ sub_hire_group). Line items + sub_hire_group are still
+Prisma (keystone = a later core step), so cross-store edits (e.g. category
+delete null-ing line-item `categoryId`) keep the Prisma write in the server
+action and the grouping write in Convex.
 
-- **Mirror**: [`src/lib/project-grouping-mirror.ts`](../src/lib/project-grouping-mirror.ts)
-  — create/patch/remove for both + `syncProjectGroupsToConvex` /
-  `syncProjectCategoriesToConvex` for the reorder/split/merge/move transactions.
-- **Write sites** (6 files): `project-categories.ts` (create/update/reorder/delete
-  — delete cascades its groups out of Convex), `project-groups.ts`
-  (create/update/price/accept/move/reorder/delete), `category-slots.ts`
-  (move-to-category + create-category-and-move; reorder stays on category_slot),
-  `group-templates.ts` (applyGroupTemplate), `line-items.ts` (group suggestedPrice
-  recalc on add), `projects.ts` (duplicateProject copies categories + groups).
-- **Clear-to-null**: moving a group to the Uncategorised zone clears
-  `categoryId`→null — a no-op in Convex (documented); tolerable for a
-  consumer-less substructure, heals on next non-null write or backfill.
-- **Backfill**: `pnpm convex:backfill:project-grouping` (29 rows; P==C).
+**Atomicity (Phase C core step 1):** the multi-table $transactions are ported to
+purpose-built atomic Convex mutations — a single mutation is fully ACID +
+serializable (OCC retries the loser), so cascade/reorder/create-at-end are
+race-free in one transaction instead of split across N network calls.
+
+- **Custom mutations** (inline in `convex/projectCategories.ts` /
+  `convex/projectGroups.ts`, `// ── CUSTOM (Phase C)` banner — re-add on CRUD
+  regen): `createAtEnd` (max(sortOrder)+1 computed in-mutation, no TOCTOU),
+  `reorder` (contiguous sortOrder in one tx), `deleteCascade`
+  (category → its groups+slots+cat-slots+category, returns deleted groupIds;
+  group → its slots+group), `projectCategories.deleteAllForProject`
+  (full project grouping purge). `categorySlots.ts` already has atomic
+  `reorderSlots` / `upsertSlotFor{Project,SubHire}Group`.
+- **Write sites**: `project-categories.ts`, `project-groups.ts`,
+  `category-slots.ts`, `group-templates.ts` (applyGroupTemplate), `line-items.ts`
+  (group suggestedPrice recalc on add), `projects.ts` (duplicateProject copies +
+  `deleteProject` now calls `deleteAllForProject` — the Prisma FK cascade that
+  used to clean these up was dropped in Phase C #254).
+- **Stale-read fixes (this PR)**: 3 residual `prisma.projectGroup` reads (which
+  read a frozen Prisma table post-cutover) rewired to Convex — `line-items.ts`
+  groupName lookup + `recalculateProjectTotals` group price/quantity (was a
+  silent revenue bug), `sub-hires.ts` group→category resolution.
+- **Clear-to-null**: `projectGroups.update` uses the `categoryId: null` sentinel
+  to clear (move group to Uncategorised) — `ctx.db.replace` drops the field.
+- **Backfill**: `pnpm convex:backfill:project-grouping` (already in prod).
 
 ### Project line items — DONE (central-graph step 4, infra-only)
 

--- a/convex/projectCategories.ts
+++ b/convex/projectCategories.ts
@@ -110,3 +110,135 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ── CUSTOM (Phase C — core grouping inversion) — re-add on regen ─────────────
+// Purpose-built atomic mutations that replace multi-call server-action sequences.
+// A single Convex mutation is fully ACID + serializable across every doc it
+// touches (OCC retries the loser of a write-write race), so cascade + reorder +
+// create-at-end become race-free here instead of split across N network calls.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Atomic create-at-end: compute max(sortOrder)+1 within the project and insert
+ * in one transaction — no read-max-then-insert TOCTOU. Caller supplies the cuid.
+ */
+export const createAtEnd = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    name: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, projectId, name, now }) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("projectCategories")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .collect();
+    const maxSort = existing.reduce((m, c) => Math.max(m, c.sortOrder ?? -1), -1);
+    const sortOrder = maxSort + 1;
+    await ctx.db.insert("projectCategories", {
+      id,
+      organizationId,
+      projectId,
+      name,
+      sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { id, sortOrder };
+  },
+});
+
+/**
+ * Atomic reorder: sortOrder = index for each id, in one transaction. Guarantees
+ * contiguous ordering even if two reorders race (the serialized loser re-runs
+ * against the winner's writes).
+ */
+export const reorder = mutation({
+  args: { orderedIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, { orderedIds, now }) => {
+    await requireService(ctx);
+    for (let i = 0; i < orderedIds.length; i++) {
+      const doc = await ctx.db
+        .query("projectCategories")
+        .withIndex("by_cuid", (q) => q.eq("id", orderedIds[i]))
+        .unique();
+      if (doc) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
+    }
+  },
+});
+
+/**
+ * Atomic cascade delete of a category: every group in it (+ each group's slots),
+ * every category slot, then the category itself. Returns the deleted group ids
+ * so the caller can null out the (still-Prisma) line items that referenced them.
+ */
+export const deleteCascade = mutation({
+  args: { categoryId: v.string() },
+  handler: async (ctx, { categoryId }) => {
+    await requireService(ctx);
+    const groups = await ctx.db
+      .query("projectGroups")
+      .withIndex("by_categoryId", (q) => q.eq("categoryId", categoryId))
+      .collect();
+    for (const g of groups) {
+      const gslots = await ctx.db
+        .query("categorySlots")
+        .withIndex("by_projectGroupId", (q) => q.eq("projectGroupId", g.id))
+        .collect();
+      for (const s of gslots) await ctx.db.delete(s._id);
+      await ctx.db.delete(g._id);
+    }
+    const catSlots = await ctx.db
+      .query("categorySlots")
+      .withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", categoryId))
+      .collect();
+    for (const s of catSlots) await ctx.db.delete(s._id);
+    const cat = await ctx.db
+      .query("projectCategories")
+      .withIndex("by_cuid", (q) => q.eq("id", categoryId))
+      .unique();
+    if (cat) await ctx.db.delete(cat._id);
+    return { groupIds: groups.map((g) => g.id) };
+  },
+});
+
+/**
+ * Atomic purge of ALL grouping rows (categories, groups, slots) for a project.
+ * Used on project delete now that the Prisma FK cascade is gone (Phase C #254).
+ * Read-your-writes within the mutation makes the overlapping slot deletes safe.
+ */
+export const deleteAllForProject = mutation({
+  args: { projectId: v.string() },
+  handler: async (ctx, { projectId }) => {
+    await requireService(ctx);
+    const cats = await ctx.db
+      .query("projectCategories")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .collect();
+    for (const c of cats) {
+      const catSlots = await ctx.db
+        .query("categorySlots")
+        .withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", c.id))
+        .collect();
+      for (const s of catSlots) await ctx.db.delete(s._id);
+    }
+    const groups = await ctx.db
+      .query("projectGroups")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .collect();
+    for (const g of groups) {
+      const gslots = await ctx.db
+        .query("categorySlots")
+        .withIndex("by_projectGroupId", (q) => q.eq("projectGroupId", g.id))
+        .collect();
+      for (const s of gslots) await ctx.db.delete(s._id);
+      await ctx.db.delete(g._id);
+    }
+    for (const c of cats) await ctx.db.delete(c._id);
+    return { categories: cats.length, groups: groups.length };
+  },
+});

--- a/convex/projectGroups.ts
+++ b/convex/projectGroups.ts
@@ -149,3 +149,80 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ── CUSTOM (Phase C — core grouping inversion) — re-add on regen ─────────────
+// See projectCategories.ts banner. Atomic create-at-end / reorder / cascade.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Atomic create-at-end within the (projectId, categoryId) bucket: compute
+ * max(sortOrder)+1 and insert in one transaction. Caller supplies the cuid.
+ */
+export const createAtEnd = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    categoryId: v.optional(v.string()),
+    title: v.string(),
+    description: v.optional(v.string()),
+    quantity: v.optional(v.number()),
+    price: v.optional(v.number()),
+    suggestedPrice: v.optional(v.number()),
+    rentalPeriod: v.optional(enums.RentalPeriod),
+    rentalQuantity: v.optional(v.number()),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const { now, ...fields } = args;
+    const bucket = fields.categoryId ?? null;
+    const existing = await ctx.db
+      .query("projectGroups")
+      .withIndex("by_projectId", (q) => q.eq("projectId", fields.projectId))
+      .collect();
+    const inBucket = existing.filter((g) => (g.categoryId ?? null) === bucket);
+    const maxSort = inBucket.reduce((m, g) => Math.max(m, g.sortOrder ?? -1), -1);
+    const sortOrder = maxSort + 1;
+    await ctx.db.insert("projectGroups", { ...fields, sortOrder, createdAt: now, updatedAt: now });
+    return { id: fields.id, sortOrder };
+  },
+});
+
+/**
+ * Atomic reorder within a category: sortOrder = index for each id, one transaction.
+ */
+export const reorder = mutation({
+  args: { orderedIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, { orderedIds, now }) => {
+    await requireService(ctx);
+    for (let i = 0; i < orderedIds.length; i++) {
+      const doc = await ctx.db
+        .query("projectGroups")
+        .withIndex("by_cuid", (q) => q.eq("id", orderedIds[i]))
+        .unique();
+      if (doc) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
+    }
+  },
+});
+
+/**
+ * Atomic cascade delete of a group: its category slots, then the group itself.
+ */
+export const deleteCascade = mutation({
+  args: { groupId: v.string() },
+  handler: async (ctx, { groupId }) => {
+    await requireService(ctx);
+    const slots = await ctx.db
+      .query("categorySlots")
+      .withIndex("by_projectGroupId", (q) => q.eq("projectGroupId", groupId))
+      .collect();
+    for (const s of slots) await ctx.db.delete(s._id);
+    const doc = await ctx.db
+      .query("projectGroups")
+      .withIndex("by_cuid", (q) => q.eq("id", groupId))
+      .unique();
+    if (doc) await ctx.db.delete(doc._id);
+  },
+});

--- a/docs/designs/convex-domain-only-decommission.md
+++ b/docs/designs/convex-domain-only-decommission.md
@@ -290,6 +290,29 @@ schema edits on kept models are deleting Prisma back-relation array fields.
   is dropped. Order: **warehouse-close** → file-upload+media → crew → crew-scheduling
   → project-subtable → asset → kit → sub-hire → **project+line-item (keystone, last;
   full-pipeline PDF integration test)**.
+  - **Refined core plan** — the entangled remainder (line-items+units, asset
+    allocation, kit, sub-hire, crew-scheduling, grouping, project scalars) is
+    bound by shared Prisma `$transaction`s and is sequenced separately in
+    [`convex-core-inversion-design.md`](./convex-core-inversion-design.md): each
+    `$transaction` → ONE purpose-built atomic Convex mutation (a single mutation
+    is fully ACID + serializable). Steps: **(1) grouping ✅ DONE** →
+    (2) line-item+asset checkout mega-flip → (3) kit → (4) sub-hire →
+    (5) projectService+crew-scheduling → (6) project scalars.
+  - **Core step 1 — grouping ✅ DONE** (`phase-c/core-grouping`). Writes were
+    already Convex-only (Phase B `e625763a`) but via non-atomic sequenced
+    `client.mutation` calls. This PR ports cascade/reorder/create into atomic
+    custom mutations (`createAtEnd`/`reorder`/`deleteCascade`/`deleteAllForProject`),
+    fixes 3 residual stale `prisma.projectGroup` reads (incl. a silent revenue
+    bug in `recalculateProjectTotals`), and fixes the **`deleteProject` Convex
+    orphan** (categories/groups/slots were leaked after #254 dropped the FK
+    cascade). Dev-validated live: 13/13 invariant checks.
+  - **⚠ Finding (broader, NOT grouping-scoped):** #254 dropped *all* domain↔domain
+    FKs, so `tx.project.delete` in `deleteProject` no longer cascades **any**
+    Prisma child rows (line-items, units, services, tasks, media, …). Grouping is
+    handled (Convex purge above); the remaining still-Prisma children are leaked
+    on project delete until their cluster inverts. Each Stage-2/core PR that
+    inverts a project-child cluster must add explicit cleanup in `deleteProject`,
+    or a stopgap `deleteMany`-by-`projectId` sweep should be added.
 - **Stage 3 — schema removal** (1 PR): delete the 71 domain models + orphaned
   `User`/`Organization` back-relation arrays from `schema.prisma`; `prisma validate`
   + `generate` clean; grep-gate zero `prisma.<domainModel>.` remaining.

--- a/docs/designs/convex-domain-only-decommission.md
+++ b/docs/designs/convex-domain-only-decommission.md
@@ -306,13 +306,17 @@ schema edits on kept models are deleting Prisma back-relation array fields.
     bug in `recalculateProjectTotals`), and fixes the **`deleteProject` Convex
     orphan** (categories/groups/slots were leaked after #254 dropped the FK
     cascade). Dev-validated live: 13/13 invariant checks.
-  - **⚠ Finding (broader, NOT grouping-scoped):** #254 dropped *all* domain↔domain
-    FKs, so `tx.project.delete` in `deleteProject` no longer cascades **any**
-    Prisma child rows (line-items, units, services, tasks, media, …). Grouping is
-    handled (Convex purge above); the remaining still-Prisma children are leaked
-    on project delete until their cluster inverts. Each Stage-2/core PR that
-    inverts a project-child cluster must add explicit cleanup in `deleteProject`,
-    or a stopgap `deleteMany`-by-`projectId` sweep should be added.
+  - **Finding (broader, NOT grouping-scoped) — INERT, no action needed now:**
+    #254 dropped *all* domain↔domain FKs, so `tx.project.delete` no longer
+    cascades **any** Prisma child (line-items, units, services, tasks, media, …).
+    Grouping's Convex rows are purged explicitly (above). The remaining
+    still-Prisma children are **orphaned dead-weight, not an active bug**: every
+    org-wide reader joins each row to a live project (`availability-read.ts`
+    `if (!p || !projectMatchesWindow(...)) continue` — an orphan has no entry in
+    the Convex-built `projectsById`, so it's skipped), and Stage 4's
+    `DROP TABLE … CASCADE` removes the rows. As each project-child cluster
+    inverts to Convex its `deleteProject` cleanup becomes Convex-native anyway.
+    No stopgap `deleteMany` sweep — it would be misleading (partial) busywork.
 - **Stage 3 — schema removal** (1 PR): delete the 71 domain models + orphaned
   `User`/`Organization` back-relation arrays from `schema.prisma`; `prisma validate`
   + `generate` clean; grep-gate zero `prisma.<domainModel>.` remaining.

--- a/src/server/category-slots.ts
+++ b/src/server/category-slots.ts
@@ -437,13 +437,6 @@ export async function createCategoryAndPlaceGroup(input: CreateCategoryAndPlaceG
     if (!shg) throw new Error("Sub-hire group not found in this project");
   }
 
-  // New category goes to end of project's category list.
-  const existingCategories = await client.query(api.projectCategories.listByProject, {
-    projectId: parsed.projectId,
-    orgId: organizationId,
-  });
-  const maxSort = existingCategories.reduce((m, c) => Math.max(m, c.sortOrder ?? -1), -1);
-
   const categoryId = createId();
   const now = Date.now();
 
@@ -461,15 +454,13 @@ export async function createCategoryAndPlaceGroup(input: CreateCategoryAndPlaceG
     }
   }
 
-  // Create category and slot in Convex.
-  await client.mutation(api.projectCategories.create, {
+  // Create category (atomic create-at-end) and slot in Convex.
+  const { sortOrder: categorySortOrder } = await client.mutation(api.projectCategories.createAtEnd, {
     id: categoryId,
     organizationId,
     projectId: parsed.projectId,
     name: parsed.name,
-    sortOrder: maxSort + 1,
-    createdAt: now,
-    updatedAt: now,
+    now,
   });
 
   await client.mutation(api.categorySlots.create, {
@@ -528,7 +519,7 @@ export async function createCategoryAndPlaceGroup(input: CreateCategoryAndPlaceG
     organizationId,
     projectId: parsed.projectId,
     name: parsed.name,
-    sortOrder: maxSort + 1,
+    sortOrder: categorySortOrder,
     createdAt: new Date(now),
     updatedAt: new Date(now),
   });

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -249,11 +249,7 @@ export async function applyGroupTemplate(
     model: i.modelId ? modelMap.get(i.modelId) ?? null : null,
   }));
 
-  // Get next sort order for the group within category from Convex
   const client = await getConvexClient();
-  const allGroups = await client.query(api.projectGroups.listByProject, { projectId, orgId: organizationId });
-  const inBucket = allGroups.filter((g) => (g.categoryId ?? null) === (parsed.categoryId ?? null));
-  const maxSortOrder = inBucket.reduce((m, g) => Math.max(m, g.sortOrder ?? -1), -1);
 
   // Get project defaults for rental period
   const project = await getProjectById(projectId);
@@ -265,11 +261,13 @@ export async function applyGroupTemplate(
   const kitItems = itemsWithModels.filter((i) => i.kitId && i.kit);
 
   // Create the group in Convex first so it has a stable ID for line items.
+  // Atomic create-at-end: sortOrder within the (project, category) bucket is
+  // computed inside the mutation (no read-max-then-insert TOCTOU).
   const groupId = createId();
   const now = Date.now();
   const rentalPeriod = project.defaultRentalPeriod ?? undefined;
   const rentalQuantity = project.defaultRentalQuantity ?? undefined;
-  await client.mutation(api.projectGroups.create, {
+  const { sortOrder: groupSortOrder } = await client.mutation(api.projectGroups.createAtEnd, {
     id: groupId,
     organizationId,
     projectId,
@@ -279,10 +277,8 @@ export async function applyGroupTemplate(
     quantity: 1,
     rentalPeriod,
     rentalQuantity,
-    sortOrder: maxSortOrder + 1,
     suggestedPrice: 0,
-    createdAt: now,
-    updatedAt: now,
+    now,
   });
 
   const group = {
@@ -297,7 +293,7 @@ export async function applyGroupTemplate(
     suggestedPrice: 0,
     rentalPeriod: project.defaultRentalPeriod ?? null,
     rentalQuantity: project.defaultRentalQuantity ?? null,
-    sortOrder: maxSortOrder + 1,
+    sortOrder: groupSortOrder,
     createdAt: new Date(now),
     updatedAt: new Date(now),
   };

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -963,14 +963,14 @@ export async function addCustomLineItem(projectId: string, data: CustomLineItemF
     });
   }
 
-  // Resolve groupName from groupId if provided
+  // Resolve groupName from groupId if provided (groups are Convex-only now)
   let groupName: string | undefined;
   if (parsed.groupId) {
-    const group = await prisma.projectGroup.findFirst({
-      where: { id: parsed.groupId, projectId, organizationId },
-      select: { title: true },
-    });
-    groupName = group?.title ?? undefined;
+    const groupConvex = await getConvexClient();
+    const group = await groupConvex.query(api.projectGroups.getById, { id: parsed.groupId });
+    if (group && group.projectId === projectId && group.organizationId === organizationId) {
+      groupName = group.title;
+    }
   }
 
   // Compute lineTotal and sortOrder so revenue and ordering are correct
@@ -1446,30 +1446,40 @@ export async function recalculateProjectTotals(projectId: string) {
   // model-rate optimizer, so their lineTotal doesn't roll into the bundle
   // price — they're "extras on top." Without this addition, a custom item
   // added to a group is invisible to the project total.
-  const groups = await prisma.projectGroup.findMany({
-    where: { projectId },
-    select: {
-      price: true,
-      quantity: true,
-      lineItems: {
+  // Groups (price/quantity) are Convex-only now; their custom-item "extras"
+  // still live in Prisma line items. Read both and join in JS.
+  const groupsConvex = await getConvexClient();
+  const convexGroups = await groupsConvex.query(api.projectGroups.listByProject, {
+    projectId,
+    orgId: project.organizationId,
+  });
+  const groupIds = convexGroups.map((g) => g.id);
+  const customGroupItems = groupIds.length
+    ? await prisma.projectLineItem.findMany({
         where: {
+          groupId: { in: groupIds },
           isCustomItem: true,
           isOptional: false,
           isKitChild: false,
           status: { not: "CANCELLED" },
         },
-        select: { lineTotal: true },
-      },
-    },
-  });
-
-  const groupRevenue = groups.reduce((sum, g) => {
-    const bundlePrice = g.price != null ? Number(g.price) : 0;
-    const customExtras = g.lineItems.reduce(
-      (s, li) => s + (li.lineTotal != null ? Number(li.lineTotal) : 0),
-      0,
+        select: { groupId: true, lineTotal: true },
+      })
+    : [];
+  const customExtrasByGroup = new Map<string, number>();
+  for (const li of customGroupItems) {
+    if (!li.groupId) continue;
+    customExtrasByGroup.set(
+      li.groupId,
+      (customExtrasByGroup.get(li.groupId) ?? 0) + (li.lineTotal != null ? Number(li.lineTotal) : 0),
     );
-    return sum + bundlePrice * g.quantity + customExtras;
+  }
+
+  const groupRevenue = convexGroups.reduce((sum, g) => {
+    const bundlePrice = g.price != null ? Number(g.price) : 0;
+    const qty = g.quantity ?? 1;
+    const customExtras = customExtrasByGroup.get(g.id) ?? 0;
+    return sum + bundlePrice * qty + customExtras;
   }, 0);
 
   // 2. Equipment revenue from standalone (ungrouped) line items —

--- a/src/server/project-categories.ts
+++ b/src/server/project-categories.ts
@@ -211,20 +211,15 @@ export async function createProjectCategory(
   const parsed = projectCategorySchema.parse(data);
   const client = await getConvexClient();
 
-  // Get next sort order from Convex
-  const existing = await client.query(api.projectCategories.listByProject, { projectId, orgId: organizationId });
-  const maxSort = existing.reduce((m, c) => Math.max(m, c.sortOrder ?? -1), -1);
-
+  // Atomic create-at-end: max(sortOrder)+1 computed inside the mutation (no TOCTOU).
   const id = createId();
   const now = Date.now();
-  await client.mutation(api.projectCategories.create, {
+  const { sortOrder } = await client.mutation(api.projectCategories.createAtEnd, {
     id,
     organizationId,
     projectId,
     name: parsed.name,
-    sortOrder: maxSort + 1,
-    createdAt: now,
-    updatedAt: now,
+    now,
   });
 
   await logActivity({
@@ -238,7 +233,7 @@ export async function createProjectCategory(
     summary: `Created category "${parsed.name}"`,
   });
 
-  return serialize({ id, organizationId, projectId, name: parsed.name, sortOrder: maxSort + 1, createdAt: new Date(now), updatedAt: new Date(now) });
+  return serialize({ id, organizationId, projectId, name: parsed.name, sortOrder, createdAt: new Date(now), updatedAt: new Date(now) });
 }
 
 export async function updateProjectCategory(
@@ -321,23 +316,9 @@ export async function deleteProjectCategory(categoryId: string) {
     });
   }
 
-  // 4. Delete each group's slot + the group itself from Convex
-  for (const g of categoryGroups) {
-    const groupSlots = await client.query(api.categorySlots.listByProjectGroupId, { projectGroupId: g.id });
-    for (const slot of groupSlots) {
-      await client.mutation(api.categorySlots.remove, { id: slot.id });
-    }
-    await client.mutation(api.projectGroups.remove, { id: g.id });
-  }
-
-  // 5. Delete remaining category slots (sub-hire group slots)
-  const catSlots = await client.query(api.categorySlots.list, { projectCategoryId: categoryId });
-  for (const slot of catSlots) {
-    await client.mutation(api.categorySlots.remove, { id: slot.id });
-  }
-
-  // 6. Delete the category from Convex
-  await client.mutation(api.projectCategories.remove, { id: categoryId });
+  // 4. Atomic Convex cascade: all groups (+ their slots), all category slots,
+  //    then the category — one transaction, no partial-cascade on mid-failure.
+  await client.mutation(api.projectCategories.deleteCascade, { categoryId });
 
   await logActivity({
     organizationId,
@@ -357,16 +338,11 @@ export async function reorderProjectCategories(
   projectId: string,
   orderedIds: string[],
 ) {
-  const { organizationId } = await requirePermission("project", "manage_line_items");
+  await requirePermission("project", "manage_line_items");
   const client = await getConvexClient();
 
-  const now = Date.now();
-  for (let i = 0; i < orderedIds.length; i++) {
-    await client.mutation(api.projectCategories.update, {
-      id: orderedIds[i],
-      patch: { sortOrder: i, updatedAt: now },
-    });
-  }
+  // Atomic reorder: contiguous sortOrder guaranteed in one transaction.
+  await client.mutation(api.projectCategories.reorder, { orderedIds, now: Date.now() });
 
   return serialize({ success: true });
 }

--- a/src/server/project-groups.ts
+++ b/src/server/project-groups.ts
@@ -68,14 +68,11 @@ export async function createProjectGroup(
   const parsed = projectGroupSchema.parse(data);
   const client = await getConvexClient();
 
-  // Get next sort order within the (project, category) bucket from Convex.
-  const existing = await client.query(api.projectGroups.listByProject, { projectId, orgId: organizationId });
-  const inBucket = existing.filter((g) => (g.categoryId ?? null) === (parsed.categoryId ?? null));
-  const maxSort = inBucket.reduce((m, g) => Math.max(m, g.sortOrder ?? -1), -1);
-
+  // Atomic create-at-end within the (project, category) bucket — sortOrder
+  // computed inside the mutation (no read-max-then-insert TOCTOU).
   const id = createId();
   const now = Date.now();
-  await client.mutation(api.projectGroups.create, {
+  const { sortOrder } = await client.mutation(api.projectGroups.createAtEnd, {
     id,
     organizationId,
     projectId,
@@ -86,10 +83,8 @@ export async function createProjectGroup(
     price: parsed.price != null ? parsed.price : undefined,
     rentalPeriod: parsed.rentalPeriod || undefined,
     rentalQuantity: parsed.rentalQuantity || undefined,
-    sortOrder: maxSort + 1,
     suggestedPrice: 0,
-    createdAt: now,
-    updatedAt: now,
+    now,
   });
 
   await logActivity({
@@ -114,7 +109,7 @@ export async function createProjectGroup(
     price: parsed.price != null ? parsed.price : null,
     rentalPeriod: parsed.rentalPeriod || null,
     rentalQuantity: parsed.rentalQuantity || null,
-    sortOrder: maxSort + 1,
+    sortOrder,
     suggestedPrice: 0,
     createdAt: new Date(now),
     updatedAt: new Date(now),
@@ -327,14 +322,8 @@ export async function deleteProjectGroup(groupId: string) {
     data: { groupId: null },
   });
 
-  // Delete the group's slot from Convex
-  const groupSlots = await client.query(api.categorySlots.listByProjectGroupId, { projectGroupId: groupId });
-  for (const slot of groupSlots) {
-    await client.mutation(api.categorySlots.remove, { id: slot.id });
-  }
-
-  // Delete the group from Convex
-  await client.mutation(api.projectGroups.remove, { id: groupId });
+  // Atomic Convex cascade: the group's slots + the group itself, one transaction.
+  await client.mutation(api.projectGroups.deleteCascade, { groupId });
 
   await logActivity({
     organizationId,
@@ -415,13 +404,8 @@ export async function reorderProjectGroups(
   await requirePermission("project", "manage_line_items");
   const client = await getConvexClient();
 
-  const now = Date.now();
-  for (let i = 0; i < orderedIds.length; i++) {
-    await client.mutation(api.projectGroups.update, {
-      id: orderedIds[i],
-      patch: { sortOrder: i, updatedAt: now },
-    });
-  }
+  // Atomic reorder within the category: contiguous sortOrder in one transaction.
+  await client.mutation(api.projectGroups.reorder, { orderedIds, now: Date.now() });
 
   return serialize({ success: true });
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -1275,6 +1275,9 @@ export async function deleteProject(id: string) {
     ...pmRows.map((pm) => convex.mutation(api.projectManagers.remove, { id: pm.id })),
     ...taskRows.map((t) => convex.mutation(api.projectTasks.remove, { id: t.id })),
   ]);
+  // Grouping (category/group/slot) lives in Convex only; the Prisma FK cascade
+  // that used to clean these up was dropped in Phase C #254, so purge them here.
+  await convex.mutation(api.projectCategories.deleteAllForProject, { projectId: id });
   await syncProjectServicesToConvex(organizationId, id);
 
   await logActivity({

--- a/src/server/sub-hires.ts
+++ b/src/server/sub-hires.ts
@@ -1030,11 +1030,10 @@ async function syncNewSubHireLineItem(
     const groupCategoryMap = new Map<string, string | null>();
     const gId = item.targetGroupId ?? orderDefaults.defaultTargetGroupId;
     if (gId) {
-      const pg = await prisma.projectGroup.findUnique({
-        where: { id: gId },
-        select: { categoryId: true },
-      });
-      if (pg) groupCategoryMap.set(gId, pg.categoryId);
+      // Project groups are Convex-only now.
+      const convex = await getConvexClient();
+      const pg = await convex.query(api.projectGroups.getById, { id: gId });
+      if (pg) groupCategoryMap.set(gId, pg.categoryId ?? null);
     }
 
     const placement = resolvePlacement(


### PR DESCRIPTION
## Phase C — core inversion, step 1: grouping (`projectCategory` + `projectGroup` + `categorySlot`)

First step of the entangled-core inversion (see `docs/designs/convex-core-inversion-design.md`). The smallest core group — it proves the **one-`$transaction` → one atomic Convex mutation** pattern the harder steps reuse.

### Context: what was already true
Grouping **writes** were already Convex-only (Phase B `e625763a`), there's no mirror, and reads went to Convex in Phase A. But the writes were done as **non-atomic sequenced `client.mutation` chains** from the server actions (cascade = N separate network calls → partial cascade on mid-failure; reorder = N updates → non-contiguous on partial failure; create = read-max-then-insert TOCTOU). And three latent bugs had crept in.

### What this PR does
1. **Atomic Convex mutations** (`convex/projectCategories.ts`, `convex/projectGroups.ts`, `// ── CUSTOM (Phase C)` banner): `createAtEnd` (max+1 in-mutation), `reorder` (contiguous in one tx), `deleteCascade` (category → groups+slots+cat-slots+category; group → slots+group), `deleteAllForProject` (full project purge). A single Convex mutation is fully ACID + serializable — OCC retries the loser of a write-write race.
2. **Rewire** all writers (`project-categories.ts`, `project-groups.ts`, `category-slots.ts`, `group-templates.ts`) to the atomic mutations. Prisma line-item null-outs + `logActivity` stay in the server actions (line items are still Prisma until the keystone step).
3. **Fix `deleteProject` orphan**: #254 dropped the project→category/group/slot FK cascade, so deleting a project leaked its grouping rows in Convex. Now calls `deleteAllForProject`.
4. **Fix 3 stale `prisma.projectGroup` reads** (frozen Prisma table post-cutover): `line-items.ts` groupName lookup; `recalculateProjectTotals` group price/quantity — **a silent revenue bug** (post-cutover group prices never rolled into project totals); `sub-hires.ts` group→category resolution.

### Validation
- **Live dev-Convex invariant exercise: 13/13** — contiguous sortOrder under *concurrent* `createAtEnd` (OCC, the key proof), reorder contiguity, group `deleteCascade`, category `deleteCascade` (+ returned groupIds), full `deleteAllForProject` purge incl. uncategorized groups.
- tsc clean · lint 0 errors · **2433** tests · `npm run build` exit 0.

### ⚠ Out-of-scope finding (flagged in the decommission doc)
#254 dropped **all** domain↔domain FKs, so `tx.project.delete` no longer cascades **any** Prisma child (line-items/units/services/tasks/media). Grouping is fixed here; the remaining still-Prisma children are leaked on project delete until their cluster inverts — each future core/Stage-2 PR must add explicit `deleteProject` cleanup (or a stopgap `deleteMany`-by-projectId sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)