### PR TITLE
fix(convex): allowlist DTOs + field-absence tests for browser composites (§3.5)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -61,6 +61,7 @@ import type * as lib_audit from "../lib/audit.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_bulkCheckin from "../lib/bulkCheckin.js";
 import type * as lib_counters from "../lib/counters.js";
+import type * as lib_dto from "../lib/dto.js";
 import type * as lib_fulfillment from "../lib/fulfillment.js";
 import type * as lib_inventory from "../lib/inventory.js";
 import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
@@ -186,6 +187,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/bulkCheckin": typeof lib_bulkCheckin;
   "lib/counters": typeof lib_counters;
+  "lib/dto": typeof lib_dto;
   "lib/fulfillment": typeof lib_fulfillment;
   "lib/inventory": typeof lib_inventory;
   "lib/lineItemUnits": typeof lib_lineItemUnits;

--- a/convex/assetDetail.test.ts
+++ b/convex/assetDetail.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "A1", status: "AVAILABLE" });
+
+    // A file with an S3 storageKey — must NOT reach the browser.
+    await ctx.db.insert("fileUploads", {
+      id: "f1",
+      organizationId: ORG,
+      fileName: "manual.pdf",
+      fileSize: 4242,
+      mimeType: "application/pdf",
+      storageKey: "org_1/secret/manual.pdf",
+      url: "https://cdn/manual.pdf",
+      thumbnailUrl: undefined,
+      uploadedById: USER,
+    });
+    await ctx.db.insert("assetMedia", { id: "am1", organizationId: ORG, assetId: "a1", fileId: "f1", type: "DOCUMENT" });
+  });
+}
+
+describe("assetDetail.bundle — allowlist DTOs (§3.5)", () => {
+  test("files carry display metadata but never storageKey / uploadedById", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.assetDetail.bundle, { assetId: "a1", orgId: ORG });
+    expect(res).not.toBeNull();
+    const file = res!.files.find((f) => f.id === "f1")!;
+    expect(file).toMatchObject({
+      id: "f1",
+      fileName: "manual.pdf",
+      fileSize: 4242,
+      mimeType: "application/pdf",
+      url: "https://cdn/manual.pdf",
+    });
+    for (const forbidden of ["storageKey", "uploadedById", "width", "height", "organizationId"]) {
+      expect(file).not.toHaveProperty(forbidden);
+    }
+  });
+});

--- a/convex/assetDetail.ts
+++ b/convex/assetDetail.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
+import { pick, FILE_META_FIELDS } from "./lib/dto";
 
 /**
  * BROWSER-facing composite for the ASSET detail page (Phase 2 native reads).
@@ -74,7 +75,11 @@ async function readAssetDetail(ctx: QueryCtx, assetId: string, orgId: string) {
   const maintenanceRecords = inOrg(await pr(refMaintIds.map((id) => ctx.db.query("maintenanceRecords").withIndex("by_cuid", (q) => q.eq("id", id)).unique())));
 
   const refFileIds = uniq([...assetMedia.map((m) => m.fileId), ...modelMedia.map((m) => m.fileId)]);
-  const files = inOrg(await pr(refFileIds.map((id) => ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", id)).unique())));
+  // Allowlist DTO (§3.5): media rendering needs the URLs + display metadata; never
+  // the file `storageKey` (the S3/blob object key) or `uploadedById`.
+  const files = inOrg(await pr(refFileIds.map((id) => ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", id)).unique()))).map((f) =>
+    pick(f, FILE_META_FIELDS),
+  );
 
   return {
     asset,

--- a/convex/equipmentTab.test.ts
+++ b/convex/equipmentTab.test.ts
@@ -55,4 +55,25 @@ describe("equipmentTab.bundle — auth gating + shape", () => {
       .query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG });
     expect(res.lineItems).toEqual([]);
   });
+
+  test("never carries user PII / file storageKey (§3.5 no-leak guard)", async () => {
+    const t = convexTest(schema, modules);
+    await seedViewer(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.equipmentTab.bundle, { projectId: "p1", orgId: ORG });
+    // No `users`/`fileUploads` are joined here; guard against a future one leaking
+    // an S3 storage key or Better-Auth PII.
+    expect(res).not.toHaveProperty("users");
+    expect(res).not.toHaveProperty("files");
+    const forbidden = ["storageKey", "email", "emailVerified", "banReason", "twoFactorEnabled"];
+    const scan = (value: unknown): void => {
+      if (Array.isArray(value)) value.forEach(scan);
+      else if (value && typeof value === "object") {
+        for (const [k, v] of Object.entries(value)) {
+          expect(forbidden).not.toContain(k);
+          scan(v);
+        }
+      }
+    };
+    scan(res);
+  });
 });

--- a/convex/kitDetail.test.ts
+++ b/convex/kitDetail.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const SCANNER = "user_scanner";
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "K1", name: "Kit One" });
+
+    // A scanner user with full Better-Auth PII — must NOT reach the browser.
+    await ctx.db.insert("users", {
+      id: SCANNER,
+      name: "Scanner Sam",
+      email: "sam@secret.example",
+      emailVerified: true,
+      image: "https://img/sam.png",
+      role: "admin",
+      banned: false,
+      banReason: "n/a",
+      twoFactorEnabled: true,
+    });
+    await ctx.db.insert("assetScanLogs", {
+      id: "sl1",
+      organizationId: ORG,
+      kitId: "k1",
+      projectId: undefined,
+      action: "SCAN_VERIFY",
+      scannedById: SCANNER,
+      scannedAt: 1_700_000_000_000,
+    });
+
+    // A file with an S3 storageKey — must NOT reach the browser.
+    await ctx.db.insert("fileUploads", {
+      id: "f1",
+      organizationId: ORG,
+      fileName: "photo.jpg",
+      fileSize: 1234,
+      mimeType: "image/jpeg",
+      storageKey: "org_1/secret/photo.jpg",
+      url: "https://cdn/photo.jpg",
+      thumbnailUrl: "https://cdn/photo_thumb.jpg",
+      uploadedById: SCANNER,
+    });
+    await ctx.db.insert("kitMedia", { id: "km1", organizationId: ORG, kitId: "k1", fileId: "f1", type: "PHOTO" });
+  });
+}
+
+describe("kitDetail.bundle — allowlist DTOs (§3.5)", () => {
+  test("users are projected to { id, name } — no PII leaks", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.kitDetail.bundle, { kitId: "k1", orgId: ORG });
+    expect(res).not.toBeNull();
+    const user = res!.users.find((u) => u.id === SCANNER)!;
+    expect(user).toEqual({ id: SCANNER, name: "Scanner Sam" });
+    for (const forbidden of ["email", "emailVerified", "image", "role", "banned", "banReason", "twoFactorEnabled"]) {
+      expect(user).not.toHaveProperty(forbidden);
+    }
+  });
+
+  test("files are projected to url-only — storageKey / uploadedById absent", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.kitDetail.bundle, { kitId: "k1", orgId: ORG });
+    const file = res!.files.find((f) => f.id === "f1")!;
+    expect(file).toEqual({ id: "f1", url: "https://cdn/photo.jpg", thumbnailUrl: "https://cdn/photo_thumb.jpg" });
+    for (const forbidden of ["storageKey", "uploadedById", "fileName", "fileSize", "mimeType"]) {
+      expect(file).not.toHaveProperty(forbidden);
+    }
+  });
+});

--- a/convex/kitDetail.ts
+++ b/convex/kitDetail.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
+import { pick, USER_PUBLIC_FIELDS, FILE_URL_FIELDS } from "./lib/dto";
 
 /**
  * BROWSER-facing composite for the KIT detail page (Phase 2 native reads). Returns
@@ -79,8 +80,12 @@ async function readKitDetail(ctx: QueryCtx, kitId: string, orgId: string) {
     bulkAssets,
     models: inOrg(modelDocs),
     projects: inOrg(projectDocs),
-    users: userDocs.filter((u): u is NonNullable<typeof u> => u !== null),
-    files: inOrg(fileDocs),
+    // Allowlist DTOs (§3.5): the kit page needs only the scanner's { id, name } and
+    // the media file URLs — never `users` PII (email/role/…) or the file storageKey.
+    users: userDocs
+      .filter((u): u is NonNullable<typeof u> => u !== null)
+      .map((u) => pick(u, USER_PUBLIC_FIELDS)),
+    files: inOrg(fileDocs).map((f) => pick(f, FILE_URL_FIELDS)),
     location: location && location.organizationId === orgId ? location : null,
     category: category && category.organizationId === orgId ? category : null,
   };

--- a/convex/lib/dto.ts
+++ b/convex/lib/dto.ts
@@ -1,0 +1,47 @@
+/**
+ * Allowlist DTO projection for browser-facing composite queries (§3.5).
+ *
+ * The detail/browser composites (projectEquipment, equipmentTab, warehouseDetail,
+ * kitDetail, assetDetail) join several tables and return them to a user token
+ * (RBAC-gated). Most of those tables are ALREADY browser-readable via the generated
+ * thin CRUD (`api.<table>.list`/`getById` on the BROWSER_READABLE allowlist), so
+ * re-returning their raw docs in a composite is not a new exposure — parity with the
+ * server action, and a future secret column on such a table must be redacted at the
+ * generator's REDACTED_FIELDS layer (where crewMembers.icalToken already lives), not
+ * here.
+ *
+ * The exceptions are the tables a composite pulls in that are NOT browser-readable
+ * AND carry sensitive columns:
+ *   • `users` (Better-Auth, EXCLUDED from CRUD) — the kit page shows a scan's
+ *     "scanned by", which needs only { id, name }. The raw row also holds email,
+ *     role, banReason, twoFactorEnabled, … — never send those to the browser.
+ *   • `fileUploads` — media rendering needs the URLs (+ name/size/type on the asset
+ *     page); the raw row also holds `storageKey` (the S3/blob object key) and
+ *     `uploadedById`. Never send the storage key to the browser.
+ *
+ * `pick` returns an explicit ALLOWLIST projection: only the named fields survive, so
+ * a column added to one of these tables later can't leak without editing the
+ * allowlist. Convex meta (`_id`, `_creationTime`) is dropped too (not in the list).
+ * Absent optional fields stay absent (the consumer's `?? default` handles them).
+ */
+
+/** Project `doc` down to exactly the allowlisted keys (undefined/absent keys skipped). */
+export function pick<T extends Record<string, unknown>, K extends keyof T>(
+  doc: T,
+  keys: readonly K[],
+): Pick<T, K> {
+  const out = {} as Pick<T, K>;
+  for (const k of keys) {
+    if (k in doc) out[k] = doc[k];
+  }
+  return out;
+}
+
+/** Browser-safe `users` projection — identity only, no PII. */
+export const USER_PUBLIC_FIELDS = ["id", "name"] as const;
+
+/** Browser-safe `fileUploads` projection for URL-only media (kit page). */
+export const FILE_URL_FIELDS = ["id", "url", "thumbnailUrl"] as const;
+
+/** Browser-safe `fileUploads` projection incl. display metadata (asset page). */
+export const FILE_META_FIELDS = ["id", "fileName", "fileSize", "mimeType", "url", "thumbnailUrl"] as const;

--- a/convex/projectEquipment.test.ts
+++ b/convex/projectEquipment.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+/** Recursively assert no forbidden key appears anywhere in the returned bundle. */
+function assertNoKeyDeep(value: unknown, forbidden: string[], path = "$") {
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertNoKeyDeep(v, forbidden, `${path}[${i}]`));
+  } else if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) {
+      expect(forbidden, `${path}.${k}`).not.toContain(k);
+      assertNoKeyDeep(v, forbidden, `${path}.${k}`);
+    }
+  }
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", quantity: 1 });
+  });
+}
+
+describe("projectEquipment.browserBundle — no sensitive leak (§3.5)", () => {
+  test("equipment bundle never carries user PII / file storageKey", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectEquipment.browserBundle, { projectId: "p1", orgId: ORG });
+    // The bundle joins no `users`/`fileUploads`; guard the boundary against a future
+    // join accidentally re-exposing an S3 storage key or Better-Auth PII.
+    expect(res).not.toHaveProperty("users");
+    expect(res).not.toHaveProperty("files");
+    assertNoKeyDeep(res, ["storageKey", "email", "emailVerified", "banReason", "twoFactorEnabled"]);
+  });
+});

--- a/convex/warehouseDetail.test.ts
+++ b/convex/warehouseDetail.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+/** Recursively assert no forbidden key appears anywhere in the returned bundle. */
+function assertNoKeyDeep(value: unknown, forbidden: string[], path = "$") {
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertNoKeyDeep(v, forbidden, `${path}[${i}]`));
+  } else if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) {
+      expect(forbidden, `${path}.${k}`).not.toContain(k);
+      assertNoKeyDeep(v, forbidden, `${path}.${k}`);
+    }
+  }
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "P1", status: "CONFIRMED", isTemplate: false });
+    await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", quantity: 1 });
+  });
+}
+
+describe("warehouseDetail.bundle — no sensitive leak (§3.5)", () => {
+  test("returns the project bundle with no user PII / file storageKey anywhere", async () => {
+    const t = convexTest(schema, modules);
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).query(api.warehouseDetail.bundle, { projectId: "p1", orgId: ORG });
+    expect(res).not.toBeNull();
+    // No `users` collection is joined here; and nothing must carry a storage key,
+    // an S3 secret, or Better-Auth PII — a regression guard on the composite shape.
+    expect(res).not.toHaveProperty("users");
+    assertNoKeyDeep(res, ["storageKey", "email", "emailVerified", "banReason", "twoFactorEnabled"]);
+  });
+});

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -37,12 +37,21 @@ convention violations (`collaboration.ts` addComment, `lib/fulfillment.ts` — t
    convex-test proves the maintained row equals the reconcile recompute after a mixed write
    sequence (`dashboardCounters.test.ts`). Every dimension is per-write maintained — none
    left on reconcile-primary.
-2. **Raw-doc browser/detail composites (Phase 1–2).** `projectEquipment.browserBundle`,
-   `equipmentTab.bundle`, `warehouseDetail`/`kitDetail`/`assetDetail` return raw Convex docs
-   (incl. `warehouseDetail` raw `units`) rather than allowlisted DTOs, with no field-absence
-   tests (§3.5). Mitigated today by equal-permission RBAC gating (a reader already gets these
-   via the server action), so not urgent — but a future sensitive column could leak silently.
-   Add field-absence tests or DTO allowlists.
+2. ~~**Raw-doc browser/detail composites (Phase 1–2).**~~ **✅ DONE (2026-07-07, PR
+   `fix/convex-composite-dtos`).** Audit finding: the only genuinely-sensitive over-exposures
+   were `kitDetail.users` (Better-Auth PII — email/role/banReason/twoFactorEnabled) and
+   `kitDetail`/`assetDetail` `fileUploads` (the S3 `storageKey` + `uploadedById`). Those are now
+   **allowlist DTOs** via `convex/lib/dto.ts` `pick()`: `users` → `{id,name}`, `files` →
+   `{id,url,thumbnailUrl}` (kit) / `+{fileName,fileSize,mimeType}` (asset). The other joined
+   collections (assets/bulkAssets/kits/models/suppliers/categories/projects/lineItems/units/
+   clients/locations) are **already browser-readable via the generated thin CRUD** (parity with
+   the server action — the composite adds no exposure), and they flow into `Doc<>`-typed
+   reconstruct mappers, so narrowing them is pure churn with zero marginal security; a future
+   secret column on such a table must be redacted at the generator's `REDACTED_FIELDS` layer
+   (where `crewMembers.icalToken` already lives). **Field-absence convex-tests added for all
+   five composites** (`kitDetail`/`assetDetail`/`warehouseDetail`/`projectEquipment`/
+   `equipmentTab`.test.ts): `not.toHaveProperty` on the PII/storageKey fields + a recursive
+   no-leak guard. Reconstruct consumers compile + their unit tests pass unchanged.
 3. **Phase 7 mostly dead code.** 6 of 7 `convex/search.ts` queries have no `src/` consumer
    (only the supplier picker is wired). Wire the remaining pickers (asset/model/kit/client/
    project), or explicitly scope them out. Multi-field pickers need a 2nd index / denormalized


### PR DESCRIPTION
Closes compliance follow-up **#2** (post-migration review, 2026-07-07): the browser/detail composites returned raw Convex docs with no field-absence tests.

## Audit finding
Most joined collections (assets/bulkAssets/kits/models/suppliers/categories/projects/lineItems/units/clients/locations) are **already browser-readable via the generated thin CRUD** — re-returning them in an RBAC-gated composite adds no exposure (parity with the server action). The genuinely-sensitive over-exposures were:
- **`kitDetail.users`** — raw Better-Auth rows (email, role, banReason, twoFactorEnabled) for a scan's "scanned by", where the page needs only `{ id, name }`.
- **`kitDetail` / `assetDetail` `fileUploads`** — raw rows carrying the S3 **`storageKey`** + `uploadedById`, where media rendering needs only the URLs (+ name/size/type on the asset page).

## What changed
- **`convex/lib/dto.ts`** (new): `pick(doc, allowlist)` — explicit allowlist projection (drops Convex meta + anything not named, so a future column can't leak). Named allowlists `USER_PUBLIC_FIELDS`, `FILE_URL_FIELDS`, `FILE_META_FIELDS`.
- **`kitDetail.ts`**: `users` → `{id,name}`, `files` → `{id,url,thumbnailUrl}`.
- **`assetDetail.ts`**: `files` → `{id,fileName,fileSize,mimeType,url,thumbnailUrl}`.
- The reconstruct consumers only read the projected fields, so they compile + their unit tests pass unchanged (verified).

## Scope rationale (documented in the design doc)
The entity/line-item collections are **not** narrowed: they're already browser-exposed raw via the generated CRUD (so narrowing the composite gives zero marginal security) and they flow into `Doc<>`-typed reconstruct mappers (narrowing = pure churn). A future secret column on such a table belongs in the generator's `REDACTED_FIELDS` layer (where `crewMembers.icalToken` already lives), which fixes *both* the CRUD and the composite. The field-absence tests lock the boundary against a future join re-exposing PII/storage keys.

## Verification
- Field-absence convex-tests for **all five** composites: `kitDetail`/`assetDetail` assert the PII + storageKey fields are absent (`not.toHaveProperty`); `warehouseDetail`/`projectEquipment`/`equipmentTab` add a recursive no-leak guard.
- `npx tsc --noEmit` clean; full convex + reconstruct suites **169/169**; codex review clean.

All composites remain behind the existing default-OFF native-read flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)