### PR TITLE
fix(convex-native): activate Phase 0 cache + ConvexError nits (review follow-up)

### DIFF
--- a/convex/collaboration.ts
+++ b/convex/collaboration.ts
@@ -433,7 +433,7 @@ export const addComment = mutation({
     // reopen first (which requires project manage_line_items). This keeps the
     // resolved state authoritative instead of silently reopening on any reply.
     if (thread.status === "resolved") {
-      throw new Error(
+      throw new ConvexError(
         "This discussion is resolved. Reopen it before replying.",
       );
     }

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -11,6 +11,7 @@
  *
  * Keep behaviour in lockstep with the source until the Prisma version is deleted.
  */
+import { ConvexError } from "convex/values";
 import { createId } from "@paralleldrive/cuid2";
 import type { MutationCtx } from "../_generated/server";
 import {
@@ -197,7 +198,7 @@ export async function returnLineUnits(
   const now = Date.now();
   const lineItem = await lineDocByCuid(ctx, args.lineItemId);
   if (!lineItem || lineItem.projectId !== args.projectId || lineItem.organizationId !== args.organizationId) {
-    throw new Error("line item not found for return");
+    throw new ConvexError("line item not found for return");
   }
   const units = await lineUnits(ctx, lineItem.id);
 

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -8,6 +8,42 @@ Tier E (auth into Convex) and the eventual Postgres DROP-TABLE decommission rema
 
 ---
 
+## ✅ Post-migration compliance review (2026-07-07)
+
+Two independent reviews (4 parallel audit agents + a Codex pass) verified all 7 phases
+are on `main`. Verdict: **present and substantially compliant**; Phases 4 & 5 clean
+(the Phase-5 "cardinal sin" — a native mutation relaxing the guard while bypassing
+invariants+audit — is **absent**; the only unaudited natives, `reorderNative`/
+`recalcNative`, are correctly unaudited at parity with their legacy paths). Everything
+ships behind default-OFF flags. **Fixed immediately** (PR: `fix/convex-native-review-nits`):
+the inert Phase-0 cache (`useAuthedQuery` now uses `convex-helpers/react/cache/hooks` so
+the mounted `ConvexQueryCacheProvider` actually caches), and two plain-`Error`-in-mutation
+convention violations (`collaboration.ts` addComment, `lib/fulfillment.ts` — the latter's
+`/not found/i` message would have been masked in prod, breaking the mirror tolerance).
+
+### Remaining compliance follow-ups (tracked, non-blocking — all behind OFF flags)
+1. **Dashboard counters not write-maintained (Phase 3, highest limit-risk).** `dashboardCounters.bump`
+   has zero production callers; freshness comes from `reconcileIfStale` → whole-org
+   `.collect()` over assets/bulkAssets/projects/crew/assignments (throttled ≤1/60s/org).
+   Fine at current tenant sizes; a 32k-doc/16MiB risk as tenants grow. Either wire `bump`
+   into the counted write paths (§3.6's stated requirement) or accept reconcile-on-view and
+   fix the now-inaccurate `schema.ts` "maintained by bump" comment. Decide before enabling
+   `NEXT_PUBLIC_NATIVE_DASHBOARD` for a large tenant.
+2. **Raw-doc browser/detail composites (Phase 1–2).** `projectEquipment.browserBundle`,
+   `equipmentTab.bundle`, `warehouseDetail`/`kitDetail`/`assetDetail` return raw Convex docs
+   (incl. `warehouseDetail` raw `units`) rather than allowlisted DTOs, with no field-absence
+   tests (§3.5). Mitigated today by equal-permission RBAC gating (a reader already gets these
+   via the server action), so not urgent — but a future sensitive column could leak silently.
+   Add field-absence tests or DTO allowlists.
+3. **Phase 7 mostly dead code.** 6 of 7 `convex/search.ts` queries have no `src/` consumer
+   (only the supplier picker is wired). Wire the remaining pickers (asset/model/kit/client/
+   project), or explicitly scope them out. Multi-field pickers need a 2nd index / denormalized
+   field first.
+4. **No `usePaginatedQuery` anywhere (§6).** Detail composites `.collect()` per-entity lists
+   (bounded, low practical risk); revisit if any single entity's line-item list can get large.
+
+---
+
 ## ▶ NEXT SESSION — START HERE (2026-07-07)
 
 **PHASES 6 + 7 ARE NOW CLOSED — the Convex-native migration is COMPLETE.** With Phases

--- a/src/hooks/use-authed-query.ts
+++ b/src/hooks/use-authed-query.ts
@@ -1,7 +1,12 @@
 "use client";
 
-import { useConvexAuth, useQuery } from "convex/react";
+import { useConvexAuth } from "convex/react";
 import type { OptionalRestArgsOrSkip } from "convex/react";
+// Phase 0: use the CACHE package's useQuery (keep-alive across navigation) rather
+// than convex/react's — `ConvexQueryCacheProvider` is mounted in convex-provider.tsx
+// but only these hooks read it, so the default hooks left this cache inert.
+// Signature is identical, so it stays a drop-in and auth-gating below is unchanged.
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import type { FunctionReference } from "convex/server";
 
 /**


### PR DESCRIPTION
Clear-cut fixes from the two-independent-review compliance audit of Phases 1–7 (4 audit agents + a Codex pass). All 7 phases verified present and substantially compliant; these are the unambiguous nits worth fixing now.

## Fixes
1. **Activate the Phase 0 query cache.** `ConvexQueryCacheProvider` is mounted, but `useAuthedQuery` (every native surface) imported `useQuery` from `convex/react` — the default hook the provider doesn't touch — so the keep-alive cache was **inert**. Now points at `convex-helpers/react/cache/hooks` (identical signature, auth-gating unchanged). This delivers the back-nav caching Phase 0 promised.
2. **`ConvexError` not plain `Error` in two mutation paths.** `collaboration.ts` addComment (resolved-thread guard) and `lib/fulfillment.ts` return helper. The fulfillment one matters: its `"...not found..."` message would be swallowed by the mirror `/not found/i` tolerance (matches ConvexError payloads only) and masked to `InternalServerError` in prod — the exact CLAUDE.md footgun.
3. **Doc:** records the audit verdict + tracked non-blocking follow-ups (dashboard counters not write-maintained, raw-doc composites without DTO allowlists/field-absence tests, Phase 7 dead search queries, no `usePaginatedQuery`).

## Not fixed here (tracked in the design doc)
The bigger items — wiring `dashboardCounters.bump` into write paths, DTO allowlists/field-absence tests, wiring the remaining 6 search pickers — are larger changes left as tracked follow-ups. All sit behind default-OFF flags, so nothing is live.

Verified the one review disagreement directly: Codex flagged `reorderNative`/`recalcNative` as a "critical" audit gap, but they're correctly unaudited at parity with their legacy paths (reorder/recalc were never audited) — not the Phase-5 cardinal sin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)