### PR TITLE
Phase 4: collapse project-detail read to native-only

### DIFF
--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -1,83 +1,49 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { createSharedResource } from "./use-shared-resource";
 import { getProject } from "@/server/projects";
 import { useProject } from "./use-projects";
-import {
-  NATIVE_PROJECT_DETAIL_ENABLED,
-  useNativeProjectDetail,
-} from "./use-native-project-equipment";
+import { useNativeProjectDetail } from "./use-native-project-equipment";
 
 /**
- * Shared store for a project's detail composite (Phase 6 — React Query removal).
- * Replaces the `useQuery({ queryKey: ["project", orgId, id], queryFn: () =>
- * getProject(id) })` readers on the project detail / edit / runsheet pages.
+ * Project detail composite (Phase 4 — native-only; the version-vector +
+ * getProject server-action path is retired).
  *
  * `["project", …, projectId]` is the SPINE of the project detail UI — header,
- * status, financial summary, managers — and is invalidated by ~10 scattered
- * writers (status/archive on the page, the services panel, the sub-hire order
- * dialog, the equipment add forms, the managers panel). A shared store keyed by
- * **projectId** lets any of those writers call `refreshProjectDetail(projectId)`
- * without prop-drilling a refetch callback through the 1000–1600-line equipment /
- * services components — reproducing React Query's shared `["project", …]` cache
- * refresh.
+ * status, financial summary, managers. The whole composite now comes from live
+ * Convex subscriptions (projectDetail.bundle + browserBundle) reconstructed
+ * client-side, reactive over the WebSocket. Writes are still server actions whose
+ * convex.mutation pushes the delta to the subscription, so the ~15 writers that
+ * call `refreshProjectDetail` no longer need to — it is kept as a no-op below.
  *
- * Cross-tab reactivity: also subscribes to the Convex `projects` table via
- * `useProject`. When another browser tab (or collaborator) mutates the project,
- * the Convex mirror fires a websocket push to ALL subscribed tabs; the updatedAt
- * change detected here triggers refreshProjectDetail, re-fetching the full Prisma
- * composite so the UI syncs without a manual refresh.
+ * `getProject` is retained only as a TYPE reference: the native reconstruction is a
+ * thin DTO of the same shape, so casting to the server type preserves consumers'
+ * typed field access.
  */
-const resource = createSharedResource((projectId: string) => getProject(projectId));
+type ProjectDetail = Awaited<ReturnType<typeof getProject>>;
 
 /** Subscribe to a project's detail composite. `projectId` is the store key. */
 export function useProjectDetail(projectId: string) {
-  // When the native flag is on, DON'T fire the old getProject server action — pass
-  // `undefined` so the shared resource skips its fetch (no double-fetch alongside
-  // the native subscriptions). The version-vector refresh effect is also a no-op
-  // then (native is reactive over the WebSocket).
-  const result = resource.use(NATIVE_PROJECT_DETAIL_ENABLED ? undefined : projectId);
-
-  // Convex subscription for cross-tab change detection (also the orgId source).
+  // The Convex project doc is both the orgId source and the cross-tab change signal.
   const convexProject = useProject(projectId);
-  const prevUpdatedAt = useRef<number | undefined>(undefined);
-
-  useEffect(() => {
-    if (NATIVE_PROJECT_DETAIL_ENABLED) return; // native path needs no manual refresh
-    const next = convexProject?.updatedAt;
-    if (next !== undefined && prevUpdatedAt.current !== undefined && next !== prevUpdatedAt.current) {
-      resource.refresh(projectId);
-    }
-    if (next !== undefined) {
-      prevUpdatedAt.current = next;
-    }
-  }, [convexProject?.updatedAt, projectId]);
-
-  // Native read-layer path (Phase 1d, default OFF). When the flag is on, the whole
-  // composite comes from live Convex subscriptions (projectDetail.bundle +
-  // browserBundle) reconstructed client-side — no server action, reactive by the
-  // WebSocket. orgId is read off the project doc this hook already subscribes to.
-  // Both paths' hooks run (rules-of-hooks); the flag only selects which result we
-  // return. When the flag is off, `useNativeProjectDetail` is a no-op (skips).
   const native = useNativeProjectDetail(projectId, convexProject?.organizationId);
-  if (NATIVE_PROJECT_DETAIL_ENABLED) {
-    // While the project doc (the orgId source) is still loading, keep isLoading
-    // true so the page shows its skeleton — NOT the "not found" state. Without
-    // this, the native hook is skipped (no orgId yet) and reports
-    // {data: undefined, isLoading: false}, which the page reads as "loaded, no
-    // project" and flashes not-found during auth/orgId resolution. `convexProject
-    // === null` (project genuinely missing) is NOT loading → not-found shows.
-    const orgResolving = convexProject === undefined;
-    return {
-      data: native.data as typeof result.data,
-      isLoading: orgResolving || native.isLoading,
-      refresh: () => resource.refresh(projectId),
-    };
-  }
 
-  return result;
+  // While the project doc (the orgId source) is still loading, keep isLoading true
+  // so the page shows its skeleton — NOT the "not found" state — during auth/orgId
+  // resolution. `convexProject === null` (genuinely missing) is NOT loading.
+  const orgResolving = convexProject === undefined;
+  return {
+    data: native.data as unknown as ProjectDetail | undefined,
+    isLoading: orgResolving || native.isLoading,
+    refresh: () => {},
+  };
 }
 
-/** Re-fetch the project and push to every subscriber (the writer's invalidate analogue). */
-export const refreshProjectDetail = resource.refresh;
+/**
+ * Historic invalidate chokepoint for the writers that call it after a project
+ * write. Now a no-op: the native projectDetail subscription pushes every change
+ * live over the WebSocket, so an explicit refetch is redundant. Signature kept
+ * unchanged to avoid touching every call site.
+ */
+export function refreshProjectDetail(_projectId?: string): void {
+  /* native subscription is reactive — nothing to invalidate */
+}


### PR DESCRIPTION
## Phase 4 — delete the legacy faked-reactivity read layer (slice 4)

With `NEXT_PUBLIC_NATIVE_PROJECT_DETAIL` live (repo var `true`), the `getProject` shared-resource + version-vector fallback in `useProjectDetail` is dead weight.

### What changed
- `use-project-detail.ts`: `useProjectDetail` now reads solely from the native `projectDetail.bundle` + `browserBundle` subscriptions (reconstructed client-side), with `orgId` sourced from the project doc it subscribes to (also the cross-tab change signal).
- `refreshProjectDetail` is kept with an unchanged signature as a **no-op** — its ~15 writer call sites no longer need to invalidate because the native subscription pushes every change live over the WebSocket. This avoids churning every caller.
- `getProject` is retained as a type-only reference so consumers' typed field access is preserved.

### Verification
- `tsc --noEmit` ✅ · `eslint` ✅ 0 errors · `next build` with native flag on ✅

Independent of #323 / #324 / #325. Same sequencing note: merging rebuilds with the native flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)