### PR TITLE
perf: parallelize model rate/T&T updates + reorder loops

### DIFF
--- a/src/server/check-items.ts
+++ b/src/server/check-items.ts
@@ -325,11 +325,14 @@ export async function reorderModelCheckItems(
   const parsed = reorderModelCheckItemsSchema.parse(data);
 
   const convex = await getConvexClient();
-  for (let index = 0; index < parsed.orderedCheckItemIds.length; index++) {
-    const checkItemId = parsed.orderedCheckItemIds[index];
-    const row = await convex.query(api.modelCheckItems.getByModelAndCheckItem, { orgId: organizationId, modelId: parsed.modelId, checkItemId });
-    if (row) await convex.mutation(api.modelCheckItems.update, { id: row.id, patch: { sortOrder: index } });
-  }
+  // Each (model, checkItem) row is independent — resolve + patch them all
+  // concurrently (was a sequential read+update per item).
+  await Promise.all(
+    parsed.orderedCheckItemIds.map(async (checkItemId, index) => {
+      const row = await convex.query(api.modelCheckItems.getByModelAndCheckItem, { orgId: organizationId, modelId: parsed.modelId, checkItemId });
+      if (row) await convex.mutation(api.modelCheckItems.update, { id: row.id, patch: { sortOrder: index } });
+    }),
+  );
 
   return { success: true };
 }
@@ -501,11 +504,13 @@ export async function reorderKitCheckItems(
   const { organizationId } = await requirePermission("checkItem", "update");
 
   const convex = await getConvexClient();
-  for (let index = 0; index < orderedCheckItemIds.length; index++) {
-    const checkItemId = orderedCheckItemIds[index];
-    const row = await convex.query(api.kitCheckItems.getByKitAndCheckItem, { orgId: organizationId, kitId, checkItemId });
-    if (row) await convex.mutation(api.kitCheckItems.update, { id: row.id, patch: { sortOrder: index } });
-  }
+  // Each (kit, checkItem) row is independent — resolve + patch concurrently.
+  await Promise.all(
+    orderedCheckItemIds.map(async (checkItemId, index) => {
+      const row = await convex.query(api.kitCheckItems.getByKitAndCheckItem, { orgId: organizationId, kitId, checkItemId });
+      if (row) await convex.mutation(api.kitCheckItems.update, { id: row.id, patch: { sortOrder: index } });
+    }),
+  );
 
   return { success: true };
 }

--- a/src/server/custom-fields.ts
+++ b/src/server/custom-fields.ts
@@ -241,14 +241,17 @@ export async function reorderCustomFieldDefinitions(orderedIds: string[]) {
   // `where: { id, organizationId }` silently skipped foreign ids; replicate that
   // org-guard by verifying ownership per id (the reorder list is small) so a
   // stray/foreign id is a no-op rather than touching another org's row.
-  for (let idx = 0; idx < orderedIds.length; idx++) {
-    const id = orderedIds[idx];
-    const doc = await convex.query(api.customFieldDefinitions.getById, { id });
-    if (!doc || doc.organizationId !== organizationId) continue;
-    await convex.mutation(api.customFieldDefinitions.update, {
-      id,
-      patch: { sortOrder: idx, updatedAt: now },
-    });
-  }
+  // Each definition is independent — verify ownership + patch sortOrder for all
+  // ids concurrently (was a sequential read+update per id).
+  await Promise.all(
+    orderedIds.map(async (id, idx) => {
+      const doc = await convex.query(api.customFieldDefinitions.getById, { id });
+      if (!doc || doc.organizationId !== organizationId) return;
+      await convex.mutation(api.customFieldDefinitions.update, {
+        id,
+        patch: { sortOrder: idx, updatedAt: now },
+      });
+    }),
+  );
   return { ok: true };
 }

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -379,16 +379,21 @@ export async function updateModel(id: string, data: ModelFormValues) {
       // Propagate T&T defaults to active Convex testTagAsset rows linked to these assets.
       const convexForTT = await getConvexClient();
       const ttNow = Date.now();
-      for (const assetId of assetIds) {
-        const ttRows = await convexForTT.query(api.testTagAssets.listByAssetId, { assetId });
-        for (const tt of ttRows) {
-          if (tt.isActive === false) continue;
-          await convexForTT.mutation(api.testTagAssets.update, {
+      // Read every asset's T&T rows concurrently, then patch all the active ones
+      // concurrently — was a nested per-asset read + per-row update loop (N assets
+      // × M rows sequential). Independent rows, no ordering dependency.
+      const ttRowsPerAsset = await Promise.all(
+        assetIds.map((assetId) => convexForTT.query(api.testTagAssets.listByAssetId, { assetId })),
+      );
+      const activeTt = ttRowsPerAsset.flat().filter((tt) => tt.isActive !== false);
+      await Promise.all(
+        activeTt.map((tt) =>
+          convexForTT.mutation(api.testTagAssets.update, {
             id: tt.id,
             patch: { equipmentClass, applianceType, testIntervalMonths: intervalMonths, updatedAt: ttNow },
-          });
-        }
-      }
+          }),
+        ),
+      );
     }
   }
 
@@ -470,32 +475,32 @@ export async function bulkUpdateRates(
 
   const convex = await getConvexClient();
   const now = Date.now();
-  for (const model of models) {
-    const current = Number((model as Record<string, unknown>)[rateType] ?? 0);
-    let newRate: number;
-
-    switch (operation) {
-      case "set":
-        newRate = value;
-        break;
-      case "multiply":
-        newRate = current * value;
-        break;
-      case "increase_percent":
-        newRate = current * (1 + value / 100);
-        break;
-    }
-
-    newRate = Math.round(newRate * 100) / 100;
-
-    const patch: Record<string, number> = { [rateType]: newRate, updatedAt: now };
-    // Auto-sync defaultRentalPrice when dailyRate changes
-    if (rateType === "dailyRate") {
-      patch.defaultRentalPrice = newRate;
-    }
-
-    await convex.mutation(api.models.update, { id: model.id, patch });
-  }
+  // Independent per-model patches — compute in memory, then fire all the updates
+  // concurrently (was one sequential Convex round-trip per selected model).
+  await Promise.all(
+    models.map((model) => {
+      const current = Number((model as Record<string, unknown>)[rateType] ?? 0);
+      let newRate: number;
+      switch (operation) {
+        case "set":
+          newRate = value;
+          break;
+        case "multiply":
+          newRate = current * value;
+          break;
+        case "increase_percent":
+          newRate = current * (1 + value / 100);
+          break;
+      }
+      newRate = Math.round(newRate * 100) / 100;
+      const patch: Record<string, number> = { [rateType]: newRate, updatedAt: now };
+      // Auto-sync defaultRentalPrice when dailyRate changes
+      if (rateType === "dailyRate") {
+        patch.defaultRentalPrice = newRate;
+      }
+      return convex.mutation(api.models.update, { id: model.id, patch });
+    }),
+  );
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## What

Two clusters of independent server-side read/update loops, converted to `Promise.all`:

**Models**
- `updateModel` — when T&T defaults change it re-read each asset's `testTagAsset` rows then patched each (nested per-asset read + per-row update). Now reads all assets' rows concurrently, then patches all active rows concurrently.
- `bulkUpdateRates` — applied each model's rate patch sequentially; now fires all model updates concurrently.

**Reorder actions** (`reorderModelCheckItems`, `reorderKitCheckItems`, `reorderCustomFieldDefinitions`)
- Each resolved a row then patched its `sortOrder` one at a time; each row is independent, so resolve + patch concurrently. Same org-guard / not-found skip per item.

All rows are independent (distinct ids, different assets/models) — no cascade, no ordering dependency.

## Codex review

Clean — "converts independent reads/mutations to Promise.all without altering the data written or the authorization checks."

🤖 Generated with [Claude Code](https://claude.com/claude-code)