### PR TITLE
feat(add-forms): standardise the placement box across add screens (#1)

### DIFF
--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -191,6 +191,20 @@ quick-create (`QuickCreateSupplier`). This was a markup/component pass only —
 no add/pricing/promotion/availability/mutation logic, data shape, or
 persisted payload changed.
 
+**Standardised placement box (`placement-fields.tsx`).** The three item add
+forms used to show *different* placement boxes: own-stock had a Category picker
+only, kit had none, custom had both Category + Group. They now all render the
+same `PlacementFields` component — a Category + Group `Select` pair (explicit
+`SelectValue` children, `"__none__"` sentinel, changing category clears the
+group) driven by `CategoryData[]`. Own-stock feeds it the categories it already
+fetches via `useProjectCategories` (which include their groups); kit receives
+`categories` from `UnifiedAddDialog` and renders a new "Placement" section;
+custom swapped its inline markup for the shared component. All three server
+actions (`addLineItem`, `addKitLineItem`, `addCustomLineItem`) already accepted
+`categoryId` + `groupId`, so this is additive UI — no add/pricing/data-shape
+change. Placement pickers stay hidden when the form is launched from a specific
+category/group context (a `targetLabel` chip shows the destination instead).
+
 `add-service-dialog.tsx` (the standalone Add service/other dialog, separate
 from `UnifiedAddDialog`) got the same dialog-context treatment: its two raw
 `<select>` elements (type, pricing type) are now the registry `Select` with

--- a/src/components/projects/__tests__/placement-fields.smoke.test.tsx
+++ b/src/components/projects/__tests__/placement-fields.smoke.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+import { PlacementFields } from "../placement-fields";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const categories = [
+  { id: "c1", name: "Audio", sortOrder: 0, groups: [{ id: "g1", title: "PA System" }] },
+] as any;
+
+describe("PlacementFields — shared Category + Group box (issue #1)", () => {
+  it("renders both a Category and a Group picker with the Uncategorized/No-group defaults", () => {
+    render(
+      <PlacementFields categories={categories} categoryId="" groupId="" onChange={() => {}} />,
+    );
+    expect(screen.getByText("Category")).toBeTruthy();
+    expect(screen.getByText("Group")).toBeTruthy();
+    // Defaults shown by the explicit SelectValue children.
+    expect(screen.getByText("Uncategorized")).toBeTruthy();
+    expect(screen.getByText("No group")).toBeTruthy();
+  });
+
+  it("disables the Group picker until a category is chosen, and enables it once set", () => {
+    const { rerender } = render(
+      <PlacementFields categories={categories} categoryId="" groupId="" onChange={() => {}} />,
+    );
+    // Two Select triggers render as comboboxes; the Group one (2nd) is disabled.
+    let triggers = screen.getAllByRole("combobox") as HTMLButtonElement[];
+    expect(triggers).toHaveLength(2);
+    expect(triggers[1].disabled).toBe(true);
+
+    rerender(
+      <PlacementFields categories={categories} categoryId="c1" groupId="" onChange={() => {}} />,
+    );
+    triggers = screen.getAllByRole("combobox") as HTMLButtonElement[];
+    expect(triggers[1].disabled).toBe(false);
+    // Category now reflects the chosen category label.
+    expect(screen.getByText("Audio")).toBeTruthy();
+  });
+});

--- a/src/components/projects/custom-item-add-form.tsx
+++ b/src/components/projects/custom-item-add-form.tsx
@@ -24,6 +24,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { DialogFooter } from "@/components/ui/dialog";
+import { PlacementFields } from "./placement-fields";
 import type { CategoryData } from "./equipment-rows";
 
 type CustomItemPricingType = "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR";
@@ -79,9 +80,6 @@ export function CustomItemAddForm({
     onError: (e: Error) => toast.error(e.message),
   });
 
-  const selectedCategory = categories.find((c) => c.id === categoryId);
-  const groupOptions = selectedCategory?.groups ?? [];
-
   // ─── Live summary ──────────────────────────────────────────────
   const qtyNum = Math.max(1, parseInt(qty) || 1);
   const priceNum = price !== "" ? parseFloat(price) : 0;
@@ -105,46 +103,15 @@ export function CustomItemAddForm({
               maxLength={200}
             />
           </Field>
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Category">
-              <Select
-                value={categoryId || "__none__"}
-                onValueChange={(val) => {
-                  setCategoryId(val === "__none__" ? "" : val);
-                  setGroupId("");
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue>{selectedCategory?.name ?? "Uncategorized"}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">Uncategorized</SelectItem>
-                  {categories.map((cat) => (
-                    <SelectItem key={cat.id} value={cat.id}>{cat.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field label="Group">
-              <Select
-                value={groupId || "__none__"}
-                onValueChange={(val) => setGroupId(val === "__none__" ? "" : val)}
-                disabled={!categoryId}
-              >
-                <SelectTrigger>
-                  <SelectValue>
-                    {groupOptions.find((g) => g.id === groupId)?.title ?? "No group"}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">No group</SelectItem>
-                  {groupOptions.map((g) => (
-                    <SelectItem key={g.id} value={g.id}>{g.title}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-          </div>
+          <PlacementFields
+            categories={categories}
+            categoryId={categoryId}
+            groupId={groupId}
+            onChange={({ categoryId, groupId }) => {
+              setCategoryId(categoryId);
+              setGroupId(groupId);
+            }}
+          />
         </section>
 
         {/* Pricing */}

--- a/src/components/projects/equipment-add-form.tsx
+++ b/src/components/projects/equipment-add-form.tsx
@@ -34,7 +34,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { PlacementFields } from "./placement-fields";
+import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 
 type AddMode = "model" | "asset-tag";
@@ -77,6 +78,7 @@ export function EquipmentAddForm({
   const [lookupTag, setLookupTag] = useState("");
   const [discountMode, setDiscountMode] = useState<"$" | "%">("$");
   const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId ?? "");
+  const [selectedGroupId, setSelectedGroupId] = useState(groupId ?? "");
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
   const [duplicateAction, setDuplicateAction] = useState<"combine" | "separate">("combine");
   const [includeAccessories, setIncludeAccessories] = useState(true);
@@ -108,10 +110,9 @@ export function EquipmentAddForm({
   // `enabled: !categoryId` (no fetch).
   const { data: categoriesData } = useProjectCategories(categoryId ? undefined : projectId);
 
-  const categoryOptions = (categoriesData ?? []).map((c: { id: string; name: string }) => ({
-    value: c.id,
-    label: c.name,
-  }));
+  // CategoryData[] (id, name, groups) for the shared PlacementFields picker —
+  // getProjectCategories already includes each category's groups.
+  const placementCategories = (categoriesData ?? []) as unknown as CategoryData[];
 
   const modelOptions = activeModels.map((m) => ({
     value: m.id,
@@ -192,9 +193,10 @@ export function EquipmentAddForm({
         disc = Math.round((gross * Number(disc)) / 100 * 100) / 100;
       }
       const effectiveCategoryId = categoryId || selectedCategoryId || undefined;
+      const effectiveGroupId = groupId || selectedGroupId || undefined;
       return addLineItem(
         projectId,
-        { ...data, discount: disc, categoryId: effectiveCategoryId, groupId },
+        { ...data, discount: disc, categoryId: effectiveCategoryId, groupId: effectiveGroupId },
         overbookConfirmed,
         duplicateAction === "separate",
         includeAccessories
@@ -572,29 +574,16 @@ export function EquipmentAddForm({
             <div className="rounded-[var(--r)] border border-line bg-paper-2/50 px-3 py-2 text-caption text-ink-2">
               Adding to <span className="font-medium text-ink">{targetLabel}</span>
             </div>
-          ) : categoryOptions.length > 0 ? (
-            <Field label="Category">
-              <Select
-                value={selectedCategoryId || "__none__"}
-                onValueChange={(val) => setSelectedCategoryId(val === "__none__" ? "" : val)}
-              >
-                <SelectTrigger>
-                  <SelectValue>
-                    {selectedCategoryId
-                      ? categoryOptions.find((c: { value: string; label: string }) => c.value === selectedCategoryId)?.label ?? "No category"
-                      : "No category"}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">No category</SelectItem>
-                  {categoryOptions.map((c: { value: string; label: string }) => (
-                    <SelectItem key={c.value} value={c.value}>
-                      {c.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
+          ) : placementCategories.length > 0 ? (
+            <PlacementFields
+              categories={placementCategories}
+              categoryId={selectedCategoryId}
+              groupId={selectedGroupId}
+              onChange={({ categoryId, groupId }) => {
+                setSelectedCategoryId(categoryId);
+                setSelectedGroupId(groupId);
+              }}
+            />
           ) : null}
 
           <Field label="Notes">

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -24,6 +24,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { PlacementFields } from "./placement-fields";
+import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useKitSearch, useKit } from "@/hooks/use-kits";
 import { useCategories } from "@/hooks/use-categories";
@@ -39,6 +41,8 @@ export interface KitAddFormProps {
   categoryId?: string;
   /** Pre-set group for the line item. */
   groupId?: string;
+  /** Available categories (with groups) for the shared placement picker. */
+  categories?: CategoryData[];
   /** Human-readable label like "Audio > PA System" when adding inside a group. */
   targetLabel?: string;
   /** Invalidate queries after a successful add. */
@@ -53,6 +57,7 @@ export function KitAddForm({
   rentalEndDate,
   categoryId,
   groupId,
+  categories,
   targetLabel,
   onInvalidate,
   onClose,
@@ -63,6 +68,8 @@ export function KitAddForm({
   const [selectedKitId, setSelectedKitId] = useState("");
   const [kitPricingMode, setKitPricingMode] = useState<KitPricingMode>("KIT_PRICE");
   const [kitUnitPrice, setKitUnitPrice] = useState("");
+  const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId ?? "");
+  const [selectedGroupId, setSelectedGroupId] = useState(groupId ?? "");
 
   // Phase 7 — native INDEXED kit search (name OR assetTag, prep excluded server-side,
   // bounded + reactive) instead of loading the whole org list to JS-filter. Debounced
@@ -70,9 +77,9 @@ export function KitAddForm({
   const [kitQuery, setKitQuery] = useState("");
   const debouncedKitQuery = useDebouncedValue(kitQuery, 200);
   const kits = useKitSearch(orgId, debouncedKitQuery);
-  const categories = useCategories(orgId);
+  const orgCategories = useCategories(orgId);
   const kitOptions = useMemo(() => {
-    const categoryNameById = new Map((categories ?? []).map((c) => [c.id, c.name]));
+    const categoryNameById = new Map((orgCategories ?? []).map((c) => [c.id, c.name]));
     return (kits ?? [])
       .filter((kit) => kit.isActive === true)
       .map((kit) => ({
@@ -80,7 +87,7 @@ export function KitAddForm({
         label: `${kit.assetTag} - ${kit.name}`,
         description: kit.categoryId ? categoryNameById.get(kit.categoryId) : undefined,
       }));
-  }, [kits, categories]);
+  }, [kits, orgCategories]);
   // Resolve the selected kit's label directly (it may not be in the current search page).
   const selectedKit = useKit(selectedKitId || undefined);
   const selectedKitLabel = selectedKit ? `${selectedKit.assetTag} - ${selectedKit.name}` : undefined;
@@ -105,8 +112,8 @@ export function KitAddForm({
         kitPricingMode,
         kitPricingMode === "KIT_PRICE" && kitUnitPrice ? parseFloat(kitUnitPrice) : undefined,
         undefined, // groupName
-        categoryId,
-        groupId,
+        (categoryId || selectedCategoryId) || undefined,
+        (groupId || selectedGroupId) || undefined,
       ),
     onSuccess: () => {
       onInvalidate();
@@ -186,6 +193,23 @@ export function KitAddForm({
             </Field>
           )}
         </section>
+
+        {/* Placement — same Category + Group picker as the other add screens.
+            Hidden when launched from a specific category/group context. */}
+        {!targetLabel && categories && categories.length > 0 && (
+          <section className="space-y-4 border-t border-line pt-5">
+            <SectionTitle title="Placement" hint="Where the kit lands on the project." />
+            <PlacementFields
+              categories={categories}
+              categoryId={selectedCategoryId}
+              groupId={selectedGroupId}
+              onChange={({ categoryId, groupId }) => {
+                setSelectedCategoryId(categoryId);
+                setSelectedGroupId(groupId);
+              }}
+            />
+          </section>
+        )}
       </div>
 
       <DialogFooter>

--- a/src/components/projects/placement-fields.tsx
+++ b/src/components/projects/placement-fields.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Shared Category + Group placement picker for the unified "Add …" forms
+ * (own-stock / kit / custom). Before this, each form rendered placement
+ * differently — own-stock had Category only, kit had none, custom had both —
+ * so the "add" screens showed different boxes. This is the single source of
+ * truth for that box so all three match.
+ *
+ * Registry `Select` with explicit `SelectValue` children and the `"__none__"`
+ * sentinel (Radix forbids empty-string `SelectItem` values). Changing the
+ * category clears the group (the group list is scoped to the category).
+ */
+
+import { Label } from "@/components/ui/label";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import type { CategoryData } from "./equipment-rows";
+
+export function PlacementFields({
+  categories,
+  categoryId,
+  groupId,
+  onChange,
+}: {
+  categories: CategoryData[];
+  categoryId: string;
+  groupId: string;
+  /** Fires with the next placement. Changing the category clears the group. */
+  onChange: (next: { categoryId: string; groupId: string }) => void;
+}) {
+  const selectedCategory = categories.find((c) => c.id === categoryId);
+  const groupOptions = selectedCategory?.groups ?? [];
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label>Category</Label>
+        <Select
+          value={categoryId || "__none__"}
+          onValueChange={(val) => onChange({ categoryId: val === "__none__" ? "" : val, groupId: "" })}
+        >
+          <SelectTrigger>
+            <SelectValue>{selectedCategory?.name ?? "Uncategorized"}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">Uncategorized</SelectItem>
+            {categories.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>{cat.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label>Group</Label>
+        <Select
+          value={groupId || "__none__"}
+          onValueChange={(val) => onChange({ categoryId, groupId: val === "__none__" ? "" : val })}
+          disabled={!categoryId}
+        >
+          <SelectTrigger>
+            <SelectValue>
+              {groupOptions.find((g) => g.id === groupId)?.title ?? "No group"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">No group</SelectItem>
+            {groupOptions.map((g) => (
+              <SelectItem key={g.id} value={g.id}>{g.title}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/projects/unified-add-dialog.tsx
+++ b/src/components/projects/unified-add-dialog.tsx
@@ -156,6 +156,7 @@ export function UnifiedAddDialog({
             rentalEndDate={rentalEndDate}
             categoryId={categoryId}
             groupId={groupId}
+            categories={categories}
             targetLabel={targetLabel}
             onInvalidate={onInvalidate}
             onClose={handleClose}


### PR DESCRIPTION
## Request
*"Custom Stock / Own Stock / Kit add screens all have different boxes — they should be standardised."*

## What differed
| Add screen | Category picker | Group picker |
|---|---|---|
| Own stock | ✅ | ❌ |
| Kit | ❌ | ❌ |
| Custom | ✅ | ✅ |

## Change
Extracts a shared **`PlacementFields`** component — a Category + Group `Select` pair (explicit `SelectValue` children, `__none__` sentinel, changing category clears the group) — and adopts it in all three forms so the placement box is **identical everywhere**:

- **Custom** — swapped its inline markup for `PlacementFields`.
- **Own stock** — gained the missing Group picker, fed by the categories it *already* fetches via `useProjectCategories` (which include their groups). No new data source.
- **Kit** — gained a whole new **"Placement"** section (`categories` passed through from `UnifiedAddDialog`).

## Safety
Purely **additive UI** — all three server actions (`addLineItem`, `addKitLineItem`, `addCustomLineItem`) already accepted `categoryId` + `groupId`, so no add/pricing/data-shape change. Placement stays hidden when the form is launched from a specific category/group context (the `targetLabel` chip shows the destination). Typecheck + lint clean; adds a `PlacementFields` smoke test.

> Worth a quick visual check on a preview: the three add dialogs should now show the same Category + Group box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)