### PR TITLE
Phase C teardown (1/2): final read-cleanup — app fully Convex-only

### DIFF
--- a/convex/crewMembers.ts
+++ b/convex/crewMembers.ts
@@ -37,6 +37,20 @@ export const getById = query({
   },
 });
 
+/**
+ * Lookup a crew member by their iCal feed token (the public-calendar bearer).
+ * Service-only — the token IS the auth. No index (icalToken is rare + nullable),
+ * so this scans + filters; a calendar feed request is infrequent.
+ */
+export const getByIcalToken = query({
+  args: { icalToken: v.string() },
+  handler: async (ctx, { icalToken }) => {
+    await requireService(ctx);
+    const docs = await ctx.db.query("crewMembers").collect();
+    return docs.find((d) => d.icalToken === icalToken) ?? null;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/fileUploads.ts
+++ b/convex/fileUploads.ts
@@ -31,6 +31,20 @@ export const getById = query({
   },
 });
 
+/**
+ * Lookup a file by its proxy `thumbnailUrl` (the data-URI fallback in
+ * src/lib/storage.ts). Service-only, cross-org (the caller has no orgId in that
+ * path). No index on thumbnailUrl (rare fallback), so this scans + filters.
+ */
+export const getByThumbnailUrl = query({
+  args: { thumbnailUrl: v.string() },
+  handler: async (ctx, { thumbnailUrl }) => {
+    await requireService(ctx);
+    const docs = await ctx.db.query("fileUploads").collect();
+    return docs.find((d) => d.thumbnailUrl === thumbnailUrl) ?? null;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/prisma/migrations/20260626000000_drop_group_template_item_kit_fk_constraint/migration.sql
+++ b/prisma/migrations/20260626000000_drop_group_template_item_kit_fk_constraint/migration.sql
@@ -1,0 +1,9 @@
+-- Drop the missed group_template_item.kitId -> kit FK constraint.
+--
+-- Kit was inverted to Convex-only (Phase C keystone). The other group_template_item
+-- FKs were dropped earlier (templateId in 20260617131400, modelId in 20260617131200),
+-- but kitId was missed — its constraint is still live from 20260415070000. Left in
+-- place, `DROP TABLE "kit" CASCADE` (Stage 4 teardown) would silently drop it and
+-- orphan group_template_item.kitId values. kitId now becomes a plain external id
+-- holding the Convex cuid (matching templateId/modelId). Column + index stay.
+ALTER TABLE "group_template_item" DROP CONSTRAINT IF EXISTS "group_template_item_kitId_fkey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -946,7 +946,6 @@ model Kit {
   media              KitMedia[]
   kitCheckItems      KitCheckItem[]
   checkRecords       CheckRecord[]
-  groupTemplateItems GroupTemplateItem[]
 
   @@unique([organizationId, assetTag])
   @@index([organizationId])
@@ -1705,8 +1704,7 @@ model GroupTemplateItem {
   organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   templateId     String // references a Convex groupTemplates doc; FK dropped Phase B
   modelId        String? // references a Convex models doc; FK dropped Phase B
-  kitId          String?
-  kit            Kit?          @relation(fields: [kitId], references: [id], onDelete: Cascade)
+  kitId          String? // references a Convex kits doc; FK dropped Phase C
   quantity       Int           @default(1)
   sortOrder      Int           @default(0)
 

--- a/src/app/api/crew/calendar/[token]/route.ts
+++ b/src/app/api/crew/calendar/[token]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../../../../../convex/_generated/api";
 import {
   generateVCalendar,
   buildDateTime,
@@ -7,6 +9,9 @@ import {
 } from "@/lib/ical";
 import type { OrgSettings } from "@/server/settings";
 import { getLocationMap } from "@/lib/locations-read";
+import { getProjectById } from "@/lib/projects-read";
+import { getCrewRoleMap } from "@/lib/crew-read";
+import { getShiftsByAssignmentIds } from "@/lib/crew-scheduling-read";
 
 /** Read the org's configured IANA timezone (default Australia/Sydney). */
 async function getOrgTimezone(organizationId: string): Promise<string> {
@@ -38,44 +43,84 @@ export async function GET(
   // Strip .ics extension if present
   const cleanToken = token.replace(/\.ics$/, "");
 
-  const member = await prisma.crewMember.findUnique({
-    where: { icalToken: cleanToken },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      icalEnabled: true,
-      organizationId: true,
-      assignments: {
-        where: {
-          status: { in: ["CONFIRMED", "ACCEPTED"] },
-        },
-        include: {
-          crewRole: { select: { name: true } },
-          project: {
-            select: {
-              name: true,
-              projectNumber: true,
-              locationId: true,
-              siteContactName: true,
-              siteContactPhone: true,
-            },
-          },
-          shifts: {
-            where: { status: { not: "CANCELLED" } },
-            orderBy: { date: "asc" },
-          },
-        },
-      },
-    },
+  // crew_member is Convex-only — look up by the iCal feed token (service-only;
+  // the token IS the auth). The nested assignments / role / project / shifts
+  // joins are resolved from Convex below instead of a Prisma `include`.
+  const convex = await getConvexClient();
+  const memberDoc = await convex.query(api.crewMembers.getByIcalToken, {
+    icalToken: cleanToken,
   });
 
-  if (!member || !member.icalEnabled) {
+  if (!memberDoc || !(memberDoc.icalEnabled ?? false)) {
     return NextResponse.json(
       { error: "Calendar feed not found or disabled" },
       { status: 404 }
     );
   }
+
+  const organizationId = memberDoc.organizationId;
+
+  // The member's CONFIRMED/ACCEPTED assignments come from Convex (org list
+  // filtered to this member). crewRole + project resolve from Convex maps;
+  // shifts (non-CANCELLED, date asc) come from the by-assignment Convex query.
+  const [orgAssignments, roleMap] = await Promise.all([
+    convex.query(api.crewAssignments.list, { orgId: organizationId }),
+    getCrewRoleMap(organizationId),
+  ]);
+  const myRawAssignments = orgAssignments.filter(
+    (a) =>
+      a.crewMemberId === memberDoc.id &&
+      (a.status === "CONFIRMED" || a.status === "ACCEPTED"),
+  );
+  const shiftsAll = await getShiftsByAssignmentIds(myRawAssignments.map((a) => a.id));
+  const shiftsByAssignment = new Map<string, typeof shiftsAll>();
+  for (const s of shiftsAll) {
+    if (s.status === "CANCELLED") continue;
+    const arr = shiftsByAssignment.get(s.assignmentId);
+    if (arr) arr.push(s);
+    else shiftsByAssignment.set(s.assignmentId, [s]);
+  }
+  for (const arr of shiftsByAssignment.values()) {
+    arr.sort((x, y) => x.date.getTime() - y.date.getTime());
+  }
+
+  // Resolve each assignment's project (Convex) once, keyed by projectId.
+  const projectIds = [...new Set(myRawAssignments.map((a) => a.projectId))];
+  const projectEntries = await Promise.all(
+    projectIds.map(async (pid) => [pid, await getProjectById(pid)] as const),
+  );
+  const projectById = new Map(projectEntries);
+
+  const member = {
+    id: memberDoc.id,
+    firstName: memberDoc.firstName,
+    lastName: memberDoc.lastName,
+    organizationId,
+    assignments: myRawAssignments.flatMap((a) => {
+      const p = projectById.get(a.projectId);
+      if (!p) return [];
+      return [
+        {
+          id: a.id,
+          phase: a.phase ?? null,
+          notes: a.notes ?? null,
+          startDate: a.startDate != null ? new Date(a.startDate) : null,
+          startTime: a.startTime ?? null,
+          endDate: a.endDate != null ? new Date(a.endDate) : null,
+          endTime: a.endTime ?? null,
+          crewRole: a.crewRoleId ? { name: roleMap.get(a.crewRoleId)?.name ?? null } : null,
+          project: {
+            name: p.name,
+            projectNumber: p.projectNumber,
+            locationId: p.locationId ?? null,
+            siteContactName: p.siteContactName ?? null,
+            siteContactPhone: p.siteContactPhone ?? null,
+          },
+          shifts: shiftsByAssignment.get(a.id) ?? [],
+        },
+      ];
+    }),
+  };
 
   const tzid = await getOrgTimezone(member.organizationId);
   // Location FK was dropped (Phase B); resolve project locations from the Convex

--- a/src/app/api/crew/respond/[token]/route.ts
+++ b/src/app/api/crew/respond/[token]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../../../../../convex/_generated/api";
 import { getProjectById } from "@/lib/projects-read";
+import { getCrewMemberById, getCrewRoleById } from "@/lib/crew-read";
 
 /**
  * GET /api/crew/respond/[token]?action=accept|decline
@@ -39,17 +39,11 @@ export async function GET(
     );
   }
 
-  // Resolve the project (Convex) + crew member / role (still-Prisma) for display.
+  // Resolve the project + crew member / role (all Convex-only) for display.
   const project = await getProjectById(assignment.projectId);
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id: assignment.crewMemberId },
-    select: { firstName: true, lastName: true },
-  });
+  const crewMember = await getCrewMemberById(assignment.crewMemberId);
   const crewRole = assignment.crewRoleId
-    ? await prisma.crewRole.findUnique({
-        where: { id: assignment.crewRoleId },
-        select: { name: true },
-      })
+    ? await getCrewRoleById(assignment.crewRoleId)
     : null;
   const projectDisplayName = project?.name ?? "this project";
 

--- a/src/app/api/documents/call-sheet/[projectId]/route.tsx
+++ b/src/app/api/documents/call-sheet/[projectId]/route.tsx
@@ -46,13 +46,12 @@ export async function GET(
     }
   }
 
-  // Validate crewMemberId if provided
+  // Validate crewMemberId if provided. crew_assignment is Convex-only — list the
+  // project's assignments and check one is for this member.
   if (crewMemberId) {
-    const { prisma } = await import("@/lib/prisma");
-    const assignment = await prisma.crewAssignment.findFirst({
-      where: { projectId, organizationId, crewMemberId },
-      select: { id: true },
-    });
+    const { getAssignmentsByProject } = await import("@/lib/crew-scheduling-read");
+    const projectAssignments = await getAssignmentsByProject(projectId, organizationId);
+    const assignment = projectAssignments.find((a) => a.crewMemberId === crewMemberId);
     if (!assignment) {
       return NextResponse.json(
         { error: "Crew member not found on this project" },

--- a/src/app/api/documents/timeline/[projectId]/route.tsx
+++ b/src/app/api/documents/timeline/[projectId]/route.tsx
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generate } from "@pdfme/generator";
 import { requireOrganization } from "@/lib/auth-server";
-import { prisma } from "@/lib/prisma";
+import { getProjectServicesFromConvex } from "@/lib/project-service-read";
 import { buildDocumentData } from "@/lib/pdfme/build-document-data";
 import {
   buildTimelineInputs,
@@ -47,22 +47,12 @@ export async function GET(
     // Build standard document data (project, org, branding, etc.)
     const data = await buildDocumentData(projectId, organizationId, "quote");
 
-    // Fetch services with crew assignments
-    const services = await prisma.projectService.findMany({
-      where: { organizationId, projectId, status: { not: "CANCELLED" } },
-      include: {
-        crewAssignments: {
-          where: { status: { notIn: ["CANCELLED", "DECLINED"] } },
-          select: {
-            crewMember: {
-              select: { firstName: true, lastName: true },
-            },
-            status: true,
-          },
-        },
-      },
-      orderBy: [{ date: "asc" }, { sortOrder: "asc" }],
-    });
+    // Fetch services with crew assignments. project_service is Convex-only —
+    // read via the helper (which attaches crewRole + crewAssignments and orders
+    // by [date asc, sortOrder asc]), then replicate the dropped Prisma filters:
+    // skip CANCELLED services and CANCELLED/DECLINED assignments.
+    const allServices = await getProjectServicesFromConvex(organizationId, projectId);
+    const services = allServices.filter((s) => s.status !== "CANCELLED");
 
     // Map to timeline service shape
     const timelineServices: TimelineService[] = services.map((s) => ({
@@ -75,7 +65,15 @@ export async function GET(
       endTime: s.endTime,
       address: s.address,
       notes: s.notes,
-      crewAssignments: s.crewAssignments,
+      crewAssignments: s.crewAssignments
+        .filter((ca) => ca.status !== "CANCELLED" && ca.status !== "DECLINED" && ca.crewMember != null)
+        .map((ca) => ({
+          crewMember: {
+            firstName: ca.crewMember!.firstName,
+            lastName: ca.crewMember!.lastName,
+          },
+          status: ca.status ?? "",
+        })),
       lineTotal: s.lineTotal ? Number(s.lineTotal) : null,
       costTotal: s.costTotal ? Number(s.costTotal) : null,
     }));

--- a/src/lib/crew-read.ts
+++ b/src/lib/crew-read.ts
@@ -45,6 +45,10 @@ export async function getCrewRolesByOrg(orgId: string): Promise<ConvexCrewRole[]
   return await (await getConvexClient()).query(api.crewRoles.list, { orgId });
 }
 
+export async function getCrewRoleById(id: string): Promise<ConvexCrewRole | null> {
+  return await (await getConvexClient()).query(api.crewRoles.getById, { id });
+}
+
 export async function getCrewSkillsByOrg(orgId: string): Promise<ConvexCrewSkill[]> {
   return await (await getConvexClient()).query(api.crewSkills.list, { orgId });
 }

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -20,6 +20,7 @@ import {
   EXCLUDED_ASSIGNMENT_STATUSES,
 } from "@/lib/crew-scheduling-read";
 import { getCrewMemberMap, getCrewRoleMap } from "@/lib/crew-read";
+import { getSubHiresByProject, getSubHireGroups } from "@/lib/sub-hire-read";
 import { computeOverbookedStatus } from "@/lib/availability";
 import { getFileAsDataUri } from "@/lib/storage";
 import { formatDate } from "./plugins/helpers";
@@ -117,21 +118,21 @@ export async function buildDocumentData(
 
   const docColor = branding?.documentColor || branding?.primaryColor || DEFAULT_DOC_COLOR;
 
-  // Project scalars are dual-written to Convex → read the Prisma-row-shaped doc.
-  // location + the line-item tree + categories live in Convex (attached below /
-  // reconstructed via buildDocumentLineItemData). crewAssignments are Convex-only
-  // (re-sourced below for call sheets). Sub-hires + their groups are still Prisma
-  // (sub_hire is a Stage-2 leaf) — read here by projectId. SubHireGroup is nested
-  // under SubHire; supplier is dual-written to Convex (attached below, not joined).
-  const [projectScalars, subHireRows] = await Promise.all([
+  // Project scalars + sub-hires + their groups are all Convex-only now. location +
+  // the line-item tree + categories live in Convex (attached below / reconstructed
+  // via buildDocumentLineItemData). crewAssignments are Convex-only (re-sourced
+  // below for call sheets). SubHireGroup is nested under SubHire (sortOrder asc);
+  // supplier is in Convex (attached below, not joined).
+  const [projectScalars, subHireBase] = await Promise.all([
     getProjectByIdMapped(projectId, organizationId),
-    prisma.subHire.findMany({
-      where: { projectId, organizationId },
-      include: {
-        groups: { orderBy: { sortOrder: "asc" } },
-      },
-    }),
+    getSubHiresByProject(projectId, organizationId),
   ]);
+  const subHireRows = await Promise.all(
+    subHireBase.map(async (sh) => ({
+      ...sh,
+      groups: await getSubHireGroups(sh.id),
+    })),
+  );
 
   if (!projectScalars) {
     throw new Error(`Project ${projectId} not found`);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -141,18 +141,20 @@ export async function getFileAsDataUri(proxyUrl: string): Promise<string | null>
       }
     }
 
-    // Strategy 2: look up the FileUpload record by thumbnailUrl
+    // Strategy 2: look up the FileUpload record by thumbnailUrl. file_upload is
+    // Convex-only — query by thumbnailUrl via the service token (no orgId in this
+    // path, so the Convex query is cross-org, mirroring the old global findFirst).
     try {
-      const { prisma } = await import("@/lib/prisma");
-      const record = await prisma.fileUpload.findFirst({
-        where: { thumbnailUrl: proxyUrl },
-        select: { storageKey: true },
+      const { getConvexClient } = await import("@/lib/convex-client");
+      const { api } = await import("../../convex/_generated/api");
+      const record = await (await getConvexClient()).query(api.fileUploads.getByThumbnailUrl, {
+        thumbnailUrl: proxyUrl,
       });
       if (record) {
         return fetchS3AsDataUri(record.storageKey);
       }
     } catch {
-      // DB lookup failed, give up
+      // Lookup failed, give up
     }
   }
 

--- a/src/lib/sub-hire-read.ts
+++ b/src/lib/sub-hire-read.ts
@@ -188,6 +188,13 @@ export async function getSubHireGroups(subHireId: string): Promise<SubHireGroupR
   return rows.map(mapSubHireGroup).sort((a, b) => a.sortOrder - b.sortOrder);
 }
 
+/** A single sub-hire group by cuid (null if missing). Not org-scoped on the Convex
+ *  side — resolve the parent sub-hire (getSubHireById) to verify org/project. */
+export async function getSubHireGroupById(id: string): Promise<SubHireGroupRow | null> {
+  const row = (await (await getConvexClient()).query(api.subHireGroups.getById, { id })) as RawGroup | null;
+  return row ? mapSubHireGroup(row) : null;
+}
+
 /** Item counts per sub-hire id (one round trip each) for the list `_count`. */
 export async function getSubHireItemCounts(subHireIds: string[]): Promise<Map<string, number>> {
   if (subHireIds.length === 0) return new Map();

--- a/src/server/brand-templates.ts
+++ b/src/server/brand-templates.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
+import { listDocumentTemplates } from "@/lib/document-template-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
@@ -243,24 +243,18 @@ export async function deleteBrandTemplate(id: string) {
   if (!template) throw new Error("Brand template not found");
 
   // Unlink any document templates pointing at this brand template. document_template
-  // is dual-written (Prisma + Convex mirror) and the PDF pipeline still reads it
-  // from Prisma, so the null must land in BOTH stores. Find the affected ids first
-  // so we can mirror each unlink to Convex.
-  const linked = await prisma.documentTemplate.findMany({
-    where: { brandTemplateId: id, organizationId },
-    select: { id: true },
-  });
+  // is Convex-only now — find the affected rows (org's templates filtered to this
+  // brandTemplateId) and clear `brandTemplateId` on each via the Convex mutation.
+  const linked = (await listDocumentTemplates(organizationId)).filter(
+    (dt) => dt.brandTemplateId === id,
+  );
   if (linked.length > 0) {
-    await prisma.documentTemplate.updateMany({
-      where: { brandTemplateId: id, organizationId },
-      data: { brandTemplateId: null },
-    });
     const convex = await getConvexClient();
     for (const dt of linked) {
-      // Clear brandTemplateId in the Convex documentTemplates mirror (matches the
-      // dropped FK's SetNull). The shared mirror helper (toConvexDoc) drops null
-      // keys, so it can't clear a field — call the mutation directly with an
-      // explicit `undefined`, which Convex `db.patch` treats as field removal.
+      // Clear brandTemplateId in Convex (matches the dropped FK's SetNull). The
+      // shared mirror helper (toConvexDoc) drops null keys, so it can't clear a
+      // field — call the mutation directly with an explicit `undefined`, which
+      // Convex `db.patch` treats as field removal.
       await convex.mutation(api.documentTemplates.update, {
         id: dt.id,
         patch: { brandTemplateId: undefined, updatedAt: Date.now() },

--- a/src/server/category-slots.ts
+++ b/src/server/category-slots.ts
@@ -27,7 +27,6 @@
  */
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/org-context";
 import { getProjectById } from "@/lib/projects-read";
 import { serialize } from "@/lib/serialize";
@@ -42,7 +41,7 @@ import { mapLineItemDoc, type MappedLineItem } from "@/lib/project-line-item-rea
 import { indexChildren, reconstructScope } from "@/lib/project-line-item-tree-read";
 import { getAssetsByOrg, getBulkAssetsByOrg, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
 import { getKitsByOrg, type ConvexKit } from "@/lib/kits-read";
-import { getSubHiresByProject, getSubHireGroups, getSubHireItems } from "@/lib/sub-hire-read";
+import { getSubHiresByProject, getSubHireGroups, getSubHireGroupById, getSubHireById, getSubHireItems } from "@/lib/sub-hire-read";
 import { recalculateProjectTotals } from "@/server/line-items";
 import {
   moveSubHireGroupToCategorySchema,
@@ -279,10 +278,15 @@ export async function moveSubHireGroupToCategory(
   );
   await requirePermission("subHire", "update");
 
-  const group = await prisma.subHireGroup.findFirst({
-    where: { id: parsed.groupId, subHire: { organizationId } },
-    include: { subHire: { select: { id: true, projectId: true } } },
-  });
+  // sub_hire_group / sub_hire are Convex-only — read the group, then its parent
+  // sub-hire (org-checked), reconstructing the `{ subHire: { id, projectId } }`
+  // shape the old Prisma include returned.
+  const groupRow = await getSubHireGroupById(parsed.groupId);
+  const parentSubHire = groupRow ? await getSubHireById(groupRow.subHireId) : null;
+  const group =
+    groupRow && parentSubHire && parentSubHire.organizationId === organizationId
+      ? { ...groupRow, subHire: { id: parentSubHire.id, projectId: parentSubHire.projectId } }
+      : null;
   if (!group) {
     throw new Error("Sub-hire group not found");
   }
@@ -483,15 +487,18 @@ export async function reorderMixedGroupsInCategory(
     }
   }
 
-  // Cross-org validation for sub-hire groups via Prisma (subHireGroup stays Prisma)
+  // Cross-org validation for sub-hire groups (Convex-only): every group must
+  // resolve to a sub-hire in this org + project.
   if (subHireGroupIds.length > 0) {
-    const shgCount = await prisma.subHireGroup.count({
-      where: {
-        id: { in: subHireGroupIds },
-        subHire: { organizationId, projectId: category.projectId },
-      },
-    });
-    if (shgCount !== subHireGroupIds.length) {
+    const checks = await Promise.all(
+      subHireGroupIds.map(async (gid) => {
+        const g = await getSubHireGroupById(gid);
+        if (!g) return false;
+        const sh = await getSubHireById(g.subHireId);
+        return !!sh && sh.organizationId === organizationId && sh.projectId === category.projectId;
+      }),
+    );
+    if (!checks.every(Boolean)) {
       throw new Error("One or more sub-hire groups do not belong to this project");
     }
   }
@@ -546,11 +553,18 @@ export async function createCategoryAndPlaceGroup(input: CreateCategoryAndPlaceG
     }
   }
   if (subHireGroupId) {
-    const shg = await prisma.subHireGroup.findFirst({
-      where: { id: subHireGroupId, subHire: { organizationId, projectId: parsed.projectId } },
-      select: { id: true },
-    });
-    if (!shg) throw new Error("Sub-hire group not found in this project");
+    // sub_hire_group / sub_hire are Convex-only — resolve the group's parent
+    // sub-hire and verify it's in this org + project.
+    const shg = await getSubHireGroupById(subHireGroupId);
+    const shgParent = shg ? await getSubHireById(shg.subHireId) : null;
+    if (
+      !shg ||
+      !shgParent ||
+      shgParent.organizationId !== organizationId ||
+      shgParent.projectId !== parsed.projectId
+    ) {
+      throw new Error("Sub-hire group not found in this project");
+    }
   }
 
   const categoryId = createId();

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/check-record-read";
 import { getModelCheckItemCountMap } from "@/lib/line-item-tree-read";
 import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
+import { getCheckItemById } from "@/lib/check-items-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import {
@@ -153,10 +154,8 @@ async function checkPredictiveMaintenance(
       // Get asset and check item details for the maintenance record
       const [asset, checkItem] = await Promise.all([
         getAssetById(assetId),
-        prisma.checkItem.findUnique({
-          where: { id: checkItemId },
-          select: { label: true },
-        }),
+        // check_item is Convex-only — read the org-scoped row (label only used).
+        getCheckItemById(organizationId, checkItemId),
       ]);
 
       if (!asset || !checkItem) continue;

--- a/src/server/crew-assignments.ts
+++ b/src/server/crew-assignments.ts
@@ -3,7 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
-import { getCrewMembersByOrg, getCrewRoleMap } from "@/lib/crew-read";
+import { getCrewMembersByOrg, getCrewRoleMap, getCrewMemberById, getCrewRoleById } from "@/lib/crew-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { createId } from "@paralleldrive/cuid2";
@@ -36,8 +36,8 @@ import {
 function resolveRate(
   rateOverride: number | null | undefined,
   rateType: string | null | undefined,
-  crewMember: { defaultDayRate: unknown; defaultHourlyRate: unknown },
-  crewRole: { defaultRate: unknown; rateType: string | null } | null,
+  crewMember: { defaultDayRate?: unknown; defaultHourlyRate?: unknown },
+  crewRole: { defaultRate?: unknown; rateType?: string | null } | null,
 ): { rate: number; rateType: string } {
   if (rateOverride != null && rateOverride > 0) {
     return { rate: rateOverride, rateType: rateType || "DAILY" };
@@ -161,19 +161,17 @@ export async function createAssignment(projectId: string, data: CrewAssignmentFo
   const project = await getProjectById(projectId);
   if (!project || project.organizationId !== organizationId) throw new Error("Project not found");
 
-  // Get crew member and role for rate cascade
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id: parsed.crewMemberId, organizationId },
-    select: { id: true, firstName: true, lastName: true, defaultDayRate: true, defaultHourlyRate: true },
-  });
+  // Get crew member and role for rate cascade (crew_member / crew_role are
+  // Convex-only — read the doc + verify org).
+  const crewMemberDoc = await getCrewMemberById(parsed.crewMemberId);
+  const crewMember = crewMemberDoc && crewMemberDoc.organizationId === organizationId ? crewMemberDoc : null;
   if (!crewMember) throw new Error("Crew member not found");
 
-  const crewRole = parsed.crewRoleId
-    ? await prisma.crewRole.findUnique({
-        where: { id: parsed.crewRoleId, organizationId },
-        select: { id: true, name: true, defaultRate: true, rateType: true },
-      })
-    : null;
+  const crewRoleDoc = parsed.crewRoleId ? await getCrewRoleById(parsed.crewRoleId) : null;
+  const crewRole =
+    crewRoleDoc && crewRoleDoc.organizationId === organizationId
+      ? { id: crewRoleDoc.id, name: crewRoleDoc.name, defaultRate: crewRoleDoc.defaultRate ?? null, rateType: crewRoleDoc.rateType ?? null }
+      : null;
 
   const startDate = parsed.startDate ? new Date(parsed.startDate as unknown as string) : null;
   const endDate = parsed.endDate ? new Date(parsed.endDate as unknown as string) : null;
@@ -260,22 +258,19 @@ export async function updateAssignment(id: string, data: CrewAssignmentFormValue
     throw new Error("Assignment not found");
   }
 
-  // crewMember (rate cascade inputs) + project (audit label) live in still-Prisma
-  // tables — read them directly; only the assignment WRITE inverts to Convex.
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id: existing.crewMemberId, organizationId },
-    select: { firstName: true, lastName: true, defaultDayRate: true, defaultHourlyRate: true },
-  });
+  // crewMember (rate cascade inputs) + project (audit label) are Convex-only —
+  // read the docs; the assignment WRITE inverts to Convex.
+  const crewMemberDoc = await getCrewMemberById(existing.crewMemberId);
+  const crewMember = crewMemberDoc && crewMemberDoc.organizationId === organizationId ? crewMemberDoc : null;
   if (!crewMember) throw new Error("Crew member not found");
 
   const project = await getProjectById(existing.projectId);
 
-  const crewRole = parsed.crewRoleId
-    ? await prisma.crewRole.findUnique({
-        where: { id: parsed.crewRoleId, organizationId },
-        select: { defaultRate: true, rateType: true },
-      })
-    : null;
+  const crewRoleDoc = parsed.crewRoleId ? await getCrewRoleById(parsed.crewRoleId) : null;
+  const crewRole =
+    crewRoleDoc && crewRoleDoc.organizationId === organizationId
+      ? { defaultRate: crewRoleDoc.defaultRate ?? null, rateType: crewRoleDoc.rateType ?? null }
+      : null;
 
   const startDate = parsed.startDate ? new Date(parsed.startDate as unknown as string) : null;
   const endDate = parsed.endDate ? new Date(parsed.endDate as unknown as string) : null;
@@ -361,10 +356,8 @@ export async function deleteAssignment(id: string) {
     throw new Error("Assignment not found");
   }
 
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id: assignment.crewMemberId, organizationId },
-    select: { firstName: true, lastName: true },
-  });
+  const crewMemberDoc = await getCrewMemberById(assignment.crewMemberId);
+  const crewMember = crewMemberDoc && crewMemberDoc.organizationId === organizationId ? crewMemberDoc : null;
   const project = await getProjectById(assignment.projectId);
 
   // Convex-only cascade delete: assignment + its shifts + its linked time entries.
@@ -394,10 +387,8 @@ export async function updateAssignmentStatus(id: string, status: string) {
     throw new Error("Assignment not found");
   }
 
-  const crewMember = await prisma.crewMember.findUnique({
-    where: { id: assignment.crewMemberId, organizationId },
-    select: { firstName: true, lastName: true },
-  });
+  const crewMemberDoc = await getCrewMemberById(assignment.crewMemberId);
+  const crewMember = crewMemberDoc && crewMemberDoc.organizationId === organizationId ? crewMemberDoc : null;
   if (!crewMember) throw new Error("Crew member not found");
   const project = await getProjectById(assignment.projectId);
 

--- a/src/server/csv.ts
+++ b/src/server/csv.ts
@@ -331,45 +331,37 @@ export async function importModelsCSV(csvContent: string): Promise<ImportResult>
       const existing = existingId ? modelById.get(existingId) ?? null : null;
 
       if (existing) {
-        const updated = await prisma.model.update({
-          where: { id: existing.id },
-          data: {
-            categoryId: data.categoryId ?? existing.categoryId,
-            sku: data.sku ?? existing.sku,
-            description: data.description ?? existing.description,
-            assetType: data.assetType,
-            defaultRentalPrice: data.defaultRentalPrice ?? existing.defaultRentalPrice,
-            dailyRate: data.dailyRate ?? existing.dailyRate,
-            weeklyRate: data.weeklyRate ?? existing.weeklyRate,
-            monthlyRate: data.monthlyRate ?? existing.monthlyRate,
-            defaultPurchasePrice: data.defaultPurchasePrice ?? existing.defaultPurchasePrice,
-            replacementCost: data.replacementCost ?? existing.replacementCost,
-            weight: data.weight ?? existing.weight,
-            powerDraw: data.powerDraw ?? existing.powerDraw,
-            requiresTestAndTag: data.requiresTestAndTag,
-            testAndTagIntervalDays: data.testAndTagIntervalDays ?? existing.testAndTagIntervalDays,
-            maintenanceIntervalDays: data.maintenanceIntervalDays ?? existing.maintenanceIntervalDays,
-            ...(data.tags.length > 0 ? { tags: data.tags } : {}),
-          },
-        });
-        await mirrorModelPatch(updated.id, updated);
+        // model is Convex-only — patch Convex directly (no Prisma write).
+        const patch = {
+          categoryId: data.categoryId ?? existing.categoryId,
+          sku: data.sku ?? existing.sku,
+          description: data.description ?? existing.description,
+          assetType: data.assetType,
+          defaultRentalPrice: data.defaultRentalPrice ?? existing.defaultRentalPrice,
+          dailyRate: data.dailyRate ?? existing.dailyRate,
+          weeklyRate: data.weeklyRate ?? existing.weeklyRate,
+          monthlyRate: data.monthlyRate ?? existing.monthlyRate,
+          defaultPurchasePrice: data.defaultPurchasePrice ?? existing.defaultPurchasePrice,
+          replacementCost: data.replacementCost ?? existing.replacementCost,
+          weight: data.weight ?? existing.weight,
+          powerDraw: data.powerDraw ?? existing.powerDraw,
+          requiresTestAndTag: data.requiresTestAndTag,
+          testAndTagIntervalDays: data.testAndTagIntervalDays ?? existing.testAndTagIntervalDays,
+          maintenanceIntervalDays: data.maintenanceIntervalDays ?? existing.maintenanceIntervalDays,
+          ...(data.tags.length > 0 ? { tags: data.tags } : {}),
+        };
+        await mirrorModelPatch(existing.id, patch);
         // Keep the dedup map current so later rows see the updated values.
-        modelById.set(updated.id, updated as unknown as ConvexModel);
+        modelById.set(existing.id, { ...existing, ...patch } as unknown as ConvexModel);
         result.updated++;
       } else {
-        const created = await prisma.model.create({
-          data: {
-            organizationId,
-            ...data,
-          },
-        });
-        await mirrorModelCreate(created);
+        // model is Convex-only — mint the cuid + create in Convex (no Prisma write).
+        const id = createId();
+        const row = { id, organizationId, ...data };
+        await mirrorModelCreate(row);
         // Register the new model so later rows in the same file dedup against it.
-        modelByDedupKey.set(
-          modelDedupKey(created.name, created.manufacturer, created.modelNumber),
-          created.id,
-        );
-        modelById.set(created.id, created as unknown as ConvexModel);
+        modelByDedupKey.set(modelDedupKey(data.name, data.manufacturer, data.modelNumber), id);
+        modelById.set(id, row as unknown as ConvexModel);
         result.created++;
       }
     } catch (e) {
@@ -612,11 +604,8 @@ export async function importModelRatesCSV(csvContent: string): Promise<ImportRes
         data.defaultRentalPrice = parsed.rates.dailyRate;
       }
 
-      const updated = await prisma.model.update({
-        where: { id: match.modelId, organizationId },
-        data,
-      });
-      await mirrorModelPatch(updated.id, updated);
+      // model is Convex-only — patch Convex directly (no Prisma write).
+      await mirrorModelPatch(match.modelId, data);
       result.updated++;
     } catch (e) {
       result.errors.push({ row: i + 1, message: e instanceof Error ? e.message : "Unknown error" });

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -106,20 +106,41 @@ export async function getKit(id: string) {
           return [{ ...mapLineItemDoc(r), project }];
         });
     })(),
-    // assetScanLog is still Prisma; scannedBy is a Better-Auth User (Prisma, kept).
-    // `project` is dual-written to Convex — resolve it from a Convex project map by
-    // projectId instead of a Prisma `include: { project: true }`.
+    // assetScanLog is Convex-only — read the org's scan logs, filter to this kit,
+    // replicate orderBy scannedAt desc + take 20. scannedBy is a Better-Auth User
+    // (Prisma, kept) batched by id; `project` resolves from a Convex project map.
     (async () => {
-      const logs = await prisma.assetScanLog.findMany({
-        where: { kitId: id },
-        take: 20,
-        orderBy: { scannedAt: "desc" },
-        include: { scannedBy: true },
+      const rawLogs = await (await getConvexClient()).query(api.assetScanLogs.list, {
+        orgId: organizationId,
       });
-      const logProjects = await getProjectsByOrg(organizationId);
+      const logs = rawLogs
+        .filter((l) => l.kitId === id)
+        .sort((a, b) => (b.scannedAt ?? 0) - (a.scannedAt ?? 0))
+        .slice(0, 20);
+
+      const userIds = [...new Set(logs.map((l) => l.scannedById).filter((u): u is string => !!u))];
+      const [logProjects, scanUsers] = await Promise.all([
+        getProjectsByOrg(organizationId),
+        userIds.length
+          ? prisma.user.findMany({ where: { id: { in: userIds } } })
+          : Promise.resolve([]),
+      ]);
       const logProjectMap = new Map(logProjects.map((p) => [p.id, p]));
+      const userMap = new Map(scanUsers.map((u) => [u.id, u]));
+
       return logs.map((l) => ({
-        ...l,
+        id: l.id,
+        organizationId: l.organizationId,
+        assetId: l.assetId ?? null,
+        bulkAssetId: l.bulkAssetId ?? null,
+        kitId: l.kitId ?? null,
+        projectId: l.projectId ?? null,
+        action: l.action,
+        scannedById: l.scannedById,
+        scannedAt: l.scannedAt != null ? new Date(l.scannedAt) : null,
+        notes: l.notes ?? null,
+        location: l.location ?? null,
+        scannedBy: userMap.get(l.scannedById) ?? null,
         project: l.projectId ? logProjectMap.get(l.projectId) ?? null : null,
       }));
     })(),

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -25,6 +25,7 @@ import { getActiveAssetsByModel, getActiveBulkAssetsByModel, getAssetById, getBu
 import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
 import { getKitById, getKitSerializedItemsByOrg, getKitBulkItemsByOrg } from "@/lib/kits-read";
 import { getSubHiresByProject } from "@/lib/sub-hire-read";
+import { getProjectServicesByOrg } from "@/lib/project-services-read";
 import { getLocationById } from "@/lib/locations-read";
 import { getAssignmentsByProject } from "@/lib/crew-scheduling-read";
 
@@ -1320,11 +1321,12 @@ export async function recalculateProjectTotals(projectId: string) {
 
   const equipmentRevenue = roundCurrency(groupRevenue + standaloneRevenue);
 
-  // 3. Service financials
-  const services = await prisma.projectService.findMany({
-    where: { projectId, status: { not: "CANCELLED" } },
-    select: { costTotal: true, lineTotal: true, showOnDocuments: true },
-  });
+  // 3. Service financials. project_service is Convex-only — read the org's
+  // services and filter to this project's non-CANCELLED rows in JS (replaces the
+  // Prisma findMany by projectId + status != CANCELLED).
+  const services = (await getProjectServicesByOrg(project.organizationId)).filter(
+    (s) => s.projectId === projectId && s.status !== "CANCELLED",
+  );
 
   // costTotal = what it costs us (all services)
   const serviceCostTotal = roundCurrency(
@@ -1334,7 +1336,7 @@ export async function recalculateProjectTotals(projectId: string) {
   // serviceRevenue = what we charge the client (only billable services shown on documents)
   const serviceRevenue = roundCurrency(
     services
-      .filter((s) => s.showOnDocuments)
+      .filter((s) => s.showOnDocuments === true)
       .reduce((sum, s) => sum + (s.lineTotal != null ? Number(s.lineTotal) : 0), 0)
   );
 

--- a/src/server/locations.ts
+++ b/src/server/locations.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
@@ -306,16 +305,14 @@ export async function deleteLocation(id: string) {
   const convex = await getConvexClient();
 
   // location_media Cascade re-implementation: the dropped Cascade FK auto-deleted
-  // a location's media rows on delete. location_media is still dual-written
-  // (Prisma rows + Convex mirror), so the cascade must land in BOTH stores —
-  // remove every locationMedia row for this location from Convex AND Prisma,
-  // then delete the location itself. (The old Cascade dropped only the join
-  // rows, leaving file_upload rows; this preserves that exact behaviour.)
+  // a location's media rows on delete. location_media is Convex-only now — remove
+  // every locationMedia row for this location from Convex, then delete the
+  // location itself. (The old Cascade dropped only the join rows, leaving
+  // file_upload rows; this preserves that exact behaviour.)
   const media = await getLocationMediaGallery(id);
   for (const m of media) {
     await convex.mutation(api.locationMedia.remove, { id: m.id });
   }
-  await prisma.locationMedia.deleteMany({ where: { locationId: id, organizationId } });
 
   await convex.mutation(api.locations.remove, { id });
 

--- a/src/server/project-groups.ts
+++ b/src/server/project-groups.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/org-context";
 import {
   projectGroupSchema,
@@ -16,6 +15,7 @@ import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import { roundCurrency } from "@/lib/formatters";
 import { recalculateProjectTotals } from "./line-items";
 import { getModelMap } from "@/lib/models-read";
+import { getProjectByIdMapped } from "@/lib/projects-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -30,10 +30,8 @@ export async function calculateSuggestedPrice(groupId: string): Promise<number> 
   const group = await client.query(api.projectGroups.getById, { id: groupId });
   if (!group) return 0;
 
-  const project = await prisma.project.findUnique({
-    where: { id: group.projectId },
-    select: { defaultRentalPeriod: true, defaultRentalQuantity: true },
-  });
+  // project is Convex-only — read the scalars (org-scoped via the group's org).
+  const project = await getProjectByIdMapped(group.projectId, group.organizationId);
 
   const allLineItems = await client.query(api.projectLineItems.listByProject, {
     projectId: group.projectId,

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import {
@@ -25,7 +24,7 @@ import {
 import { getProjectById } from "@/lib/projects-read";
 import { getProjectServicesByOrg } from "@/lib/project-services-read";
 import { getLocationById } from "@/lib/locations-read";
-import { getCrewRoleMap, getCrewMemberMap } from "@/lib/crew-read";
+import { getCrewRoleMap, getCrewMemberMap, getCrewMembersByOrg, getCrewMemberById } from "@/lib/crew-read";
 import {
   getAssignmentsByProject,
   compareAscNullsLast,
@@ -1230,24 +1229,34 @@ export async function getCrewSuggestionsForProject(projectId: string) {
     return serialize({ suggestedRoleIds: [], suggestedMembers: [] });
   }
 
-  // Get crew members with matching roles
-  const members = await prisma.crewMember.findMany({
-    where: {
-      organizationId,
-      isActive: true,
-      status: "ACTIVE",
-      crewRoleId: { in: suggestedRoleIds },
-    },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      image: true,
-      crewRole: { select: { id: true, name: true, color: true } },
-    },
-    orderBy: { lastName: "asc" },
-    take: 20,
-  });
+  // Get crew members with matching roles (crew_member / crew_role are Convex-only).
+  // Replicates the Prisma where (active + status ACTIVE + crewRoleId in roles),
+  // orderBy lastName asc, take 20, with the nested crewRole attached from the map.
+  const roleIdSet = new Set(suggestedRoleIds);
+  const [allMembers, roleMap] = await Promise.all([
+    getCrewMembersByOrg(organizationId),
+    getCrewRoleMap(organizationId),
+  ]);
+  const members = allMembers
+    .filter(
+      (m) =>
+        (m.isActive ?? true) &&
+        (m.status ?? "ACTIVE") === "ACTIVE" &&
+        m.crewRoleId != null &&
+        roleIdSet.has(m.crewRoleId),
+    )
+    .sort((a, b) => a.lastName.localeCompare(b.lastName))
+    .slice(0, 20)
+    .map((m) => {
+      const role = m.crewRoleId ? roleMap.get(m.crewRoleId) ?? null : null;
+      return {
+        id: m.id,
+        firstName: m.firstName,
+        lastName: m.lastName,
+        image: m.image ?? null,
+        crewRole: role ? { id: role.id, name: role.name, color: role.color ?? null } : null,
+      };
+    });
 
   return serialize({ suggestedRoleIds, suggestedMembers: members });
 }
@@ -1275,10 +1284,8 @@ export async function generateCrewMessage(
     siteContactPhone: convexProject.siteContactPhone ?? null,
   };
 
-  const member = await prisma.crewMember.findFirst({
-    where: { id: crewMemberId, organizationId },
-    select: { firstName: true, lastName: true, email: true, phone: true },
-  });
+  const memberDoc = await getCrewMemberById(crewMemberId);
+  const member = memberDoc && memberDoc.organizationId === organizationId ? memberDoc : null;
   if (!member) throw new Error("Crew member not found");
 
   // Assignments + their service / crewRole come from Convex (the assignment,
@@ -1350,8 +1357,8 @@ export async function generateCrewMessage(
   return serialize({
     message: lines.join("\n"),
     crewMemberName: `${member.firstName} ${member.lastName}`,
-    crewMemberPhone: member.phone,
-    crewMemberEmail: member.email,
+    crewMemberPhone: member.phone ?? null,
+    crewMemberEmail: member.email ?? null,
   });
 }
 

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -15,7 +15,7 @@ import { getModelCheckItemCountMap } from "@/lib/line-item-tree-read";
 import { buildWarehouseLineItems, buildPullSheetLineItems } from "@/lib/project-line-item-read";
 import { getKitById, getKitByAssetTag } from "@/lib/kits-read";
 import { getActiveAssetsByModel, getAssetById, getAssetByAssetTag, getAssetsByOrg, getBulkAssetsByOrg, getBulkAssetByAssetTag } from "@/lib/assets-read";
-import { getProjectById, getProjectsByOrg } from "@/lib/projects-read";
+import { getProjectById, getProjectByIdMapped, getProjectsByOrg } from "@/lib/projects-read";
 
 export async function getProjectForWarehouse(projectId: string) {
   const { organizationId } = await getOrgContext();
@@ -23,11 +23,9 @@ export async function getProjectForWarehouse(projectId: string) {
   // The whole EQUIPMENT line-item tree (lineItems → childLineItems → units, with
   // model/supplier/kit/asset/bulkAsset + check-item counts) is reconstructed from
   // the dual-written Convex tables in JS — see buildWarehouseLineItems (Phase A
-  // keystone consumer 2/4). Prisma here only supplies the project scalars; even
+  // keystone consumer 2/4). project is Convex-only too — read the scalars; even
   // location is attached from Convex below.
-  const project = await prisma.project.findUnique({
-    where: { id: projectId, organizationId },
-  });
+  const project = await getProjectByIdMapped(projectId, organizationId);
 
   if (!project) {
     throw new Error("Project not found");
@@ -721,10 +719,8 @@ export async function getProjectPullSheet(projectId: string) {
   // The EQUIPMENT line-item tree (lineItems → childLineItems, model/supplier/kit/
   // asset/bulkAsset + per-asset location graft, CANCELLED dropped, no units) is
   // reconstructed from the dual-written Convex tables — see buildPullSheetLineItems
-  // (Phase A keystone consumer 3/4). Prisma supplies only the project scalars.
-  const project = await prisma.project.findUnique({
-    where: { id: projectId, organizationId },
-  });
+  // (Phase A keystone consumer 3/4). project is Convex-only — read the scalars.
+  const project = await getProjectByIdMapped(projectId, organizationId);
 
   if (!project) {
     throw new Error("Project not found");


### PR DESCRIPTION
**Safe, reversible prerequisite for the schema teardown.** After this, nothing in `src/` reads or writes any migrated domain table via Prisma — only the kept set (Better Auth + customRole + activityLog + groupTemplateItem). No schema strip / DROP yet — that's PR 2/2.

## What changed
- **19 stale Prisma reads → Convex** (crew member/role/assignment, project, sub-hire group/head, project service, fileUpload, documentTemplate, checkItem, assetScanLog).
- **2 dead dual-write halves removed** (locationMedia deleteMany, documentTemplate updateMany).
- **csv.ts model import inverted** — 3 `prisma.model.create/update` dual-writes → Convex-only (a blind-spot miss caught by the grep gate).
- **Dropped the missed `group_template_item.kitId` FK** (+ removed the relation/back-relation) — skipped in Stage 1; would orphan + break `prisma generate` on the Kit drop.
- New Convex queries: `crewMembers.getByIcalToken`, `fileUploads.getByThumbnailUrl`.

## Validation
- `npm run build` exit 0, 0 lint errors, **2431 tests pass**. Grep-gated: zero real `prisma.<domain>` reads/writes in app code.

## Next (2/2 — irreversible)
Strip 71 models, hand-author `DROP TABLE … CASCADE`, delete ~57 scripts, rewrite the test mirror harness.