### PR TITLE
Phase 5 line-items: native removeLineItem (money domain, recalc-safe)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -62,6 +62,7 @@ import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_testtag from "../lib/testtag.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as lineItemMergeMaps from "../lineItemMergeMaps.js";
+import type * as lineItemWrites from "../lineItemWrites.js";
 import type * as locationMedia from "../locationMedia.js";
 import type * as locations from "../locations.js";
 import type * as maintenanceRecordAssets from "../maintenanceRecordAssets.js";
@@ -177,6 +178,7 @@ declare const fullApi: ApiFromModules<{
   "lib/testtag": typeof lib_testtag;
   "lib/validators": typeof lib_validators;
   lineItemMergeMaps: typeof lineItemMergeMaps;
+  lineItemWrites: typeof lineItemWrites;
   locationMedia: typeof locationMedia;
   locations: typeof locations;
   maintenanceRecordAssets: typeof maintenanceRecordAssets;

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const ACTOR = { userId: USER, userName: "Alice" };
+const args = { id: "li1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
+
+async function member(t: ReturnType<typeof convexTest>, role: string) {
+  await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role }); });
+}
+
+describe("lineItemWrites.removeNative", () => {
+  test("member removes a leaf line + its units + DELETE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+      await ctx.db.insert("projectLineItemUnits", { id: "u1", organizationId: ORG, lineItemId: "li1", assetId: "a1", ordinal: 0 });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.removeNative, args);
+    expect(res.projectId).toBe("p1");
+    await t.run(async (ctx) => {
+      const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(line).toBeNull();
+      const units = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", "li1")).collect();
+      expect(units).toHaveLength(0);
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("DELETE");
+      expect(log?.entityType).toBe("lineItem");
+    });
+  });
+
+  test("cascade-removes children (+ their units)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Kit", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+      await ctx.db.insert("projectLineItems", { id: "child1", organizationId: ORG, projectId: "p1", parentLineItemId: "li1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "KIT" });
+      await ctx.db.insert("projectLineItemUnits", { id: "cu1", organizationId: ORG, lineItemId: "child1", assetId: "a2", ordinal: 0 });
+    });
+    await t.withIdentity(SERVICE).mutation(api.lineItemWrites.removeNative, args);
+    await t.run(async (ctx) => {
+      const child = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "child1")).first();
+      expect(child).toBeNull();
+      const cu = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", "child1")).collect();
+      expect(cu).toHaveLength(0);
+    });
+  });
+
+  test("blocks removing a kit child directly (KIT_CHILD)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "KIT" });
+    });
+    await expect(t.withIdentity(SERVICE).mutation(api.lineItemWrites.removeNative, args)).rejects.toThrow(/part of a Kit/i);
+  });
+
+  test("blocks removing an accessory child directly (ACCESSORY_CHILD)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "ACCESSORY" });
+    });
+    await expect(t.withIdentity(SERVICE).mutation(api.lineItemWrites.removeNative, args)).rejects.toThrow(/accessory/i);
+  });
+
+  test("a viewer is denied (project:manage_line_items)", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.removeNative, args)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -1,0 +1,88 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { requireOrgPermission } from "./lib/auth";
+import { writeActivityLog } from "./lib/audit";
+
+/**
+ * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
+ *
+ * SCOPE: only the writes whose logic is cleanly separable from the financial
+ * orchestration. recalculateProjectTotals stays SERVER-SIDE and runs post-hoc
+ * exactly as before (it already runs after the write, never inside the write
+ * transaction — src/server/line-items.ts), so the totals math is byte-identical
+ * and parity is preserved by construction. addLineItem is NOT here — its
+ * cross-project double-booking check reads every overlapping project (Convex
+ * read-limit risk in a mutation) + accessory/kit expansion is ~400 lines of
+ * orchestration; it stays server-orchestrated for now.
+ *
+ * removeNative mirrors removeLineItemCascade (convex/projectLineItems.ts) + adds the
+ * child-removal guard (kit/accessory children can't be removed directly) + the DELETE
+ * audit, all atomic. Gated behind NATIVE_LINEITEM_WRITES.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+/** Delete a line + its fulfillment units (replica of deleteLineWithUnits). */
+async function deleteLineWithUnits(ctx: MutationCtx, lineDocId: Id<"projectLineItems">, lineCuid: string) {
+  const units = await ctx.db
+    .query("projectLineItemUnits")
+    .withIndex("by_lineItemId", (q) => q.eq("lineItemId", lineCuid))
+    .collect();
+  for (const u of units) await ctx.db.delete(u._id);
+  await ctx.db.delete(lineDocId);
+}
+
+export const removeNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+
+    const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!line) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
+    if (line.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    // Child items (kit members, sub-hire group children, accessory children) are
+    // removed via their parent, never individually — same guard as removeLineItem.
+    if (line.isKitChild) {
+      const isAccessory = line.childKind === "ACCESSORY";
+      throw new ConvexError({
+        code: isAccessory ? "ACCESSORY_CHILD" : "KIT_CHILD",
+        message: isAccessory ? "This item is an accessory of another asset." : "This item is part of a Kit.",
+      });
+    }
+
+    // Cascade-delete the children (+ their units) and the line (+ its units) — the
+    // exact removeLineItemCascade sequence, now atomic with the guard + audit.
+    const children = await ctx.db
+      .query("projectLineItems")
+      .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
+      .collect();
+    for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id);
+    await deleteLineWithUnits(ctx, line._id, line.id);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "DELETE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName: line.description || "Line item",
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Removed line item from project",
+      projectId: line.projectId,
+      createdAt: now,
+    });
+
+    // The caller recalculates project totals afterward (server-side, unchanged).
+    return { projectId: line.projectId };
+  },
+});

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -23,6 +23,9 @@ export const nativeCrewWrites = (): boolean =>
 export const nativeProjectWrites = (): boolean =>
   process.env.NATIVE_PROJECT_WRITES === "true";
 
+export const nativeLineItemWrites = (): boolean =>
+  process.env.NATIVE_LINEITEM_WRITES === "true";
+
 /**
  * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
  * UserFacingError (title + hint) the server-action path threw, so the toast UX is
@@ -52,6 +55,21 @@ const ASSET_WRITE_ERROR_MAP: Record<
     title: "Duplicate asset tag",
     message: "That asset tag already exists.",
     hint: "Use a different asset tag.",
+  },
+  // Line-item removeNative guards (mirror src/server/line-items.ts).
+  NOT_FOUND: {
+    title: "Line item not found",
+    message: "This item was deleted by someone else. Refresh the page.",
+  },
+  KIT_CHILD: {
+    title: "Cannot remove this item",
+    message: "This item is part of a Kit.",
+    hint: "Remove the Kit from the project instead — that will remove all its members at once.",
+  },
+  ACCESSORY_CHILD: {
+    title: "Cannot remove this item",
+    message: "This item is an accessory of another asset.",
+    hint: "Remove the parent asset's line to remove it, or detach the accessory from the asset in the catalog.",
   },
 };
 

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -13,6 +13,7 @@ import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
+import { nativeLineItemWrites, mapNativeWriteError } from "@/lib/native-writes";
 import { getSupplierById } from "@/lib/suppliers-read";
 import { roundCurrency } from "@/lib/formatters";
 import { calculateSuggestedPrice } from "./project-groups";
@@ -892,6 +893,38 @@ export async function removeLineItem(id: string) {
       title: "Line item not found",
       message: "This item was deleted by someone else. Refresh the page.",
     });
+  }
+
+  if (nativeLineItemWrites()) {
+    // Native: the child-removal guard + cascade (children + units) + DELETE audit
+    // run atomically in the mutation. recalc + the collab feed stay server-side
+    // (recalc already ran post-delete before — unchanged, so totals are identical).
+    try {
+      await convex.mutation(api.lineItemWrites.removeNative, {
+        id,
+        orgId: organizationId,
+        actor: { userId, userName },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+    await Promise.all([
+      recalculateProjectTotals(item.projectId),
+      writeCollabActivityEvent(
+        { organizationId, userId, userName },
+        {
+          entityType: "project",
+          entityId: item.projectId,
+          action: "line_item_removed",
+          summary: `removed ${item.description || "a line item"}`,
+          targetType: "lineItem",
+          targetId: id,
+        },
+      ),
+    ]);
+    return serialize({ success: true });
   }
 
   // Block direct removal of child items (kit members, sub-hire group children,


### PR DESCRIPTION
## Phase 5 — line-items: the first financial write goes native

Chosen deliberately as the first money write because its logic is **cleanly separable from the recalc**: `recalculateProjectTotals` already runs **post-delete** (in a `Promise.all`, never inside the write transaction), so leaving it server-side keeps totals **byte-identical — parity by construction**.

- **`convex/lineItemWrites.ts` `removeNative`** — RBAC(`project`,`manage_line_items`) + the child-removal guard (kit/accessory children can't be removed directly — coded `ConvexError`) + the exact `removeLineItemCascade` sequence (children + units, then the line + units, via a local `deleteLineWithUnits` replica) + DELETE audit — all **atomic**, closing the guard-then-cascade race.
- Wired `removeLineItem` behind **`NATIVE_LINEITEM_WRITES`**; recalc + the collab feed stay server-side (unchanged). Error codes `NOT_FOUND`/`KIT_CHILD`/`ACCESSORY_CHILD` → `UserFacingError`.

**Not `addLineItem`:** it reads *every overlapping project* for double-booking detection (Convex read-limit risk inside a mutation) + ~400 lines of accessory/kit expansion — that stays server-orchestrated (documented).

### Tests (`lineItemWrites.test.ts`, 5/5)
leaf remove + units + audit, child cascade, `KIT_CHILD` + `ACCESSORY_CHILD` guards, viewer-deny.

Flag OFF. `tsc` ✅ · `eslint` ✅ 0 errors · tests ✅ · `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)