### PR TITLE
feat(convex-native): Phase 1b — wire member/customRole mirror at all write sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "convex:backfill:warehouse-dashboard-tokens": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-warehouse-dashboard-tokens.ts",
     "convex:backfill:test-tag-auditor-tokens": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-test-tag-auditor-tokens.ts",
     "convex:backfill:maintenance-record-assets": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-maintenance-record-assets.ts",
+    "convex:backfill:members": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-members.ts",
     "convex:backfill:all": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-all.ts",
     "convex:parity": "tsx --env-file=.env --env-file=.env.local scripts/convex-parity-check.ts",
     "convex:resync:line-items": "tsx --env-file=.env --env-file=.env.local scripts/convex-resync-line-items.ts",

--- a/scripts/convex-backfill-members.ts
+++ b/scripts/convex-backfill-members.ts
@@ -1,0 +1,60 @@
+/**
+ * One-time backfill: mirror Prisma `member` + `customRole` rows into their Convex
+ * mirror tables (the native read layer's RBAC source for `requireOrgPermission`).
+ *
+ * Idempotent — upserts by cuid `id`, so re-running is safe and converges any drift.
+ * Run AFTER the Phase 1 schema + mirror functions are deployed:
+ *
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-members.ts
+ *
+ * (or `pnpm convex:backfill:members`). See docs/designs/convex-native-read-layer.md §3.3.
+ */
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+async function main() {
+  const convex = await getConvexClient();
+
+  const members = await prisma.member.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`Found ${members.length} members in Prisma.`);
+  let m = 0;
+  for (const row of members) {
+    await convex.mutation(api.members.upsert, {
+      id: row.id,
+      organizationId: row.organizationId,
+      userId: row.userId,
+      role: row.role,
+      createdAt: row.createdAt ? row.createdAt.getTime() : undefined,
+    });
+    m++;
+  }
+  console.log(`Mirrored ${m} members.`);
+
+  const roles = await prisma.customRole.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`Found ${roles.length} custom roles in Prisma.`);
+  let r = 0;
+  for (const row of roles) {
+    await convex.mutation(api.customRoles.upsert, {
+      id: row.id,
+      organizationId: row.organizationId,
+      name: row.name,
+      description: row.description ?? undefined,
+      color: row.color ?? undefined,
+      permissions: row.permissions,
+      ssoGroupClaim: row.ssoGroupClaim ?? undefined,
+      createdAt: row.createdAt ? row.createdAt.getTime() : undefined,
+      updatedAt: row.updatedAt ? row.updatedAt.getTime() : undefined,
+    });
+    r++;
+  }
+  console.log(`Mirrored ${r} custom roles.`);
+
+  console.log(`\nBackfill complete: ${m} members, ${r} custom roles.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { env } from "@/env";
 import { prisma } from "@/lib/prisma";
 import { mirrorUserToConvex } from "@/lib/user-mirror";
+import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
 import { sendEmail } from "./email";
 import { getPlatformName } from "./platform";
 import { getSiteSettingsFromConvex } from "./site-settings-read";
@@ -263,6 +264,8 @@ export const auth = betterAuth({
                     role: hasOwner ? "member" : "owner",
                   },
                 });
+                // Additive (auto-create on registration): mirror best-effort.
+                await upsertMemberMirrorByOrgUser(org.id, user.id);
               }
             }
           } catch {

--- a/src/lib/member-mirror-coverage.test.ts
+++ b/src/lib/member-mirror-coverage.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Mirror-coverage gate (docs/designs/convex-native-read-layer.md §3.3.4, §8).
+ *
+ * Membership/custom-role writes are scattered across many files. If a NEW write
+ * site is added without routing through the mirror helper, the Convex RBAC mirror
+ * silently drifts from Prisma — a stale-permission read leak once enforcement is
+ * live. This test fails CI if any file writes `member`/`customRole` in Prisma but
+ * doesn't import `member-mirror`, so the bypass can't land unnoticed.
+ */
+
+const SRC_DIR = join(process.cwd(), "src");
+
+// Prisma writes to the auth-affecting tables. `findUnique/findFirst/count/findMany`
+// are reads and intentionally excluded.
+const WRITE_RE =
+  /\b(?:prisma|tx)\.(?:member|customRole)\.(?:create|update|delete|createMany|updateMany|deleteMany|upsert)\b/;
+
+// Files that legitimately contain a write pattern but are NOT mirror call sites.
+// Keep this list tiny and justified — every entry is a deliberate exception.
+const ALLOWLIST = new Set<string>([
+  // The mirror module + its tests obviously don't import themselves.
+  "lib/member-mirror.ts",
+]);
+
+// Directories to skip: generated code (Prisma client model files contain method
+// signatures like `member.create` that match the write regex but aren't call sites).
+const SKIP_DIRS = new Set(["generated"]);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      out.push(...walk(full));
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("member/customRole mirror coverage", () => {
+  const files = walk(SRC_DIR);
+
+  it("found source files to scan", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("every member/customRole write site imports the mirror helper", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = file.slice(SRC_DIR.length + 1);
+      if (ALLOWLIST.has(rel)) continue;
+      const src = readFileSync(file, "utf8");
+      if (WRITE_RE.test(src) && !src.includes("member-mirror")) {
+        offenders.push(rel);
+      }
+    }
+    expect(
+      offenders,
+      `These files write member/customRole rows but do not import @/lib/member-mirror — ` +
+        `route the write through the mirror (or add to ALLOWLIST with justification):\n` +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("the restrictive org-facing paths use strict (Convex-first) ordering", () => {
+    // §3.3.4: revoke/demote/permission-removal must mirror with { strict: true }.
+    const mustBeStrict = [
+      "server/org-members.ts",
+      "server/custom-roles.ts",
+      "server/settings.ts",
+      "server/user-profile.ts",
+    ];
+    for (const rel of mustBeStrict) {
+      const src = readFileSync(join(SRC_DIR, rel), "utf8");
+      expect(src.includes("{ strict: true }"), `${rel} must use strict ordering`).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/src/lib/member-mirror.ts
+++ b/src/lib/member-mirror.ts
@@ -1,0 +1,203 @@
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Mirror of the Better-Auth `member` + Prisma `customRole` rows (source of truth
+ * stays in Prisma) into their Convex mirror tables, so the native read layer's
+ * `requireOrgPermission` guard can resolve a user's role + custom-role permissions
+ * inside Convex (docs/designs/convex-native-read-layer.md §3.3).
+ *
+ * WRITE-ORDERING CONTRACT (§3.3.4) — Prisma and Convex can't share a transaction,
+ * so the ORDER of the two writes decides the failure mode:
+ *
+ *   • RESTRICTIVE change (revoke / demote / permission-removal / role delete):
+ *     write the MORE-restrictive state to Convex FIRST (strict — throws on
+ *     failure), THEN commit Prisma. If Convex fails we abort before Prisma, so we
+ *     can never end up Prisma-revoked-but-Convex-granting. A failed Convex write
+ *     blocks the op (the caller retries) — temporary over-denial, never over-grant.
+ *
+ *   • ADDITIVE change (new member / promotion / new role): commit Prisma FIRST,
+ *     mirror to Convex after (best-effort — swallows). A lagging/failed mirror
+ *     denies too much, not too little — safe.
+ *
+ * The `strict` option selects the behaviour. The nightly reconcile is a backstop
+ * for drift on the best-effort paths, NOT the primary control.
+ *
+ * NOTE: enforcement is not live until the browser cutover wires a composite onto
+ * `requireOrgPermission`. Until then these writes only keep the mirror in sync;
+ * the ordering is in place so the guarantee holds the moment a reader appears.
+ */
+
+function toMillis(d: Date | number | null | undefined): number | undefined {
+  if (d == null) return undefined;
+  return d instanceof Date ? d.getTime() : typeof d === "number" ? d : undefined;
+}
+
+type MirrorOpts = { strict?: boolean };
+
+/** Run a Convex mirror write: strict ⇒ propagate failure (abort caller); else swallow. */
+async function runMirror(
+  label: string,
+  fn: () => Promise<unknown>,
+  opts: MirrorOpts | undefined,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (opts?.strict) {
+      // Restrictive change: surface the failure so the caller aborts BEFORE the
+      // Prisma write — never leave Convex granting what Prisma is about to revoke.
+      throw err;
+    }
+    console.error(`[member-mirror] ${label} failed (best-effort):`, err);
+  }
+}
+
+// ─── Members ────────────────────────────────────────────────────────────────
+
+/** Upsert an explicit member row into the Convex mirror. */
+export async function upsertMemberMirror(
+  row: {
+    id: string;
+    organizationId: string;
+    userId: string;
+    role: string;
+    createdAt?: Date | number | null;
+  },
+  opts?: MirrorOpts,
+): Promise<void> {
+  await runMirror(
+    `upsert member ${row.id}`,
+    async () => {
+      const convex = await getConvexClient();
+      await convex.mutation(api.members.upsert, {
+        id: row.id,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        role: row.role,
+        createdAt: toMillis(row.createdAt),
+      });
+    },
+    opts,
+  );
+}
+
+/** Read a member by id from Prisma and mirror it (additive — best-effort by default). */
+export async function upsertMemberMirrorById(
+  memberId: string,
+  opts?: MirrorOpts,
+): Promise<void> {
+  const m = await prisma.member.findUnique({
+    where: { id: memberId },
+    select: { id: true, organizationId: true, userId: true, role: true, createdAt: true },
+  });
+  if (!m) return;
+  await upsertMemberMirror(m, opts);
+}
+
+/** Read the member for (org, user) from Prisma and mirror it. Convenient for
+ * provisioning paths that don't surface the member id (SSO, registration). */
+export async function upsertMemberMirrorByOrgUser(
+  organizationId: string,
+  userId: string,
+  opts?: MirrorOpts,
+): Promise<void> {
+  const m = await prisma.member.findFirst({
+    where: { organizationId, userId },
+    select: { id: true, organizationId: true, userId: true, role: true, createdAt: true },
+  });
+  if (!m) return;
+  await upsertMemberMirror(m, opts);
+}
+
+/** Remove every mirrored member for (org, user) — revocation by membership. */
+export async function removeMemberMirror(
+  args: { organizationId: string; userId: string },
+  opts?: MirrorOpts,
+): Promise<void> {
+  await runMirror(
+    `remove member ${args.organizationId}/${args.userId}`,
+    async () => {
+      const convex = await getConvexClient();
+      await convex.mutation(api.members.removeByOrgAndUser, args);
+    },
+    opts,
+  );
+}
+
+// ─── Custom roles ───────────────────────────────────────────────────────────
+
+/** Upsert an explicit custom-role row into the Convex mirror. `permissions` is the
+ * JSON STRING exactly as Prisma stores it (the guard parses it at read time). */
+export async function upsertCustomRoleMirror(
+  row: {
+    id: string;
+    organizationId: string;
+    name: string;
+    description?: string | null;
+    color?: string | null;
+    permissions: string;
+    ssoGroupClaim?: string | null;
+    createdAt?: Date | number | null;
+    updatedAt?: Date | number | null;
+  },
+  opts?: MirrorOpts,
+): Promise<void> {
+  await runMirror(
+    `upsert customRole ${row.id}`,
+    async () => {
+      const convex = await getConvexClient();
+      await convex.mutation(api.customRoles.upsert, {
+        id: row.id,
+        organizationId: row.organizationId,
+        name: row.name,
+        description: row.description ?? undefined,
+        color: row.color ?? undefined,
+        permissions: row.permissions,
+        ssoGroupClaim: row.ssoGroupClaim ?? undefined,
+        createdAt: toMillis(row.createdAt),
+        updatedAt: toMillis(row.updatedAt),
+      });
+    },
+    opts,
+  );
+}
+
+/** Read a custom role by id from Prisma and mirror it. */
+export async function upsertCustomRoleMirrorById(
+  id: string,
+  opts?: MirrorOpts,
+): Promise<void> {
+  const r = await prisma.customRole.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      organizationId: true,
+      name: true,
+      description: true,
+      color: true,
+      permissions: true,
+      ssoGroupClaim: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+  if (!r) return;
+  await upsertCustomRoleMirror(r, opts);
+}
+
+/** Remove a mirrored custom role by id (role deletion). */
+export async function removeCustomRoleMirror(
+  id: string,
+  opts?: MirrorOpts,
+): Promise<void> {
+  await runMirror(
+    `remove customRole ${id}`,
+    async () => {
+      const convex = await getConvexClient();
+      await convex.mutation(api.customRoles.remove, { id });
+    },
+    opts,
+  );
+}

--- a/src/lib/sso-provisioning.ts
+++ b/src/lib/sso-provisioning.ts
@@ -1,4 +1,5 @@
 import { prisma } from "./prisma";
+import { upsertMemberMirrorByOrgUser } from "./member-mirror";
 import type { OrgSSOSettings, SSOGroupMapping } from "./sso-types";
 import type { Organization } from "@/generated/prisma/client";
 
@@ -210,6 +211,9 @@ export async function handleSSOProvisioning(data: {
         where: { id: existingMember.id },
         data: { role },
       });
+      // SSO role sync — best-effort mirror (provisioning re-runs on every login,
+      // so the mirror self-heals; the nightly reconcile is the backstop §3.3.4).
+      await upsertMemberMirrorByOrgUser(provider.organizationId, user.id);
     }
     return;
   }
@@ -221,6 +225,9 @@ export async function handleSSOProvisioning(data: {
         where: { id: existingMember.id },
         data: { role },
       });
+      // SSO role sync — best-effort mirror (provisioning re-runs on every login,
+      // so the mirror self-heals; the nightly reconcile is the backstop §3.3.4).
+      await upsertMemberMirrorByOrgUser(provider.organizationId, user.id);
     }
     return;
   }
@@ -264,6 +271,9 @@ export async function handleSSOProvisioning(data: {
       role,
     },
   });
+
+  // Additive: mirror best-effort after the Prisma commit.
+  await upsertMemberMirrorByOrgUser(provider.organizationId, user.id);
 
   return;
 }

--- a/src/server/custom-roles.ts
+++ b/src/server/custom-roles.ts
@@ -8,6 +8,11 @@ import {
   type PermissionMap,
 } from "@/lib/permissions";
 import { logActivity } from "@/lib/activity-log";
+import {
+  upsertCustomRoleMirror,
+  upsertCustomRoleMirrorById,
+  removeCustomRoleMirror,
+} from "@/lib/member-mirror";
 
 // ─── Read ───────────────────────────────────────────────────────────────────
 
@@ -69,6 +74,9 @@ export async function createCustomRole(data: {
     },
   });
 
+  // Additive: Prisma committed; mirror best-effort after (§3.3.4).
+  await upsertCustomRoleMirrorById(role.id);
+
   await logActivity({
     organizationId,
     userId,
@@ -116,6 +124,33 @@ export async function updateCustomRole(
   if (data.ssoGroupClaim !== undefined) updateData.ssoGroupClaim = data.ssoGroupClaim?.trim() || null;
   if (data.permissions !== undefined) updateData.permissions = JSON.stringify(data.permissions);
 
+  // Restrictive (a permissions edit may REMOVE permissions): mirror the merged
+  // new state to Convex FIRST (strict), then commit Prisma — never leave Convex
+  // granting a permission Prisma is about to remove (§3.3.4).
+  await upsertCustomRoleMirror(
+    {
+      id: existing.id,
+      organizationId,
+      name: data.name !== undefined ? data.name.trim() : existing.name,
+      description:
+        data.description !== undefined
+          ? data.description?.trim() || null
+          : existing.description,
+      color: data.color !== undefined ? data.color || null : existing.color,
+      permissions:
+        data.permissions !== undefined
+          ? JSON.stringify(data.permissions)
+          : existing.permissions,
+      ssoGroupClaim:
+        data.ssoGroupClaim !== undefined
+          ? data.ssoGroupClaim?.trim() || null
+          : existing.ssoGroupClaim,
+      createdAt: existing.createdAt,
+      updatedAt: existing.updatedAt,
+    },
+    { strict: true },
+  );
+
   const updated = await prisma.customRole.update({
     where: { id, organizationId },
     data: updateData,
@@ -160,6 +195,10 @@ export async function deleteCustomRole(id: string) {
       `Cannot delete this role — ${memberCount} member${memberCount > 1 ? "s" : ""} still assigned to it. Reassign them first.`,
     );
   }
+
+  // Restrictive: remove from the Convex mirror FIRST (strict), then commit the
+  // Prisma delete (§3.3.4). A Convex failure aborts the deletion.
+  await removeCustomRoleMirror(id, { strict: true });
 
   await prisma.customRole.delete({ where: { id, organizationId } });
 
@@ -207,6 +246,9 @@ export async function duplicateCustomRole(id: string, newName: string) {
     summary: `Duplicated custom role ${existing.name} as ${role.name}`,
     details: { sourceId: id, sourceName: existing.name },
   });
+
+  // Additive: Prisma committed; mirror best-effort after (§3.3.4).
+  await upsertCustomRoleMirrorById(role.id);
 
   return serialize({
     ...role,

--- a/src/server/org-members.ts
+++ b/src/server/org-members.ts
@@ -5,6 +5,10 @@ import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { sendEmail, roleChangedEmail, removedFromOrgEmail } from "@/lib/email";
 import { logActivity } from "@/lib/activity-log";
+import {
+  upsertMemberMirror,
+  removeMemberMirror,
+} from "@/lib/member-mirror";
 
 export async function getOrgMembers(params?: {
   page?: number;
@@ -106,6 +110,20 @@ export async function changeMemberRole(memberId: string, newRole: string) {
     throw new Error("Only the owner can manage admin roles.");
   }
 
+  // Restrictive (a role change may reduce permissions): mirror the NEW role to
+  // Convex FIRST (strict), then commit Prisma — never leave Convex granting the
+  // old role after Prisma demotes (§3.3.4). A Convex failure aborts the change.
+  await upsertMemberMirror(
+    {
+      id: memberId,
+      organizationId,
+      userId: target.userId,
+      role: newRole,
+      createdAt: target.createdAt,
+    },
+    { strict: true },
+  );
+
   await prisma.member.update({
     where: { id: memberId },
     data: { role: newRole },
@@ -169,6 +187,13 @@ export async function removeOrgMember(memberId: string) {
     throw new Error("Only the owner can remove admins.");
   }
 
+  // Restrictive (revocation): remove from the Convex mirror FIRST (strict), then
+  // commit the Prisma delete (§3.3.4). A Convex failure aborts the removal.
+  await removeMemberMirror(
+    { organizationId, userId: target.userId },
+    { strict: true },
+  );
+
   await prisma.member.delete({ where: { id: memberId } });
 
   await logActivity({
@@ -211,6 +236,21 @@ export async function transferOwnership(newOwnerId: string) {
   });
   if (!newOwner) throw new Error("Target must be a member of this organization.");
 
+  // transferOwnership is both a DEMOTION (old owner → admin) and a PROMOTION
+  // (new member → owner). The demotion is restrictive, so mirror it to Convex
+  // FIRST (strict) before the Prisma transaction; the promotion is additive, so
+  // mirror it best-effort AFTER (§3.3.4).
+  await upsertMemberMirror(
+    {
+      id: actor.id,
+      organizationId,
+      userId,
+      role: "admin",
+      createdAt: actor.createdAt,
+    },
+    { strict: true },
+  );
+
   await prisma.$transaction([
     prisma.member.update({
       where: { id: actor.id },
@@ -221,6 +261,14 @@ export async function transferOwnership(newOwnerId: string) {
       data: { role: "owner" },
     }),
   ]);
+
+  await upsertMemberMirror({
+    id: newOwner.id,
+    organizationId,
+    userId: newOwnerId,
+    role: "owner",
+    createdAt: newOwner.createdAt,
+  });
 
   return { success: true };
 }

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -6,6 +6,7 @@ import { serialize } from "@/lib/serialize";
 import { sendEmail } from "@/lib/email";
 import { getPlatformName } from "@/lib/platform";
 import { logActivity } from "@/lib/activity-log";
+import { upsertMemberMirrorById, removeMemberMirror } from "@/lib/member-mirror";
 import { env } from "@/env";
 import type { OrgSSOSettings } from "@/lib/sso-types";
 import { validateProjectNumberFormat, type IncrementReset } from "@/lib/project-number";
@@ -347,6 +348,9 @@ export async function addMemberByEmail(email: string, role: string) {
       summary: `Added member ${normalizedEmail} with role ${role}`,
     });
 
+    // Additive: Prisma committed; mirror best-effort after (§3.3.4).
+    await upsertMemberMirrorById(member.id);
+
     return serialize(member);
   }
 
@@ -412,6 +416,13 @@ export async function removeMember(memberId: string) {
 
   if (!member) throw new Error("Member not found");
   if (member.role === "owner") throw new Error("Cannot remove the owner");
+
+  // Restrictive (revocation): remove from the Convex mirror FIRST (strict), then
+  // commit the Prisma delete (§3.3.4).
+  await removeMemberMirror(
+    { organizationId, userId: member.userId },
+    { strict: true },
+  );
 
   await prisma.member.delete({ where: { id: memberId } });
   return { success: true };

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -3,6 +3,11 @@
 import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { removeUserFromConvex } from "@/lib/user-mirror";
+import {
+  upsertMemberMirror,
+  upsertMemberMirrorByOrgUser,
+  removeMemberMirror,
+} from "@/lib/member-mirror";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getSiteSettingsFromConvex } from "@/lib/site-settings-read";
@@ -156,6 +161,9 @@ export async function adminCreateOrganization(data: {
     });
     return newOrg;
   });
+
+  // Additive (org + owner created): mirror best-effort after the transaction.
+  await upsertMemberMirrorByOrgUser(org.id, ownerId);
 
   await logActivity({
     organizationId: org.id,
@@ -693,6 +701,14 @@ export async function adminTransferOwnership(orgId: string, newOwnerId: string) 
     return { currentOwner, newOwner };
   });
 
+  // Admin ownership transfer (demote + promote). Best-effort mirror after the
+  // transaction for both affected members (platform-admin path; nightly reconcile
+  // is the backstop §3.3.4).
+  if (result.currentOwner) {
+    await upsertMemberMirrorByOrgUser(orgId, result.currentOwner.userId);
+  }
+  await upsertMemberMirrorByOrgUser(orgId, newOwnerId);
+
   await logActivity({
     organizationId: orgId,
     userId: session.user.id,
@@ -755,6 +771,9 @@ export async function adminAddMemberToOrg(orgId: string, email: string, role: st
     data: { organizationId: orgId, userId: user.id, role },
   });
 
+  // Additive: mirror best-effort after the Prisma commit.
+  await upsertMemberMirrorByOrgUser(orgId, user.id);
+
   await logActivity({
     organizationId: orgId,
     userId: session.user.id,
@@ -779,6 +798,13 @@ export async function adminRemoveMemberFromOrg(orgId: string, memberId: string) 
   });
   if (!member) throw new Error("Member not found.");
   if (member.role === "owner") throw new Error("Cannot remove the owner. Transfer ownership first.");
+
+  // Restrictive (revocation): remove from the Convex mirror FIRST (strict), then
+  // commit the Prisma delete (§3.3.4).
+  await removeMemberMirror(
+    { organizationId: orgId, userId: member.userId },
+    { strict: true },
+  );
 
   await prisma.member.delete({ where: { id: memberId } });
 
@@ -814,6 +840,20 @@ export async function adminChangeMemberRole(orgId: string, memberId: string, new
     });
     if (!customRole) throw new Error("Custom role not found in this organization.");
   }
+
+  // Restrictive (a role change may reduce permissions): mirror the NEW role to
+  // Convex FIRST (strict), then commit Prisma (§3.3.4). Pass the new role
+  // explicitly — reading Prisma here would mirror the stale old role.
+  await upsertMemberMirror(
+    {
+      id: memberId,
+      organizationId: orgId,
+      userId: member.userId,
+      role: newRole,
+      createdAt: member.createdAt,
+    },
+    { strict: true },
+  );
 
   await prisma.member.update({
     where: { id: memberId },

--- a/src/server/sso.ts
+++ b/src/server/sso.ts
@@ -6,6 +6,7 @@ import { serialize } from "@/lib/serialize";
 import { sendEmail } from "@/lib/email";
 import { getPlatformName } from "@/lib/platform";
 import { logActivity } from "@/lib/activity-log";
+import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
 import { DEFAULT_SSO_SETTINGS, type OrgSSOSettings, type SSOGroupMapping } from "@/lib/sso-types";
 import { env } from "@/env";
 import type { OrgSettings } from "./settings";
@@ -344,6 +345,9 @@ export async function approveSSOUser(approvalId: string, role?: string) {
     entityName: approval.email,
     summary: `Approved SSO user ${approval.email} with role ${assignRole}`,
   });
+
+  // Additive (membership granted): mirror best-effort after the Prisma commit.
+  await upsertMemberMirrorByOrgUser(organizationId, approval.userId);
 
   // Send email notification
   const pName = await getPlatformName();

--- a/src/server/user-profile.ts
+++ b/src/server/user-profile.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireSession } from "@/lib/auth-server";
 import { serialize } from "@/lib/serialize";
 import { mirrorUserToConvex } from "@/lib/user-mirror";
+import { removeMemberMirror } from "@/lib/member-mirror";
 
 export async function getProfile() {
   const session = await requireSession();
@@ -76,6 +77,13 @@ export async function leaveOrganization(orgId: string) {
   if (member.role === "owner") {
     throw new Error("You are the owner. Transfer ownership to another member before leaving.");
   }
+
+  // Restrictive (self-revocation): remove from the Convex mirror FIRST (strict),
+  // then commit the Prisma delete (§3.3.4).
+  await removeMemberMirror(
+    { organizationId: orgId, userId: session.user.id },
+    { strict: true },
+  );
 
   await prisma.member.delete({ where: { id: member.id } });
   return { success: true };


### PR DESCRIPTION
## Phase 1b — mirror write-site wiring (§3.3.4)

Wires the Convex `members`/`customRoles` mirror (stood up in #298) into **every** Prisma membership/role write, applying the write-ordering contract. The `requireOrgPermission` guard still has **no callers**, so enforcement is inert and behaviour is unchanged — this PR only keeps the mirror in sync ahead of the browser cutover.

### Write-ordering contract (`src/lib/member-mirror.ts`)
- **RESTRICTIVE** (revoke / demote / permission-removal / role delete): mirror the more-restrictive state to Convex **FIRST** (`{ strict: true }` — throws, aborting before the Prisma write), so we can never end up Prisma-revoked-but-Convex-granting.
- **ADDITIVE** (create / promote / new role): Prisma first, mirror **best-effort** after; the nightly reconcile backstops drift.

### Sites wired (8 files, 23 call sites)
**Strict (Convex-first):** `org-members` changeMemberRole / removeOrgMember / transferOwnership-demotion · `custom-roles` updateCustomRole / deleteCustomRole · `settings` removeMember · `user-profile` leaveOrganization · `site-admin` adminRemoveMemberFromOrg / adminChangeMemberRole.
**Best-effort additive/provisioning:** custom-roles create+duplicate · settings addMember · sso approveSSOUser · auth.ts registration · sso-provisioning (SYNC_ON_LOGIN ×2 + AUTO_CREATE) · site-admin create/org-create/ownership-transfer-promotion.

### Guards & tooling
- **`src/lib/member-mirror-coverage.test.ts`** (the §8 CI gate): scans `src/`, fails if any file writes `member`/`customRole` in Prisma without importing the mirror helper (skips `generated/`), and asserts the restrictive org-facing paths use `{ strict: true }`. A future write can't silently bypass the mirror.
- **`scripts/convex-backfill-members.ts`** + `pnpm convex:backfill:members` — idempotent (upsert-by-id) one-time backfill of existing members + custom roles. **An operator runs this with prod env** after merge.

### Files changed
`src/lib/member-mirror.ts` (new), `src/lib/member-mirror-coverage.test.ts` (new), `scripts/convex-backfill-members.ts` (new), `package.json`, and the 8 write-site files: `src/server/{org-members,custom-roles,settings,user-profile,sso,site-admin}.ts`, `src/lib/{auth,sso-provisioning}.ts`.

### Verification
| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ exit 0 |
| `pnpm run lint` | ✅ exit 0 (0 errors) |
| `vitest` (coverage gate + rbac-parity + permissions) | ✅ **71 passed** |
| `git diff --check` | ✅ clean |
| Full local suite | 58 **pre-existing** component-test failures (react-dom env in this worktree) — proven identical on clean `main` via `git stash`; CI ran them green for #297/#298 and runs standalone, so they don't gate this PR |

### Risks / follow-ups
- **Backfill required for completeness:** until `pnpm convex:backfill:members` runs against prod, the mirror only contains rows touched by a write since merge. Harmless now (no enforcement); must run **before** the cutover PR flips a reader onto the guard. (You're running this.)
- **New Convex coupling on restrictive auth ops:** strict paths now throw if Convex is unreachable (the designed fail-closed tradeoff — over-denial, never over-grant). The app already hard-depends on Convex for all reads/writes, so the incremental coupling is small.
- Transactional admin paths (`site-admin` org-create, ownership transfer) mirror best-effort *after* the Prisma transaction (can't wrap a Convex call into a Prisma `$transaction`); reconcile is the backstop. Documented inline.

### Rollback
Revert this PR — the mirror calls are removed and the write paths return to Prisma-only. The mirror tables/guard (from #298) remain, dormant. No data migration to undo (the mirror is a derived replica).

🤖 Generated with [Claude Code](https://claude.com/claude-code)