### PR TITLE
feat(convex-native): Phase 0 — native read-layer client plumbing

### DIFF
--- a/convex/lib/permissions-core.ts
+++ b/convex/lib/permissions-core.ts
@@ -1,0 +1,234 @@
+/**
+ * Isomorphic RBAC core — the pure permission logic shared by the Next.js server
+ * (`src/lib/permissions.ts` re-exports it) AND Convex functions.
+ *
+ * This file MUST stay import-free / side-effect-free so it bundles cleanly into
+ * BOTH the Next build and the Convex deployment. Do NOT add Prisma, Node, browser,
+ * or `@/`-aliased imports here — Convex's bundler resolves only relative paths and
+ * packages, and any server-only dependency would break the Convex push.
+ *
+ * Why it lives under convex/lib: the Phase 1 `requireOrgPermission` guard
+ * (convex/lib/auth.ts) imports it with a plain relative path, while `src/` reaches
+ * it the same way the codebase already imports `convex/_generated` (relative).
+ * One source of truth for "role Z can do action A on resource R" — see
+ * docs/designs/convex-native-read-layer.md §3.3.1.
+ *
+ * The UI-only registry (PERMISSION_REGISTRY) and display labels (roleLabels) stay
+ * in src/lib/permissions.ts — Convex never needs them.
+ */
+
+export const RESOURCES = [
+  "asset",
+  "bulkAsset",
+  "model",
+  "kit",
+  "project",
+  "client",
+  "warehouse",
+  "testTag",
+  "maintenance",
+  "location",
+  "document",
+  "orgSettings",
+  "orgMembers",
+  "supplier",
+  "subHire",
+  "crew",
+  "reports",
+  "checkItem",
+] as const;
+
+export type Resource = (typeof RESOURCES)[number];
+
+export type Action = string;
+
+/** Full permission map: resource -> array of allowed actions */
+export type PermissionMap = Partial<Record<Resource, readonly string[]>>;
+
+// ─── Built-in role defaults ─────────────────────────────────────────────────
+
+const ALL_ASSET = ["create", "read", "update", "delete", "import", "export"] as const;
+const ALL_CRUD = ["create", "read", "update", "delete"] as const;
+const ALL_PROJECT = ["create", "read", "update", "delete", "manage_line_items", "generate_documents"] as const;
+
+export const rolePermissions: Record<string, PermissionMap> = {
+  owner: {
+    asset: ALL_ASSET,
+    bulkAsset: ALL_CRUD,
+    model: ALL_ASSET,
+    kit: ALL_CRUD,
+    project: ALL_PROJECT,
+    client: ALL_CRUD,
+    warehouse: ["read", "check_out", "check_in", "scan", "close"],
+    testTag: ["create", "read", "update", "delete", "quick_test", "generate_reports"],
+    maintenance: ALL_CRUD,
+    location: ALL_CRUD,
+    document: ["generate", "send", "manage_templates"],
+    orgSettings: ["read", "update"],
+    orgMembers: ["read", "invite", "update_role", "remove"],
+    supplier: ALL_CRUD,
+    subHire: ALL_CRUD,
+    crew: ALL_CRUD,
+    reports: ["view", "export", "create", "delete"],
+    checkItem: ALL_CRUD,
+  },
+  admin: {
+    asset: ALL_ASSET,
+    bulkAsset: ALL_CRUD,
+    model: ALL_ASSET,
+    kit: ALL_CRUD,
+    project: ALL_PROJECT,
+    client: ALL_CRUD,
+    warehouse: ["read", "check_out", "check_in", "scan", "close"],
+    testTag: ["create", "read", "update", "delete", "quick_test", "generate_reports"],
+    maintenance: ALL_CRUD,
+    location: ALL_CRUD,
+    document: ["generate", "send", "manage_templates"],
+    orgSettings: ["read", "update"],
+    orgMembers: ["read", "invite", "update_role", "remove"],
+    supplier: ALL_CRUD,
+    subHire: ALL_CRUD,
+    crew: ALL_CRUD,
+    reports: ["view", "export", "create", "delete"],
+    checkItem: ALL_CRUD,
+  },
+  manager: {
+    asset: ["create", "read", "update", "import", "export"],
+    bulkAsset: ["create", "read", "update"],
+    model: ["create", "read", "update", "import", "export"],
+    kit: ["create", "read", "update"],
+    project: ["create", "read", "update", "manage_line_items", "generate_documents"],
+    client: ["create", "read", "update"],
+    warehouse: ["read", "check_out", "check_in", "scan", "close"],
+    testTag: ["create", "read", "update", "quick_test", "generate_reports"],
+    maintenance: ["create", "read", "update"],
+    location: ["create", "read", "update"],
+    document: ["generate", "send", "manage_templates"],
+    orgSettings: ["read"],
+    orgMembers: ["read"],
+    supplier: ["create", "read", "update"],
+    subHire: ["create", "read", "update"],
+    crew: ["create", "read", "update"],
+    reports: ["view", "export", "create", "delete"],
+    checkItem: ALL_CRUD,
+  },
+  member: {
+    asset: ["create", "read", "update"],
+    bulkAsset: ["create", "read", "update"],
+    model: ["create", "read", "update"],
+    kit: ["read"],
+    project: ["create", "read", "update", "manage_line_items", "generate_documents"],
+    client: ["create", "read", "update"],
+    warehouse: ["read", "check_out", "check_in", "scan"],
+    testTag: ["create", "read", "update", "quick_test"],
+    maintenance: ["create", "read", "update"],
+    location: ["read"],
+    document: ["generate"],
+    orgSettings: [],
+    orgMembers: [],
+    supplier: ["read"],
+    subHire: ["create", "read"],
+    crew: ["read"],
+    reports: ["view"],
+    checkItem: ["read"],
+  },
+  // `staff` role removed (Wave 2) — was a duplicate of `member` with identical
+  // permissions. Existing `staff` members are migrated to `member` via the
+  // consolidate-staff-role migration. Better Auth's memberRoleHierarchy and
+  // sso-provisioning ROLE_HIERARCHY no longer list it. UI dropdowns no longer
+  // offer it.
+  warehouse: {
+    asset: ["read"],
+    bulkAsset: ["read"],
+    model: ["read"],
+    kit: ["read"],
+    project: ["read"],
+    client: ["read"],
+    warehouse: ["read", "check_out", "check_in", "scan", "close"],
+    testTag: ["read"],
+    maintenance: ["read"],
+    location: ["read"],
+    document: [],
+    orgSettings: [],
+    orgMembers: [],
+    supplier: ["read"],
+    subHire: ["read"],
+    crew: ["read"],
+    reports: ["view"],
+    checkItem: ["read"],
+  },
+  viewer: {
+    asset: ["read"],
+    bulkAsset: ["read"],
+    model: ["read"],
+    kit: ["read"],
+    project: ["read"],
+    client: ["read"],
+    warehouse: [],
+    testTag: ["read"],
+    maintenance: ["read"],
+    location: ["read"],
+    document: [],
+    orgSettings: [],
+    orgMembers: [],
+    supplier: ["read"],
+    subHire: ["read"],
+    crew: ["read"],
+    reports: ["view"],
+    checkItem: ["read"],
+  },
+};
+
+/**
+ * Check if a role has a specific permission.
+ * For custom roles (prefixed "custom:"), pass the resolved permissions map.
+ */
+export function hasPermission(
+  role: string,
+  resource: Resource,
+  action: string,
+  customPermissions?: PermissionMap | null,
+): boolean {
+  // Owner always has all permissions (safety net)
+  if (role === "owner") {
+    return true;
+  }
+
+  // Custom role: use provided permissions
+  if (role.startsWith("custom:")) {
+    if (!customPermissions) return false;
+    return customPermissions[resource]?.includes(action) ?? false;
+  }
+
+  // Built-in role: use static map
+  const perms = rolePermissions[role];
+  if (!perms) return false;
+  return perms[resource]?.includes(action) ?? false;
+}
+
+/**
+ * Check if a permission map has ANY write permission (create/update/delete).
+ * Used to determine if a user is effectively read-only.
+ */
+export function isReadOnly(permissions: PermissionMap): boolean {
+  for (const resource of RESOURCES) {
+    const actions = permissions[resource];
+    if (!actions) continue;
+    for (const action of actions) {
+      if (action !== "read" && action !== "view") return false;
+    }
+  }
+  return true;
+}
+
+/** All org roles in hierarchy order */
+export const ORG_ROLES = ["owner", "admin", "manager", "member", "viewer"] as const;
+export type OrgRole = (typeof ORG_ROLES)[number];
+
+/** Built-in roles that can be assigned (excludes owner — owner is transferred) */
+export const ASSIGNABLE_BUILT_IN_ROLES = ["admin", "manager", "member", "viewer"] as const;
+
+/** Check if a role string is a built-in role */
+export function isBuiltInRole(role: string): boolean {
+  return role in rolePermissions;
+}

--- a/docs/designs/convex-native-read-layer-review-response.md
+++ b/docs/designs/convex-native-read-layer-review-response.md
@@ -1,0 +1,196 @@
+# Review Response — Convex-Native Read Layer Plan
+
+Thanks for the plan. The overall direction looks right: reads-first is the correct sequencing, the existing Better Auth → Convex JWT bridge should be reused rather than rebuilt, and the plan correctly avoids exposing the current service-only Convex bundles directly to browser users.
+
+That said, I would not treat this as implementation-ready yet. There are a few issues that need tightening before we hand this to an implementation agent.
+
+## Summary Verdict
+
+The architecture is solid, but the plan needs one more hardening pass around:
+
+1. **RBAC mirror fail-closed semantics** — currently stated, but not actually designed enough to be safe.
+2. **Complete membership/custom-role write-site coverage** — there are more auth-affecting Prisma writes than the plan lists.
+3. **Convex query cache mechanics** — the plan needs to verify/use the actual `convex-helpers` cached hooks, not assume the provider alone changes normal `convex/react` `useQuery` behaviour.
+4. **Dashboard counters** — this is a mini domain design, not a sub-bullet.
+5. **Phase 4 deletion scope** — `use-shared-resource.ts` has broader Prisma/auth-adjacent usage than just project equipment.
+
+## What Looks Good
+
+- **Reads first, writes later** is the right sequencing. Moving writes, audit, and invariants into Convex first would carry much more data-integrity risk.
+- The plan correctly identifies that the auth bridge is already mostly solved:
+  - `convex/lib/auth.ts` already resolves service/user identities and has org-scoped read guards.
+  - `src/components/providers/convex-provider.tsx` already wires `ConvexProviderWithAuth`.
+  - `src/hooks/use-authed-query.ts` already avoids the “query before token attaches” browser crash class.
+- The plan correctly refuses to expose `convex/projectEquipment.bundle` directly. That query is explicitly service-only and returns raw docs including `projectLineItemUnits`.
+- The dashboard whole-org read risk is real. `src/server/dashboard.ts` does whole-org reads and JS aggregation across assets, bulk assets, projects, line items, maintenance, crew, and assignments.
+- The viewer permission correction is accurate: `viewer` does have `project: ["read"]` in `src/lib/permissions.ts`.
+
+## Required Changes Before Implementation
+
+### 1. Define the RBAC Mirror Write Ordering Contract
+
+The plan says membership/custom-role mirror writes must fail closed. I agree, but this needs a concrete ordering contract.
+
+Because Prisma and Convex cannot participate in a single transaction, this pattern is unsafe for permission removals:
+
+```ts
+await prisma.member.delete(...);
+await convex.mutation(api.membersMirror.delete, ...);
+```
+
+If the Convex write fails after the Prisma revoke succeeds, Postgres has removed access but Convex still grants native browser reads. That is fail-open.
+
+Please add an explicit rule:
+
+#### Permission-removing / restrictive changes
+
+For revocation, demotion, custom-role permission removal, custom-role deletion, or ownership transfer demotion:
+
+1. Apply the **more restrictive state to Convex first**.
+2. Then commit the Prisma source-of-truth change.
+3. If Prisma fails after Convex succeeds, reconcile later; temporary over-denial is safer than temporary over-grant.
+
+#### Additive grants
+
+For new members, promotions, or additive custom-role permissions:
+
+1. Commit Prisma first.
+2. Mirror to Convex after.
+3. A short delay or retry is acceptable because stale Convex state denies too much, not too little.
+
+#### Ownership transfer
+
+`transferOwnership` needs an explicit strategy because it is both a demotion and a promotion:
+
+- demote the old owner in Convex before Prisma demotion, or use a dedicated mirror mutation that applies the safe intermediate state;
+- then apply the Prisma transaction;
+- then apply/promote the new owner in Convex if not already mirrored.
+
+The exact mechanics can vary, but the security property must be explicit: **a failed mirror operation must never leave Convex granting permissions that Prisma has revoked.**
+
+### 2. Expand the Membership/Custom-Role Write-Site Audit
+
+The plan lists some write sites, but the actual repo has more auth-affecting membership/custom-role writes.
+
+Known write sites include at least:
+
+| File | Examples |
+|---|---|
+| `src/server/org-members.ts` | `member.update`, `member.delete`, ownership transfer |
+| `src/server/custom-roles.ts` | `customRole.create/update/delete`, duplicate role |
+| `src/server/settings.ts` | member create/delete |
+| `src/server/site-admin.ts` | org owner create, member create/delete/update |
+| `src/server/user-profile.ts` | leave organization/member delete |
+| `src/lib/auth.ts` | auto-create member on registration |
+| `src/lib/sso-provisioning.ts` | SSO role sync/member create |
+| `src/server/sso.ts` | SSO approval member create |
+
+Please make Phase 1b include a mechanical audit gate, not just a prose reminder.
+
+Suggested gate:
+
+```bash
+rg "prisma\.member\.(create|update|delete)|tx\.member\.(create|update|delete)|prisma\.customRole\.(create|update|delete)|tx\.customRole\.(create|update|delete)" src
+```
+
+Every hit must be either:
+
+- routed through the mirror helper,
+- explicitly annotated as non-auth-affecting, or
+- covered by a separate migration path.
+
+This should also have a test or lint-style script so future membership writes do not bypass the mirror accidentally.
+
+### 3. Specify the Convex Query Cache API Precisely
+
+The plan says to add `ConvexQueryCacheProvider`, but it needs to be more precise.
+
+`convex-helpers` is not currently installed in `package.json`, and the provider alone may not make ordinary `convex/react` `useQuery` calls cached. Convex Helpers exposes cached replacement hooks via its cache package; the implementation should verify the import path and hook usage against TypeScript rather than guessing.
+
+Please revise Phase 0 to say something like:
+
+- install `convex-helpers`;
+- verify the correct import path from the installed package, likely around `convex-helpers/react/cache`;
+- wrap the app in `ConvexQueryCacheProvider` in the existing Convex provider tree;
+- use the cached `useQuery` / `useQueries` hooks from Convex Helpers for migrated surfaces where keep-alive caching is required;
+- preserve the auth gating behaviour from `useAuthedQuery` so queries remain skipped until `useConvexAuth().isAuthenticated` is true;
+- configure a bounded TTL / entry count if the library supports it;
+- do not assume one-shot `convexClient.query()` warms this cache.
+
+Also, keep SSR `preloadQuery` out of the core migration unless there is a separate auth-reviewed design for minting a per-request user Convex JWT. The service token must not be used for SSR preload because it bypasses per-user read scoping.
+
+### 4. Split Dashboard Counters Into Their Own Design Slice
+
+The plan correctly flags dashboard `.collect()` risk, but “use counter tables” is underspecified.
+
+`getDashboardStats()` currently derives counts from multiple domains:
+
+- assets
+- bulk assets
+- projects
+- maintenance records
+- project line items
+- crew members
+- crew assignments
+
+Counter tables are not just a query change; they introduce write-path obligations. Please make this its own mini-design before implementation:
+
+- exact counter table schema;
+- which writes update which counters;
+- how project status/date changes update active/overdue counts;
+- how asset/bulk quantity/status changes update utilization counts;
+- how maintenance and crew writes update dashboard counts;
+- backfill script;
+- parity/reconcile script;
+- tests proving counter values match the current JS-derived values.
+
+Otherwise Phase 3 risks becoming a swamp.
+
+### 5. Narrow the Phase 4 Deletion Claim
+
+The plan says to delete `use-shared-resource.ts` once migrated, but current usage is broader than equipment.
+
+It is used by things like:
+
+- SSO settings/providers;
+- group/service templates;
+- custom roles;
+- org members;
+- organization/profile/platform name;
+- project detail/services/crew/conflicts;
+- project equipment.
+
+Some of those are Prisma/auth-adjacent and may not become native Convex reads during Phases 0–4.
+
+Please change Phase 4 to:
+
+> Delete only dead detail/equipment-specific shared-resource consumers after grep proves they are unused. Keep `use-shared-resource.ts` until every remaining Prisma-backed shared-resource consumer has a replacement.
+
+## Smaller Corrections
+
+- `members` currently has `by_organizationId` and `by_userId`, but not `by_org_user`; the plan correctly adds it. Make that a schema migration requirement.
+- `customRoles.permissions` is currently `v.string()` in Convex schema. If the plan wants a validated object in Convex, that is a schema change. Otherwise keep it as a string and parse/validate inside the guard.
+- `permissions.ts` appears pure/import-free, so relocating it to an isomorphic module is low risk.
+- Avoid mentioning `staff` in current role examples unless intentionally handling legacy data; the active assignable roles no longer include it.
+- The dashboard page currently has 6 `useServerQuery` calls. `getDashboardStats` internally fans out to 7 reads. Keep those two counts distinct.
+
+## Suggested Implementation Gate
+
+Before Phase 1 UI cutover, I would require:
+
+- [ ] `requireOrgPermission` implemented with parity tests against `requirePermission` / `hasPermission`.
+- [ ] `members.by_org_user` index added.
+- [ ] all membership/custom-role write sites audited with grep and mirrored/annotated.
+- [ ] restrictive mirror-write ordering documented and tested.
+- [ ] custom-role permission update/removal test proves active browser subscriptions stop authorizing immediately.
+- [ ] browser DTO bundle tests prove service-only/raw fields are absent.
+- [ ] Convex Helpers cache usage compiles and uses the actual cached hook API.
+- [ ] equipment native-read path remains behind a data-source flag for rollback.
+
+## Bottom Line
+
+I’m aligned with the plan’s direction. Reads-first native Convex subscriptions are the right move, and the project already has enough of the auth bridge and Convex write path in place to make this feasible.
+
+The main thing to fix before implementation is the RBAC mirror design. If that is vague, this migration can accidentally create a stale-permission read leak: revoked or demoted users retaining native Convex read access until a reconcile job catches up.
+
+Tighten the mirror semantics, make the write-site audit mechanical, verify the Convex Helpers cache API, and split dashboard counters into their own scoped design. After that, I’d be comfortable using this as the implementation brief.

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -1,0 +1,442 @@
+# Convex-Native Read Layer — Migration Design
+
+**Status:** Proposed (design + phased plan; no production code yet)
+**Author:** autoplan research session, 2026-06-28
+**Branch:** `worktree-bridge-cse_017LNKTLidv7uzAAREUiRha3`
+**Related:** [[convex-phase5-auth-bridge]], [[convex-hybrid-migration]], `perf-convex-efficiency-2026-06.md`, memory `perf-round-trip-bundles.md`
+
+---
+
+## TL;DR
+
+Today GearFlow uses Convex as an **HTTP database behind Next.js server actions**: every read is `browser → server action → ConvexHttpClient (HTTP) → compose in JS → serialize() → browser`, and "reactivity" is faked by subscribing to a cheap Convex **version-vector** query that re-runs the server action when it ticks. The goal is to make reads **native**: `browser → useQuery (WebSocket subscription) → Convex composite query → browser`, client-cached and reactive, deleting the faked-reactivity machinery.
+
+**The two findings that change the plan vs. the intake hypothesis:**
+
+1. **The auth crux is ~60% already solved.** The Phase 5 auth bridge is built and deployed: `convex/auth.config.ts` validates Better Auth ES256 JWTs, `ctx.auth.getUserIdentity()` works inside Convex today, and `requireOrgRead`/`requireOrgReadDoc` already enforce **org-scoping** on browser reads (`convex/lib/auth.ts:90-118`). The JWT already carries `orgId` + `role` claims (`src/lib/auth.ts` jwt plugin). What's missing is **RBAC** (resource/action permission checks) inside Convex — today only org-scoping is enforced for reads; full `requirePermission` RBAC stays in Prisma server actions.
+
+2. **For a surface whose writes already hit Convex, you can go native on READS without touching WRITES — and reactivity still works.** Convex invalidation is keyed on *what Convex data changed*, not *who wrote it*. Where the server-action write already calls `convex.mutation(...)`, it **already pushes live updates to every `useQuery` subscriber over the WebSocket** ([docs.convex.dev/functions/query-functions]). This is **verified for the project-equipment spike target** — its writes (line-items, project-groups, categories, sub-hires, warehouse, assets) are Convex-native and awaited (`src/server/line-items.ts:370,637,917`). **It is NOT universal:** membership/role writes (`src/server/org-members.ts:109,172,214`), custom-role writes (`src/server/custom-roles.ts:61,119,164`), org-calendar settings (`src/server/org-calendar.ts:53,82,113`), and `logActivity` (`src/lib/activity-log.ts:22`) are **Postgres-only**. A page that reads those tables can't become reactive until those writes also reach Convex. **So every surface migration begins with a per-surface write-dependency audit** (§4): list each source table the composite reads and prove every write to it mutates Convex synchronously, or the field is intentionally non-reactive.
+
+**Therefore the core migration is read-first, page-by-page, gated on a write-dependency audit.** For audited-safe surfaces, keep writes on server actions (they retain `requirePermission` + `logActivity` audit, and already trigger reactive push). Move reads to **new browser-safe composite queries** (DTOs with field allowlists — the existing `projectEquipment.bundle` is deliberately service-only and must NOT be exposed as-is, §3.4/H1), with RBAC enforced in Convex via one new guard backed by **fail-closed-mirrored** `members`/`customRoles`. Delete the version-vector + shared-resource read layer surface-by-surface.
+
+**Scope (two layers).** Phases 0–4 are the **read migration** — the reactive, near-instant app, ~6–8 weeks, the core commitment. Phases 5–7 are the **"Convex baked in, not bolted on" arc** (user-approved Tiers A–D, 2026-06-28): native writes with **atomic audit + invariants inside the mutation** (Convex becomes the domain layer, not just a write target), background jobs/side-effects as Convex crons+actions, and native search indexes — another ~6–9 weeks, sequenced after reads because writes carry the integrity risk. **Auth stays in Postgres** (Tier E / `@convex-dev/better-auth` is explicitly out of scope — alpha dependency, and the auth/domain split is a clean boundary, not an afterthought).
+
+---
+
+## 1. Current-state diagnosis (with evidence)
+
+### 1.1 The read path
+
+Canonical server-action read (`src/server/*.ts`):
+
+```
+getConvexClient()           // ConvexHttpClient + SERVICE token — src/lib/convex-client.ts:26-42
+  → convex.query(api.x)     // HTTP, often Promise.all of 5-7 reads
+  → compose/join in JS      // cross-domain joins, tree building
+  → serialize()             // Prisma Decimal→number — src/lib/serialize.ts:8-23
+  → return to browser
+```
+
+Examples: `getDashboardStats` does `Promise.all` over **7** Convex reads then composes in JS (`src/server/dashboard.ts:29-72`); `getKit` does `Promise.all` over **7** scoped reads + JS composition (`src/server/kits.ts:82-101`); `getMyHomeData` joins a Convex `clients` list onto projects in JS and calls `serialize()` (`src/server/dashboard.ts:120-121`).
+
+`getConvexClient` is a process-global `ConvexHttpClient` carrying a **service token** (full access), with a 150ms single-retry wrapper for JWKS cold-start races (`src/lib/convex-client.ts:60-67`).
+
+### 1.2 The faked-reactivity machinery
+
+Three coexisting mechanisms (this is already a **hybrid** — further along than "everything is faked"):
+
+| Mechanism | File | Reactivity | Used for |
+|---|---|---|---|
+| `useReactiveServerQuery({ watch: version })` | `src/hooks/use-reactive-server-query.ts:1-142` | Cross-user, via version-vector `useQuery` | Detail pages (kit, asset, project, warehouse) |
+| `useServerQuery({ queryKey, queryFn })` | `src/hooks/use-server-query.ts:1-147` | None (one-shot, optional poll) | Counts, badges, aggregates |
+| `createSharedResource(...).use(key)` | `src/hooks/use-shared-resource.ts:1-127` | None; writer calls `refresh(key)` | Multi-reader/writer (equipment tab) |
+| `useAuthedQuery(api.table.q, ...)` | (native Convex) | **Native** WebSocket subscription | Collaboration locks, comment counts, equipment live-sync |
+
+`useReactiveServerQuery` watches a "version vector" — a cheap `useQuery` against e.g. `convex/warehouseDetail.ts:155-197` that returns content **signatures** folding in every mutable field of the watched rows. When a write changes any watched row, the Convex mirror updates, the signature changes, Convex pushes the new vector, and the hook **re-runs the unmodified server action** (`use-reactive-server-query.ts:81,116-125`). It is a real WebSocket subscription used as a *change-notification doorbell* that triggers an HTTP refetch — paying for the WebSocket but throwing away its payload.
+
+**No client-side query cache across navigation.** `useServerQuery` clears data on key change (`use-server-query.ts:139`); `useSharedResource` dedupes within a session via a module-level `Map` but is not a persisted cache. Navigate away and back → full refetch.
+
+### 1.3 Round-trip counts on hot surfaces (on load)
+
+- **Dashboard** (`src/app/(app)/dashboard/page.tsx:60-65`): **6** independent `useServerQuery` reads (`getDashboardStats`, `getUpcomingProjects`, `getRecentActivity`, `getSubHireDashboardStats`, `getMyHomeData`, `getMyBlockingComments`). `getDashboardStats` alone fans out to 7 Convex HTTP reads behind the action.
+- **Project detail / equipment tab** (`src/components/projects/equipment-tab.tsx:129-141` + `src/hooks/use-project-equipment.ts:34-63`): **6** shared-resource composites (categories, uncatItems, uncatSubHireGroups, uncatProjectGroups, overbooked, subHires) + **1** live-sync driver watching 4 Convex tables + **2** native subscriptions (locks, comment counts).
+- **Warehouse detail** (`src/app/(app)/warehouse/[projectId]/page.tsx`): **1** version-vector subscription + **1** `useReactiveServerQuery` (`getProjectForWarehouse`) + **1** one-shot read = 3 round trips, plus on-demand scan reads.
+
+### 1.4 What specifically caps performance
+
+1. **Every navigation pays a cold HTTP round trip** (no client cache) — the server tier re-fetches and re-composes everything.
+2. **Double transport** on reactive pages: a WebSocket subscription (version vector) *plus* an HTTP refetch on every tick.
+3. **Server-tier composition + `serialize()`** adds a hop and CPU the native model removes entirely.
+4. **Fan-out actions** (`getDashboardStats` = 7 reads) serialize through one Node process per request rather than executing as one transaction in Convex.
+
+The recent perf PRs (#290–296, memory `perf-round-trip-bundles.md`) already attacked #4 by collapsing composites into single backend-local bundle queries (`convex/projectEquipment.ts`, `convex/overbooking.ts`, `convex/availabilityCheck.ts`). **Those bundle queries are the foundation for native composites** — they already read everything for a composite inside one Convex query.
+
+---
+
+## 2. Target architecture
+
+### 2.1 Native read path
+
+```
+useQuery(api.projectDetail.bundle, { projectId })   // WebSocket subscription
+  → Convex composite query (ctx-passing helpers)    // org-scope + RBAC enforced HERE
+  → returns page-sized plain object                 // no serialize() tier
+  → ConvexQueryCacheProvider keeps it warm across nav
+```
+
+- **Reads:** `useQuery` / `usePaginatedQuery` subscriptions. One **page-sized composite per surface**, composed inside a single Convex query with plain `ctx`-passing helper functions (not many `ctx.runQuery` hops — each is its own transaction; guidelines `:90-96`).
+- **Client cache:** wrap the app in `ConvexQueryCacheProvider` (`convex-helpers/react/cache/provider`) so subscriptions survive unmount and reload instantly on back-navigation ([stack.convex.dev/magic-caching]). Tradeoff: more open subscriptions = more bandwidth; it buys UX, not DB cost.
+- **Writes:** **unchanged** — stay on server actions (`requirePermission` → `convex.mutation` → `logActivity` → return). The mutation already pushes the reactive delta to all `useQuery` subscribers. Optimistic UX is added later, selectively, via native `useMutation().withOptimisticUpdate` only where audit logging can move into Convex.
+- **Reactivity:** delete the version vector. Native `useQuery` *is* the subscription.
+
+### 2.2 Before/after — project detail (the spike target)
+
+**Before:**
+```
+mount equipment-tab
+  → useProjectEquipmentLiveSync (4 Convex table subs as doorbell)
+  → 6× useSharedResource composites (each: HTTP → server action → ConvexHttpClient → compose → serialize)
+  → on any edit: Convex push → refresh(key) → 6 HTTP refetches
+  → navigate away + back: 6 cold refetches
+```
+
+**After:**
+```
+mount equipment-tab
+  → useQuery(api.projectEquipment.browserBundle, { projectId })  // NEW browser-safe DTO query
+  →   (RBAC-checked via requireOrgPermission; returns allowlisted fields only — NOT the
+  →    service-only api.projectEquipment.bundle, which exposes projectLineItemUnits)
+  → usePaginatedQuery for long line-item lists (see §6 limits — required, not optional)
+  → on any edit (server-action write still): Convex push updates the subscription in place
+  → navigate away + back: served instantly from ConvexQueryCacheProvider, re-subscribes in background
+```
+
+Net: 6 composites + 1 doorbell + server-tier compose/serialize → **1 cached subscription**, reactivity preserved, writes untouched.
+
+### 2.3 Consistency
+
+Convex gives a **single global consistent snapshot for reads over Convex tables** — all `useQuery` subscriptions reflect the same logical Convex timestamp, so a write never leaves the Convex-derived parts of a page half-stale ([docs.convex.dev/client/react]). Within that boundary this is strictly stronger than today's per-hook refetch model, where 6 shared resources can refetch at slightly different times.
+
+**Boundary caveat (per dual-voice review):** this consistency does **not** extend to data still in Postgres. Any surface that joins Postgres-only data (org settings, attached Prisma user fields beyond the mirror, activity-log pages) into a Convex-derived view is a **mixed-source surface** and has no cross-store snapshot guarantee. Each migrated surface must document its consistency boundary. Correction from the latest repo pass: the dashboard `getRecentActivity` tile does **not** read Postgres `activityLog`; it composes Convex scan/test-tag/maintenance rows and attaches Prisma `user` names (`src/server/dashboard.ts:196-274`). A native version is possible if those user fields come from the existing Convex `users` mirror/DTOs. The separate activity-log screens (`src/server/activity-log.ts`) and `logActivity` write path remain Postgres-only until Phase 5.
+
+---
+
+## 3. The auth/permissions-into-Convex design (the crux), resolved
+
+### 3.1 What exists today
+
+- **Bridge:** `convex/auth.config.ts` registers one `customJwt` provider (ES256, `applicationID: "convex"`, issuer = `BETTER_AUTH_URL`). Validates both the **service token** (`sub="gearflow-service"`, `svc:true`) and the **user token** (real `sub`, `orgId`, `role` claims).
+- **Guards (`convex/lib/auth.ts`):** `getAuthContext` returns `{kind:"service"}` | `{kind:"user", userId, orgId, role}` | `null`. `requireService` (all writes), `requireOrgRead(ctx, orgId)` and `requireOrgReadDoc(ctx, doc)` (org-scoped reads). Service detection is strict (subject **and** `svc===true`); a non-service token carrying `svc` is rejected.
+- **What's enforced for browser reads today:** org-scoping only. A user token can read any BROWSER_READABLE table for **its own org**. Sensitive columns (e.g. `crewMembers.icalToken`) are redacted for non-service callers (`redactFields`, `convex/lib/auth.ts:69-76`).
+- **RBAC model (Prisma side):** `requirePermission(resource, action)` reads the `member` row, resolves `custom:<id>` roles from `customRole.permissions` (JSON), and calls `hasPermission(role, resource, action, customPermissions)` against a static map of 18 resources × the current built-in permission profiles (`owner`, `admin`, `manager`, `member`, `warehouse`, `viewer`; `staff` is legacy/removed and not in `rolePermissions`). Note the distinction: `ORG_ROLES`/assignable UI roles currently exclude `warehouse`, but the permission profile still exists and must remain parity-tested if any mirrored row can carry it (`src/lib/org-context.ts:88-116`, `src/lib/permissions.ts`).
+
+### 3.2 The gap
+
+Native browser reads need the **same** RBAC that server actions enforce, but inside Convex. Today Convex can't make that decision — it has the user's `role` claim but **not the permission map**, and **not custom-role permissions** (only `members` identity is implied; `customRoles` are Prisma-only).
+
+### 3.3 Resolved approach: mirror membership + RBAC, check in a Convex helper
+
+**Decision: enforce RBAC inside Convex for reads, keep it for writes in Prisma.** Concretely:
+
+> **Supersedes [[convex-phase5-auth-bridge]] for the read path.** That doc recommended "Option 1: RBAC stays in server actions; Convex enforces org-scoping only," chosen when native reads weren't on the table. This migration's whole point is native browser reads, which *require* RBAC at the Convex boundary — so we deliberately adopt the Phase-5 doc's "Option 2." The Phase-5 invariant "Convex is never the authZ source of truth for **writes**" still holds: writes keep their Prisma `requirePermission` authority. Confirmed by the user at the autoplan gate (2026-06-28): Full RBAC in Convex.
+
+1. **Make the permission map isomorphic.** `src/lib/permissions.ts` is already a pure static map (`rolePermissions`, `hasPermission`). Move the pure logic into a shared module importable by **both** `src/` and `convex/` (e.g. `src/lib/permissions-core.ts` with no server-only imports; Convex imports it). One source of truth for "role Z can do action A on resource R." No behavioural change — just relocation. (Verify no `"use server"` / Prisma imports leak in; per CLAUDE.md, validation/pure modules must not live in `"use server"` files.)
+
+2. **Mirror `members` + `customRoles` into Convex — FAIL-CLOSED, not best-effort.** The schema tables already exist (`convex/schema.ts:117,143`) but have **no writers**. Unlike the `users` mirror (one chokepoint, best-effort, error-swallowed because identity is non-security), **membership/role mirrors are part of the authorization-change contract**: a revoke/demote/permission-removal that fails to reach Convex would leave a stale mirrored row that keeps granting native reads (a fail-open hole both reviewers flagged independently). Therefore:
+   - Mirror writes for **revocation/demotion/permission-removal MUST fail closed** — the restrictive Convex mirror update happens before the Prisma source-of-truth change (§3.3.4). If that Convex write throws, the Prisma change must not proceed. If Prisma later throws after Convex already became more restrictive, that is temporary over-denial and must be reconciled, not silently ignored. Additive grants can commit Prisma first and mirror afterward with retry because a lagging mirror denies too much, not too little.
+   - **Every** membership/role write site must call the mirror — these are scattered, not one chokepoint. Verified grep hits include `src/server/org-members.ts`, `src/server/custom-roles.ts`, `src/server/settings.ts`, `src/server/site-admin.ts`, `src/server/user-profile.ts`, `src/server/sso.ts`, `src/lib/sso-provisioning.ts`, and `src/lib/auth.ts`. If invitation acceptance or org import creates/updates members in another path, that path must be included too. A nightly parity reconcile (reuse Phase A/B/C tooling) is a backstop, not the primary control.
+   - `customRoles.permissions` is `v.string()` in the Convex schema today (`convex/schema.ts:143`). **Lower-risk default: keep it as the JSON string and `JSON.parse` + validate inside the guard** (mirrors Prisma's `resolvePermissions`, `src/lib/org-context.ts:70,77`). Storing a validated object instead is a deliberate schema change — only if you want the parse to happen once at mirror time.
+
+3. **Add one guard** `requireOrgPermission(ctx, orgId, resource, action)` in `convex/lib/auth.ts`. **The sketch below is corrected from the first draft — both reviewers caught real bugs** (wrong index names, missing `JSON.parse`, `.unique()` vs Prisma's duplicate-tolerant `findFirst`, custom-role lookup not org-scoped):
+   ```ts
+   export async function requireOrgPermission(ctx, orgId, resource, action) {
+     const auth = await getAuthContext(ctx);
+     if (!auth) throw new ConvexError("Unauthorized: authentication required.");
+     if (auth.kind === "service") return;                 // trusted server already checked
+     if (auth.orgId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+     // NOTE: requires a NEW compound index by_org_user on members ([organizationId, userId]).
+     // Use .first() not .unique(): Prisma Member has no @@unique([orgId,userId]) and every
+     // server-action path uses findFirst (src/lib/org-context.ts:94) — .unique() would throw
+     // InternalServerError on any duplicate (mirror double-write), diverging from Prisma.
+     const member = await ctx.db.query("members")
+       .withIndex("by_org_user", q => q.eq("organizationId", orgId).eq("userId", auth.userId))
+       .first();
+     if (!member) throw new ConvexError("Forbidden: not a member.");
+     let perms = null;                                    // PermissionMap object, not a string
+     if (member.role.startsWith("custom:")) {
+       const custom = await ctx.db.query("customRoles")
+         .withIndex("by_cuid", q => q.eq("id", member.role.slice(7)))   // index is by_cuid, not by_id
+         .first();
+       if (!custom || custom.organizationId !== orgId)    // scope by org, mirror src/server/custom-roles.ts:35
+         throw new ConvexError("Forbidden: role no longer exists.");
+       perms = typeof custom.permissions === "string"     // Prisma parses JSON (org-context.ts:70,77)
+         ? JSON.parse(custom.permissions) : custom.permissions;
+     }
+     if (!hasPermission(member.role, resource, action, perms))
+       throw new ConvexError("Forbidden: insufficient permissions.");
+   }
+   ```
+   Throws `ConvexError` (never plain `Error`) per CLAUDE.md. The new browser-safe composite queries call this once at the top. (`hasPermission` is verified import-free/pure — `src/lib/permissions.ts` has no imports — so the isomorphic relocation is genuinely low-risk.)
+
+**Why mirror membership rather than trust the JWT `role` claim?** Convex guidelines `:181-182` are explicit: never authorize from a client-supplied identifier; derive identity from `ctx.auth.getUserIdentity()` and re-read the authoritative row. The `role` claim is only as fresh as the last token mint — and the user token has a **5-minute TTL** (`USER_TOKEN_TTL`, `src/lib/auth.ts:156,180`), so trusting the claim would let a revoked role linger up to a token lifetime. The mirrored row is the authoritative check; the claim is at most a hint.
+
+#### 3.3.4 Mirror write-ordering contract — the security property that makes "fail-closed" real
+
+Saying the mirror "fails closed" is not enough — Prisma and Convex **cannot share a transaction**, so the *order* of the two writes determines the failure mode. The naive order is fail-OPEN:
+
+```ts
+await prisma.member.delete(...)      // access revoked in the source of truth
+await convex.mutation(api.membersMirror.delete, ...)  // if THIS throws → Convex STILL grants reads
+```
+
+The rule, by change direction:
+
+- **Restrictive changes** (revoke, demote, custom-role permission removal, custom-role deletion, ownership demotion): **apply the more-restrictive state to Convex FIRST, then commit the Prisma source-of-truth change.** If Prisma then fails, you have temporary over-*denial* (Convex denies, Prisma still grants) — safe; reconcile later. You can never end up with Convex granting what Prisma revoked.
+- **Additive changes** (new member, promotion, additive permission): **commit Prisma first, mirror to Convex after.** A lagging/failed mirror denies too much, not too little — safe; a short retry is fine.
+- **`transferOwnership`** (simultaneously a demotion of the old owner and a promotion of the new): treat the demotion as restrictive — demote the old owner in Convex **before** the Prisma transaction (or use a dedicated mirror mutation that writes the safe intermediate state) — then commit Prisma, then promote the new owner in Convex.
+
+**Invariant (must be tested):** *a failed mirror operation must never leave Convex granting a permission Prisma has revoked.* The nightly reconcile is a backstop for drift, not the primary control — the ordering is.
+
+**Why keep writes in Prisma RBAC *for the read migration (Phases 0–4)*?** Three reasons, all evidence-backed:
+- `logActivity` writes **only** to Postgres `activityLog` (`src/lib/activity-log.ts:20-32`); moving writes client-side loses the audit trail unless audit also moves to Convex.
+- Convex mutations today carry **zero** RBAC — they `requireService` and trust the caller (`convex/assets.ts:130-133`). Field-level/resource RBAC lives server-side.
+- Server-action writes **already** trigger the reactive push, so there is no reactivity reason to move them *for reads to work*.
+
+This is the stance for the read migration, not forever. **Phase 5 (Tiers A+B) deliberately moves writes, RBAC, invariants, and audit into Convex mutations** — atomically — which is what makes Convex the domain layer rather than a write target. It's sequenced after reads because writes are the higher-risk surface, not because it's out of scope.
+
+### 3.4 Boundary consistency
+
+- **Mirrored into Convex (read-only replicas):** `users` (exists), `members` + `customRoles` (schema tables exist at `convex/schema.ts:117,143` but need **writers** + a compound `by_org_user` index + validated permission shape). Written service-only on the Prisma write that changes them; idempotent `createIfMissing`/upsert; **failures fail-closed for revocation/demotion** (§3.3.2), best-effort only for additive grants.
+- **Stays Prisma-only (source of truth):** Better Auth (`user`, `session`, `account`, `verification`, `jwks`), `organization`, `member`, `invitation`, `customRole`, `ssoProvider`, `pendingSSOApproval`, `activityLog`.
+- **Drift control:** the mirror is one-way; revocation paths fail closed (above); a nightly parity check (reuse the existing backfill/parity tooling from the Phase A/B/C work) is a backstop that reconciles `members`/`customRoles` the same way `users` is reconciled.
+
+### 3.5 Browser-safe composites are DTOs, not raw docs (HIGH — both reviewers)
+
+The existing composite bundles are **deliberately service-only**. `convex/projectEquipment.bundle` carries an explicit comment *"Do NOT relax to `requireOrgRead` (would expose units to user tokens)"* and returns raw `projectLineItemUnits` + full asset rows (`convex/projectEquipment.ts:21,57`). Convex's only redaction mechanism today, `redactFields` (`convex/lib/auth.ts:69`), is **shallow** and applied **only** by the generated CRUD layer (which redacts just `crewMembers.icalToken`, `scripts/generate-convex-crud.cjs:87`) — composite queries bypass it entirely.
+
+**Rule:** every browser-facing composite is a **NEW** query returning **DTOs with an explicit per-entity field allowlist**, never raw Convex docs. The service bundles stay service-only and untouched. Each browser composite ships with a test asserting sensitive/service-only fields (unit internals, tokens, costs not meant for the role) are absent. This is design + per-entity allowlist work, **not** a one-line guard swap — the single biggest under-scoped item in the first draft.
+
+### 3.6 Dashboard counters are a mini-domain, not a sub-bullet (review point 4)
+
+`getDashboardStats` derives counts across **seven domains** — assets, bulk assets, projects, maintenance records, project line items, crew members, crew assignments (`src/server/dashboard.ts:29-66`) — today by whole-org `.collect()` + JS counting. A native reactive port cannot `.collect().length` (Convex has no count operator and would hit the 32k-doc/16 MiB limits on a large tenant), so the counts must come from **maintained denormalized counter tables**. That is a write-path obligation, not a read swap, and needs its own scoped design before Phase 3 starts:
+
+- **Counter table schema** (e.g. `dashboardCounters` keyed by `organizationId` + metric, or per-domain rollup rows).
+- **Which writes bump which counters** — every mutation that changes a counted dimension must update the counter in the same transaction: asset create/delete/status-change (total + checked-out + utilization), bulk-asset quantity/status, project create/status/date-change (active + overdue), maintenance create/resolve (due), crew member + assignment writes.
+- **Status/date-derived counts** (active vs overdue projects, overdue returns) — define exactly when a row transitions a counter; date-based "overdue" may need a scheduled re-evaluation (Phase 6 cron) since nothing *writes* at the moment a date passes.
+- **Backfill script** (compute initial counters from current data) and a **parity/reconcile script** (recompute from source, compare, alert on drift).
+- **Tests** proving counter values equal the current JS-derived values for a fixture org.
+
+Until this design exists, dashboard stats stay on the server-action read — do not half-migrate them.
+
+---
+
+## 4. Phased, incremental migration plan
+
+Each phase is independently shippable and reversible. **Phases 0–4 = the read migration** (the core commitment; reads convert page-by-page, legacy read layer deleted last). **Phases 5–7 = the full "Convex baked in" arc** (native writes + atomic audit, background jobs, search). The boundary matters: you get the reactive, near-instant app from Phases 0–4 alone; Phases 5–7 are what make Convex *foundational* rather than a fast read cache. **Auth stays in Postgres** (Tier E is out of scope — see end of §4).
+
+### Phase 0 — Native client plumbing (no surface changes)
+**Goal:** the app can run native `useQuery` with the user's auth, cached, alongside everything that exists.
+- **The authed browser client already exists — reuse it.** `ConvexProviderWithAuth` is wired in `src/components/providers/convex-provider.tsx` with a retry-hardened token fetch (`fetchConvexAccessToken`: 3 attempts, 150ms backoff, only de-auths on real 401/403, never on transient 5xx — a subtle correctness win already solved). `useAuthedQuery` is built on it (collaboration uses it). Verify, don't rebuild.
+- **Net-new — be precise (review point 3):** `convex-helpers` is **not in `package.json`** today, and the provider **alone does NOT make ordinary `convex/react` `useQuery` cached.** Concretely:
+  - Install `convex-helpers`; verify the exact import path against TypeScript (likely `convex-helpers/react/cache`) rather than guessing.
+  - Wrap the app in `ConvexQueryCacheProvider` inside the existing Convex provider tree (inside `GlobalErrorBoundary`, per CLAUDE.md layout rule).
+  - **Use the cached replacement hooks** (`useQuery`/`useQueries` from the cache package) on migrated surfaces that need keep-alive caching — NOT the default `convex/react` hooks, which the provider doesn't touch.
+  - **Preserve the auth gating from `useAuthedQuery`** — queries stay skipped until `useConvexAuth().isAuthenticated`, so we don't reintroduce the "query before token attaches" crash class the codebase already solved.
+  - Configure a bounded TTL / entry count if the library supports it; do NOT assume a one-shot `convexClient.query()` warms this cache.
+  - **`preloadQuery`/`usePreloadedQuery` (SSR) stays OUT of the core migration** unless a separate auth-reviewed design mints a **per-request USER JWT** for the preload. The service token must never be used for SSR preload — it bypasses per-user read scoping (would render another user's/role's data server-side). `usePaginatedQuery` is also net-new but lower-risk.
+- Make `permissions.ts` isomorphic (§3.3.1). Pure relocation (verified import-free); unit tests move with it.
+- **Ship/reversible:** additive only; nothing reads through it yet. Revert = remove provider.
+- **Effort:** ~1–2 days.
+
+### Phase 1 — De-risking spike: project detail, end-to-end native reads + in-Convex RBAC
+**Goal:** prove the whole stack on one hot, complex page. Split into ordered sub-deliverables (the first draft's single 3–5d estimate was too coarse — both reviewers):
+- **1a — Write-dependency audit.** Confirm every table the equipment composite reads is written to Convex synchronously (verified: line-items/groups/categories/sub-hires/warehouse/assets are awaited Convex mutations). Carve out anything Postgres-only.
+- **1b — RBAC mirror + revocation tests.** Mirror `members` + `customRoles` using the **write-ordering contract (§3.3.4)**, not just "best-effort"; add the `by_org_user` compound index **as a schema migration** (`members` today has only `by_organizationId` + `by_userId`); backfill (reuse `scripts/convex-backfill-*.ts`). Add the corrected `requireOrgPermission` guard.
+  - **Mechanical write-site audit gate (not a prose reminder).** Membership/custom-role writes are scattered across **8+ files** — verified by grep, more than the first draft listed:
+    ```bash
+    rg "prisma\.(member|customRole)\.(create|update|delete)|tx\.(member|customRole)\.(create|update|delete)" src
+    ```
+    Confirmed hits: `src/server/org-members.ts`, `custom-roles.ts`, `settings.ts`, `site-admin.ts`, `user-profile.ts` (leave-org), `sso.ts`, `src/lib/sso-provisioning.ts`, `src/lib/auth.ts` (auto-create member on registration). **Every hit must be** routed through the mirror helper, explicitly annotated non-auth-affecting, or covered by a separate migration path. Add a lint-style test running this grep so a future membership write can't silently bypass the mirror.
+  - **Parity tests are the gate:** for a matrix of roles (owner/manager/member/warehouse/viewer + a custom role; no `staff` — it's legacy) assert identical allow/deny in Convex vs the server action, plus "removed member's existing subscription stops authorizing immediately," "custom-role permission removal takes effect immediately," and a **restrictive-ordering test** proving a failed mirror write never leaves Convex over-granting.
+- **1c — Browser-safe equipment composite (DTO).** New `api.projectEquipment.browserBundle` returning allowlisted fields only (§3.5); leave the service bundle untouched; port the pure tree/count composition (`line-item-count-read.ts` is already pure; `project-line-item-read.ts` tree builder needs porting) into `ctx`-helpers. Field-absence tests for unit internals.
+- **1d — UI cutover.** Convert `equipment-tab.tsx` reads to native `useQuery` + `usePaginatedQuery` (required for long line-item lists, not optional — §6 limits). **Leave all writes on server actions.** Delete this page's version-vector usage + its 6 shared resources + live-sync doorbell.
+- **Verify:** edit from a second tab/user → live update with no refetch; back-nav is instant; the RBAC parity matrix passes. (Use a genuinely-denied pair for the deny assertion — e.g. **viewer vs `asset:create`** or `project:manage_line_items`; viewer DOES have `project:read`, `src/lib/permissions.ts:329`, so "viewer denied project:read" is wrong.)
+- **Ship/reversible:** one page; feature-flag the tab's data source for instant rollback to the server-action path.
+- **Effort:** ~5–7 days (this is the spike; 1b+1c carry most of the reusable scaffolding + the real risk).
+
+### Phase 2 — Roll out remaining detail surfaces
+Ordered by traffic and by how much version-vector machinery they retire: **warehouse detail → kit detail → asset detail → project finance/other tabs.** Each: build/extend the composite query with `requireOrgPermission`, convert reads to `useQuery`, delete that surface's version vector (`convex/warehouseDetail.ts`, `convex/kitDetail.ts`, `convex/assetDetail.ts` `version`/`listVersion` exports) once no consumer remains.
+- **Ship/reversible:** per surface, behind the same flag pattern.
+- **Effort:** ~1.5–3 days per surface.
+
+### Phase 3 — Dashboard + list/aggregate surfaces
+Convert the **6** dashboard `useServerQuery` reads (`src/app/(app)/dashboard/page.tsx:61-66`) — `getDashboardStats`, `getUpcomingProjects`, `getRecentActivity`, `getSubHireDashboardStats`, `getMyHomeData`, `getMyBlockingComments`. (Distinct count: 6 page-level reads; **`getDashboardStats` *internally* fans out to 7 Convex reads** — keep the two numbers separate.) **This is the highest Convex-limit risk in the whole migration:** `getDashboardStats` reads **whole-org collections** (`getAssetsByOrg`, `getBulkAssetsByOrg`, `getProjectsByOrg`, `getLineItemsByOrg`, …) and counts in JS (`src/server/dashboard.ts:29-66`). A naive native port `.collect()`s every line item + asset in the org into one query — squarely into the 32k-doc / 16 MiB / 1s wall for a large tenant. Dashboard counts must come from **maintained counter tables**, not a `.collect().length` composite (guidelines `:245-246`) — and **that is its own mini-design (§3.6), not a sub-bullet.**
+- **Carve-out correction:** the dashboard **recent activity** tile is not the same as the Postgres `activityLog`. `getRecentActivity` currently reads Convex scan/test-tag/maintenance data, then attaches Prisma user names (`src/server/dashboard.ts:196-274`). It can migrate natively if the user-name joins are served from the Convex `users` mirror and the DTO remains field-allowlisted. The **separate activity-log pages/export** (`src/server/activity-log.ts`) remain Postgres-only and are not migratable to reactive native reads until audit moves into Convex (Phase 5c).
+- Counts/badges with **no liveness need** can stay `useServerQuery` or become cheap `useQuery` — decide per datum.
+- **Effort:** ~1–2 weeks (the counter mini-design + its write-path wiring is the cost, not the read swap).
+
+### Phase 4 — Delete the legacy read layer (only what's actually dead)
+Delete per-consumer, only after grep proves zero remaining importers — **not** the whole file wholesale. Specifically:
+- `use-reactive-server-query.ts` + the `convex/*Detail.ts` `version`/`listVersion` exports: delete once every detail surface is migrated.
+- **`use-shared-resource.ts` — narrow the claim (review point 5).** It's used well beyond equipment: SSO settings/providers, group/service templates, custom roles, org members, organization/profile/platform-name, and project detail/services/crew/conflicts. **Several are Prisma/auth-adjacent and will NOT become native Convex reads during Phases 0–4.** Delete only the dead detail/equipment-specific consumers after grep; **keep `use-shared-resource.ts` itself until every remaining Prisma-backed consumer has a replacement.**
+- `use-server-query.ts`: delete only if fully retired (some no-liveness badges may legitimately keep it).
+- `serialize()` calls + dead `src/lib/*-read.ts` helpers: remove per now-dead path.
+- **Ship/reversible:** pure deletion after consumers are gone; revert = restore files.
+- **Effort:** ~1–2 days (spread across phases as consumers retire, not one big-bang delete).
+
+> **Phases 0–4 are the read migration (the core commitment). Phases 5–7 below are the "Convex baked in, not bolted on" arc** — they make Convex own the full transaction (write + rule + audit), the background jobs, and search. They are sequenced AFTER reads deliberately: writes are where data integrity lives, so we prove the reactive model on the lower-risk read path first, then move writes domain-by-domain. Tiers A–D approved by the user (2026-06-28); Tier E (auth into Convex) explicitly excluded.
+
+### Phase 5 — Native writes + audit-in-Convex + invariants-in-mutations (Tiers A+B)
+**Goal:** Convex owns the whole write transaction — the mutation, the permission check, the business invariants, AND the audit entry — atomically. This is the jump from "Convex is a store I write to" to "Convex is the domain layer."
+Per domain (assets → line-items → kits → projects → crew → …), one domain per shippable slice:
+- **5a — RBAC into the mutation.** Extend `requireOrgPermission` to mutations; the Convex mutation enforces the same resource/action check the server action did (`src/lib/org-context.ts:88`). Today mutations only `requireService` and trust the caller (`convex/assets.ts:130-133`) — this closes that.
+- **5b — Invariants/validation into the mutation (Tier B).** Move the domain rules that today live in server actions + `src/lib/validations/` into the Convex mutation so they're transactional and **cannot be bypassed** by any caller. (Zod schemas stay as the client-form contract; the mutation re-checks the invariants server-side — defence in depth, not duplication of UI validation.)
+- **5c — Audit into the same mutation.** Write the audit entry to Convex `activityLogs` (table exists, `convex/schema.ts:1346`, currently zero writers) **inside the same mutation transaction** as the data write. Today `logActivity` is a separate Postgres write that can drift (`src/lib/activity-log.ts:20-32`); folding it into the mutation makes data+audit atomic. **This unblocks the dedicated activity-log screens/export as reactive native reads** (`src/server/activity-log.ts`). The dashboard `getRecentActivity` tile is a different mixed timeline and can migrate earlier if its user-name joins use the Convex `users` mirror.
+- **5d — Native optimistic write on the client.** Swap the server-action call for `useMutation(api.x.create).withOptimisticUpdate(...)` so the edit lands in the UI instantly, rolls back on failure, and reconciles to the server result. Follow the optimistic-update pitfalls (§Appendix: never mutate `localStore`, treat client ids as throwaway, match server sort order for paginated inserts).
+- **Migrate the Postgres-only write paths flagged in §1/§3** (`org-members.ts`, `custom-roles.ts`, `org-calendar.ts`) into Convex here too — that retires the mirror's fail-closed complexity (once membership/roles are written natively in Convex, there's no Prisma→Convex mirror to keep in sync).
+- **Ship/reversible:** per domain, behind a write-path flag (server-action write vs native mutation). Each domain independently revertible.
+- **Risk:** **High** — writes are where data corruption happens. Gate each domain on a write-parity test (same inputs → same resulting Convex state + same audit entry, native vs server action) before flipping the flag.
+- **Effort:** ~4–6 weeks across all domains, incremental.
+
+### Phase 6 — Convex background jobs & side-effects (Tier C)
+**Goal:** stop using Next.js as the scheduler/glue for things Convex does natively.
+- **Scheduled work → Convex crons** (`convex/crons.ts`): overdue-return checks, maintenance reminders, sub-hire due dates, anything currently on an external/Next cron. Durable, transactional, observable in the Convex dashboard.
+- **Post-write side-effects → Convex actions via `ctx.scheduler.runAfter(0, ...)`:** email (Resend), notifications, webhook fan-out. The mutation commits, then schedules the action — so the side-effect can't fire on a rolled-back write. (Actions run in the Node runtime for external I/O; keep them thin, call back into mutations for DB writes.)
+- **Reuse:** the existing mirror/scheduler patterns from the Phase A/B/C work.
+- **Ship/reversible:** per job; the old Next.js path stays until the Convex one is verified.
+- **Risk:** Low–Med (mostly mechanical; watch action idempotency on retries).
+- **Effort:** ~1–2 weeks.
+
+### Phase 7 — Native search (Tier D)
+**Goal:** reactive, indexed search instead of JS filtering / `.collect()` + filter.
+- Add Convex **search indexes** (`searchIndex` in `convex/schema.ts`) for the hot lookups: asset tag/serial search, project name, kit name, client name. Replace the in-JS filtering currently behind asset/project pickers with `withSearchIndex` queries.
+- Results become **live** (a new matching row appears without a refetch) and stay within Convex limits (no whole-table `.collect()`).
+- **Ship/reversible:** per search surface; additive index, old path stays until cutover.
+- **Risk:** Low.
+- **Effort:** ~3–5 days (depends how many search surfaces exist).
+
+### NOT in scope — Tier E (auth into Convex)
+Running Better Auth *inside* Convex via `@convex-dev/better-auth` (to remove Postgres entirely) is **explicitly out of scope** (user decision, 2026-06-28). The component is early-alpha with a history of breaking migrations (0.8→0.12); adopting it would trade a working, deployed, secure auth system for a pre-1.0 dependency, with a single front-door cutover (no per-surface rollback). **Auth stays in Postgres + Better Auth.**
+
+This costs you nothing on the "baked in" goal: after Phases 5–7, Convex owns reads, writes, business rules, audit, background jobs, and search. Auth-in-Postgres behind the existing JWT bridge is a clean, defensible boundary that mature Convex apps run in production — not the thing that makes Convex feel bolted-on. If the component reaches a stable 1.0 and the team wants a single backend later, revisit it then as its own initiative.
+
+---
+
+## 5. Reused / Rewritten / Deleted
+
+| Asset | Disposition | Notes |
+|---|---|---|
+| Convex domain schema (96 tables) | **REUSE** | Sound; no changes. Add `members`, `customRoles` mirror tables + indexes. |
+| Convex mutations (`requireService`) | **REUSE (P0–4) → EXTEND (P5)** | Untouched for the read migration. Phase 5 adds `requireOrgPermission` + invariants + atomic audit so they become the domain layer. |
+| Bundle queries (`projectEquipment`, `overbooking`, `availabilityCheck`) | **TEMPLATE, not reuse** | Service-only by design (expose units/raw docs). Keep them service-only; build NEW browser-safe DTO composites alongside (§3.5), reusing their composition logic — not exposing them directly. |
+| `ConvexProviderWithAuth` + `fetchConvexAccessToken` (`src/components/providers/convex-provider.tsx`) | **REUSE** | Authed browser client + retry-hardened token fetch already built. |
+| User mirror (`user-mirror.ts` + `convex/users.ts`) | **REUSE as template** | Pattern for the new members/customRoles mirror. |
+| Auth bridge (`auth.config.ts`, `convex/lib/auth.ts`) | **REUSE / EXTEND** | Add `requireOrgPermission`. Org-scoping + service model unchanged. |
+| `permissions.ts` (`hasPermission`, role map) | **RELOCATE** | Into isomorphic core importable by `convex/`. No logic change. |
+| Pure composition helpers (`line-item-count-read.ts`, asset predicates) | **PORT** | Move into `ctx`-passing Convex helpers. |
+| Impure read helpers (`project-line-item-read.ts` tree builder) | **REWRITE** | Reimplement as Convex composite-query helpers. |
+| Server-action writes + `requirePermission` + `logActivity` | **KEEP (P0–4) → REWRITE (P5)** | Preserved through the read migration. Phase 5 moves them into native Convex mutations (RBAC + invariants + atomic audit); `logActivity`→Convex `activityLogs`. |
+| `logActivity` / Postgres `activityLog` | **KEEP (P0–4) → MIGRATE (P5c)** | Audit moves into the Convex mutation transaction; unblocks the dedicated activity-log screens/export as reactive native reads. |
+| External crons + Next.js side-effect glue (email, notifications) | **REWRITE (P6)** | → Convex `crons.ts` + actions via `ctx.scheduler`. |
+| JS/Postgres-filter search behind pickers | **REWRITE (P7)** | → Convex `searchIndex` + `withSearchIndex` (live results). |
+| Better Auth + Postgres auth tables + JWT bridge | **KEEP** | Auth stays in Postgres. Tier E (auth into Convex) is out of scope — the clean auth/domain boundary is not what makes Convex feel bolted-on. |
+| `use-reactive-server-query.ts` | **DELETE** (Phase 4) | Replaced by native `useQuery`. |
+| `use-shared-resource.ts` | **PARTIAL DELETE / KEEP UNTIL LAST CONSUMER** (Phase 4+) | Delete dead equipment/detail consumers as they migrate. Keep the helper itself while Prisma/auth-adjacent consumers remain (SSO, org members, custom roles, profile/org/platform-name, etc.). |
+| Version-vector queries (`*Detail.ts` `version`) | **DELETE** (per surface) | Native subscription is the doorbell. |
+| `serialize()` on read paths | **DELETE** (per path) | Convex returns plain values to `useQuery`. |
+
+---
+
+## 6. Risks, rollback, effort
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **★ RBAC parity correctness at the Convex boundary** (the single highest-risk item — both reviewers) — the guard, the index, the JSON parse, `.first()` vs `.unique()`, org-scoped custom-role lookup, AND browser composites leaking service-only fields | High likelihood if rushed / High impact | Corrected guard sketch (§3.3.3); browser DTOs with allowlists (§3.5); the Phase 1b parity matrix + field-absence tests are the **gate before any rollout** — the first-draft sketch would have failed them on day one. |
+| **Mirror is fail-OPEN on revocation** — revoked/demoted member keeps reading if the mirror write silently failed | Med / High impact | Revocation/demotion/permission-removal mirror writes **fail closed** (§3.3.2/§3.3.4); cover all scattered write sites found by the mechanical grep (`org-members.ts`, `custom-roles.ts`, `settings.ts`, `site-admin.ts`, `user-profile.ts`, `sso.ts`, `sso-provisioning.ts`, `auth.ts`, plus invitation/org-import paths if present); guard re-reads the mirrored row not the JWT claim; nightly reconcile is a backstop only. |
+| **Non-Convex writes break reactivity silently** — a migrated page reads a Postgres-only table | Med | Per-surface write-dependency audit (Phase 1a) is mandatory before each surface; membership/customRole/org-calendar/activityLog are known Postgres-only. |
+| **Composite exceeds Convex limits** (32k docs / 16 MiB / 1s) — worst on the **dashboard whole-org aggregates**, not the detail pages | Med (High on dashboard) | Counter tables for dashboard stats (not `.collect().length`); keep composites page-sized; `usePaginatedQuery` for long lists; index don't `.filter`. |
+| **Re-render storms** on large subscribed lists | Med | Paginate; split high-churn fields into own tables (guidelines `:159-160`); `React.memo` rows by `_id`. |
+| **Double-fetch** (SSR + client subscription) | Low | Accept SSR→hydrate/client subscription for the read migration. Do **not** use `preloadQuery`/`usePreloadedQuery` until a separate auth-reviewed design mints a per-request user JWT; the service token would bypass per-user scoping. |
+| **Query-cache bandwidth** (subscriptions survive unmount) | Low | Bounded by cache expiry; it's a UX/cost tradeoff, monitor. |
+| **Token refresh on WebSocket client** | Low | Verify `ConvexProviderWithAuth` refresh in Phase 0; already exercised by `useAuthedQuery`. |
+| **Write corruption during Phase 5 (Tiers A+B)** — native mutations diverge from server-action behaviour (missed invariant, wrong audit) | Med / High impact | Per-domain write-parity test (same inputs → same Convex state + same audit) gates each flag flip; one domain per slice; write-path flag for instant rollback. Writes are the higher-risk surface — this is why Phase 5 is sequenced after reads, not bundled in. |
+| **Optimistic-update bugs** (Phase 5d) — UI shows a state the server rejects | Low–Med | Follow Convex's rules (never mutate `localStore`, client ids throwaway, match server sort order); rollback is automatic on mutation failure. |
+
+**Rollback strategy:** every surface conversion sits behind a per-surface data-source flag; flipping it restores the server-action read path with zero schema/write changes. The mirror tables and `requireOrgPermission` are additive (writes and server actions ignore them), so they can ship and sit dormant. Phase 4 deletions are the only irreversible-ish step and happen only after every consumer is migrated.
+
+**Total rough effort:**
+- **Read migration (Phases 0–4): ~6–8 weeks** (Phase 0: 1–2d; Phase 1 spike: 5–7d; Phase 2: ~2–3 weeks across surfaces; Phase 3: ~1–2 weeks incl. the counter mini-design; Phase 4: 1–2d). The first draft's 3–5 weeks underweighted the RBAC mirror across scattered write sites, the browser-DTO redaction work, and the dashboard counter-table design — three reviewers flagged it as optimistic.
+- **Baked-in arc (Phases 5–7): ~6–9 weeks more** (Phase 5 native writes+audit+invariants: 4–6 wk incremental; Phase 6 jobs/side-effects: 1–2 wk; Phase 7 search: 3–5d).
+- **Grand total ~12–17 weeks** for the full Convex-native vision (Tiers A–D). Tier E (auth) excluded. The read migration delivers the reactive, near-instant app on its own at ~6–8 weeks; the rest is what makes Convex foundational.
+
+---
+
+## 7. Explicit "do NOT touch" list
+
+**Do NOT touch at all (entire migration):**
+- **Better Auth** (`src/lib/auth.ts`, sessions, org/jwt/sso/passkey plugins, Postgres auth tables) — auth stays in Postgres; Tier E is out of scope. The identity provider is correct and is the JWT source the bridge already trusts.
+- **The Convex domain schema shape** (96 tables) — sound; changes are additive only (`members`/`customRoles` mirror tables in the read phase; `searchIndex`/counter tables later).
+
+**Do NOT touch during the READ migration (Phases 0–4); deliberately changed later:**
+- **Convex mutations** — untouched through Phase 4; Phase 5 extends them (RBAC + invariants + atomic audit).
+- **The service-token write path** (`requireService`, `getConvexClient` service mint) — intact through Phase 4; Phase 5 adds user-token mutation auth alongside it.
+- **`logActivity` / `activityLog`** — Prisma-backed through Phase 4; Phase 5c moves it into the Convex mutation.
+- **`requirePermission` in server actions** — the write-path RBAC authority through Phase 4; Phase 5a moves enforcement into the mutation.
+
+The rule: **nothing on the write side moves until the read migration has proven the reactive model.** Reads first (lower risk), then writes domain-by-domain.
+
+---
+
+## 8. Pre-Phase-1 implementation gate
+
+Hard acceptance test before the Phase 1 UI cutover (1d) — all must pass:
+
+- [ ] `requireOrgPermission` implemented, with parity tests against `requirePermission`/`hasPermission` across the role matrix (owner/manager/member/warehouse/viewer + a custom role).
+- [ ] `members.by_org_user` compound index added (schema migration).
+- [ ] All membership/custom-role write sites audited via the §3.3.4 grep; each is mirrored, annotated non-auth-affecting, or on a separate migration path; a lint-style test enforces it going forward.
+- [ ] Restrictive mirror-write ordering (§3.3.4) implemented and tested — a failed mirror write never leaves Convex over-granting.
+- [ ] Custom-role permission update/removal test proves active browser subscriptions stop authorizing immediately.
+- [ ] Removed-member test proves an existing subscription stops authorizing.
+- [ ] Browser DTO bundle tests prove service-only/raw fields (units, tokens) are absent.
+- [ ] Convex Helpers cache usage compiles and uses the actual cached hook API (`convex-helpers/react/cache`), with auth gating preserved.
+- [ ] Equipment native-read path sits behind a data-source flag for instant rollback.
+
+---
+
+## Appendix — Convex anti-patterns this codebase currently exhibits (and the fix)
+
+| Anti-pattern (Convex docs/guidelines) | Where | Native fix |
+|---|---|---|
+| `ConvexHttpClient` per-request for everything, no subscriptions | all `src/server/*.ts` reads | `useQuery` subscriptions |
+| Composing pure DB reads in a separate server tier | server actions | one Convex composite query with `ctx` helpers |
+| `serialize()` on the way out | `src/lib/serialize.ts` consumers | Convex returns plain values |
+| Refetch everything on navigation | no client cache | `ConvexQueryCacheProvider` |
+| WebSocket subscription used only as an HTTP doorbell | `use-reactive-server-query.ts` | the subscription *is* the data |
+
+Sources: [docs.convex.dev/understanding/best-practices], [docs.convex.dev/client/react/optimistic-updates], [stack.convex.dev/queries-that-scale], [stack.convex.dev/magic-caching], `convex/_generated/ai/guidelines.md`.
+
+---
+
+## Appendix — Dual-voice review hardening (2026-06-28)
+
+This doc was reviewed adversarially by Codex and an independent Claude eng subagent, both reading the actual repo. They converged (high consensus) on the same code-verified findings, applied above:
+
+- **Scoped the "reads-without-writes" thesis** — true for the equipment spike (Convex-native writes) but NOT for Postgres-only writes (membership/customRole/org-calendar/activityLog). Added the mandatory per-surface write-dependency audit (Phase 1a).
+- **Made the RBAC mirror fail-closed on revocation** (was fail-open) and enumerated the scattered write sites.
+- **Corrected the `requireOrgPermission` guard** — added the missing `by_org_user` compound index, `by_cuid` (not `by_id`), `JSON.parse` of custom-role permissions, `.first()` (not `.unique()`, matching Prisma's duplicate tolerance), and org-scoped custom-role lookup.
+- **Browser composites must be DTOs with field allowlists** (§3.5) — the existing service bundles expose `projectLineItemUnits` and bypass `redactFields`; cannot be exposed as-is.
+- **Flagged the dashboard whole-org aggregates** as the top Convex-limit risk → counter tables, not `.collect().length`; later corrected the activity-feed wording to distinguish dashboard `getRecentActivity` from the Postgres `activityLog` screens.
+- **Fixed the wrong parity assertion** (viewer has `project:read`) and **raised the read-migration effort** beyond the first draft, now estimated at ~6–8 weeks.
+- Confirmed reuse wins: `ConvexProviderWithAuth` + retry-hardened token fetch already exist; `permissions.ts` is import-free/pure.
+
+### Third review pass — independent audit (2026-06-28)
+
+A third independent reviewer (code-grounded) hardened the implementation details. All accepted:
+
+- **Mirror write-ordering contract (§3.3.4)** — "fail-closed" needed concrete dual-write ordering (restrictive→Convex-first, additive→Prisma-first, `transferOwnership` special-cased). This closed the actual stale-permission read-leak hole; the single most valuable fix.
+- **Expanded write-site audit to a mechanical grep gate (Phase 1b)** — grep confirmed **8** files write `member`/`customRole` (not the ~half first listed): `org-members`, `custom-roles`, `settings`, `site-admin`, `user-profile`, `sso`, `sso-provisioning`, `auth.ts`. Added a lint-style enforcement test.
+- **Convex cache API made precise (Phase 0)** — `convex-helpers` isn't installed; the provider alone doesn't cache `convex/react` `useQuery`; must use the cache package's hooks + preserve auth gating; `preloadQuery` SSR kept out (service token would bypass per-user scoping).
+- **Dashboard counters split into a mini-design (§3.6)** — counter schema, per-write update obligations, status/date transitions, backfill, reconcile, parity tests.
+- **Narrowed Phase 4 deletion** — `use-shared-resource.ts` has broad Prisma/auth-adjacent usage; delete dead consumers only, keep the file until all migrate.
+- **Corrected my own error:** dashboard is **6** page-level `useServerQuery` reads (`getDashboardStats` internally fans to 7) — the earlier dual-voice "6→7" correction was wrong; reverted. Effort nudged to ~6–8 wk (reads) / ~12–17 wk (full A–D).
+- Added the reviewer's **pre-Phase-1 implementation gate (§8)** verbatim as the acceptance test.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "convex": "^1.40.0",
+    "convex-helpers": "^0.1.119",
     "date-fns": "^4.4.0",
     "file-type": "^22.0.1",
     "framer-motion": "^12.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       convex:
         specifier: ^1.40.0
         version: 1.40.0(react@19.2.7)
+      convex-helpers:
+        specifier: ^0.1.119
+        version: 0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(hono@4.12.23)(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -4156,6 +4159,28 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convex-helpers@0.1.119:
+    resolution: {integrity: sha512-fGNK9KAlBLk8Un729ZXBqD9S5jy910nxSrH6PloIL/Gl6TalFJvjN8+xCCwahlox8Ft+bb54SSg9MbcrsQb98w==}
+    hasBin: true
+    peerDependencies:
+      '@standard-schema/spec': ^1.0.0
+      convex: ^1.32.0
+      hono: ^4.0.5
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      typescript: ^5.5 || ^6.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@standard-schema/spec':
+        optional: true
+      hono:
+        optional: true
+      react:
+        optional: true
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   convex@1.40.0:
     resolution: {integrity: sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==}
@@ -11353,6 +11378,16 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(hono@4.12.23)(react@19.2.7)(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      convex: 1.40.0(react@19.2.7)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      hono: 4.12.23
+      react: 19.2.7
+      typescript: 6.0.3
+      zod: 4.4.3
 
   convex@1.40.0(react@19.2.7):
     dependencies:

--- a/src/components/providers/convex-provider.tsx
+++ b/src/components/providers/convex-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { ConvexReactClient, ConvexProviderWithAuth } from "convex/react";
+import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import { authClient } from "@/lib/auth-client";
 import { fetchConvexAccessToken } from "@/lib/convex-token-fetch";
 
@@ -19,8 +20,21 @@ import { fetchConvexAccessToken } from "@/lib/convex-token-fetch";
  * docs/designs/convex-phase5-auth-bridge.md.
  *
  * Inert if NEXT_PUBLIC_CONVEX_URL is unset (a deploy without the backend).
+ *
+ * Phase 0 (native read layer): wrapped in ConvexQueryCacheProvider from
+ * convex-helpers so a query subscription survives unmount for a bounded window —
+ * back-navigation reloads instantly instead of paying a cold round trip. This is
+ * additive: it only affects call sites that opt in by importing the cached hooks
+ * from "convex-helpers/react/cache"; the default `useQuery` from "convex/react"
+ * is unchanged. See docs/designs/convex-native-read-layer.md (Phase 0).
  */
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+// Bounded cache: keep an unmounted subscription alive for 5 minutes, cap the
+// number of idle (unmounted-but-retained) entries so a long session can't grow
+// the open-subscription set without limit.
+const CACHE_EXPIRATION_MS = 5 * 60 * 1000;
+const CACHE_MAX_IDLE_ENTRIES = 250;
 
 /**
  * Bridges Better Auth → Convex. `fetchAccessToken` returns the current user's
@@ -74,7 +88,12 @@ export function ConvexClientProvider({
 
   return (
     <ConvexProviderWithAuth client={client} useAuth={useBetterAuthForConvex}>
-      {children}
+      <ConvexQueryCacheProvider
+        expiration={CACHE_EXPIRATION_MS}
+        maxIdleEntries={CACHE_MAX_IDLE_ENTRIES}
+      >
+        {children}
+      </ConvexQueryCacheProvider>
     </ConvexProviderWithAuth>
   );
 }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -2,42 +2,36 @@
  * Role-based permission system for GearFlow.
  *
  * Two types of roles:
- * 1. Built-in roles (owner, admin, manager, member, staff, warehouse, viewer)
+ * 1. Built-in roles (owner, admin, manager, member, warehouse, viewer)
  *    — static defaults, always available.
  * 2. Custom roles (stored per-org in the custom_role table)
  *    — role string is "custom:<id>", permissions stored as JSON.
  *
- * The PERMISSION_REGISTRY defines every resource and its possible actions.
- * This is the single source of truth for the permission matrix UI.
+ * The pure RBAC logic (RESOURCES, rolePermissions, hasPermission, …) now lives in
+ * `convex/lib/permissions-core.ts` so it can be imported by BOTH this Next.js
+ * server module and Convex functions — one source of truth for permission checks
+ * (Phase 0 of the native read layer; see docs/designs/convex-native-read-layer.md).
+ * This file re-exports that core and adds the UI-only pieces (the matrix registry
+ * and display labels) that Convex never needs.
  */
 
-export const RESOURCES = [
-  "asset",
-  "bulkAsset",
-  "model",
-  "kit",
-  "project",
-  "client",
-  "warehouse",
-  "testTag",
-  "maintenance",
-  "location",
-  "document",
-  "orgSettings",
-  "orgMembers",
-  "supplier",
-  "subHire",
-  "crew",
-  "reports",
-  "checkItem",
-] as const;
+export {
+  RESOURCES,
+  rolePermissions,
+  hasPermission,
+  isReadOnly,
+  ORG_ROLES,
+  ASSIGNABLE_BUILT_IN_ROLES,
+  isBuiltInRole,
+} from "../../convex/lib/permissions-core";
+export type {
+  Resource,
+  Action,
+  PermissionMap,
+  OrgRole,
+} from "../../convex/lib/permissions-core";
 
-export type Resource = (typeof RESOURCES)[number];
-
-export type Action = string;
-
-/** Full permission map: resource -> array of allowed actions */
-export type PermissionMap = Partial<Record<Resource, readonly string[]>>;
+import type { Resource } from "../../convex/lib/permissions-core";
 
 /** Registry of all resources and their possible actions — drives the matrix UI */
 export const PERMISSION_REGISTRY: Record<
@@ -213,194 +207,6 @@ export const PERMISSION_REGISTRY: Record<
     ],
   },
 };
-
-// ─── Built-in role defaults ─────────────────────────────────────────────────
-
-const ALL_ASSET = ["create", "read", "update", "delete", "import", "export"] as const;
-const ALL_CRUD = ["create", "read", "update", "delete"] as const;
-const ALL_PROJECT = ["create", "read", "update", "delete", "manage_line_items", "generate_documents"] as const;
-
-export const rolePermissions: Record<string, PermissionMap> = {
-  owner: {
-    asset: ALL_ASSET,
-    bulkAsset: ALL_CRUD,
-    model: ALL_ASSET,
-    kit: ALL_CRUD,
-    project: ALL_PROJECT,
-    client: ALL_CRUD,
-    warehouse: ["read", "check_out", "check_in", "scan", "close"],
-    testTag: ["create", "read", "update", "delete", "quick_test", "generate_reports"],
-    maintenance: ALL_CRUD,
-    location: ALL_CRUD,
-    document: ["generate", "send", "manage_templates"],
-    orgSettings: ["read", "update"],
-    orgMembers: ["read", "invite", "update_role", "remove"],
-    supplier: ALL_CRUD,
-    subHire: ALL_CRUD,
-    crew: ALL_CRUD,
-    reports: ["view", "export", "create", "delete"],
-    checkItem: ALL_CRUD,
-  },
-  admin: {
-    asset: ALL_ASSET,
-    bulkAsset: ALL_CRUD,
-    model: ALL_ASSET,
-    kit: ALL_CRUD,
-    project: ALL_PROJECT,
-    client: ALL_CRUD,
-    warehouse: ["read", "check_out", "check_in", "scan", "close"],
-    testTag: ["create", "read", "update", "delete", "quick_test", "generate_reports"],
-    maintenance: ALL_CRUD,
-    location: ALL_CRUD,
-    document: ["generate", "send", "manage_templates"],
-    orgSettings: ["read", "update"],
-    orgMembers: ["read", "invite", "update_role", "remove"],
-    supplier: ALL_CRUD,
-    subHire: ALL_CRUD,
-    crew: ALL_CRUD,
-    reports: ["view", "export", "create", "delete"],
-    checkItem: ALL_CRUD,
-  },
-  manager: {
-    asset: ["create", "read", "update", "import", "export"],
-    bulkAsset: ["create", "read", "update"],
-    model: ["create", "read", "update", "import", "export"],
-    kit: ["create", "read", "update"],
-    project: ["create", "read", "update", "manage_line_items", "generate_documents"],
-    client: ["create", "read", "update"],
-    warehouse: ["read", "check_out", "check_in", "scan", "close"],
-    testTag: ["create", "read", "update", "quick_test", "generate_reports"],
-    maintenance: ["create", "read", "update"],
-    location: ["create", "read", "update"],
-    document: ["generate", "send", "manage_templates"],
-    orgSettings: ["read"],
-    orgMembers: ["read"],
-    supplier: ["create", "read", "update"],
-    subHire: ["create", "read", "update"],
-    crew: ["create", "read", "update"],
-    reports: ["view", "export", "create", "delete"],
-    checkItem: ALL_CRUD,
-  },
-  member: {
-    asset: ["create", "read", "update"],
-    bulkAsset: ["create", "read", "update"],
-    model: ["create", "read", "update"],
-    kit: ["read"],
-    project: ["create", "read", "update", "manage_line_items", "generate_documents"],
-    client: ["create", "read", "update"],
-    warehouse: ["read", "check_out", "check_in", "scan"],
-    testTag: ["create", "read", "update", "quick_test"],
-    maintenance: ["create", "read", "update"],
-    location: ["read"],
-    document: ["generate"],
-    orgSettings: [],
-    orgMembers: [],
-    supplier: ["read"],
-    subHire: ["create", "read"],
-    crew: ["read"],
-    reports: ["view"],
-    checkItem: ["read"],
-  },
-  // `staff` role removed (Wave 2) — was a duplicate of `member` with identical
-  // permissions. Existing `staff` members are migrated to `member` via the
-  // consolidate-staff-role migration. Better Auth's memberRoleHierarchy and
-  // sso-provisioning ROLE_HIERARCHY no longer list it. UI dropdowns no longer
-  // offer it.
-  warehouse: {
-    asset: ["read"],
-    bulkAsset: ["read"],
-    model: ["read"],
-    kit: ["read"],
-    project: ["read"],
-    client: ["read"],
-    warehouse: ["read", "check_out", "check_in", "scan", "close"],
-    testTag: ["read"],
-    maintenance: ["read"],
-    location: ["read"],
-    document: [],
-    orgSettings: [],
-    orgMembers: [],
-    supplier: ["read"],
-    subHire: ["read"],
-    crew: ["read"],
-    reports: ["view"],
-    checkItem: ["read"],
-  },
-  viewer: {
-    asset: ["read"],
-    bulkAsset: ["read"],
-    model: ["read"],
-    kit: ["read"],
-    project: ["read"],
-    client: ["read"],
-    warehouse: [],
-    testTag: ["read"],
-    maintenance: ["read"],
-    location: ["read"],
-    document: [],
-    orgSettings: [],
-    orgMembers: [],
-    supplier: ["read"],
-    subHire: ["read"],
-    crew: ["read"],
-    reports: ["view"],
-    checkItem: ["read"],
-  },
-};
-
-/**
- * Check if a role has a specific permission.
- * For custom roles (prefixed "custom:"), pass the resolved permissions map.
- */
-export function hasPermission(
-  role: string,
-  resource: Resource,
-  action: string,
-  customPermissions?: PermissionMap | null,
-): boolean {
-  // Owner always has all permissions (safety net)
-  if (role === "owner") {
-    return true;
-  }
-
-  // Custom role: use provided permissions
-  if (role.startsWith("custom:")) {
-    if (!customPermissions) return false;
-    return customPermissions[resource]?.includes(action) ?? false;
-  }
-
-  // Built-in role: use static map
-  const perms = rolePermissions[role];
-  if (!perms) return false;
-  return perms[resource]?.includes(action) ?? false;
-}
-
-/**
- * Check if a permission map has ANY write permission (create/update/delete).
- * Used to determine if a user is effectively read-only.
- */
-export function isReadOnly(permissions: PermissionMap): boolean {
-  for (const resource of RESOURCES) {
-    const actions = permissions[resource];
-    if (!actions) continue;
-    for (const action of actions) {
-      if (action !== "read" && action !== "view") return false;
-    }
-  }
-  return true;
-}
-
-/** All org roles in hierarchy order */
-export const ORG_ROLES = ["owner", "admin", "manager", "member", "viewer"] as const;
-export type OrgRole = (typeof ORG_ROLES)[number];
-
-/** Built-in roles that can be assigned (excludes owner — owner is transferred) */
-export const ASSIGNABLE_BUILT_IN_ROLES = ["admin", "manager", "member", "viewer"] as const;
-
-/** Check if a role string is a built-in role */
-export function isBuiltInRole(role: string): boolean {
-  return role in rolePermissions;
-}
 
 /** Role display labels */
 export const roleLabels: Record<string, string> = {


### PR DESCRIPTION
## Phase 0 — Native client plumbing

First phase of the Convex-native read layer migration (`docs/designs/convex-native-read-layer.md`). **Additive only** — nothing reads through the new plumbing yet, so runtime behaviour is unchanged. This lays the foundation the per-surface read migrations (Phase 1+) build on.

### Summary of changes
- **`convex-helpers@0.1.119`** added; app wrapped in **`ConvexQueryCacheProvider`** inside the existing `ConvexProviderWithAuth` tree (bounded: 5-min expiration, 250 idle entries). This only affects call sites that opt into the cached hooks from `convex-helpers/react/cache`; the default `convex/react` `useQuery` is untouched. Enables instant back-navigation once surfaces migrate.
- **Isomorphic RBAC core:** moved the pure permission logic (`RESOURCES`, `rolePermissions`, `hasPermission`, `isReadOnly`, role helpers + types) to **`convex/lib/permissions-core.ts`** so Convex functions and the Next server share one source of truth (the Phase 1 `requireOrgPermission` guard will import it). `src/lib/permissions.ts` re-exports it and keeps the UI-only `PERMISSION_REGISTRY` + `roleLabels`. No behaviour change — pure relocation.
- Landed the migration design doc + the independent review-response.

### Files changed
- `package.json`, `pnpm-lock.yaml` — add `convex-helpers@0.1.119` (pinned; see note)
- `src/components/providers/convex-provider.tsx` — wrap in cache provider
- `convex/lib/permissions-core.ts` — new isomorphic RBAC core
- `src/lib/permissions.ts` — re-export core, keep UI registry
- `docs/designs/convex-native-read-layer.md`, `...-review-response.md` — design + review

### Verification
| Check | Result |
|---|---|
| `npx tsc --noEmit` (after `prisma generate`) | ✅ exit 0 |
| `pnpm run lint` | ✅ exit 0 (0 errors; pre-existing warnings only, none in changed files) |
| `pnpm exec vitest run -t permission` | ✅ 22 passed, 0 failed |
| `pnpm install --frozen-lockfile` | ✅ consistent, `convex-helpers@0.1.119` locked |
| `git diff --check` | ✅ no whitespace errors |

### Risks / follow-ups
- **Version pin:** pinned to `convex-helpers@0.1.119` (not latest `0.1.120`). The local `pnpm-workspace.yaml` `minimumReleaseAge` policy holds back the 5-day-old `0.1.120`; `0.1.119` (20 days old) locks cleanly and has identical cache exports. Bump later when `0.1.120` ages in.
- **Worktree/pnpm note:** the parent dir's `pnpm-workspace.yaml` (untracked, not in CI) makes plain `pnpm add` skip the worktree lockfile; used `pnpm add --ignore-workspace` to update it. CI checks out standalone, so frozen install is consistent there.
- No functional surface change — the cache provider and permissions-core have **zero consumers** until Phase 1.

### Rollback
Revert this PR. Removing `ConvexQueryCacheProvider` and the `convex-helpers` dep restores the prior tree; `permissions-core.ts` deletion + restoring `permissions.ts` reverts the relocation. No data/schema/migration involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)