### PR TITLE
Phase 5 closeout: audit-read migration (5c) + optimistic line-item edit (5d)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3426,6 +3426,42 @@ from Postgres (`orgDefaultTaxRateFor`, only fetched when the project has no over
 server function (mixed project + org-default-tax fallback); `recalcNative` has
 member-recompute + viewer-denied coverage. Both flags default OFF.
 
+### Phase 5c/5d closeout — audit-read migration + optimistic line-item edit
+
+**Audit-read migration (Phase 5c).** The activity-log screens can now read Convex
+`activityLogs` instead of Postgres. The catch: only the 5 inverted domains wrote
+`activityLogs` (atomically, via `writeActivityLog`); the other ~39 wrote only Postgres
+via `logActivity`. So a naive read-swap would show a truncated history. Fix:
+- `logActivity` (src/lib/activity-log.ts) now DUAL-WRITES — Postgres + a mirror into
+  Convex `activityLogs` via `api.activityLogWrites.record` (idempotent by cuid,
+  service-only), behind `NATIVE_ACTIVITY_WRITES`. Same shared cuid + timestamp so the
+  two rows match. Best-effort — audit never breaks a write.
+- `convex/activityLog.{list,listByEntity,exportRows}` — native reads with parity to
+  `src/server/activity-log.ts` (org-scoped `requireOrgRead`, same filters/pagination,
+  users-mirror join, ISO `createdAt`). list/export scan the most-recent 10k rows off
+  `by_organizationId_createdAt` and filter in JS (bounded read; returns `capped`).
+- `src/server/activity-log.ts` branches on `NATIVE_ACTIVITY_READS`.
+- `scripts/convex-backfill-activity-log.ts` loads existing Postgres history — **run it
+  before flipping the read flag**, else the screen is truncated to rows written since
+  the write flag went on. Both flags default OFF. Tests: `convex/activityLog.test.ts`.
+
+This is what lets the Postgres `logActivity`/`activityLog` path be dropped in
+decommission — the last audit tie to Postgres.
+
+**Optimistic line-item edit (Phase 5d).** Edited rows update with zero latency. Unlike
+the asset-notes 5d hook (direct Convex mutation + `withOptimisticUpdate`), line-item
+edits keep going through the `updateLineItem` server action — it owns the availability
+re-check, the stale-guard, and the org default tax rate (Postgres, no Convex mirror)
+that the in-mutation recalc needs, so a pure client→Convex write couldn't get totals
+right. Instead the pending fields overlay onto the `equipmentTab.bundle` line items
+BEFORE reconstruction (`src/hooks/use-native-line-item-writes.ts` `applyOptimisticEdits`),
+the same idea as the tab's optimistic DELETE. Cleared when the write settles (rollback
+on error). Flag `NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC` (default OFF, build-inlined).
+
+**Phases 4 + 5 are now closed.** Remaining: Phases 6 (crons/side-effects) + 7 (search),
+then the Postgres decommission. Membership/organization writes stay Postgres (Better
+Auth owns them — Tier E).
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type * as activityLog from "../activityLog.js";
+import type * as activityLogWrites from "../activityLogWrites.js";
 import type * as assetBulkChildren from "../assetBulkChildren.js";
 import type * as assetDetail from "../assetDetail.js";
 import type * as assetMedia from "../assetMedia.js";
@@ -125,6 +127,8 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  activityLog: typeof activityLog;
+  activityLogWrites: typeof activityLogWrites;
   assetBulkChildren: typeof assetBulkChildren;
   assetDetail: typeof assetDetail;
   assetMedia: typeof assetMedia;

--- a/convex/activityLog.test.ts
+++ b/convex/activityLog.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+async function seedLog(
+  t: ReturnType<typeof convexTest>,
+  row: Partial<{ id: string; entityType: string; entityId: string; action: string; userId: string; projectId: string; summary: string; createdAt: number; organizationId: string }>,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("activityLogs", {
+      id: row.id ?? "a1",
+      organizationId: row.organizationId ?? ORG,
+      action: row.action ?? "UPDATE",
+      entityType: row.entityType ?? "asset",
+      entityId: row.entityId ?? "e1",
+      entityName: "Widget",
+      userId: row.userId ?? USER,
+      userName: "Alice",
+      summary: row.summary ?? "did a thing",
+      createdAt: row.createdAt ?? NOW,
+      ...(row.projectId ? { projectId: row.projectId } : {}),
+    });
+  });
+}
+
+describe("activityLogWrites.record", () => {
+  test("service inserts; duplicate id is idempotent", async () => {
+    const t = convexTest(schema, modules);
+    const entry = { id: "log1", organizationId: ORG, action: "CREATE", entityType: "asset", entityId: "e1", entityName: "W", userName: "Alice", summary: "s", createdAt: NOW };
+    const first = await t.withIdentity(SERVICE).mutation(api.activityLogWrites.record, entry);
+    const second = await t.withIdentity(SERVICE).mutation(api.activityLogWrites.record, entry);
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    const count = await t.run(async (ctx) => (await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).collect()).length);
+    expect(count).toBe(1);
+  });
+
+  test("non-service (user) denied", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.activityLogWrites.record, { id: "log2", organizationId: ORG, action: "CREATE", entityType: "asset", entityId: "e1", entityName: "W", userName: "A", summary: "s", createdAt: NOW }),
+    ).rejects.toThrow(/requires the GearFlow server/i);
+  });
+});
+
+describe("activityLog.list", () => {
+  test("org member reads own org; cross-org denied", async () => {
+    const t = convexTest(schema, modules);
+    await seedLog(t, { id: "a1" });
+    const res = await t.withIdentity(asUser(ORG)).query(api.activityLog.list, { orgId: ORG });
+    expect(res.total).toBe(1);
+    expect(res.items[0].id).toBe("a1");
+    await expect(t.withIdentity(asUser("org_other")).query(api.activityLog.list, { orgId: ORG })).rejects.toThrow(/organization mismatch/i);
+  });
+
+  test("filters (entityType, projectId, search, date) + pagination + newest-first", async () => {
+    const t = convexTest(schema, modules);
+    await seedLog(t, { id: "a1", entityType: "asset", createdAt: NOW });
+    await seedLog(t, { id: "a2", entityType: "kit", projectId: "p9", summary: "kitchen prep", createdAt: NOW + 1000 });
+    await seedLog(t, { id: "a3", entityType: "asset", createdAt: NOW + 2000 });
+
+    // newest-first by default
+    const all = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG });
+    expect(all.items.map((i) => i.id)).toEqual(["a3", "a2", "a1"]);
+
+    // entityType filter
+    const assets = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, entityType: "asset" });
+    expect(assets.total).toBe(2);
+    expect(assets.items.every((i) => i.entityType === "asset")).toBe(true);
+
+    // projectId filter
+    const proj = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, projectId: "p9" });
+    expect(proj.total).toBe(1);
+    expect(proj.items[0].id).toBe("a2");
+
+    // case-insensitive summary search
+    const search = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, search: "KITCHEN" });
+    expect(search.total).toBe(1);
+
+    // date range (exclude a1 at NOW)
+    const dated = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, startDateMs: NOW + 500 });
+    expect(dated.total).toBe(2);
+
+    // pagination
+    const p1 = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, page: 1, pageSize: 2 });
+    expect(p1.items.map((i) => i.id)).toEqual(["a3", "a2"]);
+    expect(p1.totalPages).toBe(2);
+    const p2 = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG, page: 2, pageSize: 2 });
+    expect(p2.items.map((i) => i.id)).toEqual(["a1"]);
+  });
+
+  test("joins the users mirror for {id,name,image}; createdAt is an ISO string", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", { id: USER, name: "Alice A", email: "a@x.com", image: "http://img/a.png" });
+    });
+    await seedLog(t, { id: "a1", userId: USER });
+    const res = await t.withIdentity(SERVICE).query(api.activityLog.list, { orgId: ORG });
+    expect(res.items[0].user).toEqual({ id: USER, name: "Alice A", image: "http://img/a.png" });
+    expect(res.items[0].createdAt).toBe(new Date(NOW).toISOString());
+  });
+});
+
+describe("activityLog.listByEntity", () => {
+  test("newest-first, limited, org-scoped", async () => {
+    const t = convexTest(schema, modules);
+    await seedLog(t, { id: "a1", entityType: "asset", entityId: "e1", createdAt: NOW });
+    await seedLog(t, { id: "a2", entityType: "asset", entityId: "e1", createdAt: NOW + 1000 });
+    await seedLog(t, { id: "a3", entityType: "asset", entityId: "OTHER", createdAt: NOW + 2000 });
+    const res = await t.withIdentity(asUser(ORG)).query(api.activityLog.listByEntity, { orgId: ORG, entityType: "asset", entityId: "e1", limit: 5 });
+    expect(res.total).toBe(2);
+    expect(res.items.map((i) => i.id)).toEqual(["a2", "a1"]);
+  });
+});
+
+describe("activityLog.exportRows", () => {
+  test("returns filtered rows newest-first with ISO createdAt", async () => {
+    const t = convexTest(schema, modules);
+    await seedLog(t, { id: "a1", action: "CREATE", createdAt: NOW });
+    await seedLog(t, { id: "a2", action: "DELETE", createdAt: NOW + 1000 });
+    const rows = await t.withIdentity(SERVICE).query(api.activityLog.exportRows, { orgId: ORG, action: "DELETE" });
+    expect(rows.length).toBe(1);
+    expect(rows[0].id).toBe("a2");
+    expect(rows[0].createdAt).toBe(new Date(NOW + 1000).toISOString());
+  });
+});

--- a/convex/activityLog.ts
+++ b/convex/activityLog.ts
@@ -1,0 +1,194 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import type { QueryCtx } from "./_generated/server";
+import { requireOrgRead } from "./lib/auth";
+
+/**
+ * Native reads for the activity-log SCREENS (Phase 5c audit-read migration). Parity
+ * target: src/server/activity-log.ts (getActivityLogs / getEntityActivityLog /
+ * exportActivityLogCSV), which read Postgres `activityLog`. Org-scoping only
+ * (`requireOrgRead`) — the server actions gate on `getOrgContext()`, no extra
+ * permission, so any org member may view the log.
+ *
+ * Windowing: the list/export queries scan the org's most-recent `SCAN_CAP` rows off
+ * the `by_organizationId_createdAt` index (desc) and filter/paginate in JS. This
+ * mirrors the export's existing 10k cap and keeps every read bounded (Convex read
+ * limits). For these orgs the log fits well within the window; `capped` is returned so
+ * the UI/caller can tell when it didn't. Entity lookups use the entity index directly
+ * (a single entity's history is always small).
+ */
+
+const SCAN_CAP = 10000;
+
+type LogDoc = {
+  id: string;
+  organizationId: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  entityName: string;
+  userId?: string;
+  userName: string;
+  summary: string;
+  details?: unknown;
+  metadata?: unknown;
+  projectId?: string;
+  assetId?: string;
+  kitId?: string;
+  createdAt?: number;
+};
+
+const filterArgs = {
+  entityType: v.optional(v.string()),
+  action: v.optional(v.string()),
+  userId: v.optional(v.string()),
+  entityId: v.optional(v.string()),
+  projectId: v.optional(v.string()),
+  assetId: v.optional(v.string()),
+  search: v.optional(v.string()),
+  startDateMs: v.optional(v.number()),
+  endDateMs: v.optional(v.number()),
+};
+
+/** Apply the same predicates Prisma's `where` did, in JS over the scanned window. */
+function applyFilters(
+  rows: LogDoc[],
+  f: {
+    entityType?: string;
+    action?: string;
+    userId?: string;
+    entityId?: string;
+    projectId?: string;
+    assetId?: string;
+    search?: string;
+    startDateMs?: number;
+    endDateMs?: number;
+  },
+): LogDoc[] {
+  const search = f.search?.toLowerCase();
+  return rows.filter((r) => {
+    if (f.entityType && r.entityType !== f.entityType) return false;
+    if (f.action && r.action !== f.action) return false;
+    if (f.userId && r.userId !== f.userId) return false;
+    if (f.entityId && r.entityId !== f.entityId) return false;
+    if (f.projectId && r.projectId !== f.projectId) return false;
+    if (f.assetId && r.assetId !== f.assetId) return false;
+    if (search && !r.summary.toLowerCase().includes(search)) return false;
+    const ts = r.createdAt ?? 0;
+    if (f.startDateMs != null && ts < f.startDateMs) return false;
+    if (f.endDateMs != null && ts > f.endDateMs) return false;
+    return true;
+  });
+}
+
+/** The org's most-recent rows off the createdAt index, newest first, bounded. */
+async function scanWindow(ctx: QueryCtx, orgId: string): Promise<LogDoc[]> {
+  return (await ctx.db
+    .query("activityLogs")
+    .withIndex("by_organizationId_createdAt", (q) => q.eq("organizationId", orgId))
+    .order("desc")
+    .take(SCAN_CAP)) as unknown as LogDoc[];
+}
+
+/** Join the Convex `users` mirror for {id,name,image}; null when absent (Prisma parity). */
+async function attachUsers(ctx: QueryCtx, rows: LogDoc[]) {
+  const ids = [...new Set(rows.map((r) => r.userId).filter((x): x is string => !!x))];
+  const entries = await Promise.all(
+    ids.map(async (uid) => {
+      const u = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", uid)).first();
+      return [uid, u] as const;
+    }),
+  );
+  const byId = new Map(entries);
+  return rows.map((r) => {
+    const u = r.userId ? byId.get(r.userId) : undefined;
+    return {
+      ...r,
+      // Match the serialized Prisma Date shape (ISO string) so the screen renders
+      // identically on either read path.
+      createdAt: new Date(r.createdAt ?? 0).toISOString(),
+      user: u ? { id: u.id, name: u.name, image: u.image ?? null } : null,
+    };
+  });
+}
+
+export const list = query({
+  args: {
+    orgId: v.string(),
+    page: v.optional(v.number()),
+    pageSize: v.optional(v.number()),
+    sort: v.optional(v.string()),
+    order: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+    ...filterArgs,
+  },
+  handler: async (ctx, args) => {
+    await requireOrgRead(ctx, args.orgId);
+    const page = args.page ?? 1;
+    const pageSize = args.pageSize ?? 50;
+    const sort = args.sort ?? "createdAt";
+    const order = args.order ?? "desc";
+
+    const window = await scanWindow(ctx, args.orgId);
+    const filtered = applyFilters(window, args);
+
+    // Sort. The window is already createdAt-desc; honor other sort keys in JS.
+    if (sort === "createdAt") {
+      if (order === "asc") filtered.reverse();
+    } else {
+      filtered.sort((a, b) => {
+        const av = String((a as unknown as Record<string, unknown>)[sort] ?? "");
+        const bv = String((b as unknown as Record<string, unknown>)[sort] ?? "");
+        return order === "asc" ? av.localeCompare(bv) : bv.localeCompare(av);
+      });
+    }
+
+    const total = filtered.length;
+    const pageRows = filtered.slice((page - 1) * pageSize, (page - 1) * pageSize + pageSize);
+    const items = await attachUsers(ctx, pageRows);
+
+    return {
+      items,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+      capped: window.length >= SCAN_CAP,
+    };
+  },
+});
+
+export const listByEntity = query({
+  args: {
+    orgId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { orgId, entityType, entityId, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const rows = (await ctx.db
+      .query("activityLogs")
+      .withIndex("by_organizationId_entityType_entityId", (q) =>
+        q.eq("organizationId", orgId).eq("entityType", entityType).eq("entityId", entityId),
+      )
+      .collect()) as unknown as LogDoc[];
+    rows.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    const total = rows.length;
+    const items = await attachUsers(ctx, rows.slice(0, limit ?? 5));
+    return { items, total };
+  },
+});
+
+/** Raw rows for CSV export (newest-first). CSV assembly stays server-side. */
+export const exportRows = query({
+  args: { orgId: v.string(), ...filterArgs },
+  handler: async (ctx, args) => {
+    await requireOrgRead(ctx, args.orgId);
+    const window = await scanWindow(ctx, args.orgId);
+    const filtered = applyFilters(window, args);
+    return filtered.map((r) => ({
+      ...r,
+      createdAt: new Date(r.createdAt ?? 0).toISOString(),
+    }));
+  },
+});

--- a/convex/activityLogWrites.ts
+++ b/convex/activityLogWrites.ts
@@ -1,0 +1,47 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * `record` — the transitional Postgres→Convex bridge for the audit log.
+ *
+ * The 5 inverted domains already write `activityLogs` atomically inside their native
+ * mutations (convex/lib/audit.ts `writeActivityLog`). The other ~39 domains still emit
+ * audit via `logActivity` (src/lib/activity-log.ts, a Postgres write). To make the
+ * activity-log SCREENS readable from Convex, every `logActivity` call also mirrors its
+ * row here (behind `NATIVE_ACTIVITY_WRITES`), so Convex holds the COMPLETE history.
+ *
+ * Idempotent by cuid (`createIfMissing` convention): a retried/duplicate `logActivity`
+ * mirror must not double-insert. `id` + `createdAt` are caller-supplied (a cuid +
+ * Date.now()) so the Convex row matches the Postgres row exactly. Service-token only —
+ * `logActivity` calls it via the server's `getConvexClient()`.
+ */
+export const record = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    action: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+    entityName: v.string(),
+    userId: v.optional(v.string()),
+    userName: v.string(),
+    summary: v.string(),
+    details: v.optional(v.any()),
+    metadata: v.optional(v.any()),
+    projectId: v.optional(v.string()),
+    assetId: v.optional(v.string()),
+    kitId: v.optional(v.string()),
+    createdAt: v.number(),
+  },
+  handler: async (ctx, entry) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("activityLogs")
+      .withIndex("by_cuid", (q) => q.eq("id", entry.id))
+      .first();
+    if (existing) return { created: false as const };
+    await ctx.db.insert("activityLogs", { ...entry });
+    return { created: true as const };
+  },
+});

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -7,7 +7,39 @@ open). Phase 5 (native writes) is the next major phase.
 
 ---
 
-## ▶ NEXT SESSION — START HERE (2026-07-02)
+## ▶ NEXT SESSION — START HERE (2026-07-06)
+
+**PHASES 4 AND 5 ARE CLOSED.** Read-inversion (Phase 4), write-inversion for all 5
+domains (Phase 5a–c), the write-latency fix (recalc-in-mutation, PR #349), the
+audit-read migration (Phase 5c), and optimistic line-item edit (Phase 5d) are all
+merged. What remains is genuinely separate: Phases 6 (crons/side-effects) + 7 (search),
+and the eventual Postgres decommission (DROP TABLE) once the kept tables shrink.
+
+**Latency fix — DONE + DEPLOYED (PR #349):** `recalculateProjectTotals` was ~3
+sequential server→Convex-Cloud waves on every write (the 6–12s tail). Ported byte-for-
+byte to `convex/lib/recalc.ts` and run in-mutation. Two flags (default OFF, flip in
+Coolify): `NATIVE_RECALC` (one-hop recalc for ALL domains) + the 5 line-item mutations
+recalc in-transaction under `NATIVE_LINEITEM_WRITES`. Parity: `convex/recalc.test.ts`.
+
+**Audit-read migration (Phase 5c) — DONE:** activity-log screens can now read Convex.
+`convex/activityLog.{list,listByEntity,exportRows}` (org-scoped, same filters/pagination/
+user-join as the Prisma path) + `convex/activityLogWrites.record` (idempotent mirror).
+`logActivity` dual-writes Postgres+Convex under `NATIVE_ACTIVITY_WRITES`; screens read
+Convex under `NATIVE_ACTIVITY_READS`. `scripts/convex-backfill-activity-log.ts` loads
+existing history — RUN IT before flipping the read flag. This unblocks dropping the
+Postgres `logActivity` path in decommission. Tests: `convex/activityLog.test.ts`.
+
+**Optimistic line-item edit (Phase 5d) — DONE:** edited rows update with zero latency;
+the real write stays on the `updateLineItem` server action (keeps availability re-check +
+stale-guard + the Postgres org default tax the recalc needs). Overlay-on-bundle pattern
+(`src/hooks/use-native-line-item-writes.ts`), flag `NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC`
+(default OFF). asset-notes (representative) + this are the two live 5d surfaces; rolling
+to add/kit/custom is mechanical and deferred (writes are fast, so low value).
+
+**Still out of scope (by design):** membership/organization writes stay Postgres — Better
+Auth owns them (Tier E). Full resume context + per-PR detail in memory `convex-native-read-layer.md`.
+
+### (superseded) 2026-07-02 status
 
 **Phase 4 COMPLETE + Phase 5 write-inversion COMPLETE.** The remaining work is the
 optional polish (see "Phase 5 remaining" below) + Phases 6–7. Full resume context +

--- a/scripts/convex-backfill-activity-log.ts
+++ b/scripts/convex-backfill-activity-log.ts
@@ -1,0 +1,70 @@
+/**
+ * One-time (re-runnable) backfill: copy the Postgres `activityLog` table into Convex
+ * `activityLogs` (Phase 5c audit-read migration). Idempotent — `record` skips rows
+ * already present (matched by cuid `id`), so this is both the initial load AND the heal
+ * path for the dual-write deploy window. Maps Date -> Unix ms, null JSON -> absent.
+ *
+ * Run BEFORE flipping `NATIVE_ACTIVITY_READS` on, so the screens show the COMPLETE
+ * history (not just rows written since `NATIVE_ACTIVITY_WRITES` was enabled):
+ *
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-activity-log.ts
+ *
+ * See FEATUREDOCS/54 and docs/designs/convex-native-read-layer.md (Phase 5c).
+ */
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+const BATCH = 500;
+
+async function main() {
+  const convex = await getConvexClient();
+  const total = await prisma.activityLog.count();
+  console.log(`Found ${total} activityLog rows in Prisma.`);
+
+  let created = 0;
+  let skipped = 0;
+  let cursor: string | undefined;
+
+  // Cursor-paginate by id (stable) so we never load the whole table into memory.
+  for (;;) {
+    const rows = await prisma.activityLog.findMany({
+      take: BATCH,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      orderBy: { id: "asc" },
+    });
+    if (rows.length === 0) break;
+    cursor = rows[rows.length - 1].id;
+
+    for (const r of rows) {
+      const res = await convex.mutation(api.activityLogWrites.record, {
+        id: r.id,
+        organizationId: r.organizationId,
+        action: r.action,
+        entityType: r.entityType,
+        entityId: r.entityId,
+        entityName: r.entityName,
+        userId: r.userId ?? undefined,
+        userName: r.userName,
+        summary: r.summary,
+        details: r.details ?? undefined,
+        metadata: r.metadata ?? undefined,
+        projectId: r.projectId ?? undefined,
+        assetId: r.assetId ?? undefined,
+        kitId: r.kitId ?? undefined,
+        createdAt: r.createdAt.getTime(),
+      });
+      if (res.created) created++;
+      else skipped++;
+    }
+    console.log(`  …processed ${created + skipped}/${total}`);
+  }
+
+  console.log(`\nBackfill complete: ${created} created, ${skipped} already present.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -18,6 +18,11 @@ import {
   refreshProjectOverbooked,
 } from "@/hooks/use-project-equipment";
 import { useNativeEquipmentTab } from "@/hooks/use-native-equipment-tab";
+import {
+  NATIVE_LINEITEM_OPTIMISTIC,
+  computeLineTotal,
+  type OptimisticLineEdit,
+} from "@/hooks/use-native-line-item-writes";
 import { Plus, FolderPlus, FolderTree, Pencil, ChevronDown as ChevronDownIcon } from "lucide-react";
 import {
   DropdownMenu,
@@ -126,7 +131,26 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   // views come from ONE reactive equipmentTab.bundle subscription (reconstructed
   // client-side); writes are still server actions whose convex.mutation pushes the
   // delta to this subscription, so no doorbell→refetch is needed.
-  const native = useNativeEquipmentTab(projectId, orgId);
+  // Optimistic line-item edits (Phase 5d, flag-gated): the edited row updates
+  // instantly by overlaying the pending fields onto the bundle; the real write still
+  // goes through the updateLineItem server action, and the overlay is cleared once it
+  // settles. See use-native-line-item-writes.ts.
+  const [pendingEdits, setPendingEdits] = useState<ReadonlyMap<string, OptimisticLineEdit>>(
+    () => new Map(),
+  );
+  const clearPendingEdit = useCallback((id: string) => {
+    setPendingEdits((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+  const native = useNativeEquipmentTab(
+    projectId,
+    orgId,
+    NATIVE_LINEITEM_OPTIMISTIC ? pendingEdits : undefined,
+  );
 
   // Passive section/group collaboration state: one lock subscription and one
   // comment-count subscription for the project, then row lookups by target key.
@@ -366,12 +390,18 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   const updateLineItemMut = useServerMutation({
     mutationFn: ({ id, data, allowOverbook, baseUpdatedAt }: { id: string; data: Record<string, unknown>; allowOverbook?: boolean; baseUpdatedAt?: string | number | null }) =>
       updateLineItem(id, data as Parameters<typeof updateLineItem>[1], allowOverbook ?? false, baseUpdatedAt),
-    onSuccess: () => {
+    onSuccess: (_r: unknown, { id }: { id: string }) => {
       invalidate();
+      // Drop the optimistic overlay — the reactive bundle now carries the server value.
+      clearPendingEdit(id);
       setEditLineItem(null);
       toast.success("Item updated");
     },
-    onError: (e: Error) => toast.error(e.message),
+    onError: (e: Error, { id }: { id: string }) => {
+      // Rollback: remove the overlay so the row reverts to the server state.
+      clearPendingEdit(id);
+      toast.error(e.message);
+    },
   });
 
   const removeMut = useServerMutation({
@@ -1343,14 +1373,35 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         orgId={orgId}
         isPending={updateLineItemMut.isPending}
         onClose={() => setEditLineItem(null)}
-        onSubmit={(id, data, allowOverbook, baseUpdatedAt) =>
+        onSubmit={(id, data, allowOverbook, baseUpdatedAt) => {
+          // Optimistically overlay the edited fields onto the row (flag-gated) so it
+          // updates instantly; the server action below is still the authoritative write.
+          if (NATIVE_LINEITEM_OPTIMISTIC) {
+            setPendingEdits((prev) => {
+              const next = new Map(prev);
+              next.set(id, {
+                quantity: data.quantity,
+                unitPrice: data.unitPrice,
+                discount: data.discount,
+                description: data.description,
+                notes: data.notes,
+                lineTotal: computeLineTotal(
+                  data.unitPrice,
+                  data.quantity,
+                  data.duration,
+                  data.discount,
+                ),
+              });
+              return next;
+            });
+          }
           updateLineItemMut.mutate({
             id,
             data: data as unknown as Record<string, unknown>,
             allowOverbook,
             baseUpdatedAt,
-          })
-        }
+          });
+        }}
       />
 
       {/* Move-item-to-category dialog (kebab → "Move to category").

--- a/src/hooks/use-native-equipment-tab.ts
+++ b/src/hooks/use-native-equipment-tab.ts
@@ -20,6 +20,7 @@ import type {
   LineItemData,
 } from "@/components/projects/equipment-rows";
 import type { OverbookedInfo } from "@/lib/overbooking-core";
+import { applyOptimisticEdits, type OptimisticLineEdit } from "@/hooks/use-native-line-item-writes";
 
 /**
  * Feature flag (default OFF) for the native equipment-tab read cutover (Phase 2).
@@ -57,12 +58,21 @@ const toDate = (n: number | null | undefined): Date | null =>
 export function useNativeEquipmentTab(
   projectId: string | undefined,
   orgId: string | undefined,
+  optimisticEdits?: ReadonlyMap<string, OptimisticLineEdit>,
 ): NativeEquipmentTab {
   const enabled = NATIVE_EQUIPMENT_ENABLED && !!projectId && !!orgId;
-  const bundle = useAuthedQuery(
+  const rawBundle = useAuthedQuery(
     api.equipmentTab.bundle,
     enabled ? { projectId: projectId!, orgId: orgId! } : "skip",
   );
+
+  // Overlay optimistic line-item edits (Phase 5d) onto the raw bundle BEFORE
+  // reconstruction, so an edited row updates instantly. Cleared by the caller once
+  // the server write settles; a no-op when there are none. See use-native-line-item-writes.ts.
+  const bundle = useMemo(() => {
+    if (!rawBundle || !optimisticEdits || optimisticEdits.size === 0) return rawBundle;
+    return { ...rawBundle, lineItems: applyOptimisticEdits(rawBundle.lineItems, optimisticEdits) };
+  }, [rawBundle, optimisticEdits]);
 
   // The project doc supplies the rental window the overbooked computation needs.
   const project = useProject(enabled ? projectId : undefined);

--- a/src/hooks/use-native-line-item-writes.test.ts
+++ b/src/hooks/use-native-line-item-writes.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "vitest";
+import { computeLineTotal, applyOptimisticEdits, type OptimisticLineEdit } from "./use-native-line-item-writes";
+
+describe("computeLineTotal", () => {
+  test("gross = unitPrice × qty × duration, minus discount, rounded, floored at 0", () => {
+    expect(computeLineTotal(100, 2, 3, undefined)).toBe(600);
+    expect(computeLineTotal(100, 2, 3, 50)).toBe(550);
+    expect(computeLineTotal(10.005, 1, 1, undefined)).toBe(10.01); // currency rounding
+    expect(computeLineTotal(100, 1, 1, 999)).toBe(0); // never negative
+  });
+  test("null unit price → null total (parity with server)", () => {
+    expect(computeLineTotal(undefined, 2, 1, undefined)).toBeNull();
+  });
+});
+
+describe("applyOptimisticEdits", () => {
+  const lines = [
+    { id: "l1", quantity: 1, unitPrice: 100, discount: null, description: "Old", notes: null, lineTotal: 100 },
+    { id: "l2", quantity: 5, unitPrice: 20, discount: null, description: "Keep", notes: null, lineTotal: 100 },
+  ];
+
+  test("empty overlay is a no-op reference", () => {
+    const out = applyOptimisticEdits(lines, new Map());
+    expect(out).toBe(lines);
+  });
+
+  test("patches only the matching row; leaves others untouched", () => {
+    const edit: OptimisticLineEdit = { quantity: 3, unitPrice: 100, discount: 25, description: "New", notes: "hi", lineTotal: 275 };
+    const out = applyOptimisticEdits(lines, new Map([["l1", edit]]));
+    expect(out[0]).toMatchObject({ id: "l1", quantity: 3, unitPrice: 100, discount: 25, description: "New", notes: "hi", lineTotal: 275 });
+    expect(out[1]).toBe(lines[1]); // untouched row keeps its reference
+  });
+
+  test("undefined optional fields overlay as null (cleared)", () => {
+    const edit: OptimisticLineEdit = { quantity: 2, unitPrice: undefined, discount: undefined, description: "X", notes: undefined, lineTotal: null };
+    const out = applyOptimisticEdits(lines, new Map([["l1", edit]]));
+    expect(out[0]).toMatchObject({ unitPrice: null, discount: null, notes: null, lineTotal: null });
+  });
+});

--- a/src/hooks/use-native-line-item-writes.ts
+++ b/src/hooks/use-native-line-item-writes.ts
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Phase 5d — optimistic line-item EDIT for the equipment tab.
+ *
+ * The recalc-in-mutation fix already made edits sub-second; this makes the edited
+ * ROW update with ZERO latency. Unlike the asset-notes optimistic hook (which calls a
+ * Convex mutation directly with `withOptimisticUpdate`), line-item edits must keep
+ * going through the `updateLineItem` server action: it owns the cross-project
+ * availability re-check, the stale-guard, and — critically for money — the org default
+ * tax rate, which lives in Postgres and has no Convex mirror. So a pure client→Convex
+ * write couldn't recompute project totals correctly.
+ *
+ * Instead we overlay the pending field changes onto the `equipmentTab.bundle` line
+ * items BEFORE reconstruction (see use-native-equipment-tab.ts) — the exact same idea
+ * as the tab's existing optimistic DELETE (`pendingRemovalIds`), just a patch instead
+ * of a hide. The real write still lands via the server action; the overlay is cleared
+ * once it settles, at which point the reactive bundle already carries the server value.
+ *
+ * Flag-gated + default OFF (NEXT_PUBLIC, build-inlined). Only affects the native
+ * equipment-tab read path; when off, the edit dialog uses the server-action mutation
+ * exactly as before.
+ */
+
+export const NATIVE_LINEITEM_OPTIMISTIC =
+  process.env.NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC === "true";
+
+const roundCurrency = (v: number): number => Math.round(v * 100) / 100;
+
+/** Client-side twin of the server's calculateLineTotal (line-items.ts) — same math. */
+export function computeLineTotal(
+  unitPrice: number | undefined,
+  quantity: number,
+  duration: number,
+  discount: number | undefined,
+): number | null {
+  if (unitPrice == null) return null;
+  const gross = roundCurrency(unitPrice * quantity * duration);
+  return Math.max(0, roundCurrency(gross - (discount ?? 0)));
+}
+
+/** The line-item fields an optimistic edit overlays onto the bundle doc. */
+export interface OptimisticLineEdit {
+  quantity: number;
+  unitPrice?: number;
+  discount?: number;
+  description: string;
+  notes?: string;
+  lineTotal: number | null;
+}
+
+/**
+ * Overlay pending edits onto the raw bundle line items (by cuid `id`). Pure — returns
+ * a new array only when something matched, so an empty overlay is a no-op reference.
+ */
+export function applyOptimisticEdits<
+  T extends { id: string; quantity?: number; unitPrice?: number | null; discount?: number | null; description?: string | null; notes?: string | null; lineTotal?: number | null },
+>(lineItems: readonly T[], edits: ReadonlyMap<string, OptimisticLineEdit>): T[] {
+  if (edits.size === 0) return lineItems as T[];
+  return lineItems.map((li) => {
+    const e = edits.get(li.id);
+    if (!e) return li;
+    return {
+      ...li,
+      quantity: e.quantity,
+      unitPrice: e.unitPrice ?? null,
+      discount: e.discount ?? null,
+      description: e.description,
+      notes: e.notes ?? null,
+      lineTotal: e.lineTotal,
+    };
+  });
+}

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,5 +1,9 @@
+import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import type { Prisma } from "@/generated/prisma/client";
+import { nativeActivityWrites } from "@/lib/native-writes";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 
 interface LogActivityInput {
   organizationId: string;
@@ -18,9 +22,17 @@ interface LogActivityInput {
 }
 
 export async function logActivity(input: LogActivityInput): Promise<void> {
+  // One shared id + timestamp so the Postgres row and the Convex mirror row match
+  // exactly (the mirror is idempotent by this cuid).
+  const id = createId();
+  const createdAt = new Date();
+
+  // Postgres write (unchanged behaviour — best-effort, never throws).
   try {
     await prisma.activityLog.create({
       data: {
+        id,
+        createdAt,
         ...input,
         details: input.details as unknown as Prisma.InputJsonValue,
         metadata: input.metadata as unknown as Prisma.InputJsonValue,
@@ -28,6 +40,35 @@ export async function logActivity(input: LogActivityInput): Promise<void> {
     });
   } catch (error) {
     console.error("Failed to log activity:", error);
+  }
+
+  // Phase 5c: mirror into Convex `activityLogs` so the activity-log screens can read
+  // natively with the COMPLETE cross-domain history. Best-effort — audit must never
+  // break a write. The 5 inverted domains write Convex atomically in-mutation and skip
+  // logActivity, so there's no double-count.
+  if (nativeActivityWrites()) {
+    try {
+      const convex = await getConvexClient();
+      await convex.mutation(api.activityLogWrites.record, {
+        id,
+        organizationId: input.organizationId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        entityName: input.entityName,
+        userId: input.userId,
+        userName: input.userName,
+        summary: input.summary,
+        details: input.details,
+        metadata: input.metadata,
+        projectId: input.projectId,
+        assetId: input.assetId,
+        kitId: input.kitId,
+        createdAt: createdAt.getTime(),
+      });
+    } catch (error) {
+      console.error("Failed to mirror activity to Convex:", error);
+    }
   }
 }
 

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -37,6 +37,23 @@ export const nativeRecalc = (): boolean =>
   process.env.NATIVE_RECALC === "true";
 
 /**
+ * Audit-log Phase 5c cutover (two independent flags so the write can lead the read):
+ * - `NATIVE_ACTIVITY_WRITES` — `logActivity` ALSO mirrors each row into Convex
+ *   `activityLogs` (via `api.activityLogWrites.record`), giving Convex the COMPLETE
+ *   history across all domains, not just the 5 inverted ones. Keeps the Postgres write
+ *   too (dual-write) so the read can fall back instantly.
+ * - `NATIVE_ACTIVITY_READS` — the activity-log screens read Convex `activityLogs`
+ *   instead of Postgres. Only flip AFTER writes have run long enough to backfill, or
+ *   after a one-off backfill; otherwise the screen shows a truncated history.
+ * Both default OFF.
+ */
+export const nativeActivityWrites = (): boolean =>
+  process.env.NATIVE_ACTIVITY_WRITES === "true";
+
+export const nativeActivityReads = (): boolean =>
+  process.env.NATIVE_ACTIVITY_READS === "true";
+
+/**
  * Map an assetWrites mutation's `ConvexError({ code })` back to the rich
  * UserFacingError (title + hint) the server-action path threw, so the toast UX is
  * identical whether the write ran natively or on the legacy path. Non-matching

--- a/src/server/activity-log.ts
+++ b/src/server/activity-log.ts
@@ -3,6 +3,9 @@
 import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
+import { nativeActivityReads } from "@/lib/native-writes";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 
 interface ActivityLogFilters {
   page?: number;
@@ -18,6 +21,17 @@ interface ActivityLogFilters {
   endDate?: string | Date;
   sort?: string;
   order?: "asc" | "desc";
+}
+
+/** Convert a filter date to epoch ms; endDate is pushed to end-of-day (Prisma parity). */
+function startMs(d?: string | Date): number | undefined {
+  return d != null ? new Date(d).getTime() : undefined;
+}
+function endMs(d?: string | Date): number | undefined {
+  if (d == null) return undefined;
+  const end = new Date(d);
+  end.setHours(23, 59, 59, 999);
+  return end.getTime();
 }
 
 export async function getActivityLogs(filters: ActivityLogFilters = {}) {
@@ -37,6 +51,29 @@ export async function getActivityLogs(filters: ActivityLogFilters = {}) {
     sort = "createdAt",
     order = "desc",
   } = filters;
+
+  // Phase 5c: native Convex read (complete cross-domain history via the logActivity
+  // mirror). Same shape as the Prisma path so the screen is agnostic.
+  if (nativeActivityReads()) {
+    const convex = await getConvexClient();
+    const result = await convex.query(api.activityLog.list, {
+      orgId: organizationId,
+      page,
+      pageSize,
+      sort,
+      order,
+      entityType,
+      action,
+      userId,
+      entityId,
+      projectId,
+      assetId,
+      search,
+      startDateMs: startMs(startDate),
+      endDateMs: endMs(endDate),
+    });
+    return serialize(result);
+  }
 
   const where: Record<string, unknown> = { organizationId };
 
@@ -87,6 +124,18 @@ export async function getEntityActivityLog(
   limit = 5,
 ) {
   const { organizationId } = await getOrgContext();
+
+  if (nativeActivityReads()) {
+    const convex = await getConvexClient();
+    const result = await convex.query(api.activityLog.listByEntity, {
+      orgId: organizationId,
+      entityType,
+      entityId,
+      limit,
+    });
+    return serialize(result);
+  }
+
   const where = { organizationId, entityType, entityId };
 
   const [items, total] = await Promise.all([
@@ -116,28 +165,52 @@ export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
     endDate,
   } = filters;
 
-  const where: Record<string, unknown> = { organizationId };
-  if (entityType) where.entityType = entityType;
-  if (entityId) where.entityId = entityId;
-  if (action) where.action = action;
-  if (userId) where.userId = userId;
-  if (search) where.summary = { contains: search, mode: "insensitive" };
-  if (startDate || endDate) {
-    const dateFilter: Record<string, Date> = {};
-    if (startDate) dateFilter.gte = new Date(startDate);
-    if (endDate) {
-      const end = new Date(endDate);
-      end.setHours(23, 59, 59, 999);
-      dateFilter.lte = end;
-    }
-    where.createdAt = dateFilter;
-  }
+  let items: Array<{
+    createdAt: string | Date;
+    userName: string;
+    action: string;
+    entityType: string;
+    entityName: string;
+    summary: string;
+    details?: unknown;
+  }>;
 
-  const items = await prisma.activityLog.findMany({
-    where,
-    orderBy: { createdAt: "desc" },
-    take: 10000,
-  });
+  if (nativeActivityReads()) {
+    const convex = await getConvexClient();
+    items = await convex.query(api.activityLog.exportRows, {
+      orgId: organizationId,
+      entityType,
+      entityId,
+      action,
+      userId,
+      search,
+      startDateMs: startMs(startDate),
+      endDateMs: endMs(endDate),
+    });
+  } else {
+    const where: Record<string, unknown> = { organizationId };
+    if (entityType) where.entityType = entityType;
+    if (entityId) where.entityId = entityId;
+    if (action) where.action = action;
+    if (userId) where.userId = userId;
+    if (search) where.summary = { contains: search, mode: "insensitive" };
+    if (startDate || endDate) {
+      const dateFilter: Record<string, Date> = {};
+      if (startDate) dateFilter.gte = new Date(startDate);
+      if (endDate) {
+        const end = new Date(endDate);
+        end.setHours(23, 59, 59, 999);
+        dateFilter.lte = end;
+      }
+      where.createdAt = dateFilter;
+    }
+
+    items = await prisma.activityLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: 10000,
+    });
+  }
 
   const escape = (s: string) => {
     if (s.includes(",") || s.includes('"') || s.includes("\n")) {


### PR DESCRIPTION
Closes out the two remaining Phase 5 "optional polish" items so Phases 4 and 5 are done. All flags default **OFF** — merging changes nothing in prod until flipped.

## A — Audit-read migration (Phase 5c)

The activity-log screens can now read Convex instead of Postgres. The catch: only the 5 inverted domains wrote `activityLogs`; ~39 others wrote **only** Postgres via `logActivity`, so a naive read-swap would show a truncated history. Fix:

- **`logActivity` dual-writes** — Postgres + an idempotent mirror into Convex `activityLogs` (`api.activityLogWrites.record`, service-only, `createIfMissing` by cuid), behind `NATIVE_ACTIVITY_WRITES`. Same shared cuid + timestamp; best-effort (never breaks a write).
- **`convex/activityLog.{list,listByEntity,exportRows}`** — native reads with parity to `src/server/activity-log.ts`: org-scoped (`requireOrgRead`), same filters/pagination/user-join, ISO `createdAt`. list/export scan the most-recent 10k rows off `by_organizationId_createdAt` (bounded; returns `capped`).
- **`src/server/activity-log.ts`** branches on `NATIVE_ACTIVITY_READS`.
- **`scripts/convex-backfill-activity-log.ts`** — cursor-paginated, idempotent backfill of existing history. **Run before flipping the read flag**, else the screen is truncated to rows written since the write flag went on.

This is the last audit tie to Postgres — it unblocks dropping `logActivity`/`activityLog` in decommission. Tests: `convex/activityLog.test.ts` (RBAC, every filter, pagination, user-join, idempotent record).

## B — Optimistic line-item edit (Phase 5d)

Edited rows update with **zero latency**. Unlike the asset-notes 5d hook (direct Convex mutation + `withOptimisticUpdate`), line-item edits keep going through the `updateLineItem` server action — it owns the availability re-check, stale-guard, and the Postgres org default tax rate the in-mutation recalc needs, so a pure client→Convex write couldn't get totals right. Instead the pending fields overlay onto the `equipmentTab.bundle` line items **before reconstruction** (same idea as the tab's optimistic delete), cleared when the write settles (rollback on error). Flag `NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC` (default OFF). New `src/hooks/use-native-line-item-writes.ts` (flag + `computeLineTotal` + `applyOptimisticEdits`), unit-tested.

## C — Docs

Design-doc status block + `FEATUREDOCS/54` updated to record Phases 4 + 5 as **closed**, with Phases 6/7 + Postgres decommission (and membership writes as Tier E) documented as separate remaining initiatives.

## Verification
- `npm run build` exit 0, `tsc --noEmit` clean, lint 0 errors.
- Full unit suite: **2620 passing**; Convex suite: **124 passing** (incl. new activity-log + optimistic-edit tests).
- All flags default OFF → zero behavioural change on merge.

## Rollout order after merge
1. Deploy (CI pushes the new Convex functions).
2. `NATIVE_ACTIVITY_WRITES=true` (Coolify) → let it run / then run `scripts/convex-backfill-activity-log.ts`.
3. Verify Convex has the full history, then `NATIVE_ACTIVITY_READS=true`.
4. Dogfood optimistic edit on a preview, then `NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC=true` (build-inlined — needs the repo var + rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)