### PR TITLE
feat(groups): default new project groups to Uncategorized (#5)

### DIFF
--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -146,6 +146,12 @@ All under `src/components/projects/`:
   `SubHireOrderDialog` on the new order in manage view so the user can
   immediately add items. The legacy `onOpenSubHire` bounce prop was
   removed in v0.9.1.0.
+- **`AddGroupToolbarDialog`** — the equipment-tab "Add group" dialog. The
+  category `<select>` **defaults to Uncategorized** (since v0.23.x): a group
+  is one field (title) to create, mirroring how sub-hire groups already
+  default to uncategorised. Picking Uncategorized submits `categoryId: null`
+  (the project's Uncategorized zone). There is no empty "Select category…"
+  placeholder — Create is enabled as soon as a title is typed.
 - **`PriceEditDialog`** — single dialog for editing group pricing.
   `kind=project` shows a single price input; `kind=subHire` shows charge +
   cost + computed margin per unit.

--- a/src/components/projects/__tests__/add-group-toolbar-dialog.smoke.test.tsx
+++ b/src/components/projects/__tests__/add-group-toolbar-dialog.smoke.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+import { AddGroupToolbarDialog } from "../add-group-toolbar-dialog";
+
+const baseProps = {
+  open: true,
+  isPending: false,
+  categories: [{ id: "cat1", name: "Lighting" }],
+  templates: [],
+  onOpenChange: () => {},
+};
+
+describe("AddGroupToolbarDialog — defaults to Uncategorized (issue #5)", () => {
+  it("enables Create with just a title (no category pick required) and submits categoryId=null", () => {
+    const onSubmit = vi.fn();
+    render(<AddGroupToolbarDialog {...baseProps} onSubmit={onSubmit} />);
+
+    // The category select defaults to Uncategorized (not an empty "Select…").
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("__uncategorized__");
+    // No empty placeholder option remains.
+    expect(screen.queryByRole("option", { name: /select category/i })).toBeNull();
+
+    // Type a title only — Create should already be enabled (no category step).
+    fireEvent.change(screen.getByPlaceholderText(/PA System/i), {
+      target: { value: "New Rig" },
+    });
+    const create = screen.getByRole("button", { name: /create/i }) as HTMLButtonElement;
+    expect(create.disabled).toBe(false);
+
+    fireEvent.click(create);
+    expect(onSubmit).toHaveBeenCalledWith({ categoryId: null, title: "New Rig", templateId: undefined });
+  });
+});

--- a/src/components/projects/add-group-toolbar-dialog.tsx
+++ b/src/components/projects/add-group-toolbar-dialog.tsx
@@ -73,7 +73,10 @@ function AddGroupToolbarDialogBody({
   onOpenChange,
   onSubmit,
 }: AddGroupToolbarDialogProps) {
-  const [categoryId, setCategoryId] = useState("");
+  // Default to the Uncategorized zone so creating a group is one field (title)
+  // — mirrors how sub-hire groups already default to uncategorised. The user
+  // can still pick a category, but no longer has to before Create enables.
+  const [categoryId, setCategoryId] = useState(UNCATEGORISED_VALUE);
   const [templateId, setTemplateId] = useState("");
   const [title, setTitle] = useState("");
 
@@ -111,7 +114,6 @@ function AddGroupToolbarDialogBody({
             onChange={(e) => setCategoryId(e.target.value)}
             className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
-            <option value="">Select category...</option>
             <option value={UNCATEGORISED_VALUE}>Uncategorized</option>
             {categories.map((cat) => (
               <option key={cat.id} value={cat.id}>{cat.name}</option>


### PR DESCRIPTION
## Request

*"When making a group, default to uncategorised."*

## Change

The equipment-tab **Add group** dialog forced a category choice — `categoryId` started empty and the Create button stayed disabled until you picked one. Now the category select **defaults to Uncategorized** (`categoryId: null` → the project's Uncategorized zone), mirroring how sub-hire groups already behave. Creating a group is now a single field (title); the empty "Select category…" placeholder is gone.

You can still pick a real category — it's just no longer required up front.

## Tests

Adds a jsdom smoke test: default value is Uncategorized, no empty placeholder, Create enables with only a title, and submit sends `categoryId: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)