### PR TITLE
fix(sub-hire): stop items popping out of groups/categories on add (#3)

### DIFF
--- a/FEATUREDOCS/39-sub-hires.md
+++ b/FEATUREDOCS/39-sub-hires.md
@@ -78,6 +78,8 @@ For **ungrouped items**: item target → order default → uncategorized.
 For **sub-hire groups**: group target → order default → uncategorized. Children always follow their parent.
 When `targetGroupId` is set, `categoryId` is resolved from the `ProjectGroup.categoryId`.
 
+**Placement is only ever read from these target fields, never from the generated `ProjectLineItem.groupId/categoryId`.** Because `generateSubHireLineItems` deletes + recreates every sub-hire line on each add/edit, any placement change that lands only on the line item is lost on the next regenerate — the item "pops back out" of its group/category. Therefore every path that repositions a sub-hire-derived line item **must write the placement back to the originating sub-hire entity's target fields**: `moveSubHireGroupToCategory` (group parent) and `moveLineItemToGroup` (standalone item — patches the `SubHireItem`'s `targetGroupId/targetCategoryId`, or the `SubHireGroup`'s for a group parent) both do this.
+
 ### Placement scenarios
 
 | Sub-hire entity | Target | Result on project |

--- a/src/server/project-groups.ts
+++ b/src/server/project-groups.ts
@@ -376,6 +376,38 @@ export async function moveLineItemToGroup(
     clear: moveClear,
   });
 
+  // If this line item is derived from a sub-hire, persist the placement back to
+  // the originating sub-hire entity's target* fields. generateSubHireLineItems
+  // deletes + recreates every sub-hire line on the next add/edit and resolves
+  // placement ONLY from the sub-hire entity's target*/order-default — it never
+  // reads the projectLineItem's own groupId/categoryId. Without this write-back
+  // the manual move is silently reverted and the item "pops out" of the
+  // group/category the user placed it in (mirrors moveSubHireGroupToCategory,
+  // which already writes targetCategoryId back to the sub-hire group).
+  const subHireGroupId = lineItem.subHireGroupId ?? null;
+  const subHireItemId = lineItem.subHireItemId ?? null;
+  if (subHireGroupId || subHireItemId) {
+    const targetSet: Record<string, unknown> = {};
+    const targetClear: string[] = [];
+    if (parsed.targetGroupId != null) targetSet.targetGroupId = parsed.targetGroupId;
+    else targetClear.push("targetGroupId");
+    if (parsed.targetCategoryId != null) targetSet.targetCategoryId = parsed.targetCategoryId;
+    else targetClear.push("targetCategoryId");
+    if (subHireGroupId) {
+      await client.mutation(api.subHireGroups.patchGroup, {
+        id: subHireGroupId,
+        set: targetSet,
+        clear: targetClear,
+      });
+    } else if (subHireItemId) {
+      await client.mutation(api.subHireItems.patchItem, {
+        id: subHireItemId,
+        set: targetSet,
+        clear: targetClear,
+      });
+    }
+  }
+
   // Recalculate suggestions for both old and new groups in Convex
   const now = Date.now();
   if (oldGroupId) {

--- a/src/server/subhire-placement-regression.int.test.ts
+++ b/src/server/subhire-placement-regression.int.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression test for the sub-hire grouping bug (issue #3):
+ *
+ *   "I have a sub-hire order with things I've put into groups/categories.
+ *    When I add a new thing to the sub-hire order, the things that were
+ *    already in the groups/categories get moved back OUT of them."
+ *
+ * Root cause: `generateSubHireLineItems` deletes + recreates every project
+ * line item for a sub-hire on each add/edit and resolves placement ONLY from
+ * the sub-hire entity's target fields / order-default — never from the
+ * projectLineItem's own groupId/categoryId. `moveLineItemToGroup` used to patch only the
+ * projectLineItem, so the manual placement was lost on the next regenerate.
+ *
+ * The fix makes `moveLineItemToGroup` write the placement back to the
+ * originating sub-hire item/group's target* fields (mirroring
+ * `moveSubHireGroupToCategory`), which is what regeneration reads.
+ *
+ * NOTE: assertions read the sub-hire item back from Convex directly. In this
+ * worktree the shared-dev Convex→Prisma readback is not wired, so a
+ * `testPrisma` read would NOT reflect a Convex-only write (this is the same
+ * reason the category-slots int suite has known-red Prisma-readback
+ * assertions). Reading Convex is the reliable path.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  testPrisma,
+  setupIntegrationTest,
+  createOrgFixture,
+  createUserFixture,
+} from "../../tests/helpers/integration";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+
+const h = vi.hoisted(() => ({
+  ctx: { organizationId: "", userId: "", userName: "Tester" },
+  recalcSpy: vi.fn<(projectId: string) => Promise<void>>(),
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: async () => h.ctx,
+  getOrgContext: async () => h.ctx,
+}));
+
+vi.mock("@/server/line-items", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/line-items")>();
+  return {
+    ...actual,
+    recalculateProjectTotals: h.recalcSpy,
+  };
+});
+
+import { moveLineItemToGroup } from "@/server/project-groups";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+async function createSupplierFixture(orgId: string) {
+  return testPrisma.supplier.create({ data: { organizationId: orgId, name: "Supplier" } });
+}
+async function createProjectFixture(orgId: string) {
+  return testPrisma.project.create({
+    data: { organizationId: orgId, projectNumber: `P-${createId().slice(0, 6)}`, name: "Test Project" },
+  });
+}
+async function createCategoryFixture(orgId: string, projectId: string, name = "Cat", sortOrder = 0) {
+  return testPrisma.projectCategory.create({
+    data: { organizationId: orgId, projectId, name, sortOrder },
+  });
+}
+async function createProjectGroupFixture(orgId: string, projectId: string, categoryId: string) {
+  return testPrisma.projectGroup.create({
+    data: { organizationId: orgId, projectId, categoryId, title: "PG", sortOrder: 0 },
+  });
+}
+async function createSubHireFixture(orgId: string, supplierId: string, userId: string, projectId: string) {
+  return testPrisma.subHire.create({
+    data: {
+      organizationId: orgId,
+      supplierId,
+      createdById: userId,
+      projectId,
+      orderNumber: `SO-${createId().slice(0, 6)}`,
+    },
+  });
+}
+async function createSubHireItemFixture(subHireId: string, orgId: string) {
+  return testPrisma.subHireItem.create({
+    data: { subHireId, description: "Hazer", quantity: 1 },
+  });
+}
+/** Materialise the standalone sub-hire ProjectLineItem that generateSubHireLineItems would create. */
+async function createSubHireLineItem(
+  orgId: string,
+  projectId: string,
+  subHireId: string,
+  subHireItemId: string,
+) {
+  return testPrisma.projectLineItem.create({
+    data: {
+      organizationId: orgId,
+      projectId,
+      subHireId,
+      subHireItemId,
+      isKitChild: false,
+      description: "Hazer",
+    },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("moveLineItemToGroup — persists placement back to the sub-hire item (issue #3)", () => {
+  beforeEach(async () => {
+    await setupIntegrationTest();
+    h.recalcSpy.mockClear();
+  });
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it("writes targetGroupId + targetCategoryId to the sub-hire item when moved into a project group", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const supplier = await createSupplierFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const cat = await createCategoryFixture(org.id, project.id);
+    const pg = await createProjectGroupFixture(org.id, project.id, cat.id);
+    const subHire = await createSubHireFixture(org.id, supplier.id, user.id, project.id);
+    const item = await createSubHireItemFixture(subHire.id, org.id);
+    const line = await createSubHireLineItem(org.id, project.id, subHire.id, item.id);
+
+    await moveLineItemToGroup({
+      lineItemId: line.id,
+      targetGroupId: pg.id,
+      targetCategoryId: cat.id,
+    });
+
+    const convex = await getConvexClient();
+    const itemAfter = await convex.query(api.subHireItems.getById, { id: item.id });
+    expect(itemAfter).not.toBeNull();
+    // Without the fix these stay null and the next regenerate reverts the item
+    // to the order default — "moved back OUT" of the group.
+    expect(itemAfter!.targetGroupId).toBe(pg.id);
+    expect(itemAfter!.targetCategoryId).toBe(cat.id);
+  });
+
+  it("writes targetCategoryId (and clears targetGroupId) when moved into a bare category", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const supplier = await createSupplierFixture(org.id);
+    const project = await createProjectFixture(org.id);
+    const cat = await createCategoryFixture(org.id, project.id);
+    const subHire = await createSubHireFixture(org.id, supplier.id, user.id, project.id);
+    const item = await createSubHireItemFixture(subHire.id, org.id);
+    const line = await createSubHireLineItem(org.id, project.id, subHire.id, item.id);
+
+    await moveLineItemToGroup({
+      lineItemId: line.id,
+      targetGroupId: null,
+      targetCategoryId: cat.id,
+    });
+
+    const convex = await getConvexClient();
+    const itemAfter = await convex.query(api.subHireItems.getById, { id: item.id });
+    expect(itemAfter).not.toBeNull();
+    expect(itemAfter!.targetCategoryId).toBe(cat.id);
+    expect(itemAfter!.targetGroupId ?? null).toBeNull();
+  });
+
+  it("does not touch sub-hire targets for a non-sub-hire line item", async () => {
+    const org = await createOrgFixture();
+    const user = await createUserFixture(org.id, "owner");
+    h.ctx = { organizationId: org.id, userId: user.id, userName: "Tester" };
+
+    const project = await createProjectFixture(org.id);
+    const cat = await createCategoryFixture(org.id, project.id);
+    const pg = await createProjectGroupFixture(org.id, project.id, cat.id);
+    // Plain own-stock line — no subHireId/subHireItemId.
+    const line = await testPrisma.projectLineItem.create({
+      data: {
+        organizationId: org.id,
+        projectId: project.id,
+        isKitChild: false,
+        description: "Own-stock item",
+      },
+    });
+
+    // Should simply move the line item without error (no sub-hire write-back).
+    await expect(
+      moveLineItemToGroup({ lineItemId: line.id, targetGroupId: pg.id, targetCategoryId: cat.id }),
+    ).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

Reported by user: *"I have a sub-hire order with things I've put into groups/categories. When I add a new thing to the sub-hire order, the things that were already in the groups/categories get moved back OUT of them."*

## Root cause

Every sub-hire mutation runs `generateSubHireLineItems`, which **deletes + recreates every project line item** for the sub-hire and resolves each item's placement **only** from the sub-hire entity's `targetGroupId`/`targetCategoryId` (or the order default) — never from the `ProjectLineItem`'s own `groupId`/`categoryId`.

`moveLineItemToGroup` (the generic drag-to-group/category action) patched only the `ProjectLineItem`. So a manual placement lived nowhere the regenerator reads, and the next add/edit reverted the item to the order default.

## Fix

`moveLineItemToGroup` now writes the placement back to the originating **`SubHireItem`** (or **`SubHireGroup`** for a group parent) `target*` fields — mirroring the existing `moveSubHireGroupToCategory` write-back. Regeneration then preserves it. Non-sub-hire line items are untouched (guarded on `subHireItemId`/`subHireGroupId`).

## Tests

New `subhire-placement-regression.int.test.ts` (3 cases): asserts the write-back against Convex directly. Verified red without the fix (2 failing write-back assertions), green with it.

> Note: assertions read the sub-hire item back from **Convex** rather than `testPrisma` — the shared-dev worktree doesn't wire Convex→Prisma readback (same reason the category-slots int suite has known-red Prisma-readback assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)