### PR TITLE
perf(projects): batch project-manager reconciliation (setProjectManagers)

### DIFF
--- a/convex/projectManagers.ts
+++ b/convex/projectManagers.ts
@@ -123,7 +123,13 @@ export const applyDiff = mutation({
   handler: async (ctx, a) => {
     await requireService(ctx);
     for (const m of a.add) {
-      const existing = await ctx.db.query("projectManagers").withIndex("by_cuid", (q) => q.eq("id", m.id)).unique();
+      // Dedupe on (projectId, userId), not the fresh cuid, so two calls racing
+      // from the same starting state can't both insert the same manager (the
+      // by_cuid check would miss it — each generates a different id).
+      const existing = await ctx.db
+        .query("projectManagers")
+        .withIndex("by_projectId_userId", (q) => q.eq("projectId", a.projectId).eq("userId", m.userId))
+        .first();
       if (existing) continue;
       await ctx.db.insert("projectManagers", {
         id: m.id,

--- a/convex/projectManagers.ts
+++ b/convex/projectManagers.ts
@@ -104,3 +104,38 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+/**
+ * Apply a manager diff to a project in ONE atomic mutation — collapses the
+ * client's `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(
+ * removeProjectManager)])` fan-out (one round-trip per manager) into a single
+ * call. The server action computes the diff (it needs the current rows for
+ * member validation + audit logging anyway); this mutation just inserts the new
+ * rows (createIfMissing by cuid) and deletes the removed rows.
+ */
+export const applyDiff = mutation({
+  args: {
+    organizationId: v.string(),
+    projectId: v.string(),
+    add: v.array(v.object({ id: v.string(), userId: v.string(), addedAt: v.number() })),
+    removeIds: v.array(v.string()),
+  },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    for (const m of a.add) {
+      const existing = await ctx.db.query("projectManagers").withIndex("by_cuid", (q) => q.eq("id", m.id)).unique();
+      if (existing) continue;
+      await ctx.db.insert("projectManagers", {
+        id: m.id,
+        organizationId: a.organizationId,
+        projectId: a.projectId,
+        userId: m.userId,
+        addedAt: m.addedAt,
+      });
+    }
+    for (const id of a.removeIds) {
+      const doc = await ctx.db.query("projectManagers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (doc) await ctx.db.delete(doc._id);
+    }
+  },
+});

--- a/docs/designs/bulk-operations-batching.md
+++ b/docs/designs/bulk-operations-batching.md
@@ -1,6 +1,8 @@
 # Bulk-Operation Batching — N+1 round-trip audit & fix plan
 
-**Status:** audit complete, fixes not started. Created 2026-07-06.
+**Status:** audit complete. **Wave 2 #8–9 (project managers) shipped** —
+`setProjectManagers(projectId, userIds[])` + Convex `projectManagers.applyDiff`,
+wizard rewired off the add/remove fan-out, parity test green. Created 2026-07-06.
 **Owner intent:** the app "takes ages" on bulk actions (select many assets → prep,
 submit item checks, etc.). Root cause is **one server-action round-trip per item**
 in a client loop. Fix = batch each into a single call.
@@ -71,8 +73,8 @@ are in `src/app/(app)/warehouse/[projectId]/page.tsx`.
 | 5 | warehouse page — deprep handler loop → `deprepItem` / `deprepKit` | `deprepItem`,`deprepKit` | "Deprep" selected (unbounded) | HIGH | new `deprepItemsBatch(projectId, items[])` |
 | 6 | warehouse page — `for (const kitItemId of kitLineItemIds)` → `checkOutKit` | `checkOutKit` | bulk-deploy kits | MED | new `checkOutKitsBatch` |
 | 7 | warehouse page — kit return loop → `checkInKit` | `checkInKit` | bulk-return kits | MED | new `checkInKitsBatch` |
-| 8 | `src/components/projects/project-wizard.tsx` — `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])` | `addProjectManager`/`removeProjectManager` | manager selection delta on create | HIGH | new `setProjectManagers(projectId, userIds[])` (diff server-side) |
-| 9 | `src/components/projects/project-form.tsx` — same manager add/remove fan-out | `addProjectManager`/`removeProjectManager` | manager selection delta on edit | HIGH | reuse `setProjectManagers` |
+| 8 | ✅ `src/components/projects/project-wizard.tsx` — `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])` | `addProjectManager`/`removeProjectManager` | manager selection delta on create | HIGH | ✅ `setProjectManagers(projectId, userIds[])` (diff server-side) |
+| 9 | ✅ (consolidated into `project-wizard.tsx` — no separate `project-form.tsx`; the wizard handles create AND edit) — same fan-out | `addProjectManager`/`removeProjectManager` | manager selection delta on edit | HIGH | ✅ `setProjectManagers` (same call, create + edit) |
 | 10 | `src/components/projects/equipment-tab.tsx` — multi-select move, `Promise.all(...map(moveLineItemToGroup))` | `moveLineItemToGroup` | drag N selected line items to a group | HIGH | new `moveLineItemsToGroup(moves[])` |
 | 11 | `src/app/(app)/crew/timesheets/page.tsx` **and** `src/app/(app)/crew/page.tsx` — `for (const crewId of selectedCrewIds) await createTimeEntry(...)` | `createTimeEntry` | log time for N selected crew | HIGH | new `createTimeEntries(data, crewMemberIds[])` (`createMany`) |
 

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -202,8 +202,16 @@ export function ProjectWizard({
       // Reconcile managers to the full selected set in one call — the server
       // diffs against the current rows (create mode = add all; edit mode = add
       // /remove only the delta). Was a Promise.all fan-out of one round-trip per
-      // changed manager.
-      await setProjectManagers(result.id, managerIds);
+      // changed manager. Only call when the set actually changed: setProjectManagers
+      // needs project:manage, and an unchanged save must stay a pure
+      // create/update (a non-owner without manage permission would otherwise fail
+      // on a manager no-op).
+      const managersChanged =
+        managerIds.length !== initialManagerIds.length ||
+        managerIds.some((id) => !initialManagerIds.includes(id));
+      if (managersChanged) {
+        await setProjectManagers(result.id, managerIds);
+      }
       return result;
     },
     onSuccess: (result) => {

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -18,7 +18,7 @@ import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { projectSchema, type ProjectFormValues } from "@/lib/validations/project";
 import { createProject, updateProject, peekNextProjectNumber } from "@/server/projects";
-import { addProjectManager, removeProjectManager } from "@/server/project-managers";
+import { setProjectManagers } from "@/server/project-managers";
 import { useClients } from "@/hooks/use-clients";
 import { useLocations } from "@/hooks/use-locations";
 import { useOrgTags } from "@/hooks/use-org-tags";
@@ -199,15 +199,11 @@ export function ProjectWizard({
         ? await updateProject(project.id, data)
         : await createProject({ ...data, isTemplate });
 
-      // Reconcile managers: only touch the delta — never blindly re-add (which
-      // would dupe) or blindly remove. In create mode initialManagerIds is [],
-      // so this reduces to "add all selected".
-      const toAdd = managerIds.filter((id) => !initialManagerIds.includes(id));
-      const toRemove = initialManagerIds.filter((id) => !managerIds.includes(id));
-      await Promise.all([
-        ...toAdd.map((userId) => addProjectManager(result.id, userId)),
-        ...toRemove.map((userId) => removeProjectManager(result.id, userId)),
-      ]);
+      // Reconcile managers to the full selected set in one call — the server
+      // diffs against the current rows (create mode = add all; edit mode = add
+      // /remove only the delta). Was a Promise.all fan-out of one round-trip per
+      // changed manager.
+      await setProjectManagers(result.id, managerIds);
       return result;
     },
     onSuccess: (result) => {

--- a/src/server/project-managers-batch.int.test.ts
+++ b/src/server/project-managers-batch.int.test.ts
@@ -114,6 +114,37 @@ describe("setProjectManagers — parity with the add/remove fan-out", () => {
     expect(rows[0].userId).toBe(u1.id);
   });
 
+  it("applyDiff dedupes on (projectId, userId), not the cuid (double-submit safe)", async () => {
+    // Simulates two saves racing from the same empty starting state: each
+    // computes toAdd=[u1] and mints a DIFFERENT cuid. A by_cuid guard would let
+    // both survive; the by_projectId_userId guard collapses them to one row.
+    const org = await createOrgFixture();
+    const actor = await createUserFixture(org.id, "owner");
+    const u1 = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: actor.id, userName: "Tester" };
+
+    const project = await createProjectFixture(org.id);
+    const convex = await getConvexClient();
+    await convex.mutation(api.projectManagers.applyDiff, {
+      organizationId: org.id,
+      projectId: project.id,
+      add: [{ id: createId(), userId: u1.id, addedAt: Date.now() }],
+      removeIds: [],
+    });
+    await convex.mutation(api.projectManagers.applyDiff, {
+      organizationId: org.id,
+      projectId: project.id,
+      add: [{ id: createId(), userId: u1.id, addedAt: Date.now() }],
+      removeIds: [],
+    });
+
+    const rows = await convex.query(api.projectManagers.listByProject, {
+      projectId: project.id,
+      orgId: org.id,
+    });
+    expect(rows).toHaveLength(1);
+  });
+
   it("rejects a non-member and writes nothing", async () => {
     const org = await createOrgFixture();
     const actor = await createUserFixture(org.id, "owner");

--- a/src/server/project-managers-batch.int.test.ts
+++ b/src/server/project-managers-batch.int.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration parity tests for setProjectManagers — proves the batched
+ * "set managers to exactly this set" action produces the same Convex rows as the
+ * old add/removeProjectManager fan-out loop, plus validation + idempotency.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import {
+  addProjectManager,
+  removeProjectManager,
+  setProjectManagers,
+} from "@/server/project-managers";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: {
+      organizationId: orgId,
+      projectNumber: `P-${createId().slice(0, 8)}`,
+      name: "Test Project",
+      taxRate: 0,
+    },
+  });
+}
+
+async function managerUserIds(projectId: string, orgId: string) {
+  const convex = await getConvexClient();
+  const rows = await convex.query(api.projectManagers.listByProject, { projectId, orgId });
+  return rows.map((r) => r.userId).sort();
+}
+
+describe("setProjectManagers — parity with the add/remove fan-out", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("batched set == the per-manager add/remove loop", async () => {
+    const org = await createOrgFixture();
+    const actor = await createUserFixture(org.id, "owner");
+    const u1 = await createUserFixture(org.id);
+    const u2 = await createUserFixture(org.id);
+    const u3 = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: actor.id, userName: "Tester" };
+
+    // Scenario A — old fan-out: seed {u1,u2}, then edit to {u1,u3}.
+    const projA = await createProjectFixture(org.id);
+    await addProjectManager(projA.id, u1.id);
+    await addProjectManager(projA.id, u2.id);
+    await addProjectManager(projA.id, u3.id);
+    await removeProjectManager(projA.id, u2.id);
+
+    // Scenario B — batch: set {u1,u2} then set {u1,u3}.
+    const projB = await createProjectFixture(org.id);
+    await setProjectManagers(projB.id, [u1.id, u2.id]);
+    await setProjectManagers(projB.id, [u1.id, u3.id]);
+
+    const a = await managerUserIds(projA.id, org.id);
+    const b = await managerUserIds(projB.id, org.id);
+    expect(b).toEqual(a);
+    expect(b).toEqual([u1.id, u3.id].sort());
+  });
+
+  it("create-mode: setting from empty adds exactly the selected set", async () => {
+    const org = await createOrgFixture();
+    const actor = await createUserFixture(org.id, "owner");
+    const u1 = await createUserFixture(org.id);
+    const u2 = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: actor.id, userName: "Tester" };
+
+    const project = await createProjectFixture(org.id);
+    await setProjectManagers(project.id, [u1.id, u2.id]);
+
+    expect(await managerUserIds(project.id, org.id)).toEqual([u1.id, u2.id].sort());
+  });
+
+  it("idempotent: setting the same set twice makes no change and no duplicates", async () => {
+    const org = await createOrgFixture();
+    const actor = await createUserFixture(org.id, "owner");
+    const u1 = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: actor.id, userName: "Tester" };
+
+    const project = await createProjectFixture(org.id);
+    await setProjectManagers(project.id, [u1.id]);
+    await setProjectManagers(project.id, [u1.id]);
+
+    const convex = await getConvexClient();
+    const rows = await convex.query(api.projectManagers.listByProject, {
+      projectId: project.id,
+      orgId: org.id,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(u1.id);
+  });
+
+  it("rejects a non-member and writes nothing", async () => {
+    const org = await createOrgFixture();
+    const actor = await createUserFixture(org.id, "owner");
+    const otherOrg = await createOrgFixture();
+    const outsider = await createUserFixture(otherOrg.id); // member of a DIFFERENT org
+    h.ctx = { organizationId: org.id, userId: actor.id, userName: "Tester" };
+
+    const project = await createProjectFixture(org.id);
+    await expect(setProjectManagers(project.id, [outsider.id])).rejects.toThrow(
+      /not a member/i,
+    );
+    expect(await managerUserIds(project.id, org.id)).toEqual([]);
+  });
+});

--- a/src/server/project-managers.ts
+++ b/src/server/project-managers.ts
@@ -77,6 +77,101 @@ export async function addProjectManager(projectId: string, userId: string) {
   return serialize({ id, organizationId, projectId, userId, user: user ?? null });
 }
 
+/**
+ * Set a project's managers to exactly `userIds` in ONE server round-trip + ONE
+ * atomic Convex mutation. Replaces the client-side
+ * `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])`
+ * fan-out (one round-trip per changed manager) in the project wizard/edit form.
+ *
+ * The diff is computed server-side from the current rows, so callers pass the
+ * full desired set and never compute the delta themselves. Same validation
+ * (added users must be org members) and per-add / per-remove audit logging as the
+ * single addProjectManager / removeProjectManager actions.
+ */
+export async function setProjectManagers(projectId: string, userIds: string[]) {
+  const { organizationId, userId: actorId, userName } = await requirePermission(
+    "project",
+    "manage"
+  );
+
+  const desired = [...new Set(userIds)];
+  const convex = await getConvexClient();
+  const current = await convex.query(api.projectManagers.listByProject, {
+    projectId,
+    orgId: organizationId,
+  });
+  const currentUserIds = new Set(current.map((r) => r.userId));
+  const desiredSet = new Set(desired);
+
+  const toAddUserIds = desired.filter((uid) => !currentUserIds.has(uid));
+  const toRemove = current.filter((r) => !desiredSet.has(r.userId));
+
+  // Validate every added user is an org member (Auth table — stays Prisma), in
+  // one query rather than per-user (matches addProjectManager's guard).
+  if (toAddUserIds.length > 0) {
+    const members = await prisma.member.findMany({
+      where: { organizationId, userId: { in: toAddUserIds } },
+      select: { userId: true },
+    });
+    const memberSet = new Set(members.map((m) => m.userId));
+    const nonMember = toAddUserIds.find((uid) => !memberSet.has(uid));
+    if (nonMember) {
+      throw new Error("User is not a member of this organization");
+    }
+  }
+
+  if (toAddUserIds.length === 0 && toRemove.length === 0) {
+    return serialize({ added: [], removed: [] });
+  }
+
+  const now = Date.now();
+  const add = toAddUserIds.map((uid) => ({ id: createId(), userId: uid, addedAt: now }));
+  await convex.mutation(api.projectManagers.applyDiff, {
+    organizationId,
+    projectId,
+    add,
+    removeIds: toRemove.map((r) => r.id),
+  });
+
+  // Fetch user labels for the audit log (added + removed) in one query.
+  const logUserIds = [...new Set([...toAddUserIds, ...toRemove.map((r) => r.userId)])];
+  const users = logUserIds.length
+    ? await prisma.user.findMany({
+        where: { id: { in: logUserIds } },
+        select: { id: true, name: true, email: true },
+      })
+    : [];
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const label = (uid: string) => userMap.get(uid)?.name ?? userMap.get(uid)?.email ?? uid;
+
+  for (const uid of toAddUserIds) {
+    await logActivity({
+      organizationId,
+      userId: actorId,
+      userName,
+      action: "updated",
+      entityType: "project",
+      entityId: projectId,
+      entityName: label(uid),
+      summary: `Added ${label(uid)} as project manager`,
+    });
+  }
+  for (const r of toRemove) {
+    await logActivity({
+      organizationId,
+      userId: actorId,
+      userName,
+      action: "updated",
+      entityType: "project",
+      entityId: projectId,
+      entityName: label(r.userId),
+      summary: `Removed ${label(r.userId)} as project manager`,
+    });
+  }
+
+  return serialize({ added: toAddUserIds, removed: toRemove.map((r) => r.userId) });
+}
+
 export async function removeProjectManager(projectId: string, userId: string) {
   const { organizationId, userId: actorId, userName } = await requirePermission(
     "project",


### PR DESCRIPTION
## What

The project wizard/edit form reconciled managers with a `Promise.all` fan-out of one `addProjectManager`/`removeProjectManager` server round-trip **per changed manager** (bulk-op-batching audit #8/#9; the separate `project-form.tsx` from the audit is now consolidated into `project-wizard.tsx`, which handles create AND edit).

- **`setProjectManagers(projectId, userIds[])`** — reads current rows, computes the diff server-side, validates added users are org members in one query, applies the diff in one atomic Convex mutation, logs one audit entry per add/remove (matching the single actions).
- **Convex `projectManagers.applyDiff`** — insert new rows + delete removed rows in one transaction; adds dedupe on the `by_projectId_userId` index (race-safe).
- **Wizard rewired** — one call passing the full selected set, guarded so it only fires when the manager set actually changed (preserves the old permission behaviour — see below).

## Correctness

`src/server/project-managers-batch.int.test.ts` (reads Convex rows):
- batched set == the per-manager add/remove loop
- create-mode (add all), idempotency (no dupes)
- `applyDiff` dedupes on `(projectId, userId)` under double-submit
- non-member rejection writes nothing

## Codex review

One [P1] + one [P2] found and fixed in this branch:
- [P1] `setProjectManagers` requires `project:manage`; calling it on every save gated create/edit even when managers were unchanged, so a non-owner with create/update but not manage would fail on a manager no-op. Now only called when the set changed.
- [P2] `applyDiff` deduped by fresh cuid, so two racing saves could double-insert the same manager. Now guards on `by_projectId_userId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)