### PR TITLE
Phase C: fix 3 live stale-read bugs (Convex-only tables read from frozen Prisma)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -493,6 +493,10 @@ rewired to Convex:
 - **`projectManager`** → `build-document-data.ts` call-sheet PM name/email read
   the frozen join. Now `api.projectManagers.listByProject` + a Prisma `user`
   lookup (Better Auth, kept).
+- **`assetBulkChild`** → `line-items.ts` `lookupAssetByTag` `hasAccessories`
+  flag counted DEDICATED bulk accessories from the frozen table (added after
+  cutover were invisible). Now `api.assetBulkChildren.list` filtered by
+  `parentAssetId` (the inline "stays on Prisma" comment was itself stale).
 
 **Not stale (deliberately left on Prisma):** `crewRole` / `crewSkill` reads —
 seed-only reference tables (no app writes ⇒ Prisma == Convex), and `crew.ts`'s

--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -476,6 +476,30 @@ from Convex.
   the stale #207 whose diff was mostly against now-deleted code). Verified: tsc clean,
   `vitest run document-template-read.test.ts` green, eslint clean, `pnpm build` exit 0.
 
+### Residual stale-read audit — Phase C (fixed)
+
+When a table is inverted to **Convex-only writes** (Phase B/C), its Prisma table
+**freezes** — any leftover Prisma *read* of it then silently serves stale data.
+A systematic scan (tables with zero `prisma.X.{create,update,…}` / `tx.X.…` in
+app code but a surviving `prisma.X.{findMany,…}`) found three live bugs, now
+rewired to Convex:
+
+- **`customFieldDefinition`** → `assets.ts` `resolveAssetCustomFields` validated
+  asset custom fields against frozen defs (post-cutover field add/edit/deactivate
+  ignored). Now `getActiveCustomFieldsForOrg` (Convex).
+- **`serviceTemplate`** → `project-services.ts` `generateServices` auto-added
+  from frozen templates. Now `api.serviceTemplates.list` + map. (The #411
+  "dual-write" note is itself stale — service_template is Convex-only now.)
+- **`projectManager`** → `build-document-data.ts` call-sheet PM name/email read
+  the frozen join. Now `api.projectManagers.listByProject` + a Prisma `user`
+  lookup (Better Auth, kept).
+
+**Not stale (deliberately left on Prisma):** `crewRole` / `crewSkill` reads —
+seed-only reference tables (no app writes ⇒ Prisma == Convex), and `crew.ts`'s
+`_count.crewMembers` is the `_CrewMemberToCrewSkill` m2m which has no Convex
+representation. The earlier grouping cluster's stale reads were fixed in the
+core-grouping PR. Re-run this scan after each future write-inversion.
+
 ### Central graph — analysis & recommended sequencing (NOT yet migrated)
 
 The remaining domains (`asset`, `bulk_asset`, `kit`, `project`, `project_line_item`,

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -4,6 +4,8 @@
  * plus complex data arrays for custom plugins.
  */
 import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../../convex/_generated/api";
 import { getClientById } from "@/lib/clients-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { getSupplierMap } from "@/lib/suppliers-read";
@@ -353,18 +355,24 @@ export async function buildDocumentData(
   let pmEmail = "";
 
   if (docType === "call-sheet") {
-    // Primary source: ProjectManager join table
-    const projectManagers = await prisma.projectManager.findMany({
-      where: { projectId, organizationId },
-      include: { user: { select: { name: true, email: true } } },
-      orderBy: { addedAt: "asc" },
-      take: 1,
+    // Primary source: ProjectManager join table (Convex-only now); the linked
+    // user (name/email) stays Prisma (Better Auth — kept forever).
+    const convex = await getConvexClient();
+    const pmRows = await convex.query(api.projectManagers.listByProject, {
+      projectId,
+      orgId: organizationId,
     });
+    const firstPm = pmRows
+      .slice()
+      .sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))[0];
 
-    if (projectManagers.length > 0) {
-      const pm = projectManagers[0];
-      pmName = pm.user.name || "";
-      pmEmail = pm.user.email || "";
+    if (firstPm) {
+      const user = await prisma.user.findUnique({
+        where: { id: firstPm.userId },
+        select: { name: true, email: true },
+      });
+      pmName = user?.name || "";
+      pmEmail = user?.email || "";
       pmPhone = (orgSettings.phone as string) || ""; // User has no phone field
     }
   }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/assets-read";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { validateCustomFieldValues } from "@/lib/validations/custom-field";
+import { getActiveCustomFieldsForOrg } from "@/lib/custom-fields-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -40,10 +41,9 @@ async function resolveAssetCustomFields(
   organizationId: string,
   raw: Record<string, string> | null | undefined,
 ): Promise<Record<string, string>> {
-  const defs = await prisma.customFieldDefinition.findMany({
-    where: { organizationId, entityType: "ASSET", isActive: true },
-    select: { fieldKey: true, label: true, fieldType: true, options: true, required: true },
-  });
+  // Custom field definitions are Convex-only (custom-fields.ts writes Convex);
+  // the Prisma table is frozen, so read the active ASSET defs from Convex.
+  const defs = await getActiveCustomFieldsForOrg(organizationId, "ASSET");
   if (defs.length === 0) return {};
   try {
     return validateCustomFieldValues(defs, raw);

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1326,18 +1326,20 @@ export async function lookupAssetByTag(
     }
   }
 
-  // Serialized children live in Convex — count from the org asset mirror by
-  // parentAssetId (no dedicated by-parent index, so filter the org list).
-  // assetBulkChild stays on Prisma; modelBulkAccessory is now Convex-only (Phase B).
-  const [orgAssetsForChildren, childBulkCount, modelBulksForCount] = await Promise.all([
+  // Serialized children + assetBulkChild + modelBulkAccessory all live in Convex
+  // now (Phase B). None has a by-parent index, so filter the org list. (The old
+  // prisma.assetBulkChild.count read a frozen table — DEDICATED bulk accessories
+  // added after cutover were invisible to the hasAccessories flag.)
+  const [orgAssetsForChildren, allBulkChildren, modelBulksForCount] = await Promise.all([
     getAssetsByOrg(organizationId),
-    prisma.assetBulkChild.count({ where: { parentAssetId: asset.id } }),
+    (await getConvexClient()).query(api.assetBulkChildren.list, { orgId: organizationId }),
     asset.modelId
       ? (await getConvexClient()).query(api.modelBulkAccessories.listByModelId, { modelId: asset.modelId, organizationId })
       : Promise.resolve([]),
   ]);
   const modelBulksCount = modelBulksForCount.length;
   const childAssetCount = orgAssetsForChildren.filter((a) => a.parentAssetId === asset.id).length;
+  const childBulkCount = allBulkChildren.filter((c) => c.parentAssetId === asset.id).length;
   const hasAccessories = childAssetCount > 0 || childBulkCount > 0 || modelBulksCount > 0;
 
   return serialize({ found: true as const, asset: { ...asset, model }, available, conflictsWith, hasAccessories });

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -618,11 +618,26 @@ export async function generateProjectServices(projectId: string) {
     throw new Error("Project must have at least one date (load in, load out, or event start) to generate services");
   }
 
-  // Get auto-added templates + all active templates as fallback
-  const templates = await prisma.serviceTemplate.findMany({
-    where: { organizationId, isActive: true },
-    orderBy: { sortOrder: "asc" },
-  });
+  // Get auto-added templates + all active templates as fallback. Service
+  // templates are Convex-only (this file writes them to Convex); the Prisma
+  // table is frozen, so read + map from Convex (defaults for optional fields).
+  const convex = await getConvexClient();
+  const rawTemplates = await convex.query(api.serviceTemplates.list, { orgId: organizationId });
+  const templates = rawTemplates
+    .filter((t) => t.isActive ?? true)
+    .map((t) => ({
+      type: t.type,
+      title: t.title,
+      description: t.description ?? null,
+      defaultCrewCount: t.defaultCrewCount ?? null,
+      defaultVehicle: t.defaultVehicle ?? null,
+      defaultPricingType: t.defaultPricingType ?? null,
+      defaultUnitPrice: t.defaultUnitPrice ?? null,
+      showOnDocuments: t.showOnDocuments ?? false,
+      isAutoAdded: t.isAutoAdded ?? false,
+      sortOrder: t.sortOrder ?? 0,
+    }))
+    .sort((a, b) => a.sortOrder - b.sortOrder);
 
   // Use only isAutoAdded templates; if none exist, use all active templates
   const autoTemplates = templates.filter((t) => t.isAutoAdded);


### PR DESCRIPTION
## Residual stale-read cleanup

When a table is inverted to **Convex-only writes** (Phase B/C), its Prisma table **freezes** — any leftover Prisma *read* then silently serves stale data. A systematic scan (tables with **zero** `prisma.X.{create,update,…}` / `tx.X.…` in app code but a surviving `prisma.X.{findMany,…}`) found **3 live bugs**, all fixed here by reading from Convex:

| Table | Stale read | Symptom (prod) | Fix |
|---|---|---|---|
| `customFieldDefinition` | `assets.ts` `resolveAssetCustomFields` | asset create/edit validated against **frozen** field defs — fields added/edited/deactivated after cutover ignored | `getActiveCustomFieldsForOrg` (existing Convex helper) |
| `serviceTemplate` | `project-services.ts` `generateServices` | auto-generate used **frozen** templates — new templates never auto-added, deleted ones lingered | `api.serviceTemplates.list` + map (downstream shape unchanged) |
| `projectManager` | `build-document-data.ts` call-sheet | PM name/email on the call-sheet PDF **stale/missing** for PMs set after cutover | `api.projectManagers.listByProject` + Prisma `user` lookup (Better Auth, kept) |

Verified each table has **zero** Prisma writes anywhere → genuinely frozen → these were real bugs. (The FEATUREDOCS #411 "dual-write" note for `service_template` was itself stale; corrected.)

### Deliberately NOT touched
- `crewRole` / `crewSkill` reads — **seed-only** reference tables (no app writes ⇒ Prisma == Convex, not stale), and `crew.ts`'s `_count.crewMembers` is the `_CrewMemberToCrewSkill` m2m which has **no Convex representation**. Also: crew is actively worked in open PR #260 — avoiding conflicts.
- `modelCheckItem` matches were stale **comments** only, not live reads.

### Validation
tsc clean · lint 0 errors · 2433 tests · `npm run build` exit 0. No new Convex functions — these reuse existing, well-exercised CRUD `list` queries — so no dev-push needed (same bar as Phase A read-rewires; human preview is the final gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)