### PR TITLE
feat(convex-native): native sub-hire dashboard stats (Phase 3, flag-gated)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -35,6 +35,7 @@ import type * as customFieldDefinitions from "../customFieldDefinitions.js";
 import type * as customRoles from "../customRoles.js";
 import type * as dashboardCounters from "../dashboardCounters.js";
 import type * as dashboardStats from "../dashboardStats.js";
+import type * as dashboardSubHire from "../dashboardSubHire.js";
 import type * as documentTemplates from "../documentTemplates.js";
 import type * as equipmentTab from "../equipmentTab.js";
 import type * as fileUploads from "../fileUploads.js";
@@ -141,6 +142,7 @@ declare const fullApi: ApiFromModules<{
   customRoles: typeof customRoles;
   dashboardCounters: typeof dashboardCounters;
   dashboardStats: typeof dashboardStats;
+  dashboardSubHire: typeof dashboardSubHire;
   documentTemplates: typeof documentTemplates;
   equipmentTab: typeof equipmentTab;
   fileUploads: typeof fileUploads;

--- a/convex/dashboardSubHire.ts
+++ b/convex/dashboardSubHire.ts
@@ -1,0 +1,35 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { requireOrgRead } from "./lib/auth";
+
+/**
+ * BROWSER-facing native replacement for getSubHireDashboardStats (Phase 3). The
+ * org's sub-hire heads are bounded (far fewer than the asset registry), so this
+ * reads them by_organizationId and aggregates the three stats — reactive, no
+ * counter needed. `now` + `monthStart` are client-passed (queries can't read the
+ * clock). Gated on requireOrgRead (org-scoping — matches getOrgContext).
+ */
+export const bundle = query({
+  args: { orgId: v.string(), now: v.number(), monthStart: v.number() },
+  handler: async (ctx, { orgId, now, monthStart }) => {
+    await requireOrgRead(ctx, orgId);
+    const subHires = await ctx.db
+      .query("subHires")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+
+    const activeSubHires = subHires.filter(
+      (sh) => sh.status === "CONFIRMED" || sh.status === "ON_HIRE",
+    ).length;
+
+    const monthlySubHireCost = subHires
+      .filter((sh) => sh.status !== "CANCELLED" && sh.hireStart != null && (sh.hireStart as number) >= monthStart)
+      .reduce((sum, sh) => sum + (sh.totalCost ?? 0), 0);
+
+    const overdueReturns = subHires.filter(
+      (sh) => sh.status === "ON_HIRE" && sh.hireEnd != null && (sh.hireEnd as number) < now,
+    ).length;
+
+    return { activeSubHires, monthlySubHireCost, overdueReturns };
+  },
+});

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -328,7 +328,27 @@ a missed consumed field is a silent runtime gap the type system won't catch unde
 Five flags now plumbed (Dockerfile ARG/ENV + build-image.yml build-arg):
 `NEXT_PUBLIC_NATIVE_{PROJECT_DETAIL, EQUIPMENT, WAREHOUSE, KIT, ASSET}` — set the matching GitHub repo
 variable to `true` + rebuild to flip each live (project-detail also needs the members backfill on prod).
-**Next: Phase 3** (dashboard counters, §3.6).
+
+**Phase 3 CORE COMPLETE (2026-06-29)** — the §3.6 counter mini-design + native dashboard stats:
+- **#318 (merged):** `dashboardCounters` table + `convex/dashboardCounters.ts` (`computeCounters`,
+  `reconcile`, **`reconcileIfStale`**, `bump`, `getByOrg`) + `dashboardStats.bundle` + backfill +
+  convex-test parity. The native stats tile reads the six counters O(1) + computes the two date-derived
+  metrics (`maintenanceDue`, `overdueReturns`) at read from bounded indexed queries. Behind
+  `NEXT_PUBLIC_NATIVE_DASHBOARD`.
+- **#319:** native sub-hire stats tile (`dashboardSubHire.bundle` — bounded, no counter).
+- **Maintenance mechanism — reconcile-on-view, NOT per-write bumps:** the counted dimensions change
+  across many writes incl. the GENERATED asset CRUD (can't hand-edit) and ~a dozen asset-status
+  transitions in `warehouseOps`, so atomic per-write bumps would be invasive + fragile. Instead the
+  dashboard hook fires `reconcileIfStale` on view, throttled to ≤ once/`maxAge` per org — O(1) on the
+  hot read path, zero write-site risk, fresh-enough for a stats overview. `bump` is kept for a future
+  targeted hook. Reconcile reads are bounded per-org (pagination is future hardening for huge tenants).
+- **Deferred (low-risk):** `getUpcomingProjects` / `getMyHomeData` / `getMyBlockingComments` read
+  BOUNDED project/thread sets (not the whole-org registry → not the limit risk) — convertible to native
+  composites for reactivity polish. `getRecentActivity` is the one remaining whole-org-recent read;
+  its native version needs indexed `scannedAt`/`testDate desc` reads + user-name joins off the Convex
+  `users` mirror (its own follow-up). All four are correct + flag-safe on server actions today.
+
+To flip `NEXT_PUBLIC_NATIVE_DASHBOARD`: run `pnpm convex:backfill:dashboard-counters` on prod first.
 
 ### 3.6 Dashboard counters are a mini-domain, not a sub-bullet (review point 4)
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useServerQuery } from "@/hooks/use-server-query";
-import { NATIVE_DASHBOARD_ENABLED, useNativeDashboardStats } from "@/hooks/use-native-dashboard";
+import { NATIVE_DASHBOARD_ENABLED, useNativeDashboardStats, useNativeSubHireStats } from "@/hooks/use-native-dashboard";
 import { useActiveOrganization } from "@/lib/auth-client";
 import {
   ScanBarcode,
@@ -74,7 +74,9 @@ export default function DashboardPage() {
   const statsLoading = NATIVE_DASHBOARD_ENABLED ? nativeStats.isLoading : scStatsLoading;
   const { data: upcoming } = useServerQuery({ queryKey: ["dashboard-upcoming", orgId], queryFn: getUpcomingProjects });
   const { data: activity } = useServerQuery({ queryKey: ["dashboard-activity", orgId], queryFn: getRecentActivity });
-  const { data: subHireStats } = useServerQuery({ queryKey: ["dashboard-sub-hire-stats", orgId], queryFn: getSubHireDashboardStats });
+  const nativeSubHireStats = useNativeSubHireStats(orgId);
+  const { data: scSubHireStats } = useServerQuery({ queryKey: ["dashboard-sub-hire-stats", orgId], queryFn: getSubHireDashboardStats, enabled: !NATIVE_DASHBOARD_ENABLED });
+  const subHireStats = NATIVE_DASHBOARD_ENABLED ? nativeSubHireStats : scSubHireStats;
   const { data: myHome } = useServerQuery({ queryKey: ["my-home", orgId], queryFn: getMyHomeData });
   const { data: myBlockers } = useServerQuery({ queryKey: ["my-blocking-comments", orgId], queryFn: getMyBlockingComments });
 

--- a/src/hooks/use-native-dashboard.ts
+++ b/src/hooks/use-native-dashboard.ts
@@ -61,3 +61,26 @@ export function useNativeDashboardStats(
 
   return { data, isLoading: enabled && data === undefined };
 }
+
+export interface NativeSubHireStats {
+  activeSubHires: number;
+  monthlySubHireCost: number;
+  overdueReturns: number;
+}
+
+/**
+ * Native getSubHireDashboardStats: the org's (bounded) sub-hire heads aggregated
+ * reactively — no counter needed. `now` is minute-bucketed and `monthStart` is the
+ * first of the current month (both client-computed; queries can't read the clock).
+ */
+export function useNativeSubHireStats(
+  orgId: string | undefined,
+): NativeSubHireStats | undefined {
+  const enabled = NATIVE_DASHBOARD_ENABLED && !!orgId;
+  const nowBucket = enabled ? Math.floor(Date.now() / MINUTE) * MINUTE : 0;
+  const monthStart = enabled ? new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime() : 0;
+  return useAuthedQuery(
+    api.dashboardSubHire.bundle,
+    enabled ? { orgId: orgId!, now: nowBucket, monthStart } : "skip",
+  ) as NativeSubHireStats | undefined;
+}


### PR DESCRIPTION
## What

Extends the native dashboard cutover to the **sub-hire stats** tile (`getSubHireDashboardStats`), behind the same `NEXT_PUBLIC_NATIVE_DASHBOARD` flag (default off).

- **`convex/dashboardSubHire.bundle`** (org-read): the org's sub-hire heads are bounded (far fewer than the asset registry), so this reads them `by_organizationId` and aggregates the three stats (`activeSubHires`, `monthlySubHireCost`, `overdueReturns`) reactively — no counter needed. `now` + `monthStart` are client-passed (queries can't read the clock).
- **`useNativeSubHireStats`** + dashboard page: selects native vs the `getSubHireDashboardStats` server query (`enabled: !flag` — no double-fetch).

## Phase 3 status
- **Stats tile** (the §3.6 counter mini-design — the whole-org-scan limit risk): native + merged (#318).
- **Sub-hire stats tile**: this PR.
- Remaining tiles (`getUpcomingProjects`, `getMyHomeData`, `getMyBlockingComments`, `getRecentActivity`) stay on server actions — the first three read **bounded** project/thread sets; `getRecentActivity` is the one remaining whole-org-recent read (a scoped follow-up: it needs indexed `scannedAt desc`/`testDate desc` reads + user-name joins off the Convex `users` mirror). All four are correct + flag-safe as-is.

## Test
`tsc` + lint (0 errors) + `convex dev --once` clean. CI `next build` verifies client-safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)