### PR TITLE
perf(getProject): collapse equipment + overbooking into single Convex queries (4.0s→1.5s)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -59,6 +59,7 @@ import type * as modelMedia from "../modelMedia.js";
 import type * as models from "../models.js";
 import type * as notificationDismissals from "../notificationDismissals.js";
 import type * as notificationEmailLogs from "../notificationEmailLogs.js";
+import type * as overbooking from "../overbooking.js";
 import type * as parity from "../parity.js";
 import type * as projectCategories from "../projectCategories.js";
 import type * as projectEquipment from "../projectEquipment.js";
@@ -156,6 +157,7 @@ declare const fullApi: ApiFromModules<{
   models: typeof models;
   notificationDismissals: typeof notificationDismissals;
   notificationEmailLogs: typeof notificationEmailLogs;
+  overbooking: typeof overbooking;
   parity: typeof parity;
   projectCategories: typeof projectCategories;
   projectEquipment: typeof projectEquipment;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -61,6 +61,7 @@ import type * as notificationDismissals from "../notificationDismissals.js";
 import type * as notificationEmailLogs from "../notificationEmailLogs.js";
 import type * as parity from "../parity.js";
 import type * as projectCategories from "../projectCategories.js";
+import type * as projectEquipment from "../projectEquipment.js";
 import type * as projectGroups from "../projectGroups.js";
 import type * as projectLineItemUnits from "../projectLineItemUnits.js";
 import type * as projectLineItems from "../projectLineItems.js";
@@ -157,6 +158,7 @@ declare const fullApi: ApiFromModules<{
   notificationEmailLogs: typeof notificationEmailLogs;
   parity: typeof parity;
   projectCategories: typeof projectCategories;
+  projectEquipment: typeof projectEquipment;
   projectGroups: typeof projectGroups;
   projectLineItemUnits: typeof projectLineItemUnits;
   projectLineItems: typeof projectLineItems;

--- a/convex/overbooking.ts
+++ b/convex/overbooking.ts
@@ -1,0 +1,41 @@
+import { v, ConvexError } from "convex/values";
+import { query } from "./_generated/server";
+import { requireOrgRead } from "./lib/auth";
+
+/**
+ * ONE-round-trip read of everything `computeOverbookedStatus` needs: for the given
+ * models — the line items (across all projects, for booking overlap) + active
+ * assets + bulk assets (for the stock breakdown) — plus all org projects (for the
+ * date-window join) and all org models. Replaces ~5 separate server→Convex queries
+ * in 2 waves with one backend-local query. Raw docs; the JS (sumBookingsByModel +
+ * computeStockBreakdown) stays in src/lib (parity-by-construction). requireOrgRead
+ * matches every constituent read's boundary (none were service-only).
+ */
+export const bundle = query({
+  args: { orgId: v.string(), modelIds: v.array(v.string()) },
+  handler: async (ctx, { orgId, modelIds }) => {
+    await requireOrgRead(ctx, orgId);
+    const unique = [...new Set(modelIds)];
+    // Matches the old assets/bulkAssets/projectLineItems.listByModelIds cap — guards
+    // against an unbounded 3*N index fan-out hitting Convex read/time limits.
+    if (unique.length > 1000) {
+      throw new ConvexError("overbooking.bundle: too many modelIds (" + unique.length + " > 1000)");
+    }
+
+    const [lineItemGroups, assetGroups, bulkGroups, projects, models] = await Promise.all([
+      Promise.all(unique.map((mid) => ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
+      Promise.all(unique.map((mid) => ctx.db.query("assets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
+      Promise.all(unique.map((mid) => ctx.db.query("bulkAssets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
+      ctx.db.query("projects").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+      ctx.db.query("models").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+    ]);
+
+    return {
+      lineItems: lineItemGroups.flat().filter((r) => r.organizationId === orgId),
+      assets: assetGroups.flat().filter((r) => r.organizationId === orgId),
+      bulkAssets: bulkGroups.flat().filter((r) => r.organizationId === orgId),
+      projects,
+      models,
+    };
+  },
+});

--- a/convex/projectEquipment.ts
+++ b/convex/projectEquipment.ts
@@ -1,0 +1,71 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * ONE-round-trip read of everything `buildProjectEquipmentTree` needs to rebuild a
+ * project's equipment tree. Replaces ~10 separate server→Convex queries (3
+ * sequential waves: line items/categories/groups → units/models/suppliers/orgCats →
+ * assets/bulks/kits) with a SINGLE query whose reads are all backend-local
+ * (microseconds, no network between them). This is the round-trip-count fix for the
+ * project + warehouse detail composites — the actual driver of "clicking a project
+ * takes forever" at this app's small data scale.
+ *
+ * Returns RAW docs; the JS reconstruction (mappers + reconstructScope + attach)
+ * stays in src/lib unchanged, so this is parity-by-construction with the old
+ * per-table reads (same index reads, same org filter).
+ */
+export const bundle = query({
+  args: { projectId: v.string(), orgId: v.string() },
+  handler: async (ctx, { projectId, orgId }) => {
+    // Service-only: this bundle returns `units` (projectLineItemUnits), which are
+    // service-only — the only caller is the getProject server action (service
+    // token). Do NOT relax to requireOrgRead (would expose units to user tokens).
+    await requireService(ctx);
+
+    const [lineItems, projectCategories, groups] = await Promise.all([
+      ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+      ctx.db.query("projectCategories").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+      ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+    ]);
+
+    const lineItemIds = lineItems.map((li) => li.id);
+    const units = (
+      await Promise.all(
+        lineItemIds.map((id) =>
+          ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", id)).collect(),
+        ),
+      )
+    ).flat();
+
+    const uniq = (arr: Array<string | undefined | null>): string[] => [
+      ...new Set(arr.filter((x): x is string => !!x)),
+    ];
+    const refAssetIds = uniq([...lineItems.map((li) => li.assetId), ...units.map((u) => u.assetId)]);
+    const refBulkIds = uniq([...lineItems.map((li) => li.bulkAssetId), ...units.map((u) => u.bulkAssetId)]);
+    const refKitIds = uniq(lineItems.map((li) => li.kitId));
+
+    const [assetDocs, bulkDocs, kitDocs, models, suppliers, categories] = await Promise.all([
+      Promise.all(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+      Promise.all(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+      Promise.all(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+      ctx.db.query("models").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+      ctx.db.query("suppliers").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+      ctx.db.query("categories").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+    ]);
+
+    return {
+      lineItems,
+      projectCategories,
+      groups,
+      units,
+      // Org-filter the by-id reads to match the old getAssetsByIds/etc. helpers.
+      assets: assetDocs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId),
+      bulkAssets: bulkDocs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId),
+      kits: kitDocs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId),
+      models,
+      suppliers,
+      categories,
+    };
+  },
+});

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,9 +1,7 @@
-import { getModelMap } from "@/lib/models-read";
-import { getProjectsByOrg } from "@/lib/projects-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
+import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import {
-  getLineItemsByModelIds,
   indexProjectsById,
   sumBookingsByModel,
   type DateWindow,
@@ -107,25 +105,20 @@ export async function computeOverbookedStatus(
   // Include BOTH regular items AND kit children — they all consume stock.
   // Sub-hire items are third-party stock and are excluded.
   // When no dates: only count THIS project's bookings (no date overlap possible).
-  const [orgLineItems, orgProjects] = await Promise.all([
-    getLineItemsByModelIds(organizationId, modelIds),
-    getProjectsByOrg(organizationId),
-  ]);
-  const projectsById = indexProjectsById(orgProjects);
+  // ONE round-trip for ALL overbooking inputs (was 5 separate Convex queries in 2
+  // waves: line items + projects, then models + assets + bulks). Read backend-local
+  // inside a single query; raw docs reconstructed here (parity-by-construction).
+  const convex = await getConvexClient();
+  const ob = await convex.query(api.overbooking.bundle, { orgId: organizationId, modelIds });
+
+  const orgLineItems = ob.lineItems.map(mapLineItemDoc);
+  const projectsById = indexProjectsById(ob.projects);
   const { totalByModel: totalBookedByModel, thisProjectByModel: thisProjectBookedByModel } =
     sumBookingsByModel(modelIds, orgLineItems, projectsById, window, projectId);
 
-  // Batch fetch model metadata + active assets/bulkAssets from Convex. Was an N+1:
-  // one assets.listByModel + one bulkAssets.listByModel round-trip PER model (so a
-  // projects view spanning N models fired 2N Convex queries). Now two batched
-  // queries that do all the per-model by_modelId scans server-side in one trip
-  // each, grouped here (replicating getActive*ByModel's `isActive !== false`).
-  const convex = await getConvexClient();
-  const [convexModelMap, assetsAll, bulksAll] = await Promise.all([
-    getModelMap(organizationId),
-    convex.query(api.assets.listByModelIds, { orgId: organizationId, modelIds }),
-    convex.query(api.bulkAssets.listByModelIds, { orgId: organizationId, modelIds }),
-  ]);
+  const convexModelMap = new Map(ob.models.map((m) => [m.id, m]));
+  const assetsAll = ob.assets;
+  const bulksAll = ob.bulkAssets;
   const assetMap = new Map<string, typeof assetsAll>();
   for (const a of assetsAll) {
     if (!a.modelId || a.isActive === false) continue;

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -9,7 +9,7 @@ import {
   getAssetsByIds,
   getBulkAssetsByIds,
 } from "@/lib/assets-read";
-import { type ConvexKit, getKitsByOrg, getKitsByIds, getKitMap } from "@/lib/kits-read";
+import { type ConvexKit, getKitsByOrg, getKitMap } from "@/lib/kits-read";
 import { type ConvexLocation, getLocationMap } from "@/lib/locations-read";
 import {
   buildLineItemAttachMaps,
@@ -405,48 +405,26 @@ export async function buildProjectEquipmentTree(
   projectId: string,
   organizationId: string,
 ): Promise<ProjectEquipmentTree> {
+  // ONE round-trip: read line items + categories + groups + units + the referenced
+  // assets/bulks/kits + the org's models/suppliers/categories, all inside a single
+  // Convex query (backend-local reads). Was ~10 separate server→Convex queries in 3
+  // sequential waves — the round-trip count was the latency, not the payload.
   const convex = await getConvexClient();
-  const [liDocs, catDocs, grpDocs] = await Promise.all([
-    convex.query(api.projectLineItems.listByProject, { projectId, orgId: organizationId }),
-    convex.query(api.projectCategories.listByProject, { projectId, orgId: organizationId }),
-    convex.query(api.projectGroups.listByProject, { projectId, orgId: organizationId }),
-  ]);
+  const bundleData = await convex.query(api.projectEquipment.bundle, { projectId, orgId: organizationId });
 
-  const lineItems = liDocs.map(mapLineItemDoc);
-  const lineItemIds = lineItems.map((li) => li.id);
+  const lineItems = bundleData.lineItems.map(mapLineItemDoc);
+  const attachMaps = {
+    models: new Map(bundleData.models.map((m) => [m.id, m])),
+    suppliers: new Map(bundleData.suppliers.map((s) => [s.id, s])),
+    categories: new Map(bundleData.categories.map((c) => [c.id, c])),
+  };
 
-  const [unitDocs, attachMaps] = await Promise.all([
-    lineItemIds.length
-      ? convex.query(api.projectLineItemUnits.listByLineItemIds, { lineItemIds })
-      : Promise.resolve([] as UnitDoc[]),
-    buildLineItemAttachMaps(organizationId),
-  ]);
-
-  // Scope the asset/bulk/kit reads to the ids THIS project's lines + units actually
-  // reference (was: getAssetsByOrg / getBulkAssetsByOrg / getKitsByOrg — the whole
-  // org registry, read on EVERY project refetch incl. every add/edit/delete). Same
-  // raw doc shape, so the maps below are unchanged.
-  const refAssetIds = [...new Set(
-    [...lineItems.map((li) => li.assetId), ...unitDocs.map((u) => u.assetId)]
-      .filter((x): x is string => !!x),
-  )];
-  const refBulkIds = [...new Set(
-    [...lineItems.map((li) => li.bulkAssetId), ...unitDocs.map((u) => u.bulkAssetId)]
-      .filter((x): x is string => !!x),
-  )];
-  const refKitIds = [...new Set(lineItems.map((li) => li.kitId).filter((x): x is string => !!x))];
-  const [assetArr, bulkArr, kitArr] = await Promise.all([
-    getAssetsByIds(organizationId, refAssetIds),
-    getBulkAssetsByIds(organizationId, refBulkIds),
-    getKitsByIds(organizationId, refKitIds),
-  ]);
-
-  const assetMap = new Map(assetArr.map((a) => [a.id, a]));
-  const bulkAssetMap = new Map(bulkArr.map((b) => [b.id, b]));
-  const kitMap = new Map(kitArr.map((k) => [k.id, k]));
+  const assetMap = new Map(bundleData.assets.map((a) => [a.id, a]));
+  const bulkAssetMap = new Map(bundleData.bulkAssets.map((b) => [b.id, b]));
+  const kitMap = new Map(bundleData.kits.map((k) => [k.id, k]));
 
   // Units carry `asset`/`bulkAsset` as `{ id, assetTag }` selects (PROJECT_UNIT_INCLUDE).
-  const units: UnitWithAssetSelect[] = unitDocs.map((u) => {
+  const units: UnitWithAssetSelect[] = bundleData.units.map((u) => {
     const m = mapUnitDoc(u);
     return {
       ...m,
@@ -460,8 +438,8 @@ export async function buildProjectEquipmentTree(
 
   // Grouped tree: childLineItems 1 deep. Top-level list: ALL items, 2 deep.
   const rawCategories = reconstructCategories(
-    catDocs.map(mapCategoryDoc),
-    grpDocs.map(mapGroupDoc),
+    bundleData.projectCategories.map(mapCategoryDoc),
+    bundleData.groups.map(mapGroupDoc),
     lineItems,
     byParent,
     unitsByLineItem,


### PR DESCRIPTION
## The real fix: collapse round-trips, not shrink reads

Diagnosis (timed against real Convex at prod scale, ~100 assets/20 projects): `getProject` was slow because of **round-trip COUNT**, not payload. It fired ~15-20 separate, mostly-sequential server→Convex calls. At small data each call is fast but the *count* × RTT = seconds.

Builds on #290 (parallelization, 4.0→2.8s). This PR collapses the two biggest internal fan-outs into single backend-local Convex queries:

### 1. Equipment bundle (`convex/projectEquipment.bundle`)
`buildProjectEquipmentTree` made ~10 queries in 3 sequential waves (line items/categories/groups → units/models/suppliers → assets/bulks/kits). Now **one** query reads all of it inside Convex. The JS reconstruction is unchanged → **parity-by-construction**. `requireService` (it returns service-only `units`; only caller is the getProject server action).

### 2. Overbooking bundle (`convex/overbooking.bundle`)
`computeOverbookedStatus` made ~5 queries in 2 waves. Now **one** query. Helps `getProject`, the projects list, and `checkAvailability` (the slow "after choosing a model" availability check). Keeps the >1000-modelIds cap.

### Measured
`getProject` (20-line project): **4.0s → 2.8s (#290) → 1.9s (equipment) → 1.5s (overbooking)** = ~62% faster. (Local RTT to dev Convex is higher than prod's, so prod should be better.)

- ✅ Parity tests pass (`project-equipment-scoping`, `getproject-parallel-parity`); typecheck clean; Codex-reviewed (2 findings fixed: units auth boundary, modelIds cap).

### Still coming (next PRs)
- Drop the **double-refetch** (every write runs getProject ×2 — halves add/delete latency).
- Same bundle treatment for the warehouse detail composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)