### PR TITLE
perf(1b-2): scope getKit to the kit — kill whole-org detail read (#2) [stacked on #278]

### DIFF
--- a/src/server/kit-detail-scoping.int.test.ts
+++ b/src/server/kit-detail-scoping.int.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Parity / scoping test for the entity-scoped getKit rewrite (finding #2, T-C).
+ *
+ * getKit used to read the WHOLE org's serialized items / bulk items / asset
+ * registry / bulk assets / scan logs / projects and JS-filter to the kit. It now
+ * reads each scoped to the kit (listByKitId / listByIds). The property to lock in:
+ * the composite returns EXACTLY this kit's members (with their assets + models
+ * attached) and unrelated same-org data (another kit's members/assets) never
+ * leaks in — i.e. scoping changed which rows are read, not the output.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({ ctx: { organizationId: "", userId: "tester", userName: "Tester" } }));
+vi.mock("@/lib/org-context", () => ({
+  getOrgContext: async () => h.ctx,
+  requirePermission: async () => h.ctx,
+  requireOrganization: async () => ({ organizationId: h.ctx.organizationId, session: {} }),
+}));
+
+import { getKit } from "@/server/kits";
+
+describe("getKit — entity-scoped reads (no cross-kit leak)", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("returns ONLY this kit's members with assets+models attached; ignores other kits", async () => {
+    const orgA = createId();
+    h.ctx.organizationId = orgA;
+    const convex = await getConvexClient();
+    const modelId = createId();
+    const userId = createId();
+    await convex.mutation(api.models.createIfMissing, { id: modelId, organizationId: orgA, name: "M" });
+
+    // Our kit: one serialized member (asset a1) + one bulk member (bulkAsset b1).
+    const kitId = createId();
+    const a1 = createId();
+    const b1 = createId();
+    await convex.mutation(api.kits.createIfMissing, { id: kitId, organizationId: orgA, assetTag: "KIT-1", name: "Kit One" });
+    await convex.mutation(api.assets.createIfMissing, { id: a1, organizationId: orgA, modelId, assetTag: "A1" });
+    await convex.mutation(api.bulkAssets.createIfMissing, { id: b1, organizationId: orgA, modelId, assetTag: "B1" });
+    await convex.mutation(api.kitSerializedItems.createIfMissing, { id: createId(), organizationId: orgA, kitId, assetId: a1, addedById: userId });
+    await convex.mutation(api.kitBulkItems.createIfMissing, { id: createId(), organizationId: orgA, kitId, bulkAssetId: b1, quantity: 2, addedById: userId });
+
+    // Unrelated SAME-ORG kit with its own member + asset — must not leak in.
+    const otherKit = createId();
+    const aOther = createId();
+    await convex.mutation(api.kits.createIfMissing, { id: otherKit, organizationId: orgA, assetTag: "KIT-2", name: "Kit Two" });
+    await convex.mutation(api.assets.createIfMissing, { id: aOther, organizationId: orgA, modelId, assetTag: "A-OTHER" });
+    await convex.mutation(api.kitSerializedItems.createIfMissing, { id: createId(), organizationId: orgA, kitId: otherKit, assetId: aOther, addedById: userId });
+
+    const kit = (await getKit(kitId)) as {
+      serializedItems: Array<{ assetId: string; asset: { id: string; model: { id: string } | null } }>;
+      bulkItems: Array<{ bulkAssetId: string; bulkAsset: { id: string } }>;
+    } | null;
+
+    expect(kit).not.toBeNull();
+    // exactly our serialized member, with asset + model attached
+    expect(kit!.serializedItems).toHaveLength(1);
+    expect(kit!.serializedItems[0].assetId).toBe(a1);
+    expect(kit!.serializedItems[0].asset.id).toBe(a1);
+    expect(kit!.serializedItems[0].asset.model?.id).toBe(modelId);
+    // exactly our bulk member
+    expect(kit!.bulkItems).toHaveLength(1);
+    expect(kit!.bulkItems[0].bulkAssetId).toBe(b1);
+    // the other kit's asset must not appear among members
+    expect(kit!.serializedItems.some((s) => s.assetId === aOther)).toBe(false);
+  });
+});

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -21,7 +21,6 @@ import { getPrimaryPhotoMap, getKitMediaFromConvex, withResolvedFile } from "@/l
 import { getModelById, getModelMap } from "@/lib/models-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { getCategoryMap } from "@/lib/categories-read";
-import { getProjectsByOrg } from "@/lib/projects-read";
 import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import { getAssetById, getBulkAssetById, getAssetsByOrg, getBulkAssetsByOrg, filterAvailableAssetsForKit, filterAvailableBulkAssetsForKit, sortByAssetTagAsc, mapConvexAssetToPrisma, mapConvexBulkAssetToPrisma } from "@/lib/assets-read";
 import { getKitSerializedItemsByOrg, getKitBulkItemsByOrg, countKitMembers, getKitById, getKitByAssetTag, coerceKitDeletabilityRow, computeKitDeletability } from "@/lib/kits-read";
@@ -74,91 +73,104 @@ export async function getKit(id: string) {
   const kit = await getKitById(id);
   if (!kit || kit.organizationId !== organizationId) return serialize(null);
 
-  const [
-    allSerialized,
-    allBulk,
-    allAssets,
-    allBulkAssets,
-    modelMap,
-    lineItems,
-    scanLogs,
-    maintenanceRecords,
-    media,
-  ] = await Promise.all([
-    getKitSerializedItemsByOrg(organizationId),
-    getKitBulkItemsByOrg(organizationId),
-    getAssetsByOrg(organizationId),
-    getBulkAssetsByOrg(organizationId),
-    getModelMap(organizationId),
-    (async () => {
-      // projectLineItem is Convex-only now; attach project from the Convex map.
-      const [rows, projects] = await Promise.all([
-        (await getConvexClient()).query(api.projectLineItems.listByKitId, { kitId: id, orgId: organizationId }),
-        getProjectsByOrg(organizationId),
-      ]);
-      const projMap = new Map(projects.map((p) => [p.id, p]));
-      return rows
-        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
-        .slice(0, 20)
-        .flatMap((r) => {
-          const project = projMap.get(r.projectId);
-          if (!project) return [];
-          return [{ ...mapLineItemDoc(r), project }];
-        });
-    })(),
-    // assetScanLog is Convex-only — read the org's scan logs, filter to this kit,
-    // replicate orderBy scannedAt desc + take 20. scannedBy is a Better-Auth User
-    // (Prisma, kept) batched by id; `project` resolves from a Convex project map.
-    (async () => {
-      const rawLogs = await (await getConvexClient()).query(api.assetScanLogs.list, {
-        orgId: organizationId,
-      });
-      const logs = rawLogs
-        .filter((l) => l.kitId === id)
-        .sort((a, b) => (b.scannedAt ?? 0) - (a.scannedAt ?? 0))
-        .slice(0, 20);
+  // Wave 1 — the kit's members + per-kit relations, each read SCOPED to this kit
+  // (was: collect the whole org's serialized items / bulk items / asset registry /
+  // bulk assets / scan logs / projects and JS-filter to this kit — the "smoking
+  // gun" O(org inventory) read on the hottest detail path). These return the same
+  // raw Convex doc shapes the org-wide `list` queries did, so all downstream
+  // mapping is unchanged — only the row SET narrows to this kit.
+  const convex = await getConvexClient();
+  const [serialized, bulk, modelMap, lineItemRows, scanLogRows, maintenanceRecords, media] =
+    await Promise.all([
+      convex.query(api.kitSerializedItems.listByKitId, { orgId: organizationId, kitId: id }),
+      convex.query(api.kitBulkItems.listByKitId, { orgId: organizationId, kitId: id }),
+      getModelMap(organizationId),
+      convex
+        .query(api.projectLineItems.listByKitId, { kitId: id, orgId: organizationId })
+        .then((rows) => rows.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)).slice(0, 20)),
+      // assetScanLog scoped to this kit (by_kitId), then orderBy scannedAt desc + take 20.
+      convex
+        .query(api.assetScanLogs.listByKitId, { orgId: organizationId, kitId: id })
+        .then((rows) => rows.sort((a, b) => (b.scannedAt ?? 0) - (a.scannedAt ?? 0)).slice(0, 20)),
+      // maintenanceRecord stays org-wide-then-filtered for now (smaller table; a
+      // by-kit scoped read is a follow-up). Replicates orderBy createdAt desc + take 20.
+      getMaintenanceRecordsByOrg(organizationId).then((records) =>
+        records
+          .filter((m) => m.kitId === id)
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, 20),
+      ),
+      // kit media gallery now from the Convex mirror (dual-written → identical data).
+      getKitMediaFromConvex(id),
+    ]);
 
-      const userIds = [...new Set(logs.map((l) => l.scannedById).filter((u): u is string => !!u))];
-      const [logProjects, scanUsers] = await Promise.all([
-        getProjectsByOrg(organizationId),
-        userIds.length
-          ? prisma.user.findMany({ where: { id: { in: userIds } } })
-          : Promise.resolve([]),
-      ]);
-      const logProjectMap = new Map(logProjects.map((p) => [p.id, p]));
-      const userMap = new Map(scanUsers.map((u) => [u.id, u]));
-
-      return logs.map((l) => ({
-        id: l.id,
-        organizationId: l.organizationId,
-        assetId: l.assetId ?? null,
-        bulkAssetId: l.bulkAssetId ?? null,
-        kitId: l.kitId ?? null,
-        projectId: l.projectId ?? null,
-        action: l.action,
-        scannedById: l.scannedById,
-        scannedAt: l.scannedAt != null ? new Date(l.scannedAt) : null,
-        notes: l.notes ?? null,
-        location: l.location ?? null,
-        scannedBy: userMap.get(l.scannedById) ?? null,
-        project: l.projectId ? logProjectMap.get(l.projectId) ?? null : null,
-      }));
-    })(),
-    // maintenanceRecord is Convex-only (Phase C). Read the org's records, filter
-    // to this kit, then replicate `orderBy: { createdAt: "desc" }` + `take: 20`.
-    getMaintenanceRecordsByOrg(organizationId).then((records) =>
-      records
-        .filter((m) => m.kitId === id)
-        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-        .slice(0, 20),
+  // Wave 2 — the members' assets + the projects/users referenced by the (already
+  // kit-scoped, ≤20) line items and scan logs, all read by id instead of org-wide.
+  const memberAssetIds = serialized.map((si) => si.assetId).filter((x): x is string => !!x);
+  const memberBulkIds = bulk.map((bi) => bi.bulkAssetId).filter((x): x is string => !!x);
+  const scanUserIds = [...new Set(scanLogRows.map((l) => l.scannedById).filter((u): u is string => !!u))];
+  const projectIds = [
+    ...new Set(
+      [...lineItemRows, ...scanLogRows]
+        .map((r) => r.projectId)
+        .filter((p): p is string => !!p),
     ),
-    // kit media gallery now from the Convex mirror (dual-written → identical data).
-    getKitMediaFromConvex(id),
+  ];
+
+  // listByIds caps at 1000 ids (it's user-callable). A kit could in theory have
+  // more members than that, and the old getKit had no cap — so batch in chunks of
+  // 1000 to preserve the no-cap behaviour for this trusted server caller.
+  const chunk = <T,>(arr: T[], n: number): T[][] => {
+    const out: T[][] = [];
+    for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+    return out;
+  };
+  const [memberAssets, memberBulkAssets, projects, scanUsers] = await Promise.all([
+    Promise.all(
+      chunk(memberAssetIds, 1000).map((ids) => convex.query(api.assets.listByIds, { orgId: organizationId, ids })),
+    ).then((r) => r.flat()),
+    Promise.all(
+      chunk(memberBulkIds, 1000).map((ids) => convex.query(api.bulkAssets.listByIds, { orgId: organizationId, ids })),
+    ).then((r) => r.flat()),
+    projectIds.length
+      ? convex.query(api.projects.listByIds, { orgId: organizationId, ids: projectIds })
+      : Promise.resolve([]),
+    scanUserIds.length
+      ? prisma.user.findMany({ where: { id: { in: scanUserIds } } })
+      : Promise.resolve([]),
   ]);
 
+  const projMap = new Map(projects.map((p) => [p.id, p]));
+  const userMap = new Map(scanUsers.map((u) => [u.id, u]));
+
+  // Line items: attach project from the by-id map (drop any whose project is absent).
+  const lineItems = lineItemRows.flatMap((r) => {
+    const project = projMap.get(r.projectId);
+    if (!project) return [];
+    return [{ ...mapLineItemDoc(r), project }];
+  });
+
+  // Scan logs: same mapped shape as before; scannedBy (Better-Auth User, Prisma)
+  // and project resolved from the by-id maps.
+  const scanLogs = scanLogRows.map((l) => ({
+    id: l.id,
+    organizationId: l.organizationId,
+    assetId: l.assetId ?? null,
+    bulkAssetId: l.bulkAssetId ?? null,
+    kitId: l.kitId ?? null,
+    projectId: l.projectId ?? null,
+    action: l.action,
+    scannedById: l.scannedById,
+    scannedAt: l.scannedAt != null ? new Date(l.scannedAt) : null,
+    notes: l.notes ?? null,
+    location: l.location ?? null,
+    scannedBy: userMap.get(l.scannedById) ?? null,
+    project: l.projectId ? projMap.get(l.projectId) ?? null : null,
+  }));
+
   // Map the Convex member assets to the Prisma row shape the detail page expects.
-  const assetMap = new Map(allAssets.map((a) => [a.id, mapConvexAssetToPrisma(a)]));
-  const bulkAssetMap = new Map(allBulkAssets.map((b) => [b.id, mapConvexBulkAssetToPrisma(b)]));
+  const assetMap = new Map(memberAssets.map((a) => [a.id, mapConvexAssetToPrisma(a)]));
+  const bulkAssetMap = new Map(memberBulkAssets.map((b) => [b.id, mapConvexBulkAssetToPrisma(b)]));
 
 
   // Location + Category FKs were dropped (Phase B); attach both from the Convex mirror.
@@ -171,8 +183,7 @@ export async function getKit(id: string) {
 
   // A member whose asset is absent from the mirror is anomalous (the Prisma FK
   // join always returned the asset) — drop it rather than surface a null asset.
-  const serializedItems = allSerialized
-    .filter((si) => si.kitId === id)
+  const serializedItems = serialized
     .flatMap((si) => {
       const asset = assetMap.get(si.assetId);
       if (!asset) return [];
@@ -182,8 +193,7 @@ export async function getKit(id: string) {
       }];
     });
 
-  const bulkItems = allBulk
-    .filter((bi) => bi.kitId === id)
+  const bulkItems = bulk
     .flatMap((bi) => {
       const bulkAsset = bulkAssetMap.get(bi.bulkAssetId);
       if (!bulkAsset) return [];


### PR DESCRIPTION
## Phase 1b (part 2) — the keystone rewire (#2)

**Stacked on #278** (base = `perf/03-getkit-getasset-scoped-queries`; merge #278 first, then this retargets to main). This is the actual fix for the "smoking gun."

### Before
`getKit` rendered **one** kit by reading the **entire org**: `getAssetsByOrg` (whole asset registry), `getBulkAssetsByOrg`, both kit-item tables, `assetScanLogs.list` (all org scan logs), and `getProjectsByOrg` — then JS-filtering to the kit. Paid on first paint **and** every version-vector tick (i.e. every edit).

### After
Two waves of entity-scoped reads:
1. the kit's members + per-kit relations (`kitSerializedItems.listByKitId`, `kitBulkItems.listByKitId`, `projectLineItems.listByKitId`, `assetScanLogs.listByKitId`)
2. derive member/project/user ids → fetch those by id (`assets.listByIds`, `bulkAssets.listByIds`, `projects.listByIds`, `prisma.user.findMany`)

**Parity-by-construction:** the scoped queries return the same raw Convex doc shapes the org-wide `list` queries did, so every downstream mapping (`mapConvexAssetToPrisma`, `mapLineItemDoc`, the scan-log shape) is unchanged — only the row *set* narrows. `O(org inventory)` → `O(kit contents)`.

### Testing
- New parity/scoping test `kit-detail-scoping.int.test.ts`: `getKit` returns exactly the kit's members with assets+models attached, and an unrelated same-org kit's member/asset never leaks in. ✅ passes against dev Convex.
- `npx tsc --noEmit`: clean.
- Codex review: confirmed doc-shape parity, sort/slice preservation, scan-log shape identical, null-projectId / missing-asset / dedup behaviour unchanged. Its one [P2] (the 1000-id cap becoming a new failure mode for huge kits) is fixed here by chunking the member reads in batches of 1000.

### Deliberately deferred (smaller tables)
`maintenanceRecords` + `getModelMap` stay org-wide for now — a by-kit scoping follow-up. `getAsset` rewire is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)