### PR TITLE
Phase 5 assets: native archive + delete write mutations

### DIFF
--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -124,3 +124,92 @@ describe("assetWrites.updateNotesNative — invariants (5b)", () => {
     ).rejects.toThrow(/not found/i);
   });
 });
+
+const archiveArgs = { id: "a1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
+
+describe("assetWrites.archiveNative", () => {
+  test("retires the asset + linked T&T and writes an audit row", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("testTagAssets", { id: "tt1", organizationId: ORG, assetId: "a1", testTagId: "TAG-1", description: "TAG-1", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await t.withIdentity(SERVICE).mutation(api.assetWrites.archiveNative, archiveArgs);
+    await t.run(async (ctx) => {
+      const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      expect(asset?.isActive).toBe(false);
+      expect(asset?.status).toBe("RETIRED");
+      const tt = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", "tt1")).first();
+      expect(tt?.status).toBe("RETIRED");
+      expect(tt?.isActive).toBe(false);
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.summary).toMatch(/Archived asset/);
+    });
+  });
+
+  test("a viewer is denied (asset:update)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.archiveNative, archiveArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+const deleteArgs = { id: "a1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
+
+describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
+  test("owner deletes a free asset + writes the DELETE audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t, "owner");
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.deleteNative, deleteArgs);
+    expect(res.id).toBe("a1");
+    await t.run(async (ctx) => {
+      const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      expect(asset).toBeNull();
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("DELETE");
+    });
+  });
+
+  test("a manager (no asset:delete) is denied", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t, "manager");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.deleteNative, deleteArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("blocked when referenced by a project line item (ASSET_IN_USE)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", assetId: "a1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.assetWrites.deleteNative, deleteArgs),
+    ).rejects.toThrow(/referenced by project line items/i);
+  });
+
+  test("blocked when the asset is a kit member (ASSET_IN_KIT)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER });
+    });
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.assetWrites.deleteNative, deleteArgs),
+    ).rejects.toThrow(/part of a kit/i);
+  });
+
+  test("blocked when the asset has accessory children (ASSET_HAS_ACCESSORIES)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "child", organizationId: ORG, modelId: "m1", assetTag: "CHILD", parentAssetId: "a1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.assetWrites.deleteNative, deleteArgs),
+    ).rejects.toThrow(/accessories attached/i);
+  });
+});

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -74,3 +74,143 @@ export const updateNotesNative = mutation({
     return { ok: true as const };
   },
 });
+
+/**
+ * archiveNative — soft-retire an asset (isActive:false + status RETIRED) and retire
+ * any linked test&tag entries, all in one transaction. RBAC(asset,update). Mirrors
+ * archiveAsset (src/server/assets.ts:865); adds an audit row (the server action
+ * wrote none — an intentional improvement, not a parity break on data state).
+ */
+export const archiveNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "asset", "update");
+
+    const asset = await ctx.db
+      .query("assets")
+      .withIndex("by_cuid", (q) => q.eq("id", id))
+      .first();
+    if (!asset) throw new ConvexError("Asset not found: " + id);
+    if (asset.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    // Retire linked T&T entries (Convex-only write — same as archiveAsset).
+    const linkedTT = await ctx.db
+      .query("testTagAssets")
+      .withIndex("by_organizationId_assetId", (q) => q.eq("organizationId", orgId).eq("assetId", id))
+      .collect();
+    for (const tt of linkedTT) {
+      await ctx.db.patch(tt._id, { status: "RETIRED", isActive: false, updatedAt: now });
+    }
+
+    await ctx.db.patch(asset._id, { isActive: false, status: "RETIRED", updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "asset",
+      entityId: id,
+      entityName: asset.assetTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Archived asset ${asset.assetTag}`,
+      details: { archived: true },
+      assetId: id,
+      createdAt: now,
+    });
+
+    return { ok: true as const };
+  },
+});
+
+/**
+ * deleteNative — hard-delete an asset. Enforces the orphan guards transactionally
+ * (mirrors deleteAsset, src/server/assets.ts:771): reject if it's referenced by any
+ * project line item, is a kit member, or has serialized/bulk accessory children.
+ * Retires linked T&T entries, then removes the row + writes the DELETE audit — all
+ * atomic, so the guards can't race the delete. RBAC(asset,delete).
+ *
+ * Throws a distinct ConvexError code per guard so the client can surface the exact
+ * reason (the mirror/UI reads `error.data`).
+ */
+export const deleteNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "asset", "delete");
+
+    const asset = await ctx.db
+      .query("assets")
+      .withIndex("by_cuid", (q) => q.eq("id", id))
+      .first();
+    if (!asset) throw new ConvexError("Asset not found: " + id);
+    if (asset.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    const lineItems = await ctx.db
+      .query("projectLineItems")
+      .withIndex("by_assetId", (q) => q.eq("assetId", id))
+      .collect();
+    if (lineItems.some((li) => li.organizationId === orgId)) {
+      throw new ConvexError({ code: "ASSET_IN_USE", message: "This asset is referenced by project line items." });
+    }
+
+    const kitMember = await ctx.db
+      .query("kitSerializedItems")
+      .withIndex("by_organizationId_assetId", (q) => q.eq("organizationId", orgId).eq("assetId", id))
+      .first();
+    if (kitMember) {
+      throw new ConvexError({ code: "ASSET_IN_KIT", message: "This asset is part of a kit." });
+    }
+
+    const childAssets = await ctx.db
+      .query("assets")
+      .withIndex("by_parentAssetId", (q) => q.eq("parentAssetId", id))
+      .collect();
+    const childBulk = await ctx.db
+      .query("assetBulkChildren")
+      .withIndex("by_parentAssetId", (q) => q.eq("parentAssetId", id))
+      .collect();
+    if (childAssets.some((c) => c.organizationId === orgId) || childBulk.some((c) => c.organizationId === orgId)) {
+      throw new ConvexError({ code: "ASSET_HAS_ACCESSORIES", message: "This asset has accessories attached." });
+    }
+
+    // Retire linked T&T entries (Convex-only write — same as deleteAsset).
+    const linkedTT = await ctx.db
+      .query("testTagAssets")
+      .withIndex("by_organizationId_assetId", (q) => q.eq("organizationId", orgId).eq("assetId", id))
+      .collect();
+    for (const tt of linkedTT) {
+      await ctx.db.patch(tt._id, { status: "RETIRED", isActive: false, updatedAt: now });
+    }
+
+    await ctx.db.delete(asset._id);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "DELETE",
+      entityType: "asset",
+      entityId: id,
+      entityName: asset.assetTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Deleted asset ${asset.assetTag}`,
+      details: { deleted: { assetTag: asset.assetTag } },
+      assetId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});


### PR DESCRIPTION
## Phase 5 — assets domain, step 2: archive + delete mutations

Extends the native asset-write set (builds on the merged foundation #330) with two more mechanism-complete mutations in `convex/assetWrites.ts` — additive + dormant (no live caller yet; the server actions still own the live path), fully proven by convex-test.

- **`archiveNative`** — RBAC(`asset`,`update`) + retire linked test&tag + soft-retire the asset (`isActive:false`, status `RETIRED`) + audit, one transaction. Mirrors `archiveAsset`; adds an audit row it lacked (intentional improvement).
- **`deleteNative`** — RBAC(`asset`,`delete`) + the three orphan guards enforced **transactionally** (reject if referenced by a project line item / kit member / has accessory children — distinct `ConvexError` codes) + retire linked T&T + remove + DELETE audit. Moving the guards into the mutation **closes the check-then-write race** the server action has.

### Tests (`assetWrites.test.ts`, 15/15)
+7 cases: archive effect + T&T retire + audit + viewer-deny; delete by owner + audit, **manager denied** (manager has no `asset:delete`), and each orphan guard (`ASSET_IN_USE` / `ASSET_IN_KIT` / `ASSET_HAS_ACCESSORIES`).

### Next
Wire `updateNotesNative` + `archiveNative` + `deleteNative` into the server actions behind a native-writes flag (with `ConvexError`-code → `UserFacingError` mapping so the toast UX is preserved) + optimistic client updates. Then the heavier `createNative`/`updateNative` (needs the isomorphic custom-field validator port + the T&T auto-register side-effect).

### Verification
`tsc` ✅ · `eslint` ✅ 0 errors · `convex/assetWrites.test.ts` ✅ 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)