### PR TITLE
Phase 5 crew: native create/update writes (flag-gated)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as crewRoles from "../crewRoles.js";
 import type * as crewShifts from "../crewShifts.js";
 import type * as crewSkills from "../crewSkills.js";
 import type * as crewTimeEntries from "../crewTimeEntries.js";
+import type * as crewWrites from "../crewWrites.js";
 import type * as customFieldDefinitions from "../customFieldDefinitions.js";
 import type * as customRoles from "../customRoles.js";
 import type * as dashboardActivity from "../dashboardActivity.js";
@@ -145,6 +146,7 @@ declare const fullApi: ApiFromModules<{
   crewShifts: typeof crewShifts;
   crewSkills: typeof crewSkills;
   crewTimeEntries: typeof crewTimeEntries;
+  crewWrites: typeof crewWrites;
   customFieldDefinitions: typeof customFieldDefinitions;
   customRoles: typeof customRoles;
   dashboardActivity: typeof dashboardActivity;

--- a/convex/crewWrites.test.ts
+++ b/convex/crewWrites.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const ACTOR = { userId: USER, userName: "Alice" };
+
+async function member(t: ReturnType<typeof convexTest>, role: string) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+  });
+}
+async function seedCrew(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("crewMembers", { id: "c1", organizationId: ORG, firstName: "Bob", lastName: "Ryan", status: "ACTIVE", isActive: true, notes: "old", createdAt: NOW, updatedAt: NOW });
+  });
+}
+
+describe("crewWrites.createNative", () => {
+  const createArgs = { id: "c1", organizationId: ORG, firstName: "Ada", lastName: "Lovelace", status: "ACTIVE" as const, createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1" };
+
+  test("a manager creates a crew member + CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "manager");
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.crewWrites.createNative, createArgs);
+    expect(res.id).toBe("c1");
+    await t.run(async (ctx) => {
+      const c = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "c1")).first();
+      expect(c?.firstName).toBe("Ada");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+      expect(log?.entityType).toBe("crew_member");
+    });
+  });
+
+  test("idempotent by cuid (retried create doesn't duplicate)", async () => {
+    const t = convexTest(schema, modules);
+    await seedCrew(t); // c1 already exists
+    await t.withIdentity(SERVICE).mutation(api.crewWrites.createNative, { ...createArgs, auditId: "log2" });
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "c1")).collect();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].firstName).toBe("Bob"); // original kept (createIfMissing semantics)
+    });
+  });
+
+  test("a member (crew:read only) is denied create", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.crewWrites.createNative, createArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("crewWrites.updateNative", () => {
+  const updArgs = { id: "c1", orgId: ORG, set: { firstName: "Robert", updatedAt: NOW }, clear: [] as string[], entityName: "Robert Ryan", actor: ACTOR, auditId: "log1", now: NOW };
+
+  test("applies set + UPDATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedCrew(t);
+    await t.withIdentity(SERVICE).mutation(api.crewWrites.updateNative, updArgs);
+    await t.run(async (ctx) => {
+      const c = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "c1")).first();
+      expect(c?.firstName).toBe("Robert");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+    });
+  });
+
+  test("clear removes a field", async () => {
+    const t = convexTest(schema, modules);
+    await seedCrew(t);
+    await t.withIdentity(SERVICE).mutation(api.crewWrites.updateNative, { ...updArgs, set: { updatedAt: NOW }, clear: ["notes"] });
+    await t.run(async (ctx) => {
+      const c = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "c1")).first();
+      expect(c?.notes).toBeUndefined();
+    });
+  });
+
+  test("a member is denied update", async () => {
+    const t = convexTest(schema, modules);
+    await seedCrew(t);
+    await member(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.crewWrites.updateNative, updArgs),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -1,0 +1,136 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireOrgPermission } from "./lib/auth";
+import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
+
+/**
+ * Native CREW write mutations (Phase 5) — same pattern as assetWrites/kitWrites:
+ * RBAC(requireOrgPermission "crew") + atomic audit(writeActivityLog) in one
+ * transaction. Additive; the generated convex/crewMembers.ts service mutations are
+ * untouched. Gated behind NATIVE_CREW_WRITES in src/server/crew.ts.
+ *
+ * Covers create + update (crew has no unique-tag invariant). deleteCrewMember has a
+ * multi-table scheduling cascade (assignments → shifts/time-entries, availability) —
+ * a separate slice.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+export const createNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    firstName: v.string(),
+    lastName: v.string(),
+    email: v.optional(v.string()),
+    phone: v.optional(v.string()),
+    image: v.optional(v.string()),
+    userId: v.optional(v.string()),
+    type: v.optional(enums.CrewMemberType),
+    status: v.optional(enums.CrewMemberStatus),
+    department: v.optional(v.string()),
+    defaultDayRate: v.optional(v.number()),
+    defaultHourlyRate: v.optional(v.number()),
+    overtimeMultiplier: v.optional(v.number()),
+    currency: v.optional(v.string()),
+    address: v.optional(v.string()),
+    addressLatitude: v.optional(v.number()),
+    addressLongitude: v.optional(v.number()),
+    emergencyContactName: v.optional(v.string()),
+    emergencyContactPhone: v.optional(v.string()),
+    dateOfBirth: v.optional(v.number()),
+    abnOrGst: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    icalEnabled: v.optional(v.boolean()),
+    icalToken: v.optional(v.string()),
+    crewRoleId: v.optional(v.string()),
+    skillIds: v.optional(v.array(v.string())),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+    isActive: v.optional(v.boolean()),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { actor, auditId, ...fields } = args;
+    await requireOrgPermission(ctx, fields.organizationId, "crew", "create");
+
+    // Idempotent by cuid (mirror convention — a retried create can't duplicate).
+    const existing = await ctx.db
+      .query("crewMembers")
+      .withIndex("by_cuid", (q) => q.eq("id", fields.id))
+      .first();
+    if (!existing) {
+      await ctx.db.insert("crewMembers", fields);
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: fields.organizationId,
+      action: "CREATE",
+      entityType: "crew_member",
+      entityId: fields.id,
+      entityName: `${fields.firstName} ${fields.lastName}`,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Created crew member ${fields.firstName} ${fields.lastName}`,
+      createdAt: fields.createdAt ?? fields.updatedAt ?? 0,
+    });
+
+    return { id: fields.id };
+  },
+});
+
+export const updateNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    // patchMember uses `set: v.any()` + clear[]; mirror it.
+    set: v.any(),
+    clear: v.array(v.string()),
+    entityName: v.string(),
+    details: v.optional(v.any()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, set, clear, entityName, details, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "crew", "update");
+
+    const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Crew member not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    // Apply set (+ clear-to-null) — the patchMember pattern.
+    const NEVER_CLEAR = new Set(["id", "organizationId"]);
+    if (clear.length === 0) {
+      await ctx.db.patch(doc._id, set as Record<string, unknown>);
+    } else {
+      const { _id, _creationTime, ...rest } = doc;
+      const merged: Record<string, unknown> = { ...rest, ...(set as Record<string, unknown>) };
+      for (const k of clear) {
+        if (NEVER_CLEAR.has(k)) continue;
+        delete merged[k];
+      }
+      await ctx.db.replace(doc._id, merged as typeof rest);
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "crew_member",
+      entityId: id,
+      entityName,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated crew member ${entityName}`,
+      details,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -17,6 +17,9 @@ export const nativeAssetWrites = (): boolean =>
 export const nativeKitWrites = (): boolean =>
   process.env.NATIVE_KIT_WRITES === "true";
 
+export const nativeCrewWrites = (): boolean =>
+  process.env.NATIVE_CREW_WRITES === "true";
+
 /**
  * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
  * UserFacingError (title + hint) the server-action path threw, so the toast UX is

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -5,6 +5,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { getConvexClient, toConvexDoc } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
+import { nativeCrewWrites } from "@/lib/native-writes";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import {
@@ -254,12 +255,21 @@ export async function createCrewMember(data: CrewMemberFormValues) {
   // they're read-only, backfilled as skillIds. Cascade children stay Prisma.
   const id = createId();
   const now = Date.now();
-  await (await getConvexClient()).mutation(
-    api.crewMembers.createIfMissing,
-    toConvexDoc({ id, organizationId, ...cleaned, isActive: true, createdAt: now, updatedAt: now }) as FunctionArgs<
-      typeof api.crewMembers.createIfMissing
-    >,
-  );
+  const convexDoc = toConvexDoc({ id, organizationId, ...cleaned, isActive: true, createdAt: now, updatedAt: now });
+  const convex = await getConvexClient();
+  if (nativeCrewWrites()) {
+    // Native: insert (idempotent by cuid) + CREATE audit atomic in the mutation.
+    await convex.mutation(api.crewWrites.createNative, {
+      ...convexDoc,
+      actor: { userId, userName },
+      auditId: createId(),
+    } as FunctionArgs<typeof api.crewWrites.createNative>);
+  } else {
+    await convex.mutation(
+      api.crewMembers.createIfMissing,
+      convexDoc as FunctionArgs<typeof api.crewMembers.createIfMissing>,
+    );
+  }
   const result = {
     id,
     organizationId,
@@ -269,16 +279,18 @@ export async function createCrewMember(data: CrewMemberFormValues) {
     updatedAt: new Date(now),
   };
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "CREATE",
-    entityType: "crew_member",
-    entityId: result.id,
-    entityName: `${result.firstName} ${result.lastName}`,
-    summary: `Created crew member ${result.firstName} ${result.lastName}`,
-  });
+  if (!nativeCrewWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "CREATE",
+      entityType: "crew_member",
+      entityId: result.id,
+      entityName: `${result.firstName} ${result.lastName}`,
+      summary: `Created crew member ${result.firstName} ${result.lastName}`,
+    });
+  }
 
   return serialize(result);
 }
@@ -323,29 +335,45 @@ export async function updateCrewMember(id: string, data: CrewMemberFormValues) {
   const clear = Object.entries(cleaned)
     .filter(([, val]) => val == null)
     .map(([k]) => k);
-  await (await getConvexClient()).mutation(api.crewMembers.patchMember, {
-    id,
-    set: toConvexDoc({ ...cleaned, updatedAt: now }),
-    clear,
-  });
+  const setDoc = toConvexDoc({ ...cleaned, updatedAt: now });
   const updated = { ...before, ...cleaned, updatedAt: new Date(now) };
-
   const changes = buildChanges(before, updated, [
     "firstName", "lastName", "email", "phone", "type", "status",
     "department", "defaultDayRate", "defaultHourlyRate", "address", "isActive",
   ]);
+  const entityName = `${updated.firstName} ${updated.lastName}`;
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "UPDATE",
-    entityType: "crew_member",
-    entityId: updated.id,
-    entityName: `${updated.firstName} ${updated.lastName}`,
-    summary: `Updated crew member ${updated.firstName} ${updated.lastName}`,
-    details: changes.length > 0 ? { changes } : undefined,
-  });
+  const convex = await getConvexClient();
+  if (nativeCrewWrites()) {
+    // Native: patch/clear + UPDATE audit (with the field-change diff) atomic.
+    await convex.mutation(api.crewWrites.updateNative, {
+      id,
+      orgId: organizationId,
+      set: setDoc,
+      clear,
+      entityName,
+      details: changes.length > 0 ? { changes } : undefined,
+      actor: { userId, userName },
+      auditId: createId(),
+      now,
+    } as FunctionArgs<typeof api.crewWrites.updateNative>);
+  } else {
+    await convex.mutation(api.crewMembers.patchMember, { id, set: setDoc, clear });
+  }
+
+  if (!nativeCrewWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "UPDATE",
+      entityType: "crew_member",
+      entityId: updated.id,
+      entityName,
+      summary: `Updated crew member ${entityName}`,
+      details: changes.length > 0 ? { changes } : undefined,
+    });
+  }
 
   return serialize(updated);
 }


### PR DESCRIPTION
## Phase 5 — crew domain (3rd domain on the pattern)

`convex/crewWrites.ts`: `createNative` (idempotent-by-cuid insert + CREATE audit) + `updateNative` (set/clear patch + UPDATE audit carrying the field-change diff) — each RBAC(`crew`) + atomic audit in one transaction. Wired `createCrewMember`/`updateCrewMember` behind **`NATIVE_CREW_WRITES`** (runtime env, default OFF).

`deleteCrewMember` has a scheduling cascade (assignments → shifts/time-entries, availability) — a separate slice.

### Tests (`crewWrites.test.ts`, 6/6; 35 total)
manager-create+audit, cuid-idempotency, member-denied; update set+audit, clear-removes-field, member-denied. (`crew:create/update` need `manager`.)

Flag OFF. `tsc` ✅ · `eslint` ✅ 0 errors · tests ✅ 35/35 · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)