### PR TITLE
perf(1b-1): additive by-entity Convex queries for getKit/getAsset scoping (#2 groundwork)

### DIFF
--- a/convex/assetScanLogs.ts
+++ b/convex/assetScanLogs.ts
@@ -45,6 +45,23 @@ export const listByProject = query({
   },
 });
 
+/**
+ * Scan logs for ONE kit (via by_kitId), org-filtered. Replaces the org-wide
+ * assetScanLogs.list + JS `.filter(kitId === id)` in the getKit composite. Returns
+ * raw rows; ordering/limit (scannedAt desc, take 20) stays in the caller.
+ */
+export const listByKitId = query({
+  args: { orgId: v.string(), kitId: v.string() },
+  handler: async (ctx, { orgId, kitId }) => {
+    await requireService(ctx);
+    const rows = await ctx.db
+      .query("assetScanLogs")
+      .withIndex("by_kitId", (q) => q.eq("kitId", kitId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
 /** List scan logs for a single asset within an org. */
 export const listByOrgAndAsset = query({
   args: { orgId: v.string(), assetId: v.string() },

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -55,6 +55,28 @@ export const listByModel = query({
   },
 });
 
+/**
+ * Batch point-read assets by cuid, scoped to one org. Lets a detail composite
+ * (e.g. getKit) read only its member assets by id instead of collecting the whole
+ * org registry (getAssetsByOrg) and filtering in JS. Cross-org ids are dropped,
+ * never returned. Order is NOT guaranteed (callers key by id).
+ */
+export const listByIds = query({
+  args: { orgId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { orgId, ids }) => {
+    await requireOrgRead(ctx, orgId);
+    // Dedupe + cap: this is user-callable, so an unbounded id array would fan out
+    // arbitrarily many point-reads. 1000 is comfortable headroom over any real
+    // detail composite's member count.
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("assets.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/bulkAssets.ts
+++ b/convex/bulkAssets.ts
@@ -56,6 +56,24 @@ export const listByModel = query({
   },
 });
 
+/**
+ * Batch point-read bulk assets by cuid, scoped to one org — the bulk-asset
+ * counterpart of assets.listByIds, so a detail composite reads only its members
+ * instead of getBulkAssetsByOrg. Cross-org ids are dropped.
+ */
+export const listByIds = query({
+  args: { orgId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { orgId, ids }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("bulkAssets.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/kitBulkItems.ts
+++ b/convex/kitBulkItems.ts
@@ -31,6 +31,22 @@ export const getById = query({
   },
 });
 
+/**
+ * Kit bulk-item members for ONE kit (via by_kitId), org-filtered. Replaces
+ * getKitBulkItemsByOrg + JS `.filter(kitId === id)` in the getKit composite.
+ */
+export const listByKitId = query({
+  args: { orgId: v.string(), kitId: v.string() },
+  handler: async (ctx, { orgId, kitId }) => {
+    await requireService(ctx);
+    const rows = await ctx.db
+      .query("kitBulkItems")
+      .withIndex("by_kitId", (q) => q.eq("kitId", kitId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/kitSerializedItems.ts
+++ b/convex/kitSerializedItems.ts
@@ -31,6 +31,22 @@ export const getById = query({
   },
 });
 
+/**
+ * Kit serialized-item members for ONE kit (via by_kitId), org-filtered. Replaces
+ * getKitSerializedItemsByOrg + JS `.filter(kitId === id)` in the getKit composite.
+ */
+export const listByKitId = query({
+  args: { orgId: v.string(), kitId: v.string() },
+  handler: async (ctx, { orgId, kitId }) => {
+    await requireService(ctx);
+    const rows = await ctx.db
+      .query("kitSerializedItems")
+      .withIndex("by_kitId", (q) => q.eq("kitId", kitId))
+      .collect();
+    return rows.filter((r) => r.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -33,6 +33,25 @@ export const getById = query({
   },
 });
 
+/**
+ * Batch point-read projects by cuid, scoped to one org. Lets a detail composite
+ * attach projects to its line-items / scan-logs by id instead of collecting every
+ * project in the org (getProjectsByOrg) just to build a lookup map. Cross-org ids
+ * dropped. Does NOT exclude templates — callers that need that filter on the result.
+ */
+export const listByIds = query({
+  args: { orgId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { orgId, ids }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("projects.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/src/server/scoped-detail-queries.int.test.ts
+++ b/src/server/scoped-detail-queries.int.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration tests for the additive by-entity Convex queries that let the
+ * getKit/getAsset composites read entity-scoped data instead of whole-org
+ * `.collect()`s (finding #2 groundwork). These queries are NOT wired into the
+ * composites yet — this PR only ships them additively, so the safety property
+ * to lock in now is: each returns the right rows AND never leaks across orgs.
+ *
+ * Two representative shapes are covered (the other four are structurally
+ * identical): `listByIds` (batch point-read + org filter) via assets.listByIds,
+ * and `listByKitId` (by_kitId index + org filter) via kitSerializedItems.
+ * Self-contained: synthetic org/kit ids, asserts only on its own rows.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+describe("scoped by-entity Convex queries (#2 groundwork)", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("assets.listByIds returns requested in-org assets, drops cross-org + unknown ids", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const orgB = createId();
+    const modelId = createId();
+    const a1 = createId();
+    const a2 = createId();
+    const bForeign = createId();
+
+    for (const [id, org, tag] of [
+      [a1, orgA, "A1"],
+      [a2, orgA, "A2"],
+      [bForeign, orgB, "B1"],
+    ] as const) {
+      await convex.mutation(api.assets.createIfMissing, {
+        id,
+        organizationId: org,
+        modelId,
+        assetTag: tag,
+      });
+    }
+
+    const res = await convex.query(api.assets.listByIds, {
+      orgId: orgA,
+      ids: [a1, a2, bForeign, createId()],
+    });
+
+    expect(res.map((d) => d.id).sort()).toEqual([a1, a2].sort());
+    // cross-org id present in the request must NOT be returned
+    expect(res.some((d) => d.id === bForeign)).toBe(false);
+  });
+
+  it("kitSerializedItems.listByKitId returns only this kit's items, org-filtered", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const kitId = createId();
+    const otherKit = createId();
+    const addedById = createId();
+    const m1 = createId();
+    const m2 = createId();
+
+    await convex.mutation(api.kitSerializedItems.createIfMissing, {
+      id: m1,
+      organizationId: orgA,
+      kitId,
+      assetId: createId(),
+      addedById,
+    });
+    // same org, DIFFERENT kit — must not appear
+    await convex.mutation(api.kitSerializedItems.createIfMissing, {
+      id: m2,
+      organizationId: orgA,
+      kitId: otherKit,
+      assetId: createId(),
+      addedById,
+    });
+
+    const res = await convex.query(api.kitSerializedItems.listByKitId, {
+      orgId: orgA,
+      kitId,
+    });
+    expect(res.map((d) => d.id)).toEqual([m1]);
+
+    // same kitId but a DIFFERENT org must return nothing (no cross-org leak)
+    const otherOrg = await convex.query(api.kitSerializedItems.listByKitId, {
+      orgId: createId(),
+      kitId,
+    });
+    expect(otherOrg).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Phase 1b (part 1) — by-entity query groundwork for the keystone fix (#2)

The "smoking gun": `getKit` reads the **entire org asset registry + all projects + all bulk assets** to render one kit; `getAsset` reads all projects + all maintenance to render one asset. Fixing it needs entity-scoped queries that **don't exist yet**. Per the autoplan eng review ("ship the new queries additively first, then rewire"), **this PR adds only the queries** — nothing calls them. The composite rewire + parity tests (T-C/T-D) come in a follow-up PR.

### New queries (all org-scoped — cross-org rows dropped, never leaked)
- `assets.listByIds`, `bulkAssets.listByIds`, `projects.listByIds` — batch `by_cuid` point-reads, `requireOrgRead`. **Deduped + capped at 1000 ids** (user-callable, so the fan-out is bounded — addresses a Codex [P2]).
- `kitSerializedItems.listByKitId`, `kitBulkItems.listByKitId`, `assetScanLogs.listByKitId` — `by_kitId` index scans, `requireService` (matching those tables' service-only read convention).

### Testing
- `pnpm exec convex dev --once`: compiles + pushes clean.
- New self-contained integration test `scoped-detail-queries.int.test.ts` (synthetic orgs): both query shapes return the right rows **and exclude cross-org rows**. ✅ 2/2 pass against dev Convex.
- Codex review: verified the auth split (requireOrgRead vs requireService per table), the org post-filter blocks cross-org leaks, NonNullable filter sound, by_kitId indexes exist. Its one [P2] (unbounded fan-out) is fixed in this PR.

### Why additive-first
Zero call sites change, so this is a safe, reviewable foundation. The risky part (rewiring the hottest detail path + proving output parity) is isolated to the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)