### PR TITLE
feat(convex-native): native project-detail overbooked enrichment + loading fix

### DIFF
--- a/src/hooks/use-native-project-equipment.ts
+++ b/src/hooks/use-native-project-equipment.ts
@@ -9,8 +9,10 @@ import {
 } from "@/lib/project-equipment-reconstruct";
 import {
   reconstructProjectDetail,
+  enrichProjectDetailOverbooked,
   type NativeProjectDetail,
 } from "@/lib/project-detail-reconstruct";
+import { relevantOverbookModelIds } from "@/lib/overbooking-core";
 
 /**
  * Feature flag (default OFF) for the native read-layer project-detail cutover
@@ -54,28 +56,58 @@ export function useNativeProjectEquipmentTree(
 
 /**
  * The FULL native project-detail composite — the getProject-shaped object built
- * from `projectDetail.bundle` + `projectEquipment.browserBundle`, reconstructed
- * client-side. Returns `{ data, isLoading }` matching the useProjectDetail
- * interface so `use-project-detail.ts` can swap to it behind the flag. Both
- * subscriptions skip entirely unless the flag is on and ids are present.
+ * from `projectDetail.bundle` + `projectEquipment.browserBundle` +
+ * `overbooking.bundle`, reconstructed client-side. Returns `{ data, isLoading }`
+ * matching the useProjectDetail interface so `use-project-detail.ts` can swap to it
+ * behind the flag. All subscriptions skip entirely unless the flag is on and ids
+ * are present.
  *
- * (Overbooked-flag enrichment is not yet applied — see project-detail-reconstruct
- * module header; line items render without overbook warnings until that lands.)
+ * `notFound` distinguishes "project doesn't exist / not permitted" (detail === null)
+ * from "still loading" so the page shows its not-found state only when definitive —
+ * never during auth/orgId resolution.
+ *
+ * Overbooked enrichment is reactive: the base detail renders as soon as
+ * detail+equipment land (line items default to not-overbooked); the
+ * `overbooking.bundle` subscription (keyed on the referenced model ids) then fills
+ * in `isOverbooked` / `overbookedInfo` when it arrives. Parity with `getProject`.
  */
 export function useNativeProjectDetail(
   projectId: string | undefined,
   orgId: string | undefined,
-): { data: NativeProjectDetail | undefined; isLoading: boolean } {
+): { data: NativeProjectDetail | undefined; isLoading: boolean; notFound: boolean } {
   const enabled = NATIVE_PROJECT_DETAIL_ENABLED && !!projectId && !!orgId;
   const args = enabled ? { projectId: projectId!, orgId: orgId! } : "skip";
   const detail = useAuthedQuery(api.projectDetail.bundle, args);
   const equipment = useAuthedQuery(api.projectEquipment.browserBundle, args);
 
-  const data = useMemo(() => {
+  const base = useMemo(() => {
     if (!enabled || detail === undefined || equipment === undefined) return undefined;
-    if (detail === null) return undefined; // project not found / not permitted
+    if (detail === null) return null; // project not found / not permitted
     return reconstructProjectDetail(detail, equipment);
   }, [enabled, detail, equipment]);
 
-  return { data, isLoading: enabled && data === undefined };
+  // Referenced overbookable models → the overbooking.bundle arg. Skip when there
+  // are none (no subscription, no enrichment needed — nothing is overbookable).
+  const modelIds = useMemo(
+    () => (base ? relevantOverbookModelIds(base.lineItems) : undefined),
+    [base],
+  );
+  const overbooking = useAuthedQuery(
+    api.overbooking.bundle,
+    enabled && orgId && modelIds && modelIds.length > 0
+      ? { orgId: orgId!, modelIds }
+      : "skip",
+  );
+
+  const data = useMemo(() => {
+    if (!base) return undefined; // null (not found) or undefined (loading)
+    return enrichProjectDetailOverbooked(base, overbooking ?? undefined);
+  }, [base, overbooking]);
+
+  return {
+    data,
+    // Loading until the base composite resolves to a definitive value.
+    isLoading: enabled && base === undefined,
+    notFound: base === null,
+  };
 }

--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -62,9 +62,16 @@ export function useProjectDetail(projectId: string) {
   // return. When the flag is off, `useNativeProjectDetail` is a no-op (skips).
   const native = useNativeProjectDetail(projectId, convexProject?.organizationId);
   if (NATIVE_PROJECT_DETAIL_ENABLED) {
+    // While the project doc (the orgId source) is still loading, keep isLoading
+    // true so the page shows its skeleton — NOT the "not found" state. Without
+    // this, the native hook is skipped (no orgId yet) and reports
+    // {data: undefined, isLoading: false}, which the page reads as "loaded, no
+    // project" and flashes not-found during auth/orgId resolution. `convexProject
+    // === null` (project genuinely missing) is NOT loading → not-found shows.
+    const orgResolving = convexProject === undefined;
     return {
       data: native.data as typeof result.data,
-      isLoading: native.isLoading,
+      isLoading: orgResolving || native.isLoading,
       refresh: () => resource.refresh(projectId),
     };
   }

--- a/src/lib/overbooking-core.ts
+++ b/src/lib/overbooking-core.ts
@@ -168,6 +168,23 @@ export type OverbookLineItem = {
 export type OverbookingBundleData = FunctionReturnType<typeof api.overbooking.bundle>;
 
 /**
+ * The model ids the overbooked computation actually consults — the `relevantItems`
+ * filter (`computeOverbookedStatus`): line items with a model, non-cancelled, not a
+ * sub-hire. The native read layer passes these as the `overbooking.bundle`
+ * `modelIds` arg so the bundle fetches exactly what `reconstructOverbookedStatus`
+ * needs (mirrors the server's modelIds derivation).
+ */
+export function relevantOverbookModelIds(lineItems: OverbookLineItem[]): string[] {
+  return [
+    ...new Set(
+      lineItems
+        .filter((li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null)
+        .map((li) => li.modelId!),
+    ),
+  ];
+}
+
+/**
  * PURE reconstruction of `computeOverbookedStatus` from the `overbooking.bundle`
  * payload + the project's (non-cancelled) line items. Byte-for-byte the Map the
  * server `computeOverbookedStatus` produces — the server now fetches the bundle

--- a/src/lib/project-detail-reconstruct.test.ts
+++ b/src/lib/project-detail-reconstruct.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { reconstructProjectDetail } from "./project-detail-reconstruct";
+import {
+  reconstructProjectDetail,
+  enrichProjectDetailOverbooked,
+} from "./project-detail-reconstruct";
 import type { EquipmentBundleData } from "./project-equipment-reconstruct";
+import type { OverbookingBundleData } from "./overbooking-core";
 
 /**
  * Unit coverage for the full native project-detail reconstruction (Phase 1d B.2).
@@ -95,5 +99,65 @@ describe("reconstructProjectDetail", () => {
     expect(res.media).toHaveLength(1); // m2 dropped (file unresolved)
     expect(res.media[0].id).toBe("m1");
     expect(res.media[0].file.url).toBe("http://x/a.jpg");
+  });
+
+  it("line items default to not-overbooked before enrichment", () => {
+    const equipment: EquipmentBundleData = {
+      ...EMPTY_EQUIPMENT,
+      lineItems: [d({ id: "li1", organizationId: "o1", projectId: "p1", modelId: "m1", quantity: 3, status: "QUOTED" })],
+    };
+    const res = reconstructProjectDetail(detailBundle(), equipment);
+    expect(res.lineItems).toHaveLength(1);
+    expect(res.lineItems[0].isOverbooked).toBe(false);
+    expect(res.lineItems[0].overbookedInfo).toBeNull();
+  });
+});
+
+const WIN_START = new Date("2026-01-01T00:00:00Z").getTime();
+const WIN_END = new Date("2026-01-10T00:00:00Z").getTime();
+
+describe("enrichProjectDetailOverbooked", () => {
+  // p1 books 3 of model m1, which has only 2 serialized assets → over by 1.
+  const equipment: EquipmentBundleData = {
+    ...EMPTY_EQUIPMENT,
+    lineItems: [d({ id: "li1", organizationId: "o1", projectId: "p1", modelId: "m1", quantity: 3, status: "QUOTED" })],
+  };
+  const detail = detailBundle({
+    project: d({ id: "p1", organizationId: "o1", projectNumber: "P-1", name: "Gig", createdAt: 1000, rentalStartDate: WIN_START, rentalEndDate: WIN_END }),
+  });
+  const overbooking: OverbookingBundleData = {
+    lineItems: [d({ id: "li1", organizationId: "o1", projectId: "p1", modelId: "m1", quantity: 3, status: "QUOTED" })],
+    assets: [d({ id: "a1", organizationId: "o1", modelId: "m1", status: "AVAILABLE", isActive: true }), d({ id: "a2", organizationId: "o1", modelId: "m1", status: "AVAILABLE", isActive: true })],
+    bulkAssets: [],
+    projects: [d({ id: "p1", organizationId: "o1", projectNumber: "P-1", name: "Gig", status: "CONFIRMED", isTemplate: false, rentalStartDate: WIN_START, rentalEndDate: WIN_END })],
+    models: [d({ id: "m1", organizationId: "o1", assetType: "SERIALIZED" })],
+  } as never;
+
+  it("returns the base unchanged while the overbooking bundle is still loading", () => {
+    const base = reconstructProjectDetail(detail, equipment);
+    const out = enrichProjectDetailOverbooked(base, undefined);
+    expect(out.lineItems[0].isOverbooked).toBe(false);
+    expect(out).toBe(base);
+  });
+
+  it("flags overbooked line items once the bundle lands", () => {
+    const base = reconstructProjectDetail(detail, equipment);
+    const out = enrichProjectDetailOverbooked(base, overbooking);
+    expect(out.lineItems[0].isOverbooked).toBe(true);
+    expect(out.lineItems[0].overbookedInfo).toMatchObject({ overBy: 1, totalStock: 2, effectiveStock: 2 });
+  });
+
+  it("leaves non-overbooked items false when within stock", () => {
+    const within: EquipmentBundleData = {
+      ...EMPTY_EQUIPMENT,
+      lineItems: [d({ id: "li1", organizationId: "o1", projectId: "p1", modelId: "m1", quantity: 1, status: "QUOTED" })],
+    };
+    const ob: OverbookingBundleData = {
+      ...overbooking,
+      lineItems: [d({ id: "li1", organizationId: "o1", projectId: "p1", modelId: "m1", quantity: 1, status: "QUOTED" })],
+    } as never;
+    const base = reconstructProjectDetail(detail, within);
+    const out = enrichProjectDetailOverbooked(base, ob);
+    expect(out.lineItems[0].isOverbooked).toBe(false);
   });
 });

--- a/src/lib/project-detail-reconstruct.ts
+++ b/src/lib/project-detail-reconstruct.ts
@@ -11,11 +11,12 @@
  * server-only co-residents); the TYPES come via `import type` (erased). Parity
  * with the server path is by-copy — keep these in sync if the source mappers change.
  *
- * KNOWN GAP (tracked): the overbooked-flag ENRICHMENT (`isOverbooked` /
- * `overbookedInfo` on line items) is NOT yet reconstructed here — its server math
- * (computeOverbookedStatus) has kit-parent inheritance logic best ported with the
- * live UI to verify the indicators. Until then native line items render without
- * overbook warnings (graceful: undefined → no warning), the only parity gap.
+ * Overbooked-flag enrichment (`isOverbooked` / `overbookedInfo` on the top-level
+ * line items + one level of children) is applied by
+ * {@link enrichProjectDetailOverbooked} from the `overbooking.bundle` payload,
+ * mirroring `getProject` (which passes the SAME nested top-level array to
+ * `computeOverbookedStatus`, so kit children nested under `childLineItems` are not
+ * flat-iterated — parity-by-construction).
  */
 import type { FunctionReturnType } from "convex/server";
 import type { api } from "../../convex/_generated/api";
@@ -27,6 +28,11 @@ import {
   type EquipmentBundleData,
   type ProjectEquipmentTree,
 } from "@/lib/project-equipment-reconstruct";
+import {
+  reconstructOverbookedStatus,
+  type OverbookedInfo,
+  type OverbookingBundleData,
+} from "@/lib/overbooking-core";
 
 type ProjectDetailBundle = NonNullable<FunctionReturnType<typeof api.projectDetail.bundle>>;
 type ProjectDoc = ProjectDetailBundle["project"];
@@ -171,12 +177,22 @@ type LocationWithParent =
   | (MappedLocation & { parent: MappedLocation | null })
   | null;
 
+/** The overbooked flags `getProject` adds to each enriched line-item node. */
+type OverbookedFields = { isOverbooked: boolean; overbookedInfo: OverbookedInfo | null };
+
+type TopLineItem = ProjectEquipmentTree["lineItems"][number];
+/** A top-level line item enriched with overbooked flags (children one level deep). */
+export type EnrichedLineItem = TopLineItem &
+  OverbookedFields & {
+    childLineItems?: Array<NonNullable<TopLineItem["childLineItems"]>[number] & OverbookedFields>;
+  };
+
 export type NativeProjectDetail = ProjectRow & {
   projectManagers: ProjectManagerOut[];
   media: Array<ProjectGalleryMedia & { file: GalleryFile }>;
   location: LocationWithParent;
   categories: ProjectEquipmentTree["categories"];
-  lineItems: ProjectEquipmentTree["lineItems"];
+  lineItems: EnrichedLineItem[];
   client: ProjectDetailBundle["client"];
 };
 
@@ -212,11 +228,40 @@ function reconstructLocation(detail: ProjectDetailBundle): LocationWithParent {
 }
 
 /**
+ * Apply the `lineItemId → OverbookedInfo` map onto the top-level line items + one
+ * level of children, exactly as `getProject`'s `enrichedLineItems` does. An empty
+ * map yields `isOverbooked: false` / `overbookedInfo: null` on every node (the
+ * server's behaviour when nothing is overbooked).
+ */
+function applyOverbookedMap(
+  lineItems: TopLineItem[],
+  map: Map<string, OverbookedInfo>,
+): EnrichedLineItem[] {
+  return lineItems.map((li) => {
+    const info = map.get(li.id);
+    return {
+      ...li,
+      isOverbooked: !!info,
+      overbookedInfo: info ?? null,
+      childLineItems: li.childLineItems?.map((child) => {
+        const childInfo = map.get(child.id);
+        return {
+          ...child,
+          isOverbooked: !!childInfo,
+          overbookedInfo: childInfo ?? null,
+        };
+      }),
+    } as EnrichedLineItem;
+  });
+}
+
+/**
  * Build the full getProject-shaped object from the native composites. `detail` is
  * the projectDetail.bundle (non-null), `equipment` the browserBundle.
  *
- * NOTE: overbooked-flag enrichment is not applied (see module header) — line items
- * pass through from the equipment reconstruction as-is.
+ * Line items start with default overbooked flags (`isOverbooked: false`); call
+ * {@link enrichProjectDetailOverbooked} with the `overbooking.bundle` payload to
+ * fill them in (reactively, once that subscription lands).
  */
 export function reconstructProjectDetail(
   detail: ProjectDetailBundle,
@@ -230,7 +275,30 @@ export function reconstructProjectDetail(
     media: reconstructMedia(detail.media, detail.mediaFiles),
     location: reconstructLocation(detail),
     categories,
-    lineItems,
+    lineItems: applyOverbookedMap(lineItems, new Map()),
     client: detail.client,
   };
+}
+
+/**
+ * Re-enrich a reconstructed project-detail's line items with overbooked flags from
+ * the `overbooking.bundle` payload. Parity with `getProject`: the SAME nested
+ * top-level `lineItems` array is passed to `reconstructOverbookedStatus` (kit
+ * children nested under `childLineItems` are not flat-iterated), then the resulting
+ * map is applied to the top level + one child level. `overbooking === undefined`
+ * (still loading) returns the input unchanged — badges appear when it lands.
+ */
+export function enrichProjectDetailOverbooked(
+  base: NativeProjectDetail,
+  overbooking: OverbookingBundleData | undefined,
+): NativeProjectDetail {
+  if (!overbooking) return base;
+  const map = reconstructOverbookedStatus(
+    overbooking,
+    base.lineItems,
+    base.rentalStartDate,
+    base.rentalEndDate,
+    base.id,
+  );
+  return { ...base, lineItems: applyOverbookedMap(base.lineItems, map) };
 }


### PR DESCRIPTION
## What

Closes the two remaining gaps on the native project-detail path so `NEXT_PUBLIC_NATIVE_PROJECT_DETAIL` can be flipped on. Still **default off** — merging changes nothing for users until the repo var + rebuild flips it.

### Overbooked-flag enrichment (the documented gap)
- `enrichProjectDetailOverbooked(base, overbooking.bundle)` applies the `lineItemId → OverbookedInfo` map onto the top-level line items + one child level, exactly as `getProject`'s `enrichedLineItems`.
- **Parity-by-construction:** the SAME nested top-level `lineItems` array is passed to `reconstructOverbookedStatus`, so kit children nested under `childLineItems` are not flat-iterated — matching the server's flat-vs-nested quirk precisely.
- `reconstructProjectDetail` seeds default flags (`isOverbooked:false`); the hook subscribes to `overbooking.bundle` (keyed on `relevantOverbookModelIds`, mirroring the server's modelIds derivation) and re-enriches **reactively** when it lands. No referenced models → no subscription. Badges appear ~1 round-trip after the base renders (graceful).

### Loading states (no not-found flash during auth/orgId resolution)
- `useNativeProjectDetail` now returns `notFound` and keeps `isLoading` true until the base composite resolves to a definitive value (`object | null`) — not the moment a skipped subscription returns `undefined`.
- `use-project-detail` keeps `isLoading` true while `convexProject` (the orgId source) is still loading, so the page shows its skeleton instead of flashing "Project not found" during auth resolution. `convexProject === null` (genuinely missing) still surfaces not-found.

## Test
- `enrichProjectDetailOverbooked`: loading-passthrough (returns base unchanged), overbook flag set, within-stock stays false; plus default-flags-before-enrichment. Existing `reconstructProjectDetail` tests green. `overbooking-core` parity tests (now on main) cover the math.
- `tsc` + lint (0 errors) clean. CI `next build` verifies the new client imports stay client-safe.

Builds on #311 (overbooking-core), now merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)