### PR TITLE
perf(sub-hire): cut round-trips on create + detail load (#4/#6, partial)

### DIFF
--- a/FEATUREDOCS/39-sub-hires.md
+++ b/FEATUREDOCS/39-sub-hires.md
@@ -179,6 +179,29 @@ Auto-generated via atomic counter in `Organization.metadata.subHireOrderCounter`
 | `src/components/projects/equipment-tab.tsx` | Sub-hire orders section + dialog wiring + expanded items with groups |
 | `src/components/projects/add-equipment-dialog.tsx` | Overbook shortcut callback |
 
+## Performance notes
+
+The Sub-Hire Order **modal** reads through non-reactive server actions
+(`getSubHires` list / `getSubHire` detail) via `createSharedResource`, unlike the
+equipment tab and dashboard which read sub-hire data natively through Convex
+`useQuery` (`api.equipmentTab.bundle` / `api.dashboardSubHire.bundle`). This is
+why the modal feels slower than the tab and why the create→manage handoff shows a
+skeleton while `getSubHire` loads.
+
+Latency reductions applied so far (without changing the read architecture):
+- `getSubHire` scopes its placement-label fetch to the sub-hire's project
+  (`projectCategories.listByProject` / `projectGroups.listByProject`) instead of
+  pulling every category/group in the org.
+- `createSubHire` runs the Prisma order-number reservation and the supplier fetch
+  concurrently and drops a redundant tail round-trip.
+
+**Follow-up (not yet done):** rewire the modal's two reads to Convex `useQuery`
+for true reactivity, so the create→manage handoff is instant and edits stream in
+live. Blocker to note: `getSubHire` enriches with `createdBy` (a Better Auth user
+that lives in **Postgres**, unreadable from a Convex query) and resolved media
+URLs, so a pure `useQuery` bundle needs those handled separately. Worth its own
+PR with browser QA against a seeded project.
+
 ## Migration Strategy
 
 Leave-and-layer. Legacy `isSubhire` line items remain as-is. New sub-hires use the `SubHire` entity. Both "Add Subhire" (legacy line item) and "Sub-Hire Orders" (new dialog) appear in the equipment tab.

--- a/src/server/sub-hires.ts
+++ b/src/server/sub-hires.ts
@@ -245,8 +245,16 @@ export async function getSubHire(id: string) {
       getSupplierById(subHire.supplierId),
       subHire.projectId ? getProjectById(subHire.projectId) : Promise.resolve(null),
       getSubHireMediaFromConvex(subHire.id),
-      client.query(api.projectCategories.list, { orgId: organizationId }),
-      client.query(api.projectGroups.list, { orgId: organizationId }),
+      // Placement labels only ever reference THIS project's categories/groups, so
+      // scope the fetch to the project instead of pulling every category/group in
+      // the org (a large payload for orgs with many projects). A project-less
+      // sub-hire has no placements, so an empty list is correct.
+      subHire.projectId
+        ? client.query(api.projectCategories.listByProject, { projectId: subHire.projectId, orgId: organizationId })
+        : Promise.resolve([]),
+      subHire.projectId
+        ? client.query(api.projectGroups.listByProject, { projectId: subHire.projectId, orgId: organizationId })
+        : Promise.resolve([]),
     ]);
 
   const catLabel = new Map(projectCategories.map((c) => [c.id, { id: c.id, name: c.name }]));
@@ -291,15 +299,19 @@ export async function createSubHire(input: unknown) {
   const { organizationId, userId, userName } = await requirePermission("subHire", "create");
   const data = subHireSchema.parse(input);
 
-  // Order-number reservation stays Prisma — it read-modify-writes the org metadata
-  // JSON counter, and `organization` stays Prisma forever.
-  const orderNumber = await prisma.$transaction((tx) =>
-    reserveSubHireOrderNumber(tx, organizationId),
-  );
-
   const id = createId();
   const now = Date.now();
   const convex = await getConvexClient();
+
+  // Order-number reservation stays Prisma — it read-modify-writes the org metadata
+  // JSON counter, and `organization` stays Prisma forever. The supplier fetch is
+  // independent of it (and of the create), so run both concurrently instead of
+  // three serial Convex/Postgres round-trips on the create path.
+  const [orderNumber, supplier] = await Promise.all([
+    prisma.$transaction((tx) => reserveSubHireOrderNumber(tx, organizationId)),
+    getSupplierById(data.supplierId),
+  ]);
+
   await convex.mutation(api.subHires.create, {
     id,
     organizationId,
@@ -322,9 +334,6 @@ export async function createSubHire(input: unknown) {
   // Read back the written head (Prisma-row-shaped) for the return value.
   const result = await getSubHireById(id);
   if (!result) throw new Error("Sub-hire not found after create");
-
-  // Supplier lives in Convex — fetch for the log label / return shape.
-  const supplier = await getSupplierById(result.supplierId);
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## Reports
- *"After making a new sub hire order I'm left with a blank modal for ~10s… can we make it faster by making it native?"*
- *"Doing anything to do with sub-hire orders is extremely slow. Seems not native."*

## Diagnosis
The equipment tab and dashboard read sub-hire data **natively** (reactive Convex `useQuery`). The **Sub-Hire Order modal does not** — its two reads (`getSubHires` list, `getSubHire` detail) go through non-reactive server actions. `getSubHire` fans out to ~9 Convex-over-HTTP queries, and `createSubHire` runs several sequential round-trips. The "blank 10s" is the manage-view skeleton waiting on `getSubHire` after the create handoff.

## This PR — safe latency wins (no architecture change)
- **`getSubHire`**: scope the placement-label fetch to the sub-hire's project (`projectCategories/projectGroups.listByProject`) instead of loading **every** category + group in the org.
- **`createSubHire`**: run the Prisma order-number reservation and the supplier fetch concurrently; drop a redundant tail round-trip.

## What this PR deliberately does NOT do
The full "make it native" rewire (modal reads → Convex `useQuery` for instant, reactive updates) is **not** here. It's partly blocked and higher-risk:
- `getSubHire` enriches with **`createdBy`**, a Better Auth user that lives in **Postgres** — a Convex `useQuery` can't read it.
- Media needs server-side URL resolution.
- It reshapes a 1900-line money-bearing modal that should get real browser QA against a seeded project.

I've written it up as a scoped follow-up in FEATUREDOC 39 so it can be done properly in its own PR. Flagging here so you can decide whether to prioritise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)