### PR TITLE
Phase 5 line-items: native addLineItem + addKitLineItem (completes the write domain)

### DIFF
--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -141,3 +141,61 @@ describe("lineItemWrites.addCustomNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, cargs)).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("lineItemWrites.addNative", () => {
+  const aargs = { id: "new1", organizationId: ORG, projectId: "p1", fields: { type: "EQUIPMENT" as const, description: "PAR Can", quantity: 2, unitPrice: 15 }, includeAccessories: false, actor: ACTOR, auditId: "log1", now: NOW };
+  test("member adds an inventory line (sortOrder in-mutation) + CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "e", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 2 });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs);
+    expect(res.sortOrder).toBe(3);
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "new1")).first();
+      expect(li?.description).toBe("PAR Can");
+      expect(li?.status).toBe("CONFIRMED");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+      expect(log?.entityType).toBe("lineItem");
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("lineItemWrites.addKitNative", () => {
+  const kargs = { id: "kl1", organizationId: ORG, projectId: "p1", kitId: "k1", pricingMode: "KIT_PRICE" as const, unitPrice: 500, kitLabel: "KIT-1 - Lighting", actor: ACTOR, auditId: "log1", now: NOW };
+  test("member adds a kit (parent + member child lines) + CREATE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "A-1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs);
+    await t.run(async (ctx) => {
+      const parent = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "kl1")).first();
+      expect(parent?.kitId).toBe("k1");
+      expect(parent?.isKitChild).toBeUndefined();
+      const children = await ctx.db.query("projectLineItems").withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", "kl1")).collect();
+      expect(children).toHaveLength(1); // the serialized member
+      expect(children[0].assetId).toBe("a1");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("CREATE");
+      expect(log?.kitId).toBe("k1");
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -5,6 +5,8 @@ import type { Id } from "./_generated/dataModel";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import * as enums from "./lib/validators";
+import { expandAccessoryChildLines } from "./lib/fulfillment";
+import { createKitLineItemCore } from "./projectLineItems";
 
 /**
  * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
@@ -209,6 +211,144 @@ export const addCustomNative = mutation({
       userName: actor.userName,
       summary: `Added custom item "${fields.description ?? ""}" to project`,
       projectId,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+/**
+ * addNative — insert an inventory line item (+ atomic accessory expansion via the
+ * shared expandAccessoryChildLines, the SAME helper createLineItem uses) + CREATE
+ * audit, all in one transaction. RBAC(project, manage_line_items).
+ *
+ * Option A: the server action keeps the cross-project availability/double-booking
+ * check (reads overlapping projects — a mutation can't safely do that at scale) and
+ * the price computation; it passes the resolved `fields`, and this mutation does the
+ * atomic write (parent + accessory children + units) + audit. recalc stays server-side.
+ */
+export const addNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    fields: v.object({
+      categoryId: v.optional(v.string()),
+      groupId: v.optional(v.string()),
+      type: v.optional(enums.LineItemType),
+      modelId: v.optional(v.string()),
+      assetId: v.optional(v.string()),
+      bulkAssetId: v.optional(v.string()),
+      description: v.optional(v.string()),
+      quantity: v.number(),
+      unitPrice: v.optional(v.number()),
+      pricingType: v.optional(enums.PricingType),
+      duration: v.optional(v.number()),
+      discount: v.optional(v.number()),
+      lineTotal: v.optional(v.number()),
+      groupName: v.optional(v.string()),
+      notes: v.optional(v.string()),
+      isOptional: v.optional(v.boolean()),
+      showSubhireOnDocs: v.optional(v.boolean()),
+      supplierId: v.optional(v.string()),
+      subhireOrderNumber: v.optional(v.string()),
+    }),
+    includeAccessories: v.boolean(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+
+    // Mirrors createLineItem exactly (sortOrder in-mutation, no TOCTOU; permanent
+    // accessories expanded as child lines atomically via the shared helper).
+    const sortOrder = await nextLineSort(ctx, projectId, organizationId);
+    await ctx.db.insert("projectLineItems", {
+      id,
+      organizationId,
+      projectId,
+      ...fields,
+      status: "CONFIRMED",
+      sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    });
+    if (includeAccessories && fields.type === "EQUIPMENT" && (fields.assetId || fields.modelId)) {
+      await expandAccessoryChildLines(ctx, {
+        id,
+        assetId: fields.assetId,
+        modelId: fields.modelId,
+        quantity: fields.quantity,
+        categoryId: fields.categoryId,
+        groupId: fields.groupId,
+        duration: fields.duration,
+        pricingType: fields.pricingType,
+        organizationId,
+        projectId,
+      });
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "CREATE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName: fields.description || "Line item",
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Added line item to project",
+      projectId,
+      createdAt: now,
+    });
+
+    return { id, sortOrder };
+  },
+});
+
+/**
+ * addKitNative — add a kit to a project: parent line + expanded member child lines
+ * (ITEMIZED pricing) via the SHARED createKitLineItemCore (same code createKitLineItem
+ * runs) + CREATE audit, atomic. RBAC(project, manage_line_items). The kit
+ * availability / double-booking check stays server-side; recalc stays server-side.
+ */
+export const addKitNative = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    kitId: v.string(),
+    unitPrice: v.optional(v.number()),
+    pricingMode: enums.KitPricingMode,
+    groupName: v.optional(v.string()),
+    categoryId: v.optional(v.string()),
+    groupId: v.optional(v.string()),
+    kitLabel: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, kitLabel, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+
+    await createKitLineItemCore(ctx, {
+      id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "CREATE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName: kitLabel,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Added kit ${kitLabel} to project`,
+      projectId,
+      kitId,
       createdAt: now,
     });
 

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -454,6 +454,31 @@ export const createKitLineItem = mutation({
   },
   handler: async (ctx, a) => {
     await requireService(ctx);
+    return createKitLineItemCore(ctx, a);
+  },
+});
+
+/**
+ * Kit-line expansion core (extracted so the native addKitNative in
+ * convex/lineItemWrites.ts reuses the EXACT parent + member-child creation +
+ * ITEMIZED pricing rather than duplicating it). Inserts the kit parent line + one
+ * child line per serialized / bulk member, computing sortOrder in-mutation.
+ */
+export async function createKitLineItemCore(
+  ctx: MutationCtx,
+  a: {
+    id: string;
+    organizationId: string;
+    projectId: string;
+    kitId: string;
+    unitPrice?: number;
+    pricingMode: "KIT_PRICE" | "ITEMIZED";
+    groupName?: string;
+    categoryId?: string;
+    groupId?: string;
+    now: number;
+  },
+): Promise<{ id: string }> {
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", a.kitId)).unique();
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     let sort = await nextLineSort(ctx, a.projectId, a.organizationId);
@@ -493,8 +518,7 @@ export const createKitLineItem = mutation({
       });
     }
     return { id: a.id };
-  },
-});
+}
 
 /** Clear-to-null patch for a line (edit dialog: omit assoc fields to keep, clear to null). */
 export const patchLineItem = mutation({

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -368,34 +368,51 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
   // TOCTOU) and expands permanent accessories as child lines atomically.
   const newLineId = createId();
   const convex = await getConvexClient();
-  await convex.mutation(api.projectLineItems.createLineItem, {
-    id: newLineId,
-    organizationId,
-    projectId,
-    fields: {
-      type: parsed.type,
-      modelId: parsed.modelId || undefined,
-      assetId: parsed.assetId || undefined,
-      bulkAssetId: parsed.bulkAssetId || undefined,
-      description: parsed.description || undefined,
-      quantity: parsed.quantity,
-      unitPrice: autoUnitPrice ?? undefined,
-      pricingType: autoPricingType,
-      duration: autoDuration ?? undefined,
-      discount: parsed.discount ?? undefined,
-      lineTotal: lineTotal ?? undefined,
-      groupName: parsed.groupName || undefined,
-      notes: parsed.notes || undefined,
-      isOptional: parsed.isOptional,
-      showSubhireOnDocs: parsed.showSubhireOnDocs,
-      supplierId: parsed.supplierId || undefined,
-      subhireOrderNumber: parsed.subhireOrderNumber || undefined,
-      categoryId: parsed.categoryId || undefined,
-      groupId: parsed.groupId || undefined,
-    },
-    includeAccessories,
-    now: Date.now(),
-  });
+  const lineFields = {
+    type: parsed.type,
+    modelId: parsed.modelId || undefined,
+    assetId: parsed.assetId || undefined,
+    bulkAssetId: parsed.bulkAssetId || undefined,
+    description: parsed.description || undefined,
+    quantity: parsed.quantity,
+    unitPrice: autoUnitPrice ?? undefined,
+    pricingType: autoPricingType,
+    duration: autoDuration ?? undefined,
+    discount: parsed.discount ?? undefined,
+    lineTotal: lineTotal ?? undefined,
+    groupName: parsed.groupName || undefined,
+    notes: parsed.notes || undefined,
+    isOptional: parsed.isOptional,
+    showSubhireOnDocs: parsed.showSubhireOnDocs,
+    supplierId: parsed.supplierId || undefined,
+    subhireOrderNumber: parsed.subhireOrderNumber || undefined,
+    categoryId: parsed.categoryId || undefined,
+    groupId: parsed.groupId || undefined,
+  };
+  if (nativeLineItemWrites()) {
+    // Native: atomic insert + accessory expansion (the shared expandAccessoryChildLines
+    // helper, same as createLineItem) + CREATE audit. The cross-project availability
+    // check above + the price computation stay server-side.
+    await convex.mutation(api.lineItemWrites.addNative, {
+      id: newLineId,
+      organizationId,
+      projectId,
+      fields: lineFields,
+      includeAccessories,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projectLineItems.createLineItem, {
+      id: newLineId,
+      organizationId,
+      projectId,
+      fields: lineFields,
+      includeAccessories,
+      now: Date.now(),
+    });
+  }
 
   const result = (await readBackLine(newLineId))!;
 
@@ -413,7 +430,9 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
   // enrich). Group suggested-price above already settled before recalc.
   const [, , , supplier] = await Promise.all([
     recalculateProjectTotals(projectId),
-    logActivity({
+    nativeLineItemWrites()
+      ? Promise.resolve()
+      : logActivity({
       organizationId,
       userId,
       userName,
@@ -781,7 +800,8 @@ export async function addKitLineItem(
   // kit's Convex members, computes sortOrder in-mutation, and applies ITEMIZED
   // child pricing from each member model's defaultRentalPrice.
   const parentId = createId();
-  await (await getConvexClient()).mutation(api.projectLineItems.createKitLineItem, {
+  const kitConvex = await getConvexClient();
+  const kitLineArgs = {
     id: parentId,
     organizationId,
     projectId,
@@ -792,7 +812,19 @@ export async function addKitLineItem(
     categoryId: categoryId || undefined,
     groupId: groupId || undefined,
     now: Date.now(),
-  });
+  };
+  if (nativeLineItemWrites()) {
+    // Native: parent + expanded member children (shared core) + CREATE audit atomic.
+    // The kit availability/double-booking check above stays server-side.
+    await kitConvex.mutation(api.lineItemWrites.addKitNative, {
+      ...kitLineArgs,
+      kitLabel: `${kit.assetTag} - ${kit.name}`,
+      actor: { userId, userName },
+      auditId: createId(),
+    });
+  } else {
+    await kitConvex.mutation(api.projectLineItems.createKitLineItem, kitLineArgs);
+  }
 
   const parentItem = (await readBackLine(parentId))!;
 


### PR DESCRIPTION
## Phase 5 — the last two financial writes (multi-write expansion adds)

Both go native by **reusing the exact existing expansion logic** — no duplication, so the atomic multi-insert is identical to today:

- **`addNative`** — insert parent + accessory child lines via the shared `expandAccessoryChildLines` (`convex/lib/fulfillment`, the same helper `createLineItem` uses) + CREATE audit.
- **`addKitNative`** — parent + expanded kit-member child lines + ITEMIZED pricing via the new shared **`createKitLineItemCore`**, extracted from `createKitLineItem`'s handler so both the service mutation and the native one run the same code.

Both RBAC(`project`,`manage_line_items`) + atomic audit; wired behind `NATIVE_LINEITEM_WRITES`. **Option A throughout:** the cross-project availability/double-booking checks + price computation + `recalculateProjectTotals` stay server-side (recalc post-write → totals identical).

### Tests (`lineItemWrites.test.ts`, 14/14)
addNative insert+sortOrder+audit + viewer-deny; addKitNative parent+member-child expansion+audit + viewer-deny.

**With this, every line-item + project write is native** (behind flags). Phase 5 write-inversion is complete across assets/kits/crew/projects/line-items. `tsc`/`eslint`/`build` ✅. Flags OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)