### PR TITLE
perf(1b-3): scope getAsset projects read (#2) [stacked on #278]

### DIFF
--- a/src/server/asset-detail-scoping.int.test.ts
+++ b/src/server/asset-detail-scoping.int.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Parity / scoping test for the entity-scoped getAsset rewrite (finding #2, T-D).
+ *
+ * getAsset used to call getProjectsByOrg (every project in the org) just to build
+ * a lookup map for attaching projects to the asset's ≤20 line items. It now fetches
+ * only the projects those line items reference (projects.listByIds). Property to
+ * lock in: a line item still gets its project attached correctly, and an unrelated
+ * org project is simply not needed — output is unchanged.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({ ctx: { organizationId: "", userId: "tester", userName: "Tester" } }));
+vi.mock("@/lib/org-context", () => ({
+  getOrgContext: async () => h.ctx,
+  requirePermission: async () => h.ctx,
+  requireOrganization: async () => ({ organizationId: h.ctx.organizationId, session: {} }),
+}));
+
+import { getAsset } from "@/server/assets";
+
+describe("getAsset — entity-scoped project reads", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("attaches the line item's referenced project (via scoped listByIds)", async () => {
+    const orgA = createId();
+    h.ctx.organizationId = orgA;
+    const convex = await getConvexClient();
+    const modelId = createId();
+    await convex.mutation(api.models.createIfMissing, { id: modelId, organizationId: orgA, name: "M" });
+
+    const assetId = createId();
+    await convex.mutation(api.assets.createIfMissing, { id: assetId, organizationId: orgA, modelId, assetTag: "A1" });
+
+    const projectId = createId();
+    await convex.mutation(api.projects.createIfMissing, {
+      id: projectId,
+      organizationId: orgA,
+      projectNumber: "P-100",
+      name: "Project One",
+    });
+    // an UNRELATED org project the asset never references — old code fetched it
+    // (whole-org), new code does not need it; either way it must not appear.
+    await convex.mutation(api.projects.createIfMissing, {
+      id: createId(),
+      organizationId: orgA,
+      projectNumber: "P-999",
+      name: "Unrelated",
+    });
+
+    await convex.mutation(api.projectLineItems.createIfMissing, {
+      id: createId(),
+      organizationId: orgA,
+      projectId,
+      assetId,
+      createdAt: Date.now(),
+    });
+
+    const asset = (await getAsset(assetId)) as {
+      lineItems: Array<{ projectId: string | null; project: { projectNumber: string; name: string } }>;
+    } | null;
+
+    expect(asset).not.toBeNull();
+    expect(asset!.lineItems).toHaveLength(1);
+    expect(asset!.lineItems[0].projectId).toBe(projectId);
+    expect(asset!.lineItems[0].project.projectNumber).toBe("P-100");
+    expect(asset!.lineItems[0].project.name).toBe("Project One");
+  });
+});

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -13,7 +13,6 @@ import { getSupplierById } from "@/lib/suppliers-read";
 import { getModelById, getModelWithCategoryMap, type ModelWithCategory } from "@/lib/models-read";
 import { getLocationMap, type ConvexLocation } from "@/lib/locations-read";
 import { getPrimaryPhotoMaps, getAssetMediaFromConvex, getModelMediaFromConvex, withResolvedFile } from "@/lib/media-read";
-import { getProjectsByOrg } from "@/lib/projects-read";
 import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
 import { type FilterValue } from "@/lib/table-utils";
 import {
@@ -161,11 +160,24 @@ export async function getAsset(id: string) {
     asset.parentAssetId ? getAssetById(asset.parentAssetId) : Promise.resolve(null),
   ]);
 
-  // Model (+ category) + supplier + projects + maintenance records live in Convex.
+  // Line items are already asset-scoped (listByAssetId). Order + take 20 now so we
+  // fetch ONLY the projects those rows reference — instead of getProjectsByOrg
+  // (every project in the org) just to build a lookup map for ≤20 rows.
+  const orderedLineItemDocs = [...lineItemDocs]
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+    .slice(0, 20);
+  const lineProjectIds = [
+    ...new Set(orderedLineItemDocs.map((li) => li.projectId).filter((p): p is string => !!p)),
+  ];
+
+  // Model (+ category) + supplier + referenced projects + maintenance records (Convex).
+  // (maintenanceRecords stays org-wide for now — a by-asset scoped read is a follow-up.)
   const [modelMap, supplier, projects, maintenanceRecords] = await Promise.all([
     getModelWithCategoryMap(organizationId),
     asset.supplierId ? getSupplierById(asset.supplierId) : null,
-    getProjectsByOrg(organizationId),
+    lineProjectIds.length
+      ? convex.query(api.projects.listByIds, { orgId: organizationId, ids: lineProjectIds })
+      : Promise.resolve([]),
     getMaintenanceRecordsByOrg(organizationId),
   ]);
 
@@ -272,9 +284,7 @@ export async function getAsset(id: string) {
 
   // ── lineItems (project history; createdAt desc, take 20) + project ──
   const projectMap = new Map(projects.map((p) => [p.id, p]));
-  const lineItems = [...lineItemDocs]
-    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
-    .slice(0, 20)
+  const lineItems = orderedLineItemDocs
     .map((li) => {
       const project = li.projectId ? projectMap.get(li.projectId) ?? null : null;
       return {


### PR DESCRIPTION
## Phase 1b (part 3) — getAsset projects scoping (#2)

**Stacked on #278** (base = `perf/03`). Sibling of #279 (getKit). Smaller: getAsset's one whole-org read worth fixing now is `getProjectsByOrg`.

### Before
`getAsset` called `getProjectsByOrg(org)` — **every project in the org** — only to build a lookup map for attaching projects to the asset's ≤20 line items.

### After
Fetch only the projects those line items reference: `projects.listByIds(org, projectIds)` where `projectIds` come from the already asset-scoped line items (ordered `createdAt` desc, sliced to 20). Reuses the pre-sliced `orderedLineItemDocs` rather than re-sorting/re-slicing. Parity-by-construction.

### Deliberately deferred
`maintenanceRecords` + the model/category map stay org-wide for now (a by-asset scoped maintenance read needs a new query — follow-up).

### Testing
- New parity test `asset-detail-scoping.int.test.ts`: getAsset attaches the line item's referenced project correctly via the scoped read. ✅ passes against dev Convex.
- `npx tsc --noEmit`: clean.
- Codex review: **clean on parity** — confirmed the fetched project set covers every returned line item, `orderedLineItemDocs` identical to the old sort+slice, null-projectId fallback unchanged, maintenance/model untouched. Removed the unused `getProjectsByOrg` import it flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)