### PR TITLE
fix(convex-native): skip the old getProject server action when the native flag is on

### DIFF
--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -33,13 +33,18 @@ const resource = createSharedResource((projectId: string) => getProject(projectI
 
 /** Subscribe to a project's detail composite. `projectId` is the store key. */
 export function useProjectDetail(projectId: string) {
-  const result = resource.use(projectId);
+  // When the native flag is on, DON'T fire the old getProject server action — pass
+  // `undefined` so the shared resource skips its fetch (no double-fetch alongside
+  // the native subscriptions). The version-vector refresh effect is also a no-op
+  // then (native is reactive over the WebSocket).
+  const result = resource.use(NATIVE_PROJECT_DETAIL_ENABLED ? undefined : projectId);
 
-  // Convex subscription for cross-tab change detection.
+  // Convex subscription for cross-tab change detection (also the orgId source).
   const convexProject = useProject(projectId);
   const prevUpdatedAt = useRef<number | undefined>(undefined);
 
   useEffect(() => {
+    if (NATIVE_PROJECT_DETAIL_ENABLED) return; // native path needs no manual refresh
     const next = convexProject?.updatedAt;
     if (next !== undefined && prevUpdatedAt.current !== undefined && next !== prevUpdatedAt.current) {
       resource.refresh(projectId);


### PR DESCRIPTION
## Removes the double-fetch regression on the native project-detail path

With `NEXT_PUBLIC_NATIVE_PROJECT_DETAIL` on, `useProjectDetail` returned the native result **but still fired the old `getProject` server action** (`resource.use(projectId)`) and the version-vector refresh effect alongside it — so the project page did the slow HTTP composite **and** the native subscriptions on every render + cross-tab change.

Fix: pass `undefined` to the shared resource when the flag is on (its effect guards `if (!key) return`, so the fetch is skipped), and short-circuit the refresh effect. Native path unaffected; flag-off behaviour unchanged.

Verification: `tsc` 0, `lint` 0.

Part of Phase 5 (native writes / full-native surfaces). Next: migrating the equipment **editing tab** — which is a separate surface still on 6 server-action composites + faked-reactivity (the source of the ~10s cross-tab delete latency you saw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)