### PR TITLE
perf: scope getProject + warehouse composites (the shared post-write refetch)

### DIFF
--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -36,6 +36,24 @@ export const getById = query({
   },
 });
 
+/**
+ * Batch point-read kits by cuid, scoped to one org — lets a composite read only
+ * the kits its line items reference (e.g. buildProjectEquipmentTree) instead of
+ * getKitsByOrg (every kit in the org). Cross-org ids are dropped.
+ */
+export const listByIds = query({
+  args: { orgId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { orgId, ids }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("kits.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
+  },
+});
+
 export const getByAssetTag = query({
   args: { organizationId: v.string(), assetTag: v.string() },
   handler: async (ctx, { organizationId, assetTag }) => {

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -711,6 +711,25 @@ export const listByModelId = query({
   },
 });
 
+/**
+ * Line items referencing ANY of the given models (batched by_modelId scans in one
+ * round-trip), org-filtered. Replaces a whole-org `projectLineItems.list` that
+ * availability (computeOverbookedStatus) collected then JS-filtered by the project's
+ * models. Deduped + capped.
+ */
+export const listByModelIds = query({
+  args: { modelIds: v.array(v.string()), orgId: v.string() },
+  handler: async (ctx, { modelIds, orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(modelIds)];
+    if (unique.length > 1000) throw new ConvexError("projectLineItems.listByModelIds: too many modelIds (max 1000)");
+    const groups = await Promise.all(
+      unique.map((mid) => ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect()),
+    );
+    return groups.flat().filter((r) => r.organizationId === orgId);
+  },
+});
+
 // ── CUSTOM (Phase C H) — by-kit lookup for kit delete-guards ──
 export const listByKitId = query({
   args: { kitId: v.string(), orgId: v.string() },

--- a/src/lib/assets-read.ts
+++ b/src/lib/assets-read.ts
@@ -32,6 +32,32 @@ export async function getBulkAssetsByOrg(orgId: string): Promise<ConvexBulkAsset
   return await (await getConvexClient()).query(api.bulkAssets.list, { orgId });
 }
 
+/**
+ * Scoped counterparts of getAssetsByOrg / getBulkAssetsByOrg: read only the rows
+ * a composite references by id (e.g. a project's line-item assets), instead of the
+ * whole org registry. Chunked at 1000 (the listByIds cap) so a large project can't
+ * hit it. Same raw doc shape, so callers' maps are unchanged.
+ */
+export async function getAssetsByIds(orgId: string, ids: string[]): Promise<ConvexAsset[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexAsset[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.assets.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
+export async function getBulkAssetsByIds(orgId: string, ids: string[]): Promise<ConvexBulkAsset[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexBulkAsset[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.bulkAssets.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
 export async function getAssetByAssetTag(orgId: string, assetTag: string): Promise<ConvexAsset | null> {
   return await (await getConvexClient()).query(api.assets.getByAssetTag, { organizationId: orgId, assetTag });
 }

--- a/src/lib/availability-read.ts
+++ b/src/lib/availability-read.ts
@@ -282,6 +282,19 @@ export async function getOrgLineItems(orgId: string): Promise<MappedLineItem[]> 
   return docs.map(mapLineItemDoc);
 }
 
+/**
+ * Scoped counterpart of getOrgLineItems: line items referencing only the given
+ * models (batched), instead of the whole org. Availability filters by model anyway,
+ * so this is behavior-preserving for that use — and avoids a whole-org read on every
+ * project refetch.
+ */
+export async function getLineItemsByModelIds(orgId: string, modelIds: string[]): Promise<MappedLineItem[]> {
+  if (modelIds.length === 0) return [];
+  const convex = await getConvexClient();
+  const docs: LineItemDoc[] = await convex.query(api.projectLineItems.listByModelIds, { modelIds, orgId });
+  return docs.map(mapLineItemDoc);
+}
+
 /** All line item units for the org, mapped to the Prisma unit row shape. */
 export async function getOrgLineItemUnits(orgId: string): Promise<MappedUnit[]> {
   const convex = await getConvexClient();

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -3,7 +3,7 @@ import { getProjectsByOrg } from "@/lib/projects-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import {
-  getOrgLineItems,
+  getLineItemsByModelIds,
   indexProjectsById,
   sumBookingsByModel,
   type DateWindow,
@@ -108,7 +108,7 @@ export async function computeOverbookedStatus(
   // Sub-hire items are third-party stock and are excluded.
   // When no dates: only count THIS project's bookings (no date overlap possible).
   const [orgLineItems, orgProjects] = await Promise.all([
-    getOrgLineItems(organizationId),
+    getLineItemsByModelIds(organizationId, modelIds),
     getProjectsByOrg(organizationId),
   ]);
   const projectsById = indexProjectsById(orgProjects);

--- a/src/lib/kits-read.ts
+++ b/src/lib/kits-read.ts
@@ -27,6 +27,21 @@ export async function getKitsByOrg(orgId: string): Promise<ConvexKit[]> {
   return await (await getConvexClient()).query(api.kits.list, { orgId });
 }
 
+/**
+ * Scoped counterpart of getKitsByOrg: read only the kits a composite references by
+ * id (e.g. a project's line-item kits), instead of every kit in the org. Chunked at
+ * the listByIds cap. Same doc shape, so callers' maps are unchanged.
+ */
+export async function getKitsByIds(orgId: string, ids: string[]): Promise<ConvexKit[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexKit[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.kits.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
 /** All of an org's kits keyed by cuid `id`, for attaching to joined rows. */
 export async function getKitMap(orgId: string): Promise<Map<string, ConvexKit>> {
   const all = await getKitsByOrg(orgId);

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -6,8 +6,10 @@ import {
   type ConvexBulkAsset,
   getAssetsByOrg,
   getBulkAssetsByOrg,
+  getAssetsByIds,
+  getBulkAssetsByIds,
 } from "@/lib/assets-read";
-import { type ConvexKit, getKitsByOrg, getKitMap } from "@/lib/kits-read";
+import { type ConvexKit, getKitsByOrg, getKitsByIds, getKitMap } from "@/lib/kits-read";
 import { type ConvexLocation, getLocationMap } from "@/lib/locations-read";
 import {
   buildLineItemAttachMaps,
@@ -413,14 +415,30 @@ export async function buildProjectEquipmentTree(
   const lineItems = liDocs.map(mapLineItemDoc);
   const lineItemIds = lineItems.map((li) => li.id);
 
-  const [unitDocs, attachMaps, assetArr, bulkArr, kitArr] = await Promise.all([
+  const [unitDocs, attachMaps] = await Promise.all([
     lineItemIds.length
       ? convex.query(api.projectLineItemUnits.listByLineItemIds, { lineItemIds })
       : Promise.resolve([] as UnitDoc[]),
     buildLineItemAttachMaps(organizationId),
-    getAssetsByOrg(organizationId),
-    getBulkAssetsByOrg(organizationId),
-    getKitsByOrg(organizationId),
+  ]);
+
+  // Scope the asset/bulk/kit reads to the ids THIS project's lines + units actually
+  // reference (was: getAssetsByOrg / getBulkAssetsByOrg / getKitsByOrg — the whole
+  // org registry, read on EVERY project refetch incl. every add/edit/delete). Same
+  // raw doc shape, so the maps below are unchanged.
+  const refAssetIds = [...new Set(
+    [...lineItems.map((li) => li.assetId), ...unitDocs.map((u) => u.assetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refBulkIds = [...new Set(
+    [...lineItems.map((li) => li.bulkAssetId), ...unitDocs.map((u) => u.bulkAssetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refKitIds = [...new Set(lineItems.map((li) => li.kitId).filter((x): x is string => !!x))];
+  const [assetArr, bulkArr, kitArr] = await Promise.all([
+    getAssetsByIds(organizationId, refAssetIds),
+    getBulkAssetsByIds(organizationId, refBulkIds),
+    getKitsByIds(organizationId, refKitIds),
   ]);
 
   const assetMap = new Map(assetArr.map((a) => [a.id, a]));

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -506,7 +506,7 @@ export async function buildWarehouseLineItems(projectId: string, organizationId:
   const lineItems = liDocs.map(mapLineItemDoc);
   const lineItemIds = lineItems.map((li) => li.id);
 
-  const [unitDocs, attachMaps, kitMap, modelCheckCounts, kitCheckCounts, assetArr, bulkArr] =
+  const [unitDocs, attachMaps, kitMap, modelCheckCounts, kitCheckCounts] =
     await Promise.all([
       lineItemIds.length
         ? convex.query(api.projectLineItemUnits.listByLineItemIds, { lineItemIds })
@@ -515,9 +515,23 @@ export async function buildWarehouseLineItems(projectId: string, organizationId:
       getKitMap(organizationId),
       getModelCheckItemCountMap(organizationId),
       getKitCheckItemCountMap(organizationId),
-      getAssetsByOrg(organizationId),
-      getBulkAssetsByOrg(organizationId),
     ]);
+
+  // Scope asset/bulk reads to the ids this project's lines + units reference (assets
+  // attach on BOTH lines and units here) — was getAssetsByOrg/getBulkAssetsByOrg (the
+  // whole org registry) on every warehouse refetch.
+  const refAssetIds = [...new Set(
+    [...lineItems.map((li) => li.assetId), ...unitDocs.map((u) => u.assetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refBulkIds = [...new Set(
+    [...lineItems.map((li) => li.bulkAssetId), ...unitDocs.map((u) => u.bulkAssetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const [assetArr, bulkArr] = await Promise.all([
+    getAssetsByIds(organizationId, refAssetIds),
+    getBulkAssetsByIds(organizationId, refBulkIds),
+  ]);
 
   const assetMap = new Map(assetArr.map((a) => [a.id, a]));
   const bulkAssetMap = new Map(bulkArr.map((b) => [b.id, b]));

--- a/src/server/project-equipment-scoping.int.test.ts
+++ b/src/server/project-equipment-scoping.int.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Scoping test for buildProjectEquipmentTree (the getProject equipment composite,
+ * run on every project refetch — incl. every add/edit/delete). It used to read the
+ * WHOLE org asset/bulk/kit registries to attach them to the project's line items;
+ * it now reads only the ids the lines reference. Property to lock in: a line item's
+ * asset still attaches correctly (proves the scoped read finds it), and unrelated
+ * org assets don't change the result.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { buildProjectEquipmentTree } from "@/lib/project-line-item-read";
+
+describe("buildProjectEquipmentTree — scoped asset/bulk/kit reads", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("attaches the line item's asset via the scoped read; ignores unrelated org assets", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const modelId = createId();
+    const projectId = createId();
+    const a1 = createId();
+    const lineId = createId();
+
+    await convex.mutation(api.projects.createIfMissing, {
+      id: projectId, organizationId: orgA, projectNumber: "P-1", name: "P",
+    });
+    await convex.mutation(api.assets.createIfMissing, {
+      id: a1, organizationId: orgA, modelId, assetTag: "A1",
+    });
+    // a top-level project line item referencing asset a1
+    await convex.mutation(api.projectLineItems.createIfMissing, {
+      id: lineId, organizationId: orgA, projectId, modelId, assetId: a1,
+    });
+    // an unrelated org asset NOT on the project — must not change the result and
+    // (pre-fix) would have been pulled in by the whole-org read.
+    await convex.mutation(api.assets.createIfMissing, {
+      id: createId(), organizationId: orgA, modelId, assetTag: "A-OTHER",
+    });
+
+    const tree = (await buildProjectEquipmentTree(projectId, orgA)) as {
+      lineItems: Array<{ id: string; asset: { id: string } | null }>;
+    };
+
+    const line = tree.lineItems.find((li) => li.id === lineId);
+    expect(line).toBeDefined();
+    // the scoped getAssetsByIds must have found a1 and attached it
+    expect(line!.asset?.id).toBe(a1);
+  });
+});


### PR DESCRIPTION
## Lever 1 continued — scope the project-detail + warehouse refetch composites

Every add/edit/**delete** triggers the project-detail (and warehouse) reactive refetch, which re-runs these composites. They were doing the **same whole-org over-fetch** as the old `getKit` — read the entire asset/bulk/kit registries to attach them to one project's line items.

### Fixes (parity-by-construction, Codex-reviewed clean)
- **`getProject`** (`buildProjectEquipmentTree`): replaced `getAssetsByOrg`/`getBulkAssetsByOrg`/`getKitsByOrg` (whole registries) with scoped reads over the ids the project's lines + units reference. Also scoped `computeOverbookedStatus`'s whole-org `getOrgLineItems` → `getLineItemsByModelIds` (the project's models). New queries: `kits.listByIds`, `projectLineItems.listByModelIds`; helpers `getAssetsByIds`/`getBulkAssetsByIds`/`getKitsByIds`/`getLineItemsByModelIds`.
- **`buildWarehouseLineItems`** (warehouse detail composite): same scoping for assets/bulks.

### Validation
- ✅ `tsc --noEmit` clean; ✅ Convex pushes clean.
- ✅ New integration test: `buildProjectEquipmentTree` attaches the line item's asset via the scoped read with unrelated org assets present.
- ✅ Codex reviewed both composites — confirmed the id-derivation covers every id the old whole-org maps could resolve (lines ∪ units, child rows included), org-filtered, two-wave ordering correct.
- ⚠️ Warehouse has **no green-test signal** (shared-dev warehouse tests broken pre-existing); the warehouse change is identical-pattern to the getProject change (which has a passing test) + Codex-verified.

### Deliberately NOT in this PR
- `buildPullSheetLineItems` / `buildDocumentLineItemData` (same pattern) are **PDF/docket generation, on-demand, not the hot reactive path** — and CLAUDE.md flags the PDF pipeline as footgun-prone. Deferred to a careful audited pass.
- `getKitMap` in the warehouse composite left whole-org (smaller table, different shape) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)