### PR TITLE
fix(api-mcp): exempt /api/v1/* from session-redirect middleware

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "./middleware";
+
+function req(path: string, opts?: { cookie?: string }) {
+  const r = new NextRequest(new URL(`https://flow.rvlt.app${path}`));
+  if (opts?.cookie) r.cookies.set("better-auth.session_token", opts.cookie);
+  return r;
+}
+
+/** A response is a login redirect if it 307s to /login. */
+function redirectsToLogin(res: Response): boolean {
+  const loc = res.headers.get("location");
+  return res.status === 307 && !!loc && loc.includes("/login");
+}
+
+describe("middleware — agent API routes bypass the session redirect", () => {
+  it("does NOT redirect /api/v1/* to /login (they authenticate via Bearer)", () => {
+    for (const path of ["/api/v1/whoami", "/api/v1/reserve-items", "/api/v1/mcp"]) {
+      const res = middleware(req(path)); // no session cookie
+      expect(redirectsToLogin(res), `${path} should not redirect to login`).toBe(false);
+    }
+  });
+
+  it("still redirects a normal protected route to /login when there's no session", () => {
+    const res = middleware(req("/dashboard"));
+    expect(redirectsToLogin(res)).toBe(true);
+    expect(res.headers.get("location")).toContain("callbackUrl=%2Fdashboard");
+  });
+
+  it("still lets the Better Auth routes through", () => {
+    expect(redirectsToLogin(middleware(req("/api/auth/session")))).toBe(false);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,6 +19,10 @@ export function middleware(request: NextRequest) {
   // - Org calendar feeds: /api/calendar/[token]/[feed]
   // - Crew iCal feeds: /api/crew/calendar/[token] (but NOT /api/crew/calendar/assignment/)
   // - Offer responses: /api/crew/respond/[token]
+  // - Agent-accessible API + MCP: /api/v1/* authenticate via `Authorization: Bearer`
+  //   (an API key, NOT a session cookie), so they must NOT be redirected to /login.
+  //   The route handlers do their own bearer auth and return a structured 401. See
+  //   docs/designs/api-mcp-agent-access.md.
   if (
     pathname.startsWith("/api/calendar/") ||
     (pathname.startsWith("/api/crew/calendar/") &&
@@ -28,7 +32,8 @@ export function middleware(request: NextRequest) {
     pathname.startsWith("/api/warehouse/display/") ||
     pathname.startsWith("/auditor/") ||
     pathname.startsWith("/api/auditor/") ||
-    pathname.startsWith("/api/cron/")
+    pathname.startsWith("/api/cron/") ||
+    pathname.startsWith("/api/v1/")
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
Post-deploy hotfix for the agent API (#378). The auth middleware redirects cookieless requests to `/login`; agent calls use a Bearer **API key**, not a session cookie, so `/api/v1/*` was being 307'd to an HTML login page instead of returning the structured JSON 401 from its handler.

Fix: add `/api/v1/` to the middleware's token-based public allowlist (same treatment as the existing auditor / warehouse-display / cron routes). The route handlers already do their own bearer auth.

Found by probing `GET https://flow.rvlt.app/api/v1/whoami` right after the #378 deploy (got `307 → /login`).

## Test plan
- [x] New `src/middleware.test.ts`: `/api/v1/*` is NOT redirected to login; `/dashboard` still is; `/api/auth/*` still passes. 3/3 green.
- [x] After merge: re-probe `/api/v1/whoami` (no token) → expect `401` + `{"error":{"code":"INVALID_KEY",...}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)