### PR TITLE
fix(financials): count grouped sub-hire revenue; clarify cost model (#7/#8)

### DIFF
--- a/FEATUREDOCS/39-sub-hires.md
+++ b/FEATUREDOCS/39-sub-hires.md
@@ -113,9 +113,14 @@ Sub-hire costs are integrated into the project financial calculations:
 | Field | Formula | Source |
 |-------|---------|--------|
 | `subHireCostTotal` | SUM(subHire.totalCost) for CONFIRMED/ON_HIRE/RETURNED | `recalculateProjectTotals` |
+| sub-hire **revenue** | SUM(subHire line `lineTotal`) — via `equipmentRevenue` | `recalculateProjectTotals` |
 | `margin` | total - (serviceCostTotal + labourCostTotal + **subHireCostTotal**) | `recalculateProjectTotals` |
 
 Sub-hire costs appear in the **Costs** section of the project financial summary alongside service costs and labour costs. DRAFT and CANCELLED sub-hires are excluded from the cost calculation.
+
+**Cost vs revenue use different models — mind the asymmetry.** Cost is *head-driven*: `SUM(subHire.totalCost)`, which includes even `showOnQuote:false` items (cost-only tracking) but excludes whole DRAFT/CANCELLED sub-hires. Revenue is *line-item-driven*: it sums the generated sub-hire `ProjectLineItem.lineTotal`s inside `equipmentRevenue`, so it only counts `showOnQuote` items but is agnostic to the sub-hire's DRAFT/CANCELLED status (line items are generated for DRAFT sub-hires and are not removed on cancel). A DRAFT sub-hire therefore books revenue but no cost until confirmed — intentional (optimistic quote), but a source of "cost missing" confusion.
+
+**Grouped sub-hire revenue (`subHireGroupedRevenue`).** A sub-hire line placed *into a project group* (via `targetGroupId`/order default) carries its own client charge, independent of the host group's bundle price. `equipmentRevenue`'s group term only counts `isCustomItem` extras (and zeroes them for a priced group), so a grouped sub-hire's charge would silently vanish. `recalculateProjectTotals` adds `subHireGroupedRevenue` — every non-child, non-optional sub-hire line with a `groupId` — counted individually, mirroring how the same line bills when ungrouped. Kit-style children (`isKitChild`) are excluded to avoid double-counting against their group parent's charge. Kept byte-for-byte in sync between `src/server/line-items.ts` and `convex/lib/recalc.ts`.
 
 The sub-hire item's `unitCharge` flows to the `ProjectLineItem.unitPrice`, which feeds into `suggestedPrice` for project groups. If the user overrides the group price, that's their business decision. The sub-hire order still tracks the full cost vs charge breakdown for per-order margin analysis.
 

--- a/convex/lib/recalc.ts
+++ b/convex/lib/recalc.ts
@@ -68,7 +68,27 @@ export async function recalcProjectTotals(
     )
     .reduce((sum, li) => sum + num(li.lineTotal), 0);
 
-  const equipmentRevenue = round(groupRevenue + standaloneRevenue);
+  // 2b. Sub-hire line items placed INTO a project group. A sub-hire carries its
+  // OWN client charge, independent of the host group's bundle price — but the
+  // group revenue in (1) only counts isCustomItem extras (and a priced group
+  // zeroes them entirely), so a grouped sub-hire's charge would silently vanish.
+  // Count each grouped sub-hire line's charge individually, mirroring how the
+  // SAME line bills when ungrouped in (2). Kit-style children (isKitChild) are
+  // excluded to avoid double-counting against their group parent's charge — the
+  // identical exclusion (2) applies to ungrouped sub-hire groups. Kept
+  // byte-for-byte in sync with src/server/line-items.ts.
+  const subHireGroupedRevenue = projectLines
+    .filter(
+      (li) =>
+        li.groupId != null &&
+        li.subHireId != null &&
+        !li.isOptional &&
+        !li.isKitChild &&
+        li.status !== "CANCELLED",
+    )
+    .reduce((sum, li) => sum + num(li.lineTotal), 0);
+
+  const equipmentRevenue = round(groupRevenue + standaloneRevenue + subHireGroupedRevenue);
 
   // 3. Service financials (this project's non-CANCELLED rows).
   const services = allServices.filter(

--- a/convex/recalc.test.ts
+++ b/convex/recalc.test.ts
@@ -58,6 +58,31 @@ describe("recalcProjectTotals — totals parity", () => {
     expect(p?.updatedAt).toBe(NOW + 1);
   });
 
+  test("counts a sub-hire line placed inside a priced project group (issue #8)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", {
+        id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig",
+        status: "CONFIRMED", isTemplate: false, taxRate: 10, discountPercent: 0,
+        createdAt: NOW, updatedAt: NOW,
+      });
+      // Priced group: 100 × qty 1 = 100. Its flat price covers its OWN gear only.
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: ORG, projectId: "p1", title: "Audio", price: 100, quantity: 1, sortOrder: 0 });
+      // Sub-hire line dropped INTO the priced group. Before the fix this vanished
+      // (groupRevenue's customExtras is zeroed for a priced group, and standalone
+      // requires groupId == null). It carries its own client charge (60).
+      await ctx.db.insert("projectLineItems", { id: "sl1", organizationId: ORG, projectId: "p1", status: "QUOTED", type: "EQUIPMENT", isKitChild: false, isOptional: false, groupId: "g1", subHireId: "sh1", subHireItemId: "si1", lineTotal: 60 });
+      // A kit-style child of a sub-hire group in the same group — excluded (would
+      // double-count against its parent's group charge).
+      await ctx.db.insert("projectLineItems", { id: "sl2", organizationId: ORG, projectId: "p1", status: "QUOTED", type: "EQUIPMENT", isKitChild: true, isOptional: false, groupId: "g1", subHireId: "sh1", subHireItemId: "si2", lineTotal: 40 });
+      await recalcProjectTotals(ctx, "p1", ORG, null, NOW + 1);
+    });
+
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    // group 100 + standalone 0 + grouped sub-hire 60 (child 40 excluded) = 160
+    expect(p?.equipmentRevenue).toBe(160);
+  });
+
   test("uses org default tax when the project has no override", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1538,7 +1538,27 @@ export async function recalculateProjectTotals(projectId: string) {
     )
     .reduce((sum, li) => sum + (li.lineTotal != null ? Number(li.lineTotal) : 0), 0);
 
-  const equipmentRevenue = roundCurrency(groupRevenue + standaloneRevenue);
+  // 2b. Sub-hire line items placed INTO a project group. A sub-hire carries its
+  // OWN client charge, independent of the host group's bundle price — but the
+  // group revenue in (1) only counts isCustomItem extras (and a priced group
+  // zeroes them entirely), so a grouped sub-hire's charge would silently vanish.
+  // Count each grouped sub-hire line's charge individually, mirroring how the
+  // SAME line bills when ungrouped in (2). Kit-style children (isKitChild) are
+  // excluded to avoid double-counting against their group parent's charge — the
+  // identical exclusion (2) applies to ungrouped sub-hire groups. Kept
+  // byte-for-byte in sync with convex/lib/recalc.ts.
+  const subHireGroupedRevenue = projectLines
+    .filter(
+      (li) =>
+        li.groupId != null &&
+        li.subHireId != null &&
+        !li.isOptional &&
+        !li.isKitChild &&
+        li.status !== "CANCELLED",
+    )
+    .reduce((sum, li) => sum + (li.lineTotal != null ? Number(li.lineTotal) : 0), 0);
+
+  const equipmentRevenue = roundCurrency(groupRevenue + standaloneRevenue + subHireGroupedRevenue);
 
   // 3. Service financials. project_service is Convex-only — read the org's
   // services and filter to this project's non-CANCELLED rows in JS (replaces the


### PR DESCRIPTION
## Problems reported

- *"Subhire costs are not being included in the financials breakdown for projects."*
- *"Confirm subhire revenue is being calculated for financials breakdown."*

## What I found

**Revenue — a real bug.** A sub-hire line item placed **into a project group** had its client charge silently dropped from `equipmentRevenue`:
- the group-revenue term only sums `isCustomItem` extras (and **zeroes them entirely for a priced group**), and sub-hire lines are never flagged `isCustomItem`;
- the standalone term requires `groupId == null`.

So a grouped sub-hire billed **£0 revenue** while its cost was still counted → artificially low margin, and revenue "not calculated". Ungrouped sub-hires were already counted, so it only bit once you organised them into groups/categories.

**Cost — working as designed.** `subHireCostTotal` already sums `subHire.totalCost` for CONFIRMED/ON_HIRE/RETURNED sub-hires. Cost is **excluded for DRAFT/CANCELLED** sub-hires (documented in FEATUREDOC 39) and is 0 in `ORDER_TOTAL` mode when `orderTotalCost` is unset. So "cost not included" is almost certainly a **DRAFT sub-hire** or an **empty order-total** — not a code bug. See ⚠️ below.

## Fix

Adds `subHireGroupedRevenue` to `recalculateProjectTotals`: every non-child, non-optional sub-hire line with a `groupId`, counted individually — mirroring how the same line bills when ungrouped. `isKitChild` children stay excluded to avoid double-counting their group parent's charge.

Applied **byte-for-byte to both parity-locked copies** (`src/server/line-items.ts` + `convex/lib/recalc.ts`) and locked with a `recalc.test.ts` parity case (verified red → green: dropped `100`, now `160`). Existing `group-revenue-custom-items.int.test.ts` (9 cases) still green — no custom-item regression.

## ⚠️ Decision for you: DRAFT sub-hire cost

Revenue is line-item-driven and **status-agnostic** (DRAFT sub-hires book revenue). Cost is head-driven and **excludes DRAFT**. So a DRAFT sub-hire shows revenue but no cost. That asymmetry is the most likely cause of "cost not included". I did **not** change it (it's a documented product decision). If you'd rather DRAFT sub-hire costs also count, say the word — it's a one-line change to the status gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)