### PR TITLE
feat(convex): Better-Auth users mirror — the waterfall-unlock groundwork (lever 2, step 1)

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,80 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * Convex mirror of the Better-Auth `user` table (the source of truth stays in
+ * Prisma — Better Auth owns it). Written best-effort by `src/lib/user-mirror.ts`
+ * on every user create/update. The point: let detail composites resolve the
+ * linked user (scannedBy, projectManagers.user, …) from Convex instead of a
+ * cross-domain `prisma.user` join, which is the blocker to making those pages
+ * pure-Convex live subscriptions (see docs/designs/perf-waterfall-spike-T1.md).
+ *
+ * AUTH: users are NOT org-scoped (a user is global; org membership is the `member`
+ * table), so reads/writes are SERVICE-only (the trusted backend token), matching
+ * the rest of the kept-data mirror surface. Nothing reads these yet — this PR only
+ * stands up the table + the mirror so a later PR can rewire composites onto it.
+ */
+
+export const getById = query({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    await requireService(ctx);
+    return await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+  },
+});
+
+/** Batch point-read users by id (one by_cuid lookup each). Deduped + capped. */
+export const listByIds = query({
+  args: { ids: v.array(v.string()) },
+  handler: async (ctx, { ids }) => {
+    await requireService(ctx);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("users.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null);
+  },
+});
+
+/**
+ * Insert-or-REPLACE by `id`. Idempotent under Convex OCC (the by_cuid read is in the
+ * transaction's read set, so a racing insert forces a retry → no duplicate row).
+ *
+ * Uses `replace` (not `patch`) on an existing row so the Convex doc becomes EXACTLY
+ * the mirror args — a field the caller omits (e.g. `image` after an avatar clear) is
+ * removed, not left stale. The mirror helper always re-reads the full Prisma row, so
+ * the args are the complete current state. Only the displayed/used fields are
+ * mirrored (name/email/image/role/emailVerified + timestamps); ban/2FA are not.
+ */
+export const upsert = mutation({
+  args: {
+    id: v.string(),
+    name: v.string(),
+    email: v.string(),
+    emailVerified: v.optional(v.boolean()),
+    image: v.optional(v.string()),
+    role: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+    if (existing) {
+      await ctx.db.replace(existing._id, args);
+      return existing._id;
+    }
+    return await ctx.db.insert("users", args);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (doc) await ctx.db.delete(doc._id);
+  },
+});

--- a/scripts/convex-backfill-users.ts
+++ b/scripts/convex-backfill-users.ts
@@ -1,0 +1,44 @@
+/**
+ * One-time backfill: copy the Better-Auth `user` table from Prisma into the Convex
+ * `users` mirror. Idempotent (upsert by cuid `id`) — safe to re-run; re-running is
+ * the heal path for the deploy-window gap (users created/edited between enabling
+ * the mirror writes in app code and finishing this backfill).
+ *
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-users.ts
+ *
+ * The Convex `users` table is a READ MIRROR — Better Auth (Prisma) stays the source
+ * of truth. See docs/designs/perf-waterfall-spike-T1.md (the user-mirror unlock).
+ */
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+async function main() {
+  const convex = await getConvexClient();
+  const users = await prisma.user.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`Found ${users.length} users in Prisma.`);
+
+  let n = 0;
+  for (const u of users) {
+    await convex.mutation(api.users.upsert, {
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      emailVerified: u.emailVerified ?? undefined,
+      image: u.image ?? undefined,
+      role: u.role ?? undefined,
+      createdAt: u.createdAt ? u.createdAt.getTime() : undefined,
+      updatedAt: u.updatedAt ? u.updatedAt.getTime() : undefined,
+    });
+    n++;
+    console.log(`  ~ ${u.email} (${u.id})`);
+  }
+
+  console.log(`\nUser-mirror backfill complete: ${n} upserted.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireSession } from "@/lib/auth-server";
 import { validateCsrfOrigin } from "@/lib/csrf";
 import { prisma } from "@/lib/prisma";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 import { uploadToS3, deleteFromS3, ensureBucket, storageKeyFromUrl } from "@/lib/storage";
 import sharp from "sharp";
 import { fileTypeFromBuffer } from "file-type";
@@ -83,6 +84,7 @@ export async function POST(request: NextRequest) {
       where: { id: userId },
       data: { image: url },
     });
+    await mirrorUserToConvex(userId); // keep the Convex user mirror in sync
 
     return NextResponse.json({ url });
   } catch (error) {
@@ -121,6 +123,7 @@ export async function DELETE(request: NextRequest) {
       where: { id: userId },
       data: { image: null },
     });
+    await mirrorUserToConvex(userId); // keep the Convex user mirror in sync
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { sso } from "@better-auth/sso";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { env } from "@/env";
 import { prisma } from "@/lib/prisma";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 import { sendEmail } from "./email";
 import { getPlatformName } from "./platform";
 import { getSiteSettingsFromConvex } from "./site-settings-read";
@@ -267,6 +268,10 @@ export const auth = betterAuth({
           } catch {
             // Non-critical — don't block registration
           }
+
+          // Mirror the new user into Convex (best-effort; runs after the role +
+          // org-membership writes above so the mirror captures the final role).
+          await mirrorUserToConvex(user.id);
         },
       },
     },

--- a/src/lib/user-mirror.ts
+++ b/src/lib/user-mirror.ts
@@ -1,0 +1,59 @@
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Best-effort mirror of a Better-Auth `user` row (Prisma, source of truth) into the
+ * Convex `users` mirror. Call after every user create/update (signup hook, profile
+ * edit, avatar change, admin role change).
+ *
+ * CONTRACT: this MUST NEVER throw into the calling flow — auth/profile writes are
+ * the source of truth and must succeed regardless of the mirror. A failed mirror
+ * just leaves the Convex row stale until the next write or a backfill. (Nothing
+ * reads the Convex users yet; staleness is harmless until composites are rewired.)
+ */
+export async function mirrorUserToConvex(userId: string): Promise<void> {
+  try {
+    const u = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        emailVerified: true,
+        image: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (!u) return;
+    const convex = await getConvexClient();
+    await convex.mutation(api.users.upsert, {
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      emailVerified: u.emailVerified ?? undefined,
+      image: u.image ?? undefined,
+      role: u.role ?? undefined,
+      createdAt: u.createdAt ? u.createdAt.getTime() : undefined,
+      updatedAt: u.updatedAt ? u.updatedAt.getTime() : undefined,
+    });
+  } catch (err) {
+    // Swallow — never block the auth/profile flow on a mirror failure.
+    console.error(`[user-mirror] failed to mirror user ${userId}:`, err);
+  }
+}
+
+/**
+ * Best-effort removal from the Convex `users` mirror after a Prisma user delete.
+ * Same contract: never throws into the calling flow.
+ */
+export async function removeUserFromConvex(userId: string): Promise<void> {
+  try {
+    const convex = await getConvexClient();
+    await convex.mutation(api.users.remove, { id: userId });
+  } catch (err) {
+    console.error(`[user-mirror] failed to remove user ${userId} from mirror:`, err);
+  }
+}

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -2,6 +2,7 @@
 
 import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
+import { removeUserFromConvex } from "@/lib/user-mirror";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getSiteSettingsFromConvex } from "@/lib/site-settings-read";
@@ -604,6 +605,9 @@ export async function adminDeleteUser(userId: string) {
       userId,
     });
   }
+
+  // Remove the user from the Convex `users` mirror (best-effort).
+  await removeUserFromConvex(userId);
 
   const theOrg = await getTheOrg();
   if (theOrg) {

--- a/src/server/user-mirror.int.test.ts
+++ b/src/server/user-mirror.int.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration test for the Better-Auth user → Convex `users` mirror
+ * (src/lib/user-mirror.ts + convex/users.ts). The mirror is the unlock that lets
+ * detail composites resolve linked users from Convex instead of a cross-domain
+ * Prisma join (the version-vector-waterfall fix groundwork).
+ *
+ * Properties: a user mirrors on create; re-mirroring after an update PATCHES the
+ * same row (no duplicate); listByIds returns it.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest, createOrgFixture, createUserFixture } from "../../tests/helpers/integration";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { mirrorUserToConvex, removeUserFromConvex } from "@/lib/user-mirror";
+import { prisma } from "@/lib/prisma";
+
+describe("user-mirror — Better Auth user → Convex users", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("mirrors on create and patches (not duplicates) on update", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const convex = await getConvexClient();
+
+    // Not mirrored yet.
+    expect(await convex.query(api.users.getById, { id: user.id })).toBeNull();
+
+    await mirrorUserToConvex(user.id);
+    const mirrored = await convex.query(api.users.getById, { id: user.id });
+    expect(mirrored?.id).toBe(user.id);
+    expect(mirrored?.name).toBe(user.name);
+    expect(mirrored?.email).toBe(user.email);
+
+    // Update in Prisma → re-mirror → the SAME row is patched.
+    await prisma.user.update({ where: { id: user.id }, data: { name: "Renamed" } });
+    await mirrorUserToConvex(user.id);
+    const updated = await convex.query(api.users.getById, { id: user.id });
+    expect(updated?.name).toBe("Renamed");
+    expect(updated?._id).toBe(mirrored?._id); // same document, not a duplicate
+
+    const batch = await convex.query(api.users.listByIds, { ids: [user.id] });
+    expect(batch.map((u) => u.id)).toEqual([user.id]);
+  });
+
+  it("clears image on re-mirror (replace semantics, not stale), and removes on delete", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const convex = await getConvexClient();
+
+    await prisma.user.update({ where: { id: user.id }, data: { image: "https://x/a.png" } });
+    await mirrorUserToConvex(user.id);
+    expect((await convex.query(api.users.getById, { id: user.id }))?.image).toBe("https://x/a.png");
+
+    // Clear the avatar in Prisma → re-mirror → the Convex image must be GONE
+    // (replace, not patch — patch would leave the old URL).
+    await prisma.user.update({ where: { id: user.id }, data: { image: null } });
+    await mirrorUserToConvex(user.id);
+    expect((await convex.query(api.users.getById, { id: user.id }))?.image).toBeUndefined();
+
+    // Delete → mirror removal.
+    await removeUserFromConvex(user.id);
+    expect(await convex.query(api.users.getById, { id: user.id })).toBeNull();
+  });
+});

--- a/src/server/user-profile.ts
+++ b/src/server/user-profile.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireSession } from "@/lib/auth-server";
 import { serialize } from "@/lib/serialize";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 
 export async function getProfile() {
   const session = await requireSession();
@@ -41,6 +42,9 @@ export async function updateProfile(data: { name?: string; image?: string | null
       image: true,
     },
   });
+
+  // Keep the Convex user mirror in sync (best-effort).
+  await mirrorUserToConvex(session.user.id);
 
   return serialize(updated);
 }


### PR DESCRIPTION
## Lever 2, step 1 — mirror Better-Auth users into Convex (additive, nothing reads it yet)

The version-vector → server-action waterfall (the per-tick refetch + double-refetch behind every detail page) exists because the composites join `prisma.user` — so they can't be pure Convex live subscriptions. The spike (#281) recommends mirroring users into Convex as the **small, safe unlock**. This is that step. **No composite is rewired here** — that's the next PR.

### What's here
- **`convex/users.ts`** — `getById` / `listByIds` / `upsert` / `remove` (service-only; users are global/cross-org). `upsert` uses `ctx.db.replace` so the mirror row is *exactly* the current Prisma user (an avatar clear removes the image; no staleness). OCC-safe insert-or-replace. Wires up the pre-existing (unused) Convex `users` table.
- **`src/lib/user-mirror.ts`** — `mirrorUserToConvex` / `removeUserFromConvex`, **best-effort** (try/catch'd — a Convex failure can never block signup/profile/avatar).
- **Mirror write sites** — Better-Auth `create.after` (signup + OAuth/SSO), `updateProfile`, avatar set/clear, and the site-admin user-delete (removal). Covers every name/email/image change.
- **`scripts/convex-backfill-users.ts`** — one-time idempotent backfill (run in prod later; not run here).

### Validation
- ✅ Convex push + `tsc --noEmit` clean.
- ✅ Integration test: mirror-on-create, patch-on-update (no duplicate), **image-clear via replace**, removal.
- ✅ Codex-reviewed; 3 P2s fixed (avatar-clear staleness → `replace`; delete mirroring; dropped unused ban/2FA fields). Confirmed `mirrorUserToConvex` can't throw into the auth flow, and `create.after` covers OAuth/SSO.

### Deferred (intentional)
- Role-only admin changes aren't mirrored (role isn't read from Convex yet; the backfill reconciles).
- **Next PR:** rewire one detail composite (e.g. project managers / scan-logs `scannedBy`) to read users from Convex, then convert that surface to a pure `useQuery` subscription — and measure the waterfall shrink.

### Ops note
After merge + deploy, run `pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-users.ts` against prod to seed existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)