### PR TITLE
Phase 5 line-items: native updateLineItem (Option A — leaf write + audit)

### DIFF
--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -79,3 +79,40 @@ describe("lineItemWrites.removeNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.removeNative, args)).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("lineItemWrites.patchNative", () => {
+  const pargs = { id: "li1", orgId: ORG, entityName: "Light", actor: ACTOR, auditId: "log1", now: NOW };
+  test("member patches fields + UPDATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", quantity: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 3, unitPrice: 50, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(3);
+      expect(li?.unitPrice).toBe(50);
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+      expect(log?.entityType).toBe("lineItem");
+    });
+  });
+  test("clear removes a field", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", notes: "x", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    await t.withIdentity(SERVICE).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { updatedAt: NOW }, clear: ["notes"] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.notes).toBeUndefined();
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false }); });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -86,3 +86,59 @@ export const removeNative = mutation({
     return { projectId: line.projectId };
   },
 });
+
+const LINE_NEVER_CLEAR = new Set(["id", "organizationId", "projectId"]);
+
+/**
+ * patchNative — apply a set/clear patch to a line item + UPDATE audit, atomic.
+ * RBAC(project, manage_line_items). The server action still does the availability
+ * re-check (cross-project, on quantity increase) + the stale-revision guard + builds
+ * set/clear; the write + audit move here. recalc stays server-side (post-write).
+ */
+export const patchNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    set: v.any(),
+    clear: v.array(v.string()),
+    entityName: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, set, clear, entityName, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+
+    const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    if (clear.length === 0) {
+      await ctx.db.patch(doc._id, set as Record<string, unknown>);
+    } else {
+      const { _id, _creationTime, ...rest } = doc;
+      const merged: Record<string, unknown> = { ...rest, ...(set as Record<string, unknown>) };
+      for (const k of clear) {
+        if (LINE_NEVER_CLEAR.has(k)) continue;
+        delete merged[k];
+      }
+      await ctx.db.replace(doc._id, merged as typeof rest);
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Updated line item on project",
+      projectId: doc.projectId,
+      createdAt: now,
+    });
+
+    return { projectId: doc.projectId };
+  },
+});

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -635,18 +635,36 @@ export async function updateLineItem(
   if (parsed.bulkAssetId !== undefined) setStr("bulkAssetId", parsed.bulkAssetId);
   if (parsed.supplierId !== undefined) setStr("supplierId", parsed.supplierId);
 
-  await (await getConvexClient()).mutation(api.projectLineItems.patchLineItem, {
-    id,
-    set,
-    clear,
-  });
+  const patchConvex = await getConvexClient();
+  if (nativeLineItemWrites()) {
+    // Native: RBAC + patch/clear + UPDATE audit atomic. The availability re-check +
+    // stale guard above stay server-side; recalc + collab stay below (unchanged).
+    try {
+      await patchConvex.mutation(api.lineItemWrites.patchNative, {
+        id,
+        orgId: organizationId,
+        set,
+        clear,
+        entityName: parsed.description || "Line item",
+        actor: { userId, userName },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+  } else {
+    await patchConvex.mutation(api.projectLineItems.patchLineItem, { id, set, clear });
+  }
 
   const result = (await readBackLine(id))!;
 
   // Post-write tail in parallel (recalc + best-effort audit + collab + supplier enrich).
   const [, , , supplier] = await Promise.all([
     recalculateProjectTotals(result.projectId),
-    logActivity({
+    nativeLineItemWrites()
+      ? Promise.resolve()
+      : logActivity({
       organizationId,
       userId,
       userName,


### PR DESCRIPTION
Option A for updateLineItem: the cross-project availability re-check + stale guard + set/clear build stay **server-side**; only the leaf write + audit move into `lineItemWrites.patchNative` (RBAC + patch/clear + atomic UPDATE audit). Wired behind `NATIVE_LINEITEM_WRITES`; recalc + collab stay server-side (recalc already post-write → totals identical). Tests 8/8. tsc/lint/build ✅. Flag OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)