### PR TITLE
Phase 5 assets: wire notes/archive/delete writes live (flag-gated, default off)

### DIFF
--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -1,0 +1,58 @@
+import { ConvexError } from "convex/values";
+import { UserFacingError } from "@/lib/errors";
+
+/**
+ * Per-domain feature flags for the Phase 5 native-write cutover (writes routed
+ * through the RBAC + invariants + atomic-audit mutations in convex/*Writes.ts
+ * instead of the inline-guard + service-mutation + Postgres-logActivity path).
+ *
+ * These gate SERVER-SIDE code (the server actions), so a plain runtime env var is
+ * enough — no NEXT_PUBLIC build-inlining, and it flips via the Coolify env without a
+ * rebuild. Default OFF (unset). Each domain flips independently once its write-parity
+ * is verified.
+ */
+export const nativeAssetWrites = (): boolean =>
+  process.env.NATIVE_ASSET_WRITES === "true";
+
+/**
+ * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
+ * UserFacingError (title + hint) the server-action path threw, so the toast UX is
+ * identical whether the write ran natively or on the legacy path. Non-matching
+ * errors pass through unchanged.
+ */
+const ASSET_WRITE_ERROR_MAP: Record<
+  string,
+  { title: string; message: string; hint?: string }
+> = {
+  ASSET_IN_USE: {
+    title: "Cannot delete",
+    message: "This asset is referenced by project line items.",
+    hint: "Archive it instead so the history stays intact.",
+  },
+  ASSET_IN_KIT: {
+    title: "Cannot delete",
+    message: "This asset is part of a kit.",
+    hint: "Remove it from the kit first, then delete.",
+  },
+  ASSET_HAS_ACCESSORIES: {
+    title: "Cannot delete",
+    message: "This asset has accessories attached.",
+    hint: "Detach its accessories first, then delete.",
+  },
+};
+
+export function mapAssetWriteError(e: unknown): unknown {
+  if (
+    e instanceof ConvexError &&
+    e.data &&
+    typeof e.data === "object" &&
+    "code" in e.data &&
+    typeof (e.data as { code: unknown }).code === "string"
+  ) {
+    const mapped = ASSET_WRITE_ERROR_MAP[(e.data as { code: string }).code];
+    if (mapped) {
+      return new UserFacingError({ code: (e.data as { code: string }).code, ...mapped });
+    }
+  }
+  return e;
+}

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -26,6 +26,7 @@ import {
   mapConvexAssetToPrisma,
 } from "@/lib/assets-read";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
+import { nativeAssetWrites, mapAssetWriteError } from "@/lib/native-writes";
 import { validateCustomFieldValues } from "@/lib/validations/custom-field";
 import { getActiveCustomFieldsForOrg } from "@/lib/custom-fields-read";
 import { getConvexClient } from "@/lib/convex-client";
@@ -782,6 +783,38 @@ export async function deleteAsset(id: string) {
   }
   const asset = mapConvexAssetToPrisma(assetDoc);
 
+  if (nativeAssetWrites()) {
+    // Native path: the orphan guards + T&T retire + remove + Convex audit run
+    // transactionally in the mutation (closes the check-then-write race). Map its
+    // coded ConvexError back to the rich UserFacingError so the toast is unchanged.
+    try {
+      await convex.mutation(api.assetWrites.deleteNative, {
+        id,
+        orgId: organizationId,
+        actor: { userId, userName },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapAssetWriteError(e);
+    }
+    // Transition: also write the Postgres audit so the activity-log screens (still
+    // Postgres-backed) show the delete until audit reads migrate to Convex. The
+    // mutation already wrote the Convex audit (the future reactive source of truth).
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "DELETE",
+      entityType: "asset",
+      entityId: id,
+      entityName: asset.assetTag,
+      summary: `Deleted asset ${asset.assetTag}`,
+      details: { deleted: { assetTag: asset.assetTag } },
+    });
+    return { id };
+  }
+
   const lineItemCount = (await convex.query(api.projectLineItems.listByAssetId, { assetId: id, orgId: organizationId })).length;
   if (lineItemCount > 0) {
     throw new UserFacingError({
@@ -840,9 +873,19 @@ export async function deleteAsset(id: string) {
 }
 
 export async function updateAssetNotes(id: string, notes: string) {
-  const { organizationId } = await requirePermission("asset", "update");
+  const { organizationId, userId, userName } = await requirePermission("asset", "update");
   const convex = await getConvexClient();
-  if (notes) {
+  if (nativeAssetWrites()) {
+    // Native path: RBAC + org invariant + atomic Convex audit in one mutation.
+    await convex.mutation(api.assetWrites.updateNotesNative, {
+      id,
+      orgId: organizationId,
+      notes: notes || null,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else if (notes) {
     await convex.mutation(api.assets.patchAsset, {
       id,
       set: { notes, updatedAt: Date.now() },
@@ -863,10 +906,26 @@ export async function updateAssetNotes(id: string, notes: string) {
 }
 
 export async function archiveAsset(id: string) {
-  const { organizationId } = await requirePermission("asset", "update");
+  const { organizationId, userId, userName } = await requirePermission("asset", "update");
+  const convex = await getConvexClient();
+
+  if (nativeAssetWrites()) {
+    // Native path: retire linked T&T + soft-retire the asset + audit, one transaction.
+    await convex.mutation(api.assetWrites.archiveNative, {
+      id,
+      orgId: organizationId,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+    const nativeDoc = await getAssetById(id);
+    if (!nativeDoc || nativeDoc.organizationId !== organizationId) {
+      throw new Error("Asset archive read-back failed: " + id);
+    }
+    return serialize(mapConvexAssetToPrisma(nativeDoc));
+  }
 
   // Retire linked T&T entries (Convex-only write).
-  const convex = await getConvexClient();
   const linkedTTList = await convex.query(api.testTagAssets.listByAssetId, { assetId: id });
   const archiveNow = Date.now();
   for (const tt of linkedTTList) {


### PR DESCRIPTION
## Phase 5 — assets domain, step 3: go live (behind a flag)

Routes three asset writes through the native RBAC + invariants + atomic-audit mutations (from #330/#331) behind **`NATIVE_ASSET_WRITES`** — a **server-side runtime env**, default **OFF**, flippable via the Coolify env with **no rebuild** (the gate is in the server actions, so no `NEXT_PUBLIC` build-inlining needed).

### What changed
- **`src/lib/native-writes.ts`** — `nativeAssetWrites()` flag + `mapAssetWriteError()`, which maps `deleteNative`'s coded `ConvexError` (`ASSET_IN_USE` / `ASSET_IN_KIT` / `ASSET_HAS_ACCESSORIES`) back to the rich `UserFacingError` so the toast (title + hint) is identical on either path.
- **`updateAssetNotes` / `archiveAsset` / `deleteAsset`** — flag-on calls the native mutation (passing `actor` + caller-generated `auditId` + `now`); flag-off is the unchanged legacy path.
- **delete** keeps its Postgres `logActivity` during the transition (activity-log screens are still Postgres-backed), alongside the mutation's new atomic **Convex** audit (the future reactive source of truth).

### Safety
The flag stays **OFF** — nothing changes in prod on merge. Flip it only after verifying parity live (dogfood a notes edit / archive / delete on a preview with `NATIVE_ASSET_WRITES=true`). Parity is established by construction (the mutation ports the exact guards) + the `assetWrites.test.ts` effect/audit assertions (15/15).

### Next
Optimistic client updates (5d) + the heavier `createNative`/`updateNative` (needs the isomorphic custom-field validator port + the T&T auto-register side-effect).

### Verification
`tsc` ✅ · `eslint` ✅ 0 errors · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)