### PR TITLE
perf(crew): batch "log time for N crew" (createTimeEntries)

### DIFF
--- a/convex/crewTimeEntries.ts
+++ b/convex/crewTimeEntries.ts
@@ -86,6 +86,44 @@ export const createIfMissing = mutation({
   },
 });
 
+/**
+ * Insert many time entries in ONE atomic mutation — collapses the "log time for
+ * N selected crew" client loop (one createTimeEntry round-trip per crew member).
+ * createIfMissing semantics per entry (idempotent by cuid on retry). The server
+ * action validates each crew member + assignment before calling this, so every
+ * entry here is already vetted.
+ */
+export const createMany = mutation({
+  args: {
+    entries: v.array(
+      v.object({
+        id: v.string(),
+        organizationId: v.string(),
+        assignmentId: v.optional(v.string()),
+        crewMemberId: v.string(),
+        description: v.optional(v.string()),
+        date: v.number(),
+        startTime: v.string(),
+        endTime: v.string(),
+        breakMinutes: v.optional(v.number()),
+        totalHours: v.optional(v.number()),
+        status: v.optional(enums.TimeEntryStatus),
+        notes: v.optional(v.string()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (ctx, { entries }) => {
+    await requireService(ctx);
+    for (const e of entries) {
+      const existing = await ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", e.id)).unique();
+      if (existing) continue;
+      await ctx.db.insert("crewTimeEntries", e);
+    }
+  },
+});
+
 export const update = mutation({
   args: {
     id: v.string(),

--- a/docs/designs/bulk-operations-batching.md
+++ b/docs/designs/bulk-operations-batching.md
@@ -1,6 +1,11 @@
 # Bulk-Operation Batching — N+1 round-trip audit & fix plan
 
-**Status:** audit complete, fixes not started. Created 2026-07-06.
+**Status:** audit complete. **Wave 2 #11 (crew time entries) shipped** —
+`createTimeEntries(data, crewMemberIds[])` + Convex `crewTimeEntries.createMany`,
+both crew/timesheets loops rewired (partial-success preserved), parity test
+green. **#10 is obsolete** (no multi-select move fan-out in the current code —
+move is single-item dialog-driven; reordering already uses batch array actions).
+Created 2026-07-06.
 **Owner intent:** the app "takes ages" on bulk actions (select many assets → prep,
 submit item checks, etc.). Root cause is **one server-action round-trip per item**
 in a client loop. Fix = batch each into a single call.
@@ -73,8 +78,8 @@ are in `src/app/(app)/warehouse/[projectId]/page.tsx`.
 | 7 | warehouse page — kit return loop → `checkInKit` | `checkInKit` | bulk-return kits | MED | new `checkInKitsBatch` |
 | 8 | `src/components/projects/project-wizard.tsx` — `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])` | `addProjectManager`/`removeProjectManager` | manager selection delta on create | HIGH | new `setProjectManagers(projectId, userIds[])` (diff server-side) |
 | 9 | `src/components/projects/project-form.tsx` — same manager add/remove fan-out | `addProjectManager`/`removeProjectManager` | manager selection delta on edit | HIGH | reuse `setProjectManagers` |
-| 10 | `src/components/projects/equipment-tab.tsx` — multi-select move, `Promise.all(...map(moveLineItemToGroup))` | `moveLineItemToGroup` | drag N selected line items to a group | HIGH | new `moveLineItemsToGroup(moves[])` |
-| 11 | `src/app/(app)/crew/timesheets/page.tsx` **and** `src/app/(app)/crew/page.tsx` — `for (const crewId of selectedCrewIds) await createTimeEntry(...)` | `createTimeEntry` | log time for N selected crew | HIGH | new `createTimeEntries(data, crewMemberIds[])` (`createMany`) |
+| 10 | ⛔ OBSOLETE — no multi-select move fan-out exists in current `equipment-tab.tsx`. Move is single-item (two dialogs → one `moveLineItemToGroup`); group/category **reordering** already uses batch array actions (`reorderProjectGroups`/`reorderProjectCategories` take `orderedIds[]`). Nothing to batch. | — | — | — | — (no change) |
+| 11 | ✅ `src/app/(app)/crew/timesheets/page.tsx` **and** `src/app/(app)/crew/page.tsx` — `for (const crewId of selectedCrewIds) await createTimeEntry(...)` | `createTimeEntry` | log time for N selected crew | HIGH | ✅ `createTimeEntries(data, crewMemberIds[])` (Convex `createMany`, partial-success preserved) |
 
 Single-item actions live in: `src/server/check-records.ts` (`prepItemDirect` 334,
 `pullItem` 220, `deprepItem` 394, `unpackItem` 625, `deprepKit`, `prepKitChildren`),

--- a/src/app/(app)/crew/page.tsx
+++ b/src/app/(app)/crew/page.tsx
@@ -59,7 +59,7 @@ import {
 import {
   approveTimeEntries,
   disputeTimeEntry,
-  createTimeEntry,
+  createTimeEntries,
 } from "@/server/crew-time";
 import { sendCrewOffer } from "@/server/crew-communication";
 import {
@@ -852,29 +852,29 @@ function LogTimeDialog({
     if (isGeneral) data.assignmentId = "";
     setSubmitting(true);
     try {
-      let successCount = 0;
-      const errors: string[] = [];
-      for (const crewId of selectedCrewIds) {
-        try {
-          await createTimeEntry({ ...data, crewMemberId: crewId });
-          successCount++;
-        } catch (e: any) {
-          const crew = crewList?.find((c: any) => c.id === crewId);
-          errors.push(`${crew?.firstName || ""} ${crew?.lastName || ""}: ${e.message}`);
-        }
-      }
+      // One batch call for all selected crew — the server validates each crew
+      // member individually and returns per-crew errors, preserving the old
+      // loop's partial-success behaviour.
+      const res = await createTimeEntries(data, selectedCrewIds);
+      const successCount = res.created.length;
       if (successCount > 0) {
         toast.success(`${successCount} time ${successCount === 1 ? "entry" : "entries"} added`);
         // Refresh the parent dashboard's pending-time + stats. crew-time-entries
         // is read only by crew/[id] (useServerQuery, cross-route → remounts).
         onLogged?.();
       }
-      if (errors.length > 0) {
-        toast.error(`${errors.length} failed: ${errors[0]}`);
+      if (res.errors.length > 0) {
+        const first = res.errors[0];
+        const crew = crewList?.find((c: any) => c.id === first.crewMemberId);
+        toast.error(
+          `${res.errors.length} failed: ${crew?.firstName || ""} ${crew?.lastName || ""}: ${first.message}`,
+        );
       }
       if (successCount > 0) {
         onOpenChange(false);
       }
+    } catch (e: any) {
+      toast.error(e.message);
     } finally {
       setSubmitting(false);
     }

--- a/src/app/(app)/crew/timesheets/page.tsx
+++ b/src/app/(app)/crew/timesheets/page.tsx
@@ -56,7 +56,7 @@ import {
 } from "@/components/ui/select";
 import {
   getAllTimeEntries,
-  createTimeEntry,
+  createTimeEntries,
   updateTimeEntry,
   deleteTimeEntry,
   submitTimeEntries,
@@ -766,17 +766,11 @@ function LogTimeDialog({
     if (isGeneral) data.assignmentId = "";
     setSubmitting(true);
     try {
-      let successCount = 0;
-      const errors: string[] = [];
-      for (const crewId of selectedCrewIds) {
-        try {
-          await createTimeEntry({ ...data, crewMemberId: crewId });
-          successCount++;
-        } catch (e: any) {
-          const crew = crewList?.find((c: any) => c.id === crewId);
-          errors.push(`${crew?.firstName || ""} ${crew?.lastName || ""}: ${e.message}`);
-        }
-      }
+      // One batch call for all selected crew — the server validates each crew
+      // member individually and returns per-crew errors, preserving the old
+      // loop's partial-success behaviour.
+      const res = await createTimeEntries(data, selectedCrewIds);
+      const successCount = res.created.length;
       if (successCount > 0) {
         toast.success(
           `${successCount} time ${successCount === 1 ? "entry" : "entries"} added`
@@ -785,12 +779,18 @@ function LogTimeDialog({
         // (crew dashboard) are cross-route readers that remount on navigation.
         onSaved?.();
       }
-      if (errors.length > 0) {
-        toast.error(`${errors.length} failed: ${errors[0]}`);
+      if (res.errors.length > 0) {
+        const first = res.errors[0];
+        const crew = crewList?.find((c: any) => c.id === first.crewMemberId);
+        toast.error(
+          `${res.errors.length} failed: ${crew?.firstName || ""} ${crew?.lastName || ""}: ${first.message}`,
+        );
       }
       if (successCount > 0) {
         onOpenChange(false);
       }
+    } catch (e: any) {
+      toast.error(e.message);
     } finally {
       setSubmitting(false);
     }

--- a/src/server/crew-time-batch.int.test.ts
+++ b/src/server/crew-time-batch.int.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration parity tests for createTimeEntries — proves the batched "log time
+ * for N crew" action produces the same Convex rows as the old per-crew
+ * createTimeEntry loop, and preserves the loop's partial-success behaviour
+ * (one bad crew member doesn't sink the rest).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import { createTimeEntry, createTimeEntries } from "@/server/crew-time";
+
+async function createCrew(orgId: string, first: string) {
+  const id = createId();
+  const convex = await getConvexClient();
+  await convex.mutation(api.crewMembers.createIfMissing, {
+    id,
+    organizationId: orgId,
+    firstName: first,
+    lastName: "Crew",
+  });
+  return id;
+}
+
+async function entriesByCrew(orgId: string, crewIds: string[]) {
+  const convex = await getConvexClient();
+  const all = await convex.query(api.crewTimeEntries.list, { orgId });
+  return all
+    .filter((e) => crewIds.includes(e.crewMemberId))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((e: any) => ({
+      date: e.date ?? null,
+      startTime: e.startTime ?? null,
+      endTime: e.endTime ?? null,
+      breakMinutes: e.breakMinutes ?? null,
+      totalHours: e.totalHours ?? null,
+      status: e.status ?? null,
+      description: e.description ?? null,
+      hasAssignment: !!e.assignmentId,
+    }))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+}
+
+const DATA = {
+  assignmentId: "",
+  crewMemberId: "",
+  description: "General",
+  date: new Date("2026-07-06T00:00:00.000Z"),
+  startTime: "09:00",
+  endTime: "17:00",
+  breakMinutes: 30,
+} as const;
+
+describe("createTimeEntries — parity with the per-crew createTimeEntry loop", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("batched log == the per-crew loop", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    // Loop: two crew, one createTimeEntry each.
+    const a1 = await createCrew(org.id, "Ada");
+    const a2 = await createCrew(org.id, "Bob");
+    await createTimeEntry({ ...DATA, crewMemberId: a1 });
+    await createTimeEntry({ ...DATA, crewMemberId: a2 });
+
+    // Batch: two crew, one createTimeEntries call.
+    const b1 = await createCrew(org.id, "Cy");
+    const b2 = await createCrew(org.id, "Di");
+    const res = await createTimeEntries({ ...DATA }, [b1, b2]);
+    expect(res.created.sort()).toEqual([b1, b2].sort());
+    expect(res.errors).toEqual([]);
+
+    const loop = await entriesByCrew(org.id, [a1, a2]);
+    const batch = await entriesByCrew(org.id, [b1, b2]);
+    expect(batch).toEqual(loop);
+    expect(batch).toHaveLength(2);
+    expect(batch[0].totalHours).toBe(7.5); // 8h - 30m break
+  });
+
+  it("partial success: an unknown crew id errors, the valid ones are still written", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const good = await createCrew(org.id, "Eve");
+    const bogus = createId();
+
+    const res = await createTimeEntries({ ...DATA }, [good, bogus]);
+    expect(res.created).toEqual([good]);
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].crewMemberId).toBe(bogus);
+    expect(res.errors[0].message).toMatch(/not found/i);
+
+    expect(await entriesByCrew(org.id, [good, bogus])).toHaveLength(1);
+  });
+
+  it("dedupes repeated crew ids in the input", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const c = await createCrew(org.id, "Fay");
+    const res = await createTimeEntries({ ...DATA }, [c, c, c]);
+    expect(res.created).toEqual([c]);
+    expect(await entriesByCrew(org.id, [c])).toHaveLength(1);
+  });
+});

--- a/src/server/crew-time.ts
+++ b/src/server/crew-time.ts
@@ -279,6 +279,135 @@ export async function createTimeEntry(data: CrewTimeEntryFormValues) {
   return serialize(created ? mapTimeEntry(created) : null);
 }
 
+/**
+ * Log the same time entry for many crew members in ONE server round-trip + ONE
+ * atomic Convex insert. Replaces the client-side
+ * `for (const crewId of selectedCrewIds) await createTimeEntry({ ...data, crewMemberId: crewId })`
+ * loop (one round-trip per selected crew) on the crew + timesheets pages.
+ *
+ * Preserves the loop's PARTIAL-SUCCESS behaviour: each crew member (and, if the
+ * entry is linked to an assignment, the assignment match) is validated
+ * individually; valid entries are written together and invalid ones come back in
+ * `errors` — so one bad crew member doesn't sink the rest, exactly as the old
+ * per-item try/catch did. Same per-entry audit log as createTimeEntry.
+ */
+export async function createTimeEntries(
+  data: CrewTimeEntryFormValues,
+  crewMemberIds: string[]
+) {
+  const { organizationId, userId, userName } = await requirePermission(
+    "crew",
+    "create"
+  );
+
+  const uniqueCrewIds = [...new Set(crewMemberIds)];
+  if (uniqueCrewIds.length === 0) {
+    return serialize({ created: [] as string[], errors: [] as { crewMemberId: string; message: string }[] });
+  }
+
+  // Parse the shared fields once (crewMemberId is overridden per entry below).
+  const parsed = crewTimeEntrySchema.parse({ ...data, crewMemberId: uniqueCrewIds[0] });
+  const assignmentId = parsed.assignmentId || null;
+  const totalHours = calculateTotalHours(
+    parsed.startTime,
+    parsed.endTime,
+    parsed.breakMinutes ?? 0
+  );
+  const dateMs = new Date(parsed.date as unknown as string).getTime();
+
+  const members = await getCrewMembersByOrg(organizationId);
+  const memberById = new Map(members.map((m) => [m.id, m]));
+
+  // Resolve the assignment once (shared across the batch). Per-crew match is
+  // checked below so a mismatched crew errors individually (as the loop did).
+  let assignment: Awaited<ReturnType<typeof getAssignmentById>> | null = null;
+  let projectName = parsed.description || "General";
+  if (assignmentId) {
+    assignment = await getAssignmentById(assignmentId);
+    if (!assignment || assignment.organizationId !== organizationId) {
+      throw new Error("Assignment not found");
+    }
+    const projects = await getProjectsByOrg(organizationId);
+    projectName = projects.find((p) => p.id === assignment!.projectId)?.name ?? projectName;
+  }
+
+  const now = Date.now();
+  const errors: { crewMemberId: string; message: string }[] = [];
+  const toCreate: {
+    doc: {
+      id: string;
+      organizationId: string;
+      assignmentId?: string;
+      crewMemberId: string;
+      description?: string;
+      date: number;
+      startTime: string;
+      endTime: string;
+      breakMinutes: number;
+      totalHours: number;
+      status: "DRAFT";
+      notes?: string;
+      createdAt: number;
+      updatedAt: number;
+    };
+    crewName: string;
+  }[] = [];
+
+  for (const crewId of uniqueCrewIds) {
+    const crewMember = memberById.get(crewId);
+    if (!crewMember) {
+      errors.push({ crewMemberId: crewId, message: "Crew member not found" });
+      continue;
+    }
+    if (assignmentId && assignment && assignment.crewMemberId !== crewId) {
+      errors.push({ crewMemberId: crewId, message: "Crew member does not match assignment" });
+      continue;
+    }
+    toCreate.push({
+      doc: {
+        id: createId(),
+        organizationId,
+        ...(assignmentId ? { assignmentId } : {}),
+        crewMemberId: crewId,
+        ...(parsed.description ? { description: parsed.description } : {}),
+        date: dateMs,
+        startTime: parsed.startTime,
+        endTime: parsed.endTime,
+        breakMinutes: parsed.breakMinutes ?? 0,
+        totalHours,
+        status: "DRAFT",
+        ...(parsed.notes ? { notes: parsed.notes } : {}),
+        createdAt: now,
+        updatedAt: now,
+      },
+      crewName: `${crewMember.firstName} ${crewMember.lastName}`,
+    });
+  }
+
+  const created: string[] = [];
+  if (toCreate.length > 0) {
+    const convex = await getConvexClient();
+    await convex.mutation(api.crewTimeEntries.createMany, {
+      entries: toCreate.map((t) => t.doc),
+    });
+    for (const t of toCreate) {
+      created.push(t.doc.crewMemberId);
+      await logActivity({
+        organizationId,
+        userId,
+        userName,
+        action: "CREATE",
+        entityType: "crew_time_entry",
+        entityId: t.doc.id,
+        entityName: t.crewName,
+        summary: `Logged time for ${t.crewName} on ${projectName}`,
+      });
+    }
+  }
+
+  return serialize({ created, errors });
+}
+
 export async function updateTimeEntry(
   id: string,
   data: CrewTimeEntryFormValues


### PR DESCRIPTION
## What

"Log time for N selected crew" (crew dashboard + timesheets) fired **one `createTimeEntry` server round-trip per crew member** (bulk-op-batching audit #11).

- **Convex `crewTimeEntries.createMany`** — insert all entries in one atomic mutation (createIfMissing per row, retry-safe).
- **Server action `createTimeEntries(data, crewMemberIds[])`** — parses shared fields once, validates each crew member (and, for an assignment-linked entry, the per-crew assignment match) individually, writes the valid subset in one mutation, returns per-crew `errors`.
- **Both loops rewired** — one call; same success-count + first-error toasts.

## Partial success preserved

The old loop used a per-iteration try/catch so one bad crew member didn't sink the rest. The batch keeps that: valid entries are written together, invalid ones come back in `errors`. This matters for the assignment-linked case (an assignment belongs to one crew, so a multi-crew log legitimately errors the non-matching crew).

## Correctness

`src/server/crew-time-batch.int.test.ts` (reads Convex rows): batch == the per-crew loop; partial success (unknown crew errors, valid ones still written); input dedupe.

## Codex review

Clean — "no blocking regressions identified."

## Also in this branch

Design doc marks **#10 obsolete**: there is no multi-select move fan-out in the current `equipment-tab.tsx` — move is single-item (dialog-driven `moveLineItemToGroup`), and group/category reordering already uses batch array actions (`reorderProjectGroups`/`reorderProjectCategories`). Nothing to batch there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)