### PR TITLE
perf(assets): batch bulk asset creation (createAssets)

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -133,6 +133,66 @@ export const create = mutation({
   },
 });
 
+/**
+ * Insert many assets in ONE atomic mutation with an in-transaction duplicate-tag
+ * guard — collapses createAssets' per-asset loop (dup-guard read + create +
+ * read-back = 3 round-trips per asset). The guard uses the by_organizationId_
+ * assetTag index and also catches duplicates WITHIN the batch (a prior insert in
+ * the same transaction is visible). On a dup it throws a structured ConvexError
+ * the server action maps to its DUPLICATE_ASSET_TAG UserFacingError.
+ */
+export const createMany = mutation({
+  args: {
+    assets: v.array(
+      v.object({
+        id: v.string(),
+        organizationId: v.string(),
+        modelId: v.string(),
+        assetTag: v.string(),
+        serialNumber: v.optional(v.string()),
+        customName: v.optional(v.string()),
+        status: v.optional(enums.AssetStatus),
+        condition: v.optional(enums.AssetCondition),
+        purchaseDate: v.optional(v.number()),
+        purchasePrice: v.optional(v.number()),
+        purchaseSupplier: v.optional(v.string()),
+        supplierId: v.optional(v.string()),
+        purchaseOrderNumber: v.optional(v.string()),
+        supplierOrderId: v.optional(v.string()),
+        warrantyExpiry: v.optional(v.number()),
+        notes: v.optional(v.string()),
+        locationId: v.optional(v.string()),
+        customFieldValues: v.optional(v.any()),
+        lastTestAndTagDate: v.optional(v.number()),
+        nextTestAndTagDate: v.optional(v.number()),
+        barcode: v.optional(v.string()),
+        qrCode: v.optional(v.string()),
+        images: v.optional(v.array(v.string())),
+        tags: v.optional(v.array(v.string())),
+        isActive: v.optional(v.boolean()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
+        kitId: v.optional(v.string()),
+        parentAssetId: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, { assets }) => {
+    await requireService(ctx);
+    const ids: string[] = [];
+    for (const a of assets) {
+      const dup = await ctx.db
+        .query("assets")
+        .withIndex("by_organizationId_assetTag", (q) => q.eq("organizationId", a.organizationId).eq("assetTag", a.assetTag))
+        .first();
+      if (dup) throw new ConvexError({ code: "DUPLICATE_ASSET_TAG", tag: a.assetTag });
+      await ctx.db.insert("assets", a);
+      ids.push(a.id);
+    }
+    return { ids };
+  },
+});
+
 export const createIfMissing = mutation({
   args: {
     id: v.string(),

--- a/src/server/assets-batch.int.test.ts
+++ b/src/server/assets-batch.int.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for createAssets' batched insert — proves N assets create in
+ * one atomic mutation with the same Convex rows as before, the duplicate-tag
+ * guard still fires (existing AND in-batch dupes) and rolls back atomically, and
+ * T&T rows are registered when the model requires it.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+  createModelFixture,
+} from "../../tests/helpers/integration";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({ ctx: { organizationId: "", userId: "", userName: "Tester" } }));
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+import { createAssets } from "@/server/assets";
+
+async function assetsForModel(orgId: string, modelId: string) {
+  const convex = await getConvexClient();
+  return convex.query(api.assets.listByModel, { modelId, orgId });
+}
+
+const baseData = (modelId: string) => ({ modelId, assetTag: "PLACEHOLDER" }) as never;
+
+describe("createAssets — batched insert", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+  });
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("creates N assets with the given tags in one call", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    const rows = await createAssets(baseData(model.id), [
+      { tag: "BA-1" },
+      { tag: "BA-2", serialNumber: "SN2" },
+      { tag: "BA-3" },
+    ]);
+    expect(rows.map((r) => r.assetTag).sort()).toEqual(["BA-1", "BA-2", "BA-3"]);
+
+    const inConvex = await assetsForModel(org.id, model.id);
+    expect(inConvex.map((a) => a.assetTag).sort()).toEqual(["BA-1", "BA-2", "BA-3"]);
+    expect(inConvex.find((a) => a.assetTag === "BA-2")?.serialNumber).toBe("SN2");
+  });
+
+  it("rejects an in-batch duplicate tag and writes nothing (atomic)", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    await expect(
+      createAssets(baseData(model.id), [{ tag: "DUP" }, { tag: "DUP" }]),
+    ).rejects.toMatchObject({ code: "DUPLICATE_ASSET_TAG" });
+
+    expect(await assetsForModel(org.id, model.id)).toHaveLength(0);
+  });
+
+  it("rejects a tag that already exists", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await createModelFixture(org.id);
+
+    await createAssets(baseData(model.id), [{ tag: "EXIST" }]);
+    await expect(
+      createAssets(baseData(model.id), [{ tag: "EXIST" }]),
+    ).rejects.toMatchObject({ code: "DUPLICATE_ASSET_TAG" });
+
+    expect(await assetsForModel(org.id, model.id)).toHaveLength(1);
+  });
+
+  it("registers a T&T row per asset when the model requires test-and-tag", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id);
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+    const model = await testPrisma.model.create({
+      data: { organizationId: org.id, name: "TT Model", requiresTestAndTag: true, testAndTagIntervalDays: 90 },
+    });
+
+    await createAssets(baseData(model.id), [{ tag: "TT-1" }, { tag: "TT-2" }]);
+
+    const convex = await getConvexClient();
+    const tt = await convex.query(api.testTagAssets.list, { orgId: org.id });
+    const tags = tt.map((t: { testTagId: string }) => t.testTagId).filter((t) => t === "TT-1" || t === "TT-2");
+    expect(tags.sort()).toEqual(["TT-1", "TT-2"]);
+  });
+});

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -22,6 +22,7 @@ import {
   paginate,
   getAssetById,
   getAssetByAssetTag,
+  getAssetsByIds,
   getBulkAssetById,
   mapConvexAssetToPrisma,
 } from "@/lib/assets-read";
@@ -548,50 +549,54 @@ export async function createAssets(
   try {
     const convex = await getConvexClient();
     const now = Date.now();
-    const createdRows = [];
-    for (const { tag, serialNumber } of assets) {
-      // DUP GUARD per tag (no Convex unique index).
-      const dup = await getAssetByAssetTag(organizationId, tag);
-      if (dup) {
-        throw new UserFacingError({
-          code: "DUPLICATE_ASSET_TAG",
-          title: "Duplicate asset tag",
-          message: `Asset tag "${tag}" already exists.`,
-          hint: "Use a different asset tag.",
-        });
-      }
-      const newId = createId();
-      await convex.mutation(api.assets.create, {
-        id: newId,
-        organizationId,
-        modelId: parsed.modelId,
-        assetTag: tag,
-        serialNumber: serialNumber || parsed.serialNumber || undefined,
-        customName: parsed.customName || undefined,
-        status: parsed.status,
-        condition: parsed.condition,
-        purchaseDate: parsed.purchaseDate ? new Date(parsed.purchaseDate).getTime() : undefined,
-        purchasePrice: parsed.purchasePrice != null ? Number(parsed.purchasePrice) : undefined,
-        purchaseSupplier: parsed.purchaseSupplier || undefined,
-        supplierId: parsed.supplierId || undefined,
-        warrantyExpiry: parsed.warrantyExpiry ? new Date(parsed.warrantyExpiry).getTime() : undefined,
-        notes: parsed.notes || undefined,
-        locationId: parsed.locationId || undefined,
-        customFieldValues,
-        barcode: parsed.barcode || tag,
-        qrCode: tag,
-        images: parsed.images || undefined,
-        isActive: parsed.isActive,
-        tags: parsed.tags || undefined,
-        createdAt: now,
-        updatedAt: now,
-      });
-      const created = await getAssetById(newId);
-      if (!created) throw new Error("Asset create read-back failed: " + newId);
-      createdRows.push(mapConvexAssetToPrisma(created));
-    }
-    results = createdRows;
+    // Build every asset payload in-memory, then insert them all in ONE atomic
+    // mutation (with an in-transaction dup-tag guard) + ONE batched read-back —
+    // was 3 sequential round-trips per asset (dup-guard read + create + read-back).
+    const payloads = assets.map(({ tag, serialNumber }) => ({
+      id: createId(),
+      organizationId,
+      modelId: parsed.modelId,
+      assetTag: tag,
+      serialNumber: serialNumber || parsed.serialNumber || undefined,
+      customName: parsed.customName || undefined,
+      status: parsed.status,
+      condition: parsed.condition,
+      purchaseDate: parsed.purchaseDate ? new Date(parsed.purchaseDate).getTime() : undefined,
+      purchasePrice: parsed.purchasePrice != null ? Number(parsed.purchasePrice) : undefined,
+      purchaseSupplier: parsed.purchaseSupplier || undefined,
+      supplierId: parsed.supplierId || undefined,
+      warrantyExpiry: parsed.warrantyExpiry ? new Date(parsed.warrantyExpiry).getTime() : undefined,
+      notes: parsed.notes || undefined,
+      locationId: parsed.locationId || undefined,
+      customFieldValues,
+      barcode: parsed.barcode || tag,
+      qrCode: tag,
+      images: parsed.images || undefined,
+      isActive: parsed.isActive,
+      tags: parsed.tags || undefined,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    const { ids } = await convex.mutation(api.assets.createMany, { assets: payloads });
+    const createdDocs = await getAssetsByIds(organizationId, ids);
+    const byId = new Map(createdDocs.map((d) => [d.id, d]));
+    // Preserve input order (getAssetsByIds may reorder).
+    results = ids.map((id) => {
+      const doc = byId.get(id);
+      if (!doc) throw new Error("Asset create read-back failed: " + id);
+      return mapConvexAssetToPrisma(doc);
+    });
   } catch (e: unknown) {
+    // The batch mutation throws a structured ConvexError on a duplicate tag.
+    const data = (e as { data?: { code?: string; tag?: string } })?.data;
+    if (data?.code === "DUPLICATE_ASSET_TAG") {
+      throw new UserFacingError({
+        code: "DUPLICATE_ASSET_TAG",
+        title: "Duplicate asset tag",
+        message: `Asset tag "${data.tag}" already exists.`,
+        hint: "Use a different asset tag.",
+      });
+    }
     const translated = translatePrismaError(e);
     if (translated) throw translated;
     throw e;
@@ -608,41 +613,47 @@ export async function createAssets(
       : (orgTT.defaultIntervalMonths || 3);
     const convexForTT = await getConvexClient();
     const ttNow = Date.now();
-    for (const asset of results) {
-      await convexForTT.mutation(api.testTagAssets.createIfMissing, {
-        id: createId(),
-        organizationId,
-        testTagId: asset.assetTag,
-        description: `${model.manufacturer ? model.manufacturer + " " : ""}${model.name} (${asset.assetTag})`,
-        equipmentClass: (model.defaultEquipmentClass as "CLASS_I" | "CLASS_II" | "CLASS_II_DOUBLE_INSULATED" | "LEAD_CORD_ASSEMBLY") || "CLASS_I",
-        applianceType: (model.defaultApplianceType as "APPLIANCE" | "CORD_SET" | "EXTENSION_LEAD" | "POWER_BOARD" | "RCD_PORTABLE" | "RCD_FIXED" | "THREE_PHASE" | "OTHER") || "APPLIANCE",
-        ...(model.manufacturer && { make: model.manufacturer }),
-        ...(model.modelNumber && { modelName: model.modelNumber }),
-        ...(asset.serialNumber && { serialNumber: asset.serialNumber }),
-        testIntervalMonths: intervalMonths,
-        status: "NOT_YET_TESTED",
-        assetId: asset.id,
-        isActive: true,
-        createdAt: ttNow,
-        updatedAt: ttNow,
-      });
-    }
+    // Independent T&T rows — register them concurrently (was sequential).
+    await Promise.all(
+      results.map((asset) =>
+        convexForTT.mutation(api.testTagAssets.createIfMissing, {
+          id: createId(),
+          organizationId,
+          testTagId: asset.assetTag,
+          description: `${model.manufacturer ? model.manufacturer + " " : ""}${model.name} (${asset.assetTag})`,
+          equipmentClass: (model.defaultEquipmentClass as "CLASS_I" | "CLASS_II" | "CLASS_II_DOUBLE_INSULATED" | "LEAD_CORD_ASSEMBLY") || "CLASS_I",
+          applianceType: (model.defaultApplianceType as "APPLIANCE" | "CORD_SET" | "EXTENSION_LEAD" | "POWER_BOARD" | "RCD_PORTABLE" | "RCD_FIXED" | "THREE_PHASE" | "OTHER") || "APPLIANCE",
+          ...(model.manufacturer && { make: model.manufacturer }),
+          ...(model.modelNumber && { modelName: model.modelNumber }),
+          ...(asset.serialNumber && { serialNumber: asset.serialNumber }),
+          testIntervalMonths: intervalMonths,
+          status: "NOT_YET_TESTED",
+          assetId: asset.id,
+          isActive: true,
+          createdAt: ttNow,
+          updatedAt: ttNow,
+        }),
+      ),
+    );
   }
 
-  for (const result of results) {
-    await logActivity({
-      organizationId,
-      userId,
-      userName,
-      action: "CREATE",
-      entityType: "asset",
-      entityId: result.id,
-      entityName: result.assetTag,
-      summary: `Created asset ${result.assetTag}`,
-      details: { created: { assetTag: result.assetTag, modelId: parsed.modelId } },
-      assetId: result.id,
-    });
-  }
+  // One audit entry per created asset — write them concurrently (was sequential).
+  await Promise.all(
+    results.map((result) =>
+      logActivity({
+        organizationId,
+        userId,
+        userName,
+        action: "CREATE",
+        entityType: "asset",
+        entityId: result.id,
+        entityName: result.assetTag,
+        summary: `Created asset ${result.assetTag}`,
+        details: { created: { assetTag: result.assetTag, modelId: parsed.modelId } },
+        assetId: result.id,
+      }),
+    ),
+  );
 
   return serialize(results);
 }


### PR DESCRIPTION
## What

Bulk asset creation looped **3 sequential round-trips per asset** (dup-guard read + create + read-back), then a per-asset T&T register, then a per-asset activity log — ~150 sequential calls to add 50 assets.

- **Convex `assets.createMany`** — inserts all assets in one atomic mutation with an in-transaction dup-tag guard (`by_organizationId_assetTag`, also catches duplicates within the batch), throwing a structured `ConvexError` the action maps to its existing `DUPLICATE_ASSET_TAG` UserFacingError. One batched read-back (`getAssetsByIds`).
- T&T registration + activity logging now fire concurrently (`Promise.all`).

Same result and same duplicate semantics (existing + in-batch), now atomic.

## Correctness

`src/server/assets-batch.int.test.ts`: N assets created with the right tags; in-batch dup rejected + rolls back atomically (nothing written); existing-tag dup rejected; T&T row per asset when the model requires it.

## Codex review

Clean — "preserves the duplicate-tag behavior while making creation atomic."

🤖 Generated with [Claude Code](https://claude.com/claude-code)