### PR TITLE
perf/security(0.5): index getByIcalToken — close cross-org scan DoS (#9)

### DIFF
--- a/convex/crewMembers.ts
+++ b/convex/crewMembers.ts
@@ -39,15 +39,21 @@ export const getById = query({
 
 /**
  * Lookup a crew member by their iCal feed token (the public-calendar bearer).
- * Service-only — the token IS the auth. No index (icalToken is rare + nullable),
- * so this scans + filters; a calendar feed request is infrequent.
+ * Service-only — the token IS the auth. Uses the `by_icalToken` index. The public
+ * calendar feed URL is externally reachable, so the previous full-table
+ * `.collect().find()` was a cross-org scan an attacker could trigger at will by
+ * hitting the feed endpoint with junk tokens (a scrape-able DoS). `.first()` (not
+ * `.unique()`) because `icalToken` is nullable and the index is non-unique — many
+ * rows share the `null` key, so `.unique()` would throw.
  */
 export const getByIcalToken = query({
   args: { icalToken: v.string() },
   handler: async (ctx, { icalToken }) => {
     await requireService(ctx);
-    const docs = await ctx.db.query("crewMembers").collect();
-    return docs.find((d) => d.icalToken === icalToken) ?? null;
+    return await ctx.db
+      .query("crewMembers")
+      .withIndex("by_icalToken", (q) => q.eq("icalToken", icalToken))
+      .first();
   },
 });
 

--- a/src/server/crew-ical-token.int.test.ts
+++ b/src/server/crew-ical-token.int.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration test for `api.crewMembers.getByIcalToken` (T-E from the perf
+ * remediation test plan). The query was changed from a full-table
+ * `.collect().find()` (a scrape-able cross-org DoS, since the public calendar
+ * feed URL is externally reachable) to an indexed `by_icalToken` lookup.
+ *
+ * Safety property: the indexed lookup must return the SAME result as the old
+ * scan — the matching member for a known token, null for an unknown token, and
+ * it must never match rows whose `icalToken` is null.
+ *
+ * Self-contained: creates its own org + crew members with unique cuid tokens and
+ * asserts only on its own rows, so it is robust against other data already
+ * present in the shared dev Convex deployment.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest, createOrgFixture } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+describe("crewMembers.getByIcalToken — indexed lookup", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("finds the member by token, returns null for unknown, ignores null-token rows", async () => {
+    const org = await createOrgFixture();
+    const convex = await getConvexClient();
+
+    const token = `ical_${createId()}`;
+    const targetId = createId();
+
+    // The member we expect to find by token.
+    await convex.mutation(api.crewMembers.createIfMissing, {
+      id: targetId,
+      organizationId: org.id,
+      firstName: "Ada",
+      lastName: "Lovelace",
+      icalToken: token,
+    });
+
+    // A member with NO icalToken (null key) — must never be matched by the index.
+    await convex.mutation(api.crewMembers.createIfMissing, {
+      id: createId(),
+      organizationId: org.id,
+      firstName: "Grace",
+      lastName: "Hopper",
+    });
+
+    const found = await convex.query(api.crewMembers.getByIcalToken, { icalToken: token });
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(targetId);
+    expect(found?.icalToken).toBe(token);
+
+    const missing = await convex.query(api.crewMembers.getByIcalToken, {
+      icalToken: `ical_${createId()}`,
+    });
+    expect(missing).toBeNull();
+  });
+});


### PR DESCRIPTION
## Phase 0.5 — iCal security hotfix (finding #9)

Pulled out of the perf roadmap and shipped on its own because it's a **security** issue, not just perf (both autoplan review voices flagged this).

### Problem
`convex/crewMembers.ts` `getByIcalToken` did a full-table `.collect().find()` over **every org's** crew members. The public calendar feed URL (`/api/crew/calendar/[token]`) is externally reachable, so anyone could trigger a whole-table cross-org scan by hitting it with junk tokens — a scrape-able DoS that also grows O(N) with total crew count.

### Fix
Use the **existing** `by_icalToken` index (schema.ts:1409) with `.first()`. `.first()` not `.unique()` because `icalToken` is nullable and the index is non-unique (many rows share the null key — `.unique()` would throw). Behavior-preserving: same result for a known token, null for unknown.

### Testing
- New self-contained integration test `src/server/crew-ical-token.int.test.ts` (own org + own fixtures): finds by token, null for unknown, **ignores null-token rows**. ✅ passes against the dev Convex deployment (`groovy-koala-475`).
- `pnpm exec convex dev --once` pushed clean.
- Codex code review: clean, no P1/P2 (confirmed behavior-preserving, `.first()` correct, index matches, no auth regression).

### Notes
- Behavior-preserving internal query optimization — no feature/API change.
- Heads-up (not from this PR): `category-slots.int.test.ts` has 5 pre-existing failures on `main` (likely shared-dev volatility) — flagging, not touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)