### PR TITLE
perf(warehouse): batch bulk kit deploy/return (checkOut/checkInKitsBatch)

### DIFF
--- a/docs/designs/bulk-operations-batching.md
+++ b/docs/designs/bulk-operations-batching.md
@@ -1,6 +1,10 @@
 # Bulk-Operation Batching — N+1 round-trip audit & fix plan
 
-**Status:** audit complete, fixes not started. Created 2026-07-06.
+**Status:** audit complete. **Wave 2 #6–7 (bulk kit deploy/return) shipped** —
+`checkOutKitsBatch` / `checkInKitsBatch` (loop the existing atomic warehouseOps
+kit mutations with per-kit error isolation), both warehouse bulk-kit loops
+rewired (return keeps its interactive verification/check-flow gates), parity test
+green. Created 2026-07-06.
 **Owner intent:** the app "takes ages" on bulk actions (select many assets → prep,
 submit item checks, etc.). Root cause is **one server-action round-trip per item**
 in a client loop. Fix = batch each into a single call.
@@ -69,8 +73,8 @@ are in `src/app/(app)/warehouse/[projectId]/page.tsx`.
 | 3 | warehouse page — `for (const item of readyItems)`/`readyNoCheckItems` → `prepItemDirect` | `prepItemDirect` | "Prep Selected", serialized | HIGH | route to `prepItemsBatch` |
 | 4 | warehouse page — asset-picker confirm IIFE `for (... of withoutChecks) await prepItemDirect` | `prepItemDirect` | asset-picker confirm | MED | route to `prepItemsBatch` |
 | 5 | warehouse page — deprep handler loop → `deprepItem` / `deprepKit` | `deprepItem`,`deprepKit` | "Deprep" selected (unbounded) | HIGH | new `deprepItemsBatch(projectId, items[])` |
-| 6 | warehouse page — `for (const kitItemId of kitLineItemIds)` → `checkOutKit` | `checkOutKit` | bulk-deploy kits | MED | new `checkOutKitsBatch` |
-| 7 | warehouse page — kit return loop → `checkInKit` | `checkInKit` | bulk-return kits | MED | new `checkInKitsBatch` |
+| 6 | ✅ warehouse page — `for (const kitItemId of kitLineItemIds)` → `checkOutKit` | `checkOutKit` | bulk-deploy kits | MED | ✅ `checkOutKitsBatch` |
+| 7 | ✅ warehouse page — kit return loop → `checkInKit` | `checkInKit` | bulk-return kits | MED | ✅ `checkInKitsBatch` (only the gate-passing kits; verification/check-flow kits stay interactive) |
 | 8 | `src/components/projects/project-wizard.tsx` — `Promise.all([...toAdd.map(addProjectManager), ...toRemove.map(removeProjectManager)])` | `addProjectManager`/`removeProjectManager` | manager selection delta on create | HIGH | new `setProjectManagers(projectId, userIds[])` (diff server-side) |
 | 9 | `src/components/projects/project-form.tsx` — same manager add/remove fan-out | `addProjectManager`/`removeProjectManager` | manager selection delta on edit | HIGH | reuse `setProjectManagers` |
 | 10 | `src/components/projects/equipment-tab.tsx` — multi-select move, `Promise.all(...map(moveLineItemToGroup))` | `moveLineItemToGroup` | drag N selected line items to a group | HIGH | new `moveLineItemsToGroup(moves[])` |

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -33,6 +33,8 @@ import {
   checkInItems,
   checkOutKit,
   checkInKit,
+  checkOutKitsBatch,
+  checkInKitsBatch,
   undeployItems,
   unreturnItems,
   undeprepLine,
@@ -753,6 +755,28 @@ function WarehouseProjectPage({
     mutationFn: (data: { kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }) =>
       checkInKit(projectId, data.kitId, data.returnCondition),
     onSuccess: () => invalidate(),
+    onError: (e) => showError(e),
+  });
+
+  // Bulk kit deploy/return — one round-trip for all selected kits (was one
+  // checkOutKit/checkInKit per kit). Per-kit errors come back from the server.
+  type KitBatchResult = { succeeded: string[]; errors: { kitId: string; message: string }[] };
+  const kitBatchOutMutation = useServerMutation<KitBatchResult, string[]>({
+    mutationFn: (kitIds: string[]) => checkOutKitsBatch(projectId, kitIds),
+    onSuccess: (res) => {
+      if (res.succeeded.length > 0) toast.success(`Deployed ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"}`);
+      if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} failed: ${res.errors[0].message}`);
+      invalidate();
+    },
+    onError: (e) => showError(e),
+  });
+  const kitBatchInMutation = useServerMutation<KitBatchResult, Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }>>({
+    mutationFn: (kits) => checkInKitsBatch(projectId, kits),
+    onSuccess: (res) => {
+      if (res.succeeded.length > 0) toast.success(`Returned ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"}`);
+      if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} failed: ${res.errors[0].message}`);
+      invalidate();
+    },
     onError: (e) => showError(e),
   });
 
@@ -1886,12 +1910,12 @@ function WarehouseProjectPage({
       }
     }
 
-    // Deploy kits directly
-    for (const kitItemId of kitLineItemIds) {
-      const li = lineItems.find((l) => l.id === kitItemId);
-      if (li?.kitId) {
-        kitCheckOutMutation.mutate(li.kitId);
-      }
+    // Deploy kits directly — one batch call for all selected kits.
+    const kitIdsToDeploy = kitLineItemIds
+      .map((kitItemId) => lineItems.find((l) => l.id === kitItemId)?.kitId)
+      .filter((id): id is string => !!id);
+    if (kitIdsToDeploy.length > 0) {
+      kitBatchOutMutation.mutate(kitIdsToDeploy);
     }
 
     if (serializedLineItemIds.length === 0 && bulkQtyMap.size === 0) return;
@@ -2144,7 +2168,10 @@ function WarehouseProjectPage({
       }
     }
 
-    // Return kits (including prep-kits) — check verification first
+    // Return kits (including prep-kits) — check verification first. Kits that
+    // pass the gates (verified + no check flow) are collected and returned in
+    // one batch call after the loop; gated kits stay on their interactive paths.
+    const readyKitReturns: Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }> = [];
     for (const kitId of kitIds) {
       const kitLi = lineItems.find((l) => l.kitId === kitId && !l.isKitChild);
       if (kitLi) {
@@ -2169,8 +2196,11 @@ function WarehouseProjectPage({
       const rc = returnCondition as "GOOD" | "DAMAGED" | "MISSING";
       const started = kitLiForCheck ? startKitCheckFlow(kitId, kitLiForCheck, "RETURN", rc) : false;
       if (!started) {
-        kitCheckInMutation.mutate({ kitId, returnCondition: rc });
+        readyKitReturns.push({ kitId, returnCondition: rc });
       }
+    }
+    if (readyKitReturns.length > 0) {
+      kitBatchInMutation.mutate(readyKitReturns);
     }
 
     // Return non-kit items

--- a/src/server/warehouse-kit-batch.int.test.ts
+++ b/src/server/warehouse-kit-batch.int.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration parity tests for checkOutKitsBatch / checkInKitsBatch — proves the
+ * batched kit deploy/return produces the same Convex state as looping the single
+ * checkOutKit / checkInKit actions, plus per-kit partial-success.
+ *
+ * Kits are built with no assets so the T&T preflight passes trivially; the
+ * deploy/return status flips are what we assert on (read from Convex, since
+ * Phase C writes line/kit state to Convex only).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createKitFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import {
+  checkOutKit,
+  checkInKit,
+  checkOutKitsBatch,
+  checkInKitsBatch,
+} from "@/server/warehouse";
+
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: { organizationId: orgId, projectNumber: `P-${createId().slice(0, 8)}`, name: "T", taxRate: 0 },
+  });
+}
+
+// A prepped, asset-free kit on a project: parent line + 2 KIT children, all PACKED.
+async function buildKit(orgId: string, userId: string, tag: string) {
+  const project = await createProjectFixture(orgId);
+  const kit = await createKitFixture(orgId, { assetTag: tag, name: "K", userId });
+  const parent = await testPrisma.projectLineItem.create({
+    data: {
+      organizationId: orgId, projectId: project.id, kitId: kit.id, quantity: 1,
+      status: "CONFIRMED", prepStatus: "PACKED", isKitChild: false,
+    },
+  });
+  const children = [];
+  for (let i = 0; i < 2; i++) {
+    children.push(
+      await testPrisma.projectLineItem.create({
+        data: {
+          organizationId: orgId, projectId: project.id, quantity: 1, status: "CONFIRMED",
+          prepStatus: "PACKED", parentLineItemId: parent.id, isKitChild: true, childKind: "KIT",
+        },
+      }),
+    );
+  }
+  return { project, kit, parent, children };
+}
+
+async function statuses(kitId: string, lineIds: string[]) {
+  const convex = await getConvexClient();
+  const [kit, ...lines] = await Promise.all([
+    convex.query(api.kits.getById, { id: kitId }),
+    ...lineIds.map((id) => convex.query(api.projectLineItems.getById, { id })),
+  ]);
+  return {
+    kit: kit?.status ?? null,
+    lines: lines.map((l) => l?.status ?? null),
+  };
+}
+
+describe("checkOut/checkInKitsBatch — parity with the per-kit loop", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("batch deploy == the checkOutKit loop", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const a = await buildKit(org.id, user.id, `KO-A-${createId().slice(0, 6)}`);
+    await checkOutKit(a.project.id, a.kit.id);
+
+    const b = await buildKit(org.id, user.id, `KO-B-${createId().slice(0, 6)}`);
+    const res = await checkOutKitsBatch(b.project.id, [b.kit.id]);
+    expect(res.succeeded).toEqual([b.kit.id]);
+    expect(res.errors).toEqual([]);
+
+    const sa = await statuses(a.kit.id, [a.parent.id, ...a.children.map((c) => c.id)]);
+    const sb = await statuses(b.kit.id, [b.parent.id, ...b.children.map((c) => c.id)]);
+    expect(sb).toEqual(sa);
+    expect(sb.kit).toBe("CHECKED_OUT");
+    expect(sb.lines.every((s) => s === "CHECKED_OUT")).toBe(true);
+  });
+
+  it("batch return == the checkInKit loop", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const a = await buildKit(org.id, user.id, `KI-A-${createId().slice(0, 6)}`);
+    await checkOutKit(a.project.id, a.kit.id);
+    await checkInKit(a.project.id, a.kit.id, "GOOD");
+
+    const b = await buildKit(org.id, user.id, `KI-B-${createId().slice(0, 6)}`);
+    await checkOutKit(b.project.id, b.kit.id);
+    const res = await checkInKitsBatch(b.project.id, [{ kitId: b.kit.id, returnCondition: "GOOD" }]);
+    expect(res.succeeded).toEqual([b.kit.id]);
+    expect(res.errors).toEqual([]);
+
+    const sa = await statuses(a.kit.id, [a.parent.id, ...a.children.map((c) => c.id)]);
+    const sb = await statuses(b.kit.id, [b.parent.id, ...b.children.map((c) => c.id)]);
+    expect(sb).toEqual(sa);
+  });
+
+  it("partial success: an unknown kit id errors, the valid kit still deploys", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const good = await buildKit(org.id, user.id, `KP-${createId().slice(0, 6)}`);
+    const bogus = createId();
+
+    const res = await checkOutKitsBatch(good.project.id, [good.kit.id, bogus]);
+    expect(res.succeeded).toEqual([good.kit.id]);
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].kitId).toBe(bogus);
+
+    const s = await statuses(good.kit.id, [good.parent.id]);
+    expect(s.kit).toBe("CHECKED_OUT");
+  });
+});

--- a/src/server/warehouse-kit-batch.int.test.ts
+++ b/src/server/warehouse-kit-batch.int.test.ts
@@ -127,6 +127,21 @@ describe("checkOut/checkInKitsBatch — parity with the per-kit loop", () => {
     expect(sb).toEqual(sa);
   });
 
+  it("checkInKitsBatch dedupes repeated kit ids (no double-restore)", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const b = await buildKit(org.id, user.id, `KD-${createId().slice(0, 6)}`);
+    await checkOutKit(b.project.id, b.kit.id);
+
+    const res = await checkInKitsBatch(b.project.id, [
+      { kitId: b.kit.id, returnCondition: "GOOD" },
+      { kitId: b.kit.id, returnCondition: "GOOD" },
+    ]);
+    expect(res.succeeded).toEqual([b.kit.id]); // only once, despite two entries
+  });
+
   it("partial success: an unknown kit id errors, the valid kit still deploys", async () => {
     const org = await createOrgFixture();
     const user = await createUserFixture(org.id);

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -592,6 +592,73 @@ export async function checkInKit(
   return serialize({ success: true, ...res });
 }
 
+/**
+ * Bulk-deploy many kits in ONE server round-trip. Replaces the warehouse
+ * "Deploy Selected" loop that fired one checkOutKit round-trip per kit. The
+ * project-wide blocking-comment gate is checked once; each kit's atomic checkout
+ * mutation runs in its own transaction with per-kit error isolation (one kit's
+ * T&T preflight failure doesn't sink the rest — matching the old independent
+ * per-kit mutations). Returns succeeded kit ids + per-kit errors.
+ */
+export async function checkOutKitsBatch(projectId: string, kitIds: string[]) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
+  const unique = [...new Set(kitIds)];
+  if (unique.length === 0) return serialize({ succeeded: [] as string[], errors: [] as { kitId: string; message: string }[] });
+
+  // Project-wide blocker gate (kit checkout has no line scope) — check once.
+  await assertNoBlockingComments(organizationId, projectId, { actionLabel: "check out this kit" });
+
+  const convex = await getConvexClient();
+  const now = Date.now();
+  const succeeded: string[] = [];
+  const errors: { kitId: string; message: string }[] = [];
+  for (const kitId of unique) {
+    try {
+      await convex.mutation(api.warehouseOps.checkoutKit, { organizationId, projectId, userId, kitId, now });
+      succeeded.push(kitId);
+      await logActivity({
+        organizationId, userId, userName, action: "CHECK_OUT", entityType: "kit",
+        entityId: kitId, entityName: `Kit ${kitId}`, summary: "Checked out kit with all contents", projectId, kitId,
+      });
+    } catch (e) {
+      errors.push({ kitId, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return serialize({ succeeded, errors });
+}
+
+/**
+ * Bulk-return many kits in ONE server round-trip. Replaces the warehouse
+ * "Return Selected" loop that fired one checkInKit round-trip per kit (for the
+ * kits that pass the interactive verification/check-flow gates). Each kit's
+ * atomic check-in runs in its own transaction with per-kit error isolation.
+ */
+export async function checkInKitsBatch(
+  projectId: string,
+  kits: Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }>,
+) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
+  if (kits.length === 0) return serialize({ succeeded: [] as string[], errors: [] as { kitId: string; message: string }[] });
+
+  const convex = await getConvexClient();
+  const now = Date.now();
+  const succeeded: string[] = [];
+  const errors: { kitId: string; message: string }[] = [];
+  for (const { kitId, returnCondition } of kits) {
+    try {
+      await convex.mutation(api.warehouseOps.checkinKit, { organizationId, projectId, userId, kitId, returnCondition, now });
+      succeeded.push(kitId);
+      await logActivity({
+        organizationId, userId, userName, action: "CHECK_IN", entityType: "kit",
+        entityId: kitId, entityName: `Kit ${kitId}`, summary: `Checked in kit (condition: ${returnCondition})`, projectId, kitId,
+      });
+    } catch (e) {
+      errors.push({ kitId, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return serialize({ succeeded, errors });
+}
+
 export async function getScanLog(params?: {
   projectId?: string;
   assetId?: string;

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -638,13 +638,18 @@ export async function checkInKitsBatch(
   kits: Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }>,
 ) {
   const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
-  if (kits.length === 0) return serialize({ succeeded: [] as string[], errors: [] as { kitId: string; message: string }[] });
+  // Dedupe by kitId (keep the first occurrence) — checkinKit restores the kit's
+  // bulk contents each call, so returning the same kit twice would overstate
+  // availability + double-log. (checkOutKitsBatch dedupes with `new Set`.)
+  const seen = new Set<string>();
+  const uniqueKits = kits.filter((k) => (seen.has(k.kitId) ? false : (seen.add(k.kitId), true)));
+  if (uniqueKits.length === 0) return serialize({ succeeded: [] as string[], errors: [] as { kitId: string; message: string }[] });
 
   const convex = await getConvexClient();
   const now = Date.now();
   const succeeded: string[] = [];
   const errors: { kitId: string; message: string }[] = [];
-  for (const { kitId, returnCondition } of kits) {
+  for (const { kitId, returnCondition } of uniqueKits) {
     try {
       await convex.mutation(api.warehouseOps.checkinKit, { organizationId, projectId, userId, kitId, returnCondition, now });
       succeeded.push(kitId);


### PR DESCRIPTION
## What

Bulk kit **Deploy Selected** / **Return Selected** fired one `checkOutKit`/`checkInKit` server round-trip per kit (bulk-op-batching audit #6/#7).

- **`checkOutKitsBatch(projectId, kitIds[])`** / **`checkInKitsBatch(projectId, kits[])`** — loop the existing atomic `warehouseOps.checkoutKit`/`checkinKit` mutations server-side with **per-kit error isolation** (one kit's T&T-preflight failure doesn't sink the rest, matching the old independent per-kit mutations). Checkout runs the project-wide blocking-comment gate once. Both dedupe and return `succeeded` + per-kit `errors`.
- **Deploy-selected** collects the selected kit ids → one `checkOutKitsBatch`.
- **Return-selected** collects the kits that pass the interactive verification + check-flow gates → one `checkInKitsBatch`; gated kits stay on their single-kit interactive paths (the `kitConfirm` dialog + check-flow completion still use the single mutations).

## Why a server-side loop (not one atomic mutation)

Kit checkout/return can partially fail (T&T preflight per kit), and the old code fired independent per-kit mutations. Looping the existing atomic mutations preserves that per-kit isolation while collapsing the client round-trips N→1 (the felt win). N is small for kits, so the server-side loop cost is negligible.

## Correctness

`src/server/warehouse-kit-batch.int.test.ts` (asset-free prepped kits, reads Convex status): batch deploy/return == the per-kit loop; input dedupe; partial success (unknown kit errors, valid one still deploys).

## Codex review

One [P2] fixed: `checkInKitsBatch` now dedupes by kitId (checkinKit restores bulk per call, so a dup would overstate availability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)