### PR TITLE
feat(convex-native): Phase 1d.A — native projectDetail.bundle composite

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -66,6 +66,7 @@ import type * as notificationEmailLogs from "../notificationEmailLogs.js";
 import type * as overbooking from "../overbooking.js";
 import type * as parity from "../parity.js";
 import type * as projectCategories from "../projectCategories.js";
+import type * as projectDetail from "../projectDetail.js";
 import type * as projectEquipment from "../projectEquipment.js";
 import type * as projectGroups from "../projectGroups.js";
 import type * as projectLineItemUnits from "../projectLineItemUnits.js";
@@ -168,6 +169,7 @@ declare const fullApi: ApiFromModules<{
   overbooking: typeof overbooking;
   parity: typeof parity;
   projectCategories: typeof projectCategories;
+  projectDetail: typeof projectDetail;
   projectEquipment: typeof projectEquipment;
   projectGroups: typeof projectGroups;
   projectLineItemUnits: typeof projectLineItemUnits;

--- a/convex/projectDetail.test.ts
+++ b/convex/projectDetail.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string | null) => ({ subject: USER, ...(orgId ? { orgId } : {}) });
+
+async function seedViewerAndProject(t: ReturnType<typeof convexTest>, projOrg = ORG) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("projects", {
+      id: "p1",
+      organizationId: projOrg,
+      projectNumber: "P-1",
+      name: "Test Project",
+    });
+  });
+}
+
+describe("projectDetail.bundle — auth gating", () => {
+  test("denies anonymous", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.query(api.projectDetail.bundle, { projectId: "p1", orgId: ORG }),
+    ).rejects.toThrow(/authentication required/i);
+  });
+
+  test("denies a non-member", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.withIdentity(asUser(ORG)).query(api.projectDetail.bundle, { projectId: "p1", orgId: ORG }),
+    ).rejects.toThrow(/not a member/i);
+  });
+
+  test("allows a viewer (project:read) and returns the project-detail shape", async () => {
+    const t = convexTest(schema, modules);
+    await seedViewerAndProject(t);
+    const res = await t
+      .withIdentity(asUser(ORG))
+      .query(api.projectDetail.bundle, { projectId: "p1", orgId: ORG });
+    expect(res).not.toBeNull();
+    expect(res!.project.id).toBe("p1");
+    expect(res).toHaveProperty("projectManagers");
+    expect(res).toHaveProperty("managerUsers");
+    expect(res).toHaveProperty("media");
+    expect(res).toHaveProperty("client");
+    expect(res).toHaveProperty("location");
+  });
+
+  test("returns null for a project in a different org (doc org-scope)", async () => {
+    const t = convexTest(schema, modules);
+    // Member of ORG, but the project belongs to another org.
+    await seedViewerAndProject(t, "org_other");
+    const res = await t
+      .withIdentity(asUser(ORG))
+      .query(api.projectDetail.bundle, { projectId: "p1", orgId: ORG });
+    expect(res).toBeNull();
+  });
+
+  test("service identity is allowed", async () => {
+    const t = convexTest(schema, modules);
+    const res = await t
+      .withIdentity(SERVICE)
+      .query(api.projectDetail.bundle, { projectId: "missing", orgId: ORG });
+    expect(res).toBeNull(); // auth passed; project simply absent
+  });
+});

--- a/convex/projectDetail.ts
+++ b/convex/projectDetail.ts
@@ -1,0 +1,77 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { requireOrgPermission } from "./lib/auth";
+
+/**
+ * BROWSER-facing project-detail composite for the native read-layer cutover
+ * (Phase 1d). Returns the project-detail SPINE that `getProject` composes —
+ * project scalars, project managers (+ their mirrored users), media (+ files),
+ * location (+ parent), client — as RAW docs, so the client-side reconstruction
+ * (extracted from src/lib/project-line-item-read + the getProject body) rebuilds
+ * the same shape. The equipment subtree and overbooking are separate composites
+ * (projectEquipment.browserBundle, overbooking) the client subscribes to alongside
+ * this. See docs/designs/convex-native-read-layer.md §3.5.
+ *
+ * Gated on `requireOrgPermission(orgId, "project", "read")` — the SAME permission
+ * the getProject server action enforces. Org-scoped by the indexed reads + an
+ * explicit org check on every fetched doc. `.first()` (not `.unique()`) on the
+ * by_cuid point reads to tolerate a duplicate mirror row (CLAUDE.md), matching the
+ * guard's resilience.
+ *
+ * Not consumed yet — Phase 1d wires `useQuery` onto it behind a flag.
+ */
+export const bundle = query({
+  args: { projectId: v.string(), orgId: v.string() },
+  handler: async (ctx, { projectId, orgId }) => {
+    await requireOrgPermission(ctx, orgId, "project", "read");
+
+    const project = await ctx.db
+      .query("projects")
+      .withIndex("by_cuid", (q) => q.eq("id", projectId))
+      .first();
+    if (!project || project.organizationId !== orgId) return null;
+
+    const [managers, media] = await Promise.all([
+      ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+      ctx.db.query("projectMedia").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+    ]);
+
+    const uniq = (arr: Array<string | undefined | null>): string[] => [
+      ...new Set(arr.filter((x): x is string => !!x)),
+    ];
+    const managerUserIds = uniq(managers.map((m) => m.userId));
+    const mediaFileIds = uniq(media.map((m) => m.fileId));
+
+    const user = (id: string) => ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const file = (id: string) => ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const loc = (id: string) => ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+
+    const [managerUsers, mediaFiles, client, location] = await Promise.all([
+      Promise.all(managerUserIds.map(user)),
+      Promise.all(mediaFileIds.map(file)),
+      project.clientId
+        ? ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", project.clientId!)).first()
+        : Promise.resolve(null),
+      project.locationId ? loc(project.locationId) : Promise.resolve(null),
+    ]);
+
+    const parentLocation = location && location.parentId ? await loc(location.parentId) : null;
+
+    const inOrg = <T extends { organizationId?: string | null }>(d: T | null) =>
+      d && d.organizationId === orgId ? d : null;
+
+    return {
+      project,
+      projectManagers: managers,
+      // Users are global (not org-scoped); the mirror is service-written.
+      managerUsers: managerUsers.filter((d): d is NonNullable<typeof d> => d !== null),
+      media,
+      mediaFiles: mediaFiles.filter(
+        (d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId,
+      ),
+      client: inOrg(client),
+      location: inOrg(location),
+      parentLocation: inOrg(parentLocation),
+    };
+  },
+});


### PR DESCRIPTION
## Phase 1d, Stage A — native project-detail composite (backend)

First stage of the full project-detail native cutover (the spike target). **Additive + zero-consumer** — nothing subscribes yet, so behaviour is unchanged.

### Context
`getProject` composes the project-detail **spine** (scalars + managers + media + location + client) **+** the equipment tree **+** overbooking. This PR adds the **spine** as a native Convex composite. The equipment subtree (`projectEquipment.browserBundle`, #300) and overbooking already have / will have their own browser composites that the client subscribes to alongside this and reconstructs (Stage B).

A key finding that unblocked this: `getProject`'s media resolution (`withResolvedFile`) is **pure** — file URLs already live in Convex `fileUploads`, so **no server-side S3 signing** is needed. Every `getProject` data source is Convex.

### Changes
- **`convex/projectDetail.ts` `bundle`** — returns raw docs: project, projectManagers (+ their mirrored users), projectMedia (+ fileUploads), location (+ parent), client. Gated on `requireOrgPermission(orgId, "project", "read")` (same permission the server action enforces). Every fetched doc is org-checked; point reads use `.first()` (duplicate-mirror tolerant).
- **`convex/projectDetail.test.ts`** (convex-test, 5 tests): denies anonymous / non-member; allows a viewer (`project:read`) and returns the shape; returns null for a project in another org; service allowed.

### Verification
| Check | Result |
|---|---|
| `vitest run convex/projectDetail.test.ts convex/rbac.test.ts` | ✅ **16 passed** |
| `npx tsc --noEmit` | ✅ exit 0 |
| `pnpm run lint` | ✅ exit 0 |
| `convex codegen` | ✅ pushed to shared dev |

### Remaining stages (flag-gated; need live verification in your env)
- **Stage B:** `overbooking.browserBundle` (browser-gated variant) + extract the pure reconstruction (equipment tree + overbooking enrich + managers/location/media attach) into a **client-safe module** + a native `useProjectDetail` hook (3 `useQuery` subscriptions + reconstruct) behind a default-off flag + rewire the consumer. That's where the client-safety + render need your live verification after the members backfill.

### Rollback
Revert — `projectDetail.bundle` is unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)