### PR TITLE
fix(convex): write-path-maintained dashboard counters (§3.6)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -154,6 +154,25 @@ stays in Prisma per Phase 6).
 > generated — they're added by hand per domain as Phases 3–4 cut each domain over
 > (report-style queries stay as server actions that call these + post-process).
 
+**Dashboard counter maintenance (§3.6).** Five tables — `assets`, `bulkAssets`,
+`projects`, `crewMembers`, `crewAssignments` — feed the denormalised
+`dashboardCounters` row (one per org: `activeAssets`, `checkedOutAssets`,
+`bulkQuantity`, `activeProjects`, `activeCrew`, `pendingCrewOffers`). For those
+tables the generator emits an in-transaction `bumpCountersForTable(ctx, "<table>",
+before, after)` call in `create` / `createIfMissing` / `update` / `remove`, so the
+counter row is kept correct **on the same write** — the native dashboard reads it
+O(1) and never scans the whole-org registry on view. The delta logic +
+per-entity contribution predicates live in
+[`convex/lib/counters.ts`](../convex/lib/counters.ts) (they must match
+`computeCounters` in `dashboardCounters.ts`). The **custom** (`patchAsset`,
+`bulkUpdate`, `patchProject`, `createWithUniqueNumber`, `patchMember`,
+`patchAssignment`, `createServiceAssignment`, `deleteCascade`), **native**
+(`convex/*Writes.ts`), and **warehouse-status** (`warehouseOps.ts setAssetsStatus`
++ the two direct checkout patches, `kits.ts releaseAsset`) write sites call the same
+helpers by hand. `dashboardCounters.reconcile` stays as the drift backstop (backfill
++ a throttled on-view recompute, ~1×/h/org). Re-add the generated bumps on a
+`pnpm convex:crud` regen (they're in the generator template + the CUSTOM markers).
+
 ## Phase 3 — Server-action integration (in progress: Clients + Suppliers + Locations + Models + Categories + Check-items + Test-profiles + Brand/Group-templates + Custom-fields + Section-presets done)
 
 > **Two cutover strategies have emerged.** **Hard cutover** (Clients): Convex is

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -60,6 +60,7 @@ import type * as kits from "../kits.js";
 import type * as lib_audit from "../lib/audit.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_bulkCheckin from "../lib/bulkCheckin.js";
+import type * as lib_counters from "../lib/counters.js";
 import type * as lib_fulfillment from "../lib/fulfillment.js";
 import type * as lib_inventory from "../lib/inventory.js";
 import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
@@ -184,6 +185,7 @@ declare const fullApi: ApiFromModules<{
   "lib/audit": typeof lib_audit;
   "lib/auth": typeof lib_auth;
   "lib/bulkCheckin": typeof lib_bulkCheckin;
+  "lib/counters": typeof lib_counters;
   "lib/fulfillment": typeof lib_fulfillment;
   "lib/inventory": typeof lib_inventory;
   "lib/lineItemUnits": typeof lib_lineItemUnits;

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import { bumpAssetCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -110,6 +111,7 @@ export const archiveNative = mutation({
     }
 
     await ctx.db.patch(asset._id, { isActive: false, status: "RETIRED", updatedAt: now });
+    await bumpAssetCounters(ctx, orgId, asset, { isActive: false, status: "RETIRED" });
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -196,6 +198,7 @@ export const deleteNative = mutation({
     }
 
     await ctx.db.delete(asset._id);
+    await bumpAssetCounters(ctx, orgId, asset, null);
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -310,6 +313,7 @@ export const createNative = mutation({
     }
 
     await ctx.db.insert("assets", fields);
+    await bumpAssetCounters(ctx, fields.organizationId, null, fields);
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -372,6 +376,7 @@ export const updateNative = mutation({
     // Apply set (+ clear-to-null) — the patchAsset pattern.
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, set);
+      await bumpAssetCounters(ctx, orgId, doc, { ...doc, ...set });
     } else {
       const { _id, _creationTime, ...rest } = doc;
       const merged: Record<string, unknown> = { ...rest, ...set };
@@ -380,6 +385,7 @@ export const updateNative = mutation({
         delete merged[k];
       }
       await ctx.db.replace(doc._id, merged as typeof rest);
+      await bumpAssetCounters(ctx, orgId, doc, merged);
     }
 
     const finalTag = set.assetTag ?? doc.assetTag;

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -11,6 +12,10 @@ import * as enums from "./lib/validators";
  * actions, which still own permission/validation/audit). Org-scoped reads
  * accept the service token OR a user token scoped to the same org. Lookups use the
  * cuid (`id`) via by_cuid. See FEATUREDOCS/54 and docs/designs/convex-phase5-auth-bridge.md.
+ *
+ * COUNTER MAINTENANCE (§3.6): the mutating funcs keep the dashboardCounters row in
+ * sync in-transaction via bumpCountersForTable (convex/lib/counters.ts). Emitted by
+ * the generator for the five counted tables — re-add on regen. See FEATUREDOCS/54.
  */
 
 export const list = query({
@@ -129,7 +134,9 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    return await ctx.db.insert("assets", args);
+    const _id = await ctx.db.insert("assets", args);
+    await bumpCountersForTable(ctx, "assets", null, args);
+    return _id;
   },
 });
 
@@ -187,6 +194,7 @@ export const createMany = mutation({
         .first();
       if (dup) throw new ConvexError({ code: "DUPLICATE_ASSET_TAG", tag: a.assetTag });
       await ctx.db.insert("assets", a);
+      await bumpCountersForTable(ctx, "assets", null, a);
       ids.push(a.id);
     }
     return { ids };
@@ -230,6 +238,7 @@ export const createIfMissing = mutation({
     const existing = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("assets", args);
+    await bumpCountersForTable(ctx, "assets", null, args);
     return { _id, created: true };
   },
 });
@@ -275,6 +284,7 @@ export const update = mutation({
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
+    await bumpCountersForTable(ctx, "assets", doc, { ...doc, ...safePatch });
     return doc._id;
   },
 });
@@ -286,6 +296,7 @@ export const remove = mutation({
     const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("assets not found: " + id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "assets", doc, null);
   },
 });
 
@@ -341,6 +352,7 @@ export const patchAsset = mutation({
     if (!doc) throw new ConvexError("assets not found: " + id);
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, set);
+      await bumpCountersForTable(ctx, "assets", doc, { ...doc, ...set });
       return doc._id;
     }
     const { _id, _creationTime, ...rest } = doc;
@@ -350,6 +362,7 @@ export const patchAsset = mutation({
       delete merged[k];
     }
     await ctx.db.replace(doc._id, merged as typeof rest);
+    await bumpCountersForTable(ctx, "assets", doc, merged);
     return doc._id;
   },
 });
@@ -376,6 +389,7 @@ export const bulkUpdate = mutation({
       if (!doc || doc.organizationId !== organizationId) continue;
       if (cl.length === 0) {
         await ctx.db.patch(doc._id, set);
+        await bumpCountersForTable(ctx, "assets", doc, { ...doc, ...set });
       } else {
         const { _id, _creationTime, ...rest } = doc;
         const merged: Record<string, unknown> = { ...rest, ...set };
@@ -384,6 +398,7 @@ export const bulkUpdate = mutation({
           delete merged[k];
         }
         await ctx.db.replace(doc._id, merged as typeof rest);
+        await bumpCountersForTable(ctx, "assets", doc, merged);
       }
       n++;
     }

--- a/convex/bulkAssets.ts
+++ b/convex/bulkAssets.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import { bumpCountersForTable } from "./lib/counters";
 import { adjustBulkAvailability } from "./lib/inventory";
 import * as enums from "./lib/validators";
 
@@ -111,7 +112,9 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    return await ctx.db.insert("bulkAssets", args);
+    const _id = await ctx.db.insert("bulkAssets", args);
+    await bumpCountersForTable(ctx, "bulkAssets", null, args);
+    return _id;
   },
 });
 
@@ -137,6 +140,7 @@ export const createIfMissing = mutation({
     const existing = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("bulkAssets", args);
+    await bumpCountersForTable(ctx, "bulkAssets", null, args);
     return { _id, created: true };
   },
 });
@@ -167,6 +171,7 @@ export const update = mutation({
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
+    await bumpCountersForTable(ctx, "bulkAssets", doc, { ...doc, ...safePatch });
     return doc._id;
   },
 });
@@ -178,6 +183,7 @@ export const remove = mutation({
     const doc = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("bulkAssets not found: " + id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "bulkAssets", doc, null);
   },
 });
 
@@ -216,6 +222,7 @@ export const patchBulkAsset = mutation({
     if (!doc) throw new ConvexError("bulkAssets not found: " + id);
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, set);
+      await bumpCountersForTable(ctx, "bulkAssets", doc, { ...doc, ...set });
       return doc._id;
     }
     const { _id, _creationTime, ...rest } = doc;
@@ -225,6 +232,7 @@ export const patchBulkAsset = mutation({
       delete merged[k];
     }
     await ctx.db.replace(doc._id, merged as typeof rest);
+    await bumpCountersForTable(ctx, "bulkAssets", doc, merged);
     return doc._id;
   },
 });

--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -111,7 +112,9 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    return await ctx.db.insert("crewAssignments", args);
+    const _id = await ctx.db.insert("crewAssignments", args);
+    await bumpCountersForTable(ctx, "crewAssignments", null, args);
+    return _id;
   },
 });
 
@@ -150,6 +153,7 @@ export const createIfMissing = mutation({
     const existing = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("crewAssignments", args);
+    await bumpCountersForTable(ctx, "crewAssignments", null, args);
     return { _id, created: true };
   },
 });
@@ -193,6 +197,7 @@ export const update = mutation({
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
+    await bumpCountersForTable(ctx, "crewAssignments", doc, { ...doc, ...safePatch });
     return doc._id;
   },
 });
@@ -204,6 +209,7 @@ export const remove = mutation({
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("crewAssignments not found: " + id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "crewAssignments", doc, null);
   },
 });
 
@@ -255,6 +261,7 @@ export const patchAssignment = mutation({
     const patch: Record<string, unknown> = { ...set };
     for (const k of clear ?? []) patch[k] = undefined;
     await ctx.db.patch(doc._id, patch);
+    await bumpCountersForTable(ctx, "crewAssignments", doc, { ...doc, ...patch });
     return doc._id;
   },
 });
@@ -272,6 +279,7 @@ export const deleteCascade = mutation({
     const entries = await ctx.db.query("crewTimeEntries").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect();
     for (const e of entries) await ctx.db.delete(e._id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "crewAssignments", doc, null);
   },
 });
 
@@ -314,6 +322,7 @@ export const createServiceAssignment = mutation({
       .first();
     if (dupe) return { created: false, id: dupe.id };
     await ctx.db.insert("crewAssignments", args);
+    await bumpCountersForTable(ctx, "crewAssignments", null, args);
     return { created: true, id: args.id };
   },
 });

--- a/convex/crewMembers.ts
+++ b/convex/crewMembers.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService, getAuthContext, redactFields } from "./lib/auth";
+import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -93,7 +94,9 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    return await ctx.db.insert("crewMembers", args);
+    const _id = await ctx.db.insert("crewMembers", args);
+    await bumpCountersForTable(ctx, "crewMembers", null, args);
+    return _id;
   },
 });
 
@@ -136,6 +139,7 @@ export const createIfMissing = mutation({
     const existing = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("crewMembers", args);
+    await bumpCountersForTable(ctx, "crewMembers", null, args);
     return { _id, created: true };
   },
 });
@@ -183,6 +187,7 @@ export const update = mutation({
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
+    await bumpCountersForTable(ctx, "crewMembers", doc, { ...doc, ...safePatch });
     return doc._id;
   },
 });
@@ -194,6 +199,7 @@ export const remove = mutation({
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("crewMembers not found: " + id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "crewMembers", doc, null);
   },
 });
 
@@ -216,6 +222,7 @@ export const patchMember = mutation({
     delete patch.id;
     for (const f of clear ?? []) patch[f] = undefined;
     await ctx.db.patch(doc._id, patch);
+    await bumpCountersForTable(ctx, "crewMembers", doc, { ...doc, ...patch });
     return doc._id;
   },
 });

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import { bumpCrewMemberCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -64,6 +65,7 @@ export const createNative = mutation({
       .first();
     if (!existing) {
       await ctx.db.insert("crewMembers", fields);
+      await bumpCrewMemberCounters(ctx, fields.organizationId, null, fields);
     }
 
     await writeActivityLog(ctx, {
@@ -107,6 +109,7 @@ export const updateNative = mutation({
     const NEVER_CLEAR = new Set(["id", "organizationId"]);
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, set as Record<string, unknown>);
+      await bumpCrewMemberCounters(ctx, orgId, doc, { ...doc, ...(set as Record<string, unknown>) });
     } else {
       const { _id, _creationTime, ...rest } = doc;
       const merged: Record<string, unknown> = { ...rest, ...(set as Record<string, unknown>) };
@@ -115,6 +118,7 @@ export const updateNative = mutation({
         delete merged[k];
       }
       await ctx.db.replace(doc._id, merged as typeof rest);
+      await bumpCrewMemberCounters(ctx, orgId, doc, merged);
     }
 
     await writeActivityLog(ctx, {
@@ -157,6 +161,7 @@ export const deleteNative = mutation({
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
     await ctx.db.delete(doc._id);
+    await bumpCrewMemberCounters(ctx, orgId, doc, null);
 
     await writeActivityLog(ctx, {
       id: auditId,

--- a/convex/dashboardCounters.test.ts
+++ b/convex/dashboardCounters.test.ts
@@ -133,4 +133,69 @@ describe("dashboardCounters", () => {
       t.withIdentity(asUser("other")).query(api.dashboardStats.bundle, { orgId: ORG, now: NOW }),
     ).rejects.toThrow();
   });
+
+  // §3.6: the per-write in-transaction deltas (convex/lib/counters.ts, wired into
+  // the generated + custom mutations) must keep the counter row EQUAL to the
+  // authoritative reconcile recompute after an arbitrary sequence of writes.
+  test("counters stay equal to the reconcile recompute after a write sequence", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const svc = t.withIdentity(SERVICE);
+    // Backfill so the row exists — per-write deltas require it (an absent row is
+    // left for reconcile to seed accurately; see the next test).
+    await svc.mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
+
+    // ── Assets ──
+    await svc.mutation(api.assets.create, { id: "a5", organizationId: ORG, modelId: "m1", assetTag: "a5", status: "CHECKED_OUT", isActive: true }); // +active +checkedOut
+    await svc.mutation(api.assets.patchAsset, { id: "a1", set: { status: "CHECKED_OUT" }, clear: [] }); // AVAILABLE→CHECKED_OUT: +checkedOut
+    await svc.mutation(api.assets.patchAsset, { id: "a2", set: { isActive: false }, clear: [] }); // active checked-out → inactive: -active -checkedOut
+    await svc.mutation(api.assets.remove, { id: "a5" }); // -active -checkedOut
+
+    // ── Bulk ──
+    await svc.mutation(api.bulkAssets.create, { id: "b4", organizationId: ORG, modelId: "m1", assetTag: "b4", totalQuantity: 20, isActive: true }); // +20
+    await svc.mutation(api.bulkAssets.patchBulkAsset, { id: "b1", set: { totalQuantity: 7 }, clear: [] }); // 10→7: -3
+    await svc.mutation(api.bulkAssets.patchBulkAsset, { id: "b2", set: { isActive: false }, clear: [] }); // active 5 → inactive: -5
+
+    // ── Projects ──
+    await svc.mutation(api.projects.createWithUniqueNumber, { id: "p5", organizationId: ORG, projectNumber: "P5", name: "P5", status: "PREPPING", isTemplate: false }); // +active
+    await svc.mutation(api.projects.patchProject, { id: "p1", set: { status: "QUOTED" }, clear: [] }); // CONFIRMED→QUOTED: -active
+    await svc.mutation(api.projects.remove, { id: "pov" }); // active CHECKED_OUT: -active
+
+    // ── Crew ──
+    await svc.mutation(api.crewMembers.create, { id: "c4", organizationId: ORG, firstName: "c4", lastName: "X", status: "ACTIVE" }); // +active
+    await svc.mutation(api.crewMembers.patchMember, { id: "c1", set: { status: "INACTIVE" } }); // -active
+
+    // ── Assignments ──
+    await svc.mutation(api.crewAssignments.create, { id: "ca4", organizationId: ORG, projectId: "p2", crewMemberId: "c2", status: "OFFERED" }); // +pending
+    await svc.mutation(api.crewAssignments.patchAssignment, { id: "ca1", set: { status: "ACCEPTED" } }); // OFFERED→ACCEPTED: -pending
+    await svc.mutation(api.crewAssignments.deleteCascade, { id: "ca2" }); // PENDING: -pending
+
+    // Row as maintained by the per-write deltas.
+    const maintained = await t.withIdentity(asUser(ORG)).query(api.dashboardCounters.getByOrg, { orgId: ORG });
+    // Authoritative recompute from source — must match the maintained values exactly.
+    const recomputed = await svc.mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW + 1 });
+
+    expect({
+      activeAssets: maintained?.activeAssets,
+      checkedOutAssets: maintained?.checkedOutAssets,
+      bulkQuantity: maintained?.bulkQuantity,
+      activeProjects: maintained?.activeProjects,
+      activeCrew: maintained?.activeCrew,
+      pendingCrewOffers: maintained?.pendingCrewOffers,
+    }).toEqual(recomputed);
+  });
+
+  test("a per-write delta against a not-yet-backfilled org is skipped (reconcile seeds it)", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const svc = t.withIdentity(SERVICE);
+    // No reconcile yet → row absent. A counted write must NOT create a partial row
+    // (a delta can't reconstruct the pre-existing population).
+    await svc.mutation(api.assets.create, { id: "a9", organizationId: ORG, modelId: "m1", assetTag: "a9", status: "AVAILABLE", isActive: true });
+    const before = await t.withIdentity(asUser(ORG)).query(api.dashboardCounters.getByOrg, { orgId: ORG });
+    expect(before).toBeNull();
+    // First reconcile creates it accurately (includes a9 → a1, a2, a9 active).
+    const values = await svc.mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
+    expect(values.activeAssets).toBe(3);
+  });
 });

--- a/convex/dashboardCounters.ts
+++ b/convex/dashboardCounters.ts
@@ -9,10 +9,16 @@ import { requireService, requireOrgRead } from "./lib/auth";
  * + JS counting — so the native dashboard reads them O(1) instead of scanning the
  * asset registry / line-item table (the top Convex-limit risk in the migration).
  *
- * Maintenance: `reconcile` recomputes all six from source (backfill + drift
- * correction); `bump` adjusts a single field incrementally from the write paths
- * (asset/bulk/project/crew create/delete/status-change). The date-derived metrics
- * (maintenanceDue, overdueReturns) are NOT stored — `dashboardStats.bundle`
+ * Maintenance (§3.6): the six counters are kept fresh IN-TRANSACTION on every
+ * counted write by `convex/lib/counters.ts` (`bumpCountersForTable` for the
+ * generated CRUD + per-entity `bump*Counters` for the custom / native / warehouseOps
+ * sites) — a signed delta applied in the same mutation as the data change, so the
+ * native dashboard never has to scan the whole-org registry on view. `reconcile`
+ * recomputes all six from source (backfill + a PERIODIC DRIFT BACKSTOP, no longer
+ * the primary freshness mechanism — the client now throttles `reconcileIfStale` to a
+ * long window). `bump` (this file) is the legacy single-field public entry point,
+ * retained for the reconcile parity test + any future service hook. The date-derived
+ * metrics (maintenanceDue, overdueReturns) are NOT stored — `dashboardStats.bundle`
  * computes them at read from bounded indexed queries.
  */
 
@@ -89,12 +95,15 @@ export const reconcile = mutation({
 });
 
 /**
- * Throttled reconcile triggered by the native dashboard on view: recompute only
- * when the row is missing or older than `maxAgeMs`. This keeps counters fresh
- * without per-write-site bumps or a global cron — and because it's throttled, a
- * fresh row makes it a cheap no-op (no whole-org scan). Gated on requireOrgRead so
- * an org member can only refresh their own org's counters. `now` is passed (Convex
- * mutations can't read the clock).
+ * DRIFT BACKSTOP — throttled reconcile triggered by the native dashboard on view:
+ * recompute only when the row is missing or its last reconcile (`updatedAt`) is
+ * older than `maxAgeMs`. Counters are now primarily maintained per-write
+ * (convex/lib/counters.ts); this catches any residual drift (a missed write site, a
+ * clamp) and creates the row for a brand-new org on first view. Because it's
+ * throttled to a long window (client passes ~1h) a populated row is a cheap no-op —
+ * no whole-org scan on the hot path. Gated on requireOrgRead so an org member can
+ * only refresh their own org's counters. `now` is passed (Convex mutations can't
+ * read the clock).
  */
 export const reconcileIfStale = mutation({
   args: { orgId: v.string(), now: v.number(), maxAgeMs: v.number() },

--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -3,6 +3,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { query, mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import { bumpAssetCounters } from "./lib/counters";
 import { adjustBulkAvailability } from "./lib/inventory";
 import * as enums from "./lib/validators";
 
@@ -227,6 +228,8 @@ async function releaseAsset(ctx: MutationCtx, assetId: string, now: number) {
   if (!asset) return;
   const { _id, _creationTime, kitId: _k, ...rest } = asset;
   await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: now });
+  // §3.6 dashboard counter: releasing a checked-out kit asset back to AVAILABLE.
+  await bumpAssetCounters(ctx, asset.organizationId, asset, { isActive: asset.isActive, status: "AVAILABLE" });
 }
 
 async function getAssetDoc(ctx: MutationCtx, id: string) {

--- a/convex/lib/counters.ts
+++ b/convex/lib/counters.ts
@@ -1,0 +1,151 @@
+import type { MutationCtx } from "../_generated/server";
+
+/**
+ * Write-path maintenance for the six denormalised dashboard counters
+ * (convex/dashboardCounters.ts). §3.6 of the Convex-native design requires the
+ * counts to be updated in the SAME transaction as the write that changes them, so
+ * the native dashboard never has to scan the whole-org asset / project / crew
+ * registry on view (the migration's top Convex doc/size-limit risk as tenants grow).
+ *
+ * Each counted write site computes its row's counter CONTRIBUTION before and after
+ * the change and applies the difference here. The predicates below MUST stay
+ * identical to `computeCounters` in dashboardCounters.ts — parity by construction:
+ * the reconcile backstop re-derives from the same predicates, so a per-write miss
+ * self-heals on the next reconcile rather than drifting forever.
+ * `reconcile` / `reconcileIfStale` remain as a periodic drift backstop; they are no
+ * longer the PRIMARY freshness mechanism (the client now throttles reconcile to a
+ * long window — see src/hooks/use-native-dashboard.ts).
+ *
+ * The counter row is created + seeded ONLY by reconcile / backfill (an accurate
+ * full recompute). A delta against a MISSING row is skipped: a delta can't
+ * reconstruct the pre-existing population, so we let the next reconcile create it
+ * correctly. In prod the backfill (`pnpm convex:backfill:dashboard-counters`) runs
+ * before NEXT_PUBLIC_NATIVE_DASHBOARD is flipped, so the row exists; a brand-new
+ * org's row is created on its first dashboard view (reconcileIfStale).
+ */
+
+const ACTIVE_PROJECT_STATUSES = new Set(["CONFIRMED", "PREPPING", "CHECKED_OUT", "ON_SITE"]);
+const PENDING_OFFER_STATUSES = new Set(["OFFERED", "PENDING"]);
+
+type CounterField =
+  | "activeAssets"
+  | "checkedOutAssets"
+  | "bulkQuantity"
+  | "activeProjects"
+  | "activeCrew"
+  | "pendingCrewOffers";
+
+type Delta = Partial<Record<CounterField, number>>;
+
+/**
+ * Apply a signed delta to an org's counter row, clamped at 0 (a double-decrement
+ * can't go negative). No-op when every field is 0, and when the row doesn't exist
+ * yet (see the file header). Does NOT touch `updatedAt` — that field tracks the
+ * last reconcile, which is what `reconcileIfStale` gates its drift-backstop on.
+ */
+async function applyDelta(ctx: MutationCtx, orgId: string, delta: Delta): Promise<void> {
+  let changed = false;
+  for (const key in delta) {
+    if (delta[key as CounterField]) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) return;
+
+  const row = await ctx.db
+    .query("dashboardCounters")
+    .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+    .first();
+  if (!row) return; // not yet backfilled — reconcile will create it accurately
+
+  const patch: Record<string, number> = {};
+  for (const key in delta) {
+    const d = delta[key as CounterField];
+    if (!d) continue;
+    const cur = (row as unknown as Record<string, number>)[key] ?? 0;
+    patch[key] = Math.max(0, cur + d);
+  }
+  await ctx.db.patch(row._id, patch);
+}
+
+// ── Per-entity counter contribution (MUST match computeCounters predicates) ──
+
+type AssetLike = { isActive?: boolean; status?: string } | null | undefined;
+const assetActive = (a: AssetLike) => (a && a.isActive !== false ? 1 : 0);
+const assetCheckedOut = (a: AssetLike) => (a && a.isActive !== false && a.status === "CHECKED_OUT" ? 1 : 0);
+
+type BulkLike = { isActive?: boolean; totalQuantity?: number } | null | undefined;
+const bulkQty = (b: BulkLike) => (b && b.isActive !== false ? b.totalQuantity ?? 0 : 0);
+
+type ProjectLike = { isTemplate?: boolean; status?: string } | null | undefined;
+const projectActive = (p: ProjectLike) =>
+  p && p.isTemplate !== true && ACTIVE_PROJECT_STATUSES.has(p.status ?? "") ? 1 : 0;
+
+type CrewLike = { status?: string } | null | undefined;
+const crewActive = (m: CrewLike) => (m && m.status === "ACTIVE" ? 1 : 0);
+
+type AssignLike = { status?: string | null } | null | undefined;
+const offerPending = (a: AssignLike) => (a && a.status != null && PENDING_OFFER_STATUSES.has(a.status) ? 1 : 0);
+
+// ── Typed bump helpers: pass the row BEFORE and AFTER the write (null = absent) ──
+// Used by the hand-maintained CUSTOM + native (`*Writes.ts`) + warehouseOps sites,
+// which already have the org id in scope.
+
+export async function bumpAssetCounters(ctx: MutationCtx, orgId: string, before: AssetLike, after: AssetLike) {
+  await applyDelta(ctx, orgId, {
+    activeAssets: assetActive(after) - assetActive(before),
+    checkedOutAssets: assetCheckedOut(after) - assetCheckedOut(before),
+  });
+}
+
+export async function bumpBulkCounters(ctx: MutationCtx, orgId: string, before: BulkLike, after: BulkLike) {
+  await applyDelta(ctx, orgId, { bulkQuantity: bulkQty(after) - bulkQty(before) });
+}
+
+export async function bumpProjectCounters(ctx: MutationCtx, orgId: string, before: ProjectLike, after: ProjectLike) {
+  await applyDelta(ctx, orgId, { activeProjects: projectActive(after) - projectActive(before) });
+}
+
+export async function bumpCrewMemberCounters(ctx: MutationCtx, orgId: string, before: CrewLike, after: CrewLike) {
+  await applyDelta(ctx, orgId, { activeCrew: crewActive(after) - crewActive(before) });
+}
+
+export async function bumpCrewAssignmentCounters(
+  ctx: MutationCtx,
+  orgId: string,
+  before: AssignLike,
+  after: AssignLike,
+) {
+  await applyDelta(ctx, orgId, { pendingCrewOffers: offerPending(after) - offerPending(before) });
+}
+
+// ── Generic dispatch for the GENERATED thin-CRUD mutations ──
+// scripts/generate-convex-crud.cjs emits one uniform call per counted-table write
+// (create / createIfMissing / update / remove). `before`/`after` are the row state
+// around the write (null = row absent: insert has before:null, delete after:null);
+// the org id is derived from whichever side is present (organizationId is immutable).
+
+export type CountedTable = "assets" | "bulkAssets" | "projects" | "crewMembers" | "crewAssignments";
+
+export async function bumpCountersForTable(
+  ctx: MutationCtx,
+  table: CountedTable,
+  before: Record<string, unknown> | null | undefined,
+  after: Record<string, unknown> | null | undefined,
+): Promise<void> {
+  const orgId = (after?.organizationId ?? before?.organizationId) as string | undefined;
+  if (!orgId) return;
+  switch (table) {
+    case "assets":
+      return bumpAssetCounters(ctx, orgId, before as AssetLike, after as AssetLike);
+    case "bulkAssets":
+      return bumpBulkCounters(ctx, orgId, before as BulkLike, after as BulkLike);
+    case "projects":
+      return bumpProjectCounters(ctx, orgId, before as ProjectLike, after as ProjectLike);
+    case "crewMembers":
+      return bumpCrewMemberCounters(ctx, orgId, before as CrewLike, after as CrewLike);
+    case "crewAssignments":
+      return bumpCrewAssignmentCounters(ctx, orgId, before as AssignLike, after as AssignLike);
+  }
+}

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -21,6 +21,7 @@ import {
   nextOrdinal,
   type UnitLike,
 } from "./lineItemUnits";
+import { bumpAssetCounters } from "./counters";
 
 type Ctx = MutationCtx;
 
@@ -172,6 +173,9 @@ async function setAssetStatus(ctx: Ctx, assetId: string, status: string, locatio
   } else {
     await ctx.db.patch(a._id, { status: status as typeof a.status, locationId, updatedAt: Date.now() });
   }
+  // §3.6 dashboard counter: check-in / return status churn (CHECKED_OUT→AVAILABLE
+  // etc.) flows through here, not warehouseOps.setAssetsStatus. isActive untouched.
+  await bumpAssetCounters(ctx, a.organizationId, a, { isActive: a.isActive, status });
 }
 
 /**

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
+import { bumpProjectCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
 import { projectWriteFields } from "./projects";
 
@@ -44,6 +45,7 @@ export const updateStatusNative = mutation({
 
     const from = project.status ?? "";
     await ctx.db.patch(project._id, { status, updatedAt: now });
+    await bumpProjectCounters(ctx, orgId, project, { ...project, status });
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -118,6 +120,7 @@ export const archiveNative = mutation({
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
     await ctx.db.patch(project._id, { status: "CANCELLED", updatedAt: now });
+    await bumpProjectCounters(ctx, orgId, project, { ...project, status: "CANCELLED" });
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -166,6 +169,7 @@ export const updateNative = mutation({
     const setObj = (set ?? {}) as Record<string, unknown>;
     if (clear.length === 0) {
       await ctx.db.patch(project._id, setObj);
+      await bumpProjectCounters(ctx, orgId, project, { ...project, ...setObj });
     } else {
       const { _id, _creationTime, ...rest } = project;
       const merged: Record<string, unknown> = { ...rest, ...setObj };
@@ -174,6 +178,7 @@ export const updateNative = mutation({
         delete merged[k];
       }
       await ctx.db.replace(project._id, merged as typeof rest);
+      await bumpProjectCounters(ctx, orgId, project, merged);
     }
 
     const name = (typeof setObj.name === "string" ? setObj.name : undefined) ?? project.name;
@@ -225,6 +230,7 @@ export const createNative = mutation({
     if (clash) return { created: false as const, id: clash.id };
 
     await ctx.db.insert("projects", fields);
+    await bumpProjectCounters(ctx, fields.organizationId, null, fields);
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -268,6 +274,7 @@ export const deleteNative = mutation({
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
     await ctx.db.delete(project._id);
+    await bumpProjectCounters(ctx, orgId, project, null);
 
     await writeActivityLog(ctx, {
       id: auditId,

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -103,7 +104,9 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    return await ctx.db.insert("projects", args);
+    const _id = await ctx.db.insert("projects", args);
+    await bumpCountersForTable(ctx, "projects", null, args);
+    return _id;
   },
 });
 
@@ -161,6 +164,7 @@ export const createIfMissing = mutation({
     const existing = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("projects", args);
+    await bumpCountersForTable(ctx, "projects", null, args);
     return { _id, created: true };
   },
 });
@@ -223,6 +227,7 @@ export const update = mutation({
     const safePatch = { ...patch };
     delete safePatch.organizationId;
     await ctx.db.patch(doc._id, safePatch);
+    await bumpCountersForTable(ctx, "projects", doc, { ...doc, ...safePatch });
     return doc._id;
   },
 });
@@ -234,6 +239,7 @@ export const remove = mutation({
     const doc = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("projects not found: " + id);
     await ctx.db.delete(doc._id);
+    await bumpCountersForTable(ctx, "projects", doc, null);
   },
 });
 
@@ -322,6 +328,7 @@ export const createWithUniqueNumber = mutation({
       .unique();
     if (clash) return { created: false, id: clash.id };
     await ctx.db.insert("projects", args);
+    await bumpCountersForTable(ctx, "projects", null, args);
     return { created: true, id: args.id };
   },
 });
@@ -344,6 +351,7 @@ export const patchProject = mutation({
     const patch: Record<string, unknown> = { ...set };
     for (const k of clear ?? []) patch[k] = undefined;
     await ctx.db.patch(doc._id, patch);
+    await bumpCountersForTable(ctx, "projects", doc, { ...doc, ...patch });
     return doc._id;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2144,11 +2144,14 @@ export default defineSchema({
   // Denormalised dashboard stat counters (Phase 3). One row per org holding the
   // counts getDashboardStats used to derive by whole-org `.collect()` + JS count
   // — read O(1) by the native dashboard instead of scanning the asset registry /
-  // line-item table. Maintained incrementally by `dashboardCounters.bump` from the
-  // write paths + authoritatively recomputed by `dashboardCounters.reconcile`
-  // (backfill + drift correction). Date-derived metrics (maintenanceDue,
-  // overdueReturns) are NOT stored here — they're computed at read from bounded
-  // indexed queries (nothing writes at the moment a date passes).
+  // line-item table. Maintained IN-TRANSACTION on every counted write via
+  // `bumpCountersForTable` / `bump*Counters` (convex/lib/counters.ts), wired into the
+  // generated + custom + native (`*Writes.ts`) mutations and the warehouseOps status
+  // choke point (§3.6). `dashboardCounters.reconcile` recomputes authoritatively
+  // (backfill + periodic drift backstop; `updatedAt` = last reconcile).
+  // Date-derived metrics (maintenanceDue, overdueReturns) are NOT stored here —
+  // they're computed at read from bounded indexed queries (nothing writes at the
+  // moment a date passes).
   dashboardCounters: defineTable({
     organizationId: v.string(),
     activeAssets: v.number(),

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -3,6 +3,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireService } from "./lib/auth";
+import { bumpAssetCounters } from "./lib/counters";
 import { assertTestTagAllowsCheckout } from "./lib/testtag";
 import { adjustBulkAvailability, coalesceAdjustments, type BulkAdjustment } from "./lib/inventory";
 import { type CheckInItem, type CheckInItemType, itemGroupKey, distributeReturn } from "./lib/bulkCheckin";
@@ -69,6 +70,7 @@ async function checkOutSerializedItem(
     await ctx.db.patch(unit._id, { status: "CHECKED_OUT", checkedOutAt: p.now, checkedOutById: p.userId, updatedAt: p.now });
   }
   await ctx.db.patch(asset._id, { status: "CHECKED_OUT", ...(p.projectLocationId ? { locationId: p.projectLocationId } : {}), updatedAt: p.now });
+  await bumpAssetCounters(ctx, asset.organizationId, asset, { isActive: asset.isActive, status: "CHECKED_OUT" });
   await scanLog(ctx, { organizationId: p.organizationId, assetId: p.targetAssetId, projectId: p.projectId, action: "CHECK_OUT", scannedById: p.userId, scannedAt: p.now, notes: p.notes ?? undefined });
   return "done";
 }
@@ -144,7 +146,10 @@ async function checkoutAccessoryChildren(
     await ctx.db.patch(u._id, { status: "CHECKED_OUT", checkedOutAt: p.now, checkedOutById: p.userId, updatedAt: p.now });
     if (u.assetId) {
       const asset = await assetByCuid(ctx, u.assetId);
-      if (asset) await ctx.db.patch(asset._id, { status: "CHECKED_OUT", ...(p.projectLocationId ? { locationId: p.projectLocationId } : {}), updatedAt: p.now });
+      if (asset) {
+        await ctx.db.patch(asset._id, { status: "CHECKED_OUT", ...(p.projectLocationId ? { locationId: p.projectLocationId } : {}), updatedAt: p.now });
+        await bumpAssetCounters(ctx, asset.organizationId, asset, { isActive: asset.isActive, status: "CHECKED_OUT" });
+      }
       assetsTouched.push(u.assetId);
       await scanLog(ctx, { organizationId: p.organizationId, assetId: u.assetId, projectId: p.projectId, action: "CHECK_OUT", scannedById: p.userId, scannedAt: p.now, notes: "Accessory — moved with parent" });
     } else if (u.bulkAssetId) {
@@ -346,6 +351,9 @@ async function setAssetsStatus(ctx: Ctx, assetIds: string[], status: string, loc
     } else {
       await ctx.db.patch(a._id, { status: status as typeof a.status, updatedAt: now });
     }
+    // §3.6 dashboard counter: this is the choke point for warehouse status churn
+    // (nearly every check-out/-in/force-return funnels here). isActive is untouched.
+    await bumpAssetCounters(ctx, a.organizationId, a, { isActive: a.isActive, status });
   }
 }
 

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -22,13 +22,21 @@ convention violations (`collaboration.ts` addComment, `lib/fulfillment.ts` — t
 `/not found/i` message would have been masked in prod, breaking the mirror tolerance).
 
 ### Remaining compliance follow-ups (tracked, non-blocking — all behind OFF flags)
-1. **Dashboard counters not write-maintained (Phase 3, highest limit-risk).** `dashboardCounters.bump`
-   has zero production callers; freshness comes from `reconcileIfStale` → whole-org
-   `.collect()` over assets/bulkAssets/projects/crew/assignments (throttled ≤1/60s/org).
-   Fine at current tenant sizes; a 32k-doc/16MiB risk as tenants grow. Either wire `bump`
-   into the counted write paths (§3.6's stated requirement) or accept reconcile-on-view and
-   fix the now-inaccurate `schema.ts` "maintained by bump" comment. Decide before enabling
-   `NEXT_PUBLIC_NATIVE_DASHBOARD` for a large tenant.
+1. ~~**Dashboard counters not write-maintained (Phase 3, highest limit-risk).**~~ **✅ DONE
+   (2026-07-07, PR `fix/convex-dashboard-counters-writepath`).** The six counters are now
+   maintained IN-TRANSACTION on every counted write via `convex/lib/counters.ts`
+   (`bumpCountersForTable` generic dispatch wired into the generated CRUD create/
+   createIfMissing/update/remove for the 5 counted tables + emitted by
+   `generate-convex-crud.cjs` for regen-safety; per-entity `bump*Counters` hand-wired into
+   the CUSTOM mutations, the native `*Writes.ts`, `warehouseOps.ts setAssetsStatus` [the
+   single status choke point covering ~25 call sites] + its 2 direct checkout patches, and
+   `kits.ts releaseAsset`). Predicates match `computeCounters` (parity by construction). A
+   delta against a not-yet-backfilled org is skipped (reconcile seeds it accurately).
+   `reconcile`/`reconcileIfStale` kept as a drift backstop, now throttled to ~1×/h/org (was
+   ≤1/60s) so the whole-org `.collect()` is off the hot path. `schema.ts` comment fixed.
+   convex-test proves the maintained row equals the reconcile recompute after a mixed write
+   sequence (`dashboardCounters.test.ts`). Every dimension is per-write maintained — none
+   left on reconcile-primary.
 2. **Raw-doc browser/detail composites (Phase 1–2).** `projectEquipment.browserBundle`,
    `equipmentTab.bundle`, `warehouseDetail`/`kitDetail`/`assetDetail` return raw Convex docs
    (incl. `warehouseDetail` raw `units`) rather than allowlisted DTOs, with no field-absence

--- a/scripts/generate-convex-crud.cjs
+++ b/scripts/generate-convex-crud.cjs
@@ -65,6 +65,14 @@ const BROWSER_READABLE = new Set([
   "supplierOrders", "warehouseCloses", "savedReports", "savedTableViews",
 ]);
 
+// Tables whose rows feed a denormalised dashboard counter (convex/dashboardCounters.ts,
+// §3.6). Their mutating funcs keep the counter row in sync IN-TRANSACTION via
+// bumpCountersForTable (convex/lib/counters.ts) — a per-write delta so the native
+// dashboard never scans the whole-org registry on view. `reconcile` stays as the
+// drift backstop. The dispatch is generic (keyed by table); the contribution
+// predicates live in counters.ts and must match computeCounters.
+const COUNTED = new Set(["assets", "bulkAssets", "projects", "crewMembers", "crewAssignments"]);
+
 // Browser-readable tables that also get a per-project list (they carry a
 // projectId and the UI subscribes by project, not whole-org). Emits
 // `listByProject({ projectId, orgId })` guarded by requireOrgRead.
@@ -149,9 +157,14 @@ for (const mdl of models) {
     ? `import { requireOrgRead, requireOrgReadDoc, requireService${redactedFields ? ", getAuthContext, redactFields" : ""} } from "./lib/auth";\n`
     : `import { requireService } from "./lib/auth";\n`;
 
+  // Counter-maintained tables (§3.6) import the in-transaction dispatch helper.
+  const counted = COUNTED.has(key);
+  const bump = (before, after) => (counted ? `\n    await bumpCountersForTable(ctx, "${key}", ${before}, ${after});` : "");
+
   let out = `import { v } from "convex/values";\n`;
   out += `import { query, mutation } from "./_generated/server";\n`;
   out += authImports;
+  if (counted) out += `import { bumpCountersForTable } from "./lib/counters";\n`;
   if (usesEnums) out += `import * as enums from "./lib/validators";\n`;
   out += `\n`;
   out += `/**\n * Thin CRUD for ${mdl.name} (Convex table "${key}"). GENERATED — Phase 2/5.\n *\n * AUTH (Phase 5, convex/lib/auth.ts): mutations require the trusted backend\n * SERVICE token (browser writes rejected — RBAC stays in the Next.js server\n * actions, which still own permission/validation/audit). ${browserReadable ? "Org-scoped reads\n * accept the service token OR a user token scoped to the same org." : "Reads are\n * service-only (not on the browser-readable allowlist)."} Lookups use the\n * cuid (\`id\`) via by_cuid. See FEATUREDOCS/54 and docs/designs/convex-phase5-auth-bridge.md.\n */\n\n`;
@@ -180,22 +193,24 @@ for (const mdl of models) {
     out += `export const listByParent = query({\n  args: { parentId: v.string() },\n  handler: async (ctx, { parentId }) => {\n    await requireService(ctx);\n    return await ctx.db\n      .query("${key}")\n      .withIndex("by_${pfk}", (q) => q.eq("${pfk}", parentId))\n      .collect();\n  },\n});\n\n`;
   }
 
-  out += `export const create = mutation({\n  args: {\n${createArgs}\n  },\n  handler: async (ctx, args) => {\n    await requireService(ctx);\n    return await ctx.db.insert("${key}", args);\n  },\n});\n\n`;
+  out += counted
+    ? `export const create = mutation({\n  args: {\n${createArgs}\n  },\n  handler: async (ctx, args) => {\n    await requireService(ctx);\n    const _id = await ctx.db.insert("${key}", args);${bump("null", "args")}\n    return _id;\n  },\n});\n\n`
+    : `export const create = mutation({\n  args: {\n${createArgs}\n  },\n  handler: async (ctx, args) => {\n    await requireService(ctx);\n    return await ctx.db.insert("${key}", args);\n  },\n});\n\n`;
 
   // Atomic, idempotent create for backfills (security review P0-2): the check +
   // insert happen inside ONE serializable Convex mutation, so a concurrent
   // dual-write can't race a query-then-create into duplicate \`id\` rows.
-  out += `export const createIfMissing = mutation({\n  args: {\n${createArgs}\n  },\n  handler: async (ctx, args) => {\n    await requireService(ctx);\n    const existing = await ctx.db.query("${key}").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();\n    if (existing) return { _id: existing._id, created: false };\n    const _id = await ctx.db.insert("${key}", args);\n    return { _id, created: true };\n  },\n});\n\n`;
+  out += `export const createIfMissing = mutation({\n  args: {\n${createArgs}\n  },\n  handler: async (ctx, args) => {\n    await requireService(ctx);\n    const existing = await ctx.db.query("${key}").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();\n    if (existing) return { _id: existing._id, created: false };\n    const _id = await ctx.db.insert("${key}", args);${bump("null", "args")}\n    return { _id, created: true };\n  },\n});\n\n`;
 
   // organizationId is set on create and IMMUTABLE thereafter (security review
   // P1-1): strip it from the patch so no write can move a row across tenants,
   // even if a future server bug spreads user input into the patch.
   const patchExpr = mdl.orgScoped
-    ? `const safePatch = { ...patch };\n    delete safePatch.organizationId;\n    await ctx.db.patch(doc._id, safePatch);`
-    : `await ctx.db.patch(doc._id, patch);`;
+    ? `const safePatch = { ...patch };\n    delete safePatch.organizationId;\n    await ctx.db.patch(doc._id, safePatch);${bump("doc", "{ ...doc, ...safePatch }")}`
+    : `await ctx.db.patch(doc._id, patch);${bump("doc", "{ ...doc, ...patch }")}`;
   out += `export const update = mutation({\n  args: {\n    id: ${idValidator},\n    patch: v.object({\n${patchArgs}\n    }),\n  },\n  handler: async (ctx, { id, patch }) => {\n    await requireService(ctx);\n    const doc = await ${lookup};\n    if (!doc) throw new Error("${key} not found: " + id);\n    ${patchExpr}\n    return doc._id;\n  },\n});\n\n`;
 
-  out += `export const remove = mutation({\n  args: { id: ${idValidator} },\n  handler: async (ctx, { id }) => {\n    await requireService(ctx);\n    const doc = await ${lookup};\n    if (!doc) throw new Error("${key} not found: " + id);\n    await ctx.db.delete(doc._id);\n  },\n});\n`;
+  out += `export const remove = mutation({\n  args: { id: ${idValidator} },\n  handler: async (ctx, { id }) => {\n    await requireService(ctx);\n    const doc = await ${lookup};\n    if (!doc) throw new Error("${key} not found: " + id);\n    await ctx.db.delete(doc._id);${bump("doc", "null")}\n  },\n});\n`;
 
   fs.writeFileSync(path.join(ROOT, "convex", `${key}.ts`), out);
   written++;

--- a/src/hooks/use-native-dashboard.ts
+++ b/src/hooks/use-native-dashboard.ts
@@ -14,6 +14,11 @@ import { api } from "../../convex/_generated/api";
 export const NATIVE_DASHBOARD_ENABLED = process.env.NEXT_PUBLIC_NATIVE_DASHBOARD === "true";
 
 const MINUTE = 60_000;
+// Counters are maintained per-write in-transaction (convex/lib/counters.ts), so the
+// on-view reconcile is now only a DRIFT BACKSTOP — throttle it to a long window
+// (≤ once/hour/org) instead of the old per-minute refresh, so the whole-org
+// `.collect()` recompute stays off the hot path.
+const RECONCILE_BACKSTOP_MS = 60 * MINUTE;
 
 export interface NativeDashboardStats {
   totalAssets: number;
@@ -32,9 +37,10 @@ export interface NativeDashboardStats {
  * metrics computed at read. Reactive over the WebSocket (re-runs when counters or
  * the date-derived source rows change, and each minute as `now` rolls over).
  *
- * Also fires a THROTTLED `reconcileIfStale` once on mount so the counters self-heal
- * on view (≤ once per 60s per org) without per-write-site bumps — a fresh row is a
- * cheap no-op. Skips entirely unless the flag is on and the org id is known.
+ * Counters are maintained per-write in-transaction (convex/lib/counters.ts); this
+ * hook also fires a THROTTLED `reconcileIfStale` once on mount as a DRIFT BACKSTOP
+ * (≤ once/hour/org) so any residual drift self-heals and a brand-new org gets its
+ * row — a fresh row is a cheap no-op. Skips unless the flag is on and orgId is known.
  */
 export function useNativeDashboardStats(
   orgId: string | undefined,
@@ -55,8 +61,9 @@ export function useNativeDashboardStats(
   useEffect(() => {
     if (!enabled || !isAuthenticated || !orgId || firedFor.current === orgId) return;
     firedFor.current = orgId;
-    // Best-effort: keep counters fresh on view, throttled to ≤ once/60s per org.
-    void reconcileIfStale({ orgId, now: Date.now(), maxAgeMs: MINUTE }).catch(() => {});
+    // Best-effort drift backstop: reconcile only if the row is stale by the long
+    // backstop window (per-write deltas keep it fresh in between). ≤ once/hour/org.
+    void reconcileIfStale({ orgId, now: Date.now(), maxAgeMs: RECONCILE_BACKSTOP_MS }).catch(() => {});
   }, [enabled, isAuthenticated, orgId, reconcileIfStale]);
 
   return { data, isLoading: enabled && data === undefined };


### PR DESCRIPTION
Closes compliance follow-up **#1** (post-migration review, 2026-07-07): dashboard counters were freshness-maintained only by `reconcileIfStale` → whole-org `.collect()` on view (the migration's top Convex doc/size-limit risk as tenants grow). §3.6 requires the counts to be maintained in the same transaction as the write.

## What changed
- **`convex/lib/counters.ts`** (new): `bumpCountersForTable` (generic dispatch for the generated CRUD) + per-entity `bump*Counters`. Contribution predicates mirror `computeCounters` exactly (parity by construction). A delta against a **not-yet-backfilled** org is skipped — a delta can't reconstruct the pre-existing population, so `reconcile` seeds it accurately (backfill runs before the flag flips in prod).
- **Wired into every counted write path** for `assets` / `bulkAssets` / `projects` / `crewMembers` / `crewAssignments`:
  - generated CRUD `create` / `createIfMissing` / `update` / `remove` (and `generate-convex-crud.cjs` now emits the bump, so a regen preserves it);
  - custom mutations (`patchAsset`, `bulkUpdate`, `patchBulkAsset`, `createWithUniqueNumber`, `patchProject`, `patchMember`, `patchAssignment`, `createServiceAssignment`, `deleteCascade`);
  - native `*Writes.ts` (asset/project/crew create/update/archive/delete);
  - warehouse status churn — `warehouseOps.setAssetsStatus` (the single helper behind ~25 check-out/-in/force-return sites) + its 2 direct checkout patches, `kits.releaseAsset`, and `lib/fulfillment.setAssetStatus` (the check-in return path).
- **`reconcileIfStale` demoted to a drift backstop**: client throttle 60s → 1h, so the whole-org `.collect()` is off the hot path but still catches residual drift + seeds a brand-new org.
- Fixed the stale `schema.ts` "maintained by bump" comment; updated `dashboardCounters.ts`, `use-native-dashboard.ts`, FEATUREDOCS/54, and the design-doc follow-up list.

Every counted dimension is per-write maintained — none left on reconcile-primary.

## Verification
- `convex/dashboardCounters.test.ts`: a mixed write sequence (asset create/status/archive/delete, bulk qty/archive, project create/status/delete, crew create/status, assignment create/status/delete) run through the **real mutations**, then asserts the per-write-maintained row **equals the authoritative `reconcile` recompute**. Plus a test that a delta against an un-backfilled org is skipped.
- `npx tsc --noEmit` clean; full convex suite **141/141**; `pnpm exec convex codegen` clean.
- Generator dry-run to a temp dir confirms counted tables get the bump and non-counted tables don't.
- codex review: found + fixed a P2 (check-in returns via `fulfillment.setAssetStatus` bypassed the bump).

All behind the default-OFF `NEXT_PUBLIC_NATIVE_DASHBOARD` flag — nothing live-risky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)