### PR TITLE
fix(scripts): keep the service token fresh during the activity-log backfill

### DIFF
--- a/scripts/convex-backfill-activity-log.ts
+++ b/scripts/convex-backfill-activity-log.ts
@@ -16,9 +16,14 @@ import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../convex/_generated/api";
 
 const BATCH = 500;
+// Process each batch with bounded concurrency. Two reasons: (1) speed — thousands of
+// sequential HTTP round-trips to Convex Cloud take far too long; (2) the service token
+// has a 5-min TTL, and `getConvexClient()` only re-mints it WHEN CALLED, so we must
+// re-fetch the client per mutation (cheap — cached until ~30s before expiry) rather
+// than hold one client for the whole run (which expires mid-run).
+const CONCURRENCY = 15;
 
 async function main() {
-  const convex = await getConvexClient();
   const total = await prisma.activityLog.count();
   console.log(`Found ${total} activityLog rows in Prisma.`);
 
@@ -36,27 +41,34 @@ async function main() {
     if (rows.length === 0) break;
     cursor = rows[rows.length - 1].id;
 
-    for (const r of rows) {
-      const res = await convex.mutation(api.activityLogWrites.record, {
-        id: r.id,
-        organizationId: r.organizationId,
-        action: r.action,
-        entityType: r.entityType,
-        entityId: r.entityId,
-        entityName: r.entityName,
-        userId: r.userId ?? undefined,
-        userName: r.userName,
-        summary: r.summary,
-        details: r.details ?? undefined,
-        metadata: r.metadata ?? undefined,
-        projectId: r.projectId ?? undefined,
-        assetId: r.assetId ?? undefined,
-        kitId: r.kitId ?? undefined,
-        createdAt: r.createdAt.getTime(),
-      });
-      if (res.created) created++;
-      else skipped++;
+    let idx = 0;
+    async function worker() {
+      while (idx < rows.length) {
+        const r = rows[idx++];
+        // Re-fetch per mutation so a long run keeps a fresh (auto-refreshed) token.
+        const convex = await getConvexClient();
+        const res = await convex.mutation(api.activityLogWrites.record, {
+          id: r.id,
+          organizationId: r.organizationId,
+          action: r.action,
+          entityType: r.entityType,
+          entityId: r.entityId,
+          entityName: r.entityName,
+          userId: r.userId ?? undefined,
+          userName: r.userName,
+          summary: r.summary,
+          details: r.details ?? undefined,
+          metadata: r.metadata ?? undefined,
+          projectId: r.projectId ?? undefined,
+          assetId: r.assetId ?? undefined,
+          kitId: r.kitId ?? undefined,
+          createdAt: r.createdAt.getTime(),
+        });
+        if (res.created) created++;
+        else skipped++;
+      }
     }
+    await Promise.all(Array.from({ length: CONCURRENCY }, worker));
     console.log(`  …processed ${created + skipped}/${total}`);
   }
 


### PR DESCRIPTION
The activity-log backfill expired its service token ~500 rows in:
`Error: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 6 seconds ago"}`

**Cause:** the service token has a 5-min TTL and `getConvexClient()` only re-mints it when *called*. The script grabbed one client before the loop and reused it, so on a long run (thousands of Convex-Cloud round-trips) the token expired mid-run. Re-running wouldn't help — once the already-done prefix exceeds one token window, later runs expire during the idempotent re-check before reaching new rows.

**Fix:** re-fetch the client per mutation (cheap — cached until ~30s before expiry, re-minted at the boundary) so the token stays fresh, and process each batch with bounded concurrency (15) so the whole backfill finishes in a couple of minutes. Still idempotent (`record` is `createIfMissing` by cuid), so safe to re-run.

After deploy, re-run in the prod container — it'll skip the ~500 already-mirrored rows and complete the rest:
```
npx tsx scripts/convex-backfill-activity-log.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)