### PR TITLE
docs(api-mcp): agent guide at /llms.txt + in-API discovery

### DIFF
--- a/FEATUREDOCS/56-api-mcp.md
+++ b/FEATUREDOCS/56-api-mcp.md
@@ -49,6 +49,16 @@ Design of record: [`docs/designs/api-mcp-agent-access.md`](../docs/designs/api-m
   scope, idempotency). Tool failures return a structured `isError` result the agent can
   recover from.
 
+## Agent documentation
+
+`public/llms.txt` (served at `https://flow.rvlt.app/llms.txt`) is the complete,
+self-contained guide an AI agent reads to use the API/MCP: auth, MCP + REST setup,
+every tool/endpoint with schemas, the preview→commit flow, idempotency, the full
+error-code table with recovery actions, versioning, and worked examples. Discovery is
+wired INTO the API so an agent finds it without being told: `GET /api/v1` (unauthenticated
+index) returns the docs URL + endpoints; every error envelope carries `documentation_url`;
+`whoami` returns it too. The settings page links to it for operators.
+
 ## Key management
 
 `src/server/api-keys.ts`: `createApiKey` (returns the raw secret ONCE; acting user must be

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,347 @@
+# GearFlow API + MCP — Agent Guide
+
+> GearFlow is a rental / asset-management platform for AV and theatre production
+> companies. This document is written for an AI agent (or the developer wiring one
+> up). It is the complete, self-contained reference for the agent-accessible API and
+> MCP server: how to authenticate, the tools available, how reservations work, and
+> how to recover from every error. If you are an agent, you can rely on this file
+> alone — no other page is required.
+
+Base URL: `https://flow.rvlt.app`
+API version: `v1` (all paths are under `/api/v1`; every response carries an
+`X-GearFlow-API-Version: v1` header)
+Docs URL (this file): `https://flow.rvlt.app/llms.txt`
+
+---
+
+## 1. What you can do
+
+The API exposes **capability verbs**, not raw database CRUD. Each verb is a rental
+workflow action, and every verb is bound by the same protections the human web app
+enforces: role-based permissions (RBAC), overbooking prevention, and an audit log.
+
+Current v1 verbs:
+
+| Verb | Kind | What it does |
+|------|------|--------------|
+| `whoami` | read | Confirm your key works; see the org, acting user, and scopes it grants. |
+| `reserve_items` | write | Hold gear (models) on a project. Preview availability first, then commit. |
+
+More verbs (asset-specific holds, dispatch/return, search, webhooks) are planned. Call
+`whoami` and read the MCP `tools/list` for the authoritative, always-current set.
+
+---
+
+## 2. Authentication
+
+Every request authenticates with an **API key** sent as a Bearer token:
+
+```
+Authorization: Bearer gf_live_xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Properties of a key you must understand:
+
+- **Org-scoped.** A key belongs to exactly one GearFlow organization. You never pass
+  an `organizationId` — it is bound to the key. Any org id you put in a request body
+  is ignored.
+- **Acts as a user.** Each key acts on behalf of a specific GearFlow user. Your
+  effective permission is the **intersection** of (a) the key's scopes and (b) that
+  user's live role. A broadly-scoped key still cannot exceed the user's role; if the
+  user is later demoted or deactivated, the key is narrowed immediately.
+- **Scoped.** Scopes are `resource:action` strings (for example
+  `project:manage_line_items`), or `*` for everything the user's role allows. A verb
+  is rejected with `MISSING_SCOPE` if the key lacks the required scope.
+- **Secret shown once.** The raw key is displayed only when created; only a hash is
+  stored. If you lose it, create a new one.
+
+### Getting a key
+
+A GearFlow admin (a user with the `orgSettings` permission) creates keys in the web
+app: **Settings → Integrations → API Keys → Create key**. That screen returns the
+secret once and shows a ready-to-paste MCP config. An agent cannot mint its own key;
+ask the operator to create one and give it to you.
+
+---
+
+## 3. Connect over MCP (recommended for agents)
+
+GearFlow runs an MCP (Model Context Protocol) server at:
+
+```
+https://flow.rvlt.app/api/v1/mcp
+```
+
+Transport: Streamable HTTP, JSON-RPC 2.0. Authenticate with the same
+`Authorization: Bearer <key>` header.
+
+### Client config
+
+Most MCP clients (Claude Desktop, Cursor, OpenClaw, custom) accept a server entry
+like this:
+
+```json
+{
+  "mcpServers": {
+    "gearflow": {
+      "url": "https://flow.rvlt.app/api/v1/mcp",
+      "headers": { "Authorization": "Bearer gf_live_YOUR_KEY" }
+    }
+  }
+}
+```
+
+After adding it and restarting the client, you will have the `whoami` and
+`reserve_items` tools. **Call `whoami` first** to confirm the connection and see your
+scopes.
+
+### MCP methods supported
+
+- `initialize` → returns `protocolVersion`, `capabilities`, and
+  `serverInfo` (`{ "name": "gearflow", "version": "v1" }`).
+- `tools/list` → the current tools with full JSON-Schema input definitions and
+  prose descriptions (the descriptions are the source of truth for arguments).
+- `tools/call` → run a tool. Requires the Bearer header.
+- `notifications/*` → accepted, answered with HTTP 202, no body.
+
+A tool that fails returns a normal JSON-RPC `result` with `isError: true` and a
+`content[0].text` that is the JSON error envelope (see §6) — NOT a JSON-RPC protocol
+error. Read that envelope to decide what to do next.
+
+---
+
+## 4. Use over REST (for scripts / non-MCP callers)
+
+Same auth, same behavior, plain HTTP + JSON.
+
+- `GET /api/v1` — index: version, endpoints, docs link (no auth required).
+- `GET /api/v1/whoami` — identity + scopes for your key.
+- `POST /api/v1/reserve-items` — the reserve verb (preview or commit).
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer gf_live_YOUR_KEY" \
+  https://flow.rvlt.app/api/v1/whoami
+```
+
+---
+
+## 5. Tool / endpoint reference
+
+### 5.1 `whoami`
+
+Verify the key and see what it can do. Read-only. No arguments.
+
+MCP: `tools/call` with `{ "name": "whoami", "arguments": {} }`
+REST: `GET /api/v1/whoami`
+
+Response:
+
+```json
+{
+  "apiVersion": "v1",
+  "organizationId": "org_abc123",
+  "actingUserId": "user_abc123",
+  "actingUserName": "Ada Lovelace",
+  "actorType": "apiKey",
+  "apiKeyId": "key_abc123",
+  "scopes": ["project:manage_line_items"]
+}
+```
+
+Use it to confirm which scopes you hold before attempting a write.
+
+### 5.2 `reserve_items`
+
+Hold gear on a project. This is a two-step, safe-by-default flow: **preview** (no
+write) then **commit**.
+
+MCP: `tools/call` with `{ "name": "reserve_items", "arguments": { ... } }`
+REST: `POST /api/v1/reserve-items` with the arguments as the JSON body.
+
+Arguments:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `projectId` | string | yes | The project to reserve onto. Must exist in your org. |
+| `items` | array | yes | One or more `{ "modelId": string, "quantity": integer≥1 }`. v1 is model-based only (no `assetId`). |
+| `confirm` | boolean | no | `false` (default) = preview, writes nothing. `true` = commit. |
+| `idempotencyKey` | string | when `confirm=true` | A unique id for this reservation so a retry can't double-book. See §7. |
+
+Required scope: `project:manage_line_items` (and the acting user's role must allow it).
+
+**Preview** (`confirm` omitted or `false`) — returns availability without writing:
+
+```json
+{
+  "reservationId": null,
+  "committed": false,
+  "replayed": false,
+  "lineItemIds": [],
+  "summary": "Ready to reserve 1 item(s) on Acme Show.",
+  "preview": [
+    { "modelId": "model_x", "requested": 2, "available": 5, "sufficient": true, "conflicts": [] }
+  ]
+}
+```
+
+If `sufficient` is `false` for any item, do not commit that quantity — reduce it, pick
+a different model, or tell the operator. `conflicts` lists the other projects competing
+for the same stock in the window.
+
+**Commit** (`confirm: true` + `idempotencyKey`) — creates the holds:
+
+```json
+{
+  "reservationId": "li_abc123",
+  "committed": true,
+  "replayed": false,
+  "lineItemIds": ["li_abc123"],
+  "summary": "Reserved 1 item(s) on Acme Show."
+}
+```
+
+`replayed: true` means this exact request (same `idempotencyKey`) already ran and you
+are seeing the original result — a success, not an error. Do not retry further.
+
+Notes on behavior:
+- A reservation lands as a **quote-stage line item** on the project (a non-committing
+  hold), reversible by a human in the app. It counts against availability.
+- Availability is enforced (overbooking is rejected with `INVENTORY_CONFLICT`). You
+  cannot override it from the API.
+- The write is attributed in the org's audit log to the acting user + this key.
+
+Recommended pattern: **always preview first**, show the operator what you intend, then
+commit with a fresh `idempotencyKey`.
+
+---
+
+## 6. Errors — the envelope and every code
+
+Every error (REST body and MCP `isError` tool result) uses ONE shape:
+
+```json
+{
+  "error": {
+    "code": "MISSING_SCOPE",
+    "message": "This API key is missing the 'project:manage_line_items' scope.",
+    "retryable": false,
+    "requiredScope": "project:manage_line_items",
+    "details": { },
+    "documentation_url": "https://flow.rvlt.app/llms.txt"
+  }
+}
+```
+
+- `code` is a stable machine string — branch on it, never parse `message`.
+- `retryable` tells you whether the SAME request may succeed later.
+- `requiredScope` is present on `MISSING_SCOPE`.
+- `details` carries typed, per-code data (e.g. availability conflicts).
+
+Code table:
+
+| code | HTTP | retryable | Meaning → what you should do |
+|------|------|-----------|------------------------------|
+| `INVALID_KEY` | 401 | no | Missing/unknown key. Check the `Authorization: Bearer` header; ask the operator for a valid key. |
+| `KEY_INACTIVE` | 401 | no | The key was revoked. Ask the operator for a new key. |
+| `KEY_EXPIRED` | 401 | no | The key passed its expiry. Ask the operator for a new key. |
+| `ORG_KILL_SWITCH` | 403 | no | The org disabled all API access. Stop; ask the operator to re-enable it. |
+| `MISSING_SCOPE` | 403 | no | The key lacks `requiredScope`. Ask the operator to add that scope (fixable by a human, not by retrying). |
+| `FORBIDDEN` | 403 | no | The acting user's role forbids this action entirely. Not fixable by adding a scope. |
+| `VALIDATION_ERROR` | 400 | no | The request shape is wrong. Read `details` (it names the bad field) and fix the arguments. |
+| `IDEMPOTENCY_KEY_REQUIRED` | 400 | no | You set `confirm: true` without an `idempotencyKey`. Add a unique one and retry. |
+| `INVENTORY_CONFLICT` | 409 | no | Not enough free stock (or a booking rule blocked it). Read `details`; reduce quantity, choose another model, or change dates. |
+| `STALE_PREVIEW` | 409 | yes | A preview token expired or stock changed. Re-preview, then commit. |
+| `NOT_FOUND` | 404 | no | The `projectId` (or other resource) doesn't exist in your org. Verify the id. |
+| `INTERNAL` | 500 | yes | Unexpected server error. Retry with backoff; if it persists, tell the operator. |
+
+Golden rule for agents: **if `retryable` is `false`, do not retry the same request** —
+change the input or ask the operator. Only retry `retryable: true` codes, with backoff.
+
+---
+
+## 7. Idempotency
+
+Any committing write takes an `idempotencyKey`: a unique string YOU generate for each
+distinct intended action (a UUID is ideal). If the network drops and you retry with the
+SAME key, GearFlow returns the ORIGINAL result (`replayed: true`) instead of performing
+the action twice. Reuse the same key ONLY for a retry of the exact same request; use a
+NEW key for a new reservation. Previews (`confirm: false`) never need one.
+
+---
+
+## 8. Versioning
+
+- The path is versioned: everything is under `/api/v1`.
+- Every response carries `X-GearFlow-API-Version: v1`.
+- MCP `serverInfo.version` is `v1`.
+- Additive changes (new tools, new optional fields) are non-breaking and can appear
+  without a version bump — discover them via `tools/list` rather than hard-coding.
+- Breaking changes will ship under a new version path; `/api/v1` keeps working during
+  any migration window.
+
+---
+
+## 9. Limits and safety
+
+- **Org kill switch.** An operator can instantly disable ALL of an org's keys; you will
+  then get `ORG_KILL_SWITCH` on every call. Stop and tell the operator.
+- **Key revocation / expiry.** A single key can be revoked or expire → `KEY_INACTIVE` /
+  `KEY_EXPIRED`.
+- **Overbooking is always enforced** on writes; there is no override from the API.
+- Per-key rate limits and outbound webhooks are planned but not yet enforced in v1. Be a
+  good citizen: prefer previewing over hammering, and don't poll in tight loops.
+
+---
+
+## 10. Worked examples
+
+### 10.1 MCP: confirm, preview, then reserve
+
+```jsonc
+// 1) confirm the connection
+→ {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"whoami","arguments":{}}}
+← {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":
+     "{\"organizationId\":\"org_1\",\"actingUserName\":\"Ada\",\"scopes\":[\"project:manage_line_items\"]}"}]}}
+
+// 2) preview availability (no write)
+→ {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"reserve_items",
+     "arguments":{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}]}}}
+← ... result.content[0].text = {"committed":false,"preview":[{"modelId":"model_x","requested":2,"available":5,"sufficient":true,"conflicts":[]}], ...}
+
+// 3) commit (idempotencyKey required)
+→ {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"reserve_items",
+     "arguments":{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}],
+                  "confirm":true,"idempotencyKey":"a1b2c3-unique"}}}
+← ... result.content[0].text = {"committed":true,"reservationId":"li_1","lineItemIds":["li_1"], ...}
+```
+
+### 10.2 REST: preview then commit
+
+```bash
+# preview
+curl -s -X POST https://flow.rvlt.app/api/v1/reserve-items \
+  -H "Authorization: Bearer gf_live_YOUR_KEY" -H "Content-Type: application/json" \
+  -d '{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}]}'
+
+# commit
+curl -s -X POST https://flow.rvlt.app/api/v1/reserve-items \
+  -H "Authorization: Bearer gf_live_YOUR_KEY" -H "Content-Type: application/json" \
+  -H "Idempotency-Key: a1b2c3-unique" \
+  -d '{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}],"confirm":true}'
+```
+
+(REST accepts the idempotency key either as the `Idempotency-Key` header or an
+`idempotencyKey` body field.)
+
+---
+
+## 11. Quick reference
+
+- Auth: `Authorization: Bearer gf_live_...`
+- MCP: `POST https://flow.rvlt.app/api/v1/mcp` (JSON-RPC 2.0)
+- REST: `GET /api/v1/whoami`, `POST /api/v1/reserve-items`, `GET /api/v1`
+- Always `whoami` first. Always preview before you commit. Commits need an `idempotencyKey`.
+- On error: branch on `code`; only retry when `retryable` is `true`.
+- Org is bound to the key — never send an org id.

--- a/src/app/(app)/settings/api-keys/page.tsx
+++ b/src/app/(app)/settings/api-keys/page.tsx
@@ -174,7 +174,11 @@ export default function ApiKeysSettingsPage() {
               Connect AI agents and scripts to GearFlow. Each key acts on behalf of a user
               and is bound by that user&apos;s permissions. Point an MCP client at{" "}
               <code className="text-xs">/api/v1/mcp</code> or call the REST API with{" "}
-              <code className="text-xs">Authorization: Bearer</code>.
+              <code className="text-xs">Authorization: Bearer</code>. Full agent docs:{" "}
+              <a href="/llms.txt" target="_blank" rel="noreferrer" className="underline">
+                /llms.txt
+              </a>
+              .
             </p>
           </div>
           {canEdit && (

--- a/src/app/api/v1/route.ts
+++ b/src/app/api/v1/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { API_DOCS_URL } from "@/lib/api/http";
+
+/**
+ * GET /api/v1 — unauthenticated discovery index. Points an agent that lands on the
+ * base URL at the full docs, the MCP endpoint, and the available REST endpoints.
+ * See docs/designs/api-mcp-agent-access.md and the docs at /llms.txt.
+ */
+export function GET() {
+  return NextResponse.json(
+    {
+      name: "GearFlow API",
+      apiVersion: "v1",
+      description:
+        "Agent-accessible API + MCP for GearFlow rental/asset management. Authenticate with 'Authorization: Bearer <api key>'. Read the docs before calling.",
+      documentation_url: API_DOCS_URL,
+      mcp: {
+        url: "/api/v1/mcp",
+        transport: "streamable-http (JSON-RPC 2.0)",
+      },
+      endpoints: {
+        whoami: "GET /api/v1/whoami",
+        reserve_items: "POST /api/v1/reserve-items",
+      },
+      auth: "Authorization: Bearer <api key> (create one in Settings → Integrations → API Keys)",
+    },
+    { headers: { "Cache-Control": "no-store", "X-GearFlow-API-Version": "v1" } },
+  );
+}

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { authenticateApiRequest, toErrorEnvelope } from "@/lib/api/http";
+import { authenticateApiRequest, toErrorEnvelope, API_DOCS_URL } from "@/lib/api/http";
 
 /**
  * GET /api/v1/whoami
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest) {
         actorType: actor.actorType,
         apiKeyId: actor.apiKeyId ?? null,
         scopes: actor.scopes ?? [],
+        documentation_url: API_DOCS_URL,
       },
       {
         headers: {

--- a/src/lib/api/http.test.ts
+++ b/src/lib/api/http.test.ts
@@ -42,6 +42,8 @@ describe("toErrorEnvelope", () => {
     expect(body.error.code).toBe("MISSING_SCOPE");
     expect(body.error.requiredScope).toBe("project:manage_line_items");
     expect(body.error.retryable).toBe(false);
+    // Every error points the agent at the docs so it can self-serve recovery.
+    expect(body.error.documentation_url).toContain("/llms.txt");
   });
 
   it("maps an ApiKeyAuthError (401/403) preserving its code", () => {

--- a/src/lib/api/http.ts
+++ b/src/lib/api/http.ts
@@ -36,6 +36,9 @@ const STATUS_BY_CODE: Record<string, number> = {
   NOT_FOUND: 404,
 };
 
+/** The agent-facing docs. Attached to every error so an agent can self-serve recovery. */
+export const API_DOCS_URL = "https://flow.rvlt.app/llms.txt";
+
 export interface ErrorEnvelope {
   error: {
     code: string;
@@ -43,6 +46,7 @@ export interface ErrorEnvelope {
     retryable: boolean;
     requiredScope?: string;
     details?: Record<string, unknown>;
+    documentation_url: string;
   };
 }
 
@@ -62,6 +66,7 @@ export function toErrorEnvelope(err: unknown): { status: number; body: ErrorEnve
           retryable: err.retryable,
           requiredScope: err.requiredScope,
           details: err.details,
+          documentation_url: API_DOCS_URL,
         },
       },
     };
@@ -76,6 +81,7 @@ export function toErrorEnvelope(err: unknown): { status: number; body: ErrorEnve
           message: err.message,
           retryable: false,
           requiredScope: err.requiredScope,
+          documentation_url: API_DOCS_URL,
         },
       },
     };
@@ -88,6 +94,7 @@ export function toErrorEnvelope(err: unknown): { status: number; body: ErrorEnve
         code: "INTERNAL",
         message: "An unexpected error occurred.",
         retryable: true,
+        documentation_url: API_DOCS_URL,
       },
     },
   };

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -16,7 +16,7 @@ function redirectsToLogin(res: Response): boolean {
 
 describe("middleware — agent API routes bypass the session redirect", () => {
   it("does NOT redirect /api/v1/* to /login (they authenticate via Bearer)", () => {
-    for (const path of ["/api/v1/whoami", "/api/v1/reserve-items", "/api/v1/mcp"]) {
+    for (const path of ["/api/v1", "/api/v1/whoami", "/api/v1/reserve-items", "/api/v1/mcp"]) {
       const res = middleware(req(path)); // no session cookie
       expect(redirectsToLogin(res), `${path} should not redirect to login`).toBe(false);
     }
@@ -30,5 +30,9 @@ describe("middleware — agent API routes bypass the session redirect", () => {
 
   it("still lets the Better Auth routes through", () => {
     expect(redirectsToLogin(middleware(req("/api/auth/session")))).toBe(false);
+  });
+
+  it("serves the agent docs at /llms.txt without a login redirect", () => {
+    expect(redirectsToLogin(middleware(req("/llms.txt")))).toBe(false);
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/onboarding", "/pending-approval", "/api/integrations/woocommerce/webhook"];
+const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/onboarding", "/pending-approval", "/api/integrations/woocommerce/webhook", "/llms.txt"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -33,6 +33,7 @@ export function middleware(request: NextRequest) {
     pathname.startsWith("/auditor/") ||
     pathname.startsWith("/api/auditor/") ||
     pathname.startsWith("/api/cron/") ||
+    pathname === "/api/v1" ||
     pathname.startsWith("/api/v1/")
   ) {
     return NextResponse.next();


### PR DESCRIPTION
## Summary
Full agent-facing documentation for the API + MCP (like AgentMail's llms.txt), plus in-API discovery so an agent finds it on its own.

- **`public/llms.txt`** (served at `https://flow.rvlt.app/llms.txt`): self-contained guide — auth + key model, MCP + REST quickstart with copy-paste config, every tool/endpoint with exact schemas, preview→commit flow, idempotency, the **complete error-code table with per-code recovery actions**, versioning, limits, and worked MCP + curl examples. Written for an AI agent to rely on alone.
- **Discovery wired into the API:** `GET /api/v1` (unauthenticated index → docs URL + endpoints), `documentation_url` on every error envelope and in `whoami`, and a docs link on the settings page.
- **Middleware:** exempt `/llms.txt` and the bare `/api/v1` index from the session-redirect (else an unauthenticated agent fetching the docs / index gets 307'd to `/login`).

## Test plan
- [x] `middleware.test.ts`: `/llms.txt` and `/api/v1` are not login-redirected; protected routes still are. 4/4.
- [x] `http.test.ts`: every error envelope carries `documentation_url`.
- [x] Typecheck + lint clean on changed files.
- [ ] After merge/deploy: `curl https://flow.rvlt.app/llms.txt` → 200 docs; `GET /api/v1` → index JSON; an error response includes `documentation_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)