### PR TITLE
Phase 5 projects: native status/notes/archive writes (money-free)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -86,6 +86,7 @@ import type * as projectMedia from "../projectMedia.js";
 import type * as projectNumberSequences from "../projectNumberSequences.js";
 import type * as projectServices from "../projectServices.js";
 import type * as projectTasks from "../projectTasks.js";
+import type * as projectWrites from "../projectWrites.js";
 import type * as projects from "../projects.js";
 import type * as purgeRemovedTables from "../purgeRemovedTables.js";
 import type * as savedTableViews from "../savedTableViews.js";
@@ -200,6 +201,7 @@ declare const fullApi: ApiFromModules<{
   projectNumberSequences: typeof projectNumberSequences;
   projectServices: typeof projectServices;
   projectTasks: typeof projectTasks;
+  projectWrites: typeof projectWrites;
   projects: typeof projects;
   purgeRemovedTables: typeof purgeRemovedTables;
   savedTableViews: typeof savedTableViews;

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const ACTOR = { userId: USER, userName: "Alice" };
+
+async function seedProject(t: ReturnType<typeof convexTest>, role?: string, isTemplate = false) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate, createdAt: NOW, updatedAt: NOW });
+    if (role) await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+  });
+}
+
+describe("projectWrites.updateStatusNative", () => {
+  const args = { id: "p1", orgId: ORG, status: "PREPPING" as const, actor: ACTOR, auditId: "log1", now: NOW };
+
+  test("member changes status + STATUS_CHANGE audit (from/to)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "member");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.status).toBe("PREPPING");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("STATUS_CHANGE");
+      expect(log?.details).toEqual({ changes: [{ field: "status", from: "CONFIRMED", to: "PREPPING" }] });
+    });
+  });
+
+  test("rejects a template (TEMPLATE_STATUS)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, undefined, true);
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.projectWrites.updateStatusNative, args),
+    ).rejects.toThrow(/template/i);
+  });
+
+  test("a viewer is denied (project:update)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("projectWrites.updateNotesNative", () => {
+  test("patches a whitelisted notes field + audit; clears on null", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t);
+    await t.withIdentity(SERVICE).mutation(api.projectWrites.updateNotesNative, { id: "p1", orgId: ORG, field: "crewNotes", notes: "load in 6am", actor: ACTOR, auditId: "log1", now: NOW });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.crewNotes).toBe("load in 6am");
+    });
+    await t.withIdentity(SERVICE).mutation(api.projectWrites.updateNotesNative, { id: "p1", orgId: ORG, field: "crewNotes", notes: null, actor: ACTOR, auditId: "log2", now: NOW });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.crewNotes).toBeUndefined();
+    });
+  });
+});
+
+describe("projectWrites.archiveNative", () => {
+  test("sets status CANCELLED + audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t);
+    await t.withIdentity(SERVICE).mutation(api.projectWrites.archiveNative, { id: "p1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.status).toBe("CANCELLED");
+    });
+  });
+});

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -1,0 +1,138 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireOrgPermission } from "./lib/auth";
+import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
+
+/**
+ * Native PROJECT write mutations (Phase 5) — the MONEY-FREE project writes only:
+ * status change, notes, archive. Each does RBAC(requireOrgPermission "project",
+ * "update") + invariant + atomic audit in one transaction.
+ *
+ * The financial writes (createProject/updateProject and every line-item write) call
+ * recalculateProjectTotals and are deliberately NOT here — those stay server-side so
+ * the totals math is untouched (parity preserved by construction) until they get the
+ * dedicated recalc-parity treatment. Gated behind NATIVE_PROJECT_WRITES.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+const NOTES_FIELD = v.union(
+  v.literal("crewNotes"),
+  v.literal("internalNotes"),
+  v.literal("clientNotes"),
+);
+
+export const updateStatusNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    status: enums.ProjectStatus,
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, status, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "update");
+
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+    if (project.isTemplate) {
+      throw new ConvexError({ code: "TEMPLATE_STATUS", message: "Templates don't have a status." });
+    }
+
+    const from = project.status ?? "";
+    await ctx.db.patch(project._id, { status, updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "STATUS_CHANGE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Changed project ${project.projectNumber} status from ${from} to ${status}`,
+      details: { changes: [{ field: "status", from, to: status }] },
+      projectId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+export const updateNotesNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    field: NOTES_FIELD,
+    notes: v.union(v.string(), v.null()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, field, notes, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "update");
+
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    // `undefined` clears the field (matches the server action's notes || null).
+    await ctx.db.patch(project._id, { [field]: notes ?? undefined, updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated ${field} on project ${project.projectNumber}`,
+      projectId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+export const archiveNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "update");
+
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.patch(project._id, { status: "CANCELLED", updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Archived project ${project.projectNumber}`,
+      details: { archived: true },
+      projectId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -20,6 +20,9 @@ export const nativeKitWrites = (): boolean =>
 export const nativeCrewWrites = (): boolean =>
   process.env.NATIVE_CREW_WRITES === "true";
 
+export const nativeProjectWrites = (): boolean =>
+  process.env.NATIVE_PROJECT_WRITES === "true";
+
 /**
  * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
  * UserFacingError (title + hint) the server-action path threw, so the toast UX is

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -34,6 +34,7 @@ import { type FilterValue } from "@/lib/table-utils";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { getDefaultLocation, getLocationMap, getMappedLocationsByOrg, mapLocation } from "@/lib/locations-read";
 import { createId } from "@paralleldrive/cuid2";
+import { nativeProjectWrites } from "@/lib/native-writes";
 import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import {
   renderProjectNumber,
@@ -749,26 +750,42 @@ export async function updateProjectStatus(
 
   // project is Convex-only — patch the status directly.
   const convex = await getConvexClient();
-  await convex.mutation(api.projects.patchProject, {
-    id,
-    set: { status, updatedAt: Date.now() },
-  });
+  if (nativeProjectWrites()) {
+    // Native: template guard + patch + STATUS_CHANGE audit atomic in the mutation.
+    await convex.mutation(api.projectWrites.updateStatusNative, {
+      id,
+      orgId: organizationId,
+      // A status change always carries a concrete status (the field is optional only
+      // in the shared form type).
+      status: status as NonNullable<typeof status>,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projects.patchProject, {
+      id,
+      set: { status, updatedAt: Date.now() },
+    });
+  }
 
   const updated = await getProjectByIdMapped(id, organizationId);
   if (!updated) throw new Error("Project status update failed");
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "STATUS_CHANGE",
-    entityType: "project",
-    entityId: updated.id,
-    entityName: updated.projectNumber,
-    summary: `Changed project ${updated.projectNumber} status from ${project.status} to ${status}`,
-    details: { changes: [{ field: "status", from: project.status, to: status }] },
-    projectId: updated.id,
-  });
+  if (!nativeProjectWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "STATUS_CHANGE",
+      entityType: "project",
+      entityId: updated.id,
+      entityName: updated.projectNumber,
+      summary: `Changed project ${updated.projectNumber} status from ${project.status} to ${status}`,
+      details: { changes: [{ field: "status", from: project.status, to: status }] },
+      projectId: updated.id,
+    });
+  }
 
   return serialize(updated);
 }
@@ -778,27 +795,49 @@ export async function updateProjectNotes(
   field: "crewNotes" | "internalNotes" | "clientNotes",
   notes: string,
 ) {
-  const { organizationId } = await requirePermission("project", "update");
+  const { organizationId, userId, userName } = await requirePermission("project", "update");
   // project is Convex-only — patch the single whitelisted notes field (clear when
   // emptied, mirroring the old `notes || null`).
   const convex = await getConvexClient();
-  await convex.mutation(api.projects.patchProject, {
-    id,
-    ...(notes ? { set: { [field]: notes, updatedAt: Date.now() } } : { set: { updatedAt: Date.now() }, clear: [field] }),
-  });
+  if (nativeProjectWrites()) {
+    await convex.mutation(api.projectWrites.updateNotesNative, {
+      id,
+      orgId: organizationId,
+      field,
+      notes: notes || null,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projects.patchProject, {
+      id,
+      ...(notes ? { set: { [field]: notes, updatedAt: Date.now() } } : { set: { updatedAt: Date.now() }, clear: [field] }),
+    });
+  }
   const updated = await getProjectByIdMapped(id, organizationId);
   if (!updated) throw new Error("Project notes update failed");
   return serialize(updated);
 }
 
 export async function archiveProject(id: string) {
-  const { organizationId } = await requirePermission("project", "update");
+  const { organizationId, userId, userName } = await requirePermission("project", "update");
   // project is Convex-only — set status to CANCELLED.
   const convex = await getConvexClient();
-  await convex.mutation(api.projects.patchProject, {
-    id,
-    set: { status: "CANCELLED", updatedAt: Date.now() },
-  });
+  if (nativeProjectWrites()) {
+    await convex.mutation(api.projectWrites.archiveNative, {
+      id,
+      orgId: organizationId,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projects.patchProject, {
+      id,
+      set: { status: "CANCELLED", updatedAt: Date.now() },
+    });
+  }
   const updated = await getProjectByIdMapped(id, organizationId);
   if (!updated) throw new Error("Project archive failed");
   return serialize(updated);


### PR DESCRIPTION
## Phase 5 — projects domain (money-free writes)

`convex/projectWrites.ts`: `updateStatusNative` (template guard + patch + STATUS_CHANGE audit with from/to), `updateNotesNative` (whitelisted crew/internal/client notes + audit), `archiveNative` (status CANCELLED + audit) — each RBAC(`project`,`update`) + invariant + atomic audit in one transaction. Wired `updateProjectStatus`/`updateProjectNotes`/`archiveProject` behind **`NATIVE_PROJECT_WRITES`**.

**Deliberately money-free:** `createProject`/`updateProject` and every line-item write call `recalculateProjectTotals` — those stay server-side (recalc untouched → totals parity preserved by construction) until the dedicated recalc-parity treatment. `updateProjectStatus` keeps its blocking-comments guard server-side (a pre-condition).

### Tests (`projectWrites.test.ts`, 5/5)
status change + STATUS_CHANGE audit (from/to), template reject, viewer-deny; notes patch+clear; archive→CANCELLED.

Flag OFF. `tsc` ✅ · `eslint` ✅ 0 errors · tests ✅ · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)