### PR TITLE
refactor(convex-native): client-safe overbooking-core for native reads

### DIFF
--- a/src/lib/availability-read.ts
+++ b/src/lib/availability-read.ts
@@ -34,38 +34,20 @@ import { mapLineItemDoc, mapUnitDoc, type MappedLineItem, type MappedUnit } from
 type LineItemDoc = Doc<"projectLineItems">;
 type UnitDoc = Doc<"projectLineItemUnits">;
 
-/** Project statuses excluded from availability/booking windows (Prisma `notIn`). */
-export const EXCLUDED_PROJECT_STATUSES: ReadonlySet<string> = new Set([
-  "CANCELLED",
-  "RETURNED",
-  "COMPLETED",
-  "INVOICED",
-]);
-
-/** The booking date window (inclusive overlap). */
-export interface DateWindow {
-  start: Date;
-  end: Date;
-}
-
-/**
- * Reproduces the Prisma `project` `where` used by every availability read:
- * non-template, active status, and rental window overlaps `[start, end]`.
- * A project with no rental dates is excluded (null fails the date comparison,
- * matching Prisma's behaviour on `lte`/`gte` against null).
- */
-export function projectMatchesWindow(p: ConvexProject, window: DateWindow): boolean {
-  if (p.isTemplate === true) return false;
-  if (p.status != null && EXCLUDED_PROJECT_STATUSES.has(p.status)) return false;
-  if (p.rentalStartDate == null || p.rentalEndDate == null) return false;
-  // rentalStartDate <= end AND rentalEndDate >= start
-  return p.rentalStartDate <= window.end.getTime() && p.rentalEndDate >= window.start.getTime();
-}
-
-/** Build a `projectId → ConvexProject` map from the org's projects. */
-export function indexProjectsById(projects: ConvexProject[]): Map<string, ConvexProject> {
-  return new Map(projects.map((p) => [p.id, p]));
-}
+// The window/booking pure helpers moved into the client-safe overbooking-core so
+// the native read layer can run the same math client-side. Re-exported here for
+// back-compat — every existing server caller keeps importing them from this module.
+export {
+  EXCLUDED_PROJECT_STATUSES,
+  projectMatchesWindow,
+  indexProjectsById,
+  sumBookingsByModel,
+  type DateWindow,
+} from "@/lib/overbooking-core";
+import {
+  projectMatchesWindow,
+  type DateWindow,
+} from "@/lib/overbooking-core";
 
 /** A booking row as the calendar UI consumes it — `clientName` resolved by the caller. */
 export interface BookingRow {
@@ -200,45 +182,6 @@ export function buildAssetBookings(
   unitRows.sort(rentalStartSort);
 
   return [...legacy, ...unitRows];
-}
-
-/**
- * For overbooking: sum non-cancelled, non-sub-hire bookings per model across all
- * projects whose window overlaps (or, when `window` is null, only `thisProjectId`).
- * Returns total-by-model and this-project-by-model maps, mirroring
- * `computeOverbookedStatus`'s aggregation.
- */
-export function sumBookingsByModel(
-  modelIds: string[],
-  lineItems: MappedLineItem[],
-  projectsById: Map<string, ConvexProject>,
-  window: DateWindow | null,
-  thisProjectId: string,
-): { totalByModel: Map<string, number>; thisProjectByModel: Map<string, number> } {
-  const modelSet = new Set(modelIds);
-  const totalByModel = new Map<string, number>();
-  const thisProjectByModel = new Map<string, number>();
-
-  for (const li of lineItems) {
-    if (li.modelId == null || !modelSet.has(li.modelId)) continue;
-    if (li.status === "CANCELLED") continue;
-    if (li.subHireId != null) continue;
-
-    if (window) {
-      const p = projectsById.get(li.projectId);
-      if (!p || !projectMatchesWindow(p, window)) continue;
-    } else {
-      // Dateless: only this project's bookings (no overlap possible).
-      if (li.projectId !== thisProjectId) continue;
-    }
-
-    totalByModel.set(li.modelId, (totalByModel.get(li.modelId) ?? 0) + li.quantity);
-    if (li.projectId === thisProjectId) {
-      thisProjectByModel.set(li.modelId, (thisProjectByModel.get(li.modelId) ?? 0) + li.quantity);
-    }
-  }
-
-  return { totalByModel, thisProjectByModel };
 }
 
 /**

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,235 +1,49 @@
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
-import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import {
-  indexProjectsById,
-  sumBookingsByModel,
-  type DateWindow,
-} from "@/lib/availability-read";
+  computeStockBreakdown,
+  reconstructOverbookedStatus,
+  type OverbookedInfo,
+  type OverbookLineItem,
+} from "@/lib/overbooking-core";
 
-/**
- * Canonical stock breakdown for a model.
- *
- * `effectiveStock` is the only value that should be used for availability
- * enforcement — both server-side (addLineItem, updateLineItem, checkAvailability)
- * and client-side (computeOverbookedStatus, edit dialog). Raw `totalStock`
- * includes assets that are in maintenance / lost / retired and will overstate
- * what can actually be booked.
- */
-export function computeStockBreakdown(model: {
-  assetType: "SERIALIZED" | "BULK";
-  assets: { status: string }[];
-  bulkAssets: { totalQuantity: number }[];
-}): { totalStock: number; effectiveStock: number; unavailable: number } {
-  if (model.assetType === "SERIALIZED") {
-    const totalStock = model.assets.length;
-    const unavailable = model.assets.filter(
-      (a) =>
-        a.status === "IN_MAINTENANCE" ||
-        a.status === "LOST" ||
-        a.status === "RETIRED",
-    ).length;
-    return { totalStock, effectiveStock: totalStock - unavailable, unavailable };
-  }
-  const totalStock = model.bulkAssets.reduce(
-    (sum, ba) => sum + ba.totalQuantity,
-    0,
-  );
-  return { totalStock, effectiveStock: totalStock, unavailable: 0 };
-}
-
-export interface OverbookedInfo {
-  /** How many units over capacity */
-  overBy: number;
-  /** Total active assets for this model */
-  totalStock: number;
-  /** Usable stock (totalStock minus unavailable assets) */
-  effectiveStock: number;
-  /** Total booked across all overlapping projects */
-  totalBooked: number;
-  /** True when a kit parent is overbooked only because its children are */
-  inherited?: boolean;
-  /** Number of assets in non-usable statuses (IN_MAINTENANCE, LOST, etc.) */
-  unavailableAssets?: number;
-  /** True when overbooking is ONLY caused by unavailable assets, not other bookings */
-  reducedOnly?: boolean;
-  /** Kit parent: has children that are truly overbooked (booking conflicts) */
-  hasOverbookedChildren?: boolean;
-  /** Kit parent: has children with reduced stock (unavailable assets) */
-  hasReducedChildren?: boolean;
-}
+// Re-exported for back-compat: the pure stock-breakdown + overbooked types moved
+// into the client-safe overbooking-core (so the native read layer can run the
+// same math client-side); server callers keep importing them from here.
+export { computeStockBreakdown };
+export type { OverbookedInfo };
 
 /**
  * Computes which line items on a project are overbooked.
  * Returns a Map of line item ID → overbooking details.
- * Batches all DB queries for efficiency.
  *
- * Kit children count toward model availability — if a kit contains 3 mics
- * and 2 more are added individually, all 5 count against the model's stock.
+ * IO-only wrapper: fetches the `overbooking.bundle` (ONE backend-local round trip
+ * for line items + projects + models + assets + bulks across the referenced
+ * models) and delegates the math to the client-safe
+ * {@link reconstructOverbookedStatus} (parity-by-construction). The native read
+ * layer subscribes to the same bundle and calls `reconstructOverbookedStatus`
+ * directly in the browser.
  *
- * Assets in IN_MAINTENANCE, LOST, or RETIRED status reduce effective stock.
+ * Kit children count toward model availability — if a kit contains 3 mics and 2
+ * more are added individually, all 5 count against the model's stock. Assets in
+ * IN_MAINTENANCE, LOST, or RETIRED status reduce effective stock.
  */
 export async function computeOverbookedStatus(
   organizationId: string,
-  lineItems: Array<{
-    id: string;
-    modelId: string | null;
-    quantity: number;
-    isKitChild: boolean;
-    parentLineItemId: string | null;
-    kitId: string | null;
-    status: string;
-    subHireId?: string | null;
-  }>,
+  lineItems: OverbookLineItem[],
   rentalStartDate: Date | null,
   rentalEndDate: Date | null,
   projectId: string,
 ): Promise<Map<string, OverbookedInfo>> {
-  const overbookedMap = new Map<string, OverbookedInfo>();
-
-  // Collect ALL equipment line items with a modelId (including kit children).
-  // Sub-hire items represent third-party stock and never consume our inventory.
   const relevantItems = lineItems.filter(
     (li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null,
   );
-  if (relevantItems.length === 0) return overbookedMap;
+  if (relevantItems.length === 0) return new Map();
 
   const modelIds = [...new Set(relevantItems.map((li) => li.modelId!))];
-  const hasDates = !!rentalStartDate && !!rentalEndDate;
-  const window: DateWindow | null = hasDates
-    ? { start: rentalStartDate!, end: rentalEndDate! }
-    : null;
 
-  // All overlapping bookings for these models across all projects come from the
-  // dual-written Convex line-item table now (was a nested-project Prisma query).
-  // Include BOTH regular items AND kit children — they all consume stock.
-  // Sub-hire items are third-party stock and are excluded.
-  // When no dates: only count THIS project's bookings (no date overlap possible).
-  // ONE round-trip for ALL overbooking inputs (was 5 separate Convex queries in 2
-  // waves: line items + projects, then models + assets + bulks). Read backend-local
-  // inside a single query; raw docs reconstructed here (parity-by-construction).
   const convex = await getConvexClient();
   const ob = await convex.query(api.overbooking.bundle, { orgId: organizationId, modelIds });
 
-  const orgLineItems = ob.lineItems.map(mapLineItemDoc);
-  const projectsById = indexProjectsById(ob.projects);
-  const { totalByModel: totalBookedByModel, thisProjectByModel: thisProjectBookedByModel } =
-    sumBookingsByModel(modelIds, orgLineItems, projectsById, window, projectId);
-
-  const convexModelMap = new Map(ob.models.map((m) => [m.id, m]));
-  const assetsAll = ob.assets;
-  const bulksAll = ob.bulkAssets;
-  const assetMap = new Map<string, typeof assetsAll>();
-  for (const a of assetsAll) {
-    if (!a.modelId || a.isActive === false) continue;
-    const arr = assetMap.get(a.modelId);
-    if (arr) arr.push(a); else assetMap.set(a.modelId, [a]);
-  }
-  const bulkMap = new Map<string, typeof bulksAll>();
-  for (const b of bulksAll) {
-    if (!b.modelId || b.isActive === false) continue;
-    const arr = bulkMap.get(b.modelId);
-    if (arr) arr.push(b); else bulkMap.set(b.modelId, [b]);
-  }
-
-  const stockByModel = new Map<string, number>();
-  const effectiveStockByModel = new Map<string, number>();
-  const unavailableByModel = new Map<string, number>();
-
-  for (const modelId of modelIds) {
-    const m = convexModelMap.get(modelId);
-    if (!m) continue;
-    const modelForBreakdown = {
-      assetType: (m.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
-      assets: (assetMap.get(modelId) ?? []).map((a) => ({ status: a.status ?? "AVAILABLE" })),
-      bulkAssets: (bulkMap.get(modelId) ?? []).map((ba) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
-    };
-    const { totalStock, effectiveStock, unavailable } = computeStockBreakdown(modelForBreakdown);
-    stockByModel.set(modelId, totalStock);
-    effectiveStockByModel.set(modelId, effectiveStock);
-    unavailableByModel.set(modelId, unavailable);
-  }
-
-  // For each model, check if this project's total booking exceeds available
-  for (const modelId of modelIds) {
-    const totalStock = stockByModel.get(modelId) || 0;
-    const effectiveStock = effectiveStockByModel.get(modelId) || 0;
-    const unavailable = unavailableByModel.get(modelId) || 0;
-    const totalBooked = totalBookedByModel.get(modelId) || 0;
-    const bookedByOthers = totalBooked - (thisProjectBookedByModel.get(modelId) || 0);
-    const bookedByThisProject = thisProjectBookedByModel.get(modelId) || 0;
-
-    // Check against effective stock (factors in unavailable assets)
-    const availableForProject = effectiveStock - bookedByOthers;
-
-    if (bookedByThisProject > availableForProject) {
-      const overBy = bookedByThisProject - availableForProject;
-      // Would it be overbooked if all assets were available?
-      const wouldBeOverWithFullStock = bookedByThisProject > (totalStock - bookedByOthers);
-      const reducedOnly = !wouldBeOverWithFullStock && unavailable > 0;
-
-      const info: OverbookedInfo = {
-        overBy,
-        totalStock,
-        effectiveStock,
-        totalBooked,
-        unavailableAssets: unavailable > 0 ? unavailable : undefined,
-        reducedOnly,
-      };
-      // Mark all line items of this model on this project as overbooked
-      for (const li of relevantItems) {
-        if (li.modelId === modelId) {
-          overbookedMap.set(li.id, info);
-        }
-      }
-    }
-  }
-
-  // Also mark kit parent items as overbooked if any of their children are
-  for (const li of lineItems) {
-    if (li.kitId && !li.isKitChild) {
-      const children = lineItems.filter((c) => c.parentLineItemId === li.id);
-      const overbookedChildren = children.filter((c) => overbookedMap.has(c.id));
-      if (overbookedChildren.length > 0) {
-        // Aggregate: sum up the overBy from distinct models
-        const seen = new Set<string>();
-        let totalOver = 0;
-        let totalStock = 0;
-        let effectiveStock = 0;
-        let totalBooked = 0;
-        let anyReduced = false;
-        let allReduced = true;
-        let totalUnavailable = 0;
-        for (const c of overbookedChildren) {
-          const info = overbookedMap.get(c.id)!;
-          const mid = c.modelId!;
-          if (!seen.has(mid)) {
-            seen.add(mid);
-            totalOver += info.overBy;
-            totalStock += info.totalStock;
-            effectiveStock += info.effectiveStock;
-            totalBooked += info.totalBooked;
-            totalUnavailable += info.unavailableAssets || 0;
-            if (info.reducedOnly) anyReduced = true;
-            else allReduced = false;
-          }
-        }
-        if (seen.size > 0 && !anyReduced) allReduced = false;
-        const anyOverbooked = !allReduced; // at least one child is truly overbooked
-        overbookedMap.set(li.id, {
-          overBy: totalOver,
-          totalStock,
-          effectiveStock,
-          totalBooked,
-          inherited: true,
-          unavailableAssets: totalUnavailable > 0 ? totalUnavailable : undefined,
-          reducedOnly: allReduced && anyReduced,
-          hasOverbookedChildren: anyOverbooked,
-          hasReducedChildren: anyReduced,
-        });
-      }
-    }
-  }
-
-  return overbookedMap;
+  return reconstructOverbookedStatus(ob, lineItems, rentalStartDate, rentalEndDate, projectId);
 }

--- a/src/lib/overbooking-core.test.ts
+++ b/src/lib/overbooking-core.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  reconstructOverbookedStatus,
+  type OverbookingBundleData,
+  type OverbookLineItem,
+} from "./overbooking-core";
+
+// ── Fixture builders ─────────────────────────────────────────────────────────
+// The bundle returns RAW Convex docs; reconstructOverbookedStatus maps the
+// line items via mapLineItemDoc and reads a handful of fields off the others.
+// We build minimal partial docs and cast — only the read fields matter.
+
+const ORG = "org_1";
+const THIS_PROJECT = "proj_this";
+
+function bundleLineItem(p: {
+  id: string;
+  projectId: string;
+  modelId: string | null;
+  quantity: number;
+  status?: string;
+  subHireId?: string | null;
+}) {
+  return {
+    id: p.id,
+    organizationId: ORG,
+    projectId: p.projectId,
+    modelId: p.modelId,
+    quantity: p.quantity,
+    status: p.status ?? "QUOTED",
+    subHireId: p.subHireId ?? null,
+  };
+}
+
+function project(p: {
+  id: string;
+  start: number | null;
+  end: number | null;
+  status?: string;
+  isTemplate?: boolean;
+}) {
+  return {
+    id: p.id,
+    organizationId: ORG,
+    projectNumber: "PRJ-" + p.id,
+    name: p.id,
+    status: p.status ?? "CONFIRMED",
+    isTemplate: p.isTemplate ?? false,
+    rentalStartDate: p.start,
+    rentalEndDate: p.end,
+    clientId: null,
+  };
+}
+
+function model(id: string, assetType: "SERIALIZED" | "BULK") {
+  return { id, organizationId: ORG, assetType };
+}
+
+function asset(p: { id: string; modelId: string; status?: string; isActive?: boolean }) {
+  return {
+    id: p.id,
+    organizationId: ORG,
+    modelId: p.modelId,
+    status: p.status ?? "AVAILABLE",
+    isActive: p.isActive ?? true,
+  };
+}
+
+function bulk(p: { id: string; modelId: string; totalQuantity: number; isActive?: boolean }) {
+  return {
+    id: p.id,
+    organizationId: ORG,
+    modelId: p.modelId,
+    totalQuantity: p.totalQuantity,
+    isActive: p.isActive ?? true,
+  };
+}
+
+function makeBundle(parts: {
+  lineItems?: ReturnType<typeof bundleLineItem>[];
+  assets?: ReturnType<typeof asset>[];
+  bulkAssets?: ReturnType<typeof bulk>[];
+  projects?: ReturnType<typeof project>[];
+  models?: ReturnType<typeof model>[];
+}): OverbookingBundleData {
+  return {
+    lineItems: parts.lineItems ?? [],
+    assets: parts.assets ?? [],
+    bulkAssets: parts.bulkAssets ?? [],
+    projects: parts.projects ?? [],
+    models: parts.models ?? [],
+  } as unknown as OverbookingBundleData;
+}
+
+const WINDOW_START = new Date("2026-01-01T00:00:00Z");
+const WINDOW_END = new Date("2026-01-10T00:00:00Z");
+
+describe("reconstructOverbookedStatus", () => {
+  it("returns empty when no line item has a model", () => {
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: null, quantity: 5, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const map = reconstructOverbookedStatus(makeBundle({}), items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.size).toBe(0);
+  });
+
+  it("flags a model overbooked when this project books more than effective stock", () => {
+    // 2 serialized assets, this project books 3 → overBy 1.
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 3, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: [asset({ id: "a1", modelId: "m1" }), asset({ id: "a2", modelId: "m1" })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 3 })],
+    });
+    const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.get("li1")).toMatchObject({ overBy: 1, totalStock: 2, effectiveStock: 2, totalBooked: 3 });
+  });
+
+  it("does not flag when within stock", () => {
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 2, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: [asset({ id: "a1", modelId: "m1" }), asset({ id: "a2", modelId: "m1" })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 2 })],
+    });
+    const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.has("li1")).toBe(false);
+  });
+
+  it("marks reducedOnly when overbooking is caused solely by unavailable assets", () => {
+    // 2 assets, 1 in maintenance → effective 1; this project books 2 → over by 1,
+    // but with full stock (2) it would NOT be over → reducedOnly true.
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 2, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: [asset({ id: "a1", modelId: "m1" }), asset({ id: "a2", modelId: "m1", status: "IN_MAINTENANCE" })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 2 })],
+    });
+    const info = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT).get("li1");
+    expect(info).toMatchObject({ overBy: 1, totalStock: 2, effectiveStock: 1, reducedOnly: true, unavailableAssets: 1 });
+  });
+
+  it("counts bookings from other overlapping projects against availability", () => {
+    // stock 3; another project books 2 in-window; this project books 2 → over by 1.
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 2, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: ["a1", "a2", "a3"].map((id) => asset({ id, modelId: "m1" })),
+      projects: [
+        project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() }),
+        project({ id: "proj_other", start: WINDOW_START.getTime(), end: WINDOW_END.getTime() }),
+      ],
+      lineItems: [
+        bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 2 }),
+        bundleLineItem({ id: "li_other", projectId: "proj_other", modelId: "m1", quantity: 2 }),
+      ],
+    });
+    const info = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT).get("li1");
+    expect(info).toMatchObject({ overBy: 1, totalStock: 3, totalBooked: 4 });
+  });
+
+  it("excludes sub-hire line items from stock consumption", () => {
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 5, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED", subHireId: "sh1" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: [asset({ id: "a1", modelId: "m1" })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 5, subHireId: "sh1" })],
+    });
+    const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.size).toBe(0);
+  });
+
+  it("dateless project only counts its own bookings (ignores other projects)", () => {
+    // No rental window: other-project bookings must NOT count.
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 2, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: ["a1", "a2", "a3"].map((id) => asset({ id, modelId: "m1" })),
+      projects: [
+        project({ id: THIS_PROJECT, start: null, end: null }),
+        project({ id: "proj_other", start: WINDOW_START.getTime(), end: WINDOW_END.getTime() }),
+      ],
+      lineItems: [
+        bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 2 }),
+        bundleLineItem({ id: "li_other", projectId: "proj_other", modelId: "m1", quantity: 3 }),
+      ],
+    });
+    // stock 3, only this project's 2 count → within stock, not overbooked.
+    const map = reconstructOverbookedStatus(bundle, items, null, null, THIS_PROJECT);
+    expect(map.has("li1")).toBe(false);
+  });
+
+  it("marks a kit parent overbooked (inherited) when a kit child is overbooked", () => {
+    // kit parent 'kp' with child 'kc' (model m1, stock 1, books 2 → over by 1).
+    const items: OverbookLineItem[] = [
+      { id: "kp", modelId: null, quantity: 1, isKitChild: false, parentLineItemId: null, kitId: "kit1", status: "QUOTED" },
+      { id: "kc", modelId: "m1", quantity: 2, isKitChild: true, parentLineItemId: "kp", kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      models: [model("m1", "SERIALIZED")],
+      assets: [asset({ id: "a1", modelId: "m1" })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "kc", projectId: THIS_PROJECT, modelId: "m1", quantity: 2 })],
+    });
+    const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.get("kc")).toMatchObject({ overBy: 1 });
+    expect(map.get("kp")).toMatchObject({ overBy: 1, inherited: true, hasOverbookedChildren: true });
+  });
+});

--- a/src/lib/overbooking-core.ts
+++ b/src/lib/overbooking-core.ts
@@ -1,0 +1,322 @@
+/**
+ * CLIENT-SAFE core of the overbooking computation.
+ *
+ * Zero server imports (no getConvexClient / prisma) so a browser component can
+ * import it: the native read-layer cutover subscribes to
+ * `useQuery(api.overbooking.bundle)` and reconstructs the
+ * `lineItemId → OverbookedInfo` map client-side with the SAME math the server
+ * `computeOverbookedStatus` runs — parity-by-construction.
+ *
+ * The pure pieces (`projectMatchesWindow`, `indexProjectsById`,
+ * `sumBookingsByModel`, `computeStockBreakdown`, `OverbookedInfo`, `DateWindow`)
+ * were MOVED here out of `availability-read.ts` / `availability.ts` (which keep
+ * their server-only IO co-residents) and are re-exported from those modules for
+ * back-compat. The only value dependency is the client-safe `mapLineItemDoc`
+ * (already proven client-safe in `project-equipment-reconstruct.ts`). Convex doc /
+ * entity types are `import type` (erased — safe to reference impure modules for
+ * types).
+ */
+import type { FunctionReturnType } from "convex/server";
+import type { api } from "../../convex/_generated/api";
+import type { ConvexProject } from "@/lib/projects-read";
+import type { MappedLineItem } from "@/lib/project-line-item-read";
+import { mapLineItemDoc } from "@/lib/project-equipment-reconstruct";
+
+// ─── Stock breakdown (moved from availability.ts) ────────────────────────────
+
+/**
+ * Canonical stock breakdown for a model.
+ *
+ * `effectiveStock` is the only value that should be used for availability
+ * enforcement — both server-side (addLineItem, updateLineItem, checkAvailability)
+ * and client-side (computeOverbookedStatus, edit dialog). Raw `totalStock`
+ * includes assets that are in maintenance / lost / retired and will overstate
+ * what can actually be booked.
+ */
+export function computeStockBreakdown(model: {
+  assetType: "SERIALIZED" | "BULK";
+  assets: { status: string }[];
+  bulkAssets: { totalQuantity: number }[];
+}): { totalStock: number; effectiveStock: number; unavailable: number } {
+  if (model.assetType === "SERIALIZED") {
+    const totalStock = model.assets.length;
+    const unavailable = model.assets.filter(
+      (a) =>
+        a.status === "IN_MAINTENANCE" ||
+        a.status === "LOST" ||
+        a.status === "RETIRED",
+    ).length;
+    return { totalStock, effectiveStock: totalStock - unavailable, unavailable };
+  }
+  const totalStock = model.bulkAssets.reduce(
+    (sum, ba) => sum + ba.totalQuantity,
+    0,
+  );
+  return { totalStock, effectiveStock: totalStock, unavailable: 0 };
+}
+
+export interface OverbookedInfo {
+  /** How many units over capacity */
+  overBy: number;
+  /** Total active assets for this model */
+  totalStock: number;
+  /** Usable stock (totalStock minus unavailable assets) */
+  effectiveStock: number;
+  /** Total booked across all overlapping projects */
+  totalBooked: number;
+  /** True when a kit parent is overbooked only because its children are */
+  inherited?: boolean;
+  /** Number of assets in non-usable statuses (IN_MAINTENANCE, LOST, etc.) */
+  unavailableAssets?: number;
+  /** True when overbooking is ONLY caused by unavailable assets, not other bookings */
+  reducedOnly?: boolean;
+  /** Kit parent: has children that are truly overbooked (booking conflicts) */
+  hasOverbookedChildren?: boolean;
+  /** Kit parent: has children with reduced stock (unavailable assets) */
+  hasReducedChildren?: boolean;
+}
+
+// ─── Window / booking aggregation (moved from availability-read.ts) ──────────
+
+/** Project statuses excluded from availability/booking windows (Prisma `notIn`). */
+export const EXCLUDED_PROJECT_STATUSES: ReadonlySet<string> = new Set([
+  "CANCELLED",
+  "RETURNED",
+  "COMPLETED",
+  "INVOICED",
+]);
+
+/** The booking date window (inclusive overlap). */
+export interface DateWindow {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Reproduces the Prisma `project` `where` used by every availability read:
+ * non-template, active status, and rental window overlaps `[start, end]`.
+ * A project with no rental dates is excluded (null fails the date comparison,
+ * matching Prisma's behaviour on `lte`/`gte` against null).
+ */
+export function projectMatchesWindow(p: ConvexProject, window: DateWindow): boolean {
+  if (p.isTemplate === true) return false;
+  if (p.status != null && EXCLUDED_PROJECT_STATUSES.has(p.status)) return false;
+  if (p.rentalStartDate == null || p.rentalEndDate == null) return false;
+  // rentalStartDate <= end AND rentalEndDate >= start
+  return p.rentalStartDate <= window.end.getTime() && p.rentalEndDate >= window.start.getTime();
+}
+
+/** Build a `projectId → ConvexProject` map from the org's projects. */
+export function indexProjectsById(projects: ConvexProject[]): Map<string, ConvexProject> {
+  return new Map(projects.map((p) => [p.id, p]));
+}
+
+/**
+ * For overbooking: sum non-cancelled, non-sub-hire bookings per model across all
+ * projects whose window overlaps (or, when `window` is null, only `thisProjectId`).
+ * Returns total-by-model and this-project-by-model maps, mirroring
+ * `computeOverbookedStatus`'s aggregation.
+ */
+export function sumBookingsByModel(
+  modelIds: string[],
+  lineItems: MappedLineItem[],
+  projectsById: Map<string, ConvexProject>,
+  window: DateWindow | null,
+  thisProjectId: string,
+): { totalByModel: Map<string, number>; thisProjectByModel: Map<string, number> } {
+  const modelSet = new Set(modelIds);
+  const totalByModel = new Map<string, number>();
+  const thisProjectByModel = new Map<string, number>();
+
+  for (const li of lineItems) {
+    if (li.modelId == null || !modelSet.has(li.modelId)) continue;
+    if (li.status === "CANCELLED") continue;
+    if (li.subHireId != null) continue;
+
+    if (window) {
+      const p = projectsById.get(li.projectId);
+      if (!p || !projectMatchesWindow(p, window)) continue;
+    } else {
+      // Dateless: only this project's bookings (no overlap possible).
+      if (li.projectId !== thisProjectId) continue;
+    }
+
+    totalByModel.set(li.modelId, (totalByModel.get(li.modelId) ?? 0) + li.quantity);
+    if (li.projectId === thisProjectId) {
+      thisProjectByModel.set(li.modelId, (thisProjectByModel.get(li.modelId) ?? 0) + li.quantity);
+    }
+  }
+
+  return { totalByModel, thisProjectByModel };
+}
+
+// ─── Pure overbooked reconstruction (the body of computeOverbookedStatus) ────
+
+/** The minimal line-item shape the overbooked computation reads. */
+export type OverbookLineItem = {
+  id: string;
+  modelId: string | null;
+  quantity: number;
+  isKitChild: boolean;
+  parentLineItemId: string | null;
+  kitId: string | null;
+  status: string;
+  subHireId?: string | null;
+};
+
+/** The raw-doc bundle `overbooking.bundle` returns. */
+export type OverbookingBundleData = FunctionReturnType<typeof api.overbooking.bundle>;
+
+/**
+ * PURE reconstruction of `computeOverbookedStatus` from the `overbooking.bundle`
+ * payload + the project's (non-cancelled) line items. Byte-for-byte the Map the
+ * server `computeOverbookedStatus` produces — the server now fetches the bundle
+ * and delegates here (parity-by-construction).
+ *
+ * `lineItems` are the project's line items already mapped + filtered to
+ * `status !== "CANCELLED"` (the same input contract the server passed).
+ */
+export function reconstructOverbookedStatus(
+  bundle: OverbookingBundleData,
+  lineItems: OverbookLineItem[],
+  rentalStartDate: Date | null,
+  rentalEndDate: Date | null,
+  projectId: string,
+): Map<string, OverbookedInfo> {
+  const overbookedMap = new Map<string, OverbookedInfo>();
+
+  // Collect ALL equipment line items with a modelId (including kit children).
+  // Sub-hire items represent third-party stock and never consume our inventory.
+  const relevantItems = lineItems.filter(
+    (li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null,
+  );
+  if (relevantItems.length === 0) return overbookedMap;
+
+  const modelIds = [...new Set(relevantItems.map((li) => li.modelId!))];
+  const hasDates = !!rentalStartDate && !!rentalEndDate;
+  const window: DateWindow | null = hasDates
+    ? { start: rentalStartDate!, end: rentalEndDate! }
+    : null;
+
+  const orgLineItems = bundle.lineItems.map(mapLineItemDoc);
+  const projectsById = indexProjectsById(bundle.projects as unknown as ConvexProject[]);
+  const { totalByModel: totalBookedByModel, thisProjectByModel: thisProjectBookedByModel } =
+    sumBookingsByModel(modelIds, orgLineItems, projectsById, window, projectId);
+
+  const convexModelMap = new Map(bundle.models.map((m) => [m.id, m]));
+  const assetsAll = bundle.assets;
+  const bulksAll = bundle.bulkAssets;
+  const assetMap = new Map<string, typeof assetsAll>();
+  for (const a of assetsAll) {
+    if (!a.modelId || a.isActive === false) continue;
+    const arr = assetMap.get(a.modelId);
+    if (arr) arr.push(a); else assetMap.set(a.modelId, [a]);
+  }
+  const bulkMap = new Map<string, typeof bulksAll>();
+  for (const b of bulksAll) {
+    if (!b.modelId || b.isActive === false) continue;
+    const arr = bulkMap.get(b.modelId);
+    if (arr) arr.push(b); else bulkMap.set(b.modelId, [b]);
+  }
+
+  const stockByModel = new Map<string, number>();
+  const effectiveStockByModel = new Map<string, number>();
+  const unavailableByModel = new Map<string, number>();
+
+  for (const modelId of modelIds) {
+    const m = convexModelMap.get(modelId);
+    if (!m) continue;
+    const modelForBreakdown = {
+      assetType: (m.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
+      assets: (assetMap.get(modelId) ?? []).map((a) => ({ status: a.status ?? "AVAILABLE" })),
+      bulkAssets: (bulkMap.get(modelId) ?? []).map((ba) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
+    };
+    const { totalStock, effectiveStock, unavailable } = computeStockBreakdown(modelForBreakdown);
+    stockByModel.set(modelId, totalStock);
+    effectiveStockByModel.set(modelId, effectiveStock);
+    unavailableByModel.set(modelId, unavailable);
+  }
+
+  // For each model, check if this project's total booking exceeds available
+  for (const modelId of modelIds) {
+    const totalStock = stockByModel.get(modelId) || 0;
+    const effectiveStock = effectiveStockByModel.get(modelId) || 0;
+    const unavailable = unavailableByModel.get(modelId) || 0;
+    const totalBooked = totalBookedByModel.get(modelId) || 0;
+    const bookedByOthers = totalBooked - (thisProjectBookedByModel.get(modelId) || 0);
+    const bookedByThisProject = thisProjectBookedByModel.get(modelId) || 0;
+
+    // Check against effective stock (factors in unavailable assets)
+    const availableForProject = effectiveStock - bookedByOthers;
+
+    if (bookedByThisProject > availableForProject) {
+      const overBy = bookedByThisProject - availableForProject;
+      // Would it be overbooked if all assets were available?
+      const wouldBeOverWithFullStock = bookedByThisProject > (totalStock - bookedByOthers);
+      const reducedOnly = !wouldBeOverWithFullStock && unavailable > 0;
+
+      const info: OverbookedInfo = {
+        overBy,
+        totalStock,
+        effectiveStock,
+        totalBooked,
+        unavailableAssets: unavailable > 0 ? unavailable : undefined,
+        reducedOnly,
+      };
+      // Mark all line items of this model on this project as overbooked
+      for (const li of relevantItems) {
+        if (li.modelId === modelId) {
+          overbookedMap.set(li.id, info);
+        }
+      }
+    }
+  }
+
+  // Also mark kit parent items as overbooked if any of their children are
+  for (const li of lineItems) {
+    if (li.kitId && !li.isKitChild) {
+      const children = lineItems.filter((c) => c.parentLineItemId === li.id);
+      const overbookedChildren = children.filter((c) => overbookedMap.has(c.id));
+      if (overbookedChildren.length > 0) {
+        // Aggregate: sum up the overBy from distinct models
+        const seen = new Set<string>();
+        let totalOver = 0;
+        let totalStock = 0;
+        let effectiveStock = 0;
+        let totalBooked = 0;
+        let anyReduced = false;
+        let allReduced = true;
+        let totalUnavailable = 0;
+        for (const c of overbookedChildren) {
+          const info = overbookedMap.get(c.id)!;
+          const mid = c.modelId!;
+          if (!seen.has(mid)) {
+            seen.add(mid);
+            totalOver += info.overBy;
+            totalStock += info.totalStock;
+            effectiveStock += info.effectiveStock;
+            totalBooked += info.totalBooked;
+            totalUnavailable += info.unavailableAssets || 0;
+            if (info.reducedOnly) anyReduced = true;
+            else allReduced = false;
+          }
+        }
+        if (seen.size > 0 && !anyReduced) allReduced = false;
+        const anyOverbooked = !allReduced; // at least one child is truly overbooked
+        overbookedMap.set(li.id, {
+          overBy: totalOver,
+          totalStock,
+          effectiveStock,
+          totalBooked,
+          inherited: true,
+          unavailableAssets: totalUnavailable > 0 ? totalUnavailable : undefined,
+          reducedOnly: allReduced && anyReduced,
+          hasOverbookedChildren: anyOverbooked,
+          hasReducedChildren: anyReduced,
+        });
+      }
+    }
+  }
+
+  return overbookedMap;
+}


### PR DESCRIPTION
## What

Extract the overbooked-status math into a **client-safe** module so the native read layer can compute it in the browser over a `useQuery(api.overbooking.bundle)` subscription — the shared foundation for the project-detail overbooked-flag gap and the equipment-tab overbooked view.

`computeOverbookedStatus` was server-only because `src/lib/availability.ts` imports `getConvexClient`. New `src/lib/overbooking-core.ts` (zero server imports) holds the pure pieces:
- `computeStockBreakdown`, `OverbookedInfo`, `DateWindow`, `EXCLUDED_PROJECT_STATUSES`
- `projectMatchesWindow`, `indexProjectsById`, `sumBookingsByModel`
- **`reconstructOverbookedStatus`** — the body of `computeOverbookedStatus`, taking the `overbooking.bundle` payload instead of fetching it.

## Parity-by-construction

- `availability.ts` `computeOverbookedStatus` is now a thin IO wrapper: fetch the bundle → `reconstructOverbookedStatus`. Same Map out.
- Moved symbols are **re-exported** from `availability.ts` / `availability-read.ts`, so every existing server caller keeps its import path unchanged.
- The only value dependency is the already-client-safe `mapLineItemDoc` (from `project-equipment-reconstruct.ts`).

## Test

- New `overbooking-core.test.ts` — 8 cases: overbook, within-stock, reducedOnly (unavailable-asset-driven), cross-project bookings, sub-hire exclusion, dateless project, kit-parent inheritance.
- Existing `availability.test.ts` (computeStockBreakdown via re-export) + `availability-read.test.ts` still green.
- `npx tsc --noEmit` + lint clean.

No behaviour change; no UI consumer yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)