### PR TITLE
fix(test): repair useAuthedQuery test after Phase 0 cache swap

### DIFF
--- a/src/hooks/use-authed-query.test.tsx
+++ b/src/hooks/use-authed-query.test.tsx
@@ -2,12 +2,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 
-// Mock convex/react so we can observe exactly what `useQuery` is called with for
-// each auth state — that argument (real args vs the "skip" sentinel) IS the fix.
+// Mock so we can observe exactly what `useQuery` is called with for each auth
+// state — that argument (real args vs the "skip" sentinel) IS the fix. `useQuery`
+// now comes from the convex-helpers CACHE hooks (Phase 0 keep-alive); `useConvexAuth`
+// still comes from convex/react. Mock both modules accordingly.
 const useConvexAuth = vi.fn();
 const useQuery = vi.fn();
 vi.mock("convex/react", () => ({
   useConvexAuth: () => useConvexAuth() as { isLoading: boolean; isAuthenticated: boolean },
+}));
+vi.mock("convex-helpers/react/cache/hooks", () => ({
   useQuery: (...args: unknown[]) => useQuery(...args) as unknown,
 }));
 


### PR DESCRIPTION
Follow-up to #372. That PR moved `useAuthedQuery`'s `useQuery` to the convex-helpers cache hooks but the unit test only mocked `convex/react`, so the real cache hook ran and threw `Could not find ConvexQueryCacheContext` — the Tests job went red on main (no branch protection, so #372 merged anyway). This retargets the mock to `convex-helpers/react/cache/hooks`; the 4 assertions are unchanged and pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)