### PR TITLE
Phase 5 line-items: native addCustomLineItem (fully native)

### DIFF
--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -116,3 +116,28 @@ describe("lineItemWrites.patchNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("lineItemWrites.addCustomNative", () => {
+  const cargs = { id: "cust1", organizationId: ORG, projectId: "p1", fields: { description: "Rigging labour", quantity: 1, unitPrice: 200 }, actor: ACTOR, auditId: "log1", now: NOW };
+  test("member adds a custom line (sortOrder computed) + CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "existing", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 4 });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, cargs);
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "cust1")).first();
+      expect(li?.isCustomItem).toBe(true);
+      expect(li?.sortOrder).toBe(5); // max(4)+1
+      expect(li?.description).toBe("Rigging labour");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, cargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -4,6 +4,7 @@ import type { MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
 
 /**
  * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
@@ -140,5 +141,77 @@ export const patchNative = mutation({
     });
 
     return { projectId: doc.projectId };
+  },
+});
+
+/** Next sort order for a project's lines (replica of nextLineSort). */
+async function nextLineSort(ctx: MutationCtx, projectId: string, organizationId: string): Promise<number> {
+  const lines = await ctx.db
+    .query("projectLineItems")
+    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+    .collect();
+  return lines.filter((l) => l.organizationId === organizationId).reduce((m, l) => Math.max(m, l.sortOrder ?? -1), -1) + 1;
+}
+
+/**
+ * addCustomNative — insert a custom (non-inventory) line item + CREATE audit, atomic.
+ * RBAC(project, manage_line_items). Custom items never consume inventory, so there's
+ * NO availability check to keep server-side — this is a fully-native add. sortOrder is
+ * computed in-mutation (nextLineSort replica); recalc stays server-side (post-write).
+ */
+export const addCustomNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    fields: v.object({
+      description: v.optional(v.string()),
+      quantity: v.number(),
+      unitPrice: v.optional(v.number()),
+      pricingType: v.optional(enums.PricingType),
+      duration: v.optional(v.number()),
+      discount: v.optional(v.number()),
+      notes: v.optional(v.string()),
+      isOptional: v.optional(v.boolean()),
+      categoryId: v.optional(v.string()),
+      groupId: v.optional(v.string()),
+      groupName: v.optional(v.string()),
+      lineTotal: v.optional(v.number()),
+    }),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, projectId, fields, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+
+    const sortOrder = await nextLineSort(ctx, projectId, organizationId);
+    await ctx.db.insert("projectLineItems", {
+      id,
+      organizationId,
+      projectId,
+      type: "EQUIPMENT",
+      isCustomItem: true,
+      ...fields,
+      sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "CREATE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName: fields.description || "Custom item",
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Added custom item "${fields.description ?? ""}" to project`,
+      projectId,
+      createdAt: now,
+    });
+
+    return { id };
   },
 });

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -846,33 +846,50 @@ export async function addCustomLineItem(projectId: string, data: CustomLineItemF
   const lineTotal = calculateLineTotal(parsed.unitPrice, parsed.quantity, parsed.duration, parsed.discount);
 
   const customId = createId();
-  await (await getConvexClient()).mutation(api.projectLineItems.createCustomLineItem, {
-    id: customId,
-    organizationId,
-    projectId,
-    fields: {
-      description: parsed.description,
-      quantity: parsed.quantity,
-      unitPrice: parsed.unitPrice ?? undefined,
-      pricingType: parsed.pricingType,
-      duration: parsed.duration,
-      discount: parsed.discount ?? undefined,
-      notes: parsed.notes ?? undefined,
-      isOptional: parsed.isOptional,
-      categoryId: parsed.categoryId ?? undefined,
-      groupId: parsed.groupId ?? undefined,
-      groupName: groupName ?? undefined,
-      lineTotal: lineTotal ?? undefined,
-    },
-    now: Date.now(),
-  });
+  const customFields = {
+    description: parsed.description,
+    quantity: parsed.quantity,
+    unitPrice: parsed.unitPrice ?? undefined,
+    pricingType: parsed.pricingType,
+    duration: parsed.duration,
+    discount: parsed.discount ?? undefined,
+    notes: parsed.notes ?? undefined,
+    isOptional: parsed.isOptional,
+    categoryId: parsed.categoryId ?? undefined,
+    groupId: parsed.groupId ?? undefined,
+    groupName: groupName ?? undefined,
+    lineTotal: lineTotal ?? undefined,
+  };
+  const customConvex = await getConvexClient();
+  if (nativeLineItemWrites()) {
+    // Custom items consume no inventory → fully native (RBAC + insert + audit).
+    await customConvex.mutation(api.lineItemWrites.addCustomNative, {
+      id: customId,
+      organizationId,
+      projectId,
+      fields: customFields,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await customConvex.mutation(api.projectLineItems.createCustomLineItem, {
+      id: customId,
+      organizationId,
+      projectId,
+      fields: customFields,
+      now: Date.now(),
+    });
+  }
 
   const result = (await readBackLine(customId))!;
 
   // Post-write tail in parallel (recalc + best-effort audit + collab feed).
   await Promise.all([
     recalculateProjectTotals(projectId),
-    logActivity({
+    nativeLineItemWrites()
+      ? Promise.resolve()
+      : logActivity({
       organizationId,
       userId,
       userName,


### PR DESCRIPTION
Custom line items consume no inventory → no cross-project availability check → this add is **fully native** (unlike addLineItem). `lineItemWrites.addCustomNative`: RBAC + sortOrder (nextLineSort replica) + insert + CREATE audit, atomic. Wired behind `NATIVE_LINEITEM_WRITES`; recalc + collab stay server-side. 10/10 tests. tsc/lint/build ✅. Flag OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)