### PR TITLE
perf(equipment): load referenced-only assets, not the whole org catalog (fixes ~10s equipment-tab load)

### DIFF
--- a/src/server/category-slots.ts
+++ b/src/server/category-slots.ts
@@ -39,8 +39,8 @@ import {
 } from "@/lib/line-item-tree-read";
 import { mapLineItemDoc, type MappedLineItem } from "@/lib/project-line-item-read";
 import { indexChildren, reconstructScope } from "@/lib/project-line-item-tree-read";
-import { getAssetsByOrg, getBulkAssetsByOrg, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
-import { getKitsByOrg, type ConvexKit } from "@/lib/kits-read";
+import { getAssetsByIds, getBulkAssetsByIds, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
+import { getKitsByIds, type ConvexKit } from "@/lib/kits-read";
 import { getSubHiresByProject, getSubHireGroups, getSubHireGroupById, getSubHireById, getSubHireItems } from "@/lib/sub-hire-read";
 import { recalculateProjectTotals } from "@/server/line-items";
 import {
@@ -113,12 +113,31 @@ interface AttachContext {
   kitMap: Map<string, ConvexKit>;
 }
 
-async function loadAttachContext(orgId: string): Promise<AttachContext> {
+/** Referenced asset/bulk/kit ids across a set of mapped line items (see the same
+ *  helper in project-categories.ts — both reads loaded the whole org catalog). */
+function refIdsFromLineItems(lineItems: MappedLineItem[]) {
+  const assets = new Set<string>();
+  const bulks = new Set<string>();
+  const kits = new Set<string>();
+  for (const li of lineItems) {
+    if (li.assetId) assets.add(li.assetId);
+    if (li.bulkAssetId) bulks.add(li.bulkAssetId);
+    if (li.kitId) kits.add(li.kitId);
+  }
+  return { assetIds: [...assets], bulkIds: [...bulks], kitIds: [...kits] };
+}
+
+async function loadAttachContext(
+  orgId: string,
+  refs: { assetIds: string[]; bulkIds: string[]; kitIds: string[] },
+): Promise<AttachContext> {
+  // Referenced-only (point reads by id) instead of the whole org catalog — parity
+  // by construction (attach maps key by id). The slow-equipment-tab-load fix.
   const [attachMaps, assetArr, bulkArr, kitArr] = await Promise.all([
     buildLineItemAttachMaps(orgId),
-    getAssetsByOrg(orgId),
-    getBulkAssetsByOrg(orgId),
-    getKitsByOrg(orgId),
+    getAssetsByIds(orgId, refs.assetIds),
+    getBulkAssetsByIds(orgId, refs.bulkIds),
+    getKitsByIds(orgId, refs.kitIds),
   ]);
   return {
     attachMaps,
@@ -194,7 +213,7 @@ export async function getUncategorizedSubHireGroups(projectId: string) {
   }
 
   const attachMaps = await buildLineItemAttachMaps(organizationId);
-  const ctx = await loadAttachContext(organizationId);
+  const ctx = await loadAttachContext(organizationId, refIdsFromLineItems(mappedLineItems));
   const attached = groups.map((g) => {
     const subHire = subHireById.get(g.subHireId)!;
     const items = (itemsBySubHire.get(g.subHireId) ?? []).filter((i) => i.groupId === g.id);
@@ -248,7 +267,7 @@ export async function getUncategorizedProjectGroups(projectId: string) {
     }
   }
 
-  const ctx = await loadAttachContext(organizationId);
+  const ctx = await loadAttachContext(organizationId, refIdsFromLineItems(mappedLineItems));
   const attached = uncategorized.map((g) => ({
     ...g,
     price: g.price ?? null,

--- a/src/server/project-categories.ts
+++ b/src/server/project-categories.ts
@@ -23,8 +23,8 @@ import {
   indexChildren,
   reconstructScope,
 } from "@/lib/project-line-item-tree-read";
-import { getAssetsByOrg, getBulkAssetsByOrg, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
-import { getKitsByOrg, type ConvexKit } from "@/lib/kits-read";
+import { getAssetsByIds, getBulkAssetsByIds, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
+import { getKitsByIds, type ConvexKit } from "@/lib/kits-read";
 import { getSubHiresByProject, getSubHireGroups, getSubHireItems } from "@/lib/sub-hire-read";
 import type { LineItemAttachMaps } from "@/lib/line-item-tree-read";
 
@@ -88,12 +88,35 @@ interface AttachContext {
 }
 
 /** Load the org-scoped maps the line-item tree attach needs (one round trip). */
-async function loadAttachContext(orgId: string): Promise<AttachContext> {
+/** Referenced asset/bulk/kit ids across a set of mapped line items (incl. children),
+ *  so the attach context loads ONLY what this project references instead of the
+ *  whole org catalog — the equipment-tab load was pulling every org asset/bulk/kit. */
+function refIdsFromLineItems(lineItems: MappedLineItem[]) {
+  const assets = new Set<string>();
+  const bulks = new Set<string>();
+  const kits = new Set<string>();
+  for (const li of lineItems) {
+    if (li.assetId) assets.add(li.assetId);
+    if (li.bulkAssetId) bulks.add(li.bulkAssetId);
+    if (li.kitId) kits.add(li.kitId);
+  }
+  return { assetIds: [...assets], bulkIds: [...bulks], kitIds: [...kits] };
+}
+
+async function loadAttachContext(
+  orgId: string,
+  refs: { assetIds: string[]; bulkIds: string[]; kitIds: string[] },
+): Promise<AttachContext> {
+  // Referenced-only reads: a project references a handful of assets, not the org's
+  // entire catalog. getAssetsByIds/etc. point-read by id (chunked), so the cost is
+  // O(referenced) not O(org) — the fix for the slow equipment-tab load. Parity-by-
+  // construction: the attach maps key by id, so loading exactly the referenced docs
+  // yields identical attachments to the old whole-org load.
   const [attachMaps, assetArr, bulkArr, kitArr] = await Promise.all([
     buildLineItemAttachMaps(orgId),
-    getAssetsByOrg(orgId),
-    getBulkAssetsByOrg(orgId),
-    getKitsByOrg(orgId),
+    getAssetsByIds(orgId, refs.assetIds),
+    getBulkAssetsByIds(orgId, refs.bulkIds),
+    getKitsByIds(orgId, refs.kitIds),
   ]);
   return {
     attachMaps,
@@ -187,8 +210,8 @@ export async function getProjectCategories(projectId: string) {
     };
   });
 
-  // 3. Build lookup maps + tree-attach helpers
-  const ctx = await loadAttachContext(organizationId);
+  // 3. Build lookup maps + tree-attach helpers (referenced-only — see loadAttachContext)
+  const ctx = await loadAttachContext(organizationId, refIdsFromLineItems(mappedLineItems));
   const attachMaps = ctx.attachMaps;
 
   // childLineItems matched globally by parentLineItemId (depth 1, no units —
@@ -313,7 +336,7 @@ export async function getUncategorizedLineItems(projectId: string) {
     (li) => !li.isKitChild && !li.parentLineItemId && li.categoryId == null && li.groupId == null,
   );
 
-  const ctx = await loadAttachContext(organizationId);
+  const ctx = await loadAttachContext(organizationId, refIdsFromLineItems(mappedLineItems));
   return serialize(attachScopeRows(scope, byParent, ctx));
 }
 


### PR DESCRIPTION
## Fixes the multi-second equipment-tab load

**Root cause (confirmed):** the equipment tab's reads — `getProjectCategories`, `getUncategorizedLineItems`, `getUncategorizedSubHireGroups`, `getUncategorizedProjectGroups` — built their attach context with `getAssetsByOrg` / `getBulkAssetsByOrg` / `getKitsByOrg`, pulling **every asset, bulk asset, and kit in the org** through the server action **on every tab load and every cross-tab refetch**, just to attach the handful the project actually references. On a real catalog that's the ~10s load.

## Fix
`loadAttachContext` now takes the **referenced ids** (computed from the read's mapped line items, including children) and point-reads them via `getAssetsByIds` / `getBulkAssetsByIds` / `getKitsByIds`. Cost goes from **O(org catalog) → O(referenced)**.

### Why it's parity-safe
- The attach maps key by id, and `attachScopeRows` only attaches line items present in `mappedLineItems` (the scope + `byParent` are derived from it) — so loading exactly the referenced docs yields **identical attachments**.
- `getAssetsByIds` returns `[]` on empty ids.
- `getProjectOverbookedStatus` already reads by `modelId` (untouched). The native `equipmentTab.bundle` composite (separate work-in-progress) already loads referenced-only too — this brings the existing path in line.

## Verification
| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ 0 |
| `pnpm run lint` | ✅ 0 |

This is a **server-action perf fix, not the native migration** — so it speeds up the existing path immediately (helps both the load and the cross-tab refetch), before the native cutover lands. No flag; it's a straight improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)