### PR TITLE
Phase 5 kits: native create/update/notes writes (flag-gated)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -49,6 +49,7 @@ import type * as kitCheckItems from "../kitCheckItems.js";
 import type * as kitDetail from "../kitDetail.js";
 import type * as kitMedia from "../kitMedia.js";
 import type * as kitSerializedItems from "../kitSerializedItems.js";
+import type * as kitWrites from "../kitWrites.js";
 import type * as kits from "../kits.js";
 import type * as lib_audit from "../lib/audit.js";
 import type * as lib_auth from "../lib/auth.js";
@@ -161,6 +162,7 @@ declare const fullApi: ApiFromModules<{
   kitDetail: typeof kitDetail;
   kitMedia: typeof kitMedia;
   kitSerializedItems: typeof kitSerializedItems;
+  kitWrites: typeof kitWrites;
   kits: typeof kits;
   "lib/audit": typeof lib_audit;
   "lib/auth": typeof lib_auth;

--- a/convex/kitWrites.test.ts
+++ b/convex/kitWrites.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const ACTOR = { userId: USER, userName: "Alice" };
+
+async function seedKit(t: ReturnType<typeof convexTest>, role?: string) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("kits", {
+      id: "k1",
+      organizationId: ORG,
+      assetTag: "KIT-1",
+      name: "Lighting Kit",
+      status: "AVAILABLE",
+      condition: "GOOD",
+      isActive: true,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    if (role) await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+  });
+}
+
+describe("kitWrites.createNative", () => {
+  const createArgs = {
+    id: "new1", organizationId: ORG, assetTag: "KIT-2", name: "Audio Kit",
+    status: "AVAILABLE" as const, condition: "GOOD" as const,
+    createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1",
+  };
+
+  test("a manager creates a kit + writes the CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "manager" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.kitWrites.createNative, createArgs);
+    expect(res.id).toBe("new1");
+    await t.run(async (ctx) => {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "new1")).first();
+      expect(kit?.name).toBe("Audio Kit");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+      expect(log?.kitId).toBe("new1");
+    });
+  });
+
+  test("rejects a duplicate asset tag", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t); // KIT-1
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.kitWrites.createNative, { ...createArgs, assetTag: "KIT-1" }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (kit:create)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "viewer" });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.kitWrites.createNative, createArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("kitWrites.updateNative", () => {
+  const updArgs = { id: "k1", orgId: ORG, patch: { name: "Renamed", status: "IN_MAINTENANCE" as const, updatedAt: NOW }, actor: ACTOR, auditId: "log1", now: NOW };
+
+  test("applies patch + writes the UPDATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.withIdentity(SERVICE).mutation(api.kitWrites.updateNative, updArgs);
+    await t.run(async (ctx) => {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "k1")).first();
+      expect(kit?.name).toBe("Renamed");
+      expect(kit?.status).toBe("IN_MAINTENANCE");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+    });
+  });
+
+  test("rejects a tag change that collides", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k2", organizationId: ORG, assetTag: "TAKEN", name: "Other", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.kitWrites.updateNative, { ...updArgs, patch: { assetTag: "TAKEN", updatedAt: NOW } }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (kit:update)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.kitWrites.updateNative, updArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("kitWrites.updateNotesNative", () => {
+  test("patches notes + audit; clears on null", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.withIdentity(SERVICE).mutation(api.kitWrites.updateNotesNative, { id: "k1", orgId: ORG, notes: "spare fuse inside", actor: ACTOR, auditId: "log1", now: NOW });
+    await t.run(async (ctx) => {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "k1")).first();
+      expect(kit?.notes).toBe("spare fuse inside");
+    });
+    await t.withIdentity(SERVICE).mutation(api.kitWrites.updateNotesNative, { id: "k1", orgId: ORG, notes: null, actor: ACTOR, auditId: "log2", now: NOW });
+    await t.run(async (ctx) => {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "k1")).first();
+      expect(kit?.notes).toBeUndefined();
+    });
+  });
+});

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -1,0 +1,203 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireOrgPermission } from "./lib/auth";
+import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
+
+/**
+ * Native KIT write mutations (Phase 5) — same shape as convex/assetWrites.ts:
+ * ADDITIVE (the generated convex/kits.ts service mutations are untouched), each
+ * enforcing RBAC(requireOrgPermission) + invariants + atomic audit(writeActivityLog)
+ * in one transaction. `actor`/`auditId`/`now` are caller-generated (deterministic).
+ * Gated live behind NATIVE_KIT_WRITES in src/server/kits.ts.
+ *
+ * Covers create/update/notes (the clean writes). archive/delete use the existing
+ * cascade mutations (kits.archiveCascade / deleteCascade) + their own status guards —
+ * a separate slice.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+const kitPatch = v.object({
+  organizationId: v.optional(v.string()),
+  assetTag: v.optional(v.string()),
+  name: v.optional(v.string()),
+  description: v.optional(v.string()),
+  categoryId: v.optional(v.string()),
+  status: v.optional(enums.KitStatus),
+  condition: v.optional(enums.AssetCondition),
+  locationId: v.optional(v.string()),
+  weight: v.optional(v.number()),
+  caseType: v.optional(v.string()),
+  caseDimensions: v.optional(v.string()),
+  image: v.optional(v.string()),
+  images: v.optional(v.array(v.string())),
+  barcode: v.optional(v.string()),
+  qrCode: v.optional(v.string()),
+  notes: v.optional(v.string()),
+  purchaseDate: v.optional(v.number()),
+  purchasePrice: v.optional(v.number()),
+  customFieldValues: v.optional(v.any()),
+  tags: v.optional(v.array(v.string())),
+  checkMode: v.optional(enums.KitCheckMode),
+  isPrep: v.optional(v.boolean()),
+  isActive: v.optional(v.boolean()),
+  createdAt: v.optional(v.number()),
+  updatedAt: v.optional(v.number()),
+});
+
+export const createNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    assetTag: v.string(),
+    name: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.optional(v.string()),
+    status: v.optional(enums.KitStatus),
+    condition: v.optional(enums.AssetCondition),
+    locationId: v.optional(v.string()),
+    weight: v.optional(v.number()),
+    caseType: v.optional(v.string()),
+    caseDimensions: v.optional(v.string()),
+    image: v.optional(v.string()),
+    images: v.optional(v.array(v.string())),
+    barcode: v.optional(v.string()),
+    qrCode: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    purchaseDate: v.optional(v.number()),
+    purchasePrice: v.optional(v.number()),
+    customFieldValues: v.optional(v.any()),
+    tags: v.optional(v.array(v.string())),
+    checkMode: v.optional(enums.KitCheckMode),
+    isActive: v.optional(v.boolean()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { actor, auditId, ...fields } = args;
+    await requireOrgPermission(ctx, fields.organizationId, "kit", "create");
+
+    const dup = await ctx.db
+      .query("kits")
+      .withIndex("by_organizationId_assetTag", (q) =>
+        q.eq("organizationId", fields.organizationId).eq("assetTag", fields.assetTag),
+      )
+      .first();
+    if (dup) {
+      throw new ConvexError({
+        code: "DUPLICATE_ASSET_TAG",
+        message: `Asset tag "${fields.assetTag}" already exists`,
+      });
+    }
+
+    await ctx.db.insert("kits", fields);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: fields.organizationId,
+      action: "CREATE",
+      entityType: "kit",
+      entityId: fields.id,
+      entityName: fields.assetTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Created kit ${fields.assetTag} - ${fields.name}`,
+      details: { created: { assetTag: fields.assetTag, name: fields.name } },
+      kitId: fields.id,
+      createdAt: fields.createdAt ?? fields.updatedAt ?? 0,
+    });
+
+    return { id: fields.id };
+  },
+});
+
+export const updateNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    patch: kitPatch,
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, patch, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "kit", "update");
+
+    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Kit not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    if (patch.assetTag && patch.assetTag !== doc.assetTag) {
+      const dup = await ctx.db
+        .query("kits")
+        .withIndex("by_organizationId_assetTag", (q) =>
+          q.eq("organizationId", orgId).eq("assetTag", patch.assetTag!),
+        )
+        .first();
+      if (dup && dup.id !== id) {
+        throw new ConvexError({
+          code: "DUPLICATE_ASSET_TAG",
+          message: `Asset tag "${patch.assetTag}" already exists`,
+        });
+      }
+    }
+
+    await ctx.db.patch(doc._id, patch);
+
+    const finalTag = patch.assetTag ?? doc.assetTag;
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "kit",
+      entityId: id,
+      entityName: finalTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated kit ${finalTag} - ${patch.name ?? doc.name}`,
+      kitId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+export const updateNotesNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    notes: v.union(v.string(), v.null()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, notes, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "kit", "update");
+
+    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Kit not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.patch(doc._id, { notes: notes ?? undefined, updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "kit",
+      entityId: id,
+      entityName: doc.assetTag,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated notes on kit ${doc.assetTag}`,
+      kitId: id,
+      createdAt: now,
+    });
+
+    return { ok: true as const };
+  },
+});

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -14,6 +14,9 @@ import { UserFacingError } from "@/lib/errors";
 export const nativeAssetWrites = (): boolean =>
   process.env.NATIVE_ASSET_WRITES === "true";
 
+export const nativeKitWrites = (): boolean =>
+  process.env.NATIVE_KIT_WRITES === "true";
+
 /**
  * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
  * UserFacingError (title + hint) the server-action path threw, so the toast UX is
@@ -66,3 +69,9 @@ export function mapAssetWriteError(e: unknown): unknown {
   }
   return e;
 }
+
+/**
+ * Domain-agnostic alias — the DUPLICATE_ASSET_TAG mapping is shared by the kit
+ * write path (kits reject duplicate tags with the same code).
+ */
+export const mapNativeWriteError = mapAssetWriteError;

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -16,6 +16,7 @@ import { reserveAssetTags } from "@/server/settings";
 import { logActivity } from "@/lib/activity-log";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
+import { nativeKitWrites, mapNativeWriteError } from "@/lib/native-writes";
 
 import { getPrimaryPhotoMap, getKitMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { getModelById, getModelMap } from "@/lib/models-read";
@@ -237,17 +238,10 @@ export async function createKit(data: KitFormValues) {
   const { organizationId, userId, userName } = await requirePermission("kit", "create");
   const parsed = kitSchema.parse(data);
 
-  // Dup-guard the assetTag against the Convex mirror (the Prisma unique
-  // constraint is gone now that kits are Convex-only).
-  const existingTag = await getKitByAssetTag(organizationId, parsed.assetTag);
-  if (existingTag) {
-    throw new Error(`Asset tag "${parsed.assetTag}" already exists`);
-  }
-
   const id = createId();
   const now = Date.now();
   const convex = await getConvexClient();
-  await convex.mutation(api.kits.create, {
+  const kitFields = {
     id,
     organizationId,
     name: parsed.name,
@@ -272,23 +266,45 @@ export async function createKit(data: KitFormValues) {
     checkMode: parsed.checkMode,
     createdAt: now,
     updatedAt: now,
-  });
+  };
+
+  if (nativeKitWrites()) {
+    // Native: dup-guard + insert + CREATE audit atomic in the mutation.
+    try {
+      await convex.mutation(api.kitWrites.createNative, {
+        ...kitFields,
+        actor: { userId, userName },
+        auditId: createId(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+  } else {
+    // Legacy: dup-guard in the action (the Prisma unique constraint is gone).
+    const existingTag = await getKitByAssetTag(organizationId, parsed.assetTag);
+    if (existingTag) {
+      throw new Error(`Asset tag "${parsed.assetTag}" already exists`);
+    }
+    await convex.mutation(api.kits.create, kitFields);
+  }
   await reserveAssetTags(1);
 
   const created = await getKitById(id);
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "CREATE",
-    entityType: "kit",
-    entityId: id,
-    entityName: parsed.assetTag,
-    summary: `Created kit ${parsed.assetTag} - ${parsed.name}`,
-    details: { created: { assetTag: parsed.assetTag, name: parsed.name } },
-    kitId: id,
-  });
+  if (!nativeKitWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "CREATE",
+      entityType: "kit",
+      entityId: id,
+      entityName: parsed.assetTag,
+      summary: `Created kit ${parsed.assetTag} - ${parsed.name}`,
+      details: { created: { assetTag: parsed.assetTag, name: parsed.name } },
+      kitId: id,
+    });
+  }
 
   // Always surface `id` (read-back can lag the mirror); callers route on it.
   return serialize({ ...created, id });
@@ -303,71 +319,98 @@ export async function updateKit(id: string, data: KitFormValues) {
     throw new Error("Kit not found");
   }
 
-  // Dup-guard the assetTag if it changed (Prisma unique constraint is gone).
-  if (parsed.assetTag !== existing.assetTag) {
-    const tagOwner = await getKitByAssetTag(organizationId, parsed.assetTag);
-    if (tagOwner && tagOwner.id !== id) {
-      throw new Error(`Asset tag "${parsed.assetTag}" already exists`);
-    }
-  }
-
   const now = Date.now();
   const convex = await getConvexClient();
-  await convex.mutation(api.kits.update, {
-    id,
-    patch: {
-      name: parsed.name,
-      assetTag: parsed.assetTag,
-      description: parsed.description || undefined,
-      categoryId: parsed.categoryId || undefined,
-      status: parsed.status,
-      condition: parsed.condition,
-      locationId: parsed.locationId || undefined,
-      weight: parsed.weight ?? undefined,
-      caseType: parsed.caseType || undefined,
-      caseDimensions: parsed.caseDimensions || undefined,
-      notes: parsed.notes || undefined,
-      purchaseDate: parsed.purchaseDate ? new Date(parsed.purchaseDate).getTime() : undefined,
-      purchasePrice: parsed.purchasePrice ?? undefined,
-      image: parsed.image || undefined,
-      images: parsed.images ?? undefined,
-      isActive: parsed.isActive,
-      tags: parsed.tags ?? undefined,
-      checkMode: parsed.checkMode,
-      updatedAt: now,
-    },
-  });
+  const patch = {
+    name: parsed.name,
+    assetTag: parsed.assetTag,
+    description: parsed.description || undefined,
+    categoryId: parsed.categoryId || undefined,
+    status: parsed.status,
+    condition: parsed.condition,
+    locationId: parsed.locationId || undefined,
+    weight: parsed.weight ?? undefined,
+    caseType: parsed.caseType || undefined,
+    caseDimensions: parsed.caseDimensions || undefined,
+    notes: parsed.notes || undefined,
+    purchaseDate: parsed.purchaseDate ? new Date(parsed.purchaseDate).getTime() : undefined,
+    purchasePrice: parsed.purchasePrice ?? undefined,
+    image: parsed.image || undefined,
+    images: parsed.images ?? undefined,
+    isActive: parsed.isActive,
+    tags: parsed.tags ?? undefined,
+    checkMode: parsed.checkMode,
+    updatedAt: now,
+  };
+
+  if (nativeKitWrites()) {
+    // Native: tag-change dup-guard + patch + UPDATE audit atomic.
+    try {
+      await convex.mutation(api.kitWrites.updateNative, {
+        id,
+        orgId: organizationId,
+        patch,
+        actor: { userId, userName },
+        auditId: createId(),
+        now,
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+  } else {
+    // Dup-guard the assetTag if it changed (Prisma unique constraint is gone).
+    if (parsed.assetTag !== existing.assetTag) {
+      const tagOwner = await getKitByAssetTag(organizationId, parsed.assetTag);
+      if (tagOwner && tagOwner.id !== id) {
+        throw new Error(`Asset tag "${parsed.assetTag}" already exists`);
+      }
+    }
+    await convex.mutation(api.kits.update, { id, patch });
+  }
 
   const updated = await getKitById(id);
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "UPDATE",
-    entityType: "kit",
-    entityId: id,
-    entityName: parsed.assetTag,
-    summary: `Updated kit ${parsed.assetTag} - ${parsed.name}`,
-    kitId: id,
-  });
+  if (!nativeKitWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "UPDATE",
+      entityType: "kit",
+      entityId: id,
+      entityName: parsed.assetTag,
+      summary: `Updated kit ${parsed.assetTag} - ${parsed.name}`,
+      kitId: id,
+    });
+  }
 
   // Always surface `id` (read-back can lag the mirror); callers route on it.
   return serialize({ ...updated, id });
 }
 
 export async function updateKitNotes(id: string, notes: string) {
-  const { organizationId } = await requirePermission("kit", "update");
+  const { organizationId, userId, userName } = await requirePermission("kit", "update");
   const existing = await getKitById(id);
   if (!existing || existing.organizationId !== organizationId) {
     throw new Error("Kit not found");
   }
   const convex = await getConvexClient();
-  await convex.mutation(api.kits.update, {
-    id,
-    // notes: undefined clears the field (Convex patch deletes undefined keys).
-    patch: { notes: notes || undefined, updatedAt: Date.now() },
-  });
+  if (nativeKitWrites()) {
+    await convex.mutation(api.kitWrites.updateNotesNative, {
+      id,
+      orgId: organizationId,
+      notes: notes || null,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.kits.update, {
+      id,
+      // notes: undefined clears the field (Convex patch deletes undefined keys).
+      patch: { notes: notes || undefined, updatedAt: Date.now() },
+    });
+  }
   const updated = await getKitById(id);
   return serialize(updated);
 }


### PR DESCRIPTION
## Phase 5 — kits domain (replicates the assets pattern)

Proves the native-write pattern generalizes beyond assets. `convex/kitWrites.ts`: `createNative` (dup-tag guard + insert + CREATE audit), `updateNative` (tag-change dup-guard + patch + UPDATE audit), `updateNotesNative` — each RBAC(`kit`) + invariants + atomic audit in one transaction.

- Wired `createKit`/`updateKit`/`updateKitNotes` behind **`NATIVE_KIT_WRITES`** (runtime env, default OFF).
- `native-writes.ts`: `nativeKitWrites()` + `mapNativeWriteError` (alias of the shared `DUPLICATE_ASSET_TAG` mapper).
- archive/delete keep the existing `kits.archiveCascade`/`deleteCascade` mutations + status guards (a separate slice).

### Tests (`kitWrites.test.ts`, 7/7; 29 total with assets)
manager-create+audit, dup-tag reject, viewer-deny; update patch+audit, tag-collision reject, viewer-deny; notes patch+clear. **RBAC parity note:** `kit:create/update` require `manager` (member has `kit:read` only) — verified.

Flag stays OFF. `tsc` ✅ · `eslint` ✅ 0 errors · tests ✅ 29/29 · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)