### PR TITLE
Polish pass: playful auth + confetti + shell fix + warehouse overdue logic

### DIFF
--- a/FEATUREDOCS/06-pages-layouts.md
+++ b/FEATUREDOCS/06-pages-layouts.md
@@ -19,6 +19,8 @@ div.app-shell (fixed inset-0 on mobile, relative on desktop)
 
 **Auth Layout** (`src/app/(auth)/layout.tsx`): Centered card, no sidebar
 
+**Auth playful shell** (`src/app/(auth)/auth-playful.tsx`): the login / register / admin-register screens share a decorative-only split-panel shell (`AuthShell`) following the marketing aesthetic (DESIGN.md §17 "Auth pages"). Desktop shows a `bg-paper-2` brand collage — `RvltFlowLogo` wordmark, the `FlowMascot` roadie, scattered module-hue `FeaturePatch` stickers (red is never a module hue), a CSS GAFF tape-roll sticker, doodle SVGs (star/arrow/squiggle), and Kalam (`.t-annotation`) annotations. The form sits on a `bg-card` surface with stickers peeking over the corners. Everything decorative is `aria-hidden` + `pointer-events-none`; the auth form logic (email/password/passkey/SSO, registration policy states, admin token gate) is untouched — the shell only wraps presentation. Personality/mascot/Kalam are sanctioned here per DESIGN.md §9 (onboarding moments) and §17; the DISABLED/INVITE_ONLY notice states stay plain.
+
 ## All Pages
 
 ### Authentication

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -34,9 +34,13 @@ export default async function AppLayout({ children }: { children: React.ReactNod
             <OrgActivator />
             <DynamicFavicon />
             <AppSidebar />
-            <SidebarInset className="min-h-0 min-w-0">
+            <SidebarInset className="min-h-0 min-w-0 overflow-x-clip">
               <TopBar />
-              <main className="min-w-0 flex-1 overflow-auto p-4 md:p-6 animate-page-enter">{children}</main>
+              {/* Vertical scroll only. Horizontal is CLIPPED so wide content
+                  (tables, etc.) can never shift the whole page left under the
+                  fixed sidebar / sticky top bar. Wide tables scroll inside their
+                  own overflow container (see ui/table.tsx). */}
+              <main className="min-w-0 flex-1 overflow-y-auto overflow-x-clip p-4 md:p-6 animate-page-enter">{children}</main>
             </SidebarInset>
           </MiraContextProvider>
         </BrandingProvider>

--- a/src/app/(app)/warehouse/page.tsx
+++ b/src/app/(app)/warehouse/page.tsx
@@ -102,29 +102,35 @@ type PendingAction = {
   warningMessage: string;
 };
 
-type UrgencyGroup = "overdue" | "today" | "upcoming";
+type UrgencyGroup = "overdue" | "today" | "out" | "upcoming" | "returned";
 
 function getProjectUrgency(project: Project): UrgencyGroup {
-  const startDate = project.rentalStartDate
-    ? new Date(project.rentalStartDate)
-    : null;
-  if (!startDate) return "upcoming";
-
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  // The "today" group is a 2-day prep window — it covers today AND
-  // tomorrow (the section header reads "Today / Tomorrow"). The cutoff is
-  // therefore the start of the day after tomorrow.
+  // The "today" prep window covers today AND tomorrow (header reads
+  // "Today / Tomorrow"); the cutoff is the start of the day after tomorrow.
   const dayAfterTomorrow = new Date(today);
   dayAfterTomorrow.setDate(today.getDate() + 2);
-  const projectDay = new Date(
-    startDate.getFullYear(),
-    startDate.getMonth(),
-    startDate.getDate()
-  );
+  const dayOf = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
 
-  if (projectDay < today) return "overdue";
-  if (projectDay < dayAfterTomorrow) return "today";
+  // Gear is physically back — awaiting close-out (also surfaced in the
+  // close-out bar). Never "overdue" — it's already returned.
+  if (project.status === "RETURNED") return "returned";
+
+  const isOut = project.status === "CHECKED_OUT" || project.status === "ON_SITE";
+  if (isOut) {
+    // Deployed gear is OVERDUE only when it's past its due-back (in / end) date
+    // and still out — NOT just because the out date has passed. Otherwise it's
+    // out on site and on schedule.
+    const end = project.rentalEndDate ? dayOf(new Date(project.rentalEndDate)) : null;
+    if (end && end < today) return "overdue";
+    return "out";
+  }
+
+  // Not yet out (confirmed / prepping): the prep queue, ordered by the out date.
+  const start = project.rentalStartDate ? dayOf(new Date(project.rentalStartDate)) : null;
+  if (!start) return "upcoming";
+  if (start < dayAfterTomorrow) return "today";
   return "upcoming";
 }
 
@@ -214,10 +220,20 @@ const urgencyMeta: Record<
     dot: "bg-warn",
     chip: "bg-warn-soft text-warn",
   },
+  out: {
+    label: "Out on site",
+    dot: "bg-red",
+    chip: "bg-red-soft text-red",
+  },
   upcoming: {
     label: "Upcoming",
     dot: "bg-lime",
     chip: "bg-lime/15 text-lime",
+  },
+  returned: {
+    label: "Returned · to close out",
+    dot: "bg-rep",
+    chip: "bg-rep-soft text-rep",
   },
 };
 
@@ -304,7 +320,9 @@ export default function WarehousePage() {
     const groups: Record<UrgencyGroup, Project[]> = {
       overdue: [],
       today: [],
+      out: [],
       upcoming: [],
+      returned: [],
     };
     for (const p of projects) {
       groups[getProjectUrgency(p)].push(p);
@@ -524,7 +542,7 @@ export default function WarehousePage() {
           </FadeIn>
         ) : (
           <div className="space-y-9">
-            {(["overdue", "today", "upcoming"] as const).map((key, idx) => {
+            {(["overdue", "today", "out", "returned", "upcoming"] as const).map((key, idx) => {
               const list = grouped[key];
               if (list.length === 0) return null;
               const meta = urgencyMeta[key];
@@ -753,7 +771,9 @@ const urgencyCardClass: Record<UrgencyGroup, string> = {
   overdue:
     "border-l-[3px] border-l-t-out bg-out-soft/30 ring-1 ring-t-out/20",
   today: "border-l-[3px] border-l-warn ring-1 ring-line",
+  out: "border-l-[3px] border-l-red ring-1 ring-line",
   upcoming: "border-l-[3px] border-l-lime ring-1 ring-line",
+  returned: "border-l-[3px] border-l-rep ring-1 ring-line",
 };
 
 function ProjectCard({

--- a/src/app/(auth)/auth-playful.tsx
+++ b/src/app/(auth)/auth-playful.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+/**
+ * Playful auth shell — decorative-only furniture for the login / register /
+ * admin-register screens. Everything here is cosmetic: stickers, doodles, the
+ * brand collage panel. It NEVER touches form logic. All decorative nodes are
+ * `aria-hidden` + `pointer-events-none` so the keyboard/AT experience is
+ * identical to a plain form.
+ *
+ * Stays inside DESIGN.md: dark espresso (`bg-paper`), single RVLT red accent,
+ * hard offset shadows (`--sh-stk` / `--sh-card`), module-hue FeaturePatch
+ * stickers (red is never a module hue), Kalam (`font-hand`) for handwritten
+ * annotations only — and auth pages explicitly follow the marketing aesthetic
+ * (DESIGN.md §17 "Auth pages"), so personality/mascot/Kalam are sanctioned here.
+ *
+ * Mobbin references: komoot (hand-drawn doodles + Kalam annotations scattered
+ * round the form), Alan (mascot with orbiting sticker objects), Sprig/Gusto
+ * (split-panel brand side + functional form side).
+ */
+
+import * as React from "react";
+import { FeaturePatch } from "@/components/ui/feature-patch";
+import { FlowMascot } from "@/components/ui/flow-mascot";
+import { RvltFlowLogo } from "@/components/brand/rvlt-flow-logo";
+import { FadeIn } from "@/components/ui/motion";
+import { cn } from "@/lib/utils";
+import {
+  Zap,
+  Truck,
+  Wrench,
+  CalendarCheck,
+  Boxes,
+  Sparkles,
+} from "lucide-react";
+
+/* ------------------------------------------------------------------ *
+ * GAFF tape-roll sticker — the production-industry in-joke brand mark *
+ * (DESIGN.md §17). No SVG asset exists, so this is a tasteful CSS      *
+ * roll: concentric rings with a torn-tape tab. Purely decorative.     *
+ * ------------------------------------------------------------------ */
+function GaffSticker({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none relative flex size-[58px] items-center justify-center rounded-full",
+        "bg-[#0C0A08] text-ink shadow-[var(--sh-stk)] ring-2 ring-ink/15",
+        className,
+      )}
+    >
+      {/* outer ring */}
+      <div className="absolute inset-[6px] rounded-full border-2 border-ink/25" />
+      {/* inner core */}
+      <div className="flex size-[22px] items-center justify-center rounded-full bg-card ring-2 ring-ink/20">
+        <span className="t-annotation text-[9px] leading-none text-muted">GAFF</span>
+      </div>
+      {/* torn tape tab peeling off the roll */}
+      <div className="absolute -right-3 top-1/2 h-3 w-7 -translate-y-1/2 -rotate-6 rounded-r-sm bg-ink/85 [clip-path:polygon(0_0,100%_18%,92%_82%,0_100%)]" />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Generic CSS "sticker" chip — rounded, rotated, hard-offset shadow.  *
+ * Used for little word / emoji-free label stickers.                   *
+ * ------------------------------------------------------------------ */
+function StickerChip({
+  children,
+  className,
+  tone = "cream",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  tone?: "cream" | "red" | "ink";
+}) {
+  const tones = {
+    cream: "bg-cream text-cream-ink ring-cream-ink/10",
+    red: "bg-red text-primary-foreground ring-red-700/40",
+    ink: "bg-elev text-ink ring-line-2",
+  } as const;
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "pointer-events-none inline-flex select-none items-center gap-1 rounded-full px-3 py-1 text-[12px] font-semibold ring-2 shadow-[var(--sh-stk)]",
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/* Hand-drawn squiggle arrow doodle (SVG, currentColor). */
+function DoodleArrow({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 64 40"
+      fill="none"
+      className={cn("pointer-events-none", className)}
+    >
+      <path
+        d="M3 8c14 22 33 26 54 18"
+        stroke="currentColor"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M48 33c5-3 9-6 9-7-2 0-7-1-11-3"
+        stroke="currentColor"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/* Hand-drawn sparkle / star burst doodle. */
+function DoodleStar({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 32 32"
+      fill="none"
+      className={cn("pointer-events-none", className)}
+    >
+      <path
+        d="M16 2c1.4 7.6 4.4 10.6 12 12-7.6 1.4-10.6 4.4-12 12-1.4-7.6-4.4-10.6-12-12 7.6-1.4 10.6-4.4 12-12Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+/* Hand-drawn loose squiggle / underline doodle. */
+function DoodleSquiggle({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 88 16"
+      fill="none"
+      className={cn("pointer-events-none", className)}
+    >
+      <path
+        d="M2 11c8-9 16 5 24-2s16 5 24-2 16 5 24-2"
+        stroke="currentColor"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * BrandCollage — the desktop-only red/espresso panel: wordmark, the FlowMascot
+ * roadie, a collage of module-hue FeaturePatch stickers, a GAFF roll, doodles
+ * and a Kalam annotation. Hidden below lg. Fully decorative.
+ */
+function BrandCollage() {
+  return (
+    <div className="relative hidden flex-1 overflow-hidden bg-paper-2 lg:flex">
+      {/* dot grid texture */}
+      <div aria-hidden className="absolute inset-0 opacity-[0.06]">
+        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <pattern id="auth-dot-grid" x="0" y="0" width="26" height="26" patternUnits="userSpaceOnUse">
+              <circle cx="2" cy="2" r="1.1" fill="currentColor" className="text-ink" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#auth-dot-grid)" />
+        </svg>
+      </div>
+
+      {/* big soft red glow blobs (no gradient on surfaces — these are radial halos behind content) */}
+      <div aria-hidden className="absolute -left-24 -top-24 size-72 rounded-full bg-red-soft blur-2xl" />
+      <div aria-hidden className="absolute -bottom-28 -right-16 size-80 rounded-full bg-red-soft blur-2xl" />
+
+      {/* scattered decorative stickers around the panel */}
+      <div aria-hidden className="absolute inset-0">
+        <FeaturePatch hue="amber" className="absolute left-[12%] top-[16%] -rotate-12">
+          <Truck />
+        </FeaturePatch>
+        <FeaturePatch hue="blue" size="sm" className="absolute right-[16%] top-[12%] rotate-[14deg]">
+          <Boxes />
+        </FeaturePatch>
+        <FeaturePatch hue="green" className="absolute bottom-[20%] left-[8%] rotate-[10deg]">
+          <CalendarCheck />
+        </FeaturePatch>
+        <FeaturePatch hue="coral" size="sm" className="absolute bottom-[30%] right-[12%] -rotate-[8deg]">
+          <Wrench />
+        </FeaturePatch>
+
+        <GaffSticker className="absolute right-[8%] bottom-[14%] rotate-[8deg]" />
+
+        <DoodleStar className="absolute left-[24%] top-[38%] size-6 -rotate-12 text-red" />
+        <DoodleStar className="absolute right-[26%] top-[44%] size-4 rotate-12 text-warn" />
+        <DoodleArrow className="absolute right-[22%] top-[60%] h-9 w-14 rotate-[8deg] text-ink-2/70" />
+
+        <StickerChip tone="red" className="absolute left-[14%] top-[64%] -rotate-[6deg]">
+          <Zap className="size-3" /> live & loaded
+        </StickerChip>
+        <StickerChip tone="cream" className="absolute right-[10%] top-[28%] rotate-[7deg]">
+          gear that never goes walkabout
+        </StickerChip>
+      </div>
+
+      {/* center content — wordmark, mascot, tagline */}
+      <div className="relative z-10 m-auto flex max-w-md flex-col items-start gap-7 px-12">
+        <FadeIn>
+          <RvltFlowLogo className="h-9 w-auto" title="RVLT Flow" />
+        </FadeIn>
+
+        <FadeIn delay={0.05} className="relative">
+          {/* the roadie mascot, big and friendly, with an orbiting sticker */}
+          <div className="relative inline-flex">
+            <FlowMascot className="size-28 text-ink-2" />
+            <FeaturePatch
+              hue="purple"
+              size="sm"
+              aria-hidden
+              className="absolute -right-4 -top-3 rotate-[16deg]"
+            >
+              <Sparkles />
+            </FeaturePatch>
+            <DoodleSquiggle className="absolute -bottom-2 left-1 h-3 w-20 text-red" />
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={0.1}>
+          <p className="t-display max-w-sm text-[30px] leading-[1.12] text-ink">
+            Run the show, not the{" "}
+            <span className="text-red">chaos</span>.
+          </p>
+          <p className="mt-3 max-w-sm text-[15px] leading-relaxed text-ink-2">
+            Jobs, crew, warehouse and gear — one calm command room for the
+            whole production company.
+          </p>
+          <p className="t-annotation mt-4 inline-flex items-center gap-2 text-[16px] text-red">
+            psst — the roadie&apos;s got your back
+            <DoodleArrow className="h-6 w-9 rotate-[170deg] text-red" />
+          </p>
+        </FadeIn>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * AuthShell — full-bleed split layout. Brand collage on the left (desktop),
+ * the children (form) floated on a card on the right with a couple of stickers
+ * peeking over the card edge. `accent` swaps the corner sticker per surface.
+ */
+export function AuthShell({
+  children,
+  annotation,
+  accent = "welcome",
+}: {
+  children: React.ReactNode;
+  /** Optional Kalam caption shown under the card (decorative). */
+  annotation?: string;
+  accent?: "welcome" | "join" | "admin";
+}) {
+  const cornerSticker =
+    accent === "join" ? (
+      <StickerChip tone="red" className="rotate-[8deg]">
+        <Sparkles className="size-3" /> new here? nice.
+      </StickerChip>
+    ) : accent === "admin" ? (
+      <StickerChip tone="ink" className="rotate-[8deg]">
+        <Zap className="size-3" /> keys to the kingdom
+      </StickerChip>
+    ) : (
+      <StickerChip tone="cream" className="rotate-[8deg]">
+        welcome back!
+      </StickerChip>
+    );
+
+  return (
+    <div className="fixed inset-0 z-50 flex min-h-screen bg-paper">
+      <BrandCollage />
+
+      {/* form side */}
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden p-6">
+        {/* mobile-only faint dot grid so the form side isn't a flat void */}
+        <div aria-hidden className="absolute inset-0 opacity-[0.05] lg:hidden">
+          <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+            <rect width="100%" height="100%" fill="url(#auth-dot-grid)" />
+          </svg>
+        </div>
+
+        {/* loose doodles drifting around the form side */}
+        <DoodleStar
+          aria-hidden
+          className="absolute left-[12%] top-[18%] size-5 -rotate-12 text-red/70"
+        />
+        <DoodleStar
+          aria-hidden
+          className="absolute bottom-[16%] right-[14%] size-4 rotate-12 text-warn/70"
+        />
+        <DoodleSquiggle
+          aria-hidden
+          className="absolute bottom-[24%] left-[16%] h-3 w-16 text-ink-2/40"
+        />
+
+        <FadeIn className="relative w-full max-w-sm">
+          {/* sticker peeking over the top-right corner of the card */}
+          <div aria-hidden className="pointer-events-none absolute -right-3 -top-4 z-20">
+            {cornerSticker}
+          </div>
+          {/* a little patch peeking over the bottom-left */}
+          <FeaturePatch
+            hue="amber"
+            size="sm"
+            aria-hidden
+            className="pointer-events-none absolute -bottom-4 -left-4 z-20 -rotate-[12deg]"
+          >
+            <Boxes />
+          </FeaturePatch>
+
+          {/* the actual card surface that wraps the (untouched) form */}
+          <div className="rounded-[var(--r-lg)] border-2 border-line-2 bg-card p-6 shadow-[var(--sh-card)] sm:p-8">
+            {/* mobile-only mini wordmark (desktop has the collage) */}
+            <div className="mb-6 flex items-center justify-between lg:hidden">
+              <RvltFlowLogo className="h-6 w-auto" title="RVLT Flow" />
+              <GaffSticker className="size-9 [&_span]:text-[7px]" />
+            </div>
+
+            {children}
+          </div>
+
+          {annotation ? (
+            <p
+              aria-hidden
+              className="t-annotation mt-5 flex items-center justify-center gap-2 text-center text-[15px] text-muted"
+            >
+              <DoodleStar className="size-3 text-red" />
+              {annotation}
+            </p>
+          ) : null}
+        </FadeIn>
+      </div>
+    </div>
+  );
+}
+
+/** A small Kalam annotation with a doodle arrow — for inline nudges (e.g. passkey). */
+export function HandNudge({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "t-annotation pointer-events-none inline-flex items-center gap-1.5 text-[14px] text-red",
+        className,
+      )}
+    >
+      {children}
+      <DoodleArrow className="h-5 w-8 text-red" />
+    </span>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -6,13 +6,12 @@ import Link from "next/link";
 import { signIn, organization, authClient } from "@/lib/auth-client";
 import { getTheOrgId, getTheOrgInfo, getSingleOrgSSOInfo } from "@/server/public-org";
 import { usePlatformBranding } from "@/lib/use-platform-name";
-import { DynamicIcon } from "@/components/ui/dynamic-icon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FadeIn } from "@/components/ui/motion";
 import { toast } from "sonner";
 import { Loader2, Fingerprint, ArrowLeft } from "lucide-react";
+import { AuthShell, HandNudge } from "../auth-playful";
 
 async function handlePostLogin(router: ReturnType<typeof useRouter>) {
   const orgData = await getTheOrgId();
@@ -24,24 +23,9 @@ async function handlePostLogin(router: ReturnType<typeof useRouter>) {
   router.push("/dashboard");
 }
 
-function DotGrid() {
-  return (
-    <div className="absolute inset-0 overflow-hidden opacity-[0.07]">
-      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <pattern id="dot-grid" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
-            <circle cx="2" cy="2" r="1" fill="currentColor" />
-          </pattern>
-        </defs>
-        <rect width="100%" height="100%" fill="url(#dot-grid)" />
-      </svg>
-    </div>
-  );
-}
-
 export default function LoginPage() {
   const router = useRouter();
-  const { name: platformName, icon: platformIcon } = usePlatformBranding();
+  const { name: platformName } = usePlatformBranding();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -130,154 +114,110 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex min-h-screen bg-background">
-      {/* Brand panel — hidden on mobile */}
-      <div className="hidden lg:flex lg:w-1/2 bg-bg-inset items-center justify-center relative overflow-hidden">
-        <DotGrid />
-        <div className="relative z-10 max-w-md px-12">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground font-bold text-lg">
-              {platformIcon ? (
-                <DynamicIcon name={platformIcon} className="h-5 w-5" />
-              ) : (
-                platformName.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2)
-              )}
-            </div>
-            <span className="text-2xl font-extrabold tracking-tight text-fg">
-              {platformName}
-            </span>
-          </div>
-          <p className="text-fg-3 text-[15px] leading-relaxed">
-            Equipment management for production teams.
-          </p>
-        </div>
-
-        {/* Subtle geometric accent — faint angled line */}
-        <div className="absolute -bottom-24 -right-24 h-96 w-96 rounded-full border border-fg/[0.04]" />
-        <div className="absolute -top-16 -left-16 h-64 w-64 rounded-full border border-fg/[0.04]" />
+    <AuthShell accent="welcome" annotation="venue's dark, the app isn't.">
+      <div className="mb-6">
+        <h1 className="t-title text-ink">
+          {orgName ? `Sign in to ${orgName}` : "Welcome back"}
+        </h1>
+        <p className="mt-1 text-sm text-muted">
+          {orgName
+            ? `Enter your credentials to access ${orgName}`
+            : `Sign in to your ${platformName} account`}
+        </p>
       </div>
 
-      {/* Form panel */}
-      <div className="flex flex-1 items-center justify-center p-6">
-        <FadeIn className="w-full max-w-sm">
-          {/* Mobile-only brand header */}
-          <div className="mb-8 lg:hidden">
-            <div className="flex items-center gap-2.5 mb-1">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold text-sm">
-                {platformIcon ? (
-                  <DynamicIcon name={platformIcon} className="h-4 w-4" />
-                ) : (
-                  platformName.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2)
-                )}
-              </div>
-              <span className="text-lg font-bold tracking-tight text-fg">
-                {platformName}
-              </span>
+      <div className="space-y-4">
+        {/* Email step */}
+        {step === "email" && (
+          <form onSubmit={handleEmailContinue} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@company.com"
+                autoComplete="username webauthn"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
             </div>
-          </div>
-
-          <div className="mb-6">
-            <h1 className="t-title text-fg">
-              {orgName ? `Sign in to ${orgName}` : "Welcome back"}
-            </h1>
-            <p className="mt-1 text-sm text-fg-3">
-              {orgName
-                ? `Enter your credentials to access ${orgName}`
-                : `Sign in to your ${platformName} account`}
-            </p>
-          </div>
-
-          <div className="space-y-4">
-            {/* Email step */}
-            {step === "email" && (
-              <form onSubmit={handleEmailContinue} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="you@company.com"
-                    autoComplete="username webauthn"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                  />
-                </div>
-                <Button type="submit" className="w-full" disabled={checkingSSO || passkeyLoading}>
-                  {checkingSSO && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Continue
-                </Button>
-              </form>
-            )}
-
-            {/* Password step */}
-            {step === "password" && (
-              <div className="animate-in fade-in slide-in-from-right-2 duration-200">
-                <button
-                  type="button"
-                  onClick={() => setStep("email")}
-                  className="mb-4 flex items-center gap-1 text-sm text-fg-3 hover:text-fg transition-colors"
-                >
-                  <ArrowLeft className="h-3 w-3" />
-                  Back
-                </button>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="email-pw">Email</Label>
-                    <Input
-                      id="email-pw"
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      autoComplete="username"
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="password">Password</Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      placeholder="Enter your password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <Button type="submit" className="w-full" disabled={loading || passkeyLoading}>
-                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    Sign in
-                  </Button>
-                </form>
-              </div>
-            )}
-
-            {/* Passkey */}
-            <Button
-              variant="line"
-              className="w-full"
-              onClick={handlePasskeyLogin}
-              disabled={passkeyLoading || loading || checkingSSO}
-            >
-              {passkeyLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Fingerprint className="mr-2 h-4 w-4" />
-              )}
-              Sign in with Passkey
+            <Button type="submit" className="w-full" disabled={checkingSSO || passkeyLoading}>
+              {checkingSSO && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Continue
             </Button>
-          </div>
+          </form>
+        )}
 
-          {regOpen && (
-            <p className="mt-6 text-center text-sm text-fg-3">
-              Don&apos;t have an account?{" "}
-              <Link href="/register" className="text-primary hover:underline">
-                Sign up
-              </Link>
-            </p>
+        {/* Password step */}
+        {step === "password" && (
+          <div className="animate-in fade-in slide-in-from-right-2 duration-200">
+            <button
+              type="button"
+              onClick={() => setStep("email")}
+              className="mb-4 flex items-center gap-1 text-sm text-muted hover:text-ink transition-colors"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              Back
+            </button>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email-pw">Email</Label>
+                <Input
+                  id="email-pw"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="username"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="Enter your password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={loading || passkeyLoading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Sign in
+              </Button>
+            </form>
+          </div>
+        )}
+
+        {/* Passkey — with a cheeky hand-drawn nudge */}
+        <div className="flex items-center justify-end pr-1">
+          <HandNudge>quickest way in</HandNudge>
+        </div>
+        <Button
+          variant="line"
+          className="w-full"
+          onClick={handlePasskeyLogin}
+          disabled={passkeyLoading || loading || checkingSSO}
+        >
+          {passkeyLoading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Fingerprint className="mr-2 h-4 w-4" />
           )}
-        </FadeIn>
+          Sign in with Passkey
+        </Button>
       </div>
-    </div>
+
+      {regOpen && (
+        <p className="mt-6 text-center text-sm text-muted">
+          Don&apos;t have an account?{" "}
+          <Link href="/register" className="text-link hover:underline">
+            Sign up
+          </Link>
+        </p>
+      )}
+    </AuthShell>
   );
 }

--- a/src/app/(auth)/register/admin/page.tsx
+++ b/src/app/(auth)/register/admin/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
+import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import { signUp } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,7 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { Loader2, Shield } from "lucide-react";
 import { Suspense } from "react";
-import { FadeIn } from "@/components/ui/motion";
+import { AuthShell } from "../../auth-playful";
 
 function AdminRegisterForm() {
   const router = useRouter();
@@ -45,15 +44,15 @@ function AdminRegisterForm() {
 
   if (checking) {
     return (
-      <div className="rounded-lg bg-bg-surface p-8 surface-ring text-center">
-        <Loader2 className="mx-auto h-8 w-8 animate-spin text-fg-3" />
+      <div className="flex justify-center py-6 text-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }
 
   if (!verified) {
     return (
-      <div className="rounded-lg bg-bg-surface p-8 surface-ring text-center text-fg-3">
+      <div className="py-6 text-center text-muted">
         Page not found.
       </div>
     );
@@ -90,17 +89,17 @@ function AdminRegisterForm() {
   };
 
   return (
-    <div className="rounded-lg bg-bg-surface p-6 surface-ring sm:p-8">
+    <>
       <div className="mb-6 text-center">
-        <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-destructive text-destructive-foreground">
+        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-[var(--r)] bg-red text-primary-foreground shadow-[var(--sh-stk)]">
           <Shield className="h-5 w-5" />
         </div>
-        <h2 className="t-title">Site Admin Registration</h2>
-        <p className="text-sm text-fg-3">
+        <h2 className="t-title text-ink">Site admin registration</h2>
+        <p className="mt-1 text-sm text-muted">
           Create a site administrator account.
         </p>
-        <Badge className="mx-auto mt-2 bg-red-500/10 text-red-500 border-red-500/20">
-          Site Admin Account
+        <Badge className="mx-auto mt-3 bg-red-soft text-red">
+          Site admin account
         </Badge>
       </div>
       <div>
@@ -141,26 +140,26 @@ function AdminRegisterForm() {
           </div>
           <Button type="submit" className="w-full" disabled={loading}>
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Create Admin Account
+            Create admin account
           </Button>
         </form>
       </div>
-    </div>
+    </>
   );
 }
 
 export default function AdminRegisterPage() {
   return (
-    <FadeIn>
-    <Suspense
-      fallback={
-        <div className="rounded-lg bg-bg-surface p-8 surface-ring text-center">
-          <Loader2 className="mx-auto h-8 w-8 animate-spin text-fg-3" />
-        </div>
-      }
-    >
-      <AdminRegisterForm />
-    </Suspense>
-    </FadeIn>
+    <AuthShell accent="admin" annotation="with great power, etc.">
+      <Suspense
+        fallback={
+          <div className="flex justify-center py-6 text-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted" />
+          </div>
+        }
+      >
+        <AdminRegisterForm />
+      </Suspense>
+    </AuthShell>
   );
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -6,19 +6,18 @@ import Link from "next/link";
 import { signUp, organization } from "@/lib/auth-client";
 import { getTheOrgId } from "@/server/public-org";
 import { usePlatformBranding } from "@/lib/use-platform-name";
-import { DynamicIcon } from "@/components/ui/dynamic-icon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import { Loader2, ShieldX } from "lucide-react";
-import { FadeIn } from "@/components/ui/motion";
+import { AuthShell } from "../auth-playful";
 
 function RegisterContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const inviteId = searchParams.get("invite");
-  const { name: platformName, icon: platformIcon } = usePlatformBranding();
+  const { name: platformName } = usePlatformBranding();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -79,72 +78,65 @@ function RegisterContent() {
 
   if (policy === null) {
     return (
-      <div className="rounded-lg bg-bg-surface p-8 surface-ring text-center">
-        <Loader2 className="mx-auto h-8 w-8 animate-spin text-fg-3" />
+      <div className="flex justify-center py-6 text-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }
 
   if (policy === "DISABLED" && !inviteId) {
     return (
-      <div className="rounded-lg bg-bg-surface p-6 surface-ring sm:p-8">
+      <>
         <div className="mb-6 text-center">
-          <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-destructive text-destructive-foreground">
+          <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-[var(--r)] bg-out-soft text-t-out">
             <ShieldX className="h-5 w-5" />
           </div>
-          <h2 className="t-title">Registration Disabled</h2>
-          <p className="text-sm text-fg-3">
+          <h2 className="t-title text-ink">Registration disabled</h2>
+          <p className="mt-1 text-sm text-muted">
             New account registration is currently disabled. Contact an administrator for access.
           </p>
         </div>
         <div className="flex justify-center">
-          <p className="text-sm text-fg-3">
+          <p className="text-sm text-muted">
             Already have an account?{" "}
-            <Link href="/login" className="text-primary hover:underline">
+            <Link href="/login" className="text-link hover:underline">
               Sign in
             </Link>
           </p>
         </div>
-      </div>
+      </>
     );
   }
 
   if (policy === "INVITE_ONLY" && !inviteId) {
     return (
-      <div className="rounded-lg bg-bg-surface p-6 surface-ring sm:p-8">
+      <>
         <div className="mb-6 text-center">
-          <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-bg-inset text-fg-3">
+          <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-[var(--r)] bg-elev text-muted">
             <ShieldX className="h-5 w-5" />
           </div>
-          <h2 className="t-title">Invite Only</h2>
-          <p className="text-sm text-fg-3">
+          <h2 className="t-title text-ink">Invite only</h2>
+          <p className="mt-1 text-sm text-muted">
             Registration is invite-only. Contact an administrator to get an invitation.
           </p>
         </div>
         <div className="flex justify-center">
-          <p className="text-sm text-fg-3">
+          <p className="text-sm text-muted">
             Already have an account?{" "}
-            <Link href="/login" className="text-primary hover:underline">
+            <Link href="/login" className="text-link hover:underline">
               Sign in
             </Link>
           </p>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="rounded-lg bg-bg-surface p-6 surface-ring sm:p-8">
-      <div className="mb-6 text-center">
-        <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold">
-          {platformIcon ? (
-            <DynamicIcon name={platformIcon} className="h-5 w-5" />
-          ) : (
-            platformName.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2)
-          )}
-        </div>
-        <h2 className="t-title">Create your account</h2>
-        <p className="text-sm text-fg-3">
+    <>
+      <div className="mb-6">
+        <h2 className="t-title text-ink">Create your account</h2>
+        <p className="mt-1 text-sm text-muted">
           Get started with {platformName} for your AV business
         </p>
       </div>
@@ -171,10 +163,10 @@ function RegisterContent() {
               onChange={(e) => setEmail(e.target.value)}
               required
               disabled={inviteEmailLocked}
-              className={inviteEmailLocked ? "bg-bg-inset" : ""}
+              className={inviteEmailLocked ? "bg-elev" : ""}
             />
             {inviteEmailLocked && (
-              <p className="text-xs text-fg-3">
+              <p className="text-xs text-muted">
                 Email is set from your invitation and cannot be changed.
               </p>
             )}
@@ -198,27 +190,29 @@ function RegisterContent() {
         </form>
       </div>
       <div className="mt-6 flex justify-center">
-        <p className="text-sm text-fg-3">
+        <p className="text-sm text-muted">
           Already have an account?{" "}
-          <Link href="/login" className="text-primary hover:underline">
+          <Link href="/login" className="text-link hover:underline">
             Sign in
           </Link>
         </p>
       </div>
-    </div>
+    </>
   );
 }
 
 export default function RegisterPage() {
   return (
-    <FadeIn>
-    <Suspense fallback={
-      <div className="rounded-lg bg-bg-surface p-8 surface-ring text-center">
-        <Loader2 className="mx-auto h-8 w-8 animate-spin text-fg-3" />
-      </div>
-    }>
-      <RegisterContent />
-    </Suspense>
-    </FadeIn>
+    <AuthShell accent="join" annotation="first one's on the house.">
+      <Suspense
+        fallback={
+          <div className="flex justify-center py-6 text-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted" />
+          </div>
+        }
+      >
+        <RegisterContent />
+      </Suspense>
+    </AuthShell>
   );
 }

--- a/src/components/projects/project-lifecycle.tsx
+++ b/src/components/projects/project-lifecycle.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Check, ArrowRight, Loader2, MoreHorizontal } from "lucide-react";
 import { cn, focusRing, disabledState } from "@/lib/utils";
+import { fireConfettiFromElement } from "@/lib/confetti";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -82,6 +83,24 @@ export function ProjectLifecycle({
   const showAdvance = !cancelled && nextStage && onAdvance && canAdvance;
   const showMenu = !!onStatusChange && !!statuses;
 
+  // Celebrate the big milestones: confetti bursts out of the node when a job
+  // becomes Confirmed or Completed — but only on the actual transition, never
+  // on initial load of an already-confirmed/completed job.
+  const nodeRefs = React.useRef<(HTMLSpanElement | null)[]>([]);
+  const prevStatus = React.useRef(status);
+  React.useEffect(() => {
+    if (prevStatus.current !== status) {
+      if (status === "CONFIRMED" || status === "COMPLETED") {
+        const idx = stageIndexForStatus(status);
+        // next frame so the node has its final position before we read it
+        requestAnimationFrame(() =>
+          fireConfettiFromElement(nodeRefs.current[idx], { power: 16 }),
+        );
+      }
+      prevStatus.current = status;
+    }
+  }, [status]);
+
   const controls = (showAdvance || showMenu) && (
     <div className="flex shrink-0 items-center gap-2">
       {showAdvance && (
@@ -157,6 +176,9 @@ export function ProjectLifecycle({
                 <div className="flex w-full items-center">
                   <span className={cn("h-[2px] flex-1 rounded-full", isFirst ? "opacity-0" : connectorClass(i - 1, currentIdx))} aria-hidden />
                   <span
+                    ref={(el) => {
+                      nodeRefs.current[i] = el;
+                    }}
                     className={cn(
                       "flex size-10 shrink-0 items-center justify-center rounded-full text-ui-text font-bold transition-colors",
                       state === "done" && "bg-ink text-paper",

--- a/src/lib/confetti.ts
+++ b/src/lib/confetti.ts
@@ -1,0 +1,123 @@
+/**
+ * Tiny dependency-free confetti burst. Fires a one-shot spray of paper from a
+ * screen point (e.g. a lifecycle stepper node) — used to celebrate a job hitting
+ * Confirmed / Completed. No npm dependency on purpose (keeps the lockfile clean).
+ *
+ * Usage:
+ *   import { fireConfetti, fireConfettiFromElement } from "@/lib/confetti";
+ *   fireConfettiFromElement(nodeEl);
+ */
+
+// RVLT palette — brand red + the semantic accents + ink, for a festive mix.
+const COLORS = ["#E0363D", "#B21F26", "#4FD888", "#EBA53A", "#5B8DEF", "#F5EFE2"];
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  color: string;
+  rot: number;
+  vrot: number;
+  life: number; // 0..1 remaining
+  decay: number;
+}
+
+/** Fire confetti from a viewport pixel coordinate. */
+export function fireConfetti(
+  origin: { x: number; y: number },
+  opts: { count?: number; spread?: number; power?: number } = {},
+): void {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  // Respect reduced-motion — no surprise bursts for folks who opt out.
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches) return;
+
+  const count = opts.count ?? 110;
+  const power = opts.power ?? 14;
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const canvas = document.createElement("canvas");
+  canvas.setAttribute("aria-hidden", "true");
+  canvas.style.cssText =
+    "position:fixed;inset:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;";
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const resize = () => {
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  };
+  resize();
+  document.body.appendChild(canvas);
+
+  const particles: Particle[] = Array.from({ length: count }, () => {
+    // Spray upward and out: angle biased toward "up", random magnitude.
+    const angle = -Math.PI / 2 + (Math.random() - 0.5) * (opts.spread ?? Math.PI * 0.9);
+    const speed = power * (0.4 + Math.random() * 0.9);
+    return {
+      x: origin.x,
+      y: origin.y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      size: 5 + Math.random() * 6,
+      color: COLORS[(Math.random() * COLORS.length) | 0],
+      rot: Math.random() * Math.PI,
+      vrot: (Math.random() - 0.5) * 0.4,
+      life: 1,
+      decay: 0.008 + Math.random() * 0.01,
+    };
+  });
+
+  const GRAVITY = 0.32;
+  const DRAG = 0.985;
+  let raf = 0;
+
+  const tick = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let alive = false;
+    for (const p of particles) {
+      if (p.life <= 0) continue;
+      alive = true;
+      p.vx *= DRAG;
+      p.vy = p.vy * DRAG + GRAVITY;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rot += p.vrot;
+      p.life -= p.decay;
+
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, p.life);
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rot);
+      ctx.fillStyle = p.color;
+      // little paper rectangles
+      ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6);
+      ctx.restore();
+    }
+    if (alive) {
+      raf = requestAnimationFrame(tick);
+    } else {
+      cancelAnimationFrame(raf);
+      canvas.remove();
+    }
+  };
+  raf = requestAnimationFrame(tick);
+
+  // Hard safety cap — never leak a canvas even if the tab backgrounds.
+  window.setTimeout(() => {
+    cancelAnimationFrame(raf);
+    canvas.remove();
+  }, 5000);
+}
+
+/** Fire confetti from the centre of a DOM element. */
+export function fireConfettiFromElement(
+  el: HTMLElement | null | undefined,
+  opts?: { count?: number; spread?: number; power?: number },
+): void {
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  fireConfetti({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }, opts);
+}


### PR DESCRIPTION
## Polish pass: 4 things

### 🐛 Shell overlap (reported twice — proper fix this time)
The content pane was `overflow-auto`, so wide content scrolled the **whole page** horizontally, sliding the title / lifecycle / line-item names under the fixed sidebar (and the sticky top bar rode over it). Now it scrolls **vertically only and clips horizontally**; wide tables keep their own scroll (`ui/table.tsx` + the equipment table's `overflow-x-auto`), so nothing is cut off.

### 🎉 Confetti on Confirmed + Completed
Dependency-free canvas burst (`src/lib/confetti.ts`, RVLT colours, respects `prefers-reduced-motion`, self-cleaning) fires out of the lifecycle node the moment a job hits **Confirmed** or **Completed** — only on the real transition.

### ✨ Playful login / register screens
Split-panel auth shell (`src/app/(auth)/auth-playful.tsx`): FlowMascot roadie, scattered sticker patches, a CSS GAFF tape-roll, hand-drawn Kalam doodles, a rotated sticker over the card. Login + register + admin-register. All auth logic preserved verbatim.

### 🏭 Warehouse overdue logic + "Out on site" section
Overdue was computed off the **out** date, so a deployed job showed Overdue forever once it started. Now:
- Deployed gear is **Overdue only when past its IN/return date and still out** (not everything marked back).
- New **Out on site** section for gear that's deployed but not yet due.
- **Returned** jobs get their own "to close out" group — never flagged overdue.

### No new dependencies
Confetti is hand-rolled; auth fun reuses existing assets — `package.json` / `pnpm-lock.yaml` untouched.

### Verified locally
`npm run build` ✓ · `npx tsc --noEmit` → 0 errors · `npm test` → 2446 / 2446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
