### PR TITLE
fix(docs): remove stray conflict marker from FEATUREDOCS/54

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2939,7 +2939,6 @@ off Prisma, **extending** the same `src/lib/test-tag-read.ts` helper.
   Coolify PR preview against prod Convex (per the deploy-ordering gate above:
   testTagRecord/subTestRecord are already backfilled into prod).
 
-<<<<<<< HEAD
 ## Phase C — FK-anchor mirror inversion + domain-table drop
 
 Phase B inverted only safely-invertible (leaf / no-inbound-FK) tables; the 12


### PR DESCRIPTION
One-line doc fix — removes an orphaned `<<<<<<< HEAD` marker accidentally committed during the #258 rebase resolution. No code changes.

Blocking the rebases of #259, #260, #262, #267.