### PR TITLE
Phase 5: deleteProject + deleteCrewMember native (leaf delete + audit)

### DIFF
--- a/convex/crewWrites.test.ts
+++ b/convex/crewWrites.test.ts
@@ -94,3 +94,22 @@ describe("crewWrites.updateNative", () => {
     ).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("crewWrites.deleteNative", () => {
+  const dargs = { id: "c1", orgId: ORG, name: "Bob Ryan", actor: ACTOR, auditId: "log1", now: NOW };
+  test("owner deletes a crew member + DELETE audit", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "owner"); await seedCrew(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.crewWrites.deleteNative, dargs);
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "c1")).first()).toBeNull();
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("DELETE");
+    });
+  });
+  test("a member (no crew:delete) is denied", async () => {
+    const t = convexTest(schema, modules);
+    await member(t, "member"); await seedCrew(t);
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.crewWrites.deleteNative, dargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -134,3 +134,44 @@ export const updateNative = mutation({
     return { id };
   },
 });
+
+/**
+ * deleteNative — remove a crew member row + DELETE audit, atomic. RBAC(crew, delete).
+ * Option A: the server action runs the scheduling cascade (assignments→shifts/time-
+ * entries, availability) via the existing mutations first; this does the final member-
+ * row delete + audit.
+ */
+export const deleteNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    name: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, name, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "crew", "delete");
+    const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "Crew member not found." });
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.delete(doc._id);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "DELETE",
+      entityType: "crew_member",
+      entityId: id,
+      entityName: name,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Deleted crew member ${name}`,
+      details: { deleted: { name } },
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -148,3 +148,23 @@ describe("projectWrites.createNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs)).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("projectWrites.deleteNative", () => {
+  const dargs = { id: "p1", orgId: ORG, freedAssets: 2, freedKits: 1, actor: ACTOR, auditId: "log1", now: NOW };
+  test("owner deletes project + DELETE audit (freed counts)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "owner");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs);
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first()).toBeNull();
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("DELETE");
+      expect((log?.details as { freedAssets: number }).freedAssets).toBe(2);
+    });
+  });
+  test("a member (no project:delete) is denied", async () => {
+    const t = convexTest(schema, modules);
+    await seedProject(t, "member");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -243,3 +243,47 @@ export const createNative = mutation({
     return { created: true as const, id: fields.id };
   },
 });
+
+/**
+ * deleteNative — remove the project row + DELETE audit, atomic. RBAC(project, delete).
+ * Option A: the server action runs the multi-table cascade (line items, crew
+ * assignments, managers/tasks/services, freeing checked-out assets/kits) via the
+ * existing mutations first; this does the final project-row delete + audit. `freed*`
+ * counts are computed server-side and passed for the audit detail.
+ */
+export const deleteNative = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    freedAssets: v.number(),
+    freedKits: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, freedAssets, freedKits, actor, auditId, now }) => {
+    await requireOrgPermission(ctx, orgId, "project", "delete");
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.delete(project._id);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "DELETE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Deleted project ${project.projectNumber} - ${project.name}`,
+      details: { deleted: { projectNumber: project.projectNumber, name: project.name }, freedAssets, freedKits },
+      projectId: id,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -395,22 +395,37 @@ export async function deleteCrewMember(id: string) {
   ]);
 
   // crewMember is Convex-only (Phase C); remove it + cascade its scheduling children.
-  await convex.mutation(api.crewMembers.remove, { id });
+  if (nativeCrewWrites()) {
+    // Native: member-row delete + DELETE audit atomic; the scheduling cascade below
+    // stays server-side (same order — member first, then its children).
+    await convex.mutation(api.crewWrites.deleteNative, {
+      id,
+      orgId: organizationId,
+      name: `${member.firstName} ${member.lastName}`,
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.crewMembers.remove, { id });
+  }
   for (const a of memberAssignments) await convex.mutation(api.crewAssignments.deleteCascade, { id: a.id });
   for (const t of orgTimeEntries) await convex.mutation(api.crewTimeEntries.remove, { id: t.id });
   for (const av of memberAvailability) await convex.mutation(api.crewAvailabilities.remove, { id: av.id });
 
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "DELETE",
-    entityType: "crew_member",
-    entityId: id,
-    entityName: `${member.firstName} ${member.lastName}`,
-    summary: `Deleted crew member ${member.firstName} ${member.lastName}`,
-    details: { deleted: { name: `${member.firstName} ${member.lastName}` } },
-  });
+  if (!nativeCrewWrites()) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "DELETE",
+      entityType: "crew_member",
+      entityId: id,
+      entityName: `${member.firstName} ${member.lastName}`,
+      summary: `Deleted crew member ${member.firstName} ${member.lastName}`,
+      details: { deleted: { name: `${member.firstName} ${member.lastName}` } },
+    });
+  }
 
   return { success: true };
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -1455,23 +1455,36 @@ export async function deleteProject(id: string) {
   // that used to clean these up was dropped in Phase C #254, so purge them here.
   await convex.mutation(api.projectCategories.deleteAllForProject, { projectId: id });
   // Finally delete the project doc itself (Convex-only).
-  await convex.mutation(api.projects.remove, { id });
-
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "DELETE",
-    entityType: "project",
-    entityId: id,
-    entityName: project.projectNumber,
-    summary: `Deleted project ${project.projectNumber} - ${project.name}`,
-    details: {
-      deleted: { projectNumber: project.projectNumber, name: project.name },
+  if (nativeProjectWrites()) {
+    // Native: final project-row delete + DELETE audit atomic (the cascade above ran
+    // server-side; recalc N/A for a delete).
+    await convex.mutation(api.projectWrites.deleteNative, {
+      id,
+      orgId: organizationId,
       freedAssets: checkedOutAssetIds.length,
       freedKits: checkedOutKitIds.length,
-    },
-  });
+      actor: { userId, userName },
+      auditId: createId(),
+      now: Date.now(),
+    });
+  } else {
+    await convex.mutation(api.projects.remove, { id });
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "DELETE",
+      entityType: "project",
+      entityId: id,
+      entityName: project.projectNumber,
+      summary: `Deleted project ${project.projectNumber} - ${project.name}`,
+      details: {
+        deleted: { projectNumber: project.projectNumber, name: project.name },
+        freedAssets: checkedOutAssetIds.length,
+        freedKits: checkedOutKitIds.length,
+      },
+    });
+  }
 }
 
 /** Get project milestone dates for call sheet dialog */


### PR DESCRIPTION
Completes the project + crew write surfaces. These are multi-table cascade deletes — under Option A the child-row cascade stays server-side, the final entity-row delete + DELETE audit go native (`projectWrites.deleteNative`, `crewWrites.deleteNative`). Wired behind the existing flags. +4 tests. tsc/lint/build ✅. **Every write across all 5 domains is now native behind its flag.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)