### PR TITLE
Phase 5 projects: native createProject (Option A)

### DIFF
--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -113,3 +113,38 @@ describe("projectWrites.updateNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("projectWrites.createNative", () => {
+  const cargs = { id: "np1", organizationId: ORG, projectNumber: "P-100", name: "New Gig", isTemplate: false, createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1" };
+  test("member creates a project + CREATE audit (created:true)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs);
+    expect(res).toEqual({ created: true, id: "np1" });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first();
+      expect(p?.projectNumber).toBe("P-100");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+    });
+  });
+  test("returns created:false + no insert/audit on a number clash", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "existing", organizationId: ORG, projectNumber: "P-100", name: "Taken", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
+    const res = await t.withIdentity(SERVICE).mutation(api.projectWrites.createNative, cargs);
+    expect(res).toEqual({ created: false, id: "existing" });
+    await t.run(async (ctx) => {
+      const np = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first();
+      expect(np).toBeNull();
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log).toBeNull();
+    });
+  });
+  test("a viewer is denied (project:create)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "viewer" }); });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -3,6 +3,7 @@ import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import * as enums from "./lib/validators";
+import { projectWriteFields } from "./projects";
 
 /**
  * Native PROJECT write mutations (Phase 5) — the MONEY-FREE project writes only:
@@ -191,5 +192,54 @@ export const updateNative = mutation({
     });
 
     return { id };
+  },
+});
+
+/**
+ * createNative — insert a project with the unique-project-number check + CREATE
+ * audit, atomic. RBAC(project, create). Mirrors createWithUniqueNumber: returns
+ * {created:false} without inserting/auditing when the number clashes (the server
+ * action's allocation retry loop handles that), {created:true} + audit on success.
+ * generateProjectNumber (the auto-number allocator) stays server-side.
+ */
+export const createNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectNumber: v.string(),
+    name: v.string(),
+    ...projectWriteFields,
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { actor, auditId, ...fields } = args;
+    await requireOrgPermission(ctx, fields.organizationId, "project", "create");
+
+    const clash = await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId_projectNumber", (q) =>
+        q.eq("organizationId", fields.organizationId).eq("projectNumber", fields.projectNumber),
+      )
+      .unique();
+    if (clash) return { created: false as const, id: clash.id };
+
+    await ctx.db.insert("projects", fields);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: fields.organizationId,
+      action: "CREATE",
+      entityType: "project",
+      entityId: fields.id,
+      entityName: fields.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Created ${fields.isTemplate ? "template" : "project"} ${fields.projectNumber} - ${fields.name}`,
+      projectId: fields.id,
+      createdAt: typeof fields.createdAt === "number" ? fields.createdAt : 0,
+    });
+
+    return { created: true as const, id: fields.id };
   },
 });

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -239,7 +239,7 @@ export const remove = mutation({
 
 // ─── CUSTOM (project keystone write-inversion, Phase C) ───
 
-const projectWriteFields = {
+export const projectWriteFields = {
   clientId: v.optional(v.string()),
   status: v.optional(enums.ProjectStatus),
   type: v.optional(enums.ProjectType),

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -591,12 +591,21 @@ export async function createProject(data: ProjectFormValues & { isTemplate?: boo
   };
 
   const convex = await getConvexClient();
+  // One audit id for the whole allocation loop — only the winning insert writes it.
+  const projectAuditId = createId();
   let created: { created: boolean; id: string } | null = null;
   for (let attempt = 0; attempt < 50; attempt++) {
     const projectNumber = useAutoNumber
       ? await generateProjectNumber(organizationId, autoConfig!, now)
       : (templateNumber ?? parsed.projectNumber!);
-    created = await convex.mutation(api.projects.createWithUniqueNumber, { ...baseArgs, projectNumber });
+    created = nativeProjectWrites()
+      ? await convex.mutation(api.projectWrites.createNative, {
+          ...baseArgs,
+          projectNumber,
+          actor: { userId, userName },
+          auditId: projectAuditId,
+        })
+      : await convex.mutation(api.projects.createWithUniqueNumber, { ...baseArgs, projectNumber });
     if (created.created) break;
     // Number taken. A manual / template number is a hard duplicate; an auto number
     // lost a race — loop to allocate the next one.
@@ -614,17 +623,20 @@ export async function createProject(data: ProjectFormValues & { isTemplate?: boo
   const result = await getProjectByIdMapped(id, organizationId);
   if (!result) throw new Error("Project create failed");
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "CREATE",
-    entityType: "project",
-    entityId: result.id,
-    entityName: result.projectNumber,
-    summary: `Created ${isTemplate ? "template" : "project"} ${result.projectNumber} - ${result.name}`,
-    projectId: result.id,
-  });
+  if (!nativeProjectWrites()) {
+    // Native path already wrote the CREATE audit atomically in the mutation.
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "CREATE",
+      entityType: "project",
+      entityId: result.id,
+      entityName: result.projectNumber,
+      summary: `Created ${isTemplate ? "template" : "project"} ${result.projectNumber} - ${result.name}`,
+      projectId: result.id,
+    });
+  }
 
   return serialize(result);
 }


### PR DESCRIPTION
`projectWrites.createNative`: RBAC(create) + unique-project-number clash check + insert + CREATE audit, atomic. Mirrors `createWithUniqueNumber` (returns created:false on clash without inserting/auditing; created:true+audit on success). The auto-number allocator + the 50-attempt retry loop stay server-side; one auditId spans the loop so only the winning insert audits. Wired `createProject` behind `NATIVE_PROJECT_WRITES`. 11/11 tests. tsc/lint/build ✅. Flag OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)