### PR TITLE
perf: getProject/warehouse scoping + Better-Auth user mirror (batched, one deploy)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -89,6 +89,7 @@ import type * as testTagAssets from "../testTagAssets.js";
 import type * as testTagAuditorTokens from "../testTagAuditorTokens.js";
 import type * as testTagRecords from "../testTagRecords.js";
 import type * as userNotificationPreferences from "../userNotificationPreferences.js";
+import type * as users from "../users.js";
 import type * as warehouseCloses from "../warehouseCloses.js";
 import type * as warehouseDashboardTokens from "../warehouseDashboardTokens.js";
 import type * as warehouseDetail from "../warehouseDetail.js";
@@ -184,6 +185,7 @@ declare const fullApi: ApiFromModules<{
   testTagAuditorTokens: typeof testTagAuditorTokens;
   testTagRecords: typeof testTagRecords;
   userNotificationPreferences: typeof userNotificationPreferences;
+  users: typeof users;
   warehouseCloses: typeof warehouseCloses;
   warehouseDashboardTokens: typeof warehouseDashboardTokens;
   warehouseDetail: typeof warehouseDetail;

--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -36,6 +36,24 @@ export const getById = query({
   },
 });
 
+/**
+ * Batch point-read kits by cuid, scoped to one org — lets a composite read only
+ * the kits its line items reference (e.g. buildProjectEquipmentTree) instead of
+ * getKitsByOrg (every kit in the org). Cross-org ids are dropped.
+ */
+export const listByIds = query({
+  args: { orgId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { orgId, ids }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("kits.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
+  },
+});
+
 export const getByAssetTag = query({
   args: { organizationId: v.string(), assetTag: v.string() },
   handler: async (ctx, { organizationId, assetTag }) => {

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -711,6 +711,25 @@ export const listByModelId = query({
   },
 });
 
+/**
+ * Line items referencing ANY of the given models (batched by_modelId scans in one
+ * round-trip), org-filtered. Replaces a whole-org `projectLineItems.list` that
+ * availability (computeOverbookedStatus) collected then JS-filtered by the project's
+ * models. Deduped + capped.
+ */
+export const listByModelIds = query({
+  args: { modelIds: v.array(v.string()), orgId: v.string() },
+  handler: async (ctx, { modelIds, orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(modelIds)];
+    if (unique.length > 1000) throw new ConvexError("projectLineItems.listByModelIds: too many modelIds (max 1000)");
+    const groups = await Promise.all(
+      unique.map((mid) => ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect()),
+    );
+    return groups.flat().filter((r) => r.organizationId === orgId);
+  },
+});
+
 // ── CUSTOM (Phase C H) — by-kit lookup for kit delete-guards ──
 export const listByKitId = query({
   args: { kitId: v.string(), orgId: v.string() },

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,80 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * Convex mirror of the Better-Auth `user` table (the source of truth stays in
+ * Prisma — Better Auth owns it). Written best-effort by `src/lib/user-mirror.ts`
+ * on every user create/update. The point: let detail composites resolve the
+ * linked user (scannedBy, projectManagers.user, …) from Convex instead of a
+ * cross-domain `prisma.user` join, which is the blocker to making those pages
+ * pure-Convex live subscriptions (see docs/designs/perf-waterfall-spike-T1.md).
+ *
+ * AUTH: users are NOT org-scoped (a user is global; org membership is the `member`
+ * table), so reads/writes are SERVICE-only (the trusted backend token), matching
+ * the rest of the kept-data mirror surface. Nothing reads these yet — this PR only
+ * stands up the table + the mirror so a later PR can rewire composites onto it.
+ */
+
+export const getById = query({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    await requireService(ctx);
+    return await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+  },
+});
+
+/** Batch point-read users by id (one by_cuid lookup each). Deduped + capped. */
+export const listByIds = query({
+  args: { ids: v.array(v.string()) },
+  handler: async (ctx, { ids }) => {
+    await requireService(ctx);
+    const unique = [...new Set(ids)];
+    if (unique.length > 1000) throw new ConvexError("users.listByIds: too many ids (max 1000)");
+    const docs = await Promise.all(
+      unique.map((id) => ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+    );
+    return docs.filter((d): d is NonNullable<typeof d> => d !== null);
+  },
+});
+
+/**
+ * Insert-or-REPLACE by `id`. Idempotent under Convex OCC (the by_cuid read is in the
+ * transaction's read set, so a racing insert forces a retry → no duplicate row).
+ *
+ * Uses `replace` (not `patch`) on an existing row so the Convex doc becomes EXACTLY
+ * the mirror args — a field the caller omits (e.g. `image` after an avatar clear) is
+ * removed, not left stale. The mirror helper always re-reads the full Prisma row, so
+ * the args are the complete current state. Only the displayed/used fields are
+ * mirrored (name/email/image/role/emailVerified + timestamps); ban/2FA are not.
+ */
+export const upsert = mutation({
+  args: {
+    id: v.string(),
+    name: v.string(),
+    email: v.string(),
+    emailVerified: v.optional(v.boolean()),
+    image: v.optional(v.string()),
+    role: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+    if (existing) {
+      await ctx.db.replace(existing._id, args);
+      return existing._id;
+    }
+    return await ctx.db.insert("users", args);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (doc) await ctx.db.delete(doc._id);
+  },
+});

--- a/scripts/convex-backfill-users.ts
+++ b/scripts/convex-backfill-users.ts
@@ -1,0 +1,44 @@
+/**
+ * One-time backfill: copy the Better-Auth `user` table from Prisma into the Convex
+ * `users` mirror. Idempotent (upsert by cuid `id`) — safe to re-run; re-running is
+ * the heal path for the deploy-window gap (users created/edited between enabling
+ * the mirror writes in app code and finishing this backfill).
+ *
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-users.ts
+ *
+ * The Convex `users` table is a READ MIRROR — Better Auth (Prisma) stays the source
+ * of truth. See docs/designs/perf-waterfall-spike-T1.md (the user-mirror unlock).
+ */
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+async function main() {
+  const convex = await getConvexClient();
+  const users = await prisma.user.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`Found ${users.length} users in Prisma.`);
+
+  let n = 0;
+  for (const u of users) {
+    await convex.mutation(api.users.upsert, {
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      emailVerified: u.emailVerified ?? undefined,
+      image: u.image ?? undefined,
+      role: u.role ?? undefined,
+      createdAt: u.createdAt ? u.createdAt.getTime() : undefined,
+      updatedAt: u.updatedAt ? u.updatedAt.getTime() : undefined,
+    });
+    n++;
+    console.log(`  ~ ${u.email} (${u.id})`);
+  }
+
+  console.log(`\nUser-mirror backfill complete: ${n} upserted.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireSession } from "@/lib/auth-server";
 import { validateCsrfOrigin } from "@/lib/csrf";
 import { prisma } from "@/lib/prisma";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 import { uploadToS3, deleteFromS3, ensureBucket, storageKeyFromUrl } from "@/lib/storage";
 import sharp from "sharp";
 import { fileTypeFromBuffer } from "file-type";
@@ -83,6 +84,7 @@ export async function POST(request: NextRequest) {
       where: { id: userId },
       data: { image: url },
     });
+    await mirrorUserToConvex(userId); // keep the Convex user mirror in sync
 
     return NextResponse.json({ url });
   } catch (error) {
@@ -121,6 +123,7 @@ export async function DELETE(request: NextRequest) {
       where: { id: userId },
       data: { image: null },
     });
+    await mirrorUserToConvex(userId); // keep the Convex user mirror in sync
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/lib/assets-read.ts
+++ b/src/lib/assets-read.ts
@@ -32,6 +32,32 @@ export async function getBulkAssetsByOrg(orgId: string): Promise<ConvexBulkAsset
   return await (await getConvexClient()).query(api.bulkAssets.list, { orgId });
 }
 
+/**
+ * Scoped counterparts of getAssetsByOrg / getBulkAssetsByOrg: read only the rows
+ * a composite references by id (e.g. a project's line-item assets), instead of the
+ * whole org registry. Chunked at 1000 (the listByIds cap) so a large project can't
+ * hit it. Same raw doc shape, so callers' maps are unchanged.
+ */
+export async function getAssetsByIds(orgId: string, ids: string[]): Promise<ConvexAsset[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexAsset[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.assets.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
+export async function getBulkAssetsByIds(orgId: string, ids: string[]): Promise<ConvexBulkAsset[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexBulkAsset[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.bulkAssets.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
 export async function getAssetByAssetTag(orgId: string, assetTag: string): Promise<ConvexAsset | null> {
   return await (await getConvexClient()).query(api.assets.getByAssetTag, { organizationId: orgId, assetTag });
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { sso } from "@better-auth/sso";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { env } from "@/env";
 import { prisma } from "@/lib/prisma";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 import { sendEmail } from "./email";
 import { getPlatformName } from "./platform";
 import { getSiteSettingsFromConvex } from "./site-settings-read";
@@ -267,6 +268,10 @@ export const auth = betterAuth({
           } catch {
             // Non-critical — don't block registration
           }
+
+          // Mirror the new user into Convex (best-effort; runs after the role +
+          // org-membership writes above so the mirror captures the final role).
+          await mirrorUserToConvex(user.id);
         },
       },
     },

--- a/src/lib/availability-read.ts
+++ b/src/lib/availability-read.ts
@@ -282,6 +282,19 @@ export async function getOrgLineItems(orgId: string): Promise<MappedLineItem[]> 
   return docs.map(mapLineItemDoc);
 }
 
+/**
+ * Scoped counterpart of getOrgLineItems: line items referencing only the given
+ * models (batched), instead of the whole org. Availability filters by model anyway,
+ * so this is behavior-preserving for that use — and avoids a whole-org read on every
+ * project refetch.
+ */
+export async function getLineItemsByModelIds(orgId: string, modelIds: string[]): Promise<MappedLineItem[]> {
+  if (modelIds.length === 0) return [];
+  const convex = await getConvexClient();
+  const docs: LineItemDoc[] = await convex.query(api.projectLineItems.listByModelIds, { modelIds, orgId });
+  return docs.map(mapLineItemDoc);
+}
+
 /** All line item units for the org, mapped to the Prisma unit row shape. */
 export async function getOrgLineItemUnits(orgId: string): Promise<MappedUnit[]> {
   const convex = await getConvexClient();

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -3,7 +3,7 @@ import { getProjectsByOrg } from "@/lib/projects-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import {
-  getOrgLineItems,
+  getLineItemsByModelIds,
   indexProjectsById,
   sumBookingsByModel,
   type DateWindow,
@@ -108,7 +108,7 @@ export async function computeOverbookedStatus(
   // Sub-hire items are third-party stock and are excluded.
   // When no dates: only count THIS project's bookings (no date overlap possible).
   const [orgLineItems, orgProjects] = await Promise.all([
-    getOrgLineItems(organizationId),
+    getLineItemsByModelIds(organizationId, modelIds),
     getProjectsByOrg(organizationId),
   ]);
   const projectsById = indexProjectsById(orgProjects);

--- a/src/lib/kits-read.ts
+++ b/src/lib/kits-read.ts
@@ -27,6 +27,21 @@ export async function getKitsByOrg(orgId: string): Promise<ConvexKit[]> {
   return await (await getConvexClient()).query(api.kits.list, { orgId });
 }
 
+/**
+ * Scoped counterpart of getKitsByOrg: read only the kits a composite references by
+ * id (e.g. a project's line-item kits), instead of every kit in the org. Chunked at
+ * the listByIds cap. Same doc shape, so callers' maps are unchanged.
+ */
+export async function getKitsByIds(orgId: string, ids: string[]): Promise<ConvexKit[]> {
+  if (ids.length === 0) return [];
+  const convex = await getConvexClient();
+  const out: ConvexKit[] = [];
+  for (let i = 0; i < ids.length; i += 1000) {
+    out.push(...(await convex.query(api.kits.listByIds, { orgId, ids: ids.slice(i, i + 1000) })));
+  }
+  return out;
+}
+
 /** All of an org's kits keyed by cuid `id`, for attaching to joined rows. */
 export async function getKitMap(orgId: string): Promise<Map<string, ConvexKit>> {
   const all = await getKitsByOrg(orgId);

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -6,8 +6,10 @@ import {
   type ConvexBulkAsset,
   getAssetsByOrg,
   getBulkAssetsByOrg,
+  getAssetsByIds,
+  getBulkAssetsByIds,
 } from "@/lib/assets-read";
-import { type ConvexKit, getKitsByOrg, getKitMap } from "@/lib/kits-read";
+import { type ConvexKit, getKitsByOrg, getKitsByIds, getKitMap } from "@/lib/kits-read";
 import { type ConvexLocation, getLocationMap } from "@/lib/locations-read";
 import {
   buildLineItemAttachMaps,
@@ -413,14 +415,30 @@ export async function buildProjectEquipmentTree(
   const lineItems = liDocs.map(mapLineItemDoc);
   const lineItemIds = lineItems.map((li) => li.id);
 
-  const [unitDocs, attachMaps, assetArr, bulkArr, kitArr] = await Promise.all([
+  const [unitDocs, attachMaps] = await Promise.all([
     lineItemIds.length
       ? convex.query(api.projectLineItemUnits.listByLineItemIds, { lineItemIds })
       : Promise.resolve([] as UnitDoc[]),
     buildLineItemAttachMaps(organizationId),
-    getAssetsByOrg(organizationId),
-    getBulkAssetsByOrg(organizationId),
-    getKitsByOrg(organizationId),
+  ]);
+
+  // Scope the asset/bulk/kit reads to the ids THIS project's lines + units actually
+  // reference (was: getAssetsByOrg / getBulkAssetsByOrg / getKitsByOrg — the whole
+  // org registry, read on EVERY project refetch incl. every add/edit/delete). Same
+  // raw doc shape, so the maps below are unchanged.
+  const refAssetIds = [...new Set(
+    [...lineItems.map((li) => li.assetId), ...unitDocs.map((u) => u.assetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refBulkIds = [...new Set(
+    [...lineItems.map((li) => li.bulkAssetId), ...unitDocs.map((u) => u.bulkAssetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refKitIds = [...new Set(lineItems.map((li) => li.kitId).filter((x): x is string => !!x))];
+  const [assetArr, bulkArr, kitArr] = await Promise.all([
+    getAssetsByIds(organizationId, refAssetIds),
+    getBulkAssetsByIds(organizationId, refBulkIds),
+    getKitsByIds(organizationId, refKitIds),
   ]);
 
   const assetMap = new Map(assetArr.map((a) => [a.id, a]));

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -506,7 +506,7 @@ export async function buildWarehouseLineItems(projectId: string, organizationId:
   const lineItems = liDocs.map(mapLineItemDoc);
   const lineItemIds = lineItems.map((li) => li.id);
 
-  const [unitDocs, attachMaps, kitMap, modelCheckCounts, kitCheckCounts, assetArr, bulkArr] =
+  const [unitDocs, attachMaps, kitMap, modelCheckCounts, kitCheckCounts] =
     await Promise.all([
       lineItemIds.length
         ? convex.query(api.projectLineItemUnits.listByLineItemIds, { lineItemIds })
@@ -515,9 +515,23 @@ export async function buildWarehouseLineItems(projectId: string, organizationId:
       getKitMap(organizationId),
       getModelCheckItemCountMap(organizationId),
       getKitCheckItemCountMap(organizationId),
-      getAssetsByOrg(organizationId),
-      getBulkAssetsByOrg(organizationId),
     ]);
+
+  // Scope asset/bulk reads to the ids this project's lines + units reference (assets
+  // attach on BOTH lines and units here) — was getAssetsByOrg/getBulkAssetsByOrg (the
+  // whole org registry) on every warehouse refetch.
+  const refAssetIds = [...new Set(
+    [...lineItems.map((li) => li.assetId), ...unitDocs.map((u) => u.assetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const refBulkIds = [...new Set(
+    [...lineItems.map((li) => li.bulkAssetId), ...unitDocs.map((u) => u.bulkAssetId)]
+      .filter((x): x is string => !!x),
+  )];
+  const [assetArr, bulkArr] = await Promise.all([
+    getAssetsByIds(organizationId, refAssetIds),
+    getBulkAssetsByIds(organizationId, refBulkIds),
+  ]);
 
   const assetMap = new Map(assetArr.map((a) => [a.id, a]));
   const bulkAssetMap = new Map(bulkArr.map((b) => [b.id, b]));

--- a/src/lib/user-mirror.ts
+++ b/src/lib/user-mirror.ts
@@ -1,0 +1,59 @@
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Best-effort mirror of a Better-Auth `user` row (Prisma, source of truth) into the
+ * Convex `users` mirror. Call after every user create/update (signup hook, profile
+ * edit, avatar change, admin role change).
+ *
+ * CONTRACT: this MUST NEVER throw into the calling flow — auth/profile writes are
+ * the source of truth and must succeed regardless of the mirror. A failed mirror
+ * just leaves the Convex row stale until the next write or a backfill. (Nothing
+ * reads the Convex users yet; staleness is harmless until composites are rewired.)
+ */
+export async function mirrorUserToConvex(userId: string): Promise<void> {
+  try {
+    const u = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        emailVerified: true,
+        image: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (!u) return;
+    const convex = await getConvexClient();
+    await convex.mutation(api.users.upsert, {
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      emailVerified: u.emailVerified ?? undefined,
+      image: u.image ?? undefined,
+      role: u.role ?? undefined,
+      createdAt: u.createdAt ? u.createdAt.getTime() : undefined,
+      updatedAt: u.updatedAt ? u.updatedAt.getTime() : undefined,
+    });
+  } catch (err) {
+    // Swallow — never block the auth/profile flow on a mirror failure.
+    console.error(`[user-mirror] failed to mirror user ${userId}:`, err);
+  }
+}
+
+/**
+ * Best-effort removal from the Convex `users` mirror after a Prisma user delete.
+ * Same contract: never throws into the calling flow.
+ */
+export async function removeUserFromConvex(userId: string): Promise<void> {
+  try {
+    const convex = await getConvexClient();
+    await convex.mutation(api.users.remove, { id: userId });
+  } catch (err) {
+    console.error(`[user-mirror] failed to remove user ${userId} from mirror:`, err);
+  }
+}

--- a/src/server/project-equipment-scoping.int.test.ts
+++ b/src/server/project-equipment-scoping.int.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Scoping test for buildProjectEquipmentTree (the getProject equipment composite,
+ * run on every project refetch — incl. every add/edit/delete). It used to read the
+ * WHOLE org asset/bulk/kit registries to attach them to the project's line items;
+ * it now reads only the ids the lines reference. Property to lock in: a line item's
+ * asset still attaches correctly (proves the scoped read finds it), and unrelated
+ * org assets don't change the result.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest } from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { buildProjectEquipmentTree } from "@/lib/project-line-item-read";
+
+describe("buildProjectEquipmentTree — scoped asset/bulk/kit reads", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("attaches the line item's asset via the scoped read; ignores unrelated org assets", async () => {
+    const convex = await getConvexClient();
+    const orgA = createId();
+    const modelId = createId();
+    const projectId = createId();
+    const a1 = createId();
+    const lineId = createId();
+
+    await convex.mutation(api.projects.createIfMissing, {
+      id: projectId, organizationId: orgA, projectNumber: "P-1", name: "P",
+    });
+    await convex.mutation(api.assets.createIfMissing, {
+      id: a1, organizationId: orgA, modelId, assetTag: "A1",
+    });
+    // a top-level project line item referencing asset a1
+    await convex.mutation(api.projectLineItems.createIfMissing, {
+      id: lineId, organizationId: orgA, projectId, modelId, assetId: a1,
+    });
+    // an unrelated org asset NOT on the project — must not change the result and
+    // (pre-fix) would have been pulled in by the whole-org read.
+    await convex.mutation(api.assets.createIfMissing, {
+      id: createId(), organizationId: orgA, modelId, assetTag: "A-OTHER",
+    });
+
+    const tree = (await buildProjectEquipmentTree(projectId, orgA)) as {
+      lineItems: Array<{ id: string; asset: { id: string } | null }>;
+    };
+
+    const line = tree.lineItems.find((li) => li.id === lineId);
+    expect(line).toBeDefined();
+    // the scoped getAssetsByIds must have found a1 and attached it
+    expect(line!.asset?.id).toBe(a1);
+  });
+});

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -2,6 +2,7 @@
 
 import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
+import { removeUserFromConvex } from "@/lib/user-mirror";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getSiteSettingsFromConvex } from "@/lib/site-settings-read";
@@ -604,6 +605,9 @@ export async function adminDeleteUser(userId: string) {
       userId,
     });
   }
+
+  // Remove the user from the Convex `users` mirror (best-effort).
+  await removeUserFromConvex(userId);
 
   const theOrg = await getTheOrg();
   if (theOrg) {

--- a/src/server/user-mirror.int.test.ts
+++ b/src/server/user-mirror.int.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration test for the Better-Auth user → Convex `users` mirror
+ * (src/lib/user-mirror.ts + convex/users.ts). The mirror is the unlock that lets
+ * detail composites resolve linked users from Convex instead of a cross-domain
+ * Prisma join (the version-vector-waterfall fix groundwork).
+ *
+ * Properties: a user mirrors on create; re-mirroring after an update PATCHES the
+ * same row (no duplicate); listByIds returns it.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupIntegrationTest, createOrgFixture, createUserFixture } from "../../tests/helpers/integration";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { mirrorUserToConvex, removeUserFromConvex } from "@/lib/user-mirror";
+import { prisma } from "@/lib/prisma";
+
+describe("user-mirror — Better Auth user → Convex users", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  it("mirrors on create and patches (not duplicates) on update", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const convex = await getConvexClient();
+
+    // Not mirrored yet.
+    expect(await convex.query(api.users.getById, { id: user.id })).toBeNull();
+
+    await mirrorUserToConvex(user.id);
+    const mirrored = await convex.query(api.users.getById, { id: user.id });
+    expect(mirrored?.id).toBe(user.id);
+    expect(mirrored?.name).toBe(user.name);
+    expect(mirrored?.email).toBe(user.email);
+
+    // Update in Prisma → re-mirror → the SAME row is patched.
+    await prisma.user.update({ where: { id: user.id }, data: { name: "Renamed" } });
+    await mirrorUserToConvex(user.id);
+    const updated = await convex.query(api.users.getById, { id: user.id });
+    expect(updated?.name).toBe("Renamed");
+    expect(updated?._id).toBe(mirrored?._id); // same document, not a duplicate
+
+    const batch = await convex.query(api.users.listByIds, { ids: [user.id] });
+    expect(batch.map((u) => u.id)).toEqual([user.id]);
+  });
+
+  it("clears image on re-mirror (replace semantics, not stale), and removes on delete", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    const convex = await getConvexClient();
+
+    await prisma.user.update({ where: { id: user.id }, data: { image: "https://x/a.png" } });
+    await mirrorUserToConvex(user.id);
+    expect((await convex.query(api.users.getById, { id: user.id }))?.image).toBe("https://x/a.png");
+
+    // Clear the avatar in Prisma → re-mirror → the Convex image must be GONE
+    // (replace, not patch — patch would leave the old URL).
+    await prisma.user.update({ where: { id: user.id }, data: { image: null } });
+    await mirrorUserToConvex(user.id);
+    expect((await convex.query(api.users.getById, { id: user.id }))?.image).toBeUndefined();
+
+    // Delete → mirror removal.
+    await removeUserFromConvex(user.id);
+    expect(await convex.query(api.users.getById, { id: user.id })).toBeNull();
+  });
+});

--- a/src/server/user-profile.ts
+++ b/src/server/user-profile.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireSession } from "@/lib/auth-server";
 import { serialize } from "@/lib/serialize";
+import { mirrorUserToConvex } from "@/lib/user-mirror";
 
 export async function getProfile() {
   const session = await requireSession();
@@ -41,6 +42,9 @@ export async function updateProfile(data: { name?: string; image?: string | null
       image: true,
     },
   });
+
+  // Keep the Convex user mirror in sync (best-effort).
+  await mirrorUserToConvex(session.user.id);
 
   return serialize(updated);
 }


### PR DESCRIPTION
Batches the two ready PRs into one deploy. Supersedes #285 + #286 (cherry-picked, rebased on main, re-validated together: Convex push + tsc clean).

### 1. getProject + warehouse composite scoping (lever 1, was #285)
The shared post-write refetch composites (`buildProjectEquipmentTree`, `buildWarehouseLineItems`) read the **whole** asset/bulk/kit registries to attach to one project's lines; now scoped to referenced ids. `computeOverbookedStatus`'s whole-org line-item read scoped to the project's models. Parity-by-construction, Codex-clean, with a passing scoping test.

### 2. Better-Auth user mirror (lever 2 step 1, was #286)
Stands up the Convex `users` mirror + best-effort write path (signup hook, profile, avatar set/clear, admin delete) + backfill script. **Additive — nothing reads it yet.** The unlock to later make detail pages pure-Convex subscriptions (kills the version-vector waterfall). Codex-reviewed, 3 P2s fixed, auth flow provably unbreakable by it. Test covers mirror/patch/image-clear/remove.

### ⚠️ Post-merge ops (required before the next "reader" PR)
After deploy, seed existing users into the prod Convex mirror:
```
pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-users.ts
```
(idempotent; safe to re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)