### PR TITLE
perf(1a): by_projectId_status index — range-scan checkInBulkTotals (#5)

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -827,6 +827,10 @@ export default defineSchema({
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
     .index("by_projectId", ["projectId"])
+    // Composite: range-scan a project's lines by status (e.g. CHECKED_OUT) instead
+    // of collecting ALL of a project's lines and JS-filtering. Used by
+    // warehouseOps.checkInBulkTotals (the hottest status-filtered read).
+    .index("by_projectId_status", ["projectId", "status"])
     .index("by_modelId", ["modelId"])
     .index("by_assetId", ["assetId"])
     .index("by_bulkAssetId", ["bulkAssetId"])

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -642,8 +642,14 @@ export const checkInBulkTotals = mutation({
     if (wanted.length === 0) return { returned: [] as Array<{ key: string; quantity: number; condition: string }> };
 
     const defaultLoc = await defaultLocationId(ctx, a.organizationId);
-    const rows = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
-      .filter((r) => r.organizationId === a.organizationId && r.status === "CHECKED_OUT" && !r.subHireGroupId && (!r.isKitChild || r.childKind === "ACCESSORY"))
+    // Range-scan only CHECKED_OUT lines for this project via the composite index
+    // (was: collect ALL of the project's lines then JS-filter on status). The
+    // remaining predicate (org / not-subhire-group / accessory-or-not-kit-child)
+    // stays a JS post-filter over the now-smaller candidate set.
+    const rows = (await ctx.db.query("projectLineItems")
+      .withIndex("by_projectId_status", (q) => q.eq("projectId", a.projectId).eq("status", "CHECKED_OUT"))
+      .collect())
+      .filter((r) => r.organizationId === a.organizationId && !r.subHireGroupId && (!r.isKitChild || r.childKind === "ACCESSORY"))
       .sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
 
     const toInput = async (child: typeof rows[number]): Promise<CheckInItem> => {


### PR DESCRIPTION
## Phase 1a — `by_projectId_status` index (finding #5)

`projectLineItems` had only `by_projectId`, so `checkInBulkTotals` collected **all** of a project's line items then JS-filtered `status === "CHECKED_OUT"`. Adds the composite index and range-scans only the checked-out rows.

### Scope correction (from the autoplan eng review)
The original plan claimed "5 sites." Both review voices verified only **one** (`checkInBulkTotals`, warehouseOps.ts:645) actually filters on status. The others (`quickAdd`/`ensureContainerOnProject` compute `max(sortOrder)`; `clearPrepContainer`/`syncContainerStatus` filter `prepContainer`) are not status filters — this index can't help them, so they're left alone. This PR fixes the one real site.

### Correctness
`status` is a closed enum (`v.optional(enums.LineItemStatus)`); the old JS `=== "CHECKED_OUT"` excluded `undefined`, and the index equality returns exactly those rows too. Non-status predicate (`org` / `!subHireGroupId` / accessory-or-not-kit-child) stays a JS post-filter over the smaller set. 18 indexes on the table after this (well under Convex's 32 cap).

### Testing
- `pnpm exec convex dev --once` built the index cleanly (`[+] projectLineItems.by_projectId_status`).
- `bulk-checkin.int.test.ts` (covers `checkInBulkTotals`): `5 passed | 6 failed`. **The 6 failures are pre-existing on `main`** — I verified by stashing this change and running the identical suite against the baseline schema: same `5 passed | 6 failed`. So this change is non-regressing; the 5 passing tests exercise `checkInBulkTotals` through the new index and pass.
- Codex review: clean (index equivalence, post-filter, field order all verified).

### ⚠️ Pre-existing failures to look at (NOT from this PR)
`bulk-checkin.int.test.ts` (6) and `category-slots.int.test.ts` (5) fail on `main` against the shared dev Convex deployment — looks environmental (shared-dev data state), but worth a look. I did not touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)