### PR TITLE
fix(convex): wire native indexed search pickers (Phase 7)

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -477,11 +477,14 @@ export default defineSchema({
     .index("by_organizationId_assetTag", ["organizationId", "assetTag"])
     .index("by_status", ["status"])
     .index("by_isActive", ["isActive"])
-    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] })
+    // isPrep is a filterField so the picker can exclude prep kits IN the search
+    // (exact parity with the old `isActive===true && isPrep===false` JS filter) —
+    // no post-filtering the bounded page (which could drop valid non-prep matches).
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive", "isPrep"] })
     // Second index so the kit picker (label = "{assetTag} - {name}") matches a tag
     // term too — merged with name hits in convex/search.ts (the assets tag+serial
     // pattern; no denormalized field / backfill needed).
-    .searchIndex("search_assetTag", { searchField: "assetTag", filterFields: ["organizationId", "isActive"] }),
+    .searchIndex("search_assetTag", { searchField: "assetTag", filterFields: ["organizationId", "isActive", "isPrep"] }),
 
   // KitSerializedItem
   kitSerializedItems: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -261,7 +261,12 @@ export default defineSchema({
     .index("by_defaultTestProfileId", ["defaultTestProfileId"])
     .index("by_organizationId_sku", ["organizationId", "sku"])
     .index("by_isActive", ["isActive"])
-    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] })
+    // Second index so the model picker (label = "{manufacturer} {name}") matches a
+    // manufacturer term too — merged with name hits in convex/search.ts, the same
+    // multi-index pattern assets uses for assetTag + serialNumber (no denormalized
+    // field / backfill needed).
+    .searchIndex("search_manufacturer", { searchField: "manufacturer", filterFields: ["organizationId", "isActive"] }),
 
   // Supplier
   suppliers: defineTable({
@@ -472,7 +477,11 @@ export default defineSchema({
     .index("by_organizationId_assetTag", ["organizationId", "assetTag"])
     .index("by_status", ["status"])
     .index("by_isActive", ["isActive"])
-    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] }),
+    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isActive"] })
+    // Second index so the kit picker (label = "{assetTag} - {name}") matches a tag
+    // term too — merged with name hits in convex/search.ts (the assets tag+serial
+    // pattern; no denormalized field / backfill needed).
+    .searchIndex("search_assetTag", { searchField: "assetTag", filterFields: ["organizationId", "isActive"] }),
 
   // KitSerializedItem
   kitSerializedItems: defineTable({
@@ -554,9 +563,11 @@ export default defineSchema({
     .index("by_parentAssetId", ["parentAssetId"])
     .index("by_organizationId_assetTag", ["organizationId", "assetTag"])
     .index("by_status", ["status"])
-    .index("by_isActive", ["isActive"])
-    .searchIndex("search_assetTag", { searchField: "assetTag", filterFields: ["organizationId", "isActive"] })
-    .searchIndex("search_serialNumber", { searchField: "serialNumber", filterFields: ["organizationId", "isActive"] }),
+    .index("by_isActive", ["isActive"]),
+  // (No asset search index: the tag+serial search + its `convex/search.ts` query were
+  // removed 2026-07-07 — every asset picker is a multi-select builder/table whose
+  // chips need per-id label resolution, not a single-select combobox. Re-add both
+  // alongside a real consumer.)
 
   // BulkAsset
   bulkAssets: defineTable({
@@ -773,8 +784,10 @@ export default defineSchema({
     .index("by_clientId", ["clientId"])
     .index("by_rentalStartDate_rentalEndDate", ["rentalStartDate", "rentalEndDate"])
     .index("by_isTemplate", ["isTemplate"])
-    .index("by_organizationId_status", ["organizationId", "status"])
-    .searchIndex("search_name", { searchField: "name", filterFields: ["organizationId", "isTemplate"] }),
+    .index("by_organizationId_status", ["organizationId", "status"]),
+  // (No project search index: the app never picks a project in a combobox — projects
+  // are created/edited, never selected — so its `convex/search.ts` query was removed
+  // 2026-07-07. Re-add both alongside a real single-select project picker.)
 
   // ProjectLineItem
   projectLineItems: defineTable({

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -59,7 +59,7 @@ describe("search.kits — tag or name, prep excluded", () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-001", name: "Audio Rig", isActive: true, isPrep: false, createdAt: NOW });
-      await ctx.db.insert("kits", { id: "k2", organizationId: ORG, assetTag: "AUDIO-99", name: "Spare", isActive: true, createdAt: NOW }); // isPrep undefined → included
+      await ctx.db.insert("kits", { id: "k2", organizationId: ORG, assetTag: "AUDIO-99", name: "Spare", isActive: true, isPrep: false, createdAt: NOW });
       await ctx.db.insert("kits", { id: "kp", organizationId: ORG, assetTag: "KIT-PREP", name: "Audio Prep", isActive: true, isPrep: true, createdAt: NOW });
     });
     // "Audio" matches k1 (name) + kp (name) + k2 (tag AUDIO-99) — but kp is prep → excluded.

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -11,13 +11,17 @@ const OTHER = "org_2";
 const asUser = (orgId: string) => ({ subject: "user_1", orgId });
 const NOW = 1_700_000_000_000;
 
+// NOTE: every `models` fixture sets `manufacturer` (even ""). Real Convex tolerates a
+// search over an absent optional searchField (unmatched, no error), but convex-test's
+// mock `evaluateSearchFilter` calls `.split()` on the raw value and throws on undefined
+// — so the two-index models query needs the field present in tests only.
 describe("search.models", () => {
   test("matches by name, is org-scoped, and honours the query", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "Shure SM58", isActive: true, createdAt: NOW });
-      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Sennheiser MD421", isActive: true, createdAt: NOW });
-      await ctx.db.insert("models", { id: "m3", organizationId: OTHER, name: "Shure SM7B", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "Shure SM58", manufacturer: "", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Sennheiser MD421", manufacturer: "", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m3", organizationId: OTHER, name: "Shure SM7B", manufacturer: "", isActive: true, createdAt: NOW });
     });
 
     const hits = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "Shure" });
@@ -31,44 +35,44 @@ describe("search.models", () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       for (let i = 0; i < 5; i++) {
-        await ctx.db.insert("models", { id: `m${i}`, organizationId: ORG, name: `Widget ${i}`, isActive: true, createdAt: NOW });
+        await ctx.db.insert("models", { id: `m${i}`, organizationId: ORG, name: `Widget ${i}`, manufacturer: "", isActive: true, createdAt: NOW });
       }
     });
     const hits = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "Widget", limit: 2 });
     expect(hits.length).toBe(2);
   });
-});
 
-describe("search.assets — tag or serial", () => {
-  test("matches by asset tag or serial number, merged + deduped", async () => {
+  test("matches by manufacturer too, merged + deduped with name hits", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "CAM-001", serialNumber: "SN-ABC", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
-      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "LENS-050", serialNumber: "CAM-XYZ", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "SM58", manufacturer: "Shure", isActive: true, createdAt: NOW });
+      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Shure clone", manufacturer: "Generic", isActive: true, createdAt: NOW });
     });
-    // "CAM" matches a1 by tag and a2 by serial → both, deduped.
-    const hits = await t.withIdentity(asUser(ORG)).query(api.search.assets, { orgId: ORG, query: "CAM" });
-    expect(hits.map((a) => a.id).sort()).toEqual(["a1", "a2"]);
-
-    const byTag = await t.withIdentity(asUser(ORG)).query(api.search.assets, { orgId: ORG, query: "LENS" });
-    expect(byTag.map((a) => a.id)).toEqual(["a2"]);
+    // "Shure" matches m1 by manufacturer AND m2 by name → both, deduped.
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.models, { orgId: ORG, query: "Shure" });
+    expect(hits.map((m) => m.id).sort()).toEqual(["m1", "m2"]);
   });
 });
 
-describe("search.projects — excludes templates", () => {
-  test("templates are filtered out unless includeTemplates", async () => {
+describe("search.kits — tag or name, prep excluded", () => {
+  test("matches by assetTag or name (merged) and excludes prep kits by default", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Festival Main Stage", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
-      await ctx.db.insert("projects", { id: "p2", organizationId: ORG, projectNumber: "T-1", name: "Festival Template", status: "CONFIRMED", isTemplate: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-001", name: "Audio Rig", isActive: true, isPrep: false, createdAt: NOW });
+      await ctx.db.insert("kits", { id: "k2", organizationId: ORG, assetTag: "AUDIO-99", name: "Spare", isActive: true, createdAt: NOW }); // isPrep undefined → included
+      await ctx.db.insert("kits", { id: "kp", organizationId: ORG, assetTag: "KIT-PREP", name: "Audio Prep", isActive: true, isPrep: true, createdAt: NOW });
     });
-    const hits = await t.withIdentity(asUser(ORG)).query(api.search.projects, { orgId: ORG, query: "Festival" });
-    expect(hits.map((p) => p.id)).toEqual(["p1"]);
+    // "Audio" matches k1 (name) + kp (name) + k2 (tag AUDIO-99) — but kp is prep → excluded.
+    const hits = await t.withIdentity(asUser(ORG)).query(api.search.kits, { orgId: ORG, query: "Audio" });
+    expect(hits.map((k) => k.id).sort()).toEqual(["k1", "k2"]);
 
-    const withTemplates = await t
-      .withIdentity(asUser(ORG))
-      .query(api.search.projects, { orgId: ORG, query: "Festival", includeTemplates: true });
-    expect(withTemplates.map((p) => p.id).sort()).toEqual(["p1", "p2"]);
+    // "KIT-001" matches by tag.
+    const byTag = await t.withIdentity(asUser(ORG)).query(api.search.kits, { orgId: ORG, query: "KIT-001" });
+    expect(byTag.map((k) => k.id)).toEqual(["k1"]);
+
+    // includePrep surfaces the prep kit.
+    const withPrep = await t.withIdentity(asUser(ORG)).query(api.search.kits, { orgId: ORG, query: "Audio", includePrep: true });
+    expect(withPrep.map((k) => k.id).sort()).toEqual(["k1", "k2", "kp"]);
   });
 });
 

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -46,13 +46,15 @@ export const models = query({
         .order("desc")
         .take(take);
     }
+    // isActive is filtered IN the search (exact parity with the pickers' active-only
+    // filter) so no post-filter drops valid rows out of the bounded page.
     const byName = await ctx.db
       .query("models")
-      .withSearchIndex("search_name", (s) => s.search("name", q).eq("organizationId", orgId))
+      .withSearchIndex("search_name", (s) => s.search("name", q).eq("organizationId", orgId).eq("isActive", true))
       .take(take);
     const byManufacturer = await ctx.db
       .query("models")
-      .withSearchIndex("search_manufacturer", (s) => s.search("manufacturer", q).eq("organizationId", orgId))
+      .withSearchIndex("search_manufacturer", (s) => s.search("manufacturer", q).eq("organizationId", orgId).eq("isActive", true))
       .take(take);
     const seen = new Set(byName.map((m) => m._id));
     const merged = [...byName];
@@ -83,25 +85,36 @@ export const kits = query({
     await requireOrgRead(ctx, orgId);
     const take = clampLimit(limit);
     const q = term.trim();
-    // isPrep is optional (often undefined for normal kits), so a `.eq("isPrep", false)`
-    // filterField would miss undefined rows. Filter in JS on the bounded result set.
-    const keep = (k: { isPrep?: boolean }) => includePrep || !k.isPrep;
     if (!q) {
+      // Unfocused fallback: bounded recent list, active + non-prep (matches the
+      // pickers' `isActive===true && isPrep===false`). JS-filter over a small window.
       const rows = await ctx.db
         .query("kits")
         .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
         .order("desc")
         .take(take * 2);
-      return rows.filter(keep).slice(0, take);
+      return rows
+        .filter((k) => k.isActive === true && (includePrep || k.isPrep === false))
+        .slice(0, take);
     }
+    // Filter active + (non-prep unless includePrep) IN the search via filterFields —
+    // exact parity with the old JS filter and no post-filter that could drop valid
+    // non-prep matches out of the bounded page (codex P2). isPrep uses .eq(false), so
+    // a kit with isPrep unset is excluded — same as the old `isPrep === false`.
     const byName = await ctx.db
       .query("kits")
-      .withSearchIndex("search_name", (s) => s.search("name", q).eq("organizationId", orgId))
-      .take(take * 2);
+      .withSearchIndex("search_name", (s) => {
+        const base = s.search("name", q).eq("organizationId", orgId).eq("isActive", true);
+        return includePrep ? base : base.eq("isPrep", false);
+      })
+      .take(take);
     const byTag = await ctx.db
       .query("kits")
-      .withSearchIndex("search_assetTag", (s) => s.search("assetTag", q).eq("organizationId", orgId))
-      .take(take * 2);
+      .withSearchIndex("search_assetTag", (s) => {
+        const base = s.search("assetTag", q).eq("organizationId", orgId).eq("isActive", true);
+        return includePrep ? base : base.eq("isPrep", false);
+      })
+      .take(take);
     const seen = new Set(byName.map((k) => k._id));
     const merged = [...byName];
     for (const k of byTag) {
@@ -110,7 +123,7 @@ export const kits = query({
         merged.push(k);
       }
     }
-    return merged.filter(keep).slice(0, take);
+    return merged.slice(0, take);
   },
 });
 

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -27,6 +27,12 @@ function clampLimit(limit: number | undefined): number {
   return Math.min(Math.max(1, limit ?? DEFAULT_LIMIT), MAX_LIMIT);
 }
 
+/**
+ * Models search matches EITHER name OR manufacturer (two search indexes), merged +
+ * deduped — the picker label is "{manufacturer} {name}", so a manufacturer term must
+ * match too. Name hits rank first, then manufacturer-only hits (mirrors the assets
+ * assetTag+serialNumber merge).
+ */
 export const models = query({
   args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
   handler: async (ctx, { orgId, query: term, limit }) => {
@@ -40,34 +46,71 @@ export const models = query({
         .order("desc")
         .take(take);
     }
-    return await ctx.db
+    const byName = await ctx.db
       .query("models")
-      .withSearchIndex("search_name", (s) =>
-        s.search("name", q).eq("organizationId", orgId),
-      )
+      .withSearchIndex("search_name", (s) => s.search("name", q).eq("organizationId", orgId))
       .take(take);
+    const byManufacturer = await ctx.db
+      .query("models")
+      .withSearchIndex("search_manufacturer", (s) => s.search("manufacturer", q).eq("organizationId", orgId))
+      .take(take);
+    const seen = new Set(byName.map((m) => m._id));
+    const merged = [...byName];
+    for (const m of byManufacturer) {
+      if (!seen.has(m._id)) {
+        seen.add(m._id);
+        merged.push(m);
+      }
+    }
+    return merged.slice(0, take);
   },
 });
 
+/**
+ * Kits search matches EITHER name OR assetTag (two search indexes), merged + deduped
+ * — the picker label is "{assetTag} - {name}", so a tag term must match too. Excludes
+ * prep kits by default (`includePrep`), mirroring getKits' active + non-prep default;
+ * prep exclusion is a search filterField (kits carry `isPrep`).
+ */
 export const kits = query({
-  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
-  handler: async (ctx, { orgId, query: term, limit }) => {
+  args: {
+    orgId: v.string(),
+    query: v.string(),
+    limit: v.optional(v.number()),
+    includePrep: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { orgId, query: term, limit, includePrep }) => {
     await requireOrgRead(ctx, orgId);
     const take = clampLimit(limit);
     const q = term.trim();
+    // isPrep is optional (often undefined for normal kits), so a `.eq("isPrep", false)`
+    // filterField would miss undefined rows. Filter in JS on the bounded result set.
+    const keep = (k: { isPrep?: boolean }) => includePrep || !k.isPrep;
     if (!q) {
-      return await ctx.db
+      const rows = await ctx.db
         .query("kits")
         .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
         .order("desc")
-        .take(take);
+        .take(take * 2);
+      return rows.filter(keep).slice(0, take);
     }
-    return await ctx.db
+    const byName = await ctx.db
       .query("kits")
-      .withSearchIndex("search_name", (s) =>
-        s.search("name", q).eq("organizationId", orgId),
-      )
-      .take(take);
+      .withSearchIndex("search_name", (s) => s.search("name", q).eq("organizationId", orgId))
+      .take(take * 2);
+    const byTag = await ctx.db
+      .query("kits")
+      .withSearchIndex("search_assetTag", (s) => s.search("assetTag", q).eq("organizationId", orgId))
+      .take(take * 2);
+    const seen = new Set(byName.map((k) => k._id));
+    const merged = [...byName];
+    for (const k of byTag) {
+      if (!seen.has(k._id)) {
+        seen.add(k._id);
+        merged.push(k);
+      }
+    }
+    return merged.filter(keep).slice(0, take);
   },
 });
 
@@ -115,77 +158,10 @@ export const suppliers = query({
   },
 });
 
-export const projects = query({
-  args: {
-    orgId: v.string(),
-    query: v.string(),
-    limit: v.optional(v.number()),
-    includeTemplates: v.optional(v.boolean()),
-  },
-  handler: async (ctx, { orgId, query: term, limit, includeTemplates }) => {
-    await requireOrgRead(ctx, orgId);
-    const take = clampLimit(limit);
-    const q = term.trim();
-    // isTemplate is optional (often undefined for real projects), so filter it in
-    // JS on the bounded result set rather than via the search filterField, which
-    // would only match rows where the field is explicitly present.
-    const keep = (p: { isTemplate?: boolean }) => includeTemplates || !p.isTemplate;
-    if (!q) {
-      const rows = await ctx.db
-        .query("projects")
-        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
-        .order("desc")
-        .take(take * 2);
-      return rows.filter(keep).slice(0, take);
-    }
-    const rows = await ctx.db
-      .query("projects")
-      .withSearchIndex("search_name", (s) =>
-        s.search("name", q).eq("organizationId", orgId),
-      )
-      .take(take * 2);
-    return rows.filter(keep).slice(0, take);
-  },
-});
-
-/**
- * Assets search matches EITHER asset tag OR serial number (two search indexes),
- * merged + deduped, so one picker search box covers both — relevance order is
- * assetTag hits first, then serial hits.
- */
-export const assets = query({
-  args: { orgId: v.string(), query: v.string(), limit: v.optional(v.number()) },
-  handler: async (ctx, { orgId, query: term, limit }) => {
-    await requireOrgRead(ctx, orgId);
-    const take = clampLimit(limit);
-    const q = term.trim();
-    if (!q) {
-      return await ctx.db
-        .query("assets")
-        .withIndex("by_organizationId", (x) => x.eq("organizationId", orgId))
-        .order("desc")
-        .take(take);
-    }
-    const byTag = await ctx.db
-      .query("assets")
-      .withSearchIndex("search_assetTag", (s) =>
-        s.search("assetTag", q).eq("organizationId", orgId),
-      )
-      .take(take);
-    const bySerial = await ctx.db
-      .query("assets")
-      .withSearchIndex("search_serialNumber", (s) =>
-        s.search("serialNumber", q).eq("organizationId", orgId),
-      )
-      .take(take);
-    const seen = new Set(byTag.map((a) => a._id));
-    const merged = [...byTag];
-    for (const a of bySerial) {
-      if (!seen.has(a._id)) {
-        seen.add(a._id);
-        merged.push(a);
-      }
-    }
-    return merged.slice(0, take);
-  },
-});
+// NOTE: `projects` and `assets` search queries were removed (2026-07-07). Neither had
+// a single-select picker to consume them: the app never picks a project (projects are
+// created/edited, never selected in a combobox), and every asset consumer is a
+// MULTI-select builder/table (maintenance form, asset table) whose selected-row chips
+// need per-id label resolution the bounded search page can't provide. Their search
+// indexes were dropped from schema.ts too — re-add both (query + index) alongside a
+// real single-select consumer when one is built. See docs/designs/convex-native-read-layer.md.

--- a/docs/designs/convex-native-read-layer.md
+++ b/docs/designs/convex-native-read-layer.md
@@ -52,10 +52,22 @@ convention violations (`collaboration.ts` addComment, `lib/fulfillment.ts` — t
    five composites** (`kitDetail`/`assetDetail`/`warehouseDetail`/`projectEquipment`/
    `equipmentTab`.test.ts): `not.toHaveProperty` on the PII/storageKey fields + a recursive
    no-leak guard. Reconstruct consumers compile + their unit tests pass unchanged.
-3. **Phase 7 mostly dead code.** 6 of 7 `convex/search.ts` queries have no `src/` consumer
-   (only the supplier picker is wired). Wire the remaining pickers (asset/model/kit/client/
-   project), or explicitly scope them out. Multi-field pickers need a 2nd index / denormalized
-   field first.
+3. ~~**Phase 7 mostly dead code.**~~ **✅ DONE (2026-07-07, PR `fix/convex-native-search-pickers`).**
+   Wired three more pickers to native indexed search (bounded + reactive, replacing whole-org
+   load + JS-filter): **clients** → project-wizard (`useClientSearch`); **models** → equipment-
+   add-form (`useModelSearch`); **kits** → kit-add-form (`useKitSearch`). Multi-field cases got a
+   2nd search index + merge (the assets tag+serial pattern, no backfill): **models** name **+**
+   `search_manufacturer`; **kits** name **+** `search_assetTag`, with active + non-prep filtered
+   IN the search via `filterFields` (`.eq("isActive",true).eq("isPrep",false)`, exact parity with
+   the old JS filter, no post-filtering the bounded page; `includePrep` opt-in). Each cutover
+   resolves the selected row's label via a getById hook (may be off the current search page) —
+   same pattern as the supplier cutover. **Scoped out + deleted (query + index + hook):**
+   `search.projects` (the app never picks a project in a combobox — projects are created/edited,
+   never selected) and `search.assets` (every asset consumer is a MULTI-select builder/table
+   whose selected chips need per-id label resolution the bounded search page can't give); both are
+   trivially re-addable with a real single-select consumer (noted in `schema.ts` + `search.ts`).
+   `convex/search.test.ts` covers the manufacturer + assetTag merges + prep exclusion. Every
+   remaining `search.ts` query now has a live consumer.
 4. **No `usePaginatedQuery` anywhere (§6).** Detail composites `.collect()` per-entity lists
    (bounded, low practical risk); revisit if any single entity's line-item list can get large.
 

--- a/src/components/projects/equipment-add-form.tsx
+++ b/src/components/projects/equipment-add-form.tsx
@@ -25,7 +25,8 @@ import {
   type LineItemFormValues,
 } from "@/lib/validations/line-item";
 import { addLineItem, checkAvailability, lookupAssetByTag } from "@/server/line-items";
-import { useModels } from "@/hooks/use-models";
+import { useModelSearch, useModel } from "@/hooks/use-models";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -91,14 +92,14 @@ export function EquipmentAddForm({
     },
   });
 
-  // Reactive models (Convex). Org-scoped list returns all models; re-apply
-  // getModels's default active filter and name sort client-side.
-  const modelDocs = useModels(orgId);
+  // Phase 7 — native INDEXED model search (name OR manufacturer, bounded + reactive)
+  // instead of loading the whole org catalog to JS-filter. Debounced as the user types;
+  // re-apply getModels' active filter on the bounded result set.
+  const [modelQuery, setModelQuery] = useState("");
+  const debouncedModelQuery = useDebouncedValue(modelQuery, 200);
+  const modelDocs = useModelSearch(orgId, debouncedModelQuery);
   const activeModels = useMemo(
-    () =>
-      [...(modelDocs ?? [])]
-        .filter((m) => m.isActive === true)
-        .sort((a, b) => a.name.localeCompare(b.name)),
+    () => [...(modelDocs ?? [])].filter((m) => m.isActive === true),
     [modelDocs],
   );
 
@@ -118,7 +119,12 @@ export function EquipmentAddForm({
     description: [m.manufacturer, m.modelNumber].filter(Boolean).join(" - ") || undefined,
   }));
 
-  const selectedModel = activeModels.find((m) => m.id === selectedModelId);
+  // Resolve the selected model directly (it may not be in the current search page) so
+  // the trigger label + the modelId effect below don't depend on the search results.
+  const selectedModel = useModel(selectedModelId || undefined) ?? undefined;
+  const selectedModelLabel = selectedModel
+    ? `${selectedModel.manufacturer ? `${selectedModel.manufacturer} ` : ""}${selectedModel.name}`
+    : undefined;
 
   // Model-based availability check (works with or without dates)
   const { data: availability, isLoading: availabilityLoading } = useServerQuery({
@@ -158,11 +164,11 @@ export function EquipmentAddForm({
   // When a model is selected, update form fields
   // Don't set unitPrice here — server-side optimizer will auto-price if billing period + rates exist
   useEffect(() => {
-    if (selectedModel) {
-      form.setValue("modelId", selectedModel.id);
+    if (selectedModelId) {
+      form.setValue("modelId", selectedModelId);
       form.setValue("assetId", undefined);
     }
-  }, [selectedModel, form]);
+  }, [selectedModelId, form]);
 
   // When asset is looked up, populate form
   useEffect(() => {
@@ -289,6 +295,9 @@ export function EquipmentAddForm({
                   value={selectedModelId}
                   onChange={(val) => setSelectedModelId(val)}
                   options={modelOptions}
+                  onSearchChange={setModelQuery}
+                  loading={modelDocs === undefined}
+                  selectedLabel={selectedModelLabel}
                   placeholder="Search models…"
                   searchPlaceholder="Search by name, manufacturer…"
                   emptyMessage="No models found."

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -25,8 +25,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { useActiveOrganization } from "@/lib/auth-client";
-import { useKits } from "@/hooks/use-kits";
+import { useKitSearch, useKit } from "@/hooks/use-kits";
 import { useCategories } from "@/hooks/use-categories";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 
 type KitPricingMode = "KIT_PRICE" | "ITEMIZED";
 
@@ -63,22 +64,26 @@ export function KitAddForm({
   const [kitPricingMode, setKitPricingMode] = useState<KitPricingMode>("KIT_PRICE");
   const [kitUnitPrice, setKitUnitPrice] = useState("");
 
-  // Reactive kit list (Convex). The org-scoped list returns all kits; re-apply
-  // getKits's default filter (active, non-prep) and assetTag sort client-side,
-  // and resolve the category name from the reactive categories list.
-  const kits = useKits(orgId);
+  // Phase 7 — native INDEXED kit search (name OR assetTag, prep excluded server-side,
+  // bounded + reactive) instead of loading the whole org list to JS-filter. Debounced
+  // as the user types; re-apply the active filter + resolve the category name.
+  const [kitQuery, setKitQuery] = useState("");
+  const debouncedKitQuery = useDebouncedValue(kitQuery, 200);
+  const kits = useKitSearch(orgId, debouncedKitQuery);
   const categories = useCategories(orgId);
   const kitOptions = useMemo(() => {
     const categoryNameById = new Map((categories ?? []).map((c) => [c.id, c.name]));
     return (kits ?? [])
-      .filter((kit) => kit.isActive === true && kit.isPrep === false)
-      .sort((a, b) => a.assetTag.localeCompare(b.assetTag))
+      .filter((kit) => kit.isActive === true)
       .map((kit) => ({
         value: kit.id,
         label: `${kit.assetTag} - ${kit.name}`,
         description: kit.categoryId ? categoryNameById.get(kit.categoryId) : undefined,
       }));
   }, [kits, categories]);
+  // Resolve the selected kit's label directly (it may not be in the current search page).
+  const selectedKit = useKit(selectedKitId || undefined);
+  const selectedKitLabel = selectedKit ? `${selectedKit.assetTag} - ${selectedKit.name}` : undefined;
 
   const { data: kitAvailability } = useServerQuery({
     queryKey: ["kit-availability", orgId, selectedKitId, projectId],
@@ -131,6 +136,9 @@ export function KitAddForm({
               value={selectedKitId}
               onChange={setSelectedKitId}
               options={kitOptions}
+              onSearchChange={setKitQuery}
+              loading={kits === undefined}
+              selectedLabel={selectedKitLabel}
               placeholder="Search kits…"
               searchPlaceholder="Search by tag or name…"
               emptyMessage="No kits found."

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -243,7 +243,9 @@ export function ProjectWizard({
   };
   const back = () => setStep((s) => Math.max(s - 1, 0));
 
-  const clientName = clientOptions.find((c) => c.value === v.clientId)?.label;
+  // Prefer the getById-resolved name (the selected client may be off the current
+  // bounded search page — e.g. editing an older project or after another search).
+  const clientName = selectedClientName ?? clientOptions.find((c) => c.value === v.clientId)?.label;
   const locationName = locationOptions.find((l) => l.value === v.locationId)?.label;
   const typeName = TYPE_OPTIONS.find((t) => t.value === v.type)?.label;
 

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -19,7 +19,8 @@ import { useServerQuery } from "@/hooks/use-server-query";
 import { projectSchema, type ProjectFormValues } from "@/lib/validations/project";
 import { createProject, updateProject, peekNextProjectNumber } from "@/server/projects";
 import { setProjectManagers } from "@/server/project-managers";
-import { useClients } from "@/hooks/use-clients";
+import { useClientSearch, useClient } from "@/hooks/use-clients";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useLocations } from "@/hooks/use-locations";
 import { useOrgTags } from "@/hooks/use-org-tags";
 import { getOrgMembers } from "@/server/org-members";
@@ -129,7 +130,11 @@ export function ProjectWizard({
     enabled: !isTemplate && !isEditing && !!orgId,
   });
 
-  const clients = useClients(orgId);
+  // Phase 7 — native INDEXED client search (bounded, reactive) instead of loading the
+  // whole org list to JS-filter. Debounced as the user types.
+  const [clientQuery, setClientQuery] = useState("");
+  const debouncedClientQuery = useDebouncedValue(clientQuery, 200);
+  const clients = useClientSearch(orgId, debouncedClientQuery);
   const clientOptions = (clients ?? []).map((c) => ({ value: c.id, label: c.name, description: c.contactName || undefined }));
   const rawLocations = useLocations(orgId) ?? [];
   const locNameById = new Map(rawLocations.map((l) => [l.id, l.name]));
@@ -183,6 +188,8 @@ export function ProjectWizard({
   });
 
   const v = form.watch();
+  // Resolve the selected client's label directly (it may not be in the current search page).
+  const selectedClientName = useClient(v.clientId || undefined)?.name;
 
   // Pre-fill the project code from the org's next sequence so the (now required)
   // field is populated by default — the user accepts it or types their own.
@@ -287,6 +294,7 @@ export function ProjectWizard({
               <Field label="Client">
                 <Controller control={form.control} name="clientId" render={({ field }) => (
                   <ComboboxPicker value={field.value || ""} onChange={field.onChange} options={clientOptions}
+                    onSearchChange={setClientQuery} loading={clients === undefined} selectedLabel={selectedClientName}
                     placeholder="Select client…" searchPlaceholder="Search clients…" allowClear
                     onCreateNew={() => setQuickClient(true)} createNewLabel="New client" emptyMessage="No clients found." />
                 )} />

--- a/src/hooks/use-clients.ts
+++ b/src/hooks/use-clients.ts
@@ -24,3 +24,15 @@ export function useClients(orgId: string | undefined): ClientDoc[] | undefined {
 export function useClient(id: string | undefined): ClientDoc | null | undefined {
   return useAuthedQuery(api.clients.getById, id ? { id } : "skip");
 }
+
+/**
+ * Phase 7 — reactive INDEXED client search (`api.search.clients`, by name) instead of
+ * loading the whole org list to JS-filter. `query === ""` returns a bounded
+ * most-recent list. Pass `orgId: undefined` to skip.
+ */
+export function useClientSearch(
+  orgId: string | undefined,
+  query: string,
+): ClientDoc[] | undefined {
+  return useAuthedQuery(api.search.clients, orgId ? { orgId, query } : "skip");
+}

--- a/src/hooks/use-kits.ts
+++ b/src/hooks/use-kits.ts
@@ -25,3 +25,15 @@ export function useKits(orgId: string | undefined): KitDoc[] | undefined {
 export function useKit(id: string | undefined): KitDoc | null | undefined {
   return useAuthedQuery(api.kits.getById, id ? { id } : "skip");
 }
+
+/**
+ * Phase 7 — reactive INDEXED kit search (`api.search.kits`, by name) instead of
+ * loading the whole org list to JS-filter. `query === ""` returns a bounded
+ * most-recent list. Pass `orgId: undefined` to skip.
+ */
+export function useKitSearch(
+  orgId: string | undefined,
+  query: string,
+): KitDoc[] | undefined {
+  return useAuthedQuery(api.search.kits, orgId ? { orgId, query } : "skip");
+}

--- a/src/hooks/use-models.ts
+++ b/src/hooks/use-models.ts
@@ -25,3 +25,15 @@ export function useModels(orgId: string | undefined): ModelDoc[] | undefined {
 export function useModel(id: string | undefined): ModelDoc | null | undefined {
   return useAuthedQuery(api.models.getById, id ? { id } : "skip");
 }
+
+/**
+ * Phase 7 — reactive INDEXED model search (`api.search.models`, matches name OR
+ * manufacturer) instead of loading the whole org catalog to JS-filter. `query === ""`
+ * returns a bounded most-recent list. Pass `orgId: undefined` to skip.
+ */
+export function useModelSearch(
+  orgId: string | undefined,
+  query: string,
+): ModelDoc[] | undefined {
+  return useAuthedQuery(api.search.models, orgId ? { orgId, query } : "skip");
+}


### PR DESCRIPTION
Closes compliance follow-up **#3** (post-migration review, 2026-07-07): 6 of 7 `convex/search.ts` queries were dead code (only the supplier picker was wired).

## Wired three more pickers to native indexed search
Bounded + reactive `useQuery` over `api.search.*` via `ComboboxPicker` async mode (onSearchChange + `useDebouncedValue` + loading + selectedLabel-via-getById), replacing "load the whole org list → JS-filter". Same proven pattern as the live sub-hire supplier picker:
- **Clients** → `project-wizard` (`useClientSearch`).
- **Models** → `equipment-add-form` (`useModelSearch`).
- **Kits** → `kit-add-form` (`useKitSearch`).

### Multi-field + filter handling (no backfill)
- **Models**: added a `search_manufacturer` index + merge (picker label is `{manufacturer} {name}`) — the assets tag+serial pattern.
- **Kits**: added a `search_assetTag` index + merge (label is `{tag} - {name}`), and added `isPrep` to the kit search `filterFields` so active + non-prep is filtered **in** the search (`.eq("isActive",true).eq("isPrep",false)` — exact parity with the old JS filter, no post-filtering a bounded page). Models likewise filter `isActive` in-query.

## Scoped out + deleted (query + index + hook)
- `search.projects` — the app never picks a project in a combobox (projects are created/edited, never selected).
- `search.assets` — every asset consumer is a multi-select builder/table whose selected chips need per-id label resolution the bounded search page can't provide.

Both are trivially re-addable with a real single-select consumer (noted in `schema.ts` + `search.ts`). Every remaining `search.ts` query now has a live consumer.

## Verification
- `convex/search.test.ts`: manufacturer merge, kit tag+name merge, prep exclusion + `includePrep`, org-scoping, limit clamp.
- `npx tsc --noEmit` clean; full convex suite **141/141**; lint clean (0 errors).
- codex review: fixed a **P2** (kit prep post-filtering could drop valid matches → moved to in-search filterFields) and a **P3** (wizard review row now uses the getById-resolved client name for a selection off the current search page).

The client/model/kit picker cutovers are live (unflagged), like the supplier precedent; Convex builds the new search indexes on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)