### PR TITLE
Phase 7 — native indexed search (searchIndex + reactive queries)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3458,9 +3458,42 @@ BEFORE reconstruction (`src/hooks/use-native-line-item-writes.ts` `applyOptimist
 the same idea as the tab's optimistic DELETE. Cleared when the write settles (rollback
 on error). Flag `NEXT_PUBLIC_NATIVE_LINEITEM_OPTIMISTIC` (default OFF, build-inlined).
 
-**Phases 4 + 5 are now closed.** Remaining: Phases 6 (crons/side-effects) + 7 (search),
-then the Postgres decommission. Membership/organization writes stay Postgres (Better
-Auth owns them — Tier E).
+**Phases 4 + 5 are now closed.** Remaining: the Postgres decommission. Membership/
+organization writes stay Postgres (Better Auth owns them — Tier E).
+
+## Phase 6 — background jobs & side-effects
+
+- **Crons (`convex/crons.ts`).** Convex owns the durable cron SCHEDULE (observable in
+  the dashboard). Two jobs — notification emails (15m) + test-and-tag digests (daily) —
+  call internalActions in `convex/scheduledJobs.ts` that invoke the existing Next.js
+  `/api/cron/*` executor routes (`Bearer CRON_SECRET`). The executor stays in Next
+  because both pipelines fan out to org/member/user rows sourced from Postgres/Better
+  Auth (mirrors not verified-complete in prod). **Dormant** until `ENABLE_CONVEX_CRONS=true`
+  + `CONVEX_CRON_TARGET_URL` + `CRON_SECRET` on the Convex deployment. Full route removal
+  deferred until the mirrors are verified and email parity can be checked live.
+- **Email side-effects (`convex/emails.ts` + `convex/emailActions.ts`).** A durable,
+  idempotent layer: `enqueue` (service-only mutation) schedules `deliver`
+  (`"use node"` internalAction) via `ctx.scheduler.runAfter(0, …)`. At-least-once with
+  bounded retry/backoff (3 attempts) + a `sentEmails` delivered-ledger + Resend
+  `Idempotency-Key` for provider-side dedupe. Server sends route through
+  `deliverSideEffectEmail()` (`src/lib/email-side-effect.ts`) behind
+  `NATIVE_EMAIL_SIDEEFFECTS` (default OFF). Representative wiring: crew offer/confirm/
+  cancel. Needs `RESEND_API_KEY` + `EMAIL_FROM` on the Convex deployment to deliver.
+
+## Phase 7 — native search
+
+- **Search indexes** (`convex/schema.ts` `searchIndex`): assets (tag + serial),
+  models/kits/clients/suppliers/projects (name). **Queries** (`convex/search.ts`):
+  org-scoped `withSearchIndex` reads, browser-callable (`requireOrgRead`), bounded, and
+  reactive — replacing the "load the whole org table, JS-filter in the browser" pattern.
+  Empty query → bounded most-recent list. `assets` merges tag + serial (deduped);
+  `projects` excludes templates in JS on the bounded result.
+- **UI:** `ComboboxPicker` gained a backward-compatible async-search mode
+  (`onSearchChange` / `selectedLabel` / `loading`); existing callers are unchanged.
+  Representative cutover: the sub-hire supplier picker (`useSupplierSearch`, debounced,
+  selected label via `getById`). Remaining pickers/tables follow the same shape;
+  multi-field searches (e.g. the model picker's name+manufacturer) need a second index
+  or a denormalized search field before cutover.
 
 ## Conventions
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -94,6 +94,7 @@ import type * as projectWrites from "../projectWrites.js";
 import type * as projects from "../projects.js";
 import type * as purgeRemovedTables from "../purgeRemovedTables.js";
 import type * as savedTableViews from "../savedTableViews.js";
+import type * as search from "../search.js";
 import type * as sectionPresets from "../sectionPresets.js";
 import type * as serviceTemplates from "../serviceTemplates.js";
 import type * as siteSettings from "../siteSettings.js";
@@ -213,6 +214,7 @@ declare const fullApi: ApiFromModules<{
   projects: typeof projects;
   purgeRemovedTables: typeof purgeRemovedTables;
   savedTableViews: typeof savedTableViews;
+  search: typeof search;
   sectionPresets: typeof sectionPresets;
   serviceTemplates: typeof serviceTemplates;
   siteSettings: typeof siteSettings;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -260,7 +260,8 @@ export default defineSchema({
     .index("by_categoryId", ["categoryId"])
     .index("by_defaultTestProfileId", ["defaultTestProfileId"])
     .index("by_organizationId_sku", ["organizationId", "sku"])
-    .index("by_isActive", ["isActive"]),
+    .index("by_isActive", ["isActive"])
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
 
   // Supplier
   suppliers: defineTable({
@@ -285,7 +286,8 @@ export default defineSchema({
   })
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
-    .index("by_organizationId_name", ["organizationId", "name"]),
+    .index("by_organizationId_name", ["organizationId", "name"])
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
 
   // SupplierOrder
   supplierOrders: defineTable({
@@ -469,7 +471,8 @@ export default defineSchema({
     .index("by_locationId", ["locationId"])
     .index("by_organizationId_assetTag", ["organizationId", "assetTag"])
     .index("by_status", ["status"])
-    .index("by_isActive", ["isActive"]),
+    .index("by_isActive", ["isActive"])
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
 
   // KitSerializedItem
   kitSerializedItems: defineTable({
@@ -551,7 +554,9 @@ export default defineSchema({
     .index("by_parentAssetId", ["parentAssetId"])
     .index("by_organizationId_assetTag", ["organizationId", "assetTag"])
     .index("by_status", ["status"])
-    .index("by_isActive", ["isActive"]),
+    .index("by_isActive", ["isActive"])
+    .searchIndex("search_assetTag", { searchField: "assetTag", filterFields: ["organizationId", "isActive"] })
+    .searchIndex("search_serialNumber", { searchField: "serialNumber", filterFields: ["organizationId", "isActive"] }),
 
   // BulkAsset
   bulkAssets: defineTable({
@@ -707,7 +712,8 @@ export default defineSchema({
   })
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
-    .index("by_isActive", ["isActive"]),
+    .index("by_isActive", ["isActive"])
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
 
   // Project
   projects: defineTable({
@@ -767,7 +773,8 @@ export default defineSchema({
     .index("by_clientId", ["clientId"])
     .index("by_rentalStartDate_rentalEndDate", ["rentalStartDate", "rentalEndDate"])
     .index("by_isTemplate", ["isTemplate"])
-    .index("by_organizationId_status", ["organizationId", "status"]),
+    .index("by_organizationId_status", ["organizationId", "status"])
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isTemplate"] }),
 
   // ProjectLineItem
   projectLineItems: defineTable({

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const ORG = "org_1";
+const OTHER = "org_2";
+const asUser = (orgId: string) => ({ subject: "user_1", orgId });
+const NOW = 1_700_000_000_000;
+
+describe("search.models", () => {
+  test("matches by name, is org-scoped, and honours the query", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "Shure SM58", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Sennheiser MD421", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m3", organizationId: OTHER, name: "Shure SM7B", isActive: true, createdAt: NOW });
+    });
+
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "Shure" });
+    expect(hits.map((m) => m.id)).toEqual(["m1"]); // m3 is another org
+
+    const empty = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "" });
+    expect(empty.map((m) => m.id).sort()).toEqual(["m1", "m2"]); // bounded recent, org-scoped
+  });
+
+  test("respects the limit clamp", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 5; i++) {
+        await ctx.db.insert("models", { id: `m${i}`, organizationId: ORG, name: `Widget ${i}`, isActive: true, createdAt: NOW });
+      }
+    });
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "Widget", limit: 2 });
+    expect(hits.length).toBe(2);
+  });
+});
+
+describe("search.assets — tag or serial", () => {
+  test("matches by asset tag or serial number, merged + deduped", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "CAM-001", serialNumber: "SN-ABC", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "LENS-050", serialNumber: "CAM-XYZ", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    // "CAM" matches a1 by tag and a2 by serial → both, deduped.
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.assets, { orgId: ORG, query: "CAM" });
+    expect(hits.map((a) => a.id).sort()).toEqual(["a1", "a2"]);
+
+    const byTag = await t.withIdentity(asUser(ORG)).query(api.search.assets, { orgId: ORG, query: "LENS" });
+    expect(byTag.map((a) => a.id)).toEqual(["a2"]);
+  });
+});
+
+describe("search.projects — excludes templates", () => {
+  test("templates are filtered out unless includeTemplates", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Festival Main Stage", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projects", { id: "p2", organizationId: ORG, projectNumber: "T-1", name: "Festival Template", status: "CONFIRMED", isTemplate: true, createdAt: NOW, updatedAt: NOW });
+    });
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.projects, { orgId: ORG, query: "Festival" });
+    expect(hits.map((p) => p.id)).toEqual(["p1"]);
+
+    const withTemplates = await t
+      .withIdentity(asUser(ORG))
+      .query(api.search.projects, { orgId: ORG, query: "Festival", includeTemplates: true });
+    expect(withTemplates.map((p) => p.id).sort()).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("search — auth", () => {
+  test("a user token for another org cannot read this org's search", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "c1", organizationId: ORG, name: "Acme", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(OTHER)).query(api.search.clients, { orgId: ORG, query: "Acme" }),
+    ).rejects.toThrow();
+  });
+});

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -1,0 +1,191 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { requireOrgRead } from "./lib/auth";
+
+/**
+ * Phase 7 — native reactive search over the `searchIndex`es added in schema.ts.
+ *
+ * These replace the "load the whole org table into the browser, then JS-filter"
+ * pattern behind the searchable pickers/tables. Each query:
+ *   - is org-scoped (`requireOrgRead`, browser-callable with a user token, same
+ *     as the `list` queries the pickers already subscribe to),
+ *   - returns a BOUNDED result set (never a whole-table `.collect()`), keeping it
+ *     within Convex read limits on large tenants,
+ *   - is reactive — a new matching row appears without a refetch.
+ *
+ * Empty query → a bounded most-recent list via the org index (so an unfocused
+ * picker still shows something), NOT the whole table.
+ *
+ * Kept in this hand-written module (NOT the generated `models.ts`/`assets.ts`
+ * CRUD files) so the CRUD generator never clobbers it.
+ */
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function clampLimit(limit: number | undefined): number {
+  return Math.min(Math.max(1, limit ?? DEFAULT_LIMIT), MAX_LIMIT);
+}
+
+export const models = query({
+  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, query: term, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    if (!q) {
+      return await ctx.db
+        .query("models")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take);
+    }
+    return await ctx.db
+      .query("models")
+      .withSearchIndex("search_name", (s) =>
+        s.search("name", q).eq("organizationId", orgId),
+      )
+      .take(take);
+  },
+});
+
+export const kits = query({
+  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, query: term, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    if (!q) {
+      return await ctx.db
+        .query("kits")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take);
+    }
+    return await ctx.db
+      .query("kits")
+      .withSearchIndex("search_name", (s) =>
+        s.search("name", q).eq("organizationId", orgId),
+      )
+      .take(take);
+  },
+});
+
+export const clients = query({
+  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, query: term, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    if (!q) {
+      return await ctx.db
+        .query("clients")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take);
+    }
+    return await ctx.db
+      .query("clients")
+      .withSearchIndex("search_name", (s) =>
+        s.search("name", q).eq("organizationId", orgId),
+      )
+      .take(take);
+  },
+});
+
+export const suppliers = query({
+  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, query: term, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    if (!q) {
+      return await ctx.db
+        .query("suppliers")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take);
+    }
+    return await ctx.db
+      .query("suppliers")
+      .withSearchIndex("search_name", (s) =>
+        s.search("name", q).eq("organizationId", orgId),
+      )
+      .take(take);
+  },
+});
+
+export const projects = query({
+  args: {
+    orgId: v.string(),
+    query: v.string(),
+    limit: v.optional(v.number()),
+    includeTemplates: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { orgId, query: term, limit, includeTemplates }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    // isTemplate is optional (often undefined for real projects), so filter it in
+    // JS on the bounded result set rather than via the search filterField, which
+    // would only match rows where the field is explicitly present.
+    const keep = (p: { isTemplate?: boolean }) => includeTemplates || !p.isTemplate;
+    if (!q) {
+      const rows = await ctx.db
+        .query("projects")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take * 2);
+      return rows.filter(keep).slice(0, take);
+    }
+    const rows = await ctx.db
+      .query("projects")
+      .withSearchIndex("search_name", (s) =>
+        s.search("name", q).eq("organizationId", orgId),
+      )
+      .take(take * 2);
+    return rows.filter(keep).slice(0, take);
+  },
+});
+
+/**
+ * Assets search matches EITHER asset tag OR serial number (two search indexes),
+ * merged + deduped, so one picker search box covers both — relevance order is
+ * assetTag hits first, then serial hits.
+ */
+export const assets = query({
+  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, query: term, limit }) => {
+    await requireOrgRead(ctx, orgId);
+    const take = clampLimit(limit);
+    const q = term.trim();
+    if (!q) {
+      return await ctx.db
+        .query("assets")
+        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
+        .order("desc")
+        .take(take);
+    }
+    const byTag = await ctx.db
+      .query("assets")
+      .withSearchIndex("search_assetTag", (s) =>
+        s.search("assetTag", q).eq("organizationId", orgId),
+      )
+      .take(take);
+    const bySerial = await ctx.db
+      .query("assets")
+      .withSearchIndex("search_serialNumber", (s) =>
+        s.search("serialNumber", q).eq("organizationId", orgId),
+      )
+      .take(take);
+    const seen = new Set(byTag.map((a) => a._id));
+    const merged = [...byTag];
+    for (const a of bySerial) {
+      if (!seen.has(a._id)) {
+        seen.add(a._id);
+        merged.push(a);
+      }
+    }
+    return merged.slice(0, take);
+  },
+});

--- a/src/components/projects/sub-hire-add-form.tsx
+++ b/src/components/projects/sub-hire-add-form.tsx
@@ -17,7 +17,8 @@ import { useServerMutation } from "@/hooks/use-server-mutation";
 import { toast } from "sonner";
 
 import { createSubHire } from "@/server/sub-hires";
-import { useSuppliers } from "@/hooks/use-suppliers";
+import { useSupplier, useSupplierSearch } from "@/hooks/use-suppliers";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -64,14 +65,20 @@ export function SubHireAddForm({
   const [hireEnd, setHireEnd] = useState(toDateInput(rentalEndDate));
   const [notes, setNotes] = useState("");
   const [showCreateSupplier, setShowCreateSupplier] = useState(false);
+  const [supplierQuery, setSupplierQuery] = useState("");
 
-  // Reactive supplier list from Convex; active-only (matches old getSuppliers).
-  const allSuppliers = useSuppliers(orgId);
-  const supplierOptions = (allSuppliers ?? [])
+  // Phase 7 — native INDEXED supplier search (bounded, reactive) instead of
+  // loading the whole org list to JS-filter. Debounced as the user types.
+  const debouncedSupplierQuery = useDebouncedValue(supplierQuery, 200);
+  const supplierResults = useSupplierSearch(orgId, debouncedSupplierQuery);
+  const supplierOptions = (supplierResults ?? [])
     .filter((s) => s.isActive ?? true)
     .map((s) => ({ value: s.id, label: s.name }));
 
-  const supplierName = supplierOptions.find((s) => s.value === supplierId)?.label;
+  // Resolve the selected supplier's label directly (it may not be in the current
+  // search page) so the trigger + summary always show the chosen name.
+  const selectedSupplier = useSupplier(supplierId || undefined);
+  const supplierName = selectedSupplier?.name;
 
   const createMut = useServerMutation({
     mutationFn: () =>
@@ -104,6 +111,9 @@ export function SubHireAddForm({
               value={supplierId}
               onChange={setSupplierId}
               options={supplierOptions}
+              onSearchChange={setSupplierQuery}
+              loading={supplierResults === undefined}
+              selectedLabel={supplierName}
               placeholder="Select a supplier…"
               searchPlaceholder="Search suppliers…"
               emptyMessage="No suppliers found."

--- a/src/components/ui/__tests__/combobox-picker.smoke.test.tsx
+++ b/src/components/ui/__tests__/combobox-picker.smoke.test.tsx
@@ -82,4 +82,61 @@ describe("ComboboxPicker smoke", () => {
 
     expect(onChange).toHaveBeenCalledWith("alice");
   });
+
+  // Phase 7 — async/server-search mode (onSearchChange).
+  describe("async search mode", () => {
+    it("reports the search term and does NOT filter options itself", async () => {
+      const onSearchChange = vi.fn();
+      // In async mode the parent supplies already-filtered options, so BOTH are
+      // shown regardless of the typed term (no internal JS filter).
+      render(
+        <ComboboxPicker
+          value=""
+          onChange={() => {}}
+          options={OPTIONS}
+          onSearchChange={onSearchChange}
+          placeholder="Search"
+        />,
+      );
+      // Mount effect reports the initial (empty) term.
+      expect(onSearchChange).toHaveBeenCalledWith("");
+
+      fireEvent.click(screen.getByRole("button"));
+      const input = await waitFor(() => screen.getByPlaceholderText("Search..."));
+      fireEvent.change(input, { target: { value: "zzz" } });
+
+      expect(onSearchChange).toHaveBeenLastCalledWith("zzz");
+      // Both parent-supplied options remain visible (no client-side filtering).
+      expect(screen.getByText("Alice")).toBeTruthy();
+      expect(screen.getByText("Bob")).toBeTruthy();
+    });
+
+    it("shows the selectedLabel fallback when the value isn't in options", () => {
+      render(
+        <ComboboxPicker
+          value="missing-id"
+          onChange={() => {}}
+          options={[]}
+          onSearchChange={() => {}}
+          selectedLabel="Chosen Supplier"
+        />,
+      );
+      expect(screen.getByText("Chosen Supplier")).toBeTruthy();
+    });
+
+    it("shows a Searching… affordance while loading with no results", async () => {
+      render(
+        <ComboboxPicker
+          value=""
+          onChange={() => {}}
+          options={[]}
+          onSearchChange={() => {}}
+          loading
+          placeholder="Search"
+        />,
+      );
+      fireEvent.click(screen.getByRole("button"));
+      await waitFor(() => expect(screen.getByText("Searching…")).toBeTruthy());
+    });
+  });
 });

--- a/src/components/ui/combobox-picker.tsx
+++ b/src/components/ui/combobox-picker.tsx
@@ -41,6 +41,23 @@ interface ComboboxPickerProps {
   disabled?: boolean
   /** When true, allows typing a new value that doesn't exist in options */
   creatable?: boolean
+  /**
+   * Async/server-search mode. When provided, the picker STOPS filtering
+   * `options` itself and instead reports the search term here on every
+   * keystroke — the parent is expected to fetch already-filtered `options`
+   * (e.g. a Convex `withSearchIndex` query). Absent = the default in-memory
+   * JS filter (unchanged for every existing caller).
+   */
+  onSearchChange?: (query: string) => void
+  /** Show a "Searching…" affordance while async results are in flight. */
+  loading?: boolean
+  /**
+   * Fallback label for the selected `value` when it isn't present in the
+   * currently-loaded `options` (unavoidable in async mode — the selected row
+   * may not be in the latest search page). Keeps the trigger showing the
+   * chosen item's name instead of a blank/raw id.
+   */
+  selectedLabel?: string
 }
 
 const POPUP_CLASS =
@@ -62,12 +79,18 @@ function ComboboxPicker({
   className,
   disabled = false,
   creatable = false,
+  onSearchChange,
+  loading = false,
+  selectedLabel,
 }: ComboboxPickerProps) {
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState("")
   const searchInputRef = React.useRef<HTMLInputElement>(null)
 
+  // Async mode: parent supplies already-filtered options — never re-filter here
+  // (double-filtering would hide server hits the parent already narrowed).
   const filtered = React.useMemo(() => {
+    if (onSearchChange) return options
     if (!search) return options
     const lower = search.toLowerCase()
     return options.filter(
@@ -76,11 +99,20 @@ function ComboboxPicker({
         opt.value.toLowerCase().includes(lower) ||
         opt.description?.toLowerCase().includes(lower)
     )
-  }, [options, search])
+  }, [options, search, onSearchChange])
+
+  // Async mode: report the search term to the parent so it can refetch.
+  React.useEffect(() => {
+    if (onSearchChange) onSearchChange(search)
+  }, [search, onSearchChange])
 
   const selectedOption = options.find((opt) => opt.value === value)
-  // For creatable mode, show the raw value even if it's not in options
-  const displayLabel = selectedOption?.label || (creatable && value ? value : null)
+  // For creatable mode, show the raw value even if it's not in options. In async
+  // mode fall back to `selectedLabel` when the selected row isn't in this page.
+  const displayLabel =
+    selectedOption?.label ||
+    (value ? selectedLabel : null) ||
+    (creatable && value ? value : null)
   const showClear = allowClear && !!displayLabel
 
   function handleSelect(optionValue: string) {
@@ -182,7 +214,7 @@ function ComboboxPicker({
           <div className="max-h-60 overflow-y-auto scroll-py-1 p-1">
             {filtered.length === 0 ? (
               <div className="px-2 py-4 text-center text-sm text-fg-3">
-                {emptyMessage}
+                {loading ? "Searching…" : emptyMessage}
               </div>
             ) : (
               filtered.map((option) => (

--- a/src/hooks/use-debounced-value.ts
+++ b/src/hooks/use-debounced-value.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Debounce a rapidly-changing value (e.g. a search box) so downstream effects /
+ * queries only run after the value settles. Used to throttle native indexed
+ * search subscriptions (`api.search.*`) as the user types.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 200): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/src/hooks/use-suppliers.ts
+++ b/src/hooks/use-suppliers.ts
@@ -25,3 +25,18 @@ export function useSuppliers(orgId: string | undefined): SupplierDoc[] | undefin
 export function useSupplier(id: string | undefined): SupplierDoc | null | undefined {
   return useAuthedQuery(api.suppliers.getById, id ? { id } : "skip");
 }
+
+/**
+ * Phase 7 — reactive INDEXED supplier search (`api.search.suppliers`) instead of
+ * loading the whole org list to JS-filter. `query === ""` returns a bounded
+ * most-recent list. Pass `orgId: undefined` to skip.
+ */
+export function useSupplierSearch(
+  orgId: string | undefined,
+  query: string,
+): SupplierDoc[] | undefined {
+  return useAuthedQuery(
+    api.search.suppliers,
+    orgId ? { orgId, query } : "skip",
+  );
+}


### PR DESCRIPTION
## Phase 7 — native search

Replaces the "load the whole org table into the browser, JS-filter" pattern behind pickers with reactive, indexed Convex search.

### Backend
- **Search indexes** (`convex/schema.ts`): assets (assetTag + serialNumber), models/kits/clients/suppliers/projects (name).
- **`convex/search.ts`** — org-scoped (`requireOrgRead`, browser-callable), bounded, reactive `withSearchIndex` queries. Empty query → bounded most-recent list (never a whole-table `.collect()`). `assets` merges tag + serial (deduped); `projects` excludes templates in JS on the bounded result (isTemplate is optional → unreliable as a search filter field).
- 5 convex-tests: name match + org-scoping, tag-or-serial merge, template exclusion, limit clamp, cross-org deny.

### UI
- **`ComboboxPicker`** gains a **backward-compatible** async-search mode: `onSearchChange` (parent supplies already-filtered options; picker stops JS-filtering), `selectedLabel` (fallback when the selected row isn't in the current page), `loading`. Every existing caller (no `onSearchChange`) is unchanged. New `useDebouncedValue` helper. 3 new tests + a backward-compat assertion (7/7).
- **Representative cutover:** the sub-hire supplier picker now uses `useSupplierSearch` → `api.search.suppliers` (debounced 200ms); the selected supplier's label resolves via `useSupplier(getById)` so it's always shown.

### Follow-up (documented)
Remaining pickers/tables follow the same shape. Multi-field searches (e.g. the model picker's name + manufacturer) need a second index or a denormalized search field before cutover — noted in FEATUREDOCS/54.

Codex review: no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)