### PR TITLE
perf: fix add/edit project-item ~1min slowness (N+1) + projects-view N+1 + warehouse de-dup

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -56,6 +56,24 @@ export const listByModel = query({
 });
 
 /**
+ * Batch the per-model `by_modelId` scans for MANY models into ONE round-trip.
+ * Replaces an N+1 of N separate `listByModel` calls (e.g. availability computes
+ * stock per model across a projects view). Deduped + capped; org-filtered.
+ */
+export const listByModelIds = query({
+  args: { orgId: v.string(), modelIds: v.array(v.string()) },
+  handler: async (ctx, { orgId, modelIds }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(modelIds)];
+    if (unique.length > 1000) throw new ConvexError("assets.listByModelIds: too many modelIds (max 1000)");
+    const groups = await Promise.all(
+      unique.map((mid) => ctx.db.query("assets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect()),
+    );
+    return groups.flat().filter((a) => a.organizationId === orgId);
+  },
+});
+
+/**
  * Batch point-read assets by cuid, scoped to one org. Lets a detail composite
  * (e.g. getKit) read only its member assets by id instead of collecting the whole
  * org registry (getAssetsByOrg) and filtering in JS. Cross-org ids are dropped,

--- a/convex/bulkAssets.ts
+++ b/convex/bulkAssets.ts
@@ -57,6 +57,24 @@ export const listByModel = query({
 });
 
 /**
+ * Batch the per-model `by_modelId` scans for MANY models into ONE round-trip —
+ * the bulk-asset counterpart of assets.listByModelIds, killing the per-model N+1
+ * in availability. Deduped + capped; org-filtered.
+ */
+export const listByModelIds = query({
+  args: { orgId: v.string(), modelIds: v.array(v.string()) },
+  handler: async (ctx, { orgId, modelIds }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(modelIds)];
+    if (unique.length > 1000) throw new ConvexError("bulkAssets.listByModelIds: too many modelIds (max 1000)");
+    const groups = await Promise.all(
+      unique.map((mid) => ctx.db.query("bulkAssets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect()),
+    );
+    return groups.flat().filter((b) => b.organizationId === orgId);
+  },
+});
+
+/**
  * Batch point-read bulk assets by cuid, scoped to one org — the bulk-asset
  * counterpart of assets.listByIds, so a detail composite reads only its members
  * instead of getBulkAssetsByOrg. Cross-org ids are dropped.

--- a/convex/projectLineItemUnits.ts
+++ b/convex/projectLineItemUnits.ts
@@ -32,6 +32,23 @@ export const getById = query({
   },
 });
 
+/**
+ * Units for ONE asset within an org (all statuses), via the
+ * `by_organizationId_assetId_status` index — replaces a whole-org
+ * `projectLineItemUnits.list` + JS `.filter(u => u.assetId === …)` on the
+ * add-line-item double-booking check.
+ */
+export const listByOrgAndAsset = query({
+  args: { orgId: v.string(), assetId: v.string() },
+  handler: async (ctx, { orgId, assetId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("projectLineItemUnits")
+      .withIndex("by_organizationId_assetId_status", (q) => q.eq("organizationId", orgId).eq("assetId", assetId))
+      .collect();
+  },
+});
+
 export const listByLineItem = query({
   args: { lineItemId: v.string() },
   handler: async (ctx, { lineItemId }) => {

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -697,6 +697,20 @@ export const listByAssetId = query({
   },
 });
 
+/**
+ * Line items referencing ONE model (via by_modelId), org-filtered. Replaces a
+ * whole-org `projectLineItems.list` + JS `.filter(li => li.modelId === …)` on the
+ * model-level availability check in addLineItem.
+ */
+export const listByModelId = query({
+  args: { modelId: v.string(), orgId: v.string() },
+  handler: async (ctx, { modelId, orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    return (await ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect())
+      .filter((r) => r.organizationId === orgId);
+  },
+});
+
 // ── CUSTOM (Phase C H) — by-kit lookup for kit delete-guards ──
 export const listByKitId = query({
   args: { kitId: v.string(), orgId: v.string() },

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -154,8 +154,15 @@ async function gatherTestTagAssetsAndAssert(
   organizationId: string,
   projectId: string,
   items: Array<{ lineItemId: string; assetId?: string }>,
-): Promise<Array<{ id: string; assetId?: string; bulkAssetId?: string }>> {
+): Promise<{
+  preflight: Array<{ id: string; assetId?: string; bulkAssetId?: string }>;
+  unitsByLine: Map<string, Awaited<ReturnType<typeof lineUnits>>>;
+}> {
   const preflightLineItems: Array<{ id: string; assetId?: string; bulkAssetId?: string }> = [];
+  // Cache each line's units here so the immediately-following expand stage reuses
+  // them instead of re-reading. Safe: both stages run BEFORE any mutation, so the
+  // snapshot is stable. (Do NOT extend this cache into the mutating main loop.)
+  const unitsByLine = new Map<string, Awaited<ReturnType<typeof lineUnits>>>();
   const assetIds: string[] = [];
   const bulkIds: string[] = [];
   for (const it of items) {
@@ -164,14 +171,16 @@ async function gatherTestTagAssetsAndAssert(
     preflightLineItems.push({ id: li.id, assetId: li.assetId, bulkAssetId: li.bulkAssetId });
     if (li.assetId) assetIds.push(li.assetId);
     if (li.bulkAssetId) bulkIds.push(li.bulkAssetId);
-    for (const u of await lineUnits(ctx, li.id)) {
+    const units = await lineUnits(ctx, li.id);
+    unitsByLine.set(li.id, units);
+    for (const u of units) {
       if (u.assetId) assetIds.push(u.assetId);
       if (u.bulkAssetId) bulkIds.push(u.bulkAssetId);
     }
     if (it.assetId) assetIds.push(it.assetId);
   }
   await assertTestTagAllowsCheckout(ctx, organizationId, { assetIds, bulkAssetIds: bulkIds });
-  return preflightLineItems;
+  return { preflight: preflightLineItems, unitsByLine };
 }
 
 /** Expand "deploy whole prepped line" into one item per prepped unit. */
@@ -180,13 +189,16 @@ async function expandPrepUnitAssignments(
   organizationId: string,
   items: Array<{ lineItemId: string; assetId?: string; quantity?: number; notes?: string }>,
   preflight: Array<{ id: string; assetId?: string; bulkAssetId?: string }>,
+  unitsByLine: Map<string, Awaited<ReturnType<typeof lineUnits>>>,
 ): Promise<Array<{ lineItemId: string; assetId?: string; quantity?: number; notes?: string }>> {
   const out: Array<{ lineItemId: string; assetId?: string; quantity?: number; notes?: string }> = [];
   for (const item of items) {
     if (item.assetId) { out.push(item); continue; }
     const row = preflight.find((l) => l.id === item.lineItemId);
     if (row?.assetId || row?.bulkAssetId) { out.push(item); continue; }
-    const units = (await lineUnits(ctx, item.lineItemId))
+    // Reuse the units gather already read this same (pre-mutation) snapshot;
+    // fall back to a read only for a line gather skipped (wrong org/project).
+    const units = (unitsByLine.get(item.lineItemId) ?? (await lineUnits(ctx, item.lineItemId)))
       .filter((u) => u.status !== "CHECKED_OUT" && (u.assetId || u.bulkAssetId))
       .sort((a, b) => a.ordinal - b.ordinal);
     if (units.length === 0) { out.push(item); continue; }
@@ -223,8 +235,8 @@ export const checkoutItems = mutation({
     if (!project || project.organizationId !== a.organizationId) throw new ConvexError("Project not found");
     const projectLocationId = project.locationId ?? null;
 
-    const preflight = await gatherTestTagAssetsAndAssert(ctx, a.organizationId, a.projectId, a.items);
-    const expanded = await expandPrepUnitAssignments(ctx, a.organizationId, a.items, preflight);
+    const { preflight, unitsByLine } = await gatherTestTagAssetsAndAssert(ctx, a.organizationId, a.projectId, a.items);
+    const expanded = await expandPrepUnitAssignments(ctx, a.organizationId, a.items, preflight, unitsByLine);
 
     const updated = new Set<string>();
     for (const item of expanded) {
@@ -652,6 +664,17 @@ export const checkInBulkTotals = mutation({
       .filter((r) => r.organizationId === a.organizationId && !r.subHireGroupId && (!r.isKitChild || r.childKind === "ACCESSORY"))
       .sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
 
+    // Batch-load the distinct models the rows reference once (rows share models),
+    // instead of a per-row models.by_cuid point-read inside toInput.
+    const modelIds = [...new Set(rows.map((r) => r.modelId).filter((m): m is string => !!m))];
+    const modelById = new Map(
+      (await Promise.all(
+        modelIds.map((mid) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", mid)).unique()),
+      ))
+        .filter((m): m is NonNullable<typeof m> => m !== null)
+        .map((m) => [m.id, m] as const),
+    );
+
     const toInput = async (child: typeof rows[number]): Promise<CheckInItem> => {
       const units = await lineUnits(ctx, child.id);
       let outstanding: number;
@@ -664,7 +687,7 @@ export const checkInBulkTotals = mutation({
       else if (child.subHireId) itemType = "SUBHIRE";
       else if (child.bulkAssetId) itemType = "OWNED_BULK";
       else itemType = "OWNED_SERIALISED";
-      const model = child.modelId ? await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", child.modelId!)).unique() : null;
+      const model = child.modelId ? modelById.get(child.modelId) ?? null : null;
       return {
         lineItemId: child.id, modelId: child.modelId ?? null, modelName: model?.name ?? null, modelNumber: model?.modelNumber ?? null,
         assetId: child.assetId ?? null, bulkAssetId: child.bulkAssetId ?? null, subHireId: child.subHireId ?? null,

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,6 +1,7 @@
 import { getModelMap } from "@/lib/models-read";
-import { getActiveAssetsByModel, getActiveBulkAssetsByModel } from "@/lib/assets-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 import {
   getOrgLineItems,
   indexProjectsById,
@@ -114,14 +115,29 @@ export async function computeOverbookedStatus(
   const { totalByModel: totalBookedByModel, thisProjectByModel: thisProjectBookedByModel } =
     sumBookingsByModel(modelIds, orgLineItems, projectsById, window, projectId);
 
-  // Batch fetch model metadata + active assets/bulkAssets from Convex in parallel.
-  const convexModelMap = await getModelMap(organizationId);
-  const [assetsByModel, bulksByModel] = await Promise.all([
-    Promise.all(modelIds.map(async (id) => [id, await getActiveAssetsByModel(id, organizationId)] as const)),
-    Promise.all(modelIds.map(async (id) => [id, await getActiveBulkAssetsByModel(id, organizationId)] as const)),
+  // Batch fetch model metadata + active assets/bulkAssets from Convex. Was an N+1:
+  // one assets.listByModel + one bulkAssets.listByModel round-trip PER model (so a
+  // projects view spanning N models fired 2N Convex queries). Now two batched
+  // queries that do all the per-model by_modelId scans server-side in one trip
+  // each, grouped here (replicating getActive*ByModel's `isActive !== false`).
+  const convex = await getConvexClient();
+  const [convexModelMap, assetsAll, bulksAll] = await Promise.all([
+    getModelMap(organizationId),
+    convex.query(api.assets.listByModelIds, { orgId: organizationId, modelIds }),
+    convex.query(api.bulkAssets.listByModelIds, { orgId: organizationId, modelIds }),
   ]);
-  const assetMap = new Map(assetsByModel);
-  const bulkMap = new Map(bulksByModel);
+  const assetMap = new Map<string, typeof assetsAll>();
+  for (const a of assetsAll) {
+    if (!a.modelId || a.isActive === false) continue;
+    const arr = assetMap.get(a.modelId);
+    if (arr) arr.push(a); else assetMap.set(a.modelId, [a]);
+  }
+  const bulkMap = new Map<string, typeof bulksAll>();
+  for (const b of bulksAll) {
+    if (!b.modelId || b.isActive === false) continue;
+    const arr = bulkMap.get(b.modelId);
+    if (arr) arr.push(b); else bulkMap.set(b.modelId, [b]);
+  }
 
   const stockByModel = new Map<string, number>();
   const effectiveStockByModel = new Map<string, number>();

--- a/src/server/line-item-scoped-reads.int.test.ts
+++ b/src/server/line-item-scoped-reads.int.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Integration tests for the scoped reads that replaced whole-org `.list()` +
+ * a per-unit N+1 in the add/update-line-item double-booking checks (the
+ * "adding an item takes a minute / hundreds of Convex calls" fix):
+ *   - projectLineItems.listByModelId
+ *   - projectLineItemUnits.listByOrgAndAsset
+ * Both must return the same rows the old whole-org-collect-then-filter did, and
+ * never leak across orgs.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+describe("line-item scoped reads", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("projectLineItems.listByModelId returns only this model's lines, org-scoped", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const orgB = createId();
+    const m1 = createId();
+    const m2 = createId();
+    const projectId = createId();
+    const l1 = createId();
+    const l2 = createId();
+    await convex.mutation(api.projectLineItems.createIfMissing, { id: l1, organizationId: orgA, projectId, modelId: m1 });
+    await convex.mutation(api.projectLineItems.createIfMissing, { id: l2, organizationId: orgA, projectId, modelId: m2 });
+    // same model m1 but a different org — must be excluded.
+    await convex.mutation(api.projectLineItems.createIfMissing, { id: createId(), organizationId: orgB, projectId, modelId: m1 });
+
+    const res = await convex.query(api.projectLineItems.listByModelId, { modelId: m1, orgId: orgA });
+    expect(res.map((r) => r.id)).toEqual([l1]);
+  });
+
+  it("projectLineItemUnits.listByOrgAndAsset returns only this asset's units (all statuses), org-scoped", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const orgB = createId();
+    const asset = createId();
+    const lineItemId = createId();
+    const u1 = createId();
+    const u2 = createId();
+    // two units of `asset` in orgA, different statuses
+    await convex.mutation(api.projectLineItemUnits.createIfMissing, { id: u1, organizationId: orgA, lineItemId, ordinal: 0, assetId: asset, status: "CHECKED_OUT" });
+    await convex.mutation(api.projectLineItemUnits.createIfMissing, { id: u2, organizationId: orgA, lineItemId, ordinal: 1, assetId: asset, status: "RETURNED" });
+    // a different asset, and a cross-org unit on the same asset — both excluded.
+    await convex.mutation(api.projectLineItemUnits.createIfMissing, { id: createId(), organizationId: orgA, lineItemId, ordinal: 2, assetId: createId(), status: "CHECKED_OUT" });
+    await convex.mutation(api.projectLineItemUnits.createIfMissing, { id: createId(), organizationId: orgB, lineItemId, ordinal: 0, assetId: asset, status: "CHECKED_OUT" });
+
+    const res = await convex.query(api.projectLineItemUnits.listByOrgAndAsset, { orgId: orgA, assetId: asset });
+    expect(res.map((r) => r.id).sort()).toEqual([u1, u2].sort());
+  });
+});

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -108,24 +108,28 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         const conflictSet = new Set(conflictProjectIds);
         const convex = await getConvexClient();
         // Asset may be booked via a legacy line.assetId row OR via a unit — check
-        // both in Convex (the flipped tables).
-        const [assetLines, allUnits] = await Promise.all([
+        // both in Convex (the flipped tables). Both reads are now scoped to THIS
+        // asset (was: collect every unit in the org, then JS-filter to the asset,
+        // then one getById per unit — a whole-table read + an N+1 that produced
+        // hundreds of Convex calls per add).
+        const [assetLines, assetUnits] = await Promise.all([
           convex.query(api.projectLineItems.listByAssetId, { assetId: parsed.assetId, orgId: organizationId }),
-          convex.query(api.projectLineItemUnits.list, { orgId: organizationId }),
+          convex.query(api.projectLineItemUnits.listByOrgAndAsset, { orgId: organizationId, assetId: parsed.assetId }),
         ]);
         const lineConflict = assetLines.find(
           (li) => li.status !== "CANCELLED" && conflictSet.has(li.projectId),
         );
-        const assetUnits = allUnits.filter((u) => u.assetId === parsed.assetId);
-        let unitConflictProjId: string | undefined;
-        for (const u of assetUnits) {
-          if (u.status === "RETURNED") continue;
-          const ul = await convex.query(api.projectLineItems.getById, { id: u.lineItemId });
-          if (ul && ul.status !== "CANCELLED" && conflictSet.has(ul.projectId)) {
-            unitConflictProjId = ul.projectId;
-            break;
-          }
-        }
+        // Batch-fetch the line items for the asset's live units in one round-trip
+        // (was one getById per unit).
+        const unitLineIds = [
+          ...new Set(assetUnits.filter((u) => u.status !== "RETURNED").map((u) => u.lineItemId)),
+        ];
+        const unitLines = unitLineIds.length
+          ? await convex.query(api.projectLineItems.listByIds, { ids: unitLineIds, orgId: organizationId })
+          : [];
+        const unitConflictProjId = unitLines.find(
+          (ul) => ul.status !== "CANCELLED" && conflictSet.has(ul.projectId),
+        )?.projectId;
         const conflictProjId = lineConflict?.projectId ?? unitConflictProjId;
         const conflictProject = conflictProjId ? projectMap.get(conflictProjId) : null;
         if (conflictProject) {
@@ -174,7 +178,9 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
         // When dates exist, check overlapping bookings across projects
         // When no dates, check only this project's existing bookings against stock
         // Sub-hire items don't consume our stock so they're excluded from the count.
-        const allOrgLines = await (await getConvexClient()).query(api.projectLineItems.list, { orgId: organizationId });
+        // Scoped to THIS model (was: collect every line item in the org, then
+        // JS-filter to the model).
+        const modelLines = await (await getConvexClient()).query(api.projectLineItems.listByModelId, { modelId: parsed.modelId, orgId: organizationId });
         let overlapping;
         if (hasDates) {
           const projStartMs = convexProject.rentalStartDate as number;
@@ -193,17 +199,15 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
               )
               .map((p) => p.id),
           );
-          overlapping = allOrgLines.filter(
+          overlapping = modelLines.filter(
             (li) =>
-              li.modelId === parsed.modelId &&
               li.status !== "CANCELLED" &&
               li.subHireId == null &&
               modelConflictProjectIds.has(li.projectId),
           );
         } else {
-          overlapping = allOrgLines.filter(
+          overlapping = modelLines.filter(
             (li) =>
-              li.modelId === parsed.modelId &&
               li.status !== "CANCELLED" &&
               li.subHireId == null &&
               li.projectId === projectId,
@@ -507,7 +511,8 @@ export async function updateLineItem(
         assets: activeAssets.map((a: ConvexAsset) => ({ status: a.status ?? "AVAILABLE" })),
         bulkAssets: activeBulkAssets.map((ba: ConvexBulkAsset) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
       };
-      const allOrgLines = await (await getConvexClient()).query(api.projectLineItems.list, { orgId: organizationId });
+      // Scoped to THIS model (was: collect every line item in the org).
+      const modelLines = await (await getConvexClient()).query(api.projectLineItems.listByModelId, { modelId: parsed.modelId, orgId: organizationId });
       let overlapping;
       if (hasDates) {
         const projStartMs = updateConvexProject!.rentalStartDate as number;
@@ -526,18 +531,16 @@ export async function updateLineItem(
             )
             .map((p) => p.id),
         );
-        overlapping = allOrgLines.filter(
+        overlapping = modelLines.filter(
           (li) =>
-            li.modelId === parsed.modelId &&
             li.status !== "CANCELLED" &&
             li.subHireId == null &&
             li.id !== id &&
             updateConflictProjectIds.has(li.projectId),
         );
       } else {
-        overlapping = allOrgLines.filter(
+        overlapping = modelLines.filter(
           (li) =>
-            li.modelId === parsed.modelId &&
             li.status !== "CANCELLED" &&
             li.subHireId == null &&
             li.id !== id &&
@@ -733,8 +736,8 @@ export async function addKitLineItem(
       .map((p) => p.id);
     const kitProjectMap = new Map(kitAddAllProjects.map((p) => [p.id, p]));
     const kitConflictSet = new Set(kitConflictProjectIds);
-    const allOrgLines = await (await getConvexClient()).query(api.projectLineItems.list, { orgId: organizationId });
-    const conflict = allOrgLines.find(
+    const kitLines = await (await getConvexClient()).query(api.projectLineItems.listByKitId, { kitId, orgId: organizationId });
+    const conflict = kitLines.find(
       (li) =>
         li.kitId === kitId &&
         !li.isKitChild &&
@@ -1002,8 +1005,10 @@ export async function checkAvailability(
   // When no dates: only count bookings on the current project (stock-only check)
   // Line items + projects both live in Convex — read both, filter/join in JS.
   const convex = await getConvexClient();
+  // Line items scoped to THIS model (was: every line item in the org, then a
+  // `li.modelId !== modelId` skip in the loop below).
   const [allOrgLines, allProjects] = await Promise.all([
-    convex.query(api.projectLineItems.list, { orgId: organizationId }),
+    convex.query(api.projectLineItems.listByModelId, { modelId, orgId: organizationId }),
     getProjectsByOrg(organizationId),
   ]);
   const projectById = new Map(allProjects.map((p) => [p.id, p]));
@@ -1221,7 +1226,7 @@ export async function checkKitAvailability(
   const kitAvailProjectMap = new Map(kitAvailAllProjects.map((p) => [p.id, p]));
   const kitAvailConflictSet = new Set(kitAvailConflictProjectIds);
 
-  const kitAvailOrgLines = await (await getConvexClient()).query(api.projectLineItems.list, { orgId: organizationId });
+  const kitAvailOrgLines = await (await getConvexClient()).query(api.projectLineItems.listByKitId, { kitId, orgId: organizationId });
   const conflict = kitAvailOrgLines.find(
     (li) =>
       li.kitId === kitId &&

--- a/src/server/list-by-model-ids.int.test.ts
+++ b/src/server/list-by-model-ids.int.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Integration test for assets.listByModelIds / bulkAssets.listByModelIds — the
+ * batched queries that kill the per-model N+1 in availability (one listByModel
+ * round-trip PER model). They must return all matching docs across the requested
+ * models, org-scoped (cross-org dropped), in one call.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+describe("assets/bulkAssets.listByModelIds — batched per-model scans", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("returns assets across the requested models, org-scoped (no cross-org leak)", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const orgB = createId();
+    const m1 = createId();
+    const m2 = createId();
+    const m3 = createId(); // not requested
+
+    const a1 = createId();
+    const a2 = createId();
+    const aOtherModel = createId();
+    const aForeign = createId();
+    await convex.mutation(api.assets.createIfMissing, { id: a1, organizationId: orgA, modelId: m1, assetTag: "A1" });
+    await convex.mutation(api.assets.createIfMissing, { id: a2, organizationId: orgA, modelId: m2, assetTag: "A2" });
+    await convex.mutation(api.assets.createIfMissing, { id: aOtherModel, organizationId: orgA, modelId: m3, assetTag: "A3" });
+    // same requested model m1, but a DIFFERENT org — must be excluded.
+    await convex.mutation(api.assets.createIfMissing, { id: aForeign, organizationId: orgB, modelId: m1, assetTag: "AF" });
+
+    const res = await convex.query(api.assets.listByModelIds, { orgId: orgA, modelIds: [m1, m2] });
+    const ids = res.map((a) => a.id).sort();
+    expect(ids).toEqual([a1, a2].sort());
+    expect(res.some((a) => a.id === aForeign)).toBe(false); // cross-org excluded
+    expect(res.some((a) => a.id === aOtherModel)).toBe(false); // unrequested model excluded
+  });
+
+  it("bulkAssets.listByModelIds groups bulk assets by the requested models", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const m1 = createId();
+    const b1 = createId();
+    await convex.mutation(api.bulkAssets.createIfMissing, { id: b1, organizationId: orgA, modelId: m1, assetTag: "B1" });
+
+    const res = await convex.query(api.bulkAssets.listByModelIds, { orgId: orgA, modelIds: [m1] });
+    expect(res.map((b) => b.id)).toEqual([b1]);
+  });
+});


### PR DESCRIPTION
## Fixes the "adding/editing a project item takes ~a minute, hundreds of Convex calls" report

Three perf fixes. The first is the one behind the reported slowness.

### 1. Add/edit project item — whole-org reads + N+1 (the ~1-minute hang)
`addLineItem` / `updateLineItem` / `checkAvailability` did their double-booking & availability checks with:
- a **per-unit `projectLineItems.getById` loop** over `projectLineItemUnits.list` (**every unit in the org**) — the "hundreds of log lines";
- **whole-org `projectLineItems.list`** then JS-filter by `modelId`/`kitId`, at **5 sites**.

**Fix:** new `projectLineItemUnits.listByOrgAndAsset` (by `by_organizationId_assetId_status`) + `projectLineItems.listByModelId` (by `by_modelId`); reuse existing `listByKitId`/`listByIds`. The asset-conflict path now does a scoped units read + **one batched `listByIds`** instead of the per-unit loop; the model/kit paths read scoped instead of whole-org. Codex-reviewed **behavior-preserving** (double-booking detection unchanged). Integration test covers the new scoped queries.

### 2. Projects-view N+1 — batched per-model asset reads (your earlier logs)
`computeOverbookedStatus` fired `assets.listByModel` + `bulkAssets.listByModel` **per model** (2N round-trips). New batched `listByModelIds` → **2N → 2**. The reactive project refetch hits this too, so it compounds with #1. Tested + Codex clean.

### 3. Warehouse checkout/check-in de-dup (#6a)
Batch the per-row model lookup in `checkInBulkTotals`; cache pre-mutation units gather→expand in `checkoutItems`. Behavior-preserving (Codex clean).

### Validation
- ✅ `tsc --noEmit` clean; ✅ Convex pushes clean; ✅ new integration tests pass; ✅ availability unit tests pass; ✅ Codex reviews clean on all three (behavior-preserving).
- ⚠️ Warehouse integration tests are **broken on `main`** vs the shared dev deployment (pre-existing, verified by baseline stash-compare) — so #6a has no green-test signal there; validated by non-regression + Codex.

### Deferred (rationale in thread)
#6b (nested-kit cascade — HIGH risk, no test env) and #3 (drop double-refetch — low value post-#2, UX risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)