### PR TITLE
feat(convex-native): Phase 5 — equipmentTab.bundle native composite (data layer)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as crewTimeEntries from "../crewTimeEntries.js";
 import type * as customFieldDefinitions from "../customFieldDefinitions.js";
 import type * as customRoles from "../customRoles.js";
 import type * as documentTemplates from "../documentTemplates.js";
+import type * as equipmentTab from "../equipmentTab.js";
 import type * as fileUploads from "../fileUploads.js";
 import type * as groupTemplateItems from "../groupTemplateItems.js";
 import type * as groupTemplates from "../groupTemplates.js";
@@ -137,6 +138,7 @@ declare const fullApi: ApiFromModules<{
   customFieldDefinitions: typeof customFieldDefinitions;
   customRoles: typeof customRoles;
   documentTemplates: typeof documentTemplates;
+  equipmentTab: typeof equipmentTab;
   fileUploads: typeof fileUploads;
   groupTemplateItems: typeof groupTemplateItems;
   groupTemplates: typeof groupTemplates;

--- a/convex/equipmentTab.test.ts
+++ b/convex/equipmentTab.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string | null) => ({ subject: USER, ...(orgId ? { orgId } : {}) });
+
+async function seedViewer(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+  });
+}
+
+describe("equipmentTab.bundle — auth gating + shape", () => {
+  test("denies anonymous", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG }),
+    ).rejects.toThrow(/authentication required/i);
+  });
+
+  test("denies a non-member", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.withIdentity(asUser(ORG)).query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG }),
+    ).rejects.toThrow(/not a member/i);
+  });
+
+  test("allows a viewer (project:read) and returns all view-data keys", async () => {
+    const t = convexTest(schema, modules);
+    await seedViewer(t);
+    const res = await t
+      .withIdentity(asUser(ORG))
+      .query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG });
+    for (const k of [
+      "lineItems", "categories", "groups", "categorySlots", "subHires",
+      "subHireGroups", "subHireItems", "assets", "bulkAssets", "kits",
+      "models", "suppliers", "orgCategories",
+    ]) {
+      expect(res).toHaveProperty(k);
+      expect(Array.isArray((res as Record<string, unknown>)[k])).toBe(true);
+    }
+  });
+
+  test("service identity is allowed", async () => {
+    const t = convexTest(schema, modules);
+    const res = await t
+      .withIdentity(SERVICE)
+      .query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG });
+    expect(res.lineItems).toEqual([]);
+  });
+});

--- a/convex/equipmentTab.ts
+++ b/convex/equipmentTab.ts
@@ -1,0 +1,86 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import type { QueryCtx } from "./_generated/server";
+import { requireOrgPermission } from "./lib/auth";
+
+/**
+ * BROWSER-facing composite for the project EQUIPMENT EDITING TAB (Phase 5 native
+ * reads). Returns, as RAW docs, everything the tab's six server-action reads
+ * (getProjectCategories / getUncategorizedLineItems / getUncategorized{SubHire,
+ * Project}Groups / getSubHires) need, so the client reconstructs all of them from
+ * ONE live subscription instead of re-fetching six server actions on every change
+ * (the old useProjectEquipmentLiveSync doorbell → refetch path, the source of the
+ * slow cross-tab propagation). Gated on requireOrgPermission(project, read).
+ *
+ * Overbooking is NOT here — it stays on overbooking.bundle (already browser-safe)
+ * and computeOverbookedStatus (kept as-is; see equipment-tab-reconstruct).
+ */
+async function readEquipmentTab(ctx: QueryCtx, projectId: string, orgId: string) {
+  const [lineItems, categories, groups, subHires] = await Promise.all([
+    ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+    ctx.db.query("projectCategories").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+    ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+    ctx.db.query("subHires").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
+  ]);
+
+  // Category slots: one indexed read per category (typically ≤10).
+  const slotArrays = await Promise.all(
+    categories.map((c) =>
+      ctx.db.query("categorySlots").withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", c.id)).collect(),
+    ),
+  );
+  const categorySlots = slotArrays.flat();
+
+  // Sub-hire groups + items: per sub-hire.
+  const subHireIds = subHires.map((s) => s.id);
+  const [shGroupArrays, shItemArrays] = await Promise.all([
+    Promise.all(subHireIds.map((id) => ctx.db.query("subHireGroups").withIndex("by_subHireId", (q) => q.eq("subHireId", id)).collect())),
+    Promise.all(subHireIds.map((id) => ctx.db.query("subHireItems").withIndex("by_subHireId", (q) => q.eq("subHireId", id)).collect())),
+  ]);
+  const subHireGroups = shGroupArrays.flat();
+  const subHireItems = shItemArrays.flat();
+
+  // Referenced assets/bulks/kits (point reads by id, like projectEquipment.bundle).
+  const uniq = (arr: Array<string | undefined | null>): string[] => [
+    ...new Set(arr.filter((x): x is string => !!x)),
+  ];
+  const refAssetIds = uniq(lineItems.map((li) => li.assetId));
+  const refBulkIds = uniq(lineItems.map((li) => li.bulkAssetId));
+  const refKitIds = uniq(lineItems.map((li) => li.kitId));
+
+  const [assetDocs, bulkDocs, kitDocs, models, suppliers, orgCategories] = await Promise.all([
+    Promise.all(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    Promise.all(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    Promise.all(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    ctx.db.query("models").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+    ctx.db.query("suppliers").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+    ctx.db.query("categories").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+  ]);
+
+  const inOrg = <T extends { organizationId?: string | null }>(arr: (T | null)[]) =>
+    arr.filter((d): d is T => d !== null && d.organizationId === orgId);
+
+  return {
+    lineItems,
+    categories,
+    groups,
+    categorySlots,
+    subHires,
+    subHireGroups,
+    subHireItems,
+    assets: inOrg(assetDocs),
+    bulkAssets: inOrg(bulkDocs),
+    kits: inOrg(kitDocs),
+    models,
+    suppliers,
+    orgCategories,
+  };
+}
+
+export const bundle = query({
+  args: { projectId: v.string(), orgId: v.string() },
+  handler: async (ctx, { projectId, orgId }) => {
+    await requireOrgPermission(ctx, orgId, "project", "read");
+    return readEquipmentTab(ctx, projectId, orgId);
+  },
+});

--- a/src/lib/project-equipment-reconstruct.ts
+++ b/src/lib/project-equipment-reconstruct.ts
@@ -397,7 +397,7 @@ type AttachedNode = MappedLineItem & {
  * → `Date`) onto every node of a model/supplier-attached tree, recursing into
  * `childLineItems`. A null/missing id → `null`. Units are left untouched.
  */
-function attachAssetBulkKitPlain<
+export function attachAssetBulkKitPlain<
   T extends { assetId: string | null; bulkAssetId: string | null; kitId: string | null; childLineItems?: unknown },
 >(
   rows: T[],


### PR DESCRIPTION
## Phase 5, slice 1 — native data layer for the equipment editing tab

The equipment **editing** tab reads from **6 server-action composites** and re-fetches all of them on every change (`useProjectEquipmentLiveSync` doorbell → refetch) — the source of the ~10s cross-tab delete latency. This adds the single native composite the client will reconstruct all 6 views from (one live subscription, no refetch).

**Additive + zero-consumer** — nothing reads it yet.

### Changes
- **`convex/equipmentTab.ts` `bundle`**: raw docs for the whole tab — line items, categories, groups, category slots, sub-hires + groups + items, referenced assets/bulks/kits, org models/suppliers/categories. Gated on `requireOrgPermission(project, read)`; referenced-by-id reads org-filtered.
- **`convex/equipmentTab.test.ts`**: 4 convex-test cases (anonymous/non-member denied, viewer allowed + all 13 view keys present, service allowed).
- **export `attachAssetBulkKitPlain`** from `project-equipment-reconstruct` — the client reconstruction will reuse the existing client-safe attach machinery.

### Verification
| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ 0 |
| `pnpm run lint` | ✅ 0 |
| `vitest convex/equipmentTab.test.ts` | ✅ 4 passed |

### Next slices (Phase 5)
1. Client reconstruction of the 6 views (category tree + uncategorized, reusing the attach helpers — they're interconnected so they land together).
2. Wire `equipment-tab.tsx` behind `NEXT_PUBLIC_NATIVE_EQUIPMENT` (default off; you verify rendering live).
3. Optimistic native writes — **`recalculateProjectTotals` stays server-side** (a deliberate call: I won't port the financial math blind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)