### PR TITLE
Phase 5 projects: native updateProject (Option A)

### DIFF
--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -80,3 +80,36 @@ describe("projectWrites.archiveNative", () => {
     });
   });
 });
+
+describe("projectWrites.updateNative", () => {
+  const uargs = { id: "p1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
+  test("member patches fields + UPDATE audit (label from doc)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "member");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { name: "Renamed Gig", taxRate: 10, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.name).toBe("Renamed Gig");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+      expect(log?.entityName).toBe("P1");
+      expect(log?.summary).toContain("Renamed Gig");
+    });
+  });
+  test("clear removes a field", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, clientNotes: "x", createdAt: NOW, updatedAt: NOW });
+    });
+    await t.withIdentity(SERVICE).mutation(api.projectWrites.updateNative, { ...uargs, set: { updatedAt: NOW }, clear: ["clientNotes"] });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.clientNotes).toBeUndefined();
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -136,3 +136,60 @@ export const archiveNative = mutation({
     return { id };
   },
 });
+
+const PROJECT_NEVER_CLEAR = new Set(["id", "organizationId", "projectNumber"]);
+
+/**
+ * updateNative — general project field patch (set/clear) + UPDATE audit, atomic.
+ * RBAC(project, update). Option A: the server action keeps Zod validation + the
+ * conditional recalc (only when taxRate changes — recalc stays server-side, totals
+ * identical); the write + audit move here.
+ */
+export const updateNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    set: v.any(),
+    clear: v.array(v.string()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, set, clear, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "update");
+
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    const setObj = (set ?? {}) as Record<string, unknown>;
+    if (clear.length === 0) {
+      await ctx.db.patch(project._id, setObj);
+    } else {
+      const { _id, _creationTime, ...rest } = project;
+      const merged: Record<string, unknown> = { ...rest, ...setObj };
+      for (const k of clear) {
+        if (PROJECT_NEVER_CLEAR.has(k)) continue;
+        delete merged[k];
+      }
+      await ctx.db.replace(project._id, merged as typeof rest);
+    }
+
+    const name = (typeof setObj.name === "string" ? setObj.name : undefined) ?? project.name;
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated project ${project.projectNumber} - ${name}`,
+      projectId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -692,11 +692,25 @@ export async function updateProject(id: string, data: ProjectFormValues) {
   setOrClear("invoicedTotal", parsed.invoicedTotal ?? null);
 
   const convex = await getConvexClient();
-  await convex.mutation(api.projects.patchProject, {
-    id,
-    set,
-    ...(clear.length > 0 ? { clear } : {}),
-  });
+  if (nativeProjectWrites()) {
+    // Native: RBAC + patch/clear + UPDATE audit atomic. Zod validation stays above;
+    // recalc stays below (server-side, unchanged → totals identical).
+    await convex.mutation(api.projectWrites.updateNative, {
+      id,
+      orgId: organizationId,
+      set,
+      clear,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projects.patchProject, {
+      id,
+      set,
+      ...(clear.length > 0 ? { clear } : {}),
+    });
+  }
 
   // Recalculate totals if tax rate changed
   if (parsed.taxRate !== undefined) {
@@ -706,17 +720,19 @@ export async function updateProject(id: string, data: ProjectFormValues) {
   const updated = await getProjectByIdMapped(id, organizationId);
   if (!updated) throw new Error("Project update failed");
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "UPDATE",
-    entityType: "project",
-    entityId: updated.id,
-    entityName: updated.projectNumber,
-    summary: `Updated project ${updated.projectNumber} - ${updated.name}`,
-    projectId: updated.id,
-  });
+  if (!nativeProjectWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "UPDATE",
+      entityType: "project",
+      entityId: updated.id,
+      entityName: updated.projectNumber,
+      summary: `Updated project ${updated.projectNumber} - ${updated.name}`,
+      projectId: updated.id,
+    });
+  }
 
   return serialize(updated);
 }


### PR DESCRIPTION
Option A: `projectWrites.updateNative` (RBAC + set/clear patch + atomic UPDATE audit, label from the project doc). Wired `updateProject` behind `NATIVE_PROJECT_WRITES` — Zod validation + the conditional recalc (only when taxRate changes) stay server-side (totals identical). 8/8 tests. tsc/lint/build ✅. Flag OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)