### PR TITLE
perf(convex): parallelize the biggest cascade mirror loops (Class 2 sweep)

### DIFF
--- a/docs/designs/bulk-operations-batching.md
+++ b/docs/designs/bulk-operations-batching.md
@@ -88,6 +88,15 @@ template), `src/server/project-managers.ts`, line-item move action, crew time-en
 Mostly `for (const x) await removeXFromConvex(x.id)` in cascade delete/archive. Fix by
 `Promise.all` or a batched Convex mutation. No per-click UX impact; improves cascades.
 
+**Sweep started (2026-07-06):** the highest-cardinality cascades are done via
+`Promise.all` — `models.ts` deleteModel (assets + bulk assets), `projects.ts`
+deleteProject (line-item cascade + crew-assignment cascade + kit resets — the
+200-line cascade was the worst), `kits.ts` deleteKit (check-items + media),
+`supplier-orders.ts` (order items). Remaining (lower cardinality / need review):
+`models.ts` bulkUpdateRates, `warehouse.ts` force-return, `project-categories.ts`,
+`sub-hires.ts`, `line-items.ts`, `document-templates.ts`, `crew-assignments.ts`,
+`crew-scheduling-mirror.ts`, `site-admin.ts`.
+
 | File (grep anchor) | Looped mirror call | Cascade trigger |
 |---|---|---|
 | `src/server/models.ts` archiveModel | `removeAssetFromConvex`/`removeBulkAssetFromConvex` per asset | archive model w/ many assets |

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -546,13 +546,14 @@ export async function deleteKit(id: string) {
 
   // Clean up kit-scoped metadata that the cascade doesn't cover. kitCheckItem
   // rows are removed via their dedicated mutation; kitMedia rows (Convex-only,
-  // Phase C) are removed directly below.
-  for (const row of kitCheckItemRows) await convexKits.mutation(api.kitCheckItems.remove, { id: row.id });
-  // kitMedia is Convex-only (Phase C); remove the kit's media rows directly (the
-  // old syncMediaForParent reconcile is gone with the mirror). Files are left on
-  // S3, as the prior cascade did.
+  // Phase C) are removed directly below. Files are left on S3, as the prior
+  // cascade did. Both sets are independent rows — fire concurrently (was one
+  // sequential Convex round-trip per row).
   const kitMediaRows = await getKitMediaFromConvex(id);
-  for (const m of kitMediaRows) await convexKits.mutation(api.kitMedia.remove, { id: m.id });
+  await Promise.all([
+    ...kitCheckItemRows.map((row) => convexKits.mutation(api.kitCheckItems.remove, { id: row.id })),
+    ...kitMediaRows.map((m) => convexKits.mutation(api.kitMedia.remove, { id: m.id })),
+  ]);
 
   if (!nativeKitWrites()) {
     await logActivity({

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -417,12 +417,17 @@ export async function archiveModel(id: string) {
     convexForAssets.query(api.assets.listByModel, { modelId: id, orgId: organizationId }),
     convexForAssets.query(api.bulkAssets.listByModel, { modelId: id, orgId: organizationId }),
   ]);
-  for (const a of assetsToRemove) {
-    if (a.organizationId === organizationId) await convexForAssets.mutation(api.assets.remove, { id: a.id });
-  }
-  for (const b of bulkToRemove) {
-    if (b.organizationId === organizationId) await convexForAssets.mutation(api.bulkAssets.remove, { id: b.id });
-  }
+  // Fire the removals concurrently (independent rows, no ordering dependency) —
+  // was one sequential Convex round-trip per asset. A model with many assets
+  // otherwise took N sequential HTTP calls to delete.
+  await Promise.all([
+    ...assetsToRemove
+      .filter((a) => a.organizationId === organizationId)
+      .map((a) => convexForAssets.mutation(api.assets.remove, { id: a.id })),
+    ...bulkToRemove
+      .filter((b) => b.organizationId === organizationId)
+      .map((b) => convexForAssets.mutation(api.bulkAssets.remove, { id: b.id })),
+  ]);
 
   // Soft archive — models are Convex-only. Org-guard via the prior doc.
   const existing = await getModelById(id);

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -1406,12 +1406,14 @@ export async function deleteProject(id: string) {
   if (checkedOutKitIds.length > 0) {
     const allKitSerialized = await getKitSerializedItemsByOrg(organizationId);
     const checkedOutKitIdSet = new Set(checkedOutKitIds);
-    for (const kitId of checkedOutKitIds) {
-      await convex.mutation(api.kits.update, {
-        id: kitId,
-        patch: { status: "AVAILABLE", ...(defaultLocation?.id ? { locationId: defaultLocation.id } : {}), updatedAt: now },
-      });
-    }
+    await Promise.all(
+      checkedOutKitIds.map((kitId) =>
+        convex.mutation(api.kits.update, {
+          id: kitId,
+          patch: { status: "AVAILABLE", ...(defaultLocation?.id ? { locationId: defaultLocation.id } : {}), updatedAt: now },
+        }),
+      ),
+    );
     for (const ks of allKitSerialized) {
       if (checkedOutKitIdSet.has(ks.kitId)) kitAssetIds.push(ks.assetId);
     }
@@ -1428,18 +1430,20 @@ export async function deleteProject(id: string) {
   // Remove the project's line items from Convex. The project↔line-item FK is
   // dropped, so prisma.project.delete no longer cascades — explicitly cascade
   // each top-level line (removeLineItemCascade handles its children + units).
-  for (const li of lineItems) {
-    if (li.parentLineItemId == null) {
-      await convex.mutation(api.projectLineItems.removeLineItemCascade, { id: li.id });
-    }
-  }
+  // Fire concurrently (each top-level line is independent) — was one sequential
+  // Convex round-trip per line, so a 200-line project took 200 sequential calls.
+  await Promise.all(
+    lineItems
+      .filter((li) => li.parentLineItemId == null)
+      .map((li) => convex.mutation(api.projectLineItems.removeLineItemCascade, { id: li.id })),
+  );
 
   // Tidy the remaining Convex sub-tables / crew cascade, then delete the project
   // doc. The project + all its sub-tables are Convex-only now (no Prisma FK
   // cascade remains — dropped in Phase C #254), so each is removed explicitly.
-  for (const aid of crewAssignmentIds) {
-    await convex.mutation(api.crewAssignments.deleteCascade, { id: aid });
-  }
+  await Promise.all(
+    crewAssignmentIds.map((aid) => convex.mutation(api.crewAssignments.deleteCascade, { id: aid })),
+  );
   // Delete Convex-only sub-table rows (PM/tasks/services).
   const [pmRows, taskRows, serviceRows] = await Promise.all([
     convex.query(api.projectManagers.listByProject, { projectId: id, orgId: organizationId }),

--- a/src/server/supplier-orders.ts
+++ b/src/server/supplier-orders.ts
@@ -256,7 +256,9 @@ export async function deleteSupplierOrder(id: string) {
 
   const convex = await getConvexClient();
   const items = await getSupplierOrderItems(id);
-  for (const it of items) await convex.mutation(api.supplierOrderItems.remove, { id: it.id });
+  // Remove the order's items concurrently before the order row (independent
+  // rows) — was one sequential Convex round-trip per item.
+  await Promise.all(items.map((it) => convex.mutation(api.supplierOrderItems.remove, { id: it.id })));
   await convex.mutation(api.supplierOrders.remove, { id });
 
   await logActivity({


### PR DESCRIPTION
## What

Class 2 of the bulk-op-batching audit: server-side Convex mirror loops. These aren't browser round-trips (no per-click UX impact), but a cascade delete fired **one sequential Convex round-trip per row**, so a big cascade took N sequential HTTP calls. Converts the highest-cardinality ones to concurrent `Promise.all` (independent rows, no ordering dependency — Convex has no FKs):

- **`models.ts` deleteModel** — remove all assets + bulk assets under the model
- **`projects.ts` deleteProject** — top-level line-item cascade (the 200-line worst case), crew-assignment cascade, checked-out kit resets
- **`kits.ts` deleteKit** — kit check-items + kit media
- **`supplier-orders.ts`** — order items before the order row

Matches the `Promise.all` pattern the codebase already uses for the project sub-tables (PM/tasks/services) in the same `deleteProject`.

## Scope

This is the high-value slice. Remaining lower-cardinality Class 2 sites (`models.bulkUpdateRates`, `warehouse` force-return, `project-categories`, `sub-hires`, `line-items`, `document-templates`, `crew-assignments`, `crew-scheduling-mirror`, `site-admin`) are tracked in the design doc as follow-up.

## Codex review

Clean — "did not identify a discrete correctness issue introduced by the patch."

🤖 Generated with [Claude Code](https://claude.com/claude-code)