### PR TITLE
feat(convex-native): Phase 1d B.2 — full native useProjectDetail (flag-gated, default off)

### DIFF
--- a/src/hooks/use-native-project-equipment.ts
+++ b/src/hooks/use-native-project-equipment.ts
@@ -7,6 +7,10 @@ import {
   reconstructProjectEquipmentTree,
   type ProjectEquipmentTree,
 } from "@/lib/project-equipment-reconstruct";
+import {
+  reconstructProjectDetail,
+  type NativeProjectDetail,
+} from "@/lib/project-detail-reconstruct";
 
 /**
  * Feature flag (default OFF) for the native read-layer project-detail cutover
@@ -46,4 +50,32 @@ export function useNativeProjectEquipmentTree(
     () => (data ? reconstructProjectEquipmentTree(data) : undefined),
     [data],
   );
+}
+
+/**
+ * The FULL native project-detail composite — the getProject-shaped object built
+ * from `projectDetail.bundle` + `projectEquipment.browserBundle`, reconstructed
+ * client-side. Returns `{ data, isLoading }` matching the useProjectDetail
+ * interface so `use-project-detail.ts` can swap to it behind the flag. Both
+ * subscriptions skip entirely unless the flag is on and ids are present.
+ *
+ * (Overbooked-flag enrichment is not yet applied — see project-detail-reconstruct
+ * module header; line items render without overbook warnings until that lands.)
+ */
+export function useNativeProjectDetail(
+  projectId: string | undefined,
+  orgId: string | undefined,
+): { data: NativeProjectDetail | undefined; isLoading: boolean } {
+  const enabled = NATIVE_PROJECT_DETAIL_ENABLED && !!projectId && !!orgId;
+  const args = enabled ? { projectId: projectId!, orgId: orgId! } : "skip";
+  const detail = useAuthedQuery(api.projectDetail.bundle, args);
+  const equipment = useAuthedQuery(api.projectEquipment.browserBundle, args);
+
+  const data = useMemo(() => {
+    if (!enabled || detail === undefined || equipment === undefined) return undefined;
+    if (detail === null) return undefined; // project not found / not permitted
+    return reconstructProjectDetail(detail, equipment);
+  }, [enabled, detail, equipment]);
+
+  return { data, isLoading: enabled && data === undefined };
 }

--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -4,6 +4,10 @@ import { useEffect, useRef } from "react";
 import { createSharedResource } from "./use-shared-resource";
 import { getProject } from "@/server/projects";
 import { useProject } from "./use-projects";
+import {
+  NATIVE_PROJECT_DETAIL_ENABLED,
+  useNativeProjectDetail,
+} from "./use-native-project-equipment";
 
 /**
  * Shared store for a project's detail composite (Phase 6 — React Query removal).
@@ -44,6 +48,21 @@ export function useProjectDetail(projectId: string) {
       prevUpdatedAt.current = next;
     }
   }, [convexProject?.updatedAt, projectId]);
+
+  // Native read-layer path (Phase 1d, default OFF). When the flag is on, the whole
+  // composite comes from live Convex subscriptions (projectDetail.bundle +
+  // browserBundle) reconstructed client-side — no server action, reactive by the
+  // WebSocket. orgId is read off the project doc this hook already subscribes to.
+  // Both paths' hooks run (rules-of-hooks); the flag only selects which result we
+  // return. When the flag is off, `useNativeProjectDetail` is a no-op (skips).
+  const native = useNativeProjectDetail(projectId, convexProject?.organizationId);
+  if (NATIVE_PROJECT_DETAIL_ENABLED) {
+    return {
+      data: native.data as typeof result.data,
+      isLoading: native.isLoading,
+      refresh: () => resource.refresh(projectId),
+    };
+  }
 
   return result;
 }

--- a/src/lib/project-detail-reconstruct.test.ts
+++ b/src/lib/project-detail-reconstruct.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { reconstructProjectDetail } from "./project-detail-reconstruct";
+import type { EquipmentBundleData } from "./project-equipment-reconstruct";
+
+/**
+ * Unit coverage for the full native project-detail reconstruction (Phase 1d B.2).
+ * Parity guard for the getProject-shaped object the native useProjectDetail returns.
+ */
+
+const EMPTY_EQUIPMENT: EquipmentBundleData = {
+  lineItems: [], projectCategories: [], groups: [], units: [],
+  assets: [], bulkAssets: [], kits: [], models: [], suppliers: [], categories: [],
+};
+
+const d = <T extends Record<string, unknown>>(o: T) =>
+  ({ _id: `id_${o.id ?? "x"}`, _creationTime: 0, ...o }) as never;
+
+// Minimal projectDetail.bundle fixture.
+function detailBundle(overrides: Record<string, unknown> = {}) {
+  return {
+    project: d({ id: "p1", organizationId: "o1", projectNumber: "P-1", name: "Gig", createdAt: 1000 }),
+    projectManagers: [],
+    managerUsers: [],
+    media: [],
+    mediaFiles: [],
+    client: null,
+    location: null,
+    parentLocation: null,
+    ...overrides,
+  } as never;
+}
+
+describe("reconstructProjectDetail", () => {
+  it("maps project scalars (defaults + epoch→Date) and empty relations", () => {
+    const res = reconstructProjectDetail(detailBundle(), EMPTY_EQUIPMENT);
+    expect(res.id).toBe("p1");
+    expect(res.name).toBe("Gig");
+    expect(res.status).toBe("ENQUIRY"); // default
+    expect(res.createdAt).toBeInstanceOf(Date);
+    expect(res.projectManagers).toEqual([]);
+    expect(res.media).toEqual([]);
+    expect(res.location).toBeNull();
+    expect(res.client).toBeNull();
+    expect(res.categories).toEqual([]);
+    expect(res.lineItems).toEqual([]);
+  });
+
+  it("attaches managers to their mirrored users (sorted by addedAt)", () => {
+    const res = reconstructProjectDetail(
+      detailBundle({
+        projectManagers: [
+          d({ id: "pm2", organizationId: "o1", projectId: "p1", userId: "u2", addedAt: 200 }),
+          d({ id: "pm1", organizationId: "o1", projectId: "p1", userId: "u1", addedAt: 100 }),
+        ],
+        managerUsers: [
+          d({ id: "u1", name: "Alice", email: "a@x.com" }),
+          d({ id: "u2", name: "Bob", email: "b@x.com" }),
+        ],
+      }),
+      EMPTY_EQUIPMENT,
+    );
+    expect(res.projectManagers.map((m) => m.id)).toEqual(["pm1", "pm2"]); // addedAt order
+    expect(res.projectManagers[0].user?.name).toBe("Alice");
+    expect(res.projectManagers[0].addedAt).toBeInstanceOf(Date);
+  });
+
+  it("reconstructs location with parent + inherits address/coords when child has none", () => {
+    const res = reconstructProjectDetail(
+      detailBundle({
+        location: d({ id: "loc1", organizationId: "o1", name: "Bay 3", parentId: "loc0" }),
+        parentLocation: d({ id: "loc0", organizationId: "o1", name: "HQ", address: "1 Main St", latitude: 1, longitude: 2 }),
+      }),
+      EMPTY_EQUIPMENT,
+    );
+    expect(res.location?.id).toBe("loc1");
+    expect(res.location?.parent?.id).toBe("loc0");
+    // child had no address/coords → inherits parent's
+    expect(res.location?.address).toBe("1 Main St");
+    expect(res.location?.latitude).toBe(1);
+  });
+
+  it("resolves media files and drops file-less rows", () => {
+    const res = reconstructProjectDetail(
+      detailBundle({
+        media: [
+          d({ id: "m1", organizationId: "o1", projectId: "p1", fileId: "f1", sortOrder: 0 }),
+          d({ id: "m2", organizationId: "o1", projectId: "p1", fileId: "missing", sortOrder: 1 }),
+        ],
+        mediaFiles: [
+          d({ id: "f1", organizationId: "o1", fileName: "a.jpg", fileSize: 10, mimeType: "image/jpeg", storageKey: "k", url: "http://x/a.jpg", uploadedById: "u1" }),
+        ],
+      }),
+      EMPTY_EQUIPMENT,
+    );
+    expect(res.media).toHaveLength(1); // m2 dropped (file unresolved)
+    expect(res.media[0].id).toBe("m1");
+    expect(res.media[0].file.url).toBe("http://x/a.jpg");
+  });
+});

--- a/src/lib/project-detail-reconstruct.ts
+++ b/src/lib/project-detail-reconstruct.ts
@@ -1,0 +1,236 @@
+/**
+ * CLIENT-SAFE reconstruction of the full getProject shape (Phase 1d, Stage B.2).
+ *
+ * Combines the three native composites the project-detail page needs —
+ * `projectDetail.bundle` (project + managers + media + location + client),
+ * `projectEquipment.browserBundle` (the equipment tree, via
+ * project-equipment-reconstruct), and (later) `overbooking.bundle` — into the
+ * exact object the `getProject` server action returns, so `useProjectDetail` can
+ * subscribe natively. ZERO server imports: the runtime mappers below are COPIES of
+ * the pure ones in projects-read / locations-read / media-read (which keep
+ * server-only co-residents); the TYPES come via `import type` (erased). Parity
+ * with the server path is by-copy — keep these in sync if the source mappers change.
+ *
+ * KNOWN GAP (tracked): the overbooked-flag ENRICHMENT (`isOverbooked` /
+ * `overbookedInfo` on line items) is NOT yet reconstructed here — its server math
+ * (computeOverbookedStatus) has kit-parent inheritance logic best ported with the
+ * live UI to verify the indicators. Until then native line items render without
+ * overbook warnings (graceful: undefined → no warning), the only parity gap.
+ */
+import type { FunctionReturnType } from "convex/server";
+import type { api } from "../../convex/_generated/api";
+import type { ProjectRow } from "@/lib/projects-read";
+import type { MappedLocation } from "@/lib/locations-read";
+import type { ProjectGalleryMedia, GalleryFile } from "@/lib/media-read";
+import {
+  reconstructProjectEquipmentTree,
+  type EquipmentBundleData,
+  type ProjectEquipmentTree,
+} from "@/lib/project-equipment-reconstruct";
+
+type ProjectDetailBundle = NonNullable<FunctionReturnType<typeof api.projectDetail.bundle>>;
+type ProjectDoc = ProjectDetailBundle["project"];
+type ManagerRow = ProjectDetailBundle["projectManagers"][number];
+type UserDoc = ProjectDetailBundle["managerUsers"][number];
+type MediaRow = ProjectDetailBundle["media"][number];
+type FileDoc = ProjectDetailBundle["mediaFiles"][number];
+type LocationDoc = NonNullable<ProjectDetailBundle["location"]>;
+
+// ─── Pure helpers (copied from the source mappers) ──────────────────────────
+
+const toDate = (v: number | undefined | null): Date | null =>
+  typeof v === "number" ? new Date(v) : null;
+const orNull = <T>(v: T | undefined | null): T | null => (v == null ? null : v);
+
+/** Copy of projects-read.mapProject: Convex project doc → Prisma row shape. */
+function mapProject(d: ProjectDoc): ProjectRow {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    projectNumber: d.projectNumber,
+    name: d.name,
+    clientId: orNull(d.clientId),
+    status: (d.status ?? "ENQUIRY") as ProjectRow["status"],
+    type: (d.type ?? "OTHER") as ProjectRow["type"],
+    description: orNull(d.description),
+    locationId: orNull(d.locationId),
+    siteContactName: orNull(d.siteContactName),
+    siteContactPhone: orNull(d.siteContactPhone),
+    siteContactEmail: orNull(d.siteContactEmail),
+    loadInDate: toDate(d.loadInDate),
+    loadInTime: orNull(d.loadInTime),
+    eventStartDate: toDate(d.eventStartDate),
+    eventStartTime: orNull(d.eventStartTime),
+    eventEndDate: toDate(d.eventEndDate),
+    eventEndTime: orNull(d.eventEndTime),
+    loadOutDate: toDate(d.loadOutDate),
+    loadOutTime: orNull(d.loadOutTime),
+    rentalStartDate: toDate(d.rentalStartDate),
+    rentalEndDate: toDate(d.rentalEndDate),
+    projectManagerId: orNull(d.projectManagerId),
+    defaultRentalPeriod: orNull(d.defaultRentalPeriod) as ProjectRow["defaultRentalPeriod"],
+    defaultRentalQuantity: orNull(d.defaultRentalQuantity),
+    taxRate: orNull(d.taxRate),
+    equipmentRevenue: orNull(d.equipmentRevenue),
+    serviceCostTotal: orNull(d.serviceCostTotal),
+    labourCostTotal: orNull(d.labourCostTotal),
+    subHireCostTotal: orNull(d.subHireCostTotal),
+    margin: orNull(d.margin),
+    crewNotes: orNull(d.crewNotes),
+    internalNotes: orNull(d.internalNotes),
+    clientNotes: orNull(d.clientNotes),
+    subtotal: orNull(d.subtotal),
+    discountPercent: orNull(d.discountPercent),
+    discountAmount: orNull(d.discountAmount),
+    taxAmount: orNull(d.taxAmount),
+    total: orNull(d.total),
+    depositPercent: orNull(d.depositPercent),
+    depositPaid: orNull(d.depositPaid),
+    invoicedTotal: orNull(d.invoicedTotal),
+    tags: d.tags ?? [],
+    isTemplate: d.isTemplate ?? false,
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+/** Copy of locations-read.mapLocation. */
+function mapLocation(doc: LocationDoc): MappedLocation {
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    name: doc.name,
+    address: doc.address ?? null,
+    latitude: doc.latitude ?? null,
+    longitude: doc.longitude ?? null,
+    type: (doc.type ?? "WAREHOUSE") as MappedLocation["type"],
+    isDefault: doc.isDefault ?? false,
+    parentId: doc.parentId ?? null,
+    notes: doc.notes ?? null,
+    tags: doc.tags ?? [],
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
+/** Copy of media-read.mapGalleryFile. */
+function mapGalleryFile(doc: FileDoc | null | undefined): GalleryFile | null {
+  if (!doc) return null;
+  return {
+    id: doc.id,
+    organizationId: doc.organizationId,
+    fileName: doc.fileName,
+    fileSize: doc.fileSize,
+    mimeType: doc.mimeType,
+    storageKey: doc.storageKey,
+    url: doc.url,
+    thumbnailUrl: doc.thumbnailUrl ?? null,
+    width: doc.width ?? null,
+    height: doc.height ?? null,
+    uploadedById: doc.uploadedById,
+    createdAt: new Date(doc.createdAt ?? 0),
+    updatedAt: new Date(doc.updatedAt ?? 0),
+  };
+}
+
+/** Reconstruct project media (sort by sortOrder, attach file, drop file-less rows —
+ * matches getProjectMediaFromConvex + withResolvedFile). */
+function reconstructMedia(
+  rows: MediaRow[],
+  files: FileDoc[],
+): Array<ProjectGalleryMedia & { file: GalleryFile }> {
+  const fileMap = new Map(files.map((f) => [f.id, f]));
+  return [...rows]
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+    .map((m) => ({
+      id: m.id,
+      organizationId: m.organizationId,
+      fileId: m.fileId,
+      displayName: m.displayName ?? null,
+      sortOrder: m.sortOrder ?? 0,
+      createdAt: new Date(m.createdAt ?? 0),
+      file: mapGalleryFile(fileMap.get(m.fileId)),
+      projectId: m.projectId,
+      type: (m.type ?? "OTHER") as ProjectGalleryMedia["type"],
+    }))
+    .filter((m): m is ProjectGalleryMedia & { file: GalleryFile } => m.file !== null);
+}
+
+// ─── Assembly ───────────────────────────────────────────────────────────────
+
+type ManagerUser = { id: string; name: string; email: string; image: string | null };
+type ProjectManagerOut = {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  userId: string;
+  addedAt: Date | null;
+  user: ManagerUser | null;
+};
+type LocationWithParent =
+  | (MappedLocation & { parent: MappedLocation | null })
+  | null;
+
+export type NativeProjectDetail = ProjectRow & {
+  projectManagers: ProjectManagerOut[];
+  media: Array<ProjectGalleryMedia & { file: GalleryFile }>;
+  location: LocationWithParent;
+  categories: ProjectEquipmentTree["categories"];
+  lineItems: ProjectEquipmentTree["lineItems"];
+  client: ProjectDetailBundle["client"];
+};
+
+function attachManagers(rows: ManagerRow[], users: UserDoc[]): ProjectManagerOut[] {
+  const userMap = new Map<string, ManagerUser>(
+    users.map((u) => [u.id, { id: u.id, name: u.name, email: u.email, image: u.image ?? null }]),
+  );
+  return [...rows]
+    .sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))
+    .map((pm) => ({
+      id: pm.id,
+      organizationId: pm.organizationId,
+      projectId: pm.projectId,
+      userId: pm.userId,
+      addedAt: pm.addedAt != null ? new Date(pm.addedAt) : null,
+      user: userMap.get(pm.userId) ?? null,
+    }));
+}
+
+function reconstructLocation(detail: ProjectDetailBundle): LocationWithParent {
+  if (!detail.location) return null;
+  const loc = mapLocation(detail.location) as MappedLocation & { parent: MappedLocation | null };
+  loc.parent = detail.parentLocation ? mapLocation(detail.parentLocation) : null;
+  // Inherit address/coordinates from parent when the child has none (mirrors getProject).
+  if (loc.parent) {
+    if (!loc.address) loc.address = loc.parent.address;
+    if (loc.latitude == null && loc.longitude == null && loc.parent.latitude != null) {
+      loc.latitude = loc.parent.latitude;
+      loc.longitude = loc.parent.longitude;
+    }
+  }
+  return loc;
+}
+
+/**
+ * Build the full getProject-shaped object from the native composites. `detail` is
+ * the projectDetail.bundle (non-null), `equipment` the browserBundle.
+ *
+ * NOTE: overbooked-flag enrichment is not applied (see module header) — line items
+ * pass through from the equipment reconstruction as-is.
+ */
+export function reconstructProjectDetail(
+  detail: ProjectDetailBundle,
+  equipment: EquipmentBundleData,
+): NativeProjectDetail {
+  const project = mapProject(detail.project);
+  const { categories, lineItems } = reconstructProjectEquipmentTree(equipment);
+  return {
+    ...project,
+    projectManagers: attachManagers(detail.projectManagers, detail.managerUsers),
+    media: reconstructMedia(detail.media, detail.mediaFiles),
+    location: reconstructLocation(detail),
+    categories,
+    lineItems,
+    client: detail.client,
+  };
+}


### PR DESCRIPTION
## Phase 1d, Stage B.2 — full native project-detail read (behind a flag)

Wires the project detail page to a **100% native, reactive** read behind `NATIVE_PROJECT_DETAIL_ENABLED` (**default OFF**). Merging changes nothing for users. With the flag on (after the members backfill), the whole `getProject` composite comes from live Convex subscriptions reconstructed client-side — **no server action, reactive over the WebSocket**.

**This makes the backfill the literal last blocker:** with the flag on but no backfill, `requireOrgPermission` denies (no member row); with the backfill, the native page works.

### Changes
- **`src/lib/project-detail-reconstruct.ts`** (NEW, client-safe): `reconstructProjectDetail` combines `projectDetail.bundle` + `projectEquipment.browserBundle` into the exact `getProject` shape — project scalars (`mapProject`), managers + mirrored users, media + files, location + parent + address/coord inheritance, equipment tree, client. Pure mappers **copied** from `projects-read`/`locations-read`/`media-read` (which keep server-only co-residents); types via `import type` (erased). **Zero server imports.**
- **`use-native-project-equipment.ts`**: `useNativeProjectDetail` — two auth-gated subscriptions + reconstruct; returns the `{ data, isLoading }` shape `useProjectDetail` expects; skips unless the flag is on.
- **`use-project-detail.ts`**: returns the native result when the flag is on (orgId read off the project doc it already subscribes to), else the unchanged server path.
- **4 unit tests** (parity guard): scalars + defaults + epoch→Date, manager attach + sort, location parent + inheritance, media file resolution + file-less drop.

### Client-safety is now CI-verified
`useProjectDetail` is in the project page's import graph, so **`next build` exercises the whole reconstruction graph** — if any server-only import had leaked into the client-safe modules, the Build job would fail.

### Known gap (tracked, documented in the module)
The overbooked-flag **enrichment** (`isOverbooked`/`overbookedInfo` on line items) isn't reconstructed yet — its server math has kit-parent inheritance best ported with the live UI to verify the indicators. Until then native line items render **without** overbook warnings (graceful: `undefined` → no warning). Everything else renders natively + reactively. This is the one remaining parity item.

### Verification
| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ exit 0 |
| `pnpm run lint` | ✅ exit 0 |
| `vitest` reconstruct (equipment + detail) | ✅ **8 passed** |
| Flag default off | ✅ zero user-facing change on merge |

### Remaining to go live (yours)
1. `pnpm convex:backfill:members` (populates the mirror `requireOrgPermission` reads).
2. Set `NEXT_PUBLIC_NATIVE_PROJECT_DETAIL=true` and confirm the project detail page renders identically (the rendering check only you can do).
3. Port the overbooked-flag enrichment (the one documented gap).
4. Once happy: delete the server-action `getProject` read path + version-vector layer for this surface.

### Rollback
Flag is default-off; revert removes the native modules + hook. `getProject` path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)