### PR TITLE
Phase 5: kit archive/delete cascades + lineItem reorder native

### DIFF
--- a/convex/kitWrites.test.ts
+++ b/convex/kitWrites.test.ts
@@ -123,3 +123,40 @@ describe("kitWrites.updateNotesNative", () => {
     });
   });
 });
+
+describe("kitWrites.archiveNative / deleteNative", () => {
+  const args = { id: "k1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
+  test("owner archives an AVAILABLE kit + releases members + audit", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, "owner");
+    await t.run(async (ctx) => { await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER }); });
+    await t.withIdentity(asUser(ORG)).mutation(api.kitWrites.archiveNative, args);
+    await t.run(async (ctx) => {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "k1")).first();
+      expect(kit?.status).toBe("RETIRED");
+      expect(kit?.isActive).toBe(false);
+      const members = await ctx.db.query("kitSerializedItems").withIndex("by_kitId", (q) => q.eq("kitId", "k1")).collect();
+      expect(members).toHaveLength(0); // released
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("DELETE");
+    });
+  });
+  test("owner deletes an AVAILABLE kit", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, "owner");
+    await t.withIdentity(asUser(ORG)).mutation(api.kitWrites.deleteNative, args);
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "k1")).first()).toBeNull();
+    });
+  });
+  test("blocks archive of a non-AVAILABLE kit", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
+    await expect(t.withIdentity(SERVICE).mutation(api.kitWrites.archiveNative, args)).rejects.toThrow(/AVAILABLE/i);
+  });
+  test("a manager (no kit:delete) is denied", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, "manager");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.kitWrites.deleteNative, args)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import { releaseKitMembers } from "./kits";
 import * as enums from "./lib/validators";
 
 /**
@@ -199,5 +200,48 @@ export const updateNotesNative = mutation({
     });
 
     return { ok: true as const };
+  },
+});
+
+
+/**
+ * archiveNative / deleteNative — kit soft-retire / hard-delete with the member-release
+ * cascade (releaseKitMembers, the SAME helper the service archiveCascade/deleteCascade
+ * use) + audit, atomic. RBAC(kit, delete). The status guard (AVAILABLE only) runs
+ * inside the mutation.
+ */
+export const archiveNative = mutation({
+  args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "kit", "delete");
+    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
+    if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be archived" });
+    await releaseKitMembers(ctx, id, orgId, now);
+    await ctx.db.patch(kit._id, { isActive: false, status: "RETIRED", updatedAt: now });
+    await writeActivityLog(ctx, {
+      id: auditId, organizationId: orgId, action: "DELETE", entityType: "kit", entityId: id,
+      entityName: kit.assetTag, userId: actor.userId, userName: actor.userName,
+      summary: `Archived kit ${kit.assetTag} - ${kit.name}`, kitId: id, createdAt: now,
+    });
+    return { id };
+  },
+});
+
+export const deleteNative = mutation({
+  args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
+  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "kit", "delete");
+    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
+    if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be deleted" });
+    await releaseKitMembers(ctx, id, orgId, now);
+    await ctx.db.delete(kit._id);
+    await writeActivityLog(ctx, {
+      id: auditId, organizationId: orgId, action: "DELETE", entityType: "kit", entityId: id,
+      entityName: kit.assetTag, userId: actor.userId, userName: actor.userName,
+      summary: `Deleted kit ${kit.assetTag} - ${kit.name}`, kitId: id, createdAt: now,
+    });
+    return { id };
   },
 });

--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -347,7 +347,7 @@ export const removeBulkItem = mutation({
 });
 
 /** Release all members + (archive: soft-delete / delete: hard-delete) the kit, atomically. */
-async function releaseKitMembers(ctx: MutationCtx, kitId: string, organizationId: string, now: number) {
+export async function releaseKitMembers(ctx: MutationCtx, kitId: string, organizationId: string, now: number) {
   const serialized = await ctx.db.query("kitSerializedItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect();
   for (const m of serialized) {
     await releaseAsset(ctx, m.assetId, now);

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -199,3 +199,30 @@ describe("lineItemWrites.addKitNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs)).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("lineItemWrites.reorderNative", () => {
+  test("member reorders lines (sortOrder/groupName) + org-scoped", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 0 });
+      await ctx.db.insert("projectLineItems", { id: "l2", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 1 });
+      await ctx.db.insert("projectLineItems", { id: "lOther", organizationId: "org_other", projectId: "p9", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 5 });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, { orgId: ORG, items: [{ id: "l2", sortOrder: 0 }, { id: "l1", sortOrder: 1, groupName: "Stage" }, { id: "lOther", sortOrder: 0 }], now: NOW });
+    await t.run(async (ctx) => {
+      const l1 = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "l1")).first();
+      const l2 = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "l2")).first();
+      const other = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "lOther")).first();
+      expect(l1?.sortOrder).toBe(1);
+      expect(l1?.groupName).toBe("Stage");
+      expect(l2?.sortOrder).toBe(0);
+      expect(other?.sortOrder).toBe(5); // cross-org row untouched
+    });
+  });
+  test("viewer denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, { orgId: ORG, items: [], now: NOW })).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -355,3 +355,26 @@ export const addKitNative = mutation({
     return { id };
   },
 });
+
+/**
+ * reorderNative — bulk sort-order / groupName update for a project's lines. RBAC
+ * (project, manage_line_items). Mirrors reorderLineItems; org-scopes each row. No
+ * audit (reorder is not audited on the legacy path).
+ */
+export const reorderNative = mutation({
+  args: {
+    orgId: v.string(),
+    items: v.array(v.object({ id: v.string(), sortOrder: v.number(), groupName: v.optional(v.string()) })),
+    now: v.number(),
+  },
+  handler: async (ctx, { orgId, items, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    for (const it of items) {
+      const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).first();
+      if (doc && doc.organizationId === orgId) {
+        await ctx.db.patch(doc._id, { sortOrder: it.sortOrder, groupName: it.groupName, updatedAt: now });
+      }
+    }
+    return { ok: true as const };
+  },
+});

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -431,25 +431,38 @@ export async function archiveKit(id: string) {
   // then soft-deletes the kit (isActive=false, status=RETIRED). The status
   // re-guard lives inside the mutation.
   const convex = await getConvexClient();
-  await convex.mutation(api.kits.archiveCascade, {
-    organizationId,
-    kitId: id,
-    now: Date.now(),
-  });
+  if (nativeKitWrites()) {
+    // Native: member-release cascade + soft-retire + audit atomic in the mutation.
+    await convex.mutation(api.kitWrites.archiveNative, {
+      id,
+      orgId: organizationId,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.kits.archiveCascade, {
+      organizationId,
+      kitId: id,
+      now: Date.now(),
+    });
+  }
 
   const archived = await getKitById(id);
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "DELETE",
-    entityType: "kit",
-    entityId: id,
-    entityName: kit.assetTag,
-    summary: `Archived kit ${kit.assetTag} - ${kit.name}`,
-    kitId: id,
-  });
+  if (!nativeKitWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "DELETE",
+      entityType: "kit",
+      entityId: id,
+      entityName: kit.assetTag,
+      summary: `Archived kit ${kit.assetTag} - ${kit.name}`,
+      kitId: id,
+    });
+  }
 
   return serialize(archived);
 }
@@ -512,11 +525,24 @@ export async function deleteKit(id: string) {
   // Atomic Convex cascade: releases serialized assets + restores bulk
   // quantities, deletes member rows, then hard-deletes the kit row. The status
   // re-guard lives inside the mutation.
-  await convexKits.mutation(api.kits.deleteCascade, {
-    organizationId,
-    kitId: id,
-    now: Date.now(),
-  });
+  if (nativeKitWrites()) {
+    // Native: member-release cascade + hard-delete + audit atomic in the mutation.
+    // (The referencing-line-item guard above + the checkItem/media cleanup below
+    // stay server-side.)
+    await convexKits.mutation(api.kitWrites.deleteNative, {
+      id,
+      orgId: organizationId,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convexKits.mutation(api.kits.deleteCascade, {
+      organizationId,
+      kitId: id,
+      now: Date.now(),
+    });
+  }
 
   // Clean up kit-scoped metadata that the cascade doesn't cover. kitCheckItem
   // rows are removed via their dedicated mutation; kitMedia rows (Convex-only,
@@ -528,16 +554,18 @@ export async function deleteKit(id: string) {
   const kitMediaRows = await getKitMediaFromConvex(id);
   for (const m of kitMediaRows) await convexKits.mutation(api.kitMedia.remove, { id: m.id });
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "DELETE",
-    entityType: "kit",
-    entityId: id,
-    entityName: tagForLog,
-    summary: `Permanently deleted kit ${tagForLog} - ${nameForLog}`,
-  });
+  if (!nativeKitWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "DELETE",
+      entityType: "kit",
+      entityId: id,
+      entityName: tagForLog,
+      summary: `Permanently deleted kit ${tagForLog} - ${nameForLog}`,
+    });
+  }
 
   return serialize({ id, hardDeleted: true });
 }

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1052,7 +1052,7 @@ export async function reorderLineItems(
   itemIds: string[],
   groupUpdates?: { id: string; groupName: string | null }[],
 ) {
-  await requirePermission("project", "manage_line_items");
+  const { organizationId: reorderOrgId } = await requirePermission("project", "manage_line_items");
 
   // Build the reorder payload: each id gets sortOrder = its index. groupUpdates
   // (id -> groupName) are merged in; ids that only appear in groupUpdates are
@@ -1071,10 +1071,19 @@ export async function reorderLineItems(
     items.push({ id, sortOrder: extraSort++, groupName: groupName || undefined });
   }
 
-  await (await getConvexClient()).mutation(api.projectLineItems.reorderLineItems, {
-    items,
-    now: Date.now(),
-  });
+  const reorderConvex = await getConvexClient();
+  if (nativeLineItemWrites()) {
+    await reorderConvex.mutation(api.lineItemWrites.reorderNative, {
+      orgId: reorderOrgId,
+      items,
+      now: Date.now(),
+    });
+  } else {
+    await reorderConvex.mutation(api.projectLineItems.reorderLineItems, {
+      items,
+      now: Date.now(),
+    });
+  }
 
   return serialize({ success: true });
 }


### PR DESCRIPTION
Completes the kit + line-item write surfaces. Kit `archiveNative`/`deleteNative` (RBAC + AVAILABLE guard + member-release cascade via the shared `releaseKitMembers` + audit); lineItem `reorderNative` (RBAC + org-scoped bulk sortOrder patch). Wired behind the existing flags; the referencing-line-item guard + checkItem/media cleanup stay server-side. 27 tests. tsc/lint/build ✅. Flags OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)