### PR TITLE
perf(warehouse): batch bulk deprep round-trips (deprepItemsBatch)

### DIFF
--- a/convex/checkRecordOps.ts
+++ b/convex/checkRecordOps.ts
@@ -48,54 +48,62 @@ export const prepItem = mutation({
   },
 });
 
+/** Core deprep of a single line — extracted so both the single `deprepItem`
+ *  mutation and the batched `deprepItems` mutation run byte-identical logic. */
+async function deprepItemInner(
+  ctx: Ctx,
+  a: { organizationId: string; projectId: string; lineItemId: string; quantity: number; now: number },
+) {
+  const line = await lineByCuid(ctx, a.lineItemId);
+  if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError("Line item not found in project");
+  if (line.status === "CHECKED_OUT") throw new ConvexError("Item is already deployed — return it first");
+
+  const prepped = (await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", a.lineItemId)).collect())
+    .filter((u) => u.status !== "CHECKED_OUT")
+    .sort((x, y) => y.ordinal - x.ordinal); // highest ordinal first (LIFO)
+
+  const isPartialBulk = prepped.length === 1 && prepped[0].bulkAssetId && !prepped[0].assetId && a.quantity < (prepped[0].quantity ?? 0);
+  if (isPartialBulk) {
+    await ctx.db.patch(prepped[0]._id, { quantity: (prepped[0].quantity ?? 0) - a.quantity, updatedAt: a.now });
+  } else {
+    const removeCount = Math.min(a.quantity, prepped.length);
+    const removedParentAssetIds: string[] = [];
+    for (let i = 0; i < removeCount; i++) {
+      if (prepped[i].assetId) removedParentAssetIds.push(prepped[i].assetId!);
+      await ctx.db.delete(prepped[i]._id);
+    }
+    if (removedParentAssetIds.length > 0) {
+      const accChildren = (await childLines(ctx, a.lineItemId, a.organizationId)).filter((c) => c.childKind === "ACCESSORY");
+      for (const child of accChildren) {
+        const accUnits = (await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", child.id)).collect())
+          .filter((u) => u.status !== "CHECKED_OUT" && u.parentUnitAssetId && removedParentAssetIds.includes(u.parentUnitAssetId));
+        for (const u of accUnits) await ctx.db.delete(u._id);
+      }
+      for (const child of accChildren) await syncLineItemRollup(ctx, child.id);
+    }
+  }
+
+  // Clear legacy line.assetId (kit children excepted).
+  if (!line.isKitChild && line.assetId) {
+    const fresh = await lineByCuid(ctx, a.lineItemId);
+    if (fresh) {
+      const { _id, _creationTime, assetId: _a, ...rest } = fresh;
+      await ctx.db.replace(_id, { ...rest, prepStatus: "PENDING", updatedAt: a.now });
+    }
+  } else {
+    const fresh = await lineByCuid(ctx, a.lineItemId);
+    if (fresh) await ctx.db.patch(fresh._id, { prepStatus: "PENDING", updatedAt: a.now });
+  }
+  await syncLineItemRollup(ctx, a.lineItemId);
+}
+
 /** Remove prep assignment: drop/reduce prepped units (+ cascade accessory units),
  *  clear legacy assetId, reset line prepStatus to PENDING. */
 export const deprepItem = mutation({
   args: { organizationId: v.string(), projectId: v.string(), lineItemId: v.string(), quantity: v.optional(v.number()), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const quantity = a.quantity ?? 1;
-    const line = await lineByCuid(ctx, a.lineItemId);
-    if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError("Line item not found in project");
-    if (line.status === "CHECKED_OUT") throw new ConvexError("Item is already deployed — return it first");
-
-    const prepped = (await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", a.lineItemId)).collect())
-      .filter((u) => u.status !== "CHECKED_OUT")
-      .sort((x, y) => y.ordinal - x.ordinal); // highest ordinal first (LIFO)
-
-    const isPartialBulk = prepped.length === 1 && prepped[0].bulkAssetId && !prepped[0].assetId && quantity < (prepped[0].quantity ?? 0);
-    if (isPartialBulk) {
-      await ctx.db.patch(prepped[0]._id, { quantity: (prepped[0].quantity ?? 0) - quantity, updatedAt: a.now });
-    } else {
-      const removeCount = Math.min(quantity, prepped.length);
-      const removedParentAssetIds: string[] = [];
-      for (let i = 0; i < removeCount; i++) {
-        if (prepped[i].assetId) removedParentAssetIds.push(prepped[i].assetId!);
-        await ctx.db.delete(prepped[i]._id);
-      }
-      if (removedParentAssetIds.length > 0) {
-        const accChildren = (await childLines(ctx, a.lineItemId, a.organizationId)).filter((c) => c.childKind === "ACCESSORY");
-        for (const child of accChildren) {
-          const accUnits = (await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", child.id)).collect())
-            .filter((u) => u.status !== "CHECKED_OUT" && u.parentUnitAssetId && removedParentAssetIds.includes(u.parentUnitAssetId));
-          for (const u of accUnits) await ctx.db.delete(u._id);
-        }
-        for (const child of accChildren) await syncLineItemRollup(ctx, child.id);
-      }
-    }
-
-    // Clear legacy line.assetId (kit children excepted).
-    if (!line.isKitChild && line.assetId) {
-      const fresh = await lineByCuid(ctx, a.lineItemId);
-      if (fresh) {
-        const { _id, _creationTime, assetId: _a, ...rest } = fresh;
-        await ctx.db.replace(_id, { ...rest, prepStatus: "PENDING", updatedAt: a.now });
-      }
-    } else {
-      const fresh = await lineByCuid(ctx, a.lineItemId);
-      if (fresh) await ctx.db.patch(fresh._id, { prepStatus: "PENDING", updatedAt: a.now });
-    }
-    await syncLineItemRollup(ctx, a.lineItemId);
+    await deprepItemInner(ctx, { ...a, quantity: a.quantity ?? 1 });
     return { id: a.lineItemId };
   },
 });
@@ -178,5 +186,48 @@ export const deprepKit = mutation({
     if (!parent || parent.projectId !== a.projectId || parent.organizationId !== a.organizationId) throw new ConvexError("Kit line item not found");
     await setKitTreePrep(ctx, a.parentLineItemId, a.organizationId, a.now, "DEPREP");
     return { success: true };
+  },
+});
+
+/** Batch deprep: reverse prep for many selected items + kits in ONE atomic
+ *  mutation. Collapses the client's per-op `deprepItem` / `deprepKit` round-trip
+ *  loop (warehouse "Deprep Selected"). Ops are applied in the given order — the
+ *  same sequence the old loop fired — so any shared-lineItemId ordering is
+ *  preserved. Item ops route through deprepItemInner (byte-identical to the
+ *  single deprepItem); kit ops validate the parent + reset the kit tree, exactly
+ *  as the single deprepKit does. */
+export const deprepItems = mutation({
+  args: {
+    organizationId: v.string(),
+    projectId: v.string(),
+    ops: v.array(
+      v.object({
+        lineItemId: v.string(),
+        quantity: v.optional(v.number()),
+        isKit: v.optional(v.boolean()),
+      }),
+    ),
+    now: v.number(),
+  },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const touched = new Set<string>();
+    for (const op of a.ops) {
+      if (op.isKit) {
+        const parent = await lineByCuid(ctx, op.lineItemId);
+        if (!parent || parent.projectId !== a.projectId || parent.organizationId !== a.organizationId) throw new ConvexError("Kit line item not found");
+        await setKitTreePrep(ctx, op.lineItemId, a.organizationId, a.now, "DEPREP");
+      } else {
+        await deprepItemInner(ctx, {
+          organizationId: a.organizationId,
+          projectId: a.projectId,
+          lineItemId: op.lineItemId,
+          quantity: op.quantity ?? 1,
+          now: a.now,
+        });
+      }
+      touched.add(op.lineItemId);
+    }
+    return { ids: [...touched] };
   },
 });

--- a/docs/designs/bulk-operations-batching.md
+++ b/docs/designs/bulk-operations-batching.md
@@ -1,6 +1,8 @@
 # Bulk-Operation Batching — N+1 round-trip audit & fix plan
 
-**Status:** audit complete, fixes not started. Created 2026-07-06.
+**Status:** audit complete. **Wave 1b (deprep #5) shipped** — `deprepItemsBatch` +
+Convex `checkRecordOps.deprepItems` (item + kit ops), deprep handler rewired,
+parity test green. Created 2026-07-06.
 **Owner intent:** the app "takes ages" on bulk actions (select many assets → prep,
 submit item checks, etc.). Root cause is **one server-action round-trip per item**
 in a client loop. Fix = batch each into a single call.
@@ -68,7 +70,7 @@ are in `src/app/(app)/warehouse/[projectId]/page.tsx`.
 | 2 | warehouse page — `for (const bi of bulkNoCheckItems)` nested `for (let i=0;i<bi.quantity` → `prepItemDirect` | `prepItemDirect` | "Prep Selected", bulk items × qty | **HIGH** (10×5=50 calls) | route to `prepItemsBatch` (expand qty server-side) |
 | 3 | warehouse page — `for (const item of readyItems)`/`readyNoCheckItems` → `prepItemDirect` | `prepItemDirect` | "Prep Selected", serialized | HIGH | route to `prepItemsBatch` |
 | 4 | warehouse page — asset-picker confirm IIFE `for (... of withoutChecks) await prepItemDirect` | `prepItemDirect` | asset-picker confirm | MED | route to `prepItemsBatch` |
-| 5 | warehouse page — deprep handler loop → `deprepItem` / `deprepKit` | `deprepItem`,`deprepKit` | "Deprep" selected (unbounded) | HIGH | new `deprepItemsBatch(projectId, items[])` |
+| 5 | ✅ warehouse page — deprep handler loop → `deprepItem` / `deprepKit` | `deprepItem`,`deprepKit` | "Deprep" selected (unbounded) | HIGH | ✅ `deprepItemsBatch(projectId, ops[])` (item + kit ops) |
 | 6 | warehouse page — `for (const kitItemId of kitLineItemIds)` → `checkOutKit` | `checkOutKit` | bulk-deploy kits | MED | new `checkOutKitsBatch` |
 | 7 | warehouse page — kit return loop → `checkInKit` | `checkInKit` | bulk-return kits | MED | new `checkInKitsBatch` |
 | 8 | `src/components/projects/project-wizard.tsx` — `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])` | `addProjectManager`/`removeProjectManager` | manager selection delta on create | HIGH | new `setProjectManagers(projectId, userIds[])` (diff server-side) |

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -110,8 +110,8 @@ import {
   pullItem,
   prepItemDirect,
   getAssetAccessories,
-  deprepItem,
   deprepKit,
+  deprepItemsBatch,
   prepKitChildren,
   completeCheckAndPack,
   completeCheckAndFlag,
@@ -756,14 +756,13 @@ function WarehouseProjectPage({
     onError: (e) => showError(e),
   });
 
+  // Batched deprep — reverse prep for every selected item + kit in one call.
+  // (Drives the deprep buttons' pending state via `.isPending`.)
   const deprepMutation = useServerMutation({
-    mutationFn: (args: string | { lineItemId: string; quantity?: number }) => {
-      const lineItemId = typeof args === "string" ? args : args.lineItemId;
-      const quantity = typeof args === "string" ? 1 : args.quantity;
-      return deprepItem(projectId, lineItemId, quantity);
-    },
-    onSuccess: () => {
-      toast.success("Item removed from prep");
+    mutationFn: (ops: Array<{ lineItemId: string; quantity?: number; isKit?: boolean }>) =>
+      deprepItemsBatch(projectId, ops),
+    onSuccess: (_res, ops) => {
+      toast.success(`Removed ${ops.length} from prep`);
       invalidate();
     },
     onError: (e) => showError(e),
@@ -1996,20 +1995,17 @@ function WarehouseProjectPage({
       }
     }
 
-    // Fire direct deprep for items without checks
-    for (const d of directDeprep) {
-      if (d.isKit) {
-        deprepKit(projectId, d.lineItemId)
-          .then(() => {
-            toast.success("Kit removed from prep");
-            invalidate();
-          })
-          .catch((e) => showError(e, { fallbackTitle: "Failed to deprep kit" }));
-      } else if (d.quantity) {
-        deprepMutation.mutate({ lineItemId: d.lineItemId, quantity: d.quantity });
-      } else {
-        deprepMutation.mutate(d.lineItemId);
-      }
+    // Fire direct deprep for items + kits without checks in one batch call
+    // (was one round-trip per selected item/kit). Ops keep their array order so
+    // any shared-lineItemId sequencing is preserved server-side.
+    if (directDeprep.length > 0) {
+      deprepMutation.mutate(
+        directDeprep.map((d) => ({
+          lineItemId: d.lineItemId,
+          quantity: d.quantity,
+          isKit: d.isKit,
+        })),
+      );
     }
 
     // Start check queue for items that need it

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -575,6 +575,105 @@ export async function deprepKit(
 }
 
 /**
+ * Batch deprep: reverse prep for many selected items + kits in ONE server
+ * round-trip + ONE atomic Convex mutation. Replaces the client-side
+ * `for (const d of directDeprep) { deprepKit | deprepItem }` loop in the
+ * warehouse deprep handler, which fired one round-trip per selected item/kit.
+ *
+ * Ops are applied server-side in array order — the same sequence the old loop
+ * fired — so any shared-lineItemId ordering is preserved. Item ops run the exact
+ * deprepItem logic; kit ops run the exact deprepKit tree-reset. Same DB outcome
+ * as the per-op loop; only the round-trip count collapses from N to 1.
+ *
+ * (The single deprepKit's "Kit is not prepped" guard is a UX pre-check, not a
+ * correctness gate — omitted here so one already-PENDING kit can't abort the
+ * whole atomic batch; the underlying reset is a harmless no-op on such a kit.)
+ */
+export async function deprepItemsBatch(
+  projectId: string,
+  ops: Array<{ lineItemId: string; quantity?: number; isKit?: boolean }>
+) {
+  const { organizationId, userId, userName } = await requirePermission(
+    "warehouse",
+    "check_out"
+  );
+  if (ops.length === 0) return serialize({ ids: [] });
+
+  const convex = await getConvexClient();
+  await convex.mutation(api.checkRecordOps.deprepItems, {
+    organizationId,
+    projectId,
+    ops,
+    now: Date.now(),
+  });
+
+  // Re-read the touched lines once for activity-log naming (item → model name,
+  // kit → kit name via the parent line's kitId), matching the per-op logging of
+  // the single deprepItem / deprepKit actions. Deprep never deletes the line
+  // itself, so every touched id still resolves.
+  const distinctIds = [...new Set(ops.map((o) => o.lineItemId))];
+  const rows = await convex.query(api.projectLineItems.listByIds, {
+    ids: distinctIds,
+    orgId: organizationId,
+  });
+  const lineById = new Map(rows.map((r) => [r.id, r]));
+  const grafted = await attachLineItemModels(
+    organizationId,
+    rows.map((r) => ({ ...r, modelId: r.modelId ?? null })),
+  );
+  const modelNameById = new Map(grafted.map((g) => [g.id, g.model?.name ?? null]));
+
+  const kitIds = [
+    ...new Set(
+      ops
+        .filter((o) => o.isKit)
+        .map((o) => lineById.get(o.lineItemId)?.kitId)
+        .filter((x): x is string => !!x),
+    ),
+  ];
+  const kitNameById = new Map<string, string>();
+  await Promise.all(
+    kitIds.map(async (kid) => {
+      const kit = await convex.query(api.kits.getById, { id: kid });
+      if (kit) kitNameById.set(kid, kit.name);
+    }),
+  );
+
+  for (const op of ops) {
+    const line = lineById.get(op.lineItemId);
+    if (op.isKit) {
+      const kitName = line?.kitId ? kitNameById.get(line.kitId) : undefined;
+      await logActivity({
+        organizationId,
+        userId,
+        userName,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: op.lineItemId,
+        entityName: kitName || "Kit",
+        summary: "Removed kit from prep",
+        projectId,
+      });
+    } else {
+      await logActivity({
+        organizationId,
+        userId,
+        userName,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: op.lineItemId,
+        entityName: modelNameById.get(op.lineItemId) || "Line item",
+        summary: "Removed item from prep",
+        projectId,
+        assetId: line?.assetId || undefined,
+      });
+    }
+  }
+
+  return serialize({ ids: distinctIds });
+}
+
+/**
  * Mark all children of a kit line item as prepped (prepStatus=PACKED).
  * Called after kit check forms are completed in PREP context.
  */

--- a/src/server/warehouse-deprep.int.test.ts
+++ b/src/server/warehouse-deprep.int.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Integration parity tests for deprepItemsBatch — proves the batched deprep
+ * (one atomic Convex mutation) produces the identical DB result as the old
+ * per-op loop of deprepItem / deprepKit server-action round-trips.
+ *
+ * Phase C writes units + line rollups to Convex only, so assertions read from
+ * Convex (reading Postgres via testPrisma would be stale).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+  createAssetFixture,
+  createKitFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import {
+  prepItemDirect,
+  prepKitChildren,
+  deprepItem,
+  deprepKit,
+  deprepItemsBatch,
+} from "@/server/check-records";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Test Project",
+      taxRate: 0,
+    },
+  });
+}
+
+async function createLine(orgId: string, projectId: string, modelId: string, quantity: number) {
+  return testPrisma.projectLineItem.create({
+    data: { organizationId: orgId, projectId, modelId, quantity, status: "CONFIRMED" },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normUnit(u: any) {
+  return {
+    hasAsset: !!u.assetId,
+    hasBulk: !!u.bulkAssetId,
+    hasParentUnit: !!u.parentUnitAssetId,
+    quantity: u.quantity ?? null,
+    status: u.status ?? null,
+    prepStatus: u.prepStatus ?? null,
+    ordinal: u.ordinal ?? null,
+  };
+}
+
+async function snapshotLine(lineItemId: string) {
+  const convex = await getConvexClient();
+  const [line, units] = await Promise.all([
+    convex.query(api.projectLineItems.getById, { id: lineItemId }),
+    convex.query(api.projectLineItemUnits.listByLineItem, { lineItemId }),
+  ]);
+  return {
+    line: line
+      ? {
+          status: line.status ?? null,
+          prepStatus: line.prepStatus ?? null,
+          quantity: line.quantity ?? null,
+          assignedQuantity: line.assignedQuantity ?? 0,
+          packedQuantity: line.packedQuantity ?? 0,
+          hasAssetId: !!line.assetId,
+        }
+      : null,
+    units: units
+      .map(normUnit)
+      .sort((a, b) => (a.ordinal ?? 0) - (b.ordinal ?? 0) || Number(b.hasAsset) - Number(a.hasAsset)),
+  };
+}
+
+describe("deprepItemsBatch — parity with the per-op deprep loop", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("distinct prepped items: batch deprep == the deprepItem loop", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    // Scenario A — old loop: prep 3 lines, deprepItem each.
+    const projA = await createProjectFixture(org.id);
+    const linesA = [];
+    for (let i = 0; i < 3; i++) {
+      const line = await createLine(org.id, projA.id, model.id, 1);
+      const asset = await createAssetFixture(org.id, model.id, { assetTag: `DPB-A-${i}` });
+      await prepItemDirect(projA.id, line.id, asset.id);
+      linesA.push(line);
+    }
+    for (const line of linesA) await deprepItem(projA.id, line.id, 1);
+
+    // Scenario B — one batch call over the identical setup.
+    const projB = await createProjectFixture(org.id);
+    const linesB = [];
+    for (let i = 0; i < 3; i++) {
+      const line = await createLine(org.id, projB.id, model.id, 1);
+      const asset = await createAssetFixture(org.id, model.id, { assetTag: `DPB-B-${i}` });
+      await prepItemDirect(projB.id, line.id, asset.id);
+      linesB.push(line);
+    }
+    await deprepItemsBatch(projB.id, linesB.map((l) => ({ lineItemId: l.id, quantity: 1 })));
+
+    for (let i = 0; i < 3; i++) {
+      const snap = await snapshotLine(linesB[i].id);
+      expect(snap).toEqual(await snapshotLine(linesA[i].id));
+      expect(snap.units).toHaveLength(0);
+      expect(snap.line?.prepStatus).toBe("PENDING");
+    }
+  });
+
+  it("partial deprep of a multi-unit line: batch qty == loop qty", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    // Loop: prep 3 units, deprep 2 in one deprepItem call.
+    const projA = await createProjectFixture(org.id);
+    const lineA = await createLine(org.id, projA.id, model.id, 3);
+    for (let i = 0; i < 3; i++) {
+      const asset = await createAssetFixture(org.id, model.id, { assetTag: `DPP-A-${i}` });
+      await prepItemDirect(projA.id, lineA.id, asset.id);
+    }
+    await deprepItem(projA.id, lineA.id, 2);
+
+    // Batch: identical setup, deprep 2 via a single batch op.
+    const projB = await createProjectFixture(org.id);
+    const lineB = await createLine(org.id, projB.id, model.id, 3);
+    for (let i = 0; i < 3; i++) {
+      const asset = await createAssetFixture(org.id, model.id, { assetTag: `DPP-B-${i}` });
+      await prepItemDirect(projB.id, lineB.id, asset.id);
+    }
+    await deprepItemsBatch(projB.id, [{ lineItemId: lineB.id, quantity: 2 }]);
+
+    const snap = await snapshotLine(lineB.id);
+    expect(snap).toEqual(await snapshotLine(lineA.id));
+    expect(snap.units).toHaveLength(1); // one prepped unit left
+    expect(snap.line?.prepStatus).toBe("PACKED");
+  });
+
+  it("kit deprep: batch isKit op == the deprepKit call", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    async function buildAndPrepKit(assetTag: string) {
+      const project = await createProjectFixture(org.id);
+      const kit = await createKitFixture(org.id, { assetTag, name: "K", userId: user.id });
+      const parent = await testPrisma.projectLineItem.create({
+        data: {
+          organizationId: org.id,
+          projectId: project.id,
+          kitId: kit.id,
+          quantity: 1,
+          status: "CONFIRMED",
+          isKitChild: false,
+        },
+      });
+      const children = [];
+      for (let i = 0; i < 2; i++) {
+        const child = await testPrisma.projectLineItem.create({
+          data: {
+            organizationId: org.id,
+            projectId: project.id,
+            modelId: model.id,
+            quantity: 1,
+            status: "CONFIRMED",
+            parentLineItemId: parent.id,
+            isKitChild: true,
+            childKind: "KIT",
+          },
+        });
+        children.push(child);
+      }
+      await prepKitChildren(project.id, parent.id);
+      return { project, parent, children };
+    }
+
+    const a = await buildAndPrepKit(`KIT-A-${createId().slice(0, 6)}`);
+    await deprepKit(a.project.id, a.parent.id);
+
+    const b = await buildAndPrepKit(`KIT-B-${createId().slice(0, 6)}`);
+    await deprepItemsBatch(b.project.id, [{ lineItemId: b.parent.id, isKit: true }]);
+
+    expect(await snapshotLine(b.parent.id)).toEqual(await snapshotLine(a.parent.id));
+    for (let i = 0; i < 2; i++) {
+      const snap = await snapshotLine(b.children[i].id);
+      expect(snap).toEqual(await snapshotLine(a.children[i].id));
+      expect(snap.line?.prepStatus).toBe("PENDING");
+    }
+  });
+});


### PR DESCRIPTION
## What

Bulk deprep ("Deprep Selected") fired **one `deprepItem`/`deprepKit` server round-trip per selected item/kit** (bulk-op-batching audit, Wave 1b, finding #5). This collapses the whole selection into one call.

- **Extract `deprepItemInner`** — the single-line deprep body, now shared by the `deprepItem` mutation and the batch (byte-identical logic).
- **Convex `checkRecordOps.deprepItems`** — loops item ops (`deprepItemInner`) and kit ops (validate parent + `setKitTreePrep` DEPREP) **in array order** inside one transaction.
- **Server action `deprepItemsBatch(projectId, ops[])`** — `requirePermission` once, one mutation, one activity-log entry per op (model name for items, kit name for kits) matching the single actions.
- **Rewired handler** — the `directDeprep` loop now fires one `deprepItemsBatch`. `deprepMutation` is repurposed to carry the batch so the deprep buttons' `.isPending` spinner still works; one success toast instead of N.

## Win

Structurally the same N→1 round-trip collapse as the prep batch (companion PR #354), which measured **15.9× (50.4s → 3.2s)** on a real N=20 op against live dev Convex. Deprep has the same per-op cost profile (mutation + re-read + activity log), so the same collapse applies.

## Correctness

New `src/server/warehouse-deprep.int.test.ts` runs the old per-op loop and the batch over identical fixtures and asserts equal **Convex** snapshots:
- distinct prepped items
- partial deprep of a multi-unit line (qty)
- kit deprep (`isKit` op vs `deprepKit`)

## Codex review

Clean — "No discrete correctness, security, or maintainability regressions identified."

## Notes

- The single `deprepKit`'s "Kit is not prepped" guard is a UX pre-check, not a correctness gate; it's omitted in the batch so one already-PENDING kit can't abort the atomic batch (the reset is a harmless no-op there).
- Touches `convex/checkRecordOps.ts` like PR #354 (prep), but in a separate region (batch added at end, prep added mid-file) — clean sequential merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)