### PR TITLE
perf: read scannedBy from the Convex users mirror (lever 2, step 2a)

### DIFF
--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -136,12 +136,16 @@ export async function getKit(id: string) {
       ? convex.query(api.projects.listByIds, { orgId: organizationId, ids: projectIds })
       : Promise.resolve([]),
     scanUserIds.length
-      ? prisma.user.findMany({ where: { id: { in: scanUserIds } } })
+      ? convex.query(api.users.listByIds, { ids: scanUserIds })
       : Promise.resolve([]),
   ]);
 
   const projMap = new Map(projects.map((p) => [p.id, p]));
-  const userMap = new Map(scanUsers.map((u) => [u.id, u]));
+  // scannedBy now resolves from the Convex `users` mirror (was a cross-domain
+  // prisma.user join) — the page reads only id/name/email/image.
+  const userMap = new Map(
+    scanUsers.map((u) => [u.id, { id: u.id, name: u.name, email: u.email, image: u.image ?? null }]),
+  );
 
   // Line items: attach project from the by-id map (drop any whose project is absent).
   const lineItems = lineItemRows.flatMap((r) => {

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -430,6 +430,11 @@ export async function getProject(id: string) {
   // Order by addedAt asc (mirrors the dropped Prisma `orderBy: { addedAt: "asc" }`).
   const sortedPmRows = [...pmRows].sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0));
   const pmUserIds = [...new Set(sortedPmRows.map((pm) => pm.userId))];
+  // NOTE: left as a prisma.user join (NOT yet moved to the Convex users mirror).
+  // The project page assumes pm.user is non-null (reads pm.user.id), so a
+  // best-effort-mirror gap would crash it — this one waits for the surface
+  // conversion PR (page null-guard / guaranteed mirror) rather than a standalone
+  // swap. kits/warehouse `scannedBy` are null-safe and already moved.
   const pmUsers = pmUserIds.length > 0
     ? await prisma.user.findMany({
         where: { id: { in: pmUserIds } },

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -513,14 +513,18 @@ export async function getScanLog(params?: {
 
   // Attach scannedBy (Better Auth user — stays Prisma).
   const scannedByIds = [...new Set(pageLogs.map((l) => l.scannedById))];
+  const convexScanUsers = await getConvexClient();
   const [scanUsers, modelMap, allAssets, allBulkAssets, allProjects] = await Promise.all([
-    scannedByIds.length > 0 ? prisma.user.findMany({ where: { id: { in: scannedByIds } } }) : Promise.resolve([]),
+    scannedByIds.length > 0 ? convexScanUsers.query(api.users.listByIds, { ids: scannedByIds }) : Promise.resolve([]),
     getModelMap(organizationId),
     getAssetsByOrg(organizationId),
     getBulkAssetsByOrg(organizationId),
     getProjectsByOrg(organizationId),
   ]);
-  const scanUserMap = new Map(scanUsers.map((u) => [u.id, u]));
+  // scannedBy now resolves from the Convex `users` mirror (was a prisma.user join).
+  const scanUserMap = new Map(
+    scanUsers.map((u) => [u.id, { id: u.id, name: u.name, email: u.email, image: u.image ?? null }]),
+  );
   const scanAssetMap = new Map(allAssets.map((a) => [a.id, a]));
   const scanBulkAssetMap = new Map(allBulkAssets.map((b) => [b.id, b]));
   const scanProjectMap = new Map(allProjects.map((p) => [p.id, p]));


### PR DESCRIPTION
## Lever 2, step 2a — start moving composite user joins onto the Convex mirror

With the `users` mirror now populated (forward-mirror + the prod backfill you ran), this moves the **null-safe** cross-domain `prisma.user` joins onto `api.users.listByIds` — the prerequisite for making these composites pure-Convex (so a later PR can convert the surface to a live `useQuery` subscription and delete the version-vector waterfall for that page).

### What's swapped
- **getKit** scan-log `scannedBy` (kits.ts)
- **warehouse** scan-log `scannedBy` (warehouse.ts)

Both consumers are **null-safe** — a rare/transient mirror gap degrades to a blank scanner name, never a crash. Mapped to `{id,name,email,image}` (the only fields read; verified). Rides on the already-tested `api.users.listByIds`.

### Deliberately NOT swapped (codex-flagged, handled)
- **getProject** `projectManagers.user` — the project page reads `pm.user.id` assuming non-null, so a mirror gap would **crash** it. Left on `prisma.user` (with an explanatory comment) until the surface-conversion PR can null-guard the consumers or guarantee the mirror.

### Tradeoff (accepted)
The mirror is best-effort, so a `scannedBy` name/avatar can be briefly stale if a mirror write fails — acceptable for an audit-log scanner name. This is the inherent property of the read-mirror architecture (the spike's chosen approach).

### Validation
- ✅ `tsc --noEmit` clean; ✅ Convex push clean.
- ✅ Codex-reviewed: shape parity confirmed for the kept swaps; only the projects.ts crash-risk was flagged → reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)