### PR TITLE
Phase 4: retire equipment-tab doorbell + collapse reads to native

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -7,23 +7,17 @@ import { api } from "../../../convex/_generated/api";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { refreshProjectDetail } from "@/hooks/use-project-detail";
 import {
-  useProjectCategories,
+  // Read hooks are retired here (the tab reads natively) — but the refresh
+  // chokepoints stay: they invalidate the shared server-action stores that the
+  // still-server-action equipment add-form / sub-hire dialog read (category
+  // dropdowns etc.), keeping those in sync after a tab write.
   refreshProjectCategories,
-  useUncategorizedItems,
   refreshUncategorizedItems,
-  useUncategorizedSubHireGroups,
   refreshUncategorizedSubHireGroups,
-  useUncategorizedProjectGroups,
   refreshUncategorizedProjectGroups,
-  useProjectOverbooked,
   refreshProjectOverbooked,
-  useProjectSubHires,
-  useProjectEquipmentLiveSync,
 } from "@/hooks/use-project-equipment";
-import {
-  NATIVE_EQUIPMENT_ENABLED,
-  useNativeEquipmentTab,
-} from "@/hooks/use-native-equipment-tab";
+import { useNativeEquipmentTab } from "@/hooks/use-native-equipment-tab";
 import { Plus, FolderPlus, FolderTree, Pencil, ChevronDown as ChevronDownIcon } from "lucide-react";
 import {
   DropdownMenu,
@@ -127,22 +121,12 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
-  // Native read-layer path (Phase 2, default OFF). When the flag is on, ALL six
-  // equipment views come from ONE reactive equipmentTab.bundle subscription
-  // (reconstructed client-side) — no server actions, no doorbell→refetch. Both the
-  // native hook and the server-action hooks below run (rules-of-hooks); the flag
-  // only selects which result we use. When off, the native hook is a no-op (skips).
+  // Native read-layer path (Phase 4 — the six server-action shared-resource reads +
+  // the useProjectEquipmentLiveSync doorbell are retired here). ALL six equipment
+  // views come from ONE reactive equipmentTab.bundle subscription (reconstructed
+  // client-side); writes are still server actions whose convex.mutation pushes the
+  // delta to this subscription, so no doorbell→refetch is needed.
   const native = useNativeEquipmentTab(projectId, orgId);
-
-  // Cross-tab live sync: subscribe to the dual-written line-item / group /
-  // category Convex tables and re-fetch the equipment composites whenever
-  // another tab (or collaborator) edits pricing, moves items, or changes groups.
-  // The native path is already reactive over its own subscription — skip the
-  // doorbell there (pass undefined so the live-sync subscriptions don't fire).
-  useProjectEquipmentLiveSync(
-    NATIVE_EQUIPMENT_ENABLED ? undefined : projectId,
-    NATIVE_EQUIPMENT_ENABLED ? undefined : orgId,
-  );
 
   // Passive section/group collaboration state: one lock subscription and one
   // comment-count subscription for the project, then row lookups by target key.
@@ -298,26 +282,15 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
     });
   }, []);
 
-  // Server-action shared resources (the legacy path). When native is on, each is
-  // passed `undefined` so its fetch skips (no double-fetch alongside the native
-  // subscription); the value comes from `native` instead.
-  const scKey = NATIVE_EQUIPMENT_ENABLED ? undefined : projectId;
-  const { data: scCategories = [], isLoading: scLoading } = useProjectCategories(scKey);
-  const { data: scUncategorizedItems = [] } = useUncategorizedItems(scKey);
-  const { data: scUncategorizedSubHireGroups = [] } = useUncategorizedSubHireGroups(scKey);
-  const { data: scUncategorizedProjectGroups = [] } = useUncategorizedProjectGroups(scKey);
-  const { data: scOverbookedMap = {} } = useProjectOverbooked(scKey);
+  // All six equipment views come from the single native subscription.
+  const categories = native.categories;
+  const isLoading = native.isLoading;
+  const uncategorizedItems = native.uncategorizedItems;
+  const uncategorizedSubHireGroups = native.uncategorizedSubHireGroups;
+  const uncategorizedProjectGroups = native.uncategorizedProjectGroups;
+  const overbookedMap = native.overbookedMap;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: scProjectSubHires = [] } = useProjectSubHires(scKey) as { data: any[] };
-
-  const categories = NATIVE_EQUIPMENT_ENABLED ? native.categories : scCategories;
-  const isLoading = NATIVE_EQUIPMENT_ENABLED ? native.isLoading : scLoading;
-  const uncategorizedItems = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedItems : scUncategorizedItems;
-  const uncategorizedSubHireGroups = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedSubHireGroups : scUncategorizedSubHireGroups;
-  const uncategorizedProjectGroups = NATIVE_EQUIPMENT_ENABLED ? native.uncategorizedProjectGroups : scUncategorizedProjectGroups;
-  const overbookedMap = NATIVE_EQUIPMENT_ENABLED ? native.overbookedMap : scOverbookedMap;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const projectSubHires = (NATIVE_EQUIPMENT_ENABLED ? native.projectSubHires : scProjectSubHires) as any[];
+  const projectSubHires = native.projectSubHires as any[];
 
   const { data: templates = [] } = useGroupTemplates(orgId);
 

--- a/src/hooks/use-project-equipment.ts
+++ b/src/hooks/use-project-equipment.ts
@@ -1,13 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import { createSharedResource } from "./use-shared-resource";
-import {
-  useProjectLineItems,
-  useProjectGroups,
-  useProjectCategories as useConvexProjectCategories,
-  useProjectSubHireDocs,
-} from "./use-projects";
 import {
   getProjectCategories,
   getUncategorizedLineItems,
@@ -61,94 +54,3 @@ const subHire = createSharedResource((subHireId: string) => getSubHire(subHireId
 /** Subscribe to a single sub-hire's detail. Key = subHireId. */
 export const useSubHire = subHire.use;
 export const refreshSubHire = subHire.refresh;
-
-/**
- * Cross-tab live sync for the equipment-tab composition.
- *
- * The equipment composites (categories, uncategorized items, overbooked status)
- * are deep cross-domain server-action reads — they stay server actions because
- * Prisma still owns the asset/unit/kit physical joins. But line items, groups,
- * and categories are all dual-written to Convex, so we subscribe to those tables
- * directly. When ANOTHER tab (or collaborator) edits a price, moves an item, adds
- * a group, etc., the Convex mirror pushes the change over the websocket; the
- * fingerprint below changes and we re-fetch the composites so this tab updates
- * live — no manual refresh.
- *
- * Mount once in the equipment tab. The local writer still calls invalidate()
- * synchronously; this only fires the redundant-but-harmless refresh once the
- * Convex push lands (and is the ONLY refresh other tabs get).
- */
-function fingerprintLineItems(
-  items: { id: string; updatedAt?: number; unitPrice?: number; lineTotal?: number; quantity?: number; discount?: number; categoryId?: string; groupId?: string; status?: string; sortOrder?: number }[] | undefined,
-): string | undefined {
-  if (!items) return undefined;
-  return items
-    .map((i) => `${i.id}:${i.updatedAt ?? 0}:${i.unitPrice ?? ""}:${i.lineTotal ?? ""}:${i.quantity ?? ""}:${i.discount ?? ""}:${i.categoryId ?? ""}:${i.groupId ?? ""}:${i.status ?? ""}:${i.sortOrder ?? ""}`)
-    .sort()
-    .join("|");
-}
-
-function fingerprintGrouping(
-  rows: { id: string; updatedAt?: number; sortOrder?: number }[] | undefined,
-  extra?: (r: { id: string }) => string,
-): string | undefined {
-  if (!rows) return undefined;
-  return rows
-    .map((r) => `${r.id}:${r.updatedAt ?? 0}:${r.sortOrder ?? ""}:${extra?.(r) ?? ""}`)
-    .sort()
-    .join("|");
-}
-
-/** Subscribe to Convex line-item/group/category/sub-hire tables and refresh the equipment composites on any cross-tab change. */
-export function useProjectEquipmentLiveSync(
-  projectId: string | undefined,
-  orgId: string | undefined,
-) {
-  const lineItems = useProjectLineItems(projectId, orgId);
-  const groups = useProjectGroups(projectId, orgId);
-  const cats = useConvexProjectCategories(projectId, orgId);
-  const subHires = useProjectSubHireDocs(projectId, orgId);
-
-  const liFp = fingerprintLineItems(lineItems);
-  const grpFp = fingerprintGrouping(
-    groups,
-    (r) => `${(r as { title?: string; price?: number; quantity?: number; categoryId?: string }).title ?? ""}:${(r as { price?: number }).price ?? ""}:${(r as { quantity?: number }).quantity ?? ""}:${(r as { categoryId?: string }).categoryId ?? ""}`,
-  );
-  const catFp = fingerprintGrouping(cats, (r) => (r as { name?: string }).name ?? "");
-  // Sub-hire fingerprint covers order-level edits (status, cost, supplier, target
-  // category/group). Item/group line edits inside a sub-hire bump the parent's
-  // updatedAt via the recalc sweep, so the parent row is a sufficient signal.
-  const shFp = fingerprintGrouping(
-    subHires as { id: string; updatedAt?: number }[] | undefined,
-    (r) => {
-      const s = r as { status?: string; totalCost?: number; supplierId?: string; defaultTargetCategoryId?: string; defaultTargetGroupId?: string };
-      return `${s.status ?? ""}:${s.totalCost ?? ""}:${s.supplierId ?? ""}:${s.defaultTargetCategoryId ?? ""}:${s.defaultTargetGroupId ?? ""}`;
-    },
-  );
-
-  const prev = useRef<{ li?: string; grp?: string; cat?: string; sh?: string }>({});
-
-  useEffect(() => {
-    if (!projectId) return;
-    const p = prev.current;
-    const equipChanged =
-      (liFp !== undefined && p.li !== undefined && liFp !== p.li) ||
-      (grpFp !== undefined && p.grp !== undefined && grpFp !== p.grp) ||
-      (catFp !== undefined && p.cat !== undefined && catFp !== p.cat);
-    const subHireChanged = shFp !== undefined && p.sh !== undefined && shFp !== p.sh;
-    if (equipChanged || subHireChanged) {
-      refreshProjectCategories(projectId);
-      refreshUncategorizedItems(projectId);
-      refreshUncategorizedProjectGroups(projectId);
-      refreshProjectOverbooked(projectId);
-    }
-    if (subHireChanged) {
-      refreshProjectSubHires(projectId);
-      refreshUncategorizedSubHireGroups(projectId);
-    }
-    if (liFp !== undefined) p.li = liFp;
-    if (grpFp !== undefined) p.grp = grpFp;
-    if (catFp !== undefined) p.cat = catFp;
-    if (shFp !== undefined) p.sh = shFp;
-  }, [projectId, liFp, grpFp, catFp, shFp]);
-}


### PR DESCRIPTION
## Phase 4 — delete the legacy faked-reactivity read layer (slice 2)

With `NEXT_PUBLIC_NATIVE_EQUIPMENT` live (repo var `true`), the equipment editing tab's six server-action shared-resource **reads** and the `useProjectEquipmentLiveSync` cross-tab **doorbell** are dead weight. All six views now come solely from the reactive `equipmentTab.bundle` subscription.

### What changed
- `equipment-tab.tsx`: dropped the flag ternaries + the six `sc*` shared-resource reads + the `useProjectEquipmentLiveSync(...)` doorbell call. Views read straight from `native`.
- Deleted `useProjectEquipmentLiveSync` from `use-project-equipment.ts` (the tab was its only caller) + its two fingerprint helpers + the now-unused `use-projects` table subscriptions.

### Deliberately kept
- The `invalidate()` chokepoint and the `refresh*` functions it calls. Those shared stores are **still read** by the server-action equipment **add-form** and **sub-hire order dialog** (category dropdowns etc.), so a tab write must still invalidate them. Writes remain server actions; their `convex.mutation` pushes the reactive delta to the native subscription.

### Verification
- `tsc --noEmit` ✅ · `eslint` (changed files) ✅ 0 errors · `next build` with native flags on ✅

Independent of #323 (touches different files). Same sequencing note as #323: merging rebuilds with the native flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)