### PR TITLE
perf(detail-pages): parallelize warehouse / asset / kit read waterfalls

### DIFF
--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -140,6 +140,10 @@ export async function getAsset(id: string) {
 
   // Composite sub-reads — all from Convex (asset/projectLineItem/assetBulkChild
   // are Convex-only; media/maintenance/testTag/scanLog already mirrored).
+  // ONE parallel wave for EVERYTHING that needs only org + the asset scalars (was 3
+  // sequential waves). The model-map / supplier / maintenance / model-media /
+  // model-accessory reads only depend on asset.modelId/supplierId (known above), so
+  // they fold in here; only `projects` (below) needs this wave's line-item rows.
   const [
     media,
     childAssetDocs,
@@ -149,6 +153,11 @@ export async function getAsset(id: string) {
     testTagDocs,
     maintenanceLinks,
     parentAssetDoc,
+    modelMap,
+    supplier,
+    maintenanceRecords,
+    modelMediaRows,
+    modelBulkAccessoriesRaw,
   ] = await Promise.all([
     getAssetMediaFromConvex(id),
     convex.query(api.assets.listByParentAssetId, { parentAssetId: id, orgId: organizationId }),
@@ -158,6 +167,13 @@ export async function getAsset(id: string) {
     convex.query(api.testTagAssets.listByAssetId, { assetId: id }),
     convex.query(api.maintenanceRecordAssets.listByAssetIds, { assetIds: [id] }),
     asset.parentAssetId ? getAssetById(asset.parentAssetId) : Promise.resolve(null),
+    getModelWithCategoryMap(organizationId),
+    asset.supplierId ? getSupplierById(asset.supplierId) : Promise.resolve(null),
+    getMaintenanceRecordsByOrg(organizationId),
+    asset.modelId ? getModelMediaFromConvex(asset.modelId) : Promise.resolve([]),
+    asset.modelId
+      ? convex.query(api.modelBulkAccessories.listByModelId, { modelId: asset.modelId, organizationId })
+      : Promise.resolve([]),
   ]);
 
   // Line items are already asset-scoped (listByAssetId). Order + take 20 now so we
@@ -170,24 +186,11 @@ export async function getAsset(id: string) {
     ...new Set(orderedLineItemDocs.map((li) => li.projectId).filter((p): p is string => !!p)),
   ];
 
-  // Model (+ category) + supplier + referenced projects + maintenance records (Convex).
-  // (maintenanceRecords stays org-wide for now — a by-asset scoped read is a follow-up.)
-  const [modelMap, supplier, projects, maintenanceRecords] = await Promise.all([
-    getModelWithCategoryMap(organizationId),
-    asset.supplierId ? getSupplierById(asset.supplierId) : null,
-    lineProjectIds.length
-      ? convex.query(api.projects.listByIds, { orgId: organizationId, ids: lineProjectIds })
-      : Promise.resolve([]),
-    getMaintenanceRecordsByOrg(organizationId),
-  ]);
-
-  // Model media (gallery) + the model's bulk accessories — both Convex.
-  const [modelMediaRows, modelBulkAccessoriesRaw] = await Promise.all([
-    asset.modelId ? getModelMediaFromConvex(asset.modelId) : Promise.resolve([]),
-    asset.modelId
-      ? convex.query(api.modelBulkAccessories.listByModelId, { modelId: asset.modelId, organizationId })
-      : Promise.resolve([]),
-  ]);
+  // Only the referenced projects depend on this request's line items (the kit-scoped
+  // lineProjectIds derived above) — everything else was folded into the wave above.
+  const projects = lineProjectIds.length
+    ? await convex.query(api.projects.listByIds, { orgId: organizationId, ids: lineProjectIds })
+    : [];
 
   const assetModel = asset.modelId ? modelMap.get(asset.modelId) ?? null : null;
 

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -177,13 +177,14 @@ export async function getKit(id: string) {
   const bulkAssetMap = new Map(memberBulkAssets.map((b) => [b.id, mapConvexBulkAssetToPrisma(b)]));
 
 
-  // Location + Category FKs were dropped (Phase B); attach both from the Convex mirror.
-  const location = kit.locationId
-    ? (await getLocationMap(organizationId)).get(kit.locationId) ?? null
-    : null;
-  const category = kit.categoryId
-    ? (await getCategoryMap(organizationId)).get(kit.categoryId) ?? null
-    : null;
+  // Location + Category FKs were dropped (Phase B); attach both from the Convex
+  // mirror — the two maps in one parallel wave (were two sequential round-trips).
+  const [kitLocationMap, kitCategoryMap] = await Promise.all([
+    kit.locationId ? getLocationMap(organizationId) : Promise.resolve(null),
+    kit.categoryId ? getCategoryMap(organizationId) : Promise.resolve(null),
+  ]);
+  const location = kit.locationId && kitLocationMap ? kitLocationMap.get(kit.locationId) ?? null : null;
+  const category = kit.categoryId && kitCategoryMap ? kitCategoryMap.get(kit.categoryId) ?? null : null;
 
   // A member whose asset is absent from the mirror is anomalous (the Prisma FK
   // join always returned the asset) — drop it rather than surface a null asset.

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -35,13 +35,15 @@ export async function getProjectForWarehouse(projectId: string) {
     throw new Error("Cannot perform warehouse operations on a template");
   }
 
-  const lineItems = await buildWarehouseLineItems(projectId, organizationId);
-
-  // Clients + location live in Convex — attach instead of a Prisma join.
-  const client = project.clientId ? await getClientById(project.clientId) : null;
-  const location = project.locationId
-    ? (await getLocationMap(organizationId)).get(project.locationId) ?? null
-    : null;
+  // ONE parallel wave (was 3 SEQUENTIAL round-trips: line-item tree → client →
+  // location). All independent of each other — each needs only projectId/orgId or
+  // the project scalars already read above.
+  const [lineItems, client, locationMap] = await Promise.all([
+    buildWarehouseLineItems(projectId, organizationId),
+    project.clientId ? getClientById(project.clientId) : Promise.resolve(null),
+    project.locationId ? getLocationMap(organizationId) : Promise.resolve(null),
+  ]);
+  const location = project.locationId && locationMap ? locationMap.get(project.locationId) ?? null : null;
   return serialize({ ...project, lineItems, client, location });
 }
 


### PR DESCRIPTION
## The other detail pages — same round-trip collapse

After the project page (#290-294), this sweeps the remaining detail-page loaders. Pure sequential→parallel reorders (behavior-preserving, Codex-clean, parity-tested):

- **`getProjectForWarehouse`**: was `project → lineItems → client → location` (4 sequential). Now `project`, then one wave of `[buildWarehouseLineItems, client, locationMap]`. **4 → 2 waves.**
- **`getAsset`**: was 3 stacked waves; wave 1 now absorbs every read depending only on `asset.modelId`/`supplierId` (model map, supplier, maintenance, model media, accessories); wave 2 is just the referenced `projects`. **4 → 2 waves.**
- **`getKit`**: `location` + `category` reads were two sequential awaits → one wave.

Parity test: `getAsset` returns asset + model + lineItem.project; `getProjectForWarehouse` returns the tree. Typecheck + Codex clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)