### PR TITLE
feat(convex-native): native equipment-tab cutover (flag-gated, default off)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -80,6 +80,7 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED=${{ vars.NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED }}
             NEXT_PUBLIC_NATIVE_PROJECT_DETAIL=${{ vars.NEXT_PUBLIC_NATIVE_PROJECT_DETAIL }}
+            NEXT_PUBLIC_NATIVE_EQUIPMENT=${{ vars.NEXT_PUBLIC_NATIVE_EQUIPMENT }}
 
       # Tell Coolify to pull the new image and redeploy. This is Coolify's
       # "Deploy Webhook (auth required)" API endpoint (app → Webhooks):

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ ARG NEXT_PUBLIC_GOOGLE_CONFIGURED
 ARG NEXT_PUBLIC_MICROSOFT_CONFIGURED
 ARG NEXT_PUBLIC_SENTRY_DSN
 ARG NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED
-# Native read-layer cutover flag (Phase 1d). Unset/"" → off (server-action path).
-# Set to "true" via the GitHub repo variable to inline it on into the client bundle.
+# Native read-layer cutover flags. Unset/"" → off (server-action path). Set to
+# "true" via the matching GitHub repo variable to inline it on into the client bundle.
 ARG NEXT_PUBLIC_NATIVE_PROJECT_DETAIL
+ARG NEXT_PUBLIC_NATIVE_EQUIPMENT
 
 ENV DATABASE_URL=$DATABASE_URL \
     BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET \
@@ -47,7 +48,8 @@ ENV DATABASE_URL=$DATABASE_URL \
     NEXT_PUBLIC_MICROSOFT_CONFIGURED=$NEXT_PUBLIC_MICROSOFT_CONFIGURED \
     NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN \
     NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED=$NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED \
-    NEXT_PUBLIC_NATIVE_PROJECT_DETAIL=$NEXT_PUBLIC_NATIVE_PROJECT_DETAIL
+    NEXT_PUBLIC_NATIVE_PROJECT_DETAIL=$NEXT_PUBLIC_NATIVE_PROJECT_DETAIL \
+    NEXT_PUBLIC_NATIVE_EQUIPMENT=$NEXT_PUBLIC_NATIVE_EQUIPMENT
 
 # Prisma client (codegen only — no DB access) + Next production build.
 RUN pnpm exec prisma generate && pnpm run build

--- a/convex/equipmentTab.ts
+++ b/convex/equipmentTab.ts
@@ -60,18 +60,15 @@ async function readEquipmentTab(ctx: QueryCtx, projectId: string, orgId: string)
     ...subHires.map((s) => s.supplierId),
   ]);
 
-  const pointRead = <T,>(
-    table: "assets" | "bulkAssets" | "kits" | "models" | "suppliers" | "categories",
-    ids: string[],
-  ) =>
-    Promise.all(ids.map((id) => ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).unique())) as Promise<(T | null)[]>;
-
+  // Per-table point reads (each keeps its full Doc type — the attach maps and the
+  // client reconstruction read concrete fields like id/categoryId/assetTag).
+  const byCuid = <T>(rows: Promise<T | null>[]) => Promise.all(rows);
   const [assetDocs, bulkDocs, kitDocs, modelDocs, supplierDocs] = await Promise.all([
-    pointRead<{ organizationId?: string | null }>("assets", refAssetIds),
-    pointRead<{ organizationId?: string | null }>("bulkAssets", refBulkIds),
-    pointRead<{ organizationId?: string | null }>("kits", refKitIds),
-    pointRead<{ organizationId?: string | null; categoryId?: string | null }>("models", refModelIds),
-    pointRead<{ organizationId?: string | null }>("suppliers", refSupplierIds),
+    byCuid(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    byCuid(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    byCuid(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    byCuid(refModelIds.map((id) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    byCuid(refSupplierIds.map((id) => ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
   ]);
 
   const inOrg = <T extends { organizationId?: string | null }>(arr: (T | null)[]) =>
@@ -82,7 +79,9 @@ async function readEquipmentTab(ctx: QueryCtx, projectId: string, orgId: string)
 
   // Categories referenced by the (in-org) models, point-read by id.
   const refCategoryIds = uniq(models.map((m) => m.categoryId));
-  const categoryDocs = await pointRead<{ organizationId?: string | null }>("categories", refCategoryIds);
+  const categoryDocs = await Promise.all(
+    refCategoryIds.map((id) => ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+  );
 
   return {
     lineItems,

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -265,6 +265,44 @@ The existing composite bundles are **deliberately service-only**. `convex/projec
 
 **Rule:** every browser-facing composite is a **NEW** query returning **DTOs with an explicit per-entity field allowlist**, never raw Convex docs. The service bundles stay service-only and untouched. Each browser composite ships with a test asserting sensitive/service-only fields (unit internals, tokens, costs not meant for the role) are absent. This is design + per-entity allowlist work, **not** a one-line guard swap — the single biggest under-scoped item in the first draft.
 
+### 3.5.1 Execution progress — Phases 1–2 (2026-06-28)
+
+Phase 0/1 landed earlier (PRs #297–304: client plumbing, isomorphic RBAC core
+`convex/lib/permissionsCore.ts`, `requireOrgPermission` + members/customRoles
+mirror, convex-test harness, `projectDetail.bundle`, `projectEquipment.browserBundle`,
+the client-safe `project-equipment-reconstruct.ts`, and the flag-gated native
+`useProjectDetail`). Phase 2 continued:
+
+- **`equipmentTab.bundle` referenced-only** (#310, merged): models/suppliers/categories
+  point-read by referenced ids, never whole-org `.collect()` (mirrors the assets/bulks/kits
+  fix).
+- **`overbooking-core.ts`** (#311, merged): the overbooked math extracted client-safe —
+  `computeStockBreakdown`, `projectMatchesWindow`, `indexProjectsById`,
+  `sumBookingsByModel`, `reconstructOverbookedStatus`, `relevantOverbookModelIds`.
+  `availability.ts`/`availability-read.ts` re-export them; `computeOverbookedStatus`
+  is now a thin IO wrapper delegating to the core. This is the shared foundation for
+  every overbooked view.
+- **Project-detail finished** (#312, merged): `enrichProjectDetailOverbooked` ports the
+  overbooked-flag enrichment (the documented gap) — applies the map onto top-level line
+  items + one child level exactly as `getProject`, passing the SAME nested array to
+  `reconstructOverbookedStatus` so the kit-children-nested quirk is preserved. Also fixed
+  the native loading flash: `useNativeProjectDetail` returns `notFound`, and
+  `use-project-detail` holds `isLoading` true while the orgId source (`useProject`) is
+  still resolving (was flashing "Project not found" during auth resolution). Ready to flip
+  `NEXT_PUBLIC_NATIVE_PROJECT_DETAIL` live.
+- **Equipment editing tab native cutover** (#313, open): `equipment-tab-reconstruct.ts`
+  reconstructs all six views (getProjectCategories tree + mixedGroups slot ordering,
+  uncat items/sub-hire-groups/project-groups, overbooked via the core, getSubHires slice)
+  from one `equipmentTab.bundle` subscription; `useNativeEquipmentTab` + `equipment-tab.tsx`
+  select native vs the six server resources behind `NEXT_PUBLIC_NATIVE_EQUIPMENT` (default
+  off; build-arg plumbed). Writes stay server actions (their `convex.mutation` pushes the
+  reactive delta — the `useProjectEquipmentLiveSync` doorbell is retired on this path).
+
+**Pattern established for the remaining Phase-2 surfaces** (warehouse/kit/asset/finance):
+referenced-only browser composite → client-safe pure reconstruction module (zero server
+imports; reuse the attach/tree helpers; unit-test parity) → `useNative*` hook + flag-gated
+consumer select → CI `next build` verifies client-safety → user flips the flag + verifies live.
+
 ### 3.6 Dashboard counters are a mini-domain, not a sub-bullet (review point 4)
 
 `getDashboardStats` derives counts across **seven domains** — assets, bulk assets, projects, maintenance records, project line items, crew members, crew assignments (`src/server/dashboard.ts:29-66`) — today by whole-org `.collect()` + JS counting. A native reactive port cannot `.collect().length` (Convex has no count operator and would hit the 32k-doc/16 MiB limits on a large tenant), so the counts must come from **maintained denormalized counter tables**. That is a write-path obligation, not a read swap, and needs its own scoped design before Phase 3 starts:

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -20,6 +20,10 @@ import {
   useProjectSubHires,
   useProjectEquipmentLiveSync,
 } from "@/hooks/use-project-equipment";
+import {
+  NATIVE_EQUIPMENT_ENABLED,
+  useNativeEquipmentTab,
+} from "@/hooks/use-native-equipment-tab";
 import { Plus, FolderPlus, FolderTree, Pencil, ChevronDown as ChevronDownIcon } from "lucide-react";
 import {
   DropdownMenu,
@@ -123,10 +127,22 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
+  // Native read-layer path (Phase 2, default OFF). When the flag is on, ALL six
+  // equipment views come from ONE reactive equipmentTab.bundle subscription
+  // (reconstructed client-side) — no server actions, no doorbell→refetch. Both the
+  // native hook and the server-action hooks below run (rules-of-hooks); the flag
+  // only selects which result we use. When off, the native hook is a no-op (skips).
+  const native = useNativeEquipmentTab(projectId, orgId);
+
   // Cross-tab live sync: subscribe to the dual-written line-item / group /
   // category Convex tables and re-fetch the equipment composites whenever
   // another tab (or collaborator) edits pricing, moves items, or changes groups.
-  useProjectEquipmentLiveSync(projectId, orgId);
+  // The native path is already reactive over its own subscription — skip the
+  // doorbell there (pass undefined so the live-sync subscriptions don't fire).
+  useProjectEquipmentLiveSync(
+    NATIVE_EQUIPMENT_ENABLED ? undefined : projectId,
+    NATIVE_EQUIPMENT_ENABLED ? undefined : orgId,
+  );
 
   // Passive section/group collaboration state: one lock subscription and one
   // comment-count subscription for the project, then row lookups by target key.
@@ -282,23 +298,30 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
     });
   }, []);
 
-  const { data: categories = [], isLoading } = useProjectCategories(projectId);
+  // Server-action shared resources (the legacy path). When native is on, each is
+  // passed `undefined` so its fetch skips (no double-fetch alongside the native
+  // subscription); the value comes from `native` instead.
+  const scKey = NATIVE_EQUIPMENT_ENABLED ? undefined : projectId;
+  const { data: scCategories = [], isLoading: scLoading } = useProjectCategories(scKey);
+  const { data: scUncategorizedItems = [] } = useUncategorizedItems(scKey);
+  const { data: scUncategorizedSubHireGroups = [] } = useUncategorizedSubHireGroups(scKey);
+  const { data: scUncategorizedProjectGroups = [] } = useUncategorizedProjectGroups(scKey);
+  const { data: scOverbookedMap = {} } = useProjectOverbooked(scKey);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: scProjectSubHires = [] } = useProjectSubHires(scKey) as { data: any[] };
 
-  const { data: uncategorizedItems = [] } = useUncategorizedItems(projectId);
-
-  const { data: uncategorizedSubHireGroups = [] } = useUncategorizedSubHireGroups(projectId);
-
-  const { data: uncategorizedProjectGroups = [] } = useUncategorizedProjectGroups(projectId);
+  const categories = NATIVE_EQUIPMENT_ENABLED ? native.categories : scCategories;
+  const isLoading = NATIVE_EQUIPMENT_ENABLED ? native.isLoading : scLoading;
+  const uncategorizedItems = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedItems : scUncategorizedItems;
+  const uncategorizedSubHireGroups = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedSubHireGroups : scUncategorizedSubHireGroups;
+  const uncategorizedProjectGroups = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedProjectGroups : scUncategorizedProjectGroups;
+  const overbookedMap = NATIVE_EQUIPMENT_ENABLED ? native.overbookedMap : scOverbookedMap;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const projectSubHires = (NATIVE_EQUIPMENT_ENABLED ? native.projectSubHires : scProjectSubHires) as any[];
 
   const { data: templates = [] } = useGroupTemplates(orgId);
 
   const { data: servicesData } = useProjectServices(projectId);
-
-  const { data: overbookedMap = {} } = useProjectOverbooked(projectId);
-
-  // Availability check for the currently-edited line item (equipment w/ modelId only)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: projectSubHires = [] } = useProjectSubHires(projectId) as { data: any[] };
 
   const templateOptions = (templates as { id: string; name: string; description: string | null; items: unknown[] }[]).map(
     (t) => ({ id: t.id, name: t.name, description: t.description, itemCount: t.items.length })

--- a/src/hooks/use-native-equipment-tab.ts
+++ b/src/hooks/use-native-equipment-tab.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { useProject } from "@/hooks/use-projects";
+import { api } from "../../convex/_generated/api";
+import {
+  reconstructProjectCategories,
+  reconstructUncategorizedLineItems,
+  reconstructUncategorizedSubHireGroups,
+  reconstructUncategorizedProjectGroups,
+  reconstructProjectSubHires,
+  reconstructOverbookedRecord,
+  type ProjectSubHireSummary,
+} from "@/lib/equipment-tab-reconstruct";
+import type {
+  CategoryData,
+  GroupData,
+  SubHireGroupData,
+  LineItemData,
+} from "@/components/projects/equipment-rows";
+import type { OverbookedInfo } from "@/lib/overbooking-core";
+
+/**
+ * Feature flag (default OFF) for the native equipment-tab read cutover (Phase 2).
+ * Until "true" in the build env, equipment-tab keeps its six server-action shared
+ * resources — so merging the cutover changes nothing for users. Inlined at build
+ * time, so flipping it needs the Dockerfile/build-image build-arg + repo var.
+ */
+export const NATIVE_EQUIPMENT_ENABLED =
+  process.env.NEXT_PUBLIC_NATIVE_EQUIPMENT === "true";
+
+export interface NativeEquipmentTab {
+  categories: CategoryData[];
+  uncategorizedItems: LineItemData[];
+  uncategorizedSubHireGroups: SubHireGroupData[];
+  uncategorizedProjectGroups: GroupData[];
+  overbookedMap: Record<string, OverbookedInfo>;
+  projectSubHires: ProjectSubHireSummary[];
+  isLoading: boolean;
+}
+
+const toDate = (n: number | null | undefined): Date | null =>
+  typeof n === "number" ? new Date(n) : null;
+
+/**
+ * Native equipment editing tab: ONE `equipmentTab.bundle` subscription (+
+ * `overbooking.bundle` for the overbooked view) reconstructs all six views the
+ * tab's server actions returned — reactive over the WebSocket, no doorbell→refetch.
+ * Skips entirely unless the flag is on and ids are present (so the hook is a no-op
+ * when the flag is off — equipment-tab keeps its server-action path).
+ *
+ * Cross-tab liveness is automatic: writes are still server actions, but each calls
+ * convex.mutation, which pushes the delta to this useQuery subscription — the
+ * `useProjectEquipmentLiveSync` doorbell is no longer needed on this path.
+ */
+export function useNativeEquipmentTab(
+  projectId: string | undefined,
+  orgId: string | undefined,
+): NativeEquipmentTab {
+  const enabled = NATIVE_EQUIPMENT_ENABLED && !!projectId && !!orgId;
+  const bundle = useAuthedQuery(
+    api.equipmentTab.bundle,
+    enabled ? { projectId: projectId!, orgId: orgId! } : "skip",
+  );
+
+  // The project doc supplies the rental window the overbooked computation needs.
+  const project = useProject(enabled ? projectId : undefined);
+
+  // Overbooked: referenced models from the FLAT non-cancelled line items (mirrors
+  // getProjectOverbookedStatus's modelIds). Skip the subscription when none.
+  const modelIds = useMemo(() => {
+    if (!bundle) return undefined;
+    return [
+      ...new Set(
+        bundle.lineItems
+          .filter((li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null)
+          .map((li) => li.modelId!),
+      ),
+    ];
+  }, [bundle]);
+  const overbooking = useAuthedQuery(
+    api.overbooking.bundle,
+    enabled && orgId && modelIds && modelIds.length > 0
+      ? { orgId: orgId!, modelIds }
+      : "skip",
+  );
+
+  const categories = useMemo(
+    () => (bundle ? reconstructProjectCategories(bundle) : []),
+    [bundle],
+  );
+  const uncategorizedItems = useMemo(
+    () => (bundle ? reconstructUncategorizedLineItems(bundle) : []),
+    [bundle],
+  );
+  const uncategorizedSubHireGroups = useMemo(
+    () => (bundle ? reconstructUncategorizedSubHireGroups(bundle) : []),
+    [bundle],
+  );
+  const uncategorizedProjectGroups = useMemo(
+    () => (bundle ? reconstructUncategorizedProjectGroups(bundle) : []),
+    [bundle],
+  );
+  const projectSubHires = useMemo(
+    () => (bundle ? reconstructProjectSubHires(bundle) : []),
+    [bundle],
+  );
+  const overbookedMap = useMemo(
+    () =>
+      bundle && projectId
+        ? reconstructOverbookedRecord(
+            bundle,
+            overbooking ?? undefined,
+            toDate(project?.rentalStartDate),
+            toDate(project?.rentalEndDate),
+            projectId,
+          )
+        : {},
+    [bundle, overbooking, project?.rentalStartDate, project?.rentalEndDate, projectId],
+  );
+
+  return {
+    categories,
+    uncategorizedItems,
+    uncategorizedSubHireGroups,
+    uncategorizedProjectGroups,
+    overbookedMap,
+    projectSubHires,
+    isLoading: enabled && bundle === undefined,
+  };
+}

--- a/src/lib/equipment-tab-reconstruct.test.ts
+++ b/src/lib/equipment-tab-reconstruct.test.ts
@@ -130,6 +130,20 @@ describe("reconstructProjectCategories", () => {
       { kind: "project", sortOrder: 2, projectGroupId: "g1" },
     ]);
   });
+
+  it("places a sub-hire-group parent line (subHireGroupId + categoryId) in BOTH buckets, like the server's dual pass", () => {
+    const b = bundle({
+      categories: [d({ id: "c1", organizationId: ORG, projectId: PROJ, name: "Audio", sortOrder: 0 })],
+      subHires: [d({ id: "sh1", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-1", status: "ON_HIRE" })],
+      subHireGroups: [d({ id: "shg1", subHireId: "sh1", title: "Hired", sortOrder: 0, targetCategoryId: "c1" })],
+      // The synthetic sub-hire-group parent carries BOTH subHireGroupId and categoryId.
+      lineItems: [li({ id: "shgParent", subHireGroupId: "shg1", categoryId: "c1" })],
+      suppliers: [d({ id: "sup1", organizationId: ORG, name: "AVHire Co" })],
+    });
+    const [cat] = reconstructProjectCategories(b);
+    expect(cat.subHireGroupTargets?.[0].lineItems?.map((i) => i.id)).toEqual(["shgParent"]);
+    expect(cat.lineItems?.map((i) => i.id)).toEqual(["shgParent"]); // also in the category bucket
+  });
 });
 
 describe("reconstructProjectSubHires", () => {

--- a/src/lib/equipment-tab-reconstruct.test.ts
+++ b/src/lib/equipment-tab-reconstruct.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  reconstructProjectCategories,
+  reconstructUncategorizedLineItems,
+  reconstructUncategorizedSubHireGroups,
+  reconstructUncategorizedProjectGroups,
+  reconstructProjectSubHires,
+  reconstructOverbookedRecord,
+  type EquipmentTabBundleData,
+} from "./equipment-tab-reconstruct";
+import type { OverbookingBundleData } from "./overbooking-core";
+
+/**
+ * Parity coverage for the native equipment-tab reconstruction — the six views the
+ * tab's server actions returned, rebuilt from one equipmentTab.bundle.
+ */
+
+const d = <T extends Record<string, unknown>>(o: T) =>
+  ({ _id: `id_${o.id ?? "x"}`, _creationTime: 0, ...o }) as never;
+
+const EMPTY: EquipmentTabBundleData = {
+  lineItems: [], categories: [], groups: [], categorySlots: [], subHires: [],
+  subHireGroups: [], subHireItems: [], assets: [], bulkAssets: [], kits: [],
+  models: [], suppliers: [], orgCategories: [],
+} as never;
+
+function bundle(parts: Partial<Record<keyof EquipmentTabBundleData, unknown[]>>): EquipmentTabBundleData {
+  return { ...EMPTY, ...parts } as never;
+}
+
+const ORG = "o1";
+const PROJ = "p1";
+
+function li(p: Record<string, unknown>) {
+  return d({ organizationId: ORG, projectId: PROJ, quantity: 1, status: "QUOTED", ...p });
+}
+
+describe("reconstructUncategorizedLineItems", () => {
+  it("returns top-level items with no category/group, attached with model + asset", () => {
+    const b = bundle({
+      lineItems: [
+        li({ id: "li1", modelId: "m1", assetId: "a1", quantity: 2 }),
+        li({ id: "li2", categoryId: "c1" }), // categorized → excluded
+        li({ id: "li3", groupId: "g1" }), // grouped → excluded
+        li({ id: "kc", parentLineItemId: "li1", isKitChild: true }), // child → excluded
+      ],
+      models: [d({ id: "m1", organizationId: ORG, name: "SM58", categoryId: "cat1" })],
+      assets: [d({ id: "a1", organizationId: ORG, modelId: "m1", assetTag: "SM58-001", status: "AVAILABLE" })],
+      orgCategories: [d({ id: "cat1", organizationId: ORG, name: "Audio" })],
+    });
+    const out = reconstructUncategorizedLineItems(b);
+    expect(out.map((i) => i.id)).toEqual(["li1"]);
+    expect(out[0].model?.name).toBe("SM58");
+    expect(out[0].asset?.assetTag).toBe("SM58-001");
+  });
+});
+
+describe("reconstructUncategorizedProjectGroups", () => {
+  it("returns groups with no category, each with its line items", () => {
+    const b = bundle({
+      groups: [
+        d({ id: "g1", organizationId: ORG, projectId: PROJ, title: "Mics", quantity: 1, sortOrder: 1 }),
+        d({ id: "g2", organizationId: ORG, projectId: PROJ, categoryId: "c1", title: "InCat", sortOrder: 0 }),
+      ],
+      lineItems: [li({ id: "li1", groupId: "g1" })],
+    });
+    const out = reconstructUncategorizedProjectGroups(b);
+    expect(out.map((g) => g.id)).toEqual(["g1"]);
+    expect(out[0].title).toBe("Mics");
+    expect(out[0].lineItems?.map((i) => i.id)).toEqual(["li1"]);
+  });
+});
+
+describe("reconstructUncategorizedSubHireGroups", () => {
+  it("returns uncategorized sub-hire groups with items, subHire + supplier, and line items", () => {
+    const b = bundle({
+      subHires: [d({ id: "sh1", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-1", status: "DRAFT" })],
+      subHireGroups: [d({ id: "shg1", subHireId: "sh1", title: "Hired Lights", quantity: 2, cost: 100, charge: 150, sortOrder: 0 })],
+      subHireItems: [d({ id: "it1", subHireId: "sh1", groupId: "shg1", description: "Mover", quantity: 4, unitCost: 25, unitCharge: 40 })],
+      lineItems: [li({ id: "li1", subHireGroupId: "shg1" })],
+      suppliers: [d({ id: "sup1", organizationId: ORG, name: "AVHire Co" })],
+    });
+    const out = reconstructUncategorizedSubHireGroups(b);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("shg1");
+    expect(out[0].subHire.orderNumber).toBe("SH-1");
+    expect(out[0].subHire.supplier?.name).toBe("AVHire Co");
+    expect(out[0].items?.map((i) => i.id)).toEqual(["it1"]);
+    expect(out[0].lineItems?.map((i) => i.id)).toEqual(["li1"]);
+  });
+
+  it("excludes categorized sub-hire groups", () => {
+    const b = bundle({
+      subHires: [d({ id: "sh1", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-1", status: "DRAFT" })],
+      subHireGroups: [d({ id: "shg1", subHireId: "sh1", title: "Cat'd", sortOrder: 0, targetCategoryId: "c1" })],
+    });
+    expect(reconstructUncategorizedSubHireGroups(b)).toEqual([]);
+  });
+});
+
+describe("reconstructProjectCategories", () => {
+  it("builds categories with groups, sub-hire targets, direct items, and mixedGroups in slot order", () => {
+    const b = bundle({
+      categories: [d({ id: "c1", organizationId: ORG, projectId: PROJ, name: "Audio", sortOrder: 0 })],
+      groups: [d({ id: "g1", organizationId: ORG, projectId: PROJ, categoryId: "c1", title: "Mics", quantity: 1, sortOrder: 5 })],
+      subHires: [d({ id: "sh1", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-1", status: "ON_HIRE" })],
+      subHireGroups: [d({ id: "shg1", subHireId: "sh1", title: "Hired", sortOrder: 9, targetCategoryId: "c1" })],
+      // Slot order: sub-hire group BEFORE the project group despite higher group.sortOrder.
+      categorySlots: [
+        d({ id: "sl1", projectCategoryId: "c1", projectGroupId: "g1", sortOrder: 2 }),
+        d({ id: "sl2", projectCategoryId: "c1", subHireGroupId: "shg1", sortOrder: 1 }),
+      ],
+      lineItems: [
+        li({ id: "liDirect", categoryId: "c1" }),
+        li({ id: "liInGroup", groupId: "g1" }),
+        li({ id: "liInSHG", subHireGroupId: "shg1" }),
+      ],
+      suppliers: [d({ id: "sup1", organizationId: ORG, name: "AVHire Co" })],
+    });
+    const [cat] = reconstructProjectCategories(b);
+    expect(cat.id).toBe("c1");
+    expect(cat.groups.map((g) => g.id)).toEqual(["g1"]);
+    expect(cat.groups[0].lineItems?.map((i) => i.id)).toEqual(["liInGroup"]);
+    expect(cat.subHireGroupTargets?.map((s) => s.id)).toEqual(["shg1"]);
+    expect(cat.subHireGroupTargets?.[0].lineItems?.map((i) => i.id)).toEqual(["liInSHG"]);
+    expect(cat.lineItems?.map((i) => i.id)).toEqual(["liDirect"]);
+    // mixedGroups ordered by slot.sortOrder (sub-hire 1, project 2).
+    expect(cat.mixedGroups).toEqual([
+      { kind: "subHire", sortOrder: 1, subHireGroupId: "shg1" },
+      { kind: "project", sortOrder: 2, projectGroupId: "g1" },
+    ]);
+  });
+});
+
+describe("reconstructProjectSubHires", () => {
+  it("returns summaries with _count.items + supplier, newest first", () => {
+    const b = bundle({
+      subHires: [
+        d({ id: "sh1", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-1", status: "DRAFT", totalCost: 10, totalCharge: 20, createdAt: 100 }),
+        d({ id: "sh2", organizationId: ORG, projectId: PROJ, supplierId: "sup1", createdById: "u1", orderNumber: "SH-2", status: "ON_HIRE", createdAt: 200 }),
+      ],
+      subHireItems: [
+        d({ id: "it1", subHireId: "sh1", description: "x", quantity: 1 }),
+        d({ id: "it2", subHireId: "sh1", description: "y", quantity: 1 }),
+      ],
+      suppliers: [d({ id: "sup1", organizationId: ORG, name: "AVHire Co" })],
+    });
+    const out = reconstructProjectSubHires(b);
+    expect(out.map((s) => s.id)).toEqual(["sh2", "sh1"]); // createdAt desc
+    expect(out.find((s) => s.id === "sh1")?._count.items).toBe(2);
+    expect(out[0].supplier?.name).toBe("AVHire Co");
+  });
+});
+
+describe("reconstructOverbookedRecord", () => {
+  const WIN_START = new Date("2026-01-01T00:00:00Z");
+  const WIN_END = new Date("2026-01-10T00:00:00Z");
+
+  it("returns {} with no overbooking bundle", () => {
+    expect(reconstructOverbookedRecord(EMPTY, undefined, WIN_START, WIN_END, PROJ)).toEqual({});
+  });
+
+  it("flags an overbooked model (flat kit-child input — books 3 of stock 2)", () => {
+    const b = bundle({ lineItems: [li({ id: "li1", modelId: "m1", quantity: 3 })] });
+    const ob: OverbookingBundleData = {
+      lineItems: [d({ id: "li1", organizationId: ORG, projectId: PROJ, modelId: "m1", quantity: 3, status: "QUOTED" })],
+      assets: [d({ id: "a1", organizationId: ORG, modelId: "m1", status: "AVAILABLE", isActive: true }), d({ id: "a2", organizationId: ORG, modelId: "m1", status: "AVAILABLE", isActive: true })],
+      bulkAssets: [],
+      projects: [d({ id: PROJ, organizationId: ORG, projectNumber: "P-1", name: "Gig", status: "CONFIRMED", isTemplate: false, rentalStartDate: WIN_START.getTime(), rentalEndDate: WIN_END.getTime() })],
+      models: [d({ id: "m1", organizationId: ORG, assetType: "SERIALIZED" })],
+    } as never;
+    const rec = reconstructOverbookedRecord(b, ob, WIN_START, WIN_END, PROJ);
+    expect(rec["li1"]).toMatchObject({ overBy: 1 });
+  });
+});

--- a/src/lib/equipment-tab-reconstruct.ts
+++ b/src/lib/equipment-tab-reconstruct.ts
@@ -1,0 +1,505 @@
+/**
+ * CLIENT-SAFE reconstruction of the project EQUIPMENT EDITING TAB's six
+ * server-action reads from the ONE `equipmentTab.bundle` subscription (+
+ * `overbooking.bundle` for the overbooked view). Zero server imports.
+ *
+ * The six views, reproduced byte-for-byte from the server actions they replace
+ * (parity-by-construction — these are direct ports with the same composition):
+ *   1. reconstructProjectCategories   ← getProjectCategories
+ *   2. reconstructUncategorizedLineItems ← getUncategorizedLineItems
+ *   3. reconstructUncategorizedSubHireGroups ← getUncategorizedSubHireGroups
+ *   4. reconstructUncategorizedProjectGroups ← getUncategorizedProjectGroups
+ *   5. reconstructOverbookedRecord     ← getProjectOverbookedStatus
+ *   6. reconstructProjectSubHires      ← getSubHires({ projectId }) — equipment-tab
+ *      slice only (summary + draft detection; SubHireExpandedItems fetches its own).
+ *
+ * Reuses the pure line-item attach/tree helpers from project-equipment-reconstruct
+ * and project-line-item-tree-read. The sub-hire mappers are COPIES of the pure ones
+ * in sub-hire-read.ts (which keeps server-only co-residents) — keep them in sync.
+ */
+import type { FunctionReturnType } from "convex/server";
+import type { Doc } from "../../convex/_generated/dataModel";
+import type { api } from "../../convex/_generated/api";
+import type {
+  SubHireStatus,
+  SubHirePricingMode,
+  SubHirePaymentStatus,
+  PricingType,
+} from "@/generated/prisma/client";
+import type { ConvexAsset, ConvexBulkAsset } from "@/lib/assets-read";
+import type { ConvexKit } from "@/lib/kits-read";
+import type { ConvexModel } from "@/lib/models-read";
+import type { ConvexSupplier } from "@/lib/suppliers-read";
+import type { ConvexCategory } from "@/lib/categories-read";
+import type {
+  CategoryData,
+  GroupData,
+  SubHireGroupData,
+  LineItemData,
+  MixedGroupSlot,
+} from "@/components/projects/equipment-rows";
+import {
+  mapLineItemDoc,
+  mapCategoryDoc,
+  mapGroupDoc,
+  attachLineItemTree,
+  attachAssetBulkKitPlain,
+  resolveAttachedSupplier,
+  type LineItemAttachMaps,
+  type MappedLineItem,
+} from "@/lib/project-equipment-reconstruct";
+import { indexChildren, reconstructScope } from "@/lib/project-line-item-tree-read";
+import {
+  reconstructOverbookedStatus,
+  type OverbookedInfo,
+  type OverbookingBundleData,
+} from "@/lib/overbooking-core";
+
+/** The raw-doc bundle `equipmentTab.bundle` returns. */
+export type EquipmentTabBundleData = FunctionReturnType<typeof api.equipmentTab.bundle>;
+
+// ─── Sub-hire mappers (copies of sub-hire-read.ts pure mappers) ──────────────
+
+type RawSubHire = Doc<"subHires">;
+type RawItem = Doc<"subHireItems">;
+type RawGroup = Doc<"subHireGroups">;
+
+const toDate = (v: number | undefined): Date | null => (typeof v === "number" ? new Date(v) : null);
+const orNull = <T>(v: T | undefined): T | null => (v === undefined ? null : v);
+const req = <T>(v: T | undefined): T => v as T;
+
+interface SubHireRow {
+  id: string;
+  organizationId: string;
+  supplierId: string;
+  projectId: string | null;
+  createdById: string;
+  orderNumber: string;
+  supplierReference: string | null;
+  status: SubHireStatus;
+  hireStart: Date | null;
+  hireEnd: Date | null;
+  totalCost: number;
+  totalCharge: number;
+  pricingMode: SubHirePricingMode;
+  orderTotalCost: number | null;
+  orderTotalCharge: number | null;
+  showOnDocs: boolean;
+  paymentStatus: SubHirePaymentStatus;
+  notes: string | null;
+  defaultTargetCategoryId: string | null;
+  defaultTargetGroupId: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+interface SubHireItemRow {
+  id: string;
+  subHireId: string;
+  groupId: string | null;
+  modelId: string | null;
+  description: string;
+  quantity: number;
+  unitCost: number;
+  unitCharge: number;
+  pricingType: PricingType;
+  duration: number;
+  discount: number;
+  showOnQuote: boolean;
+  showOnDocs: boolean;
+  sortOrder: number;
+  targetCategoryId: string | null;
+  targetGroupId: string | null;
+}
+
+interface SubHireGroupRow {
+  id: string;
+  subHireId: string;
+  title: string;
+  sortOrder: number;
+  quantity: number;
+  cost: number | null;
+  charge: number | null;
+  showOnQuote: boolean;
+  showOnDocs: boolean;
+  targetCategoryId: string | null;
+  targetGroupId: string | null;
+}
+
+function mapSubHire(d: RawSubHire): SubHireRow {
+  return {
+    id: d.id,
+    organizationId: req(d.organizationId),
+    supplierId: req(d.supplierId),
+    projectId: orNull(d.projectId),
+    createdById: req(d.createdById),
+    orderNumber: req(d.orderNumber),
+    supplierReference: orNull(d.supplierReference),
+    status: (d.status ?? "DRAFT") as SubHireStatus,
+    hireStart: toDate(d.hireStart),
+    hireEnd: toDate(d.hireEnd),
+    totalCost: d.totalCost ?? 0,
+    totalCharge: d.totalCharge ?? 0,
+    pricingMode: (d.pricingMode ?? "ITEMIZED") as SubHirePricingMode,
+    orderTotalCost: orNull(d.orderTotalCost),
+    orderTotalCharge: orNull(d.orderTotalCharge),
+    showOnDocs: d.showOnDocs ?? false,
+    paymentStatus: (d.paymentStatus ?? "UNPAID") as SubHirePaymentStatus,
+    notes: orNull(d.notes),
+    defaultTargetCategoryId: orNull(d.defaultTargetCategoryId),
+    defaultTargetGroupId: orNull(d.defaultTargetGroupId),
+    createdAt: toDate(d.createdAt),
+    updatedAt: toDate(d.updatedAt),
+  };
+}
+
+function mapSubHireItem(d: RawItem): SubHireItemRow {
+  return {
+    id: d.id,
+    subHireId: req(d.subHireId),
+    groupId: orNull(d.groupId),
+    modelId: orNull(d.modelId),
+    description: req(d.description),
+    quantity: d.quantity ?? 1,
+    unitCost: d.unitCost ?? 0,
+    unitCharge: d.unitCharge ?? 0,
+    pricingType: (d.pricingType ?? "FLAT") as PricingType,
+    duration: d.duration ?? 1,
+    discount: d.discount ?? 0,
+    showOnQuote: d.showOnQuote ?? true,
+    showOnDocs: d.showOnDocs ?? false,
+    sortOrder: d.sortOrder ?? 0,
+    targetCategoryId: orNull(d.targetCategoryId),
+    targetGroupId: orNull(d.targetGroupId),
+  };
+}
+
+function mapSubHireGroup(d: RawGroup): SubHireGroupRow {
+  return {
+    id: d.id,
+    subHireId: req(d.subHireId),
+    title: req(d.title),
+    sortOrder: d.sortOrder ?? 0,
+    quantity: d.quantity ?? 1,
+    cost: orNull(d.cost),
+    charge: orNull(d.charge),
+    showOnQuote: d.showOnQuote ?? true,
+    showOnDocs: d.showOnDocs ?? false,
+    targetCategoryId: orNull(d.targetCategoryId),
+    targetGroupId: orNull(d.targetGroupId),
+  };
+}
+
+// ─── Shared attach context (one per bundle) ──────────────────────────────────
+
+interface EquipmentContext {
+  mappedLineItems: MappedLineItem[];
+  byParent: Map<string, MappedLineItem[]>;
+  attachMaps: LineItemAttachMaps;
+  assetMap: Map<string, ConvexAsset>;
+  bulkAssetMap: Map<string, ConvexBulkAsset>;
+  kitMap: Map<string, ConvexKit>;
+}
+
+function buildContext(bundle: EquipmentTabBundleData): EquipmentContext {
+  const mappedLineItems = bundle.lineItems.map(mapLineItemDoc);
+  return {
+    mappedLineItems,
+    byParent: indexChildren(mappedLineItems),
+    attachMaps: {
+      models: new Map(bundle.models.map((m) => [m.id, m as unknown as ConvexModel])),
+      suppliers: new Map(bundle.suppliers.map((s) => [s.id, s as unknown as ConvexSupplier])),
+      categories: new Map(bundle.orgCategories.map((c) => [c.id, c as unknown as ConvexCategory])),
+    },
+    assetMap: new Map(bundle.assets.map((a) => [a.id, a as unknown as ConvexAsset])),
+    bulkAssetMap: new Map(bundle.bulkAssets.map((b) => [b.id, b as unknown as ConvexBulkAsset])),
+    kitMap: new Map(bundle.kits.map((k) => [k.id, k as unknown as ConvexKit])),
+  };
+}
+
+/**
+ * Reconstruct (childLineItems depth 1, NO units) + fully attach a scope of mapped
+ * line items — matching the old Prisma include shape these reads used (mirror of
+ * project-categories.ts attachScopeRows: server uses an empty unit map here too).
+ */
+function attachScope(scopeRows: MappedLineItem[], ctx: EquipmentContext): LineItemData[] {
+  const reconstructed = reconstructScope(scopeRows, ctx.byParent, {
+    unitsByLineItem: new Map(),
+    depth: 1,
+  });
+  const withModelSupplier = attachLineItemTree(reconstructed, ctx.attachMaps);
+  return attachAssetBulkKitPlain(
+    withModelSupplier as never[],
+    ctx.assetMap,
+    ctx.bulkAssetMap,
+    ctx.kitMap,
+  ) as unknown as LineItemData[];
+}
+
+// ─── View 1: getProjectCategories ────────────────────────────────────────────
+
+/** SubHireGroupData (categorized or not) from a mapped group + its sub-hire/items. */
+function buildSubHireGroupData(
+  g: SubHireGroupRow,
+  subHireById: Map<string, SubHireRow>,
+  itemsByGroupId: Map<string, SubHireItemRow[]>,
+  lineItemsBySubHireGroupId: Map<string, MappedLineItem[]>,
+  ctx: EquipmentContext,
+): SubHireGroupData {
+  const subHire = subHireById.get(g.subHireId)!;
+  return {
+    id: g.id,
+    title: g.title,
+    quantity: g.quantity,
+    cost: g.cost,
+    charge: g.charge,
+    sortOrder: g.sortOrder,
+    targetCategoryId: g.targetCategoryId,
+    showOnQuote: g.showOnQuote,
+    showOnDocs: g.showOnDocs,
+    subHire: {
+      id: subHire.id,
+      orderNumber: subHire.orderNumber,
+      status: subHire.status,
+      supplier: resolveAttachedSupplier(subHire.supplierId, ctx.attachMaps),
+    },
+    items: itemsByGroupId.get(g.id) ?? [],
+    lineItems: attachScope(lineItemsBySubHireGroupId.get(g.id) ?? [], ctx),
+  };
+}
+
+/** GroupData (project group) from a mapped group + its line items. */
+function buildGroupData(
+  g: ReturnType<typeof mapGroupDoc>,
+  lineItemsByGroupId: Map<string, MappedLineItem[]>,
+  ctx: EquipmentContext,
+): GroupData {
+  return {
+    id: g.id,
+    title: g.title,
+    description: g.description,
+    quantity: g.quantity,
+    price: g.price,
+    suggestedPrice: g.suggestedPrice,
+    rentalPeriod: g.rentalPeriod,
+    rentalQuantity: g.rentalQuantity,
+    sortOrder: g.sortOrder,
+    lineItems: attachScope(lineItemsByGroupId.get(g.id) ?? [], ctx),
+  };
+}
+
+export function reconstructProjectCategories(bundle: EquipmentTabBundleData): CategoryData[] {
+  const ctx = buildContext(bundle);
+  const { mappedLineItems } = ctx;
+
+  // Category slots → sortOrder lookups (for the mixedGroups ordering).
+  const slotByGroupId = new Map(
+    bundle.categorySlots.filter((s) => s.projectGroupId).map((s) => [s.projectGroupId!, s]),
+  );
+  const slotBySubHireGroupId = new Map(
+    bundle.categorySlots.filter((s) => s.subHireGroupId).map((s) => [s.subHireGroupId!, s]),
+  );
+
+  // Sub-hire groups (categorized) + their items, keyed for assembly.
+  const subHireById = new Map(bundle.subHires.map((s) => [s.id, mapSubHire(s)]));
+  const subHireItems = bundle.subHireItems.map(mapSubHireItem);
+  const itemsByGroupId = new Map<string, SubHireItemRow[]>();
+  for (const it of subHireItems) {
+    if (!it.groupId) continue;
+    const arr = itemsByGroupId.get(it.groupId) ?? [];
+    arr.push(it);
+    itemsByGroupId.set(it.groupId, arr);
+  }
+  const categorizedSHGroups = bundle.subHireGroups
+    .map(mapSubHireGroup)
+    .filter((g) => g.targetCategoryId != null)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  const shGroupIdSet = new Set(categorizedSHGroups.map((g) => g.id));
+
+  // Top-level line items keyed by their grouping (mirror getProjectCategories).
+  const lineItemsBySubHireGroupId = new Map<string, MappedLineItem[]>();
+  const lineItemsByGroupId = new Map<string, MappedLineItem[]>();
+  const lineItemsByCatId = new Map<string, MappedLineItem[]>();
+  for (const li of mappedLineItems) {
+    if (li.isKitChild || li.parentLineItemId) continue;
+    if (li.subHireGroupId && shGroupIdSet.has(li.subHireGroupId)) {
+      const arr = lineItemsBySubHireGroupId.get(li.subHireGroupId) ?? [];
+      arr.push(li);
+      lineItemsBySubHireGroupId.set(li.subHireGroupId, arr);
+    } else if (li.groupId) {
+      const arr = lineItemsByGroupId.get(li.groupId) ?? [];
+      arr.push(li);
+      lineItemsByGroupId.set(li.groupId, arr);
+    } else if (li.categoryId) {
+      const arr = lineItemsByCatId.get(li.categoryId) ?? [];
+      arr.push(li);
+      lineItemsByCatId.set(li.categoryId, arr);
+    }
+  }
+
+  // Project groups + sub-hire groups grouped by category.
+  const groupsByCategoryId = new Map<string, ReturnType<typeof mapGroupDoc>[]>();
+  for (const g of bundle.groups.map(mapGroupDoc)) {
+    if (!g.categoryId) continue;
+    const arr = groupsByCategoryId.get(g.categoryId) ?? [];
+    arr.push(g);
+    groupsByCategoryId.set(g.categoryId, arr);
+  }
+  const subHireGroupsByCategory = new Map<string, SubHireGroupRow[]>();
+  for (const sg of categorizedSHGroups) {
+    if (!sg.targetCategoryId) continue;
+    const arr = subHireGroupsByCategory.get(sg.targetCategoryId) ?? [];
+    arr.push(sg);
+    subHireGroupsByCategory.set(sg.targetCategoryId, arr);
+  }
+
+  return bundle.categories
+    .map(mapCategoryDoc)
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+    .map((cat) => {
+      const catGroups = (groupsByCategoryId.get(cat.id) ?? [])
+        .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+        .map((g) => buildGroupData(g, lineItemsByGroupId, ctx));
+
+      const catSubHireGroups = (subHireGroupsByCategory.get(cat.id) ?? []).map((sg) =>
+        buildSubHireGroupData(sg, subHireById, itemsByGroupId, lineItemsBySubHireGroupId, ctx),
+      );
+
+      const mixedGroups: MixedGroupSlot[] = [
+        ...catGroups.map((g) => ({
+          kind: "project" as const,
+          sortOrder: slotByGroupId.get(g.id)?.sortOrder ?? g.sortOrder ?? 0,
+          projectGroupId: g.id,
+        })),
+        ...catSubHireGroups.map((sg) => ({
+          kind: "subHire" as const,
+          sortOrder: slotBySubHireGroupId.get(sg.id)?.sortOrder ?? sg.sortOrder ?? 0,
+          subHireGroupId: sg.id,
+        })),
+      ].sort((a, b) => a.sortOrder - b.sortOrder);
+
+      return {
+        id: cat.id,
+        name: cat.name,
+        sortOrder: cat.sortOrder,
+        groups: catGroups,
+        subHireGroupTargets: catSubHireGroups,
+        lineItems: attachScope(lineItemsByCatId.get(cat.id) ?? [], ctx),
+        mixedGroups,
+      };
+    });
+}
+
+// ─── View 2: getUncategorizedLineItems ───────────────────────────────────────
+
+export function reconstructUncategorizedLineItems(bundle: EquipmentTabBundleData): LineItemData[] {
+  const ctx = buildContext(bundle);
+  const scope = ctx.mappedLineItems.filter(
+    (li) => !li.isKitChild && !li.parentLineItemId && li.categoryId == null && li.groupId == null,
+  );
+  return attachScope(scope, ctx);
+}
+
+// ─── View 3: getUncategorizedSubHireGroups ───────────────────────────────────
+
+export function reconstructUncategorizedSubHireGroups(
+  bundle: EquipmentTabBundleData,
+): SubHireGroupData[] {
+  const ctx = buildContext(bundle);
+  const groups = bundle.subHireGroups
+    .map(mapSubHireGroup)
+    .filter((g) => g.targetCategoryId == null)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  if (groups.length === 0) return [];
+
+  const subHireById = new Map(bundle.subHires.map((s) => [s.id, mapSubHire(s)]));
+  const itemsByGroupId = new Map<string, SubHireItemRow[]>();
+  for (const it of bundle.subHireItems.map(mapSubHireItem)) {
+    if (!it.groupId) continue;
+    const arr = itemsByGroupId.get(it.groupId) ?? [];
+    arr.push(it);
+    itemsByGroupId.set(it.groupId, arr);
+  }
+  const groupIdSet = new Set(groups.map((g) => g.id));
+  const lineItemsBySubHireGroupId = new Map<string, MappedLineItem[]>();
+  for (const li of ctx.mappedLineItems) {
+    if (li.isKitChild || li.parentLineItemId) continue;
+    if (li.subHireGroupId && groupIdSet.has(li.subHireGroupId)) {
+      const arr = lineItemsBySubHireGroupId.get(li.subHireGroupId) ?? [];
+      arr.push(li);
+      lineItemsBySubHireGroupId.set(li.subHireGroupId, arr);
+    }
+  }
+  return groups.map((g) =>
+    buildSubHireGroupData(g, subHireById, itemsByGroupId, lineItemsBySubHireGroupId, ctx),
+  );
+}
+
+// ─── View 4: getUncategorizedProjectGroups ───────────────────────────────────
+
+export function reconstructUncategorizedProjectGroups(bundle: EquipmentTabBundleData): GroupData[] {
+  const ctx = buildContext(bundle);
+  const uncategorized = bundle.groups
+    .map(mapGroupDoc)
+    .filter((g) => !g.categoryId)
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+  if (uncategorized.length === 0) return [];
+
+  const groupIdSet = new Set(uncategorized.map((g) => g.id));
+  const lineItemsByGroupId = new Map<string, MappedLineItem[]>();
+  for (const li of ctx.mappedLineItems) {
+    if (li.isKitChild || li.parentLineItemId) continue;
+    if (li.groupId && groupIdSet.has(li.groupId)) {
+      const arr = lineItemsByGroupId.get(li.groupId) ?? [];
+      arr.push(li);
+      lineItemsByGroupId.set(li.groupId, arr);
+    }
+  }
+  return uncategorized.map((g) => buildGroupData(g, lineItemsByGroupId, ctx));
+}
+
+// ─── View 5: getProjectOverbookedStatus ──────────────────────────────────────
+
+/**
+ * `lineItemId → OverbookedInfo` record. Mirrors getProjectOverbookedStatus: the
+ * FLAT non-cancelled mapped line items are passed to reconstructOverbookedStatus
+ * (kit children included flat — different from getProject, which passes the nested
+ * tree). `null` project window / dates → still computed (dateless = this-project
+ * only). Returns `{}` when no overbooking bundle yet.
+ */
+export function reconstructOverbookedRecord(
+  bundle: EquipmentTabBundleData,
+  overbooking: OverbookingBundleData | undefined,
+  rentalStartDate: Date | null,
+  rentalEndDate: Date | null,
+  projectId: string,
+): Record<string, OverbookedInfo> {
+  if (!overbooking) return {};
+  const lineItems = bundle.lineItems.map(mapLineItemDoc).filter((li) => li.status !== "CANCELLED");
+  const map = reconstructOverbookedStatus(overbooking, lineItems, rentalStartDate, rentalEndDate, projectId);
+  return Object.fromEntries(map);
+}
+
+// ─── View 6: getSubHires({ projectId }) — equipment-tab slice ─────────────────
+
+/** The sub-hire summary fields the equipment-tab consumes (+ _count + supplier). */
+export type ProjectSubHireSummary = SubHireRow & {
+  _count: { items: number };
+  supplier: ConvexSupplier | null;
+};
+
+export function reconstructProjectSubHires(bundle: EquipmentTabBundleData): ProjectSubHireSummary[] {
+  const ctx = buildContext(bundle);
+  const itemCounts = new Map<string, number>();
+  for (const it of bundle.subHireItems) {
+    itemCounts.set(it.subHireId, (itemCounts.get(it.subHireId) ?? 0) + 1);
+  }
+  return bundle.subHires
+    .map(mapSubHire)
+    .sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0))
+    .map((sh) => ({
+      ...sh,
+      _count: { items: itemCounts.get(sh.id) ?? 0 },
+      supplier: resolveAttachedSupplier(sh.supplierId, ctx.attachMaps),
+    }));
+}

--- a/src/lib/equipment-tab-reconstruct.ts
+++ b/src/lib/equipment-tab-reconstruct.ts
@@ -316,7 +316,12 @@ export function reconstructProjectCategories(bundle: EquipmentTabBundleData): Ca
     .sort((a, b) => a.sortOrder - b.sortOrder);
   const shGroupIdSet = new Set(categorizedSHGroups.map((g) => g.id));
 
-  // Top-level line items keyed by their grouping (mirror getProjectCategories).
+  // Top-level line items keyed by their grouping. Mirror getProjectCategories'
+  // TWO INDEPENDENT passes (not one mutually-exclusive chain): a synthetic
+  // sub-hire-group parent line carries BOTH a subHireGroupId and a categoryId, so
+  // the server lands it in subHireGroupLineItems AND lineItemsByCatId. Pass 2 keys
+  // by groupId-else-categoryId without consulting subHireGroupId, exactly like
+  // src/server/project-categories.ts:186-195 + 222-235.
   const lineItemsBySubHireGroupId = new Map<string, MappedLineItem[]>();
   const lineItemsByGroupId = new Map<string, MappedLineItem[]>();
   const lineItemsByCatId = new Map<string, MappedLineItem[]>();
@@ -326,7 +331,11 @@ export function reconstructProjectCategories(bundle: EquipmentTabBundleData): Ca
       const arr = lineItemsBySubHireGroupId.get(li.subHireGroupId) ?? [];
       arr.push(li);
       lineItemsBySubHireGroupId.set(li.subHireGroupId, arr);
-    } else if (li.groupId) {
+    }
+  }
+  for (const li of mappedLineItems) {
+    if (li.isKitChild || li.parentLineItemId) continue;
+    if (li.groupId) {
       const arr = lineItemsByGroupId.get(li.groupId) ?? [];
       arr.push(li);
       lineItemsByGroupId.set(li.groupId, arr);


### PR DESCRIPTION
## What

Migrates the project **equipment editing tab** — the active ~15s-load pain — to ONE reactive `equipmentTab.bundle` subscription, reconstructing all six views client-side, behind `NEXT_PUBLIC_NATIVE_EQUIPMENT` (**default OFF**, so merging changes nothing for users).

Before: 6 server-action shared-resource composites + a `useProjectEquipmentLiveSync` doorbell that refetches all 6 on every Convex tick + cold refetch on every navigation.
After: 1 cached `useQuery(equipmentTab.bundle)` subscription (+ `overbooking.bundle` for the overbooked view), reconstructed client-side, reactive over the WebSocket.

## Pieces
- **`src/lib/equipment-tab-reconstruct.ts`** (client-safe, zero server imports): direct ports of `getProjectCategories` (categories → groups / sub-hire-group targets / direct line items + `mixedGroups` slot ordering), `getUncategorized{LineItems,SubHireGroups,ProjectGroups}`, `getProjectOverbookedStatus` (via overbooking-core, FLAT line-item input matching the server), and the equipment-tab slice of `getSubHires` (summary + `_count` + supplier). Reuses the pure attach/tree helpers; sub-hire mappers are copies of the pure `sub-hire-read` ones. **8 unit tests** cover every view incl. mixedGroups ordering + overbooked.
- **`equipmentTab.bundle` typing**: per-table point reads so referenced docs keep their full `Doc` type.
- **`useNativeEquipmentTab`** hook + **`equipment-tab.tsx`** wiring: flag selects native vs the 6 server resources; when native, the resources are passed `undefined` (skip — no double-fetch) and the doorbell is skipped. Writes stay server actions; their `convex.mutation` pushes the reactive delta.

## Parity
Each view is a line-by-line port of its server action (same filters, same grouping, same `attachScope` with empty units). Writes unchanged → `requirePermission` + `logActivity` audit preserved.

## To go live (follow-up + user)
1. Plumb `NEXT_PUBLIC_NATIVE_EQUIPMENT` as a Dockerfile/build-image build-arg + repo var (separate tiny PR).
2. User flips it and verifies the tab renders identically + cross-tab live updates.

## Test
- `equipment-tab-reconstruct.test.ts` (8) + `equipment-rows.test.ts` green; `tsc` + lint (0 errors) clean. CI `next build` verifies the new client imports stay client-safe.

Builds on #310 (referenced-only bundle) + #311 (overbooking-core), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)