### PR TITLE
chore(api-mcp): brand the API/MCP as RVLT Flow

### DIFF
--- a/FEATUREDOCS/56-api-mcp.md
+++ b/FEATUREDOCS/56-api-mcp.md
@@ -1,6 +1,6 @@
 # 56 — Agent-Accessible API + MCP
 
-Lets AI agents (Claude, OpenClaw, scripts) and power users read and write GearFlow
+Lets AI agents (Claude, OpenClaw, scripts) and power users read and write RVLT Flow
 through a stable, org-scoped API exposed **MCP-first** with a REST facade. v1 ships a
 "safe rental-ops layer": broad reads + curated preview→commit capability verbs, bound
 by the SAME overbooking / RBAC / audit protections the web UI enforces.
@@ -42,7 +42,7 @@ Design of record: [`docs/designs/api-mcp-agent-access.md`](../docs/designs/api-m
   `POST /reserve-items`. `Authorization: Bearer <key>`. Errors use one agent-native
   envelope (`src/lib/api/http.ts` `toErrorEnvelope`): stable `code`, `retryable`,
   `requiredScope`, typed `details`; unknown errors become an opaque 500. `/v1` +
-  `X-GearFlow-API-Version` header.
+  `X-RVLT-Api-Version` header.
 - **MCP** (`POST /api/v1/mcp`, `src/lib/api/mcp.ts`): JSON-RPC 2.0 Streamable HTTP —
   `initialize`, `tools/list`, `tools/call` for `whoami` + `reserve_items`. Tool
   descriptions are prompt-shaped (prerequisites, effect, preview behaviour, required

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
-# GearFlow API + MCP — Agent Guide
+# RVLT Flow API + MCP — Agent Guide
 
-> GearFlow is a rental / asset-management platform for AV and theatre production
+> RVLT Flow is a rental / asset-management platform for AV and theatre production
 > companies. This document is written for an AI agent (or the developer wiring one
 > up). It is the complete, self-contained reference for the agent-accessible API and
 > MCP server: how to authenticate, the tools available, how reservations work, and
@@ -9,7 +9,7 @@
 
 Base URL: `https://flow.rvlt.app`
 API version: `v1` (all paths are under `/api/v1`; every response carries an
-`X-GearFlow-API-Version: v1` header)
+`X-RVLT-Api-Version: v1` header)
 Docs URL (this file): `https://flow.rvlt.app/llms.txt`
 
 ---
@@ -37,15 +37,15 @@ More verbs (asset-specific holds, dispatch/return, search, webhooks) are planned
 Every request authenticates with an **API key** sent as a Bearer token:
 
 ```
-Authorization: Bearer gf_live_xxxxxxxxxxxxxxxxxxxxxxxx
+Authorization: Bearer rvlt_live_xxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 Properties of a key you must understand:
 
-- **Org-scoped.** A key belongs to exactly one GearFlow organization. You never pass
+- **Org-scoped.** A key belongs to exactly one RVLT Flow organization. You never pass
   an `organizationId` — it is bound to the key. Any org id you put in a request body
   is ignored.
-- **Acts as a user.** Each key acts on behalf of a specific GearFlow user. Your
+- **Acts as a user.** Each key acts on behalf of a specific RVLT Flow user. Your
   effective permission is the **intersection** of (a) the key's scopes and (b) that
   user's live role. A broadly-scoped key still cannot exceed the user's role; if the
   user is later demoted or deactivated, the key is narrowed immediately.
@@ -57,7 +57,7 @@ Properties of a key you must understand:
 
 ### Getting a key
 
-A GearFlow admin (a user with the `orgSettings` permission) creates keys in the web
+A RVLT Flow admin (a user with the `orgSettings` permission) creates keys in the web
 app: **Settings → Integrations → API Keys → Create key**. That screen returns the
 secret once and shows a ready-to-paste MCP config. An agent cannot mint its own key;
 ask the operator to create one and give it to you.
@@ -66,7 +66,7 @@ ask the operator to create one and give it to you.
 
 ## 3. Connect over MCP (recommended for agents)
 
-GearFlow runs an MCP (Model Context Protocol) server at:
+RVLT Flow runs an MCP (Model Context Protocol) server at:
 
 ```
 https://flow.rvlt.app/api/v1/mcp
@@ -83,9 +83,9 @@ like this:
 ```json
 {
   "mcpServers": {
-    "gearflow": {
+    "rvlt-flow": {
       "url": "https://flow.rvlt.app/api/v1/mcp",
-      "headers": { "Authorization": "Bearer gf_live_YOUR_KEY" }
+      "headers": { "Authorization": "Bearer rvlt_live_YOUR_KEY" }
     }
   }
 }
@@ -98,7 +98,7 @@ scopes.
 ### MCP methods supported
 
 - `initialize` → returns `protocolVersion`, `capabilities`, and
-  `serverInfo` (`{ "name": "gearflow", "version": "v1" }`).
+  `serverInfo` (`{ "name": "rvlt-flow", "version": "v1" }`).
 - `tools/list` → the current tools with full JSON-Schema input definitions and
   prose descriptions (the descriptions are the source of truth for arguments).
 - `tools/call` → run a tool. Requires the Bearer header.
@@ -121,7 +121,7 @@ Same auth, same behavior, plain HTTP + JSON.
 Example:
 
 ```bash
-curl -H "Authorization: Bearer gf_live_YOUR_KEY" \
+curl -H "Authorization: Bearer rvlt_live_YOUR_KEY" \
   https://flow.rvlt.app/api/v1/whoami
 ```
 
@@ -265,7 +265,7 @@ change the input or ask the operator. Only retry `retryable: true` codes, with b
 
 Any committing write takes an `idempotencyKey`: a unique string YOU generate for each
 distinct intended action (a UUID is ideal). If the network drops and you retry with the
-SAME key, GearFlow returns the ORIGINAL result (`replayed: true`) instead of performing
+SAME key, RVLT Flow returns the ORIGINAL result (`replayed: true`) instead of performing
 the action twice. Reuse the same key ONLY for a retry of the exact same request; use a
 NEW key for a new reservation. Previews (`confirm: false`) never need one.
 
@@ -274,7 +274,7 @@ NEW key for a new reservation. Previews (`confirm: false`) never need one.
 ## 8. Versioning
 
 - The path is versioned: everything is under `/api/v1`.
-- Every response carries `X-GearFlow-API-Version: v1`.
+- Every response carries `X-RVLT-Api-Version: v1`.
 - MCP `serverInfo.version` is `v1`.
 - Additive changes (new tools, new optional fields) are non-breaking and can appear
   without a version bump — discover them via `tools/list` rather than hard-coding.
@@ -322,12 +322,12 @@ NEW key for a new reservation. Previews (`confirm: false`) never need one.
 ```bash
 # preview
 curl -s -X POST https://flow.rvlt.app/api/v1/reserve-items \
-  -H "Authorization: Bearer gf_live_YOUR_KEY" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer rvlt_live_YOUR_KEY" -H "Content-Type: application/json" \
   -d '{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}]}'
 
 # commit
 curl -s -X POST https://flow.rvlt.app/api/v1/reserve-items \
-  -H "Authorization: Bearer gf_live_YOUR_KEY" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer rvlt_live_YOUR_KEY" -H "Content-Type: application/json" \
   -H "Idempotency-Key: a1b2c3-unique" \
   -d '{"projectId":"proj_42","items":[{"modelId":"model_x","quantity":2}],"confirm":true}'
 ```
@@ -339,7 +339,7 @@ curl -s -X POST https://flow.rvlt.app/api/v1/reserve-items \
 
 ## 11. Quick reference
 
-- Auth: `Authorization: Bearer gf_live_...`
+- Auth: `Authorization: Bearer rvlt_live_...`
 - MCP: `POST https://flow.rvlt.app/api/v1/mcp` (JSON-RPC 2.0)
 - REST: `GET /api/v1/whoami`, `POST /api/v1/reserve-items`, `GET /api/v1`
 - Always `whoami` first. Always preview before you commit. Commits need an `idempotencyKey`.

--- a/src/app/(app)/settings/api-keys/page.tsx
+++ b/src/app/(app)/settings/api-keys/page.tsx
@@ -81,7 +81,7 @@ function mcpConfig(origin: string, token: string) {
   return JSON.stringify(
     {
       mcpServers: {
-        gearflow: {
+        "rvlt-flow": {
           url: `${origin}/api/v1/mcp`,
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -171,7 +171,7 @@ export default function ApiKeysSettingsPage() {
           <div>
             <h2 className="t-title text-ink">API keys</h2>
             <p className="text-sm text-fg-3 mt-1 max-w-prose">
-              Connect AI agents and scripts to GearFlow. Each key acts on behalf of a user
+              Connect AI agents and scripts to RVLT Flow. Each key acts on behalf of a user
               and is bound by that user&apos;s permissions. Point an MCP client at{" "}
               <code className="text-xs">/api/v1/mcp</code> or call the REST API with{" "}
               <code className="text-xs">Authorization: Bearer</code>. Full agent docs:{" "}

--- a/src/app/api/v1/mcp/route.ts
+++ b/src/app/api/v1/mcp/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleMcpMessage, type JsonRpcRequest } from "@/lib/api/mcp";
 
-const V1 = { "X-GearFlow-API-Version": "v1" };
+const V1 = { "X-RVLT-Api-Version": "v1" };
 
 /**
- * POST /api/v1/mcp — GearFlow's MCP server (Streamable HTTP, JSON-RPC 2.0).
+ * POST /api/v1/mcp — RVLT Flow's MCP server (Streamable HTTP, JSON-RPC 2.0).
  *
  * Point an MCP client here with `Authorization: Bearer <api key>`. Supports
  * `initialize`, `tools/list`, and `tools/call` (whoami, reserve_items). Notifications

--- a/src/app/api/v1/reserve-items/route.ts
+++ b/src/app/api/v1/reserve-items/route.ts
@@ -3,7 +3,7 @@ import { authenticateApiRequest, toErrorEnvelope } from "@/lib/api/http";
 import { reserveItems } from "@/lib/api/reserve-items";
 import { convexReservationPort } from "@/lib/api/reserve-port";
 
-const V1 = { "X-GearFlow-API-Version": "v1" };
+const V1 = { "X-RVLT-Api-Version": "v1" };
 
 /**
  * POST /api/v1/reserve-items

--- a/src/app/api/v1/route.ts
+++ b/src/app/api/v1/route.ts
@@ -9,10 +9,10 @@ import { API_DOCS_URL } from "@/lib/api/http";
 export function GET() {
   return NextResponse.json(
     {
-      name: "GearFlow API",
+      name: "RVLT Flow API",
       apiVersion: "v1",
       description:
-        "Agent-accessible API + MCP for GearFlow rental/asset management. Authenticate with 'Authorization: Bearer <api key>'. Read the docs before calling.",
+        "Agent-accessible API + MCP for RVLT Flow rental/asset management. Authenticate with 'Authorization: Bearer <api key>'. Read the docs before calling.",
       documentation_url: API_DOCS_URL,
       mcp: {
         url: "/api/v1/mcp",
@@ -24,6 +24,6 @@ export function GET() {
       },
       auth: "Authorization: Bearer <api key> (create one in Settings → Integrations → API Keys)",
     },
-    { headers: { "Cache-Control": "no-store", "X-GearFlow-API-Version": "v1" } },
+    { headers: { "Cache-Control": "no-store", "X-RVLT-Api-Version": "v1" } },
   );
 }

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       {
         headers: {
           "Cache-Control": "no-store",
-          "X-GearFlow-API-Version": "v1",
+          "X-RVLT-Api-Version": "v1",
         },
       },
     );
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
     const { status, body } = toErrorEnvelope(err);
     return NextResponse.json(body, {
       status,
-      headers: { "X-GearFlow-API-Version": "v1" },
+      headers: { "X-RVLT-Api-Version": "v1" },
     });
   }
 }

--- a/src/lib/api-key.test.ts
+++ b/src/lib/api-key.test.ts
@@ -44,15 +44,15 @@ beforeEach(() => {
 
 describe("hashApiKey / generateApiKey", () => {
   it("hashes deterministically and never returns the raw token in the hash", () => {
-    expect(hashApiKey("gf_live_abc")).toBe(hashApiKey("gf_live_abc"));
-    expect(hashApiKey("gf_live_abc")).not.toContain("gf_live_abc");
-    expect(hashApiKey("gf_live_abc")).toHaveLength(64); // sha256 hex
+    expect(hashApiKey("rvlt_live_abc")).toBe(hashApiKey("rvlt_live_abc"));
+    expect(hashApiKey("rvlt_live_abc")).not.toContain("rvlt_live_abc");
+    expect(hashApiKey("rvlt_live_abc")).toHaveLength(64); // sha256 hex
   });
 
   it("generates a key whose prefix is a real substring and whose hash matches", () => {
     const { raw, prefix, tokenHash } = generateApiKey();
     expect(raw.startsWith(prefix)).toBe(true);
-    expect(raw.startsWith("gf_live_")).toBe(true);
+    expect(raw.startsWith("rvlt_live_")).toBe(true);
     expect(tokenHash).toBe(hashApiKey(raw));
     // Two keys never collide.
     expect(generateApiKey().raw).not.toBe(raw);
@@ -116,7 +116,7 @@ describe("getApiKeyActorContext — validation + resolution", () => {
   it("resolves a valid key to an apiKey ActorContext with its scopes", async () => {
     apiKeyFindUnique.mockResolvedValue(keyRow());
 
-    const actor = await getApiKeyActorContext("gf_live_whatever");
+    const actor = await getApiKeyActorContext("rvlt_live_whatever");
 
     expect(actor).toEqual({
       organizationId: "org_1",
@@ -128,7 +128,7 @@ describe("getApiKeyActorContext — validation + resolution", () => {
     });
     // Looked up by hash, not raw token.
     expect(apiKeyFindUnique).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { tokenHash: hashApiKey("gf_live_whatever") } }),
+      expect.objectContaining({ where: { tokenHash: hashApiKey("rvlt_live_whatever") } }),
     );
   });
 

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -16,7 +16,7 @@ import type { ActorContext } from "./actor-context";
  * See docs/designs/api-mcp-agent-access.md.
  */
 
-const KEY_PREFIX = "gf_live_";
+const KEY_PREFIX = "rvlt_live_";
 
 /** Stable machine-readable reasons an API key can be rejected (mapped to the API error envelope). */
 export type ApiKeyRejectionCode =
@@ -55,7 +55,7 @@ export function generateApiKey(): {
 } {
   const secret = randomBytes(24).toString("hex");
   const raw = `${KEY_PREFIX}${secret}`;
-  // Display prefix: scheme + first 6 chars of the secret, e.g. "gf_live_ab12cd".
+  // Display prefix: scheme + first 6 chars of the secret, e.g. "rvlt_live_ab12cd".
   const prefix = `${KEY_PREFIX}${secret.slice(0, 6)}`;
   return { raw, prefix, tokenHash: hashApiKey(raw) };
 }

--- a/src/lib/api/http.test.ts
+++ b/src/lib/api/http.test.ts
@@ -20,8 +20,8 @@ beforeEach(() => vi.clearAllMocks());
 
 describe("extractBearerToken", () => {
   it("pulls the token from a well-formed header (case-insensitive)", () => {
-    expect(extractBearerToken("Bearer gf_live_abc")).toBe("gf_live_abc");
-    expect(extractBearerToken("bearer  gf_live_xyz  ")).toBe("gf_live_xyz");
+    expect(extractBearerToken("Bearer rvlt_live_abc")).toBe("rvlt_live_abc");
+    expect(extractBearerToken("bearer  rvlt_live_xyz  ")).toBe("rvlt_live_xyz");
   });
   it("returns null for missing or malformed headers", () => {
     expect(extractBearerToken(null)).toBeNull();
@@ -77,10 +77,10 @@ describe("authenticateApiRequest", () => {
       scopes: ["assets:read"],
     });
 
-    const actor = await authenticateApiRequest("Bearer gf_live_abc");
+    const actor = await authenticateApiRequest("Bearer rvlt_live_abc");
 
     expect(actor.actorType).toBe("apiKey");
     expect(actor.organizationId).toBe("org_1");
-    expect(getApiKeyActorContext).toHaveBeenCalledWith("gf_live_abc");
+    expect(getApiKeyActorContext).toHaveBeenCalledWith("rvlt_live_abc");
   });
 });

--- a/src/lib/api/mcp.test.ts
+++ b/src/lib/api/mcp.test.ts
@@ -32,7 +32,7 @@ describe("handleMcpMessage — protocol", () => {
     const res = await handleMcpMessage({ jsonrpc: "2.0", id: 1, method: "initialize" }, "Bearer x");
     expect(res!.result).toMatchObject({
       protocolVersion: expect.any(String),
-      serverInfo: { name: "gearflow", version: "v1" },
+      serverInfo: { name: "rvlt-flow", version: "v1" },
     });
   });
 
@@ -65,7 +65,7 @@ describe("handleMcpMessage — tools/call", () => {
     authenticateApiRequest.mockResolvedValue(actor);
     const res = await handleMcpMessage(
       { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "whoami", arguments: {} } },
-      "Bearer gf_live_x",
+      "Bearer rvlt_live_x",
     );
     const content = (res!.result as { content: { text: string }[] }).content[0].text;
     expect(JSON.parse(content)).toMatchObject({ organizationId: "org_1", actorType: "apiKey" });
@@ -84,7 +84,7 @@ describe("handleMcpMessage — tools/call", () => {
           arguments: { projectId: "p1", items: [{ modelId: "m1", quantity: 2 }], confirm: false },
         },
       },
-      "Bearer gf_live_x",
+      "Bearer rvlt_live_x",
     );
     expect(reserveItems).toHaveBeenCalledWith(
       actor,

--- a/src/lib/api/mcp.ts
+++ b/src/lib/api/mcp.ts
@@ -5,7 +5,7 @@ import { ApiError } from "./errors";
 
 /**
  * Minimal MCP (Model Context Protocol) server over Streamable HTTP (JSON-RPC 2.0).
- * Exposes GearFlow capability verbs as MCP tools so an agent (Claude, OpenClaw, …)
+ * Exposes RVLT Flow capability verbs as MCP tools so an agent (Claude, OpenClaw, …)
  * can call them natively. Handles `initialize`, `tools/list`, and `tools/call`;
  * notifications get no response. Tool DESCRIPTIONS are treated as the docs/prompt —
  * each states prerequisites, effect, preview behaviour, required scope, and idempotency.
@@ -14,7 +14,7 @@ import { ApiError } from "./errors";
  */
 
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
-export const MCP_SERVER_INFO = { name: "gearflow", version: "v1" } as const;
+export const MCP_SERVER_INFO = { name: "rvlt-flow", version: "v1" } as const;
 
 export const MCP_TOOLS = [
   {

--- a/src/server/api-keys.test.ts
+++ b/src/server/api-keys.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/org-context", () => ({
 }));
 vi.mock("@/lib/activity-log", () => ({ logActivity: vi.fn(async () => {}) }));
 vi.mock("@/lib/api-key", () => ({
-  generateApiKey: () => ({ raw: "gf_live_SECRET", prefix: "gf_live_ab", tokenHash: "hash_of_secret" }),
+  generateApiKey: () => ({ raw: "rvlt_live_SECRET", prefix: "rvlt_live_ab", tokenHash: "hash_of_secret" }),
 }));
 
 const prismaMock = vi.hoisted(() => ({
@@ -23,14 +23,14 @@ import { logActivity } from "@/lib/activity-log";
 beforeEach(() => {
   vi.clearAllMocks();
   prismaMock.member.findFirst.mockResolvedValue({ id: "mem_1" });
-  prismaMock.apiKey.create.mockResolvedValue({ id: "key_1", name: "Agent", prefix: "gf_live_ab" });
+  prismaMock.apiKey.create.mockResolvedValue({ id: "key_1", name: "Agent", prefix: "rvlt_live_ab" });
 });
 
 describe("createApiKey", () => {
   it("stores only the hash, returns the raw secret once, and audits", async () => {
     const res = await createApiKey({ name: "Agent", scopes: ["project:manage_line_items"] });
 
-    expect(res.token).toBe("gf_live_SECRET");
+    expect(res.token).toBe("rvlt_live_SECRET");
     const createArg = prismaMock.apiKey.create.mock.calls[0][0];
     expect(createArg.data.tokenHash).toBe("hash_of_secret");
     expect(createArg.data.token).toBeUndefined(); // raw secret is never persisted
@@ -82,7 +82,7 @@ describe("setOrgApiKillSwitch", () => {
 
 describe("listApiKeys", () => {
   it("returns keys + kill-switch state without any secret", async () => {
-    prismaMock.apiKey.findMany.mockResolvedValue([{ id: "key_1", prefix: "gf_live_ab", name: "Agent" }]);
+    prismaMock.apiKey.findMany.mockResolvedValue([{ id: "key_1", prefix: "rvlt_live_ab", name: "Agent" }]);
     prismaMock.organization.findUnique.mockResolvedValue({ apiKillSwitchAt: null });
 
     const res = await listApiKeys();


### PR DESCRIPTION
## Summary
The product is **RVLT Flow**, not GearFlow. This rebrands the agent- and user-facing surfaces of the just-shipped API/MCP feature:

- Prose → "RVLT Flow" in `public/llms.txt`, the `GET /api/v1` index, the settings page, FEATUREDOCS/56, and code comments.
- API key prefix `gf_live_` → `rvlt_live_`.
- MCP server id + client-config key `gearflow` → `rvlt-flow`.
- Version header `X-GearFlow-API-Version` → `X-RVLT-Api-Version`.

Safe: the feature is brand-new — no external consumers, no keys minted yet — so changing the prefix/header/ids has no migration or breakage. Scoped to the API/MCP feature only; a full-app rebrand is a separate effort.

## Test plan
- [x] 60 API-layer tests green (prefix/serverInfo assertions updated).
- [x] Typecheck + lint clean on changed files.
- [ ] After deploy: `/llms.txt` shows "RVLT Flow", responses carry `X-RVLT-Api-Version`, a new key starts with `rvlt_live_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)