### PR TITLE
Phase C: config leftovers — bug-fixes + final small inversions

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -494,6 +494,22 @@ rewired to Convex:
   flag counted DEDICATED bulk accessories from the frozen table (added after
   cutover were invisible). Now `api.assetBulkChildren.list` filtered by
   `parentAssetId` (the inline "stays on Prisma" comment was itself stale).
+- **`maintenanceRecord`** (writes already Convex-only) → five surviving Prisma
+  reads served stale records, and one write hit the dead Postgres copy:
+  - **Reads** rewired to `getMaintenanceRecordsByOrg` (+ JS filter/sort/slice
+    replicating the old `where`/`orderBy`/`take`), with the asset join from
+    `getMaintenanceAssetLinksByRecordIds` + `getAssetsByOrg` and the
+    `reportedBy`/`assignedTo` Better-Auth-User names from a Prisma `user` lookup:
+    `api/calendar/[token]/[feed]/route.ts` (maintenance feed),
+    `notifications.ts` (overdue maintenance), `notification-email-sender.ts`
+    (overdue maintenance email), `dashboard.ts` `getRecentActivity`,
+    `kits.ts` `getKit` (filtered by `kitId`).
+  - **Write** — `site-admin.ts` `adminDeleteUser` cleared `reportedById`/
+    `assignedToId` on the dead Postgres table inside the `$transaction`; those
+    two `tx.maintenanceRecord.updateMany` lines were removed, and a new
+    Convex `api.maintenanceRecords.scrubUserRefs({ organizationId, userId })`
+    mutation (sets the matching FK field to `undefined` to clear it) now runs
+    post-commit for every org in the cross-org GDPR sweep (`allOrgsForSweep`).
 
 **Not stale (deliberately left on Prisma):** `crewRole` / `crewSkill` reads —
 seed-only reference tables (no app writes ⇒ Prisma == Convex), and `crew.ts`'s
@@ -3269,6 +3285,49 @@ The family (read + write) is fully migrated.
   set + CLEAR responseToken, getByResponseToken, patchShift clear +
   removeScheduledByAssignment (preserves non-SCHEDULED), patchTimeEntry approval-reset,
   deleteCascade (assignment + shifts + linked time-entry).
+
+### Phase C — config leftovers (final non-keystone sweep) — DONE
+
+A scoping pass found the scary clusters were already done: the **model cluster**
+(model + modelMedia + modelCheckItem + modelBulkAccessory + supplierModelRate) is
+fully Convex-only (zero app Prisma reads/writes — the ~200 model joins all attach
+from `getModelMap`), as are maintenanceRecordAsset, serviceTemplate, brandTemplate,
+groupTemplate parent, savedTableView, notificationDismissal,
+userNotificationPreference, wooCommerceOrderLog. `savedReport` no longer exists;
+`sectionPreset` is orphaned (no app refs). So the remaining work was bug-fixes on
+already-inverted tables + three small inversions.
+
+- **Bug-fixes (stale reads on Convex-only tables):**
+  - **group-templates** — `getGroupTemplates` did `prisma.groupTemplateItem.findMany({
+    include: { model, kit } })`, but `GroupTemplateItem` has **no `model` relation**
+    (FK dropped) so Prisma **threw at runtime** (the list surface was broken), and
+    `kit` (Convex-only) returned null. `applyGroupTemplate` had the same kit bug
+    (silently dropped kit items). Both now resolve model via `getModelMap` + kit via
+    `getKitMap`.
+  - **documentTemplate PDF** — `generate-pdf.ts` loaded the template from Prisma
+    while the UI/writes are Convex-only (split-brain) → now `document-template-read`.
+  - **maintenanceRecord** — 5 stale reads + the user-delete FK-scrub (see the
+    residual stale-read audit above).
+- **Write-inversions:**
+  - **checkItem** — was Prisma-first + an inline mirror → Convex-only
+    (create/`patchCheckItem`/remove); mirror helpers deleted. Already dual-written,
+    no backfill.
+  - **wooCommerceIntegration** — was **pure-Prisma** (Convex table unused) → Convex-only
+    hard cutover. New `woocommerce-integration-read.ts`; the upserts →
+    read-then-update-or-create; webhook read+write → Convex. **Added the missing
+    `webhookSecret` field** to the Convex schema + validators (the webhook HMAC check
+    needs it) + `patchWooCommerceIntegration`. **Needs prod backfill before deploy**
+    (`scripts/convex-backfill-woocommerce-integration.ts`) — Convex copy is empty.
+  - **notificationEmailLog** — was **pure-Prisma** → Convex-only (dedup read, create,
+    sentAt-cutoff prune as a list-and-remove loop). Optional prod backfill
+    (`scripts/convex-backfill-notification-email-log.ts`) avoids a one-time duplicate-
+    email burst.
+- **Validation:** `npm run build` exit 0 + lint 0 errors + 2431 tests, AND a **live
+  dev-Convex exercise (8/8)**: woo create + `webhookSecret` round-trip + patch
+  set/CLEAR (secret preserved), checkItem create + patch set/CLEAR + remove,
+  emailLog create/list/prune.
+- **Prod backfills to run on deploy:** `convex-backfill-woocommerce-integration.ts`
+  (required) + `convex-backfill-notification-email-log.ts` (optional).
 
 ## Conventions
 

--- a/convex/checkItems.ts
+++ b/convex/checkItems.ts
@@ -118,3 +118,36 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+// ─── CUSTOM (Phase C) ───
+// The generated `update` mutation can't unset a field (the wire drops nulls).
+// `patchCheckItem` applies `set` then explicitly clears each key in `clear` to
+// `undefined`, so optional fields (description, category, measurementUnit,
+// measurementMin/Max, dropdownOptions) can be emptied when an edit drops them
+// (e.g. switching a check item's type). Mirrors convex/subHires.ts patchSubHire.
+export const patchCheckItem = mutation({
+  args: {
+    id: v.string(),
+    set: v.object({
+      label: v.optional(v.string()),
+      description: v.optional(v.string()),
+      type: v.optional(enums.CheckItemType),
+      category: v.optional(v.string()),
+      measurementUnit: v.optional(v.string()),
+      measurementMin: v.optional(v.number()),
+      measurementMax: v.optional(v.number()),
+      dropdownOptions: v.optional(v.any()),
+      updatedAt: v.optional(v.number()),
+    }),
+    clear: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, { id, set, clear }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("checkItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc) throw new ConvexError("checkItems not found: " + id);
+    const patch: Record<string, unknown> = { ...set };
+    for (const k of clear ?? []) patch[k] = undefined;
+    await ctx.db.patch(doc._id, patch);
+    return doc._id;
+  },
+});

--- a/convex/maintenanceRecords.ts
+++ b/convex/maintenanceRecords.ts
@@ -142,3 +142,37 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+// ─── CUSTOM (Phase C) ───────────────────────────────────────────────────────
+
+/**
+ * Scrub a deleted Better Auth user's FK references from an org's maintenance
+ * records. Re-implements the Prisma `updateMany({ reportedById|assignedToId:
+ * userId } → null)` the user-delete sweep used to run against the (now dead)
+ * Postgres `maintenance_record` table. For each record where `reportedById` or
+ * `assignedToId` equals `userId`, patch the matching field to `undefined`
+ * (Convex `db.patch` with a field = `undefined` deletes it → clears to null);
+ * the non-matching field is left untouched.
+ */
+export const scrubUserRefs = mutation({
+  args: { organizationId: v.string(), userId: v.string() },
+  handler: async (ctx, { organizationId, userId }) => {
+    await requireService(ctx);
+    const docs = await ctx.db
+      .query("maintenanceRecords")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+      .collect();
+    let scrubbed = 0;
+    for (const doc of docs) {
+      const matchReported = doc.reportedById === userId;
+      const matchAssigned = doc.assignedToId === userId;
+      if (!matchReported && !matchAssigned) continue;
+      const patch: { reportedById?: undefined; assignedToId?: undefined } = {};
+      if (matchReported) patch.reportedById = undefined;
+      if (matchAssigned) patch.assignedToId = undefined;
+      await ctx.db.patch(doc._id, patch);
+      scrubbed += 1;
+    }
+    return { scrubbed };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1705,6 +1705,7 @@ export default defineSchema({
     id: v.string(),
     organizationId: v.string(),
     isEnabled: v.optional(v.boolean()),
+    webhookSecret: v.optional(v.string()),
     storeUrl: v.optional(v.string()),
     productMatchField: v.optional(v.string()),
     customFieldKey: v.optional(v.string()),

--- a/convex/wooCommerceIntegrations.ts
+++ b/convex/wooCommerceIntegrations.ts
@@ -36,6 +36,7 @@ export const create = mutation({
     id: v.string(),
     organizationId: v.string(),
     isEnabled: v.optional(v.boolean()),
+    webhookSecret: v.optional(v.string()),
     storeUrl: v.optional(v.string()),
     productMatchField: v.optional(v.string()),
     customFieldKey: v.optional(v.string()),
@@ -65,6 +66,7 @@ export const createIfMissing = mutation({
     id: v.string(),
     organizationId: v.string(),
     isEnabled: v.optional(v.boolean()),
+    webhookSecret: v.optional(v.string()),
     storeUrl: v.optional(v.string()),
     productMatchField: v.optional(v.string()),
     customFieldKey: v.optional(v.string()),
@@ -98,6 +100,7 @@ export const update = mutation({
     patch: v.object({
       organizationId: v.optional(v.string()),
       isEnabled: v.optional(v.boolean()),
+      webhookSecret: v.optional(v.string()),
       storeUrl: v.optional(v.string()),
       productMatchField: v.optional(v.string()),
       customFieldKey: v.optional(v.string()),
@@ -135,5 +138,46 @@ export const remove = mutation({
     const doc = await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("wooCommerceIntegrations not found: " + id);
     await ctx.db.delete(doc._id);
+  },
+});
+
+// ─── CUSTOM (Phase C) ───
+// The generated `update` mutation can't unset a field (the wire drops nulls).
+// `patchWooCommerceIntegration` applies `set` then explicitly clears each key in
+// `clear` to `undefined`, so optional string fields (storeUrl, customFieldKey,
+// rentalStartKey, etc.) can be emptied. Mirrors convex/subHires.ts patchSubHire.
+export const patchWooCommerceIntegration = mutation({
+  args: {
+    id: v.string(),
+    set: v.object({
+      isEnabled: v.optional(v.boolean()),
+      webhookSecret: v.optional(v.string()),
+      storeUrl: v.optional(v.string()),
+      productMatchField: v.optional(v.string()),
+      customFieldKey: v.optional(v.string()),
+      rentalStartKey: v.optional(v.string()),
+      rentalEndKey: v.optional(v.string()),
+      eventStartKey: v.optional(v.string()),
+      deliveryAddressKey: v.optional(v.string()),
+      notesKey: v.optional(v.string()),
+      dateFormat: v.optional(v.string()),
+      locationMetaKey: v.optional(v.string()),
+      defaultLocationId: v.optional(v.string()),
+      defaultProjectType: v.optional(v.string()),
+      autoConfirmEnquiry: v.optional(v.boolean()),
+      notifyUserIds: v.optional(v.array(v.string())),
+      lastPayload: v.optional(v.any()),
+      updatedAt: v.optional(v.number()),
+    }),
+    clear: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, { id, set, clear }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc) throw new ConvexError("wooCommerceIntegrations not found: " + id);
+    const patch: Record<string, unknown> = { ...set };
+    for (const k of clear ?? []) patch[k] = undefined;
+    await ctx.db.patch(doc._id, patch);
+    return doc._id;
   },
 });

--- a/scripts/convex-backfill-notification-email-log.ts
+++ b/scripts/convex-backfill-notification-email-log.ts
@@ -1,0 +1,46 @@
+/**
+ * One-time backfill: copy NotificationEmailLog rows from Prisma into Convex.
+ *
+ * Phase C HARD CUTOVER (notificationEmailLog was pure-Prisma — never dual-written).
+ * It's an append-only dedup log pruned to ~30 days; backfilling avoids a one-time
+ * burst of duplicate notification emails right after the cutover (the dedup lookup
+ * would otherwise see an empty Convex table). Lower-risk than the woo integration,
+ * but cheap + idempotent. Run in the Coolify app container (env injected, no .env):
+ *
+ *   npx tsx scripts/convex-backfill-notification-email-log.ts
+ *
+ * Idempotent (createIfMissing by cuid `id`). Re-runnable safely. See FEATUREDOCS/54.
+ */
+import { type FunctionArgs } from "convex/server";
+import { prisma } from "@/lib/prisma";
+import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+type CreateArgs = FunctionArgs<typeof api.notificationEmailLogs.create>;
+
+async function main() {
+  const convex = await getConvexClient();
+  // Only the rows still within the prune window matter for dedup; backfill all
+  // present rows (the prune job trims the rest on its next run).
+  const rows = await prisma.notificationEmailLog.findMany({ orderBy: { sentAt: "asc" } });
+  console.log(`Found ${rows.length} notification_email_log row(s) in Prisma.`);
+
+  let created = 0;
+  let skipped = 0;
+  for (const r of rows) {
+    const res = await convex.mutation(
+      api.notificationEmailLogs.createIfMissing,
+      toConvexDoc(r) as CreateArgs,
+    );
+    if (res.created) created++;
+    else skipped++;
+  }
+
+  console.log(`\nBackfill complete: ${created} created, ${skipped} already present.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/convex-backfill-woocommerce-integration.ts
+++ b/scripts/convex-backfill-woocommerce-integration.ts
@@ -1,0 +1,46 @@
+/**
+ * One-time backfill: copy WooCommerceIntegration rows from Prisma into Convex.
+ *
+ * Phase C HARD CUTOVER (wooCommerceIntegration was pure-Prisma — never dual-written,
+ * so the Convex table is empty). MUST run in prod BEFORE the read-inversion deploys,
+ * else existing integrations lose their config + webhookSecret (HMAC check breaks).
+ * Idempotent — skips a row already present in Convex (matched by cuid `id`). Maps
+ * Date -> Unix ms, null -> absent, JSON (`lastPayload`) passes through (see toConvexDoc).
+ * One row per org. Run directly in the Coolify app container (env injected, no .env):
+ *
+ *   npx tsx scripts/convex-backfill-woocommerce-integration.ts
+ *
+ * Re-runnable safely. See FEATUREDOCS/54 and docs/designs/convex-domain-only-decommission.md.
+ */
+import { type FunctionArgs } from "convex/server";
+import { prisma } from "@/lib/prisma";
+import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+type CreateArgs = FunctionArgs<typeof api.wooCommerceIntegrations.create>;
+
+async function main() {
+  const convex = await getConvexClient();
+  const rows = await prisma.wooCommerceIntegration.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`Found ${rows.length} woo_commerce_integration row(s) in Prisma.`);
+
+  let created = 0;
+  let skipped = 0;
+  for (const r of rows) {
+    const res = await convex.mutation(
+      api.wooCommerceIntegrations.createIfMissing,
+      toConvexDoc(r) as CreateArgs,
+    );
+    if (res.created) created++;
+    else skipped++;
+    console.log(`  + org ${r.organizationId} (${r.id})${r.webhookSecret ? " [secret]" : ""}`);
+  }
+
+  console.log(`\nBackfill complete: ${created} created, ${skipped} already present.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/calendar/[token]/[feed]/route.ts
+++ b/src/app/api/calendar/[token]/[feed]/route.ts
@@ -4,6 +4,9 @@ import { getClientMap } from "@/lib/clients-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
 import { getLocationsByOrg } from "@/lib/locations-read";
 import { getModelMap } from "@/lib/models-read";
+import { getAssetsByOrg } from "@/lib/assets-read";
+import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
+import { getMaintenanceAssetLinksByRecordIds } from "@/lib/maintenance-record-asset-read";
 import { getCrewMemberMap, getCrewRoleMap } from "@/lib/crew-read";
 import {
   getAssignmentsByOrg,
@@ -225,32 +228,40 @@ async function buildMaintenanceFeed(
   orgName: string,
   tzid: string
 ): Promise<string> {
-  const records = await prisma.maintenanceRecord.findMany({
-    where: {
-      organizationId: orgId,
-      status: { in: ["SCHEDULED", "IN_PROGRESS"] },
-      scheduledDate: { not: null },
-    },
-    include: {
-      assignedTo: { select: { name: true } },
-      assets: {
-        include: {
-          asset: {
-            select: {
-              assetTag: true,
-              customName: true,
-              modelId: true,
-            },
-          },
-        },
-      },
-    },
-    orderBy: { scheduledDate: "asc" },
-  });
+  // maintenanceRecord is Convex-only (Phase C). Read the org's records from
+  // Convex, replicate the old `where` (status in [SCHEDULED, IN_PROGRESS],
+  // scheduledDate != null) + `orderBy: { scheduledDate: "asc" }` in JS.
+  const allRecords = await getMaintenanceRecordsByOrg(orgId);
+  const records = allRecords
+    .filter(
+      (r) =>
+        (r.status === "SCHEDULED" || r.status === "IN_PROGRESS") &&
+        r.scheduledDate != null,
+    )
+    .sort((a, b) => (a.scheduledDate!.getTime() - b.scheduledDate!.getTime()));
 
-  // Model FK was dropped (Phase B); resolve asset model names from the Convex
-  // mirror (replaces the old nested `asset.model.select.name`).
-  const modelMap = await getModelMap(orgId);
+  // The maintenanceRecordAsset join + assets live in Convex; assignedTo is a
+  // Better Auth User (Prisma). Resolve both, plus model names for the labels.
+  const recordIds = records.map((r) => r.id);
+  const [assetLinks, allAssets, modelMap] = await Promise.all([
+    getMaintenanceAssetLinksByRecordIds(recordIds),
+    getAssetsByOrg(orgId),
+    getModelMap(orgId),
+  ]);
+  const assetMap = new Map(allAssets.map((a) => [a.id, a]));
+  const linksByRecord = new Map<string, typeof assetLinks>();
+  for (const l of assetLinks) {
+    const arr = linksByRecord.get(l.maintenanceRecordId) ?? [];
+    arr.push(l);
+    linksByRecord.set(l.maintenanceRecordId, arr);
+  }
+  const assignedToIds = [
+    ...new Set(records.map((r) => r.assignedToId).filter((id): id is string => !!id)),
+  ];
+  const assignedToUsers = assignedToIds.length > 0
+    ? await prisma.user.findMany({ where: { id: { in: assignedToIds } }, select: { id: true, name: true } })
+    : [];
+  const assignedToNameMap = new Map(assignedToUsers.map((u) => [u.id, u.name]));
 
   const events: ICalEvent[] = [];
 
@@ -260,12 +271,14 @@ async function buildMaintenanceFeed(
     const dtstart = buildDateTime(r.scheduledDate, null, tzid);
     const dtend = new Date(dtstart); // Same day — flagged as all-day below
 
-    const assetNames = r.assets
-      .map((a) => {
-        const modelName = a.asset.modelId
-          ? modelMap.get(a.asset.modelId)?.name ?? ""
+    const assetNames = (linksByRecord.get(r.id) ?? [])
+      .flatMap((l) => {
+        const asset = assetMap.get(l.assetId);
+        if (!asset) return [];
+        const modelName = asset.modelId
+          ? modelMap.get(asset.modelId)?.name ?? ""
           : "";
-        return a.asset.customName || `${modelName} (${a.asset.assetTag})`;
+        return [asset.customName || `${modelName} (${asset.assetTag})`];
       })
       .join(", ");
 
@@ -275,7 +288,8 @@ async function buildMaintenanceFeed(
       `Status: ${r.status.replace(/_/g, " ")}`,
     ];
     if (r.description) descLines.push(`Details: ${r.description}`);
-    if (r.assignedTo?.name) descLines.push(`Assigned To: ${r.assignedTo.name}`);
+    const assignedToName = r.assignedToId ? assignedToNameMap.get(r.assignedToId) : null;
+    if (assignedToName) descLines.push(`Assigned To: ${assignedToName}`);
     if (assetNames) descLines.push(`Assets: ${assetNames}`);
 
     events.push({

--- a/src/app/api/integrations/woocommerce/webhook/route.ts
+++ b/src/app/api/integrations/woocommerce/webhook/route.ts
@@ -1,10 +1,10 @@
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../../../../../convex/_generated/api";
 import { getTheOrg } from "@/lib/single-org";
 import { verifyWebhookSignature } from "@/lib/woocommerce-utils";
 import { findCompletedOrderLog } from "@/lib/woocommerce-order-logs-read";
+import { getWooCommerceIntegrationByOrg } from "@/lib/woocommerce-integration-read";
 import {
   processWooCommerceOrder,
   type WooOrder,
@@ -56,10 +56,8 @@ export async function POST(request: Request) {
     orgId = org.id;
   }
 
-  // 6. Load the org's WooCommerce integration config
-  const integration = await prisma.wooCommerceIntegration.findUnique({
-    where: { organizationId: orgId },
-  });
+  // 6. Load the org's WooCommerce integration config (Convex-only)
+  const integration = await getWooCommerceIntegrationByOrg(orgId);
   if (!integration?.isEnabled) {
     return Response.json({ error: "Integration not enabled" }, { status: 404 });
   }
@@ -78,10 +76,10 @@ export async function POST(request: Request) {
 
   const order = parsed;
 
-  // 9. Store last payload for "Test & Detect" feature
-  await prisma.wooCommerceIntegration.update({
-    where: { organizationId: orgId },
-    data: { lastPayload: order as never },
+  // 9. Store last payload for "Test & Detect" feature (Convex-only update)
+  await (await getConvexClient()).mutation(api.wooCommerceIntegrations.update, {
+    id: integration.id,
+    patch: { lastPayload: order, updatedAt: Date.now() },
   });
 
   // 10. Only process order.created topic

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -11,8 +11,8 @@
  */
 import { generate } from "@pdfme/generator";
 import type { Template } from "@pdfme/common";
-import { prisma } from "@/lib/prisma";
 import { getBrandTemplateForOrg } from "@/lib/brand-templates-read";
+import { listDocumentTemplates, getDocumentTemplateById, type DocumentTemplateRow } from "@/lib/document-template-read";
 import { gearflowPlugins } from "./plugins";
 import { getPdfmeFonts } from "./fonts";
 import { buildDocumentData } from "./build-document-data";
@@ -52,14 +52,16 @@ async function loadTemplate(
   templateId?: string,
 ): Promise<LoadedTemplate> {
   try {
-    // Build query for the specific template or org default
-    const where = templateId
-      ? { id: templateId, organizationId, isDraft: false }
-      : { organizationId, type: docType, isDefault: true, isDraft: false };
-
-    const record = await prisma.documentTemplate.findFirst({
-      where,
-    });
+    // documentTemplate is Convex-only — load via the Convex read helper (replaces
+    // the dead Prisma read; Postgres documentTemplate is no longer authoritative).
+    let record: DocumentTemplateRow | null;
+    if (templateId) {
+      const t = await getDocumentTemplateById(templateId);
+      record = t && t.organizationId === organizationId && !t.isDraft ? t : null;
+    } else {
+      const all = await listDocumentTemplates(organizationId);
+      record = all.find((t) => t.type === docType && t.isDefault && !t.isDraft) ?? null;
+    }
 
     if (!record) {
       return { sections: null, template: null, settings: null, brandAccentColor: null, brandFooterText: null, brandFooterSecondLine: null };

--- a/src/lib/woocommerce-integration-read.ts
+++ b/src/lib/woocommerce-integration-read.ts
@@ -1,0 +1,87 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+/**
+ * Server-side read helper for the WooCommerceIntegration domain (Phase C config
+ * leftover inversion). `wooCommerceIntegration` is now Convex-only — written via
+ * api.wooCommerceIntegrations.* in src/server/woocommerce.ts and the webhook route.
+ *
+ * The table is one-per-org (organizationId @unique), so the org's row is the single
+ * element of `api.wooCommerceIntegrations.list({ orgId })`. This helper maps the Convex
+ * doc back into the Prisma-row shape the old `prisma.wooCommerceIntegration.findUnique`
+ * returned (epoch-ms → Date, absent optionals → null).
+ */
+
+type RawWooCommerceIntegration = Doc<"wooCommerceIntegrations">;
+
+const toDate = (value: number | undefined): Date | null =>
+  typeof value === "number" ? new Date(value) : null;
+
+export interface WooCommerceIntegrationRow {
+  id: string;
+  organizationId: string;
+  isEnabled: boolean;
+  webhookSecret: string;
+  storeUrl: string | null;
+  productMatchField: string;
+  customFieldKey: string | null;
+  rentalStartKey: string | null;
+  rentalEndKey: string | null;
+  eventStartKey: string | null;
+  deliveryAddressKey: string | null;
+  notesKey: string | null;
+  dateFormat: string;
+  locationMetaKey: string | null;
+  defaultLocationId: string | null;
+  defaultProjectType: string;
+  autoConfirmEnquiry: boolean;
+  notifyUserIds: string[];
+  lastPayload: unknown;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export function mapWooCommerceIntegration(
+  d: RawWooCommerceIntegration,
+): WooCommerceIntegrationRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    isEnabled: d.isEnabled ?? false,
+    webhookSecret: d.webhookSecret ?? "",
+    storeUrl: d.storeUrl ?? null,
+    productMatchField: d.productMatchField ?? "sku",
+    customFieldKey: d.customFieldKey ?? null,
+    rentalStartKey: d.rentalStartKey ?? null,
+    rentalEndKey: d.rentalEndKey ?? null,
+    eventStartKey: d.eventStartKey ?? null,
+    deliveryAddressKey: d.deliveryAddressKey ?? null,
+    notesKey: d.notesKey ?? null,
+    dateFormat: d.dateFormat ?? "auto",
+    locationMetaKey: d.locationMetaKey ?? null,
+    defaultLocationId: d.defaultLocationId ?? null,
+    defaultProjectType: d.defaultProjectType ?? "DRY_HIRE",
+    autoConfirmEnquiry: d.autoConfirmEnquiry ?? false,
+    notifyUserIds: d.notifyUserIds ?? [],
+    lastPayload: d.lastPayload ?? null,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+/**
+ * The org's WooCommerce integration row (or null). Replaces
+ * `prisma.wooCommerceIntegration.findUnique({ where: { organizationId } })`.
+ */
+export async function getWooCommerceIntegrationByOrg(
+  orgId: string,
+): Promise<WooCommerceIntegrationRow | null> {
+  const rows = (await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.wooCommerceIntegrations.list, {
+      orgId,
+    }),
+  )) as RawWooCommerceIntegration[];
+  const row = rows[0];
+  return row ? mapWooCommerceIntegration(row) : null;
+}

--- a/src/server/check-items.ts
+++ b/src/server/check-items.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { type FunctionArgs } from "convex/server";
-import { prisma } from "@/lib/prisma";
-import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
+import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getModelById, getModelMap } from "@/lib/models-read";
@@ -24,30 +22,13 @@ import {
   type ReorderModelCheckItemsValues,
 } from "@/lib/validations/check-item";
 
-// Check items are DUAL-WRITTEN: every create/update/delete writes the Prisma
-// `check_item` row (the durable FK anchor — model_check_item, kit_check_item, and
-// check_record all carry a required + Cascade FK to it) AND the Convex
-// `checkItems` doc (the reactive read source). Prisma is written first; the Convex
-// payload is derived from the written row via toConvexDoc so they can't drift. The
-// model/kit assignment join tables + cross-domain readers stay on the always-fresh
-// Prisma mirror. See FEATUREDOCS/54.
-
-/** Mirror a freshly written Prisma check-item row into Convex (create). */
-async function mirrorCheckItemToConvex(row: Record<string, unknown>) {
-  await (await getConvexClient()).mutation(
-    api.checkItems.createIfMissing,
-    toConvexDoc(row) as FunctionArgs<typeof api.checkItems.createIfMissing>,
-  );
-}
-
-/** Mirror an updated Prisma check-item row into Convex (patch, id stripped). */
-async function patchCheckItemInConvex(id: string, row: Record<string, unknown>) {
-  const { id: _id, ...patch } = toConvexDoc(row);
-  await (await getConvexClient()).mutation(api.checkItems.update, {
-    id,
-    patch: patch as FunctionArgs<typeof api.checkItems.update>["patch"],
-  });
-}
+// Check items are CONVEX-ONLY (Phase C config-leftover inversion): every
+// create/update/delete writes the Convex `checkItems` doc directly (createId() +
+// Date.now()) with no Prisma row. The model/kit assignment join tables were
+// already Convex-only; check_record snapshot reads stay Prisma on purpose (see
+// check-records.ts). Reads go through src/lib/check-items-read.ts. Clears (emptied
+// optional fields) go through the custom api.checkItems.patchCheckItem mutation.
+// See FEATUREDOCS/54.
 
 // ─── Check Item Library ─────────────────────────────────────────────────────
 
@@ -115,15 +96,26 @@ export async function createCheckItem(data: CheckItemFormValues) {
   );
   const parsed = checkItemSchema.parse(data);
 
-  const result = await prisma.checkItem.create({
-    data: {
-      ...parsed,
-      dropdownOptions: parsed.dropdownOptions as unknown as undefined,
-      organizationId,
-      createdById: userId,
-    },
+  const id = createId();
+  const now = Date.now();
+  await (await getConvexClient()).mutation(api.checkItems.create, {
+    id,
+    organizationId,
+    label: parsed.label,
+    description: parsed.description || undefined,
+    type: parsed.type ?? "PASS_FAIL",
+    category: parsed.category || undefined,
+    measurementUnit: parsed.measurementUnit || undefined,
+    measurementMin: parsed.measurementMin ?? undefined,
+    measurementMax: parsed.measurementMax ?? undefined,
+    dropdownOptions: parsed.dropdownOptions ?? undefined,
+    createdById: userId,
+    createdAt: now,
+    updatedAt: now,
   });
-  await mirrorCheckItemToConvex(result);
+
+  const result = await getCheckItemById(organizationId, id);
+  if (!result) throw new Error("Failed to load check item after create");
 
   await logActivity({
     organizationId,
@@ -146,14 +138,40 @@ export async function updateCheckItem(id: string, data: CheckItemFormValues) {
   );
   const parsed = checkItemSchema.parse(data);
 
-  const result = await prisma.checkItem.update({
-    where: { id, organizationId },
-    data: {
-      ...parsed,
-      dropdownOptions: parsed.dropdownOptions as unknown as undefined,
-    },
+  // Org-scoped existence guard (replaces Prisma `update where {id, organizationId}`).
+  const existing = await getCheckItemById(organizationId, id);
+  if (!existing) throw new Error("Check item not found");
+
+  // Build `set` (present values) + `clear` (omitted optional fields). The form
+  // submits the full object, so an absent optional means "cleared" (e.g. switching
+  // the type drops measurement/dropdown fields).
+  const set: Record<string, unknown> = {
+    label: parsed.label,
+    type: parsed.type ?? "PASS_FAIL",
+    updatedAt: Date.now(),
+  };
+  const clear: string[] = [];
+  const nullableFields = {
+    description: parsed.description,
+    category: parsed.category,
+    measurementUnit: parsed.measurementUnit,
+    measurementMin: parsed.measurementMin,
+    measurementMax: parsed.measurementMax,
+    dropdownOptions: parsed.dropdownOptions,
+  } as const;
+  for (const [key, value] of Object.entries(nullableFields)) {
+    if (value === undefined || value === null || value === "") clear.push(key);
+    else set[key] = value;
+  }
+
+  await (await getConvexClient()).mutation(api.checkItems.patchCheckItem, {
+    id,
+    set,
+    clear,
   });
-  await patchCheckItemInConvex(id, result);
+
+  const result = await getCheckItemById(organizationId, id);
+  if (!result) throw new Error("Failed to load check item after update");
 
   await logActivity({
     organizationId,
@@ -193,9 +211,9 @@ export async function deleteCheckItem(id: string) {
     );
   }
 
-  const result = await prisma.checkItem.delete({
-    where: { id, organizationId },
-  });
+  // Org-scoped existence guard (replaces Prisma `delete where {id, organizationId}`).
+  const result = await getCheckItemById(organizationId, id);
+  if (!result) throw new Error("Check item not found");
   await (await getConvexClient()).mutation(api.checkItems.remove, { id });
 
   await logActivity({
@@ -366,10 +384,10 @@ export async function bulkAddCheckItemsToModels(
   // Model lives in Convex — fetch names for audit log via map.
   const convexModelMap = await getModelMap(organizationId);
   const models = modelIds.map((id) => ({ id, name: convexModelMap.get(id)?.name ?? id }));
-  const checkItems = await prisma.checkItem.findMany({
-    where: { id: { in: checkItemIds }, organizationId },
-    select: { id: true, label: true },
-  });
+  // check_item is Convex-only — read labels from the org's Convex check items.
+  const idSet = new Set(checkItemIds);
+  const allCheckItems = await getCheckItemsForOrg(organizationId);
+  const checkItems = allCheckItems.filter((c) => idSet.has(c.id));
 
   const checkLabels = checkItems.map((c) => c.label).join(", ");
   const modelNames = models.map((m) => m.name);

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -201,14 +201,14 @@ export async function getRecentActivity() {
     convex.query(api.assetScanLogs.list, { orgId: organizationId }),
     convex.query(api.testTagRecords.list, { orgId: organizationId }),
     convex.query(api.testTagAssets.list, { orgId: organizationId }),
-    prisma.maintenanceRecord.findMany({
-      where: { organizationId },
-      include: {
-        reportedBy: { select: { id: true, name: true } },
-      },
-      orderBy: { updatedAt: "desc" },
-      take: 10,
-    }),
+    // maintenanceRecord is Convex-only (Phase C). Read the org's records, then
+    // replicate `orderBy: { updatedAt: "desc" }` + `take: 10` in JS. reportedBy
+    // (a Better Auth User) is attached from Prisma below.
+    getMaintenanceRecordsByOrg(organizationId).then((records) =>
+      [...records]
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+        .slice(0, 10),
+    ),
     getModelMap(organizationId),
     getAssetsByOrg(organizationId),
     getBulkAssetsByOrg(organizationId),
@@ -263,6 +263,15 @@ export async function getRecentActivity() {
     arr.push(l);
     linksByRecord.set(l.maintenanceRecordId, arr);
   }
+  // reportedBy is a Better Auth User (Prisma KEPT table) — resolve names for the
+  // records' reportedById refs (replaces the old `include: { reportedBy }`).
+  const reportedByIds = [
+    ...new Set(maintenanceRecords.map((m) => m.reportedById).filter((id): id is string => !!id)),
+  ];
+  const reportedByUsers = reportedByIds.length > 0
+    ? await prisma.user.findMany({ where: { id: { in: reportedByIds } }, select: { id: true, name: true } })
+    : [];
+  const reportedByMap = new Map(reportedByUsers.map((u) => [u.id, u]));
 
   const withModels = {
     logs: scanLogsSorted.map((l) => {
@@ -280,6 +289,7 @@ export async function getRecentActivity() {
     testRecords,
     maintenanceRecords: maintenanceRecords.map((m) => ({
       ...m,
+      reportedBy: m.reportedById ? reportedByMap.get(m.reportedById) ?? null : null,
       assets: (linksByRecord.get(m.id) ?? [])
         .slice(0, 3) // preserve the old include `take: 3`
         .map((l) => {

--- a/src/server/group-templates.ts
+++ b/src/server/group-templates.ts
@@ -6,6 +6,7 @@ import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { requirePermission } from "@/lib/org-context";
 import { getModelMap } from "@/lib/models-read";
+import { getKitMap } from "@/lib/kits-read";
 import { getProjectById } from "@/lib/projects-read";
 import {
   getGroupTemplateParents,
@@ -57,20 +58,26 @@ export async function getGroupTemplates() {
   const parents = await getGroupTemplateParents(organizationId);
   if (parents.length === 0) return serialize([]);
 
-  // One Prisma round-trip for ALL templates' items, then group by templateId —
-  // reproduces the per-template `include: { items: { include: { model, kit } } }`
-  // with the same selects and `orderBy: { sortOrder: "asc" }`.
-  const items = await prisma.groupTemplateItem.findMany({
-    where: { organizationId, templateId: { in: parents.map((p) => p.id) } },
-    include: {
-      model: {
-        select: { id: true, name: true, dailyRate: true, weeklyRate: true },
-      },
-      kit: {
-        select: { id: true, name: true, assetTag: true },
-      },
-    },
-    orderBy: { sortOrder: "asc" },
+  // One Prisma round-trip for ALL templates' items (groupTemplateItem is a Prisma
+  // child table), then attach model + kit from Convex. model/kit are Convex-only —
+  // the old Prisma `include: { model, kit }` threw on `model` (no such relation) and
+  // returned null on `kit` (no Prisma kit rows). Resolve both from the Convex maps.
+  const [rawItems, modelMap, kitMap] = await Promise.all([
+    prisma.groupTemplateItem.findMany({
+      where: { organizationId, templateId: { in: parents.map((p) => p.id) } },
+      orderBy: { sortOrder: "asc" },
+    }),
+    getModelMap(organizationId),
+    getKitMap(organizationId),
+  ]);
+  const items = rawItems.map((it) => {
+    const m = it.modelId ? modelMap.get(it.modelId) : undefined;
+    const k = it.kitId ? kitMap.get(it.kitId) : undefined;
+    return {
+      ...it,
+      model: m ? { id: m.id, name: m.name, dailyRate: m.dailyRate ?? null, weeklyRate: m.weeklyRate ?? null } : null,
+      kit: k ? { id: k.id, name: k.name, assetTag: k.assetTag ?? null } : null,
+    };
   });
 
   const itemsByTemplate = new Map<string, typeof items>();
@@ -246,13 +253,18 @@ export async function applyGroupTemplate(
   }
   const templateItems = await prisma.groupTemplateItem.findMany({
     where: { templateId: parsed.templateId, organizationId },
-    include: { kit: true },
     orderBy: { sortOrder: "asc" },
   });
-  const modelMap = await getModelMap(organizationId);
+  // model + kit are Convex-only — resolve both from the Convex maps (the old
+  // `include: { kit: true }` returned null and silently dropped kit items).
+  const [modelMap, kitMap] = await Promise.all([
+    getModelMap(organizationId),
+    getKitMap(organizationId),
+  ]);
   const itemsWithModels = templateItems.map((i) => ({
     ...i,
     model: i.modelId ? modelMap.get(i.modelId) ?? null : null,
+    kit: i.kitId ? kitMap.get(i.kitId) ?? null : null,
   }));
 
   const client = await getConvexClient();

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -25,6 +25,7 @@ import { getProjectsByOrg } from "@/lib/projects-read";
 import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import { getAssetById, getBulkAssetById, getAssetsByOrg, getBulkAssetsByOrg, filterAvailableAssetsForKit, filterAvailableBulkAssetsForKit, sortByAssetTagAsc, mapConvexAssetToPrisma, mapConvexBulkAssetToPrisma } from "@/lib/assets-read";
 import { getKitSerializedItemsByOrg, getKitBulkItemsByOrg, countKitMembers, getKitById, getKitByAssetTag, coerceKitDeletabilityRow, computeKitDeletability } from "@/lib/kits-read";
+import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
 
 /**
  * Per-kit member-item counts + primary photo (kitId -> meta).
@@ -111,11 +112,14 @@ export async function getKit(id: string) {
       orderBy: { scannedAt: "desc" },
       include: { scannedBy: true, project: true },
     }),
-    prisma.maintenanceRecord.findMany({
-      where: { kitId: id },
-      take: 20,
-      orderBy: { createdAt: "desc" },
-    }),
+    // maintenanceRecord is Convex-only (Phase C). Read the org's records, filter
+    // to this kit, then replicate `orderBy: { createdAt: "desc" }` + `take: 20`.
+    getMaintenanceRecordsByOrg(organizationId).then((records) =>
+      records
+        .filter((m) => m.kitId === id)
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .slice(0, 20),
+    ),
     // kit media gallery now from the Convex mirror (dual-written → identical data).
     getKitMediaFromConvex(id),
   ]);

--- a/src/server/notification-email-sender.ts
+++ b/src/server/notification-email-sender.ts
@@ -24,6 +24,8 @@ import { sendEmail } from "@/lib/email";
 import { getModelMap } from "@/lib/models-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
 import { getAssetsByOrg } from "@/lib/assets-read";
+import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
+import { getMaintenanceAssetLinksByRecordIds } from "@/lib/maintenance-record-asset-read";
 import {
   getCrewAssignmentsByOrg,
   getCrewTimeEntriesByOrg,
@@ -118,18 +120,32 @@ async function buildOrgNotifications(ctx: BuildContext): Promise<NotificationToS
   const modelMap = await getModelMap(organizationId);
 
   // 1. Overdue maintenance
-  const overdueMaintenance = await prisma.maintenanceRecord.findMany({
-    where: {
-      organizationId,
-      status: { in: ["SCHEDULED", "IN_PROGRESS"] },
-      scheduledDate: { lt: now },
-    },
-    include: { assets: { include: { asset: true } } },
-    take: 50,
-  });
+  // maintenanceRecord is Convex-only (Phase C). Read the org's records, replicate
+  // the old `where` (status in [SCHEDULED, IN_PROGRESS], scheduledDate < now) +
+  // `take: 50` in JS. The maintenanceRecordAsset join + assets live in Convex.
+  const overdueMaintenance = (await getMaintenanceRecordsByOrg(organizationId))
+    .filter(
+      (m) =>
+        (m.status === "SCHEDULED" || m.status === "IN_PROGRESS") &&
+        m.scheduledDate != null &&
+        m.scheduledDate.getTime() < now.getTime(),
+    )
+    .slice(0, 50);
+
+  const overdueRecordIds = overdueMaintenance.map((m) => m.id);
+  const overdueLinks = await getMaintenanceAssetLinksByRecordIds(overdueRecordIds);
+  const overdueAssets = await getAssetsByOrg(organizationId);
+  const overdueAssetMap = new Map(overdueAssets.map((a) => [a.id, a]));
+  const overdueLinksByRecord = new Map<string, typeof overdueLinks>();
+  for (const l of overdueLinks) {
+    const arr = overdueLinksByRecord.get(l.maintenanceRecordId) ?? [];
+    arr.push(l);
+    overdueLinksByRecord.set(l.maintenanceRecordId, arr);
+  }
   for (const m of overdueMaintenance) {
-    const first = m.assets[0]?.asset;
-    const count = m.assets.length;
+    const recordLinks = overdueLinksByRecord.get(m.id) ?? [];
+    const first = recordLinks[0] ? overdueAssetMap.get(recordLinks[0].assetId) : undefined;
+    const count = recordLinks.length;
     const firstModelName = first?.modelId ? modelMap.get(first.modelId)?.name : undefined;
     const desc = first
       ? count > 1

--- a/src/server/notification-email-sender.ts
+++ b/src/server/notification-email-sender.ts
@@ -17,6 +17,7 @@
  * Re-emailing pending invitations from here would just be noise.
  */
 
+import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
@@ -372,13 +373,13 @@ export async function sendNotificationEmails(): Promise<SendNotificationEmailsRe
     if (notifications.length === 0 || recipients.length === 0) continue;
 
     // Pre-fetch existing log rows for these keys to avoid one query per pair.
-    const existing = await prisma.notificationEmailLog.findMany({
-      where: {
-        organizationId: org.id,
-        notificationKey: { in: notifications.map((n) => n.key) },
-      },
-      select: { userId: true, notificationKey: true },
-    });
+    // notificationEmailLog is Convex-only (Phase C): list the org's logs and apply
+    // the `notificationKey IN [...]` filter in JS.
+    const keySet = new Set(notifications.map((n) => n.key));
+    const existing = (await (await getConvexClient()).query(
+      api.notificationEmailLogs.list,
+      { orgId: org.id },
+    )).filter((e) => keySet.has(e.notificationKey));
     const alreadySent = new Set(existing.map((e) => `${e.userId}::${e.notificationKey}`));
 
     for (const notif of notifications) {
@@ -400,12 +401,12 @@ export async function sendNotificationEmails(): Promise<SendNotificationEmailsRe
         try {
           const { subject, html } = notif.build(recipient, ctx);
           await sendEmail({ to: recipient.email, subject, html });
-          await prisma.notificationEmailLog.create({
-            data: {
-              organizationId: org.id,
-              userId: recipient.userId,
-              notificationKey: notif.key,
-            },
+          await (await getConvexClient()).mutation(api.notificationEmailLogs.create, {
+            id: createId(),
+            organizationId: org.id,
+            userId: recipient.userId,
+            notificationKey: notif.key,
+            sentAt: Date.now(),
           });
           alreadySent.add(dedupeKey);
           result.sent += 1;
@@ -429,9 +430,22 @@ export async function sendNotificationEmails(): Promise<SendNotificationEmailsRe
  * see in the active set anymore eventually fall out.
  */
 export async function pruneStaleNotificationEmailLogs(): Promise<number> {
-  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  const result = await prisma.notificationEmailLog.deleteMany({
-    where: { sentAt: { lt: cutoff } },
-  });
-  return result.count;
+  // notificationEmailLog is Convex-only (Phase C). The old deleteMany spanned every
+  // org; the Convex `list` query is org-scoped, so iterate orgs (still in Postgres —
+  // Better Auth), list each org's logs, and remove the ones older than the cutoff.
+  const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  const convex = await getConvexClient();
+  const orgs = await prisma.organization.findMany({ select: { id: true } });
+
+  let count = 0;
+  for (const org of orgs) {
+    const logs = await convex.query(api.notificationEmailLogs.list, { orgId: org.id });
+    for (const log of logs) {
+      if ((log.sentAt ?? 0) < cutoffMs) {
+        await convex.mutation(api.notificationEmailLogs.remove, { id: log.id });
+        count += 1;
+      }
+    }
+  }
+  return count;
 }

--- a/src/server/notifications.ts
+++ b/src/server/notifications.ts
@@ -9,6 +9,8 @@ import { serialize } from "@/lib/serialize";
 import { getModelMap } from "@/lib/models-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
 import { getAssetsByOrg } from "@/lib/assets-read";
+import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
+import { getMaintenanceAssetLinksByRecordIds } from "@/lib/maintenance-record-asset-read";
 import {
   getDismissedKeysForUser,
   getDismissalsForUser,
@@ -120,19 +122,33 @@ export async function getNotifications(): Promise<AppNotification[]> {
   const modelMap = await getModelMap(organizationId);
 
   // 1. Overdue maintenance
-  const overdueMaintenance = await prisma.maintenanceRecord.findMany({
-    where: {
-      organizationId,
-      status: { in: ["SCHEDULED", "IN_PROGRESS"] },
-      scheduledDate: { lt: now },
-    },
-    include: { assets: { include: { asset: true } } },
-    take: 10,
-  });
+  // maintenanceRecord is Convex-only (Phase C). Read the org's records, replicate
+  // the old `where` (status in [SCHEDULED, IN_PROGRESS], scheduledDate < now) +
+  // `take: 10` in JS. The maintenanceRecordAsset join + assets live in Convex.
+  const overdueMaintenance = (await getMaintenanceRecordsByOrg(organizationId))
+    .filter(
+      (m) =>
+        (m.status === "SCHEDULED" || m.status === "IN_PROGRESS") &&
+        m.scheduledDate != null &&
+        m.scheduledDate.getTime() < now.getTime(),
+    )
+    .slice(0, 10);
+
+  const overdueRecordIds = overdueMaintenance.map((m) => m.id);
+  const overdueLinks = await getMaintenanceAssetLinksByRecordIds(overdueRecordIds);
+  const overdueAssets = await getAssetsByOrg(organizationId);
+  const overdueAssetMap = new Map(overdueAssets.map((a) => [a.id, a]));
+  const overdueLinksByRecord = new Map<string, typeof overdueLinks>();
+  for (const l of overdueLinks) {
+    const arr = overdueLinksByRecord.get(l.maintenanceRecordId) ?? [];
+    arr.push(l);
+    overdueLinksByRecord.set(l.maintenanceRecordId, arr);
+  }
 
   for (const m of overdueMaintenance) {
-    const firstAsset = m.assets[0]?.asset;
-    const assetCount = m.assets.length;
+    const recordLinks = overdueLinksByRecord.get(m.id) ?? [];
+    const firstAsset = recordLinks[0] ? overdueAssetMap.get(recordLinks[0].assetId) : undefined;
+    const assetCount = recordLinks.length;
     const firstModelName = firstAsset?.modelId ? modelMap.get(firstAsset.modelId)?.name : undefined;
     const desc = firstAsset
       ? assetCount > 1

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -538,8 +538,8 @@ export async function adminDeleteUser(userId: string) {
 
   await prisma.$transaction(async (tx) => {
     // Null out nullable User FK references (KEPT tables only).
-    await tx.maintenanceRecord.updateMany({ where: { reportedById: userId }, data: { reportedById: null } });
-    await tx.maintenanceRecord.updateMany({ where: { assignedToId: userId }, data: { assignedToId: null } });
+    // maintenanceRecord is Convex-only now — its reportedById/assignedToId FK
+    // scrub runs post-commit via api.maintenanceRecords.scrubUserRefs below.
     await tx.project.updateMany({ where: { projectManagerId: userId }, data: { projectManagerId: null } });
 
     // Delete records with non-nullable User FKs (KEPT tables only).
@@ -579,6 +579,16 @@ export async function adminDeleteUser(userId: string) {
   }
   for (const item of testTagRecordsToRemove) {
     await convexForDelete.mutation(api.testTagRecords.remove, { id: item.id });
+  }
+
+  // maintenanceRecord is Convex-only: clear this user's reportedById/assignedToId
+  // FK references across every org (GDPR sweep is cross-org). Replaces the two
+  // dead Prisma `maintenanceRecord.updateMany` calls removed from the tx above.
+  for (const org of allOrgsForSweep) {
+    await convexForDelete.mutation(api.maintenanceRecords.scrubUserRefs, {
+      organizationId: org.id,
+      userId,
+    });
   }
 
   const theOrg = await getTheOrg();

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -19,6 +19,7 @@ import {
   getWooCommerceOrderLogsPage,
   getFailedOrderLogById,
 } from "@/lib/woocommerce-order-logs-read";
+import { getWooCommerceIntegrationByOrg } from "@/lib/woocommerce-integration-read";
 import {
   wooCommerceIntegrationSchema,
   type WooCommerceIntegrationFormValues,
@@ -29,17 +30,19 @@ import {
 // with no Prisma row and no mirror; reads go through
 // src/lib/woocommerce-order-logs-read.ts. The table has NO @@unique constraint and no
 // inbound FK — webhook idempotency (dedup by wooOrderId + COMPLETED) is replicated as a
-// Convex read-before-write in the webhook route. wooCommerceIntegration stays on Prisma
-// (not part of this bucket). The Prisma `woocommerce_order_log` table is left unwritten
-// until Phase C drops it.
+// Convex read-before-write in the webhook route. The Prisma `woocommerce_order_log`
+// table is left unwritten until Phase C drops it.
+//
+// wooCommerceIntegration is ALSO Convex-only now (Phase C config-leftover inversion):
+// one-per-org row written via api.wooCommerceIntegrations.* (createId() + Date.now()),
+// read via src/lib/woocommerce-integration-read.ts. Clears (empty optional strings) go
+// through the custom api.wooCommerceIntegrations.patchWooCommerceIntegration mutation.
 
 // ─── Server Actions (UI) ────────────────────────────────────────────────────
 
 export async function getWooCommerceIntegration() {
   const { organizationId } = await requirePermission("orgSettings", "read");
-  const integration = await prisma.wooCommerceIntegration.findUnique({
-    where: { organizationId },
-  });
+  const integration = await getWooCommerceIntegrationByOrg(organizationId);
   return integration ? serialize(integration) : null;
 }
 
@@ -47,39 +50,73 @@ export async function updateWooCommerceIntegration(data: WooCommerceIntegrationF
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
   const parsed = wooCommerceIntegrationSchema.parse(data);
 
-  const existing = await prisma.wooCommerceIntegration.findUnique({
-    where: { organizationId },
-  });
+  const convex = await getConvexClient();
+  const existing = await getWooCommerceIntegrationByOrg(organizationId);
 
-  const result = await prisma.wooCommerceIntegration.upsert({
-    where: { organizationId },
-    create: {
+  // Nullable optional-string fields: empty → cleared/omitted.
+  const nullableKeys = [
+    "storeUrl",
+    "customFieldKey",
+    "rentalStartKey",
+    "rentalEndKey",
+    "eventStartKey",
+    "deliveryAddressKey",
+    "notesKey",
+    "locationMetaKey",
+    "defaultLocationId",
+  ] as const;
+
+  const now = Date.now();
+  if (existing) {
+    // Build a `set` of present values + a `clear` list of emptied nullable fields.
+    const set: Record<string, unknown> = {
+      isEnabled: parsed.isEnabled,
+      productMatchField: parsed.productMatchField,
+      dateFormat: parsed.dateFormat,
+      defaultProjectType: parsed.defaultProjectType,
+      autoConfirmEnquiry: parsed.autoConfirmEnquiry,
+      notifyUserIds: parsed.notifyUserIds,
+      updatedAt: now,
+    };
+    const clear: string[] = [];
+    for (const k of nullableKeys) {
+      const value = parsed[k];
+      if (value) set[k] = value;
+      else clear.push(k);
+    }
+    await convex.mutation(api.wooCommerceIntegrations.patchWooCommerceIntegration, {
+      id: existing.id,
+      set,
+      clear,
+    });
+  } else {
+    const id = createId();
+    await convex.mutation(api.wooCommerceIntegrations.create, {
+      id,
       organizationId,
-      webhookSecret: existing?.webhookSecret || generateSecret(),
-      ...parsed,
-      storeUrl: parsed.storeUrl || null,
-      customFieldKey: parsed.customFieldKey || null,
-      rentalStartKey: parsed.rentalStartKey || null,
-      rentalEndKey: parsed.rentalEndKey || null,
-      eventStartKey: parsed.eventStartKey || null,
-      deliveryAddressKey: parsed.deliveryAddressKey || null,
-      notesKey: parsed.notesKey || null,
-      locationMetaKey: parsed.locationMetaKey || null,
-      defaultLocationId: parsed.defaultLocationId || null,
-    },
-    update: {
-      ...parsed,
-      storeUrl: parsed.storeUrl || null,
-      customFieldKey: parsed.customFieldKey || null,
-      rentalStartKey: parsed.rentalStartKey || null,
-      rentalEndKey: parsed.rentalEndKey || null,
-      eventStartKey: parsed.eventStartKey || null,
-      deliveryAddressKey: parsed.deliveryAddressKey || null,
-      notesKey: parsed.notesKey || null,
-      locationMetaKey: parsed.locationMetaKey || null,
-      defaultLocationId: parsed.defaultLocationId || null,
-    },
-  });
+      webhookSecret: generateSecret(),
+      isEnabled: parsed.isEnabled,
+      productMatchField: parsed.productMatchField,
+      dateFormat: parsed.dateFormat,
+      defaultProjectType: parsed.defaultProjectType,
+      autoConfirmEnquiry: parsed.autoConfirmEnquiry,
+      notifyUserIds: parsed.notifyUserIds,
+      storeUrl: parsed.storeUrl || undefined,
+      customFieldKey: parsed.customFieldKey || undefined,
+      rentalStartKey: parsed.rentalStartKey || undefined,
+      rentalEndKey: parsed.rentalEndKey || undefined,
+      eventStartKey: parsed.eventStartKey || undefined,
+      deliveryAddressKey: parsed.deliveryAddressKey || undefined,
+      notesKey: parsed.notesKey || undefined,
+      locationMetaKey: parsed.locationMetaKey || undefined,
+      defaultLocationId: parsed.defaultLocationId || undefined,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const result = await getWooCommerceIntegrationByOrg(organizationId);
+  if (!result) throw new Error("Failed to load WooCommerce integration after save");
 
   await logActivity({
     organizationId,
@@ -99,16 +136,28 @@ export async function regenerateWebhookSecret() {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
   const secret = generateSecret();
-  const result = await prisma.wooCommerceIntegration.upsert({
-    where: { organizationId },
-    create: {
+  const convex = await getConvexClient();
+  const existing = await getWooCommerceIntegrationByOrg(organizationId);
+
+  let entityId: string;
+  if (existing) {
+    await convex.mutation(api.wooCommerceIntegrations.update, {
+      id: existing.id,
+      patch: { webhookSecret: secret, updatedAt: Date.now() },
+    });
+    entityId = existing.id;
+  } else {
+    const id = createId();
+    const now = Date.now();
+    await convex.mutation(api.wooCommerceIntegrations.create, {
+      id,
       organizationId,
       webhookSecret: secret,
-    },
-    update: {
-      webhookSecret: secret,
-    },
-  });
+      createdAt: now,
+      updatedAt: now,
+    });
+    entityId = id;
+  }
 
   await logActivity({
     organizationId,
@@ -116,7 +165,7 @@ export async function regenerateWebhookSecret() {
     userName,
     action: "UPDATE",
     entityType: "wooCommerceIntegration",
-    entityId: result.id,
+    entityId,
     entityName: "WooCommerce Integration",
     summary: "Regenerated WooCommerce webhook secret",
   });
@@ -150,9 +199,7 @@ export async function retryFailedOrder(logId: string) {
   const log = await getFailedOrderLogById(organizationId, logId);
   if (!log) throw new Error("Order log not found or not in FAILED status");
 
-  const integration = await prisma.wooCommerceIntegration.findUnique({
-    where: { organizationId },
-  });
+  const integration = await getWooCommerceIntegrationByOrg(organizationId);
   if (!integration?.isEnabled) throw new Error("Integration not enabled");
 
   // Re-process the stored payload
@@ -162,10 +209,7 @@ export async function retryFailedOrder(logId: string) {
 export async function getLastPayloadMetaKeys() {
   const { organizationId } = await requirePermission("orgSettings", "read");
 
-  const integration = await prisma.wooCommerceIntegration.findUnique({
-    where: { organizationId },
-    select: { lastPayload: true },
-  });
+  const integration = await getWooCommerceIntegrationByOrg(organizationId);
 
   if (!integration?.lastPayload) return null;
 


### PR DESCRIPTION
The final non-keystone sweep. A scoping pass found the scary clusters were **already done** — the model cluster (model + modelMedia + modelCheckItem + modelBulkAccessory + supplierModelRate), serviceTemplate, brandTemplate, groupTemplate parent, savedTableView, notifications sub-tables, wooCommerceOrderLog are all already Convex-only. `savedReport` doesn't exist; `sectionPreset` is orphaned. So this PR is **bug-fixes on already-inverted tables + three small inversions.**

## Bug-fixes (stale reads on Convex-only tables)
- **group-templates** — `getGroupTemplates` did `include: { model, kit }` on `groupTemplateItem`, but there's **no `model` relation** (FK dropped) → Prisma **threw at runtime** (list surface broken); `kit` returned null. `applyGroupTemplate` had the same kit bug (silently dropped kit items). Both now resolve via `getModelMap` + `getKitMap`.
- **documentTemplate PDF** — `generate-pdf.ts` read Prisma while UI/writes are Convex-only (split-brain) → `document-template-read`.
- **maintenanceRecord** — 5 stale reads (calendar feed, overdue notification + email, dashboard, kit-detail) + the user-delete FK-scrub (`site-admin`) → Convex (`getMaintenanceRecordsByOrg` + new `maintenanceRecords.scrubUserRefs`).

## Write-inversions
- **checkItem** — Prisma-first + inline mirror → Convex-only (`patchCheckItem` for clear-to-null); mirror deleted. Already dual-written → no backfill.
- **wooCommerceIntegration** — **pure-Prisma → Convex-only hard cutover.** New read helper; upserts → read-then-update-or-create; webhook → Convex. **Added the missing `webhookSecret` field** to the Convex schema (the webhook HMAC check needs it).
- **notificationEmailLog** — **pure-Prisma → Convex-only** (dedup read, create, sentAt-prune loop).

## ⚠️ Prod backfills (these two tables were never dual-written — Convex is empty)
Run after merge / on deploy:
- `scripts/convex-backfill-woocommerce-integration.ts` — **required** (else integrations lose config + webhookSecret)
- `scripts/convex-backfill-notification-email-log.ts` — optional (avoids a one-time duplicate-email burst)

## Validation
- `npm run build` exit 0, 0 lint errors, **2431 tests pass**.
- **Live dev-Convex exercise 8/8:** woo create + webhookSecret round-trip + patch set/CLEAR (secret preserved), checkItem create + patch set/CLEAR + remove, emailLog create/list/prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)