### PR TITLE
Phase 5 assets: native create + update writes (completes the domain)

### DIFF
--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -213,3 +213,91 @@ describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
     ).rejects.toThrow(/accessories attached/i);
   });
 });
+
+describe("assetWrites.createNative", () => {
+  const createArgs = {
+    id: "new1", organizationId: ORG, modelId: "m1", assetTag: "NEW-1",
+    status: "AVAILABLE" as const, condition: "GOOD" as const,
+    createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1",
+  };
+
+  test("member creates an asset + writes the CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs);
+    expect(res.id).toBe("new1");
+    await t.run(async (ctx) => {
+      const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "new1")).first();
+      expect(asset?.assetTag).toBe("NEW-1");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+    });
+  });
+
+  test("rejects a duplicate asset tag (DUPLICATE_ASSET_TAG)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t); // seeds TAG-1
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.assetWrites.createNative, { ...createArgs, assetTag: "TAG-1" }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (asset:create)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "viewer" });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("assetWrites.updateNative", () => {
+  const updArgs = { id: "a1", orgId: ORG, set: { assetTag: "TAG-1", status: "IN_MAINTENANCE" as const, updatedAt: NOW }, clear: [] as string[], actor: ACTOR, auditId: "log1", now: NOW };
+
+  test("applies set + writes the UPDATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t);
+    await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNative, updArgs);
+    await t.run(async (ctx) => {
+      const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      expect(asset?.status).toBe("IN_MAINTENANCE");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+    });
+  });
+
+  test("clear removes an optional field", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "TAG-1", status: "AVAILABLE", condition: "GOOD", isActive: true, notes: "old", createdAt: NOW, updatedAt: NOW });
+    });
+    await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNative, { ...updArgs, set: { updatedAt: NOW }, clear: ["notes"] });
+    await t.run(async (ctx) => {
+      const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      expect(asset?.notes).toBeUndefined();
+    });
+  });
+
+  test("rejects a tag change that collides with another asset (DUPLICATE_ASSET_TAG)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t); // a1 / TAG-1
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "TAKEN", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.assetWrites.updateNative, { ...updArgs, set: { assetTag: "TAKEN", updatedAt: NOW } }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (asset:update)", async () => {
+    const t = convexTest(schema, modules);
+    await seedAsset(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNative, updArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
 
 /**
  * Native ASSET write mutations (Phase 5 — Convex becomes the domain layer, not just
@@ -207,6 +208,191 @@ export const deleteNative = mutation({
       userName: actor.userName,
       summary: `Deleted asset ${asset.assetTag}`,
       details: { deleted: { assetTag: asset.assetTag } },
+      assetId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+// Patchable asset fields (mirrors convex/assets.ts assetSet — kept local so a CRUD
+// regen of assets.ts can't clobber the native-write path). Reused by updateNative.
+const assetSet = v.object({
+  modelId: v.optional(v.string()),
+  assetTag: v.optional(v.string()),
+  serialNumber: v.optional(v.string()),
+  customName: v.optional(v.string()),
+  status: v.optional(enums.AssetStatus),
+  condition: v.optional(enums.AssetCondition),
+  purchaseDate: v.optional(v.number()),
+  purchasePrice: v.optional(v.number()),
+  purchaseSupplier: v.optional(v.string()),
+  supplierId: v.optional(v.string()),
+  purchaseOrderNumber: v.optional(v.string()),
+  supplierOrderId: v.optional(v.string()),
+  warrantyExpiry: v.optional(v.number()),
+  notes: v.optional(v.string()),
+  locationId: v.optional(v.string()),
+  customFieldValues: v.optional(v.any()),
+  lastTestAndTagDate: v.optional(v.number()),
+  nextTestAndTagDate: v.optional(v.number()),
+  barcode: v.optional(v.string()),
+  qrCode: v.optional(v.string()),
+  images: v.optional(v.array(v.string())),
+  tags: v.optional(v.array(v.string())),
+  isActive: v.optional(v.boolean()),
+  createdAt: v.optional(v.number()),
+  updatedAt: v.optional(v.number()),
+  kitId: v.optional(v.string()),
+  parentAssetId: v.optional(v.string()),
+});
+const ASSET_NEVER_CLEAR = new Set(["id", "organizationId", "modelId", "assetTag"]);
+
+/**
+ * createNative — insert an asset with the dup-tag guard + CREATE audit in ONE
+ * transaction. RBAC(asset,create). The dup guard (by_organizationId_assetTag) and
+ * the audit are now atomic with the insert, closing the check-then-write race two
+ * concurrent creates of the same tag hit in the server-action path. Zod + custom-
+ * field validation + the Postgres tag counter + T&T auto-register stay in the server
+ * action (create is a form submit, not a client-direct optimistic write). Throws
+ * ConvexError({code:"DUPLICATE_ASSET_TAG"}) → mapped to UserFacingError by the caller.
+ */
+export const createNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    modelId: v.string(),
+    assetTag: v.string(),
+    serialNumber: v.optional(v.string()),
+    customName: v.optional(v.string()),
+    status: v.optional(enums.AssetStatus),
+    condition: v.optional(enums.AssetCondition),
+    purchaseDate: v.optional(v.number()),
+    purchasePrice: v.optional(v.number()),
+    purchaseSupplier: v.optional(v.string()),
+    supplierId: v.optional(v.string()),
+    purchaseOrderNumber: v.optional(v.string()),
+    supplierOrderId: v.optional(v.string()),
+    warrantyExpiry: v.optional(v.number()),
+    notes: v.optional(v.string()),
+    locationId: v.optional(v.string()),
+    customFieldValues: v.optional(v.any()),
+    lastTestAndTagDate: v.optional(v.number()),
+    nextTestAndTagDate: v.optional(v.number()),
+    barcode: v.optional(v.string()),
+    qrCode: v.optional(v.string()),
+    images: v.optional(v.array(v.string())),
+    tags: v.optional(v.array(v.string())),
+    isActive: v.optional(v.boolean()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+    kitId: v.optional(v.string()),
+    parentAssetId: v.optional(v.string()),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { actor, auditId, ...fields } = args;
+    await requireOrgPermission(ctx, fields.organizationId, "asset", "create");
+
+    const dup = await ctx.db
+      .query("assets")
+      .withIndex("by_organizationId_assetTag", (q) =>
+        q.eq("organizationId", fields.organizationId).eq("assetTag", fields.assetTag),
+      )
+      .first();
+    if (dup) {
+      throw new ConvexError({
+        code: "DUPLICATE_ASSET_TAG",
+        message: `Asset tag "${fields.assetTag}" already exists.`,
+      });
+    }
+
+    await ctx.db.insert("assets", fields);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: fields.organizationId,
+      action: "CREATE",
+      entityType: "asset",
+      entityId: fields.id,
+      entityName: fields.assetTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Created asset ${fields.assetTag}`,
+      details: { created: { assetTag: fields.assetTag, modelId: fields.modelId } },
+      assetId: fields.id,
+      createdAt: fields.createdAt ?? fields.updatedAt ?? 0,
+    });
+
+    return { id: fields.id };
+  },
+});
+
+/**
+ * updateNative — apply a set/clear patch (the patchAsset clear-to-null pattern) with
+ * the tag-change dup guard + UPDATE audit, all in one transaction. RBAC(asset,update).
+ * The server action still does Zod + custom-field validation (+ builds set/clear) and
+ * the T&T backfill; the dup guard + audit move here (atomic).
+ */
+export const updateNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    set: assetSet,
+    clear: v.array(v.string()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, set, clear, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "asset", "update");
+
+    const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Asset not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    // DUP GUARD only when the tag changed (mirrors updateAsset).
+    if (set.assetTag && set.assetTag !== doc.assetTag) {
+      const dup = await ctx.db
+        .query("assets")
+        .withIndex("by_organizationId_assetTag", (q) =>
+          q.eq("organizationId", orgId).eq("assetTag", set.assetTag!),
+        )
+        .first();
+      if (dup && dup.id !== id) {
+        throw new ConvexError({
+          code: "DUPLICATE_ASSET_TAG",
+          message: `Asset tag "${set.assetTag}" already exists.`,
+        });
+      }
+    }
+
+    // Apply set (+ clear-to-null) — the patchAsset pattern.
+    if (clear.length === 0) {
+      await ctx.db.patch(doc._id, set);
+    } else {
+      const { _id, _creationTime, ...rest } = doc;
+      const merged: Record<string, unknown> = { ...rest, ...set };
+      for (const k of clear) {
+        if (ASSET_NEVER_CLEAR.has(k)) continue;
+        delete merged[k];
+      }
+      await ctx.db.replace(doc._id, merged as typeof rest);
+    }
+
+    const finalTag = set.assetTag ?? doc.assetTag;
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "asset",
+      entityId: id,
+      entityName: finalTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated asset ${finalTag}`,
       assetId: id,
       createdAt: now,
     });

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -39,6 +39,11 @@ const ASSET_WRITE_ERROR_MAP: Record<
     message: "This asset has accessories attached.",
     hint: "Detach its accessories first, then delete.",
   },
+  DUPLICATE_ASSET_TAG: {
+    title: "Duplicate asset tag",
+    message: "That asset tag already exists.",
+    hint: "Use a different asset tag.",
+  },
 };
 
 export function mapAssetWriteError(e: unknown): unknown {
@@ -49,9 +54,14 @@ export function mapAssetWriteError(e: unknown): unknown {
     "code" in e.data &&
     typeof (e.data as { code: unknown }).code === "string"
   ) {
-    const mapped = ASSET_WRITE_ERROR_MAP[(e.data as { code: string }).code];
+    const code = (e.data as { code: string }).code;
+    const mapped = ASSET_WRITE_ERROR_MAP[code];
     if (mapped) {
-      return new UserFacingError({ code: (e.data as { code: string }).code, ...mapped });
+      // Prefer the mutation's own message (some carry dynamic detail, e.g. the
+      // offending asset tag) over the static fallback.
+      const dyn = (e.data as { message?: unknown }).message;
+      const message = typeof dyn === "string" && dyn ? dyn : mapped.message;
+      return new UserFacingError({ code, title: mapped.title, message, hint: mapped.hint });
     }
   }
   return e;

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -414,21 +414,12 @@ export async function createAsset(data: AssetFormValues) {
   const model = await getModelById(parsed.modelId);
 
   try {
-    // DUP GUARD: Convex has no unique index — reject a duplicate tag up front.
-    const dup = await getAssetByAssetTag(organizationId, parsed.assetTag);
-    if (dup) {
-      throw new UserFacingError({
-        code: "DUPLICATE_ASSET_TAG",
-        title: "Duplicate asset tag",
-        message: `Asset tag "${parsed.assetTag}" already exists.`,
-        hint: "Use a different asset tag.",
-      });
-    }
-
     const convex = await getConvexClient();
     const newId = createId();
     const now = Date.now();
-    await convex.mutation(api.assets.create, {
+    // Shared insert payload (identical for the legacy service mutation and the
+    // native mutation — only the guard/audit placement differs).
+    const assetFields = {
       id: newId,
       organizationId,
       modelId: parsed.modelId,
@@ -453,7 +444,32 @@ export async function createAsset(data: AssetFormValues) {
       tags: parsed.tags || undefined,
       createdAt: now,
       updatedAt: now,
-    });
+    };
+
+    if (nativeAssetWrites()) {
+      // Native: dup-guard + insert + CREATE audit atomic in the mutation.
+      try {
+        await convex.mutation(api.assetWrites.createNative, {
+          ...assetFields,
+          actor: { userId, userName },
+          auditId: createId(),
+        });
+      } catch (e) {
+        throw mapAssetWriteError(e);
+      }
+    } else {
+      // Legacy: DUP GUARD in the action (Convex has no unique index), then insert.
+      const dup = await getAssetByAssetTag(organizationId, parsed.assetTag);
+      if (dup) {
+        throw new UserFacingError({
+          code: "DUPLICATE_ASSET_TAG",
+          title: "Duplicate asset tag",
+          message: `Asset tag "${parsed.assetTag}" already exists.`,
+          hint: "Use a different asset tag.",
+        });
+      }
+      await convex.mutation(api.assets.create, assetFields);
+    }
     // Read back the persisted row in the Prisma shape callers expect.
     const created = await getAssetById(newId);
     if (!created) throw new Error("Asset create read-back failed: " + newId);
@@ -488,18 +504,21 @@ export async function createAsset(data: AssetFormValues) {
       });
     }
 
-    await logActivity({
-      organizationId,
-      userId,
-      userName,
-      action: "CREATE",
-      entityType: "asset",
-      entityId: result.id,
-      entityName: result.assetTag,
-      summary: `Created asset ${result.assetTag}`,
-      details: { created: { assetTag: result.assetTag, modelId: parsed.modelId } },
-      assetId: result.id,
-    });
+    if (!nativeAssetWrites()) {
+      // Native path already wrote the CREATE audit atomically in the mutation.
+      await logActivity({
+        organizationId,
+        userId,
+        userName,
+        action: "CREATE",
+        entityType: "asset",
+        entityId: result.id,
+        entityName: result.assetTag,
+        summary: `Created asset ${result.assetTag}`,
+        details: { created: { assetTag: result.assetTag, modelId: parsed.modelId } },
+        assetId: result.id,
+      });
+    }
 
     return serialize(result);
   } catch (e: unknown) {
@@ -649,8 +668,9 @@ export async function updateAsset(id: string, data: AssetFormValues) {
 
   let updated;
   try {
-    // DUP GUARD only when the tag changed.
-    if (parsed.assetTag !== before.assetTag) {
+    // DUP GUARD only when the tag changed (legacy path; the native mutation runs
+    // this guard atomically with the write).
+    if (!nativeAssetWrites() && parsed.assetTag !== before.assetTag) {
       const dup = await getAssetByAssetTag(organizationId, parsed.assetTag);
       if (dup && dup.id !== id) {
         throw new UserFacingError({
@@ -691,7 +711,24 @@ export async function updateAsset(id: string, data: AssetFormValues) {
     setOrClear("locationId", parsed.locationId);
 
     const convex = await getConvexClient();
-    await convex.mutation(api.assets.patchAsset, { id, set, clear });
+    if (nativeAssetWrites()) {
+      // Native: tag-change dup-guard + patch/clear + UPDATE audit atomic.
+      try {
+        await convex.mutation(api.assetWrites.updateNative, {
+          id,
+          orgId: organizationId,
+          set,
+          clear,
+          actor: { userId, userName },
+          auditId: createId(),
+          now: Date.now(),
+        });
+      } catch (e) {
+        throw mapAssetWriteError(e);
+      }
+    } else {
+      await convex.mutation(api.assets.patchAsset, { id, set, clear });
+    }
     const updatedDoc = await getAssetById(id);
     if (!updatedDoc) throw new Error("Asset update read-back failed: " + id);
     updated = mapConvexAssetToPrisma(updatedDoc);
@@ -701,17 +738,20 @@ export async function updateAsset(id: string, data: AssetFormValues) {
     throw e;
   }
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "UPDATE",
-    entityType: "asset",
-    entityId: updated.id,
-    entityName: updated.assetTag,
-    summary: `Updated asset ${updated.assetTag}`,
-    assetId: updated.id,
-  });
+  if (!nativeAssetWrites()) {
+    // Native path already wrote the UPDATE audit atomically in the mutation.
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "UPDATE",
+      entityType: "asset",
+      entityId: updated.id,
+      entityName: updated.assetTag,
+      summary: `Updated asset ${updated.assetTag}`,
+      assetId: updated.id,
+    });
+  }
 
   // Register in T&T if model requires it and not already registered
   // Model lives in Convex — fetch for T&T requirements check.


### PR DESCRIPTION
## Phase 5 — assets domain complete

Adds `createNative` + `updateNative` and wires `createAsset`/`updateAsset` behind `NATIVE_ASSET_WRITES`. With #330–#332, the assets write-inversion is now **complete**: create / update / delete / archive / notes all run as native mutations (RBAC + invariants + atomic audit) when the flag is on.

- **`createNative`** — RBAC(`asset`,`create`) + dup-tag guard (`by_organizationId_assetTag`) + insert + CREATE audit, one transaction; closes the check-then-write race two concurrent creates of the same tag hit today. Zod + custom-field validation + the Postgres tag counter + T&T auto-register stay in the server action (create is a form submit, not client-direct).
- **`updateNative`** — RBAC(`asset`,`update`) + tag-change dup-guard + set/clear patch (the `patchAsset` clear-to-null pattern) + UPDATE audit, one transaction.
- **`native-writes.ts`** — maps `DUPLICATE_ASSET_TAG` → `UserFacingError`, preferring the mutation's dynamic message (carries the offending tag).
- server actions: flag-on calls the native mutation + skips the now-in-mutation dup-guard and `logActivity`; flag-off unchanged.

### Tests (`assetWrites.test.ts`, 22/22)
+7: create effect+audit, dup-tag reject, viewer-deny; update set+audit, clear-removes-field, tag-collision reject, viewer-deny.

Flag stays **OFF** (verify parity live before flipping). Next: optimistic client (5d) + the next domains.

### Verification
`tsc` ✅ · `eslint` ✅ 0 errors · `assetWrites.test.ts` ✅ 22/22 · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)