### PR TITLE
perf(convex): parallelize the Class 2 cascade tail (bounded on the big sweeps)

### DIFF
--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,31 @@
+/**
+ * Bounded-concurrency helpers. Use these instead of a bare `Promise.all(...)`
+ * when the fan-out size is unbounded (cross-org / GDPR sweeps, whole-platform
+ * prunes): firing thousands of concurrent Convex/HTTP requests can hit
+ * connection/rate limits and make the whole batch reject — leaving a cleanup
+ * half-done. Batching caps the in-flight count while still parallelizing.
+ */
+
+/** Run async thunks in batches of `limit` at a time (default 20). */
+export async function runWithConcurrency<T>(
+  thunks: Array<() => Promise<T>>,
+  limit = 20,
+): Promise<T[]> {
+  const results: T[] = [];
+  for (let i = 0; i < thunks.length; i += limit) {
+    results.push(...(await Promise.all(thunks.slice(i, i + limit).map((t) => t()))));
+  }
+  return results;
+}
+
+/** Map `items` through `fn` in batches of `limit` at a time (default 20). */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  fn: (item: T) => Promise<R>,
+  limit = 20,
+): Promise<R[]> {
+  return runWithConcurrency(
+    items.map((item) => () => fn(item)),
+    limit,
+  );
+}

--- a/src/server/brand-templates.ts
+++ b/src/server/brand-templates.ts
@@ -71,14 +71,16 @@ async function unsetBrandDefaultsInConvex(organizationId: string, exceptId?: str
   const brands = (await convex.query(api.brandTemplates.list, {
     orgId: organizationId,
   })) as ConvexBrandTemplate[];
-  for (const b of brands) {
-    if (b.isDefault && b.id !== exceptId) {
-      await convex.mutation(api.brandTemplates.update, {
-        id: b.id,
-        patch: { isDefault: false, updatedAt: Date.now() },
-      });
-    }
-  }
+  await Promise.all(
+    brands
+      .filter((b) => b.isDefault && b.id !== exceptId)
+      .map((b) =>
+        convex.mutation(api.brandTemplates.update, {
+          id: b.id,
+          patch: { isDefault: false, updatedAt: Date.now() },
+        }),
+      ),
+  );
 }
 
 /**

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -409,9 +409,13 @@ export async function deleteCrewMember(id: string) {
   } else {
     await convex.mutation(api.crewMembers.remove, { id });
   }
-  for (const a of memberAssignments) await convex.mutation(api.crewAssignments.deleteCascade, { id: a.id });
-  for (const t of orgTimeEntries) await convex.mutation(api.crewTimeEntries.remove, { id: t.id });
-  for (const av of memberAvailability) await convex.mutation(api.crewAvailabilities.remove, { id: av.id });
+  // Within each set the rows are distinct, so parallelize each. Keep the three
+  // sets SEQUENTIAL: an assignment's deleteCascade can remove its linked time
+  // entries, so the assignments must finish before the time-entry removals run
+  // (preserves the original ordering; avoids removing an already-gone row).
+  await Promise.all(memberAssignments.map((a) => convex.mutation(api.crewAssignments.deleteCascade, { id: a.id })));
+  await Promise.all(orgTimeEntries.map((t) => convex.mutation(api.crewTimeEntries.remove, { id: t.id })));
+  await Promise.all(memberAvailability.map((av) => convex.mutation(api.crewAvailabilities.remove, { id: av.id })));
 
   if (!nativeCrewWrites()) {
     await logActivity({

--- a/src/server/notification-email-sender.ts
+++ b/src/server/notification-email-sender.ts
@@ -437,15 +437,15 @@ export async function pruneStaleNotificationEmailLogs(): Promise<number> {
   const convex = await getConvexClient();
   const orgs = await prisma.organization.findMany({ select: { id: true } });
 
-  let count = 0;
-  for (const org of orgs) {
-    const logs = await convex.query(api.notificationEmailLogs.list, { orgId: org.id });
-    for (const log of logs) {
-      if ((log.sentAt ?? 0) < cutoffMs) {
-        await convex.mutation(api.notificationEmailLogs.remove, { id: log.id });
-        count += 1;
-      }
-    }
-  }
-  return count;
+  // Read each org's logs concurrently, then remove every stale log concurrently
+  // (flat rows, independent) — was a nested per-org read + per-log delete loop.
+  const perOrgLogs = await Promise.all(
+    orgs.map((org) => convex.query(api.notificationEmailLogs.list, { orgId: org.id })),
+  );
+  const staleLogIds = perOrgLogs
+    .flat()
+    .filter((log) => (log.sentAt ?? 0) < cutoffMs)
+    .map((log) => log.id);
+  await Promise.all(staleLogIds.map((id) => convex.mutation(api.notificationEmailLogs.remove, { id })));
+  return staleLogIds.length;
 }

--- a/src/server/notification-email-sender.ts
+++ b/src/server/notification-email-sender.ts
@@ -48,6 +48,7 @@ import {
   type NotificationPreferenceValues,
 } from "@/lib/validations/notification-preferences";
 import { getUserNotificationPreferenceMap } from "@/lib/user-notification-preferences-read";
+import { mapWithConcurrency, runWithConcurrency } from "@/lib/concurrency";
 
 interface OrgRecipient {
   userId: string;
@@ -437,15 +438,24 @@ export async function pruneStaleNotificationEmailLogs(): Promise<number> {
   const convex = await getConvexClient();
   const orgs = await prisma.organization.findMany({ select: { id: true } });
 
-  // Read each org's logs concurrently, then remove every stale log concurrently
-  // (flat rows, independent) — was a nested per-org read + per-log delete loop.
-  const perOrgLogs = await Promise.all(
-    orgs.map((org) => convex.query(api.notificationEmailLogs.list, { orgId: org.id })),
+  // Process orgs with BOUNDED concurrency (not a bare Promise.all over every
+  // org's logs at once): a platform with many orgs / huge log tables would
+  // otherwise hold every row in memory and fan out unbounded requests, throttling
+  // Convex and failing the scheduled prune. Read a batch of orgs' logs, delete
+  // their stale rows (bounded), then move on.
+  let count = 0;
+  await mapWithConcurrency(
+    orgs,
+    async (org) => {
+      const logs = await convex.query(api.notificationEmailLogs.list, { orgId: org.id });
+      const staleIds = logs.filter((log) => (log.sentAt ?? 0) < cutoffMs).map((log) => log.id);
+      await runWithConcurrency(
+        staleIds.map((id) => () => convex.mutation(api.notificationEmailLogs.remove, { id })),
+        20,
+      );
+      count += staleIds.length;
+    },
+    10,
   );
-  const staleLogIds = perOrgLogs
-    .flat()
-    .filter((log) => (log.sentAt ?? 0) < cutoffMs)
-    .map((log) => log.id);
-  await Promise.all(staleLogIds.map((id) => convex.mutation(api.notificationEmailLogs.remove, { id })));
-  return staleLogIds.length;
+  return count;
 }

--- a/src/server/notifications.ts
+++ b/src/server/notifications.ts
@@ -101,9 +101,7 @@ export async function pruneStaleDismissals(activeKeys: string[]): Promise<number
   if (stale.length === 0) return 0;
 
   const convex = await getConvexClient();
-  for (const row of stale) {
-    await convex.mutation(api.notificationDismissals.remove, { id: row.id });
-  }
+  await Promise.all(stale.map((row) => convex.mutation(api.notificationDismissals.remove, { id: row.id })));
   return stale.length;
 }
 

--- a/src/server/project-categories.ts
+++ b/src/server/project-categories.ts
@@ -448,13 +448,15 @@ export async function deleteProjectCategory(categoryId: string) {
 
   // 3. Null out categoryId/groupId on the affected line items (Convex).
   const nowClear = Date.now();
-  for (const li of affected) {
-    await client.mutation(api.projectLineItems.patchLineItem, {
-      id: li.id,
-      set: { updatedAt: nowClear },
-      clear: ["categoryId", "groupId"],
-    });
-  }
+  await Promise.all(
+    affected.map((li) =>
+      client.mutation(api.projectLineItems.patchLineItem, {
+        id: li.id,
+        set: { updatedAt: nowClear },
+        clear: ["categoryId", "groupId"],
+      }),
+    ),
+  );
 
   // 4. Atomic Convex cascade: all groups (+ their slots), all category slots,
   //    then the category — one transaction, no partial-cascade on mid-failure.

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -19,6 +19,7 @@ import { getPlatformName } from "@/lib/platform";
 import { getTheOrg, invalidateOrgCache } from "@/lib/single-org";
 import { env } from "@/env";
 import { logActivity } from "@/lib/activity-log";
+import { runWithConcurrency } from "@/lib/concurrency";
 
 /** Verify the current user is a site admin. Throws if not. */
 async function requireSiteAdmin() {
@@ -569,31 +570,35 @@ export async function adminDeleteUser(userId: string) {
   // kitSerializedItem and kitBulkItem are Convex-only: clear the user FKs on
   // line items and delete the kit-member rows this user added.
   // Every follow-up here is an independent FK-clear / row-remove across distinct
-  // Convex tables (maintenanceRecord.scrubUserRefs is per-org) — fire them all
-  // concurrently. Was one sequential Convex round-trip per row across ~9 loops
-  // (a heavy GDPR sweep). Convex serialises any same-doc writes internally.
-  await Promise.all([
-    ...lineItemsToClearCheckedOut.map((li) =>
+  // Convex tables (maintenanceRecord.scrubUserRefs is per-org) — was one
+  // sequential Convex round-trip per row across ~9 loops (a heavy GDPR sweep).
+  // Run them with BOUNDED concurrency (not a bare Promise.all): a user who
+  // touched thousands of rows would otherwise fan out thousands of concurrent
+  // requests, hit Convex/HTTP limits, reject the whole batch, and leave the
+  // already-deleted user with unswept references.
+  const deletionTasks: Array<() => Promise<unknown>> = [
+    ...lineItemsToClearCheckedOut.map((li) => () =>
       convexForDelete.mutation(api.projectLineItems.patchLineItem, { id: li.id, set: {}, clear: ["checkedOutById"] }),
     ),
-    ...lineItemsToClearReturned.map((li) =>
+    ...lineItemsToClearReturned.map((li) => () =>
       convexForDelete.mutation(api.projectLineItems.patchLineItem, { id: li.id, set: {}, clear: ["returnedById"] }),
     ),
     // project is Convex-only — clear the projectManagerId FK on this user's projects.
-    ...projectsToClearManager.map((p) =>
+    ...projectsToClearManager.map((p) => () =>
       convexForDelete.mutation(api.projects.patchProject, { id: p.id, set: {}, clear: ["projectManagerId"] }),
     ),
-    ...serializedItemsToRemove.map((item) => convexForDelete.mutation(api.kitSerializedItems.remove, { id: item.id })),
-    ...bulkItemsToRemove.map((item) => convexForDelete.mutation(api.kitBulkItems.remove, { id: item.id })),
-    ...scanLogsToRemove.map((item) => convexForDelete.mutation(api.assetScanLogs.remove, { id: item.id })),
-    ...subTestRecordsToRemove.map((item) => convexForDelete.mutation(api.subTestRecords.remove, { id: item.id })),
-    ...testTagRecordsToRemove.map((item) => convexForDelete.mutation(api.testTagRecords.remove, { id: item.id })),
+    ...serializedItemsToRemove.map((item) => () => convexForDelete.mutation(api.kitSerializedItems.remove, { id: item.id })),
+    ...bulkItemsToRemove.map((item) => () => convexForDelete.mutation(api.kitBulkItems.remove, { id: item.id })),
+    ...scanLogsToRemove.map((item) => () => convexForDelete.mutation(api.assetScanLogs.remove, { id: item.id })),
+    ...subTestRecordsToRemove.map((item) => () => convexForDelete.mutation(api.subTestRecords.remove, { id: item.id })),
+    ...testTagRecordsToRemove.map((item) => () => convexForDelete.mutation(api.testTagRecords.remove, { id: item.id })),
     // maintenanceRecord is Convex-only: clear this user's reportedById/assignedToId
     // FK references across every org (GDPR sweep is cross-org).
-    ...allOrgsForSweep.map((org) =>
+    ...allOrgsForSweep.map((org) => () =>
       convexForDelete.mutation(api.maintenanceRecords.scrubUserRefs, { organizationId: org.id, userId }),
     ),
-  ]);
+  ];
+  await runWithConcurrency(deletionTasks, 20);
 
   // Remove the user from the Convex `users` mirror (best-effort).
   await removeUserFromConvex(userId);

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -568,51 +568,32 @@ export async function adminDeleteUser(userId: string) {
   // Convex-only follow-ups (cannot run inside a $transaction). projectLineItem,
   // kitSerializedItem and kitBulkItem are Convex-only: clear the user FKs on
   // line items and delete the kit-member rows this user added.
-  for (const li of lineItemsToClearCheckedOut) {
-    await convexForDelete.mutation(api.projectLineItems.patchLineItem, {
-      id: li.id,
-      set: {},
-      clear: ["checkedOutById"],
-    });
-  }
-  for (const li of lineItemsToClearReturned) {
-    await convexForDelete.mutation(api.projectLineItems.patchLineItem, {
-      id: li.id,
-      set: {},
-      clear: ["returnedById"],
-    });
-  }
-  // project is Convex-only — clear the projectManagerId FK on this user's projects.
-  for (const p of projectsToClearManager) {
-    await convexForDelete.mutation(api.projects.patchProject, {
-      id: p.id,
-      set: {},
-      clear: ["projectManagerId"],
-    });
-  }
-  for (const item of serializedItemsToRemove) {
-    await convexForDelete.mutation(api.kitSerializedItems.remove, { id: item.id });
-  }
-  for (const item of bulkItemsToRemove) {
-    await convexForDelete.mutation(api.kitBulkItems.remove, { id: item.id });
-  }
-  for (const item of scanLogsToRemove) await convexForDelete.mutation(api.assetScanLogs.remove, { id: item.id });
-  for (const item of subTestRecordsToRemove) {
-    await convexForDelete.mutation(api.subTestRecords.remove, { id: item.id });
-  }
-  for (const item of testTagRecordsToRemove) {
-    await convexForDelete.mutation(api.testTagRecords.remove, { id: item.id });
-  }
-
-  // maintenanceRecord is Convex-only: clear this user's reportedById/assignedToId
-  // FK references across every org (GDPR sweep is cross-org). Replaces the two
-  // dead Prisma `maintenanceRecord.updateMany` calls removed from the tx above.
-  for (const org of allOrgsForSweep) {
-    await convexForDelete.mutation(api.maintenanceRecords.scrubUserRefs, {
-      organizationId: org.id,
-      userId,
-    });
-  }
+  // Every follow-up here is an independent FK-clear / row-remove across distinct
+  // Convex tables (maintenanceRecord.scrubUserRefs is per-org) — fire them all
+  // concurrently. Was one sequential Convex round-trip per row across ~9 loops
+  // (a heavy GDPR sweep). Convex serialises any same-doc writes internally.
+  await Promise.all([
+    ...lineItemsToClearCheckedOut.map((li) =>
+      convexForDelete.mutation(api.projectLineItems.patchLineItem, { id: li.id, set: {}, clear: ["checkedOutById"] }),
+    ),
+    ...lineItemsToClearReturned.map((li) =>
+      convexForDelete.mutation(api.projectLineItems.patchLineItem, { id: li.id, set: {}, clear: ["returnedById"] }),
+    ),
+    // project is Convex-only — clear the projectManagerId FK on this user's projects.
+    ...projectsToClearManager.map((p) =>
+      convexForDelete.mutation(api.projects.patchProject, { id: p.id, set: {}, clear: ["projectManagerId"] }),
+    ),
+    ...serializedItemsToRemove.map((item) => convexForDelete.mutation(api.kitSerializedItems.remove, { id: item.id })),
+    ...bulkItemsToRemove.map((item) => convexForDelete.mutation(api.kitBulkItems.remove, { id: item.id })),
+    ...scanLogsToRemove.map((item) => convexForDelete.mutation(api.assetScanLogs.remove, { id: item.id })),
+    ...subTestRecordsToRemove.map((item) => convexForDelete.mutation(api.subTestRecords.remove, { id: item.id })),
+    ...testTagRecordsToRemove.map((item) => convexForDelete.mutation(api.testTagRecords.remove, { id: item.id })),
+    // maintenanceRecord is Convex-only: clear this user's reportedById/assignedToId
+    // FK references across every org (GDPR sweep is cross-org).
+    ...allOrgsForSweep.map((org) =>
+      convexForDelete.mutation(api.maintenanceRecords.scrubUserRefs, { organizationId: org.id, userId }),
+    ),
+  ]);
 
   // Remove the user from the Convex `users` mirror (best-effort).
   await removeUserFromConvex(userId);

--- a/src/server/test-tag-profiles.ts
+++ b/src/server/test-tag-profiles.ts
@@ -458,29 +458,13 @@ export async function seedDefaultProfiles() {
   }
 
   const convex = await getConvexClient();
-  const created: TestProfileRow[] = [];
-  for (const p of toCreate) {
-    const id = createId();
-    const now = Date.now();
-    await convex.mutation(api.testProfiles.create, {
-      id,
-      organizationId,
-      name: p.name,
-      equipmentClass: p.equipmentClass,
-      applianceType: p.applianceType,
-      visualChecks: p.visualChecks,
-      electricalTests: p.electricalTests,
-      thresholds: p.thresholds,
-      requiresSubTests: p.requiresSubTests,
-      defaultSubTestCount: p.defaultSubTestCount,
-      subTestLabel: p.subTestLabel,
-      isDefault: true,
-      isActive: true,
-      createdAt: now,
-      updatedAt: now,
-    });
-    created.push(
-      profileRow({
+  const now = Date.now();
+  // Independent default profiles — create them all concurrently (was sequential).
+  // Promise.all preserves order, so `created` keeps the toCreate order.
+  const created: TestProfileRow[] = await Promise.all(
+    toCreate.map(async (p) => {
+      const id = createId();
+      await convex.mutation(api.testProfiles.create, {
         id,
         organizationId,
         name: p.name,
@@ -496,9 +480,26 @@ export async function seedDefaultProfiles() {
         isActive: true,
         createdAt: now,
         updatedAt: now,
-      }),
-    );
-  }
+      });
+      return profileRow({
+        id,
+        organizationId,
+        name: p.name,
+        equipmentClass: p.equipmentClass,
+        applianceType: p.applianceType,
+        visualChecks: p.visualChecks,
+        electricalTests: p.electricalTests,
+        thresholds: p.thresholds,
+        requiresSubTests: p.requiresSubTests,
+        defaultSubTestCount: p.defaultSubTestCount,
+        subTestLabel: p.subTestLabel,
+        isDefault: true,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }),
+  );
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## What

The remaining server-side mirror-loop cascades (Class 2 tail from the design doc), converted from sequential `for..await` to concurrent:

- **project-categories** — clear categoryId/groupId on affected line items (category delete)
- **brand-templates** — unset `isDefault` on the other default brands
- **notifications** — prune stale dismissals
- **notification-email-sender** — GC old email logs (cross-org)
- **test-tag-profiles** — seed default AS/NZS profiles (order-preserving)
- **crew.deleteMember** — parallelize within each delete set, keep the **three sets sequential** (an assignment's `deleteCascade` can remove its linked time entries)
- **site-admin.deleteUserPermanently** — the ~9 FK-clear / row-remove loops (GDPR sweep)

## Bounded where it matters

Codex flagged the two **cross-platform unbounded** paths (GDPR user delete, log prune): a bare `Promise.all` over thousands of rows could hit Convex/HTTP limits, reject, and leave cleanup half-done. Added `src/lib/concurrency.ts` (`runWithConcurrency` / `mapWithConcurrency`, batches of N) and used it there — still parallel, but the in-flight count is capped.

## Left sequential (on purpose)

- crew delete's three sets (cascade → entries ordering)
- test-tag reminder **email sends** (external provider, rate-limit safety)

## Codex review

Caught the unbounded-concurrency [P2]s; fixed with bounded batching. Re-review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)