### PR TITLE
feat(kits): kit per-unit fulfillment — Phases 1+2 (write path + backfill)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as assetScanLogs from "../assetScanLogs.js";
 import type * as assetWrites from "../assetWrites.js";
 import type * as assets from "../assets.js";
 import type * as availabilityCheck from "../availabilityCheck.js";
+import type * as backfillKitUnits from "../backfillKitUnits.js";
 import type * as brandTemplates from "../brandTemplates.js";
 import type * as bulkAssets from "../bulkAssets.js";
 import type * as categories from "../categories.js";
@@ -147,6 +148,7 @@ declare const fullApi: ApiFromModules<{
   assetWrites: typeof assetWrites;
   assets: typeof assets;
   availabilityCheck: typeof availabilityCheck;
+  backfillKitUnits: typeof backfillKitUnits;
   brandTemplates: typeof brandTemplates;
   bulkAssets: typeof bulkAssets;
   categories: typeof categories;

--- a/convex/backfillKitUnits.test.ts
+++ b/convex/backfillKitUnits.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+//
+// Kit per-unit fulfillment — Phase 2 backfill (docs/designs/kit-per-unit-fulfillment.md).
+// Verifies unit-less kit member child lines get a unit carrying the line's current
+// lifecycle, idempotently, while loose / accessory / nested / already-seeded lines are
+// left alone.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+/** A pre-change kit member child line (no unit). */
+function kitChild(id: string, extra: Record<string, unknown>) {
+  return { id, organizationId: ORG, projectId: "p1", type: "EQUIPMENT" as const, isKitChild: true, parentLineItemId: "kl1", createdAt: NOW, updatedAt: NOW, ...extra };
+}
+
+async function runBackfill(t: T, apply = true) {
+  let cursor: string | null = null;
+  let scanned = 0;
+  let created = 0;
+  for (;;) {
+    const r: { scanned: number; created: number; isDone: boolean; continueCursor: string } = await t.withIdentity(SERVICE).mutation(api.backfillKitUnits.backfillKitUnitsPage, { cursor, apply });
+    scanned += r.scanned;
+    created += r.created;
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+  return { scanned, created };
+}
+const unitsFor = (t: T, lineId: string) => t.run(async (ctx) => ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", lineId)).collect());
+
+describe("backfillKitUnits — carries line lifecycle", () => {
+  test("deployed / returned / prepped / bulk members each backfill at the right stage", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT", checkedOutAt: NOW, checkedOutById: USER }));
+      await ctx.db.insert("projectLineItems", kitChild("ret", { assetId: "aRet", status: "RETURNED", returnedAt: NOW, returnedById: USER, returnCondition: "DAMAGED" }));
+      await ctx.db.insert("projectLineItems", kitChild("prep", { assetId: "aPrep", status: "CONFIRMED", prepStatus: "PACKED", prepContainer: "Case 3" }));
+      await ctx.db.insert("projectLineItems", kitChild("bulk", { bulkAssetId: "b1", quantity: 3, status: "CHECKED_OUT", checkedOutAt: NOW, checkedOutById: USER }));
+    });
+    const { created } = await runBackfill(t);
+    expect(created).toBe(4);
+
+    const [out] = await unitsFor(t, "out");
+    expect(out.status).toBe("CHECKED_OUT");
+    expect(out.assetId).toBe("aOut");
+    expect(out.checkedOutById).toBe(USER);
+    expect(out.returnedQuantity).toBe(0);
+
+    const [ret] = await unitsFor(t, "ret");
+    expect(ret.status).toBe("RETURNED");
+    expect(ret.returnCondition).toBe("DAMAGED");
+    expect(ret.returnedQuantity).toBe(1);
+
+    const [prep] = await unitsFor(t, "prep");
+    expect(prep.status).toBe("CONFIRMED");
+    expect(prep.prepStatus).toBe("PACKED");
+    expect(prep.prepContainer).toBe("Case 3");
+
+    const [bulk] = await unitsFor(t, "bulk");
+    expect(bulk.bulkAssetId).toBe("b1");
+    expect(bulk.quantity).toBe(3);
+    expect(bulk.status).toBe("CHECKED_OUT");
+  });
+});
+
+describe("backfillKitUnits — idempotent + dry-run", () => {
+  test("re-running the backfill creates nothing new", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT" })); });
+    expect((await runBackfill(t)).created).toBe(1);
+    expect((await runBackfill(t)).created).toBe(0);
+    expect(await unitsFor(t, "out")).toHaveLength(1);
+  });
+
+  test("dry-run scans but writes nothing", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT" })); });
+    const { scanned, created } = await runBackfill(t, false);
+    expect(scanned).toBe(1);
+    expect(created).toBe(0);
+    expect(await unitsFor(t, "out")).toHaveLength(0);
+  });
+
+  test("a member already seeded (Phase 1) keeps its live unit, untouched", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", kitChild("seeded", { assetId: "aS", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItemUnits", { id: "liveU", organizationId: ORG, lineItemId: "seeded", assetId: "aS", ordinal: 1, status: "CHECKED_OUT", checkedOutById: "someone", createdAt: NOW, updatedAt: NOW });
+    });
+    expect((await runBackfill(t)).created).toBe(0);
+    const units = await unitsFor(t, "seeded");
+    expect(units).toHaveLength(1);
+    expect(units[0].id).toBe("liveU");
+    expect(units[0].checkedOutById).toBe("someone"); // not clobbered
+  });
+});
+
+describe("backfillKitUnits — leaves non-kit-member lines alone", () => {
+  test("loose, accessory, nested-kit-parent, and asset-free lines are skipped", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "loose", organizationId: ORG, projectId: "p1", type: "EQUIPMENT" as const, isKitChild: false, assetId: "aL", status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", kitChild("acc", { assetId: "aAcc", childKind: "ACCESSORY", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", kitChild("nested", { kitId: "k2", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", kitChild("svc", { status: "CONFIRMED" })); // no asset/bulk
+    });
+    const { scanned, created } = await runBackfill(t);
+    expect(scanned).toBe(0);
+    expect(created).toBe(0);
+    for (const id of ["loose", "acc", "nested", "svc"]) expect(await unitsFor(t, id)).toHaveLength(0);
+  });
+});

--- a/convex/backfillKitUnits.ts
+++ b/convex/backfillKitUnits.ts
@@ -1,0 +1,75 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+import { ensureBulkUnit, ensureSerialisedUnit } from "./lib/fulfillment";
+
+/**
+ * Kit per-unit fulfillment — Phase 2 backfill.
+ * See docs/designs/kit-per-unit-fulfillment.md.
+ *
+ * Kits added AFTER Phase 1 seed their member units at kit-add (createKitLineItemCore);
+ * kits added before it have none. This pages the projectLineItems table and, for every
+ * unit-less kit MEMBER child line — a serialised or bulk member, NOT a nested-kit parent
+ * (no own units) and NOT an accessory (already unit-backed) — creates the unit carrying
+ * the line's CURRENT lifecycle, so a deployed / returned / prepped member backfills at
+ * the right stage rather than bare CONFIRMED (codex #8).
+ *
+ * SERVICE-only. Idempotent: a member that already has its unit (Phase-1 seed or a prior
+ * run) is skipped, so re-runs are safe and never clobber live state. `apply=false` is a
+ * dry-run that only counts. Paginated because one query can't scan a large table.
+ *
+ * NB: NO `ANALYZE` — projectLineItemUnits is a Convex table (ANALYZE is Postgres-only;
+ * the CLAUDE.md ANALYZE rule is for Prisma bulk migrations).
+ *
+ * Driver: scripts/convex-backfill-kit-units.ts (pages the cursor until isDone).
+ */
+export const backfillKitUnitsPage = mutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    apply: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, { cursor, apply, numItems }) => {
+    await requireService(ctx);
+    const res = await ctx.db.query("projectLineItems").paginate({ cursor, numItems: numItems ?? 300 });
+
+    let scanned = 0;
+    let created = 0;
+    for (const line of res.page) {
+      if (!line.isKitChild || line.childKind === "ACCESSORY" || line.kitId) continue;
+      const isBulk = !!line.bulkAssetId;
+      if (!line.assetId && !isBulk) continue;
+      // Already seeded (Phase 1) or backfilled by a prior run? Skip — never clobber
+      // live state. A kit member line carries exactly one unit, so any unit = done.
+      const already = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", line.id)).first();
+      if (already) continue;
+      scanned++; // a member that NEEDS a unit
+      if (!apply) continue;
+
+      const ensured = isBulk
+        ? await ensureBulkUnit(ctx, { organizationId: line.organizationId, lineItemId: line.id, bulkAssetId: line.bulkAssetId!, quantity: line.quantity ?? 1 })
+        : await ensureSerialisedUnit(ctx, { organizationId: line.organizationId, lineItemId: line.id, assetId: line.assetId! });
+      // Idempotent guard against a concurrent writer that seeded since the check.
+      if (!ensured.created) continue;
+
+      const u = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", ensured.id)).unique();
+      if (!u) continue;
+      await ctx.db.patch(u._id, {
+        status: line.status ?? "CONFIRMED",
+        returnedQuantity: isBulk ? (line.returnedQuantity ?? 0) : line.status === "RETURNED" ? 1 : 0,
+        ...(line.prepStatus !== undefined ? { prepStatus: line.prepStatus } : {}),
+        ...(line.prepContainer !== undefined ? { prepContainer: line.prepContainer } : {}),
+        ...(line.checkedOutAt !== undefined ? { checkedOutAt: line.checkedOutAt } : {}),
+        ...(line.checkedOutById !== undefined ? { checkedOutById: line.checkedOutById } : {}),
+        ...(line.returnedAt !== undefined ? { returnedAt: line.returnedAt } : {}),
+        ...(line.returnedById !== undefined ? { returnedById: line.returnedById } : {}),
+        ...(line.returnCondition !== undefined ? { returnCondition: line.returnCondition } : {}),
+        ...(line.returnStatus !== undefined ? { returnStatus: line.returnStatus } : {}),
+        ...(line.returnNotes !== undefined ? { returnNotes: line.returnNotes } : {}),
+        updatedAt: line.updatedAt ?? Date.now(),
+      });
+      created++;
+    }
+    return { scanned, created, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});

--- a/convex/checkRecordOps.ts
+++ b/convex/checkRecordOps.ts
@@ -2,7 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireService } from "./lib/auth";
-import { prepUnit, syncLineItemRollup } from "./lib/fulfillment";
+import { ensureBulkUnit, ensureSerialisedUnit, lineUnits, prepUnit, syncLineItemRollup } from "./lib/fulfillment";
 
 /**
  * Check-records prep/return — Convex port of the line-item/unit writes in
@@ -201,16 +201,39 @@ export const completeCheckAndDeprepLine = mutation({
   },
 });
 
+/**
+ * Kit per-unit fulfillment (Phase 1): additively carry a kit member line's PREP
+ * state onto its unit row(s), so the member shows Prepped/Assigned per job like
+ * loose gear. Unit-only — line status stays owned by the caller's patch this
+ * phase. Self-heals a missing unit (pre-change kit prepped after the migration)
+ * via the same ensure* find-or-create used at kit-add. Never touches CHECKED_OUT
+ * or RETURNED units (a returned member's history must survive a deprep).
+ * See docs/designs/kit-per-unit-fulfillment.md.
+ */
+async function setKitMemberUnitPrep(ctx: Ctx, child: { id: string; organizationId: string; assetId?: string; bulkAssetId?: string; quantity?: number }, now: number, mode: "PREP" | "DEPREP") {
+  if (mode === "PREP") {
+    if (child.assetId) await ensureSerialisedUnit(ctx, { organizationId: child.organizationId, lineItemId: child.id, assetId: child.assetId });
+    else if (child.bulkAssetId) await ensureBulkUnit(ctx, { organizationId: child.organizationId, lineItemId: child.id, bulkAssetId: child.bulkAssetId, quantity: child.quantity ?? 1 });
+  }
+  for (const u of await lineUnits(ctx, child.id)) {
+    if (u.status === "CHECKED_OUT" || u.status === "RETURNED") continue;
+    if (mode === "PREP") await ctx.db.patch(u._id, { status: "CONFIRMED", prepStatus: "PACKED", updatedAt: now });
+    else await ctx.db.patch(u._id, { prepStatus: "PENDING", updatedAt: now });
+  }
+}
+
 async function setKitTreePrep(ctx: Ctx, parentLineItemId: string, organizationId: string, now: number, mode: "PREP" | "DEPREP") {
   const children = await childLines(ctx, parentLineItemId, organizationId);
   for (const child of children) {
     if (child.status === "CHECKED_OUT" || child.status === "CANCELLED") continue;
     if (mode === "PREP") await ctx.db.patch(child._id, { status: "CONFIRMED", prepStatus: "PACKED", updatedAt: now });
     else await ctx.db.patch(child._id, { prepStatus: "PENDING", updatedAt: now });
+    if (!child.kitId) await setKitMemberUnitPrep(ctx, child, now, mode);
     for (const gc of await childLines(ctx, child.id, organizationId)) {
       if (gc.status === "CHECKED_OUT" || gc.status === "CANCELLED") continue;
       if (mode === "PREP") await ctx.db.patch(gc._id, { status: "CONFIRMED", prepStatus: "PACKED", updatedAt: now });
       else await ctx.db.patch(gc._id, { prepStatus: "PENDING", updatedAt: now });
+      if (!gc.kitId) await setKitMemberUnitPrep(ctx, gc, now, mode);
     }
   }
   const parent = await lineByCuid(ctx, parentLineItemId);

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+//
+// Kit per-unit fulfillment (Phase 1) — docs/designs/kit-per-unit-fulfillment.md.
+// Verifies that kit MEMBER UNIT rows are seeded at kit-add and flipped through
+// every warehouse kit operation, while the legacy line/asset path keeps working
+// (belt still owns asset status this phase).
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+type T = ReturnType<typeof convexTest>;
+
+/** Seed a kit (serialised member A-1, optional bulk member B-1 qty 3) and build
+ *  its project line items + member units via the real createKitLineItem path. */
+async function seedKit(t: T, opts?: { bulk?: boolean }) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "A-1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER });
+    if (opts?.bulk) {
+      await ctx.db.insert("bulkAssets", { id: "b1", organizationId: ORG, modelId: "m1", assetTag: "B-1", availableQuantity: 10, totalQuantity: 10, isActive: true });
+      await ctx.db.insert("kitBulkItems", { id: "kb1", organizationId: ORG, kitId: "k1", bulkAssetId: "b1", quantity: 3, addedById: USER });
+    }
+  });
+  await t.withIdentity(SERVICE).mutation(api.projectLineItems.createKitLineItem, { id: "kl1", organizationId: ORG, projectId: "p1", kitId: "k1", pricingMode: "KIT_PRICE", now: NOW });
+}
+
+/** All member units under the kit parent line kl1. */
+function memberUnits(t: T) {
+  return t.run(async (ctx) => {
+    const children = await ctx.db.query("projectLineItems").withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", "kl1")).collect();
+    const out = [] as Array<Record<string, unknown>>;
+    for (const c of children) {
+      const us = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", c.id)).collect();
+      out.push(...us);
+    }
+    return out;
+  });
+}
+const serialUnit = (units: Array<Record<string, unknown>>) => units.find((u) => u.assetId === "a1")!;
+const bulkUnit = (units: Array<Record<string, unknown>>) => units.find((u) => u.bulkAssetId === "b1")!;
+const assetStatus = (t: T) => t.run(async (ctx) => (await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).unique())?.status);
+
+const co = (t: T) => t.withIdentity(SERVICE).mutation(api.warehouseOps.checkoutKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
+const ci = (t: T, cond: "GOOD" | "DAMAGED" | "MISSING" = "GOOD") => t.withIdentity(SERVICE).mutation(api.warehouseOps.checkinKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", returnCondition: cond, now: NOW });
+
+describe("kit per-unit — seeding", () => {
+  test("createKitLineItem seeds one CONFIRMED unit per serialised member", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    const units = await memberUnits(t);
+    expect(units).toHaveLength(1);
+    expect(serialUnit(units).status).toBe("CONFIRMED");
+    expect(serialUnit(units).assetId).toBe("a1");
+  });
+
+  test("bulk member seeds one unit carrying its quantity", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, { bulk: true });
+    const units = await memberUnits(t);
+    expect(units).toHaveLength(2);
+    expect(bulkUnit(units).quantity).toBe(3);
+    expect(bulkUnit(units).status).toBe("CONFIRMED");
+  });
+});
+
+describe("kit per-unit — checkout / checkin", () => {
+  test("checkout flips member unit → CHECKED_OUT and the belt still flips the asset", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    expect(serialUnit(await memberUnits(t)).status).toBe("CHECKED_OUT");
+    expect(serialUnit(await memberUnits(t)).checkedOutById).toBe(USER);
+    expect(await assetStatus(t)).toBe("CHECKED_OUT"); // legacy belt unchanged
+  });
+
+  test("checkin flips CHECKED_OUT member unit → RETURNED with return stamps", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await ci(t, "GOOD");
+    const u = serialUnit(await memberUnits(t));
+    expect(u.status).toBe("RETURNED");
+    expect(u.returnedQuantity).toBe(1);
+    expect(u.returnCondition).toBe("GOOD");
+    expect(await assetStatus(t)).toBe("AVAILABLE");
+  });
+
+  test("bulk member returns its full quantity", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t, { bulk: true });
+    await co(t);
+    expect(bulkUnit(await memberUnits(t)).status).toBe("CHECKED_OUT");
+    await ci(t, "GOOD");
+    const u = bulkUnit(await memberUnits(t));
+    expect(u.status).toBe("RETURNED");
+    expect(u.returnedQuantity).toBe(3);
+  });
+
+  test("DAMAGED checkin records the condition on the unit", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await ci(t, "DAMAGED");
+    expect(serialUnit(await memberUnits(t)).returnCondition).toBe("DAMAGED");
+  });
+});
+
+describe("kit per-unit — reverse + force", () => {
+  test("undeployKit: CHECKED_OUT unit → CONFIRMED (re-packed)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.undeployKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
+    const u = serialUnit(await memberUnits(t));
+    expect(u.status).toBe("CONFIRMED");
+    expect(u.prepStatus).toBe("PACKED");
+  });
+
+  test("unreturnKit: RETURNED unit → CHECKED_OUT and clears return stamps", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await ci(t, "GOOD");
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.unreturnKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
+    const u = serialUnit(await memberUnits(t));
+    expect(u.status).toBe("CHECKED_OUT");
+    expect(u.returnedAt).toBeUndefined();
+    expect(u.returnCondition).toBeUndefined();
+    expect(u.returnedQuantity).toBe(0);
+  });
+
+  test("forceReturnKit flips member unit → RETURNED", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKit, { organizationId: ORG, kitId: "k1", userId: USER, now: NOW });
+    expect(serialUnit(await memberUnits(t)).status).toBe("RETURNED");
+  });
+
+  test("forceReturnAsset flips the kit member's unit → RETURNED (no split-brain)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnAsset, { organizationId: ORG, assetId: "a1", userId: USER, now: NOW });
+    expect(serialUnit(await memberUnits(t)).status).toBe("RETURNED");
+  });
+});
+
+describe("kit per-unit — prep tree", () => {
+  test("prepKitChildren packs member units; deprepKit resets them to PENDING", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.withIdentity(SERVICE).mutation(api.checkRecordOps.prepKitChildren, { organizationId: ORG, projectId: "p1", parentLineItemId: "kl1", now: NOW });
+    expect(serialUnit(await memberUnits(t)).prepStatus).toBe("PACKED");
+    await t.withIdentity(SERVICE).mutation(api.checkRecordOps.deprepKit, { organizationId: ORG, projectId: "p1", parentLineItemId: "kl1", now: NOW });
+    expect(serialUnit(await memberUnits(t)).prepStatus).toBe("PENDING");
+  });
+
+  test("deprep does not delete a RETURNED member unit (history survives)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await co(t);
+    await ci(t, "GOOD");
+    await t.withIdentity(SERVICE).mutation(api.checkRecordOps.deprepKit, { organizationId: ORG, projectId: "p1", parentLineItemId: "kl1", now: NOW });
+    const u = serialUnit(await memberUnits(t));
+    expect(u.status).toBe("RETURNED"); // untouched by deprep
+  });
+});
+
+describe("kit per-unit — pre-change kit (no units)", () => {
+  test("checkinKit does not throw and creates no units for a unit-less kit", async () => {
+    const t = convexTest(schema, modules);
+    // A kit deployed before the migration: parent + child line, CHECKED_OUT, NO units.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "A-1", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "kl1", organizationId: ORG, projectId: "p1", kitId: "k1", type: "EQUIPMENT", status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "kc1", organizationId: ORG, projectId: "p1", parentLineItemId: "kl1", assetId: "a1", type: "EQUIPMENT", status: "CHECKED_OUT", isKitChild: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(ci(t, "GOOD")).resolves.toBeTruthy();
+    expect(await memberUnits(t)).toHaveLength(0); // no unit invented on the legacy path
+    expect(await assetStatus(t)).toBe("AVAILABLE"); // belt still restored the asset
+  });
+});

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -14,7 +14,10 @@ const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
 const SERVICE = { subject: "gearflow-service", svc: true };
-type T = ReturnType<typeof convexTest>;
+// Infer the schema-typed tester from a real call (so ctx.db inside t.run knows
+// our indexes); manually applying the generic trips convexTest's constraint.
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
 
 /** Seed a kit (serialised member A-1, optional bulk member B-1 qty 3) and build
  *  its project line items + member units via the real createKitLineItem path. */

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -178,6 +178,68 @@ describe("kit per-unit — prep tree", () => {
   });
 });
 
+describe("kit per-unit — accessories on a member", () => {
+  // acc1 is a permanent accessory of member asset a1 (a child asset).
+  async function seedKitWithAccessory(t: T) {
+    await seedKit(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "acc1", organizationId: ORG, modelId: "m1", assetTag: "ACC-1", parentAssetId: "a1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+  }
+  function accessoryUnits(t: T) {
+    return t.run(async (ctx) => {
+      const kids = await ctx.db.query("projectLineItems").withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", "kl1")).collect();
+      const member = kids.find((k) => k.assetId === "a1")!;
+      const accLines = (await ctx.db.query("projectLineItems").withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", member.id)).collect()).filter((c) => c.childKind === "ACCESSORY");
+      const out = [] as Array<Record<string, unknown>>;
+      for (const c of accLines) {
+        for (const u of await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", c.id)).collect()) out.push(u);
+      }
+      return out;
+    });
+  }
+  const accAssetStatus = (t: T) => t.run(async (ctx) => (await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "acc1")).unique())?.status);
+
+  test("checkout deploys the member's accessory unit + asset", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithAccessory(t);
+    await co(t);
+    const us = await accessoryUnits(t);
+    expect(us.length).toBeGreaterThan(0);
+    expect(us[0].status).toBe("CHECKED_OUT");
+    expect(us[0].parentUnitAssetId).toBe("a1");
+    expect(await accAssetStatus(t)).toBe("CHECKED_OUT");
+  });
+
+  test("checkin returns the member's accessory unit + asset", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithAccessory(t);
+    await co(t);
+    await ci(t, "GOOD");
+    const us = await accessoryUnits(t);
+    expect(us[0].status).toBe("RETURNED");
+    expect(await accAssetStatus(t)).toBe("AVAILABLE");
+  });
+
+  test("undeployKit reverses the accessory back to prepped (not stranded deployed)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithAccessory(t);
+    await co(t);
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.undeployKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
+    expect((await accessoryUnits(t))[0].status).toBe("CONFIRMED");
+    expect(await accAssetStatus(t)).toBe("AVAILABLE");
+  });
+
+  test("forceReturnKit returns the member's accessory (no stuck asset)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithAccessory(t);
+    await co(t);
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKit, { organizationId: ORG, kitId: "k1", userId: USER, now: NOW });
+    expect((await accessoryUnits(t))[0].status).toBe("RETURNED");
+    expect(await accAssetStatus(t)).toBe("AVAILABLE");
+  });
+});
+
 describe("kit per-unit — pre-change kit (no units)", () => {
   test("checkinKit does not throw and creates no units for a unit-less kit", async () => {
     const t = convexTest(schema, modules);

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -25,7 +25,7 @@ import { bumpAssetCounters } from "./counters";
 
 type Ctx = MutationCtx;
 
-async function lineUnits(ctx: Ctx, lineItemId: string) {
+export async function lineUnits(ctx: Ctx, lineItemId: string) {
   return await ctx.db
     .query("projectLineItemUnits")
     .withIndex("by_lineItemId", (q) => q.eq("lineItemId", lineItemId))

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -3,7 +3,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { query, mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
-import { expandAccessoryChildLines, syncLineItemRollup } from "./lib/fulfillment";
+import { ensureBulkUnit, ensureSerialisedUnit, expandAccessoryChildLines, syncLineItemRollup } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
 import * as enums from "./lib/validators";
 
@@ -502,25 +502,35 @@ export async function createKitLineItemCore(
       const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", si.assetId)).unique();
       const model = asset?.modelId ? await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", asset.modelId!)).unique() : null;
       const childPrice = itemized && model?.defaultRentalPrice != null ? Number(model.defaultRentalPrice) : undefined;
+      const childId = createId();
       await ctx.db.insert("projectLineItems", {
-        id: createId(), organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT",
+        id: childId, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT",
         modelId: asset?.modelId, assetId: si.assetId, description: model?.name ?? asset?.modelId ?? "",
         quantity: 1, unitPrice: childPrice, pricingType: "PER_DAY", duration: 1, lineTotal: childPrice,
         sortOrder: sort++, isKitChild: true, parentLineItemId: a.id, status: "CONFIRMED", createdAt: a.now, updatedAt: a.now,
       });
+      // Kit per-unit fulfillment (Phase 1): seed the member's unit row at kit-add,
+      // in CONFIRMED state, so serials are visible/trackable per job exactly like
+      // loose gear. Prep/checkout/checkin patch this row. See
+      // docs/designs/kit-per-unit-fulfillment.md.
+      await ensureSerialisedUnit(ctx, { organizationId: a.organizationId, lineItemId: childId, assetId: si.assetId });
     }
     const bulk = await ctx.db.query("kitBulkItems").withIndex("by_kitId", (q) => q.eq("kitId", a.kitId)).collect();
     for (const bi of bulk) {
       const ba = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", bi.bulkAssetId)).unique();
       const model = ba?.modelId ? await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", ba.modelId!)).unique() : null;
       const childTotal = itemized && model?.defaultRentalPrice != null ? Number(model.defaultRentalPrice) * bi.quantity : undefined;
+      const childId = createId();
       await ctx.db.insert("projectLineItems", {
-        id: createId(), organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT",
+        id: childId, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT",
         modelId: ba?.modelId, bulkAssetId: bi.bulkAssetId, description: `${bi.quantity}x ${model?.name ?? ba?.modelId ?? ""}`,
         quantity: bi.quantity, unitPrice: childTotal != null ? childTotal / bi.quantity : undefined, pricingType: "PER_DAY",
         duration: 1, lineTotal: childTotal, sortOrder: sort++, isKitChild: true, parentLineItemId: a.id,
         status: "CONFIRMED", createdAt: a.now, updatedAt: a.now,
       });
+      // Kit per-unit fulfillment (Phase 1): seed the bulk member's unit (one row
+      // carrying quantity, like a loose bulk line).
+      await ensureBulkUnit(ctx, { organizationId: a.organizationId, lineItemId: childId, bulkAssetId: bi.bulkAssetId, quantity: bi.quantity });
     }
     return { id: a.id };
 }

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -409,6 +409,47 @@ async function patchKitMemberUnits(
   }
 }
 
+/** A kit's serialised member lines — direct serialised children plus the
+ *  serialised members of any nested kit. These are valid accessory parents
+ *  (childKind unset), so their asset-level accessories expand under them. */
+async function serialisedKitMemberLines(ctx: Ctx, kitParentLineId: string, organizationId: string) {
+  const out: Array<{ id: string; assetId: string }> = [];
+  for (const c of await childLines(ctx, kitParentLineId, organizationId)) {
+    if (c.kitId) {
+      for (const gc of await childLines(ctx, c.id, organizationId)) if (!gc.kitId && gc.assetId) out.push({ id: gc.id, assetId: gc.assetId });
+    } else if (c.assetId) {
+      out.push({ id: c.id, assetId: c.assetId });
+    }
+  }
+  return out;
+}
+
+/** Deploy each kit member's asset-level accessories with the kit. Reuses the
+ *  loose-gear helpers, which own the accessory unit AND asset flip (the kit belt
+ *  covers member assets, not accessory assets). Idempotent: expand is find-or-create
+ *  so this works whether or not the kit was prepped first. */
+async function cascadeKitAccessoriesOut(ctx: Ctx, kitParentLineId: string, organizationId: string, p: { projectId: string; userId: string; loc: string | null; now: number }) {
+  for (const m of await serialisedKitMemberLines(ctx, kitParentLineId, organizationId)) {
+    await expandAccessoriesForAsset(ctx, { organizationId, lineItemId: m.id, assetId: m.assetId });
+    await checkoutAccessoryChildren(ctx, { organizationId, projectId: p.projectId, parentLineItemId: m.id, parentUnitAssetId: m.assetId, userId: p.userId, projectLocationId: p.loc, now: p.now });
+  }
+}
+
+/** Return each kit member's accessories with the kit. */
+async function cascadeKitAccessoriesIn(ctx: Ctx, kitParentLineId: string, organizationId: string, p: { projectId: string; userId: string; defaultLocationId: string | null; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }) {
+  for (const m of await serialisedKitMemberLines(ctx, kitParentLineId, organizationId)) {
+    await checkinAccessoryChildren(ctx, { organizationId, projectId: p.projectId, parentLineItemId: m.id, returnCondition: p.returnCondition, userId: p.userId, defaultLocationId: p.defaultLocationId, returnedAssetId: m.assetId });
+  }
+}
+
+/** Reverse each kit member's accessories with the kit (un-deploy / un-return), so a
+ *  move-back never leaves an accessory stranded a stage ahead of its parent. */
+async function cascadeKitAccessoriesReverse(ctx: Ctx, kitParentLineId: string, organizationId: string, p: { fromStatus: string; toStatus: "CONFIRMED" | "CHECKED_OUT"; toPrepStatus?: "PACKED"; assetStatus: string; locationId: string | null; clearLoc: boolean; now: number }) {
+  for (const m of await serialisedKitMemberLines(ctx, kitParentLineId, organizationId)) {
+    await reverseAccessoryChildren(ctx, { organizationId, parentLineItemId: m.id, ...p });
+  }
+}
+
 export const checkoutKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
@@ -457,8 +498,10 @@ export const checkoutKit = mutation({
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
 
     // Kit per-unit: flip member units CONFIRMED → CHECKED_OUT (unit rows only;
-    // the belt above owns asset status this phase).
+    // the belt above owns asset status this phase), then deploy each member's
+    // asset-level accessories with the kit.
     await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CONFIRMED"], () => ({ status: "CHECKED_OUT", checkedOutAt: a.now, checkedOutById: a.userId }), a.now);
+    await cascadeKitAccessoriesOut(ctx, kitLine.id, a.organizationId, { projectId: a.projectId, userId: a.userId, loc, now: a.now });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Kit deployed with all contents" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -508,10 +551,12 @@ export const checkinKit = mutation({
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, 1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
 
-    // Kit per-unit: flip member units CHECKED_OUT → RETURNED (unit rows only).
-    // Bulk members return their full quantity. RETURNED units are retained as job
-    // history (deprep/close never delete them).
+    // Kit per-unit: flip member units CHECKED_OUT → RETURNED (unit rows only),
+    // then return each member's accessories with the kit. Bulk members return
+    // their full quantity. RETURNED units are retained as job history (deprep/close
+    // never delete them).
     await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: a.now, returnedById: a.userId, returnCondition: a.returnCondition }), a.now);
+    await cascadeKitAccessoriesIn(ctx, kitLine.id, a.organizationId, { projectId: a.projectId, userId: a.userId, defaultLocationId, returnCondition: a.returnCondition });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: `Kit returned — condition: ${a.returnCondition}` });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -731,8 +776,10 @@ export const undeployKit = mutation({
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, 1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
 
-    // Kit per-unit: member units CHECKED_OUT → CONFIRMED (re-packed).
+    // Kit per-unit: member units CHECKED_OUT → CONFIRMED (re-packed), and reverse
+    // the members' accessories with them.
     await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CHECKED_OUT"], () => ({ status: "CONFIRMED", prepStatus: "PACKED" }), a.now);
+    await cascadeKitAccessoriesReverse(ctx, kitLine.id, a.organizationId, { fromStatus: "CHECKED_OUT", toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE", locationId: defLoc, clearLoc: true, now: a.now });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Prepped (un-deploy)" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -779,6 +826,7 @@ export const unreturnKit = mutation({
     // Kit per-unit: member units RETURNED → CHECKED_OUT. Clear the return stamps
     // so a re-deployed unit doesn't carry contradictory returned* history.
     await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["RETURNED"], () => ({ status: "CHECKED_OUT", returnedQuantity: 0, checkedOutAt: a.now, checkedOutById: a.userId, returnedAt: undefined, returnedById: undefined, returnCondition: undefined, returnStatus: undefined, returnNotes: undefined }), a.now);
+    await cascadeKitAccessoriesReverse(ctx, kitLine.id, a.organizationId, { fromStatus: "RETURNED", toStatus: "CHECKED_OUT", assetStatus: "CHECKED_OUT", locationId: projLoc, clearLoc: false, now: a.now });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Deployed (un-return)" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -883,9 +931,10 @@ export const forceReturnKit = mutation({
       .filter((l) => l.organizationId === a.organizationId && !l.isKitChild);
     for (const p of parents) {
       await restoreKitParentLine(ctx, p, a.organizationId, loc, a.now, kitsToRestore);
-      // Kit per-unit: flip this kit's CHECKED_OUT member units → RETURNED so a
-      // force-return doesn't leave members stuck deployed on the equipment tab.
+      // Kit per-unit: flip this kit's CHECKED_OUT member units → RETURNED (and its
+      // accessories) so a force-return doesn't leave members stuck deployed.
       await patchKitMemberUnits(ctx, p.id, a.organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD" }), a.now);
+      await cascadeKitAccessoriesIn(ctx, p.id, a.organizationId, { projectId: p.projectId, userId: a.userId, defaultLocationId: loc, returnCondition: "GOOD" });
     }
 
     if (loc != null) await ctx.db.patch(kit._id, { status: "AVAILABLE", locationId: loc, updatedAt: a.now });

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -14,6 +14,7 @@ import {
   syncLineItemRollup,
   returnLineUnits,
   checkinAccessoryChildren,
+  lineUnits,
 } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
 
@@ -358,6 +359,57 @@ async function setAssetsStatus(ctx: Ctx, assetIds: string[], status: string, loc
   }
 }
 
+// ── Kit per-unit fulfillment (Phase 1) ───────────────────────────────────────
+// Additively maintain kit MEMBER UNIT rows alongside the legacy kit line/asset
+// path. This phase the legacy path still OWNS line status, asset status +
+// counters, and bulk availability (setAssetsStatus above); these helpers touch
+// ONLY the projectLineItemUnit rows, so members become visible/trackable per job
+// exactly like loose gear. A member line with no unit (a pre-change kit not yet
+// backfilled) is a silent no-op — Phase 2 backfill fills those, and prep
+// self-heals any prepped after the migration. Phase 3 moves asset-flipping into
+// the unit path and deletes the legacy belt. See
+// docs/designs/kit-per-unit-fulfillment.md.
+
+/** Apply `makePatch(unit)` to every unit on `lineItemId` whose current status is
+ *  in `fromStatuses` (or all units when null). `updatedAt` is stamped for you. */
+async function patchLineUnitRows(
+  ctx: Ctx,
+  lineItemId: string,
+  fromStatuses: string[] | null,
+  makePatch: (u: Awaited<ReturnType<typeof lineUnits>>[number]) => Record<string, unknown>,
+  now: number,
+): Promise<number> {
+  let n = 0;
+  for (const u of await lineUnits(ctx, lineItemId)) {
+    if (fromStatuses && !fromStatuses.includes(u.status ?? "")) continue;
+    await ctx.db.patch(u._id, { ...makePatch(u), updatedAt: now });
+    n++;
+  }
+  return n;
+}
+
+/** Walk a kit's member lines — direct children + nested-kit grandchildren — and
+ *  patch their unit rows. A nested-kit PARENT child line carries no units of its
+ *  own (its grandchildren do), so it is skipped as a unit target. */
+async function patchKitMemberUnits(
+  ctx: Ctx,
+  kitParentLineId: string,
+  organizationId: string,
+  fromStatuses: string[] | null,
+  makePatch: (u: Awaited<ReturnType<typeof lineUnits>>[number]) => Record<string, unknown>,
+  now: number,
+): Promise<void> {
+  for (const c of await childLines(ctx, kitParentLineId, organizationId)) {
+    if (c.kitId) {
+      for (const gc of await childLines(ctx, c.id, organizationId)) {
+        if (!gc.kitId) await patchLineUnitRows(ctx, gc.id, fromStatuses, makePatch, now);
+      }
+    } else {
+      await patchLineUnitRows(ctx, c.id, fromStatuses, makePatch, now);
+    }
+  }
+}
+
 export const checkoutKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
@@ -404,6 +456,10 @@ export const checkoutKit = mutation({
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, -1))];
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, -1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
+
+    // Kit per-unit: flip member units CONFIRMED → CHECKED_OUT (unit rows only;
+    // the belt above owns asset status this phase).
+    await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CONFIRMED"], () => ({ status: "CHECKED_OUT", checkedOutAt: a.now, checkedOutById: a.userId }), a.now);
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Kit deployed with all contents" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -452,6 +508,11 @@ export const checkinKit = mutation({
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, 1))];
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, 1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
+
+    // Kit per-unit: flip member units CHECKED_OUT → RETURNED (unit rows only).
+    // Bulk members return their full quantity. RETURNED units are retained as job
+    // history (deprep/close never delete them).
+    await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: a.now, returnedById: a.userId, returnCondition: a.returnCondition }), a.now);
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: `Kit returned — condition: ${a.returnCondition}` });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
@@ -671,6 +732,9 @@ export const undeployKit = mutation({
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, 1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
 
+    // Kit per-unit: member units CHECKED_OUT → CONFIRMED (re-packed).
+    await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["CHECKED_OUT"], () => ({ status: "CONFIRMED", prepStatus: "PACKED" }), a.now);
+
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Prepped (un-deploy)" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
   },
@@ -713,6 +777,10 @@ export const unreturnKit = mutation({
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, -1)));
     if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
 
+    // Kit per-unit: member units RETURNED → CHECKED_OUT. Clear the return stamps
+    // so a re-deployed unit doesn't carry contradictory returned* history.
+    await patchKitMemberUnits(ctx, kitLine.id, a.organizationId, ["RETURNED"], () => ({ status: "CHECKED_OUT", returnedQuantity: 0, checkedOutAt: a.now, checkedOutById: a.userId, returnedAt: undefined, returnedById: undefined, returnCondition: undefined, returnStatus: undefined, returnNotes: undefined }), a.now);
+
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Deployed (un-return)" });
     return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
   },
@@ -721,6 +789,19 @@ export const unreturnKit = mutation({
 // ── Force-return + container/quick-add (Group E3/E4) ──────────────────────────
 
 const FORCE_RET = (now: number) => ({ status: "RETURNED" as const, returnedQuantity: 1, returnedAt: now, returnCondition: "GOOD" as const, updatedAt: now });
+
+/** Kit per-unit: force-return the CHECKED_OUT unit(s) bound to one asset, wherever
+ *  they live (loose line or kit member). Mirrors FORCE_RET onto the unit row so
+ *  force-return doesn't leave a member unit stuck CHECKED_OUT (split-brain). */
+async function forceReturnAssetUnits(ctx: Ctx, organizationId: string, assetId: string, userId: string, now: number) {
+  const units = await ctx.db
+    .query("projectLineItemUnits")
+    .withIndex("by_organizationId_assetId_status", (q) => q.eq("organizationId", organizationId).eq("assetId", assetId).eq("status", "CHECKED_OUT"))
+    .collect();
+  for (const u of units) {
+    await ctx.db.patch(u._id, { status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: now, returnedById: userId, returnCondition: "GOOD", updatedAt: now });
+  }
+}
 
 export const forceReturnAsset = mutation({
   args: { organizationId: v.string(), assetId: v.string(), userId: v.string(), now: v.number() },
@@ -733,6 +814,7 @@ export const forceReturnAsset = mutation({
     for (const li of await linesByAsset(ctx, a.assetId, a.organizationId)) {
       if (li.status === "CHECKED_OUT") await ctx.db.patch(li._id, FORCE_RET(a.now));
     }
+    await forceReturnAssetUnits(ctx, a.organizationId, a.assetId, a.userId, a.now);
     await setAssetsStatus(ctx, [a.assetId], "AVAILABLE", loc, true, a.now);
     return { success: true };
   },
@@ -750,6 +832,7 @@ export const bulkForceReturnAssets = mutation({
       for (const li of await linesByAsset(ctx, assetId, a.organizationId)) {
         if (li.status === "CHECKED_OUT") await ctx.db.patch(li._id, FORCE_RET(a.now));
       }
+      await forceReturnAssetUnits(ctx, a.organizationId, assetId, a.userId, a.now);
       await setAssetsStatus(ctx, [assetId], "AVAILABLE", loc, true, a.now);
       count++;
     }
@@ -799,7 +882,12 @@ export const forceReturnKit = mutation({
 
     const parents = (await ctx.db.query("projectLineItems").withIndex("by_kitId", (q) => q.eq("kitId", a.kitId)).collect())
       .filter((l) => l.organizationId === a.organizationId && !l.isKitChild);
-    for (const p of parents) await restoreKitParentLine(ctx, p, a.organizationId, loc, a.now, kitsToRestore);
+    for (const p of parents) {
+      await restoreKitParentLine(ctx, p, a.organizationId, loc, a.now, kitsToRestore);
+      // Kit per-unit: flip this kit's CHECKED_OUT member units → RETURNED so a
+      // force-return doesn't leave members stuck deployed on the equipment tab.
+      await patchKitMemberUnits(ctx, p.id, a.organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD" }), a.now);
+    }
 
     if (loc != null) await ctx.db.patch(kit._id, { status: "AVAILABLE", locationId: loc, updatedAt: a.now });
     else { const { _id, _creationTime, locationId: _l, ...rest } = kit; await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: a.now }); }

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -14,7 +14,6 @@ import {
   syncLineItemRollup,
   returnLineUnits,
   checkinAccessoryChildren,
-  lineUnits,
 } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
 

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -264,6 +264,43 @@ kit**, not move it to a loose line. Decide the guard model (same-kit +
 same-model slot) before enabling. **Out of scope for Phases 1–3**; visibility +
 per-unit lifecycle + history land first.
 
+## Performance — Convex-native, one call per kit operation (hard invariant)
+
+This whole path runs on the **Convex-native** surface and adds **zero new
+round-trips**:
+
+- **Reads** are reactive-native — the equipment tab reads one live
+  `api.equipmentTab.bundle` subscription (`use-native-equipment-tab.ts`); kit-member
+  units ride that same bundle. No Prisma, no polling.
+- **Writes** are Convex mutations, and `projectLineItemUnits` has **no Prisma
+  mirror** (only `member-mirror.ts` / `user-mirror.ts` exist), so unit writes are
+  Convex-only — no dual-write cost.
+
+**Single-call invariant (the thing to protect):** every kit operation does **all N
+members in ONE Convex mutation**, never one round-trip per member. This is already
+true today (`checkoutKit`/`checkinKit` loop all members internally in a single
+transaction; `checkOutKitsBatch` is one client round-trip). The migration must keep
+it true:
+
+- **All** per-member unit work — `ensureSerialisedUnit`/`ensureBulkUnit` at seed,
+  status patches at checkout/checkin/prep, `expandAccessoriesForAsset`,
+  `syncLineItemRollup`, asset flips — runs **inside** `createKitLineItemCore` /
+  `checkoutKit` / `checkinKit` / `setKitTreePrep` / `deprepKit`, looping members in
+  the mutation body. **Never** loop `convex.mutation(...)` per member from the
+  server action. The server action's only job stays: one `requirePermission`, one
+  mutation call, one `logActivity`.
+- The nested-kit recursion also stays in-mutation (grandchildren flip in the same
+  transaction as the parent).
+- **Ceiling to respect:** a single mutation has Convex read/write/time limits. A
+  huge or deeply nested kit (dozens of members × accessories) does all that work in
+  one transaction — bounded-size check required; if real kits can exceed it,
+  paginate the *backfill*-style pattern rather than splitting the live checkout into
+  per-member calls (which would reintroduce the round-trip cost we're avoiding).
+- **Multi-kit batches** (`checkOutKitsBatch`/`checkInKitsBatch`) intentionally stay
+  one-mutation-per-kit for per-kit error isolation — that's per *kit*, not per
+  *member*, and is not a regression. (Collapsing multi-kit into a single mutation is
+  a separate batching effort, out of scope — see [[bulk-op-batching]].)
+
 ## Risks
 
 1. **Split-brain asset sets (codex #12, the real one)** — the legacy belt flips

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -40,6 +40,37 @@ checks. It has **zero effect on the write path today** and gains none here. Unit
 creation (visibility / tracking / reassign) and scan granularity (checkMode) are
 **orthogonal**, and we keep them that way.
 
+### Settled sub-decisions (eng review + codex outside voice, 2026-07-12)
+
+These refine the phases below; the review-outcomes appendix records the reasoning.
+
+1. **Units are created at child-line creation** (`createKitLineItemCore`,
+   `projectLineItems.ts:472`), not opportunistically at checkout. A kit added to a
+   project seeds its member units in `CONFIRMED` state immediately, mirroring how
+   loose lines relate to units. Prep/checkout/checkin then **patch existing
+   units**. This gives the per-unit **prep** lifecycle for free and shrinks the
+   backfill to pre-change kits only. Cost: Phase 1 also rewrites the kit prep path
+   and the kit-edit-after-add path (below).
+2. **Display = one row per member, retagged from its unit.** Kit members stay
+   one-row-per-child; Phase 3 changes only the **tag source** (`child.units[0]`
+   instead of `line.asset`) and adds the status badge. **No per-unit expansion
+   rows** — each member has exactly one unit, so expansion is redundant and would
+   reintroduce the `calculateItemHeight` tail-drop bug. This supersedes the earlier
+   "render kit-child per-unit rows" prescription.
+3. **Both paths flip asset status in Phase 1, made idempotent by transition.**
+   The new unit path flips asset status like `checkOutSerializedItem`; the legacy
+   `kitSerializedItems` flip still runs as a belt. `bumpAssetCounters` is gated on
+   an **actual status change**, so a second fixed-status write is a counter no-op.
+   Per codex: the double-count was never the real hazard — the real transitional
+   risk is the **two sources holding different asset sets** (see #4).
+4. **Verification stays on the live `kitSerializedItems` definition + a parity
+   guard.** Fulfillment reads the child-line snapshot/units; verification keeps
+   reading the live kit definition, but a parity check **errors** if a project's
+   child-line asset set diverges from the current kit definition (happens when an
+   `AVAILABLE` kit is edited after being added to a project). Surfaces divergence
+   as an operator-fixable error rather than silently validating one set and
+   deploying another.
+
 Why all-kits and not PER_ITEM-only:
 - The goal — members visible + trackable per job — applies to *every* kit;
   `KIT_LEVEL` members are exactly as invisible today as `PER_ITEM` ones
@@ -130,69 +161,97 @@ silent bug.
 
 ## Phased rollout (multi-PR — do NOT one-shot)
 
-### Phase 1 — Write path: create + flip kit-member units
-Rewrite `checkoutKit` / `checkinKit` (and reverse mutations `undeployKit`,
-`unreturnKit`, `forceReturnKit`) to mint and flip units, converging kit members
-onto the loose-gear helpers.
+### Phase 1 — Create units at kit-add; flip them through the warehouse
+Seed units when kit child lines are created, and make every kit warehouse
+mutation patch those units — converging kit members onto the loose-gear helpers.
 
-- **Checkout** — for each **serialised** direct child line (`c.assetId`, not a
-  nested kit): `ensureSerialisedUnit(line, assetId)` → patch unit
-  `CHECKED_OUT`+`checkedOut*` → flip asset (as `checkOutSerializedItem` does) →
-  `scanLog`. For each **bulk** child line: `ensureBulkUnit(line, bulkAssetId, qty)`
-  + the existing bulk-availability adjustment. Recurse into nested kits.
+- **Seed at creation** — in `createKitLineItemCore` (`projectLineItems.ts:472`),
+  after inserting each serialised child line call `ensureSerialisedUnit(line,
+  assetId)`; after each bulk child line call `ensureBulkUnit(line, bulkAssetId,
+  qty)`. Units start `CONFIRMED`. Recurse for nested-kit grandchildren.
+- **Kit-edit-after-add** — the path that adds/removes a member on a project's kit
+  (adds/removes a child line) must create/cancel the matching unit in lockstep,
+  or the snapshot and its units drift. Trace every child-line mutator, not just
+  creation.
+- **Prep / deprep (in scope — codex #3)** — `prepKitChildren` → `setKitTreePrep`
+  and `deprepKit` (`checkRecordOps.ts:204`) today patch **lines only**. Rewrite
+  them to patch `unit.prepStatus` (`PACKED` / `PENDING`) so the per-unit prep
+  lifecycle actually exists. `deprep` must preserve CHECKED_OUT/RETURNED units
+  (same guard as `deprepItemInner`).
+- **Checkout** — for each serialised member: patch its (already-existing) unit
+  `CHECKED_OUT`+`checkedOut*`, flip asset as `checkOutSerializedItem` does,
+  `scanLog`; for each bulk member: patch the bulk unit + existing availability
+  adjustment. **Also run `expandAccessoriesForAsset`** for each member so
+  accessories-on-kit-members get their units (codex #6). Recurse nested kits.
 - **Check-in** — flip each CHECKED_OUT member unit `RETURNED`+`returned*`+
-  `returnCondition`; restore asset via `assetStatusFromReturnCondition`. Cascade
-  accessory child units (existing `checkinAccessoryChildren`).
-- **Line status** — replace the direct child-line status patches with
-  `syncLineItemRollup(childLineId)` so kit-child line status derives from its
-  units, matching loose gear. Kit **parent** line + `kits` doc status stay
+  `returnCondition`; restore asset via `assetStatusFromReturnCondition`; cascade
+  accessory child units. **Legacy fallback (codex #1):** if a member has no unit
+  (a kit added before this change, pre-backfill), fall back to the legacy line/
+  asset flip and do not throw. This tolerance is removed in Phase 3 once backfill
+  guarantees units exist.
+- **Reverse + force mutations** — `undeployKit`, `unreturnKit`, `forceReturnKit`,
+  **and `forceReturnAsset` / `bulkForceReturnAssets`** (`warehouseOps.ts:318`,
+  codex #10) must flip units too, or they go split-brain. `unreturnKit` must
+  **clear** `returnedAt`/`returnedById`/`returnCondition`/`returnStatus`/
+  `returnNotes` when flipping back to CHECKED_OUT, not just the status (codex #11).
+- **Line status** — replace direct child-line status patches with
+  `syncLineItemRollup(childLineId)`. Kit **parent** line + `kits` doc status stay
   patched directly (kit-level, not unit-derived).
-- **Keep** `kitSerializedItems`-driven asset flip **as a transitional belt** this
-  phase (idempotent with the unit flip) — Phase 3 removes it once units are the
-  source of truth. Do **not** remove it before backfill (Phase 2) lands, or
-  in-flight kits lose their asset flip.
-- **`ConvexError` only**; mirror writes via `createIfMissing` semantics
-  (`ensure*` helpers already are). Guarded `updateMany`-style single-row
-  assertions per the parent design's concurrency rule.
-- **Prep/deprep:** confirm whether kit-child lines flow through `prepItem`/
-  `deprepItemInner` today (loose gear preps per line; kits historically travel as
-  a case). If they do, `prepUnit` already handles them once units exist; if not,
-  units are created at checkout only — document which, no behaviour regression.
-- **Tests:** integration — checkout a kit → N member units CHECKED_OUT, asset
-  statuses flipped, rollup correct; check-in → units RETURNED, assets restored;
-  nested kit; kit with bulk member; accessory on a kit member; reverse
-  mutations. Equipment-tab reconstruct shows member units.
+- **Asset-status belt + idempotency** — keep the `kitSerializedItems`-driven flip
+  this phase; gate `bumpAssetCounters` on an **actual status transition** so the
+  belt and the unit flip together never double-count. **Parity guard (codex #9):**
+  error if a project's child-line asset set diverges from the live
+  `kitSerializedItems` definition at verification time.
+- **`ConvexError` only**; `ensure*` helpers are already `createIfMissing`-safe.
+  Guarded single-row assertions per the parent design's concurrency rule.
+- **Tests:** see the coverage diagram in the eng-review appendix — checkout /
+  check-in / prep / reverse / force / nested / bulk / accessory / pre-change
+  fallback (regression) / parity guard / kit-edit sync.
 
-### Phase 2 — Backfill already-deployed kits
-`scripts/backfill-kit-member-units.ts` (dry-run default; run from the
-`migrate.yml` GitHub Actions workflow — prod SSH freezes on long scripts; refresh
-the Convex service token per mutation per
-[[convex-backfill-token-refresh]]).
+### Phase 2 — Backfill kits added before Phase 1
+Only kits whose child lines predate Phase 1 lack units (going-forward kits are
+seeded at creation).
 
-- For every kit-child line (serialised: has `assetId`; bulk: has `bulkAssetId`)
-  **with no existing unit**, create one via the same `ensure*` helpers, stamping
-  status/lifecycle from the **current line** state (CHECKED_OUT lines →
-  CHECKED_OUT unit with `checkedOut*`; RETURNED lines → RETURNED unit with
-  `returned*`/`returnCondition`; else CONFIRMED). Idempotent — safe to re-run.
+- **Mechanism (codex #7):** a **registered, paginated Convex mutation** (e.g.
+  `convex/backfillKitUnits.ts`) invoked from a workflow/CLI, **not** a `tsx`
+  script calling `ensure*` helpers — those are internal server helpers, not
+  script-callable. Follow the existing backfill-mutation pattern; refresh the
+  Convex service token per batch per [[convex-backfill-token-refresh]].
+- For every kit-child line with no existing unit, create one via the same helpers,
+  stamping **full lifecycle** from the current line — not bare CONFIRMED (codex
+  #8): CHECKED_OUT lines → CHECKED_OUT unit with `checkedOut*`; RETURNED lines →
+  RETURNED unit with `returned*`/`returnCondition`; **prepped lines → carry
+  `prepStatus: PACKED`**; bulk lines → carry `quantity` **and partial
+  `returnedQuantity`**. Idempotent — safe to re-run.
 - Recurse nested kits; skip accessory children (already unit-backed).
-- Nothing new reads these until Phase 1 is deployed *and* the equipment-tab
-  exclusion is lifted, so backfill is non-destructive and reversible.
-- **End the migration with `ANALYZE "projectLineItemUnit";`** (bulk-insert stats
-  hygiene — CLAUDE.md). Parity-check: every pre-backfill CHECKED_OUT/RETURNED kit
-  member reachable via `unit → line → project` with matching `assetId`.
+- Non-destructive: nothing new reads these until Phase 3 lifts the display path,
+  so backfill is reversible.
+- **No `ANALYZE`.** `projectLineItemUnits` is a **Convex** table; `ANALYZE` is
+  PostgreSQL and has no meaning here (the CLAUDE.md ANALYZE rule is Prisma/Postgres
+  only). Convex needs no post-bulk stats step.
+- **Parity check:** every pre-backfill CHECKED_OUT/RETURNED kit member reachable
+  via `unit → line → project` with matching `assetId`.
 
 ### Phase 3 — Surface + strip the old path
-- **Equipment tab:** lift the `isKitChild` exclusion in
-  `equipment-row-descriptors.ts:63` so kit members expand per-unit with a status
-  badge; verify `equipment-tab-reconstruct` attaches member units.
-- **PDF:** render kit-child per-unit rows in `gearflow-table.ts`; **add matching
-  height reservation** in `section-renderer.ts` `calculateItemHeight`; update
-  `buildDeliveryDocketGroups` to source tags/quantities from units. **One
-  cross-pipeline integration test** per the PDF rule.
+- **Equipment tab (retag, do NOT expand):** source each kit-child row's tag from
+  `child.units[0]` instead of `line.asset`, and add the status badge. **Leave**
+  the `isKitChild` exclusion in `equipment-row-descriptors.ts:63` as-is — a
+  one-unit member has nothing to expand, so lifting it does nothing useful and
+  only risks a redundant row (codex #4). **Hide the Reassign control for
+  kit-child units** — `reassignSerialisedUnit` throws on kit children, so an
+  exposed dropdown would offer an always-erroring action (kit-member reassign is
+  Phase 4).
+- **PDF (minimal):** `gearflow-table.ts` already reads `child.units` for tags and
+  only expands when `quantity > 1` (`:805`); serialised kit members are qty-1, so
+  **no new row and no `calculateItemHeight` change** are needed — just confirm the
+  tag now resolves from the unit. Do **not** add per-unit rows for kit children.
+  Still ship **one cross-pipeline integration test** (docket regression: kit row
+  count unchanged, tag sourced from unit) per the PDF rule.
 - **Strip** the `kitSerializedItems → kitSerializedAssetIds → setAssetsStatus`
-  fulfillment flip from checkout/check-in (units are now the source of truth).
-  `kitSerializedItems` remains the kit **definition** table — only its use *as a
-  runtime fulfillment source* is retired.
+  fulfillment flip and the Phase-1 legacy check-in fallback (units now guaranteed
+  by backfill). `kitSerializedItems` remains the kit **definition** table (and the
+  verification source per the parity-guard decision) — only its use *as a runtime
+  fulfillment/asset-flip source* is retired.
 - Unblocks the parent design's deferred **`line.assetId` column drop** for kit
   children (now stored on the unit). Coordinate with that design; likely its own
   follow-up PR.
@@ -207,20 +266,25 @@ per-unit lifecycle + history land first.
 
 ## Risks
 
-1. **Silent PDF tail-drop** — kit-child units rendered without matching
-   `calculateItemHeight` reservation. Mitigation: the PDF integration test;
-   ship render + height in the same PR.
-2. **Double asset flip** — Phase 1 keeps both the unit flip and the legacy
-   `kitSerializedItems` flip. They're idempotent per asset (`setAssetsStatus`
-   patches to a fixed status), but verify no counter double-count in
-   `bumpAssetCounters`. Remove the legacy flip in Phase 3.
-3. **Backfill drift** — stale planner stats after bulk insert → pool stalls.
-   Mitigation: `ANALYZE` terminates the migration.
-4. **Half-migrated window** — equipment tab / PDF start reading member units
-   before backfill completes → some kits show units, others don't. Mitigation:
-   Phase 3 surfacing ships **after** Phase 2 backfill is deployed + verified;
-   `getAssetTag`'s `line.asset` fallback keeps un-backfilled members showing a
-   tag meanwhile.
+1. **Split-brain asset sets (codex #12, the real one)** — the legacy belt flips
+   assets from `kitSerializedItems` while the unit path flips from child-line
+   snapshots. If those sets differ (kit edited after add), unrelated assets flip.
+   Mitigation: the parity guard errors on divergence; the kit-edit-after-add sync
+   keeps them aligned going forward.
+2. **Pre-change kit check-in with no units (codex #1)** — a kit deployed before
+   Phase 1, checked in after, has no units to flip. Mitigation: the Phase-1 legacy
+   check-in fallback (no throw); backfill then guarantees units; fallback removed
+   in Phase 3. Regression test required.
+3. **Counter double-count** — belt + unit flip both touch asset status.
+   Mitigation: `bumpAssetCounters` gated on an actual status transition, so the
+   second fixed-status write is a no-op. (Lower severity than #1 per codex.)
+4. **Large / nested kit mutation size** — seeding units at kit-add and patching
+   them at checkout happen in single Convex mutations; a 50-member or deeply
+   nested kit could approach Convex mutation limits. Mitigation: bounded-size
+   check; paginate if kits can be huge (reuse the backfill pattern).
+5. **Prep-path miss** — if `setKitTreePrep`/`deprepKit` aren't rewritten, the
+   per-unit prep lifecycle silently doesn't exist. Mitigation: they are explicitly
+   in Phase 1 scope; prep integration test.
 
 ## Docs to update as phases land
 - **FEATUREDOCS/60** (assets on a job) — the "Physical kit member" row moves
@@ -230,5 +294,61 @@ per-unit lifecycle + history land first.
 - **line-item-fulfillment-model.md** — mark the line-89/line-163 contradiction
   resolved (link here); update the Phase 4 column-drop status.
 - **ARCHITECTURE.md** table if a new FEATUREDOCS file is added.
+
+---
+
+## Eng-review appendix (2026-07-12)
+
+`/plan-eng-review` + codex outside voice. Cross-model agreement on display model
+(codex #4/#5 ↔ Issue 2) and phase ordering (codex #1). Decisions above.
+
+### What already exists (reused, not rebuilt)
+- **Per-unit fulfillment machinery** — `ensureSerialisedUnit` / `ensureBulkUnit` /
+  `ensureAccessoryUnit`, `syncLineItemRollup`, `returnLineUnits`,
+  `checkOutSerializedItem` (`convex/lib/fulfillment.ts`, `warehouseOps.ts`). Kits
+  converge onto these; no parallel path.
+- **Accessory child-kind unit pattern** (`parentUnitAssetId`) — the precedent for
+  minting units for a non-loose child kind.
+- **`projectLineItemUnits` schema** — already has every field/index needed; no
+  schema change.
+- **Kit prep path** (`prepKitChildren`/`setKitTreePrep`/`deprepKit`) — exists but
+  patches lines only; Phase 1 extends it to units rather than adding a new path.
+
+### NOT in scope (deferred, with rationale)
+- **Kit-member reassign** — Phase 4. Identity is tied to the kit slot; needs a
+  same-kit-slot guard model. Visibility + lifecycle + history land first.
+- **`line.assetId` column drop for kit children** — parent design's follow-up;
+  unblocked by Phase 3 but shipped separately.
+- **Collapsing kitSerializedItems into the snapshot / making project kits a live
+  reference** — verification stays on the live definition + parity guard; a full
+  snapshot-vs-live redesign is out of scope.
+- **checkMode changes** — stays a scan-granularity-only control, untouched.
+- **Paginating kit checkout for huge kits** — only if the bounded-size check shows
+  real kits hit Convex limits.
+
+### Failure modes (new codepaths)
+| Codepath | Realistic failure | Test? | Error handling? | Silent? |
+|---|---|---|---|---|
+| checkinKit, pre-change kit | no unit to flip → throw / stuck asset | **required (regression)** | legacy fallback | would be silent → **must test** |
+| forceReturnAsset / bulk | patches line, not unit → split-brain | required | flip units | silent → **critical gap until fixed** |
+| checkout, edited kit | belt vs snapshot flip different assets | required | parity guard errors | guard makes it loud |
+| seed at kit-add, huge kit | Convex mutation limit → 500 | perf test | bounded check | user sees warehouse 500 |
+| prep path not rewritten | per-unit prepStatus never set | required | n/a | silent feature-absence |
+
+Critical gaps flagged: **pre-change checkin fallback** and **forceReturn
+split-brain** — both are regression-class, auto-added to the plan.
+
+### Parallelization
+Largely **sequential** — Phase 1 → 2 → 3 are hard-ordered (backfill must follow
+the write path and precede the display cutover). Within Phase 1 there is one
+parallel split:
+- **Lane A:** `convex/warehouseOps.ts` write/reverse/force mutations + parity guard.
+- **Lane B:** `createKitLineItemCore` seeding + `setKitTreePrep`/`deprepKit` prep
+  rewrite (`projectLineItems.ts`, `checkRecordOps.ts`).
+
+Lanes A and B touch disjoint files and can be built in parallel worktrees, but both
+must land before Phase 2. Phase 3 (equipment-tab + PDF) is a separate lane gated on
+Phase 2. Backfill mutation (`convex/backfillKitUnits.ts`) can be written anytime but
+run only after Phase 1 deploys.
 </content>
 </invoke>

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -1,0 +1,234 @@
+# Kit Per-Unit Fulfillment
+
+Unify **physical kit members** into the per-unit fulfillment model so their
+serials are tracked per-job like loose gear — visible on the Equipment tab,
+carrying per-unit prep/deploy/return/history, and eventually reassignable.
+
+Kits are the **un-migrated island** of the fulfillment migration
+([line-item-fulfillment-model.md](./line-item-fulfillment-model.md)). Loose and
+group gear moved to `projectLineItemUnit` rows; kits never did. This doc
+finishes that migration for kits.
+
+## The contradiction this resolves
+
+`line-item-fulfillment-model.md` contradicts itself and never settled it:
+
+- **line 89–91:** "Single-qty serialised lines **and kit children get exactly
+  one unit row — uniform model.** … the order-line `assetId`/`bulkAssetId` FKs
+  are dropped." (Open Question 1, "resolved — uniform beats a smaller diff.")
+- **line 163–170 (Phase 4 audit):** "**Kit children carry their asset directly
+  on `line.assetId` (no unit row)** — `checkOutKit` writes it; `checkInItems`
+  has a no-unit fallback that reads it. Dropping the column would break the kit
+  flow." Column drop **deferred** until "a follow-on design answers where
+  kit-children store their asset assignment."
+
+**This is that follow-on design.** Resolution: **the line-89 answer wins.** Kit
+members get real `projectLineItemUnit` rows. The line-163 blocker (`checkOutKit`
+never created units) is exactly what Phase 1 below fixes.
+
+## Decision (settled 2026-07-12)
+
+**All kits go per-unit, regardless of `checkMode`.** Every serialised kit member
+gets a `projectLineItemUnit`; every bulk kit member gets a bulk unit — created
+at kit checkout (and prep, where kit lines flow through it), flipped RETURNED at
+check-in.
+
+`checkMode` (`KIT_LEVEL` | `PER_ITEM`) stays **exactly as it is today**: it gates
+only the pre-write **inspection questionnaire** granularity
+(`warehouse/[projectId]/page.tsx:594-651`) — one kit-level check vs. per-member
+checks. It has **zero effect on the write path today** and gains none here. Unit
+creation (visibility / tracking / reassign) and scan granularity (checkMode) are
+**orthogonal**, and we keep them that way.
+
+Why all-kits and not PER_ITEM-only:
+- The goal — members visible + trackable per job — applies to *every* kit;
+  `KIT_LEVEL` members are exactly as invisible today as `PER_ITEM` ones
+  (`equipment-row-descriptors.ts:63` hard-excludes **all** `isKitChild` from unit
+  expansion).
+- PER_ITEM-only leaves **two permanent write paths**, defeating Phase 3 ("strip
+  the old path") and blocking the deferred `line.assetId` column drop forever.
+
+## Current state (verified, do not re-derive)
+
+### Kit write path — no units, dual-sourced asset flip
+`checkoutKit` / `checkinKit` (`convex/warehouseOps.ts:361-458`) flip **asset
+status** and **line status** directly and **never create unit rows**:
+- `kitSerializedAssetIds(kitId)` (`:336-338`) reads the kit *definition* table
+  `kitSerializedItems` and returns member `assetId`s → `setAssetsStatus`
+  (`:343-359`) patches each `asset.status`.
+- Assets are flipped from **two** sources that overlap for a normal kit: the
+  kit-child line's `assetId` (`:394`) **and** `kitSerializedItems` (`:402`).
+- Line rollup fields are patched directly on parent + child lines (`:383-385`),
+  **not** derived from units via `syncLineItemRollup`.
+- `checkMode` is **not read** anywhere in `warehouseOps.ts`.
+
+### Kit line shape (`convex/projectLineItems.ts:472-526`)
+- **Kit parent line:** `kitId` set, no `isKitChild`, no `parentLineItemId`.
+  Found by `kitParentLine` (`by_kitId` + `!isKitChild`).
+- **Serialised member child line:** one per `kitSerializedItems` row, `quantity:1`,
+  `assetId: si.assetId` (`:507`), `isKitChild:true`, `parentLineItemId:parent`.
+  → each serial already has its own qty-1 child line.
+- **Bulk member child line:** one per `kitBulkItems` row, `bulkAssetId`,
+  `quantity: N`, `isKitChild:true`. No `assetId`.
+- **Nested-kit child line:** a child line that itself has `kitId` set; its own
+  `childLineItems` are the grandchildren. Detected everywhere as
+  `children.filter(c => c.kitId)`.
+- `childKind: "KIT"` is **never written** in production — kit members are keyed by
+  `isKitChild`/`kitId`. `childKind: "ACCESSORY"` *is* written, for accessories.
+
+### Loose-gear unit path (the pattern to copy)
+- `ensureSerialisedUnit(ctx, {organizationId, lineItemId, assetId})`
+  (`convex/lib/fulfillment.ts:63-90`) — idempotent find-or-create on
+  `by_lineItemId_assetId`; inserts `{ordinal, assetId, quantity:1,
+  returnedQuantity:0, status:"CONFIRMED"}`. Caller then patches lifecycle.
+- `ensureBulkUnit` (`:93-116`) — one row per `(line, bulkAssetId)`, carrying
+  `quantity`.
+- `ensureAccessoryUnit` (`:119-155`) — one unit per parent physical unit, linked
+  by `parentUnitAssetId`. **This is the precedent for minting units for a
+  non-loose child kind.**
+- Checkout: `checkOutSerializedItem` (`warehouseOps.ts:51-77`) = `ensureSerialisedUnit`
+  → patch unit `CHECKED_OUT` + `checkedOut*` → patch asset `CHECKED_OUT` →
+  `bumpAssetCounters` → `scanLog`. `finalizeCheckoutItem` cascades accessories +
+  `syncLineItemRollup`.
+- Return: `returnLineUnits` (`fulfillment.ts:186-307`) flips unit `RETURNED` +
+  `returned*` + `returnCondition`; restores asset via `assetStatusFromReturnCondition`.
+- `syncLineItemRollup` (`fulfillment.ts:43-61`) recomputes the parent line's
+  counters/`status`/`prepStatus` **from its unit rows** after every write.
+- Deprep deletes only still-prepped units, **never** CHECKED_OUT/RETURNED/CANCELLED
+  (`checkRecordOps.ts:110-116`). RETURNED units are immutable job history.
+
+### No schema change required
+`projectLineItemUnits` (`convex/schema.ts:887-919`) already has `lineItemId`,
+`assetId`, `bulkAssetId`, `parentUnitAssetId`, `quantity`, `status`, `prepStatus`,
+lifecycle stamps, and the `by_lineItemId_assetId` / `by_lineItemId_status` indexes.
+A kit member's unit links to its **kit-child line** via `lineItemId`; that line
+already carries `isKitChild` + `parentLineItemId` + (for nested) `kitId`. **No
+`kitId` column on the unit is needed** — kit context is one hop away through the
+line. This migration is a **write-path + backfill** change, not a schema change.
+
+## Downstream consumers (cross-cutting audit — all must be covered)
+
+| Consumer | Reads today | Kit members today | Required change |
+|---|---|---|---|
+| `equipmentTab.ts` bundle | units + `line.asset` | flat child row, tag from `line.asset`; **hard-excluded** from unit expansion (`equipment-row-descriptors.ts:63`) | stop excluding `isKitChild`; members now have units → per-unit rows + status badge |
+| `getAssetTag` (`gearflow-table.ts:153`) | units → `line.asset` fallback | falls to `line.asset` | no change (fallback still fires until backfill; then units win) |
+| gearflow-table rendering | units (top-level+accessory); `line.asset` (kit children) | one tag, no per-unit sub-rows | render kit-child per-unit rows from `child.units` |
+| **`section-renderer.ts` `calculateItemHeight`** | reserves per-unit only if `quantity>1` (`:278,295`) | 1 `CHILD_ROW_PT` each | **reserve per-unit height for kit children with units — miss this → silent tail-drop (v0.8.1.1-class bug)** |
+| `section-renderer.ts` `getFilteredParentItems` | line `status` | excluded (surfaced via parent) | verify: status now unit-derived via rollup |
+| `gearflow-table.ts` top-level filter | line `status` | excluded | mirror of above |
+| `buildDeliveryDocketGroups` (+ twin) | line `status` | promoted under kit name, tag from `line.asset` | tag from units; docket quantity from checked-out units |
+| `checkoutKit`/`checkinKit` | `kitSerializedItems` + child `line.assetId` | no units | **create/flip units (Phase 1)** |
+| Kit verification (`SCAN_VERIFY`) | `kitSerializedItems` / scan | tag-scan verify, no units | keep as-is (checkMode-gated); may cross-check against units later |
+| Accessories on kit members | `projectLineItemUnit` + `parentUnitAssetId` | already per-unit | ensure kit-member units become valid accessory *parents* |
+
+**PDF rule (CLAUDE.md):** any `DocumentLineItem` shape change must be verified
+against all 5 consumers **with an integration test** through
+`structureLineItems → calculateItemHeight → filter → plugin render`. Kit members
+gaining units *is* such a change (kit-child `units[]` goes from always-empty to
+populated). The height-calc reservation for kit-child units is the highest-risk
+silent bug.
+
+## Phased rollout (multi-PR — do NOT one-shot)
+
+### Phase 1 — Write path: create + flip kit-member units
+Rewrite `checkoutKit` / `checkinKit` (and reverse mutations `undeployKit`,
+`unreturnKit`, `forceReturnKit`) to mint and flip units, converging kit members
+onto the loose-gear helpers.
+
+- **Checkout** — for each **serialised** direct child line (`c.assetId`, not a
+  nested kit): `ensureSerialisedUnit(line, assetId)` → patch unit
+  `CHECKED_OUT`+`checkedOut*` → flip asset (as `checkOutSerializedItem` does) →
+  `scanLog`. For each **bulk** child line: `ensureBulkUnit(line, bulkAssetId, qty)`
+  + the existing bulk-availability adjustment. Recurse into nested kits.
+- **Check-in** — flip each CHECKED_OUT member unit `RETURNED`+`returned*`+
+  `returnCondition`; restore asset via `assetStatusFromReturnCondition`. Cascade
+  accessory child units (existing `checkinAccessoryChildren`).
+- **Line status** — replace the direct child-line status patches with
+  `syncLineItemRollup(childLineId)` so kit-child line status derives from its
+  units, matching loose gear. Kit **parent** line + `kits` doc status stay
+  patched directly (kit-level, not unit-derived).
+- **Keep** `kitSerializedItems`-driven asset flip **as a transitional belt** this
+  phase (idempotent with the unit flip) — Phase 3 removes it once units are the
+  source of truth. Do **not** remove it before backfill (Phase 2) lands, or
+  in-flight kits lose their asset flip.
+- **`ConvexError` only**; mirror writes via `createIfMissing` semantics
+  (`ensure*` helpers already are). Guarded `updateMany`-style single-row
+  assertions per the parent design's concurrency rule.
+- **Prep/deprep:** confirm whether kit-child lines flow through `prepItem`/
+  `deprepItemInner` today (loose gear preps per line; kits historically travel as
+  a case). If they do, `prepUnit` already handles them once units exist; if not,
+  units are created at checkout only — document which, no behaviour regression.
+- **Tests:** integration — checkout a kit → N member units CHECKED_OUT, asset
+  statuses flipped, rollup correct; check-in → units RETURNED, assets restored;
+  nested kit; kit with bulk member; accessory on a kit member; reverse
+  mutations. Equipment-tab reconstruct shows member units.
+
+### Phase 2 — Backfill already-deployed kits
+`scripts/backfill-kit-member-units.ts` (dry-run default; run from the
+`migrate.yml` GitHub Actions workflow — prod SSH freezes on long scripts; refresh
+the Convex service token per mutation per
+[[convex-backfill-token-refresh]]).
+
+- For every kit-child line (serialised: has `assetId`; bulk: has `bulkAssetId`)
+  **with no existing unit**, create one via the same `ensure*` helpers, stamping
+  status/lifecycle from the **current line** state (CHECKED_OUT lines →
+  CHECKED_OUT unit with `checkedOut*`; RETURNED lines → RETURNED unit with
+  `returned*`/`returnCondition`; else CONFIRMED). Idempotent — safe to re-run.
+- Recurse nested kits; skip accessory children (already unit-backed).
+- Nothing new reads these until Phase 1 is deployed *and* the equipment-tab
+  exclusion is lifted, so backfill is non-destructive and reversible.
+- **End the migration with `ANALYZE "projectLineItemUnit";`** (bulk-insert stats
+  hygiene — CLAUDE.md). Parity-check: every pre-backfill CHECKED_OUT/RETURNED kit
+  member reachable via `unit → line → project` with matching `assetId`.
+
+### Phase 3 — Surface + strip the old path
+- **Equipment tab:** lift the `isKitChild` exclusion in
+  `equipment-row-descriptors.ts:63` so kit members expand per-unit with a status
+  badge; verify `equipment-tab-reconstruct` attaches member units.
+- **PDF:** render kit-child per-unit rows in `gearflow-table.ts`; **add matching
+  height reservation** in `section-renderer.ts` `calculateItemHeight`; update
+  `buildDeliveryDocketGroups` to source tags/quantities from units. **One
+  cross-pipeline integration test** per the PDF rule.
+- **Strip** the `kitSerializedItems → kitSerializedAssetIds → setAssetsStatus`
+  fulfillment flip from checkout/check-in (units are now the source of truth).
+  `kitSerializedItems` remains the kit **definition** table — only its use *as a
+  runtime fulfillment source* is retired.
+- Unblocks the parent design's deferred **`line.assetId` column drop** for kit
+  children (now stored on the unit). Coordinate with that design; likely its own
+  follow-up PR.
+
+### Phase 4 (follow-up, scoped separately) — reassign for kit members
+Today `reassignSerialisedUnit` blocks kit children
+(`warehouseOps.ts:1046`). A kit member's identity is tied to its kit slot, so
+"reassign" means **swap which serial fills a same-model slot within the same
+kit**, not move it to a loose line. Decide the guard model (same-kit +
+same-model slot) before enabling. **Out of scope for Phases 1–3**; visibility +
+per-unit lifecycle + history land first.
+
+## Risks
+
+1. **Silent PDF tail-drop** — kit-child units rendered without matching
+   `calculateItemHeight` reservation. Mitigation: the PDF integration test;
+   ship render + height in the same PR.
+2. **Double asset flip** — Phase 1 keeps both the unit flip and the legacy
+   `kitSerializedItems` flip. They're idempotent per asset (`setAssetsStatus`
+   patches to a fixed status), but verify no counter double-count in
+   `bumpAssetCounters`. Remove the legacy flip in Phase 3.
+3. **Backfill drift** — stale planner stats after bulk insert → pool stalls.
+   Mitigation: `ANALYZE` terminates the migration.
+4. **Half-migrated window** — equipment tab / PDF start reading member units
+   before backfill completes → some kits show units, others don't. Mitigation:
+   Phase 3 surfacing ships **after** Phase 2 backfill is deployed + verified;
+   `getAssetTag`'s `line.asset` fallback keeps un-backfilled members showing a
+   tag meanwhile.
+
+## Docs to update as phases land
+- **FEATUREDOCS/60** (assets on a job) — the "Physical kit member" row moves
+  from `line.assetId` to `projectLineItemUnit`; kit members become unit-expanded.
+- **FEATUREDOCS/48** (child assets & accessories) — kit-member child kind now
+  unit-backed.
+- **line-item-fulfillment-model.md** — mark the line-89/line-163 contradiction
+  resolved (link here); update the Phase 4 column-drop status.
+- **ARCHITECTURE.md** table if a new FEATUREDOCS file is added.
+</content>
+</invoke>

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -348,6 +348,17 @@ it true:
 
 ---
 
+## Implementation status
+
+- **Phase 1 — COMPLETE (2026-07-12).** Seeding, prep tree, checkout/checkin,
+  reverse (undeploy/unreturn), force (forceReturnKit/Asset/bulk), and
+  accessories-on-members all wired unit-only alongside the untouched legacy belt.
+  17 integration tests in `convex/kitPerUnit.test.ts`; full convex suite green
+  (269). `bumpAssetCounters` left unchanged (already idempotent). Kit-edit sync
+  found unnecessary; parity guard moved to Phase 3 (see Phase 1 notes above).
+  Members are **not yet visible** on the equipment tab/PDF — that's Phase 3.
+- **Phase 2 — NEXT.** Backfill kits added before Phase 1.
+
 ## Eng-review appendix (2026-07-12)
 
 `/plan-eng-review` + codex outside voice. Cross-model agreement on display model

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -169,10 +169,12 @@ mutation patch those units — converging kit members onto the loose-gear helper
   after inserting each serialised child line call `ensureSerialisedUnit(line,
   assetId)`; after each bulk child line call `ensureBulkUnit(line, bulkAssetId,
   qty)`. Units start `CONFIRMED`. Recurse for nested-kit grandchildren.
-- **Kit-edit-after-add** — the path that adds/removes a member on a project's kit
-  (adds/removes a child line) must create/cancel the matching unit in lockstep,
-  or the snapshot and its units drift. Trace every child-line mutator, not just
-  creation.
+- **Kit-edit-after-add — verified unnecessary (impl audit 2026-07-12).** Kit
+  child lines are created ONLY by `createKitLineItemCore` (now seeds units) and
+  deleted ONLY by `removeNative` (cascades unit deletes). No mutation swaps a
+  member's `assetId` or adds a member to an existing project kit
+  (`kitAllocations.ts` is per-model revenue % only), so the snapshot + its units
+  can't drift post-add. No sync code required.
 - **Prep / deprep (in scope — codex #3)** — `prepKitChildren` → `setKitTreePrep`
   and `deprepKit` (`checkRecordOps.ts:204`) today patch **lines only**. Rewrite
   them to patch `unit.prepStatus` (`PACKED` / `PENDING`) so the per-unit prep
@@ -197,11 +199,18 @@ mutation patch those units — converging kit members onto the loose-gear helper
 - **Line status** — replace direct child-line status patches with
   `syncLineItemRollup(childLineId)`. Kit **parent** line + `kits` doc status stay
   patched directly (kit-level, not unit-derived).
-- **Asset-status belt + idempotency** — keep the `kitSerializedItems`-driven flip
-  this phase; gate `bumpAssetCounters` on an **actual status transition** so the
-  belt and the unit flip together never double-count. **Parity guard (codex #9):**
-  error if a project's child-line asset set diverges from the live
-  `kitSerializedItems` definition at verification time.
+- **Asset-status belt** — untouched this phase (belt-owns-assets decision): the
+  legacy `kitSerializedItems`/child-`assetId` flip keeps owning asset status +
+  counters. The unit path never touches assets in Phase 1, so there is no double
+  flip. (`bumpAssetCounters` is already delta-based + re-reads the asset before
+  each bump, so it stays idempotent regardless — verified, no code change.)
+- **Parity guard → deferred to Phase 3 (impl audit 2026-07-12).** A hard divergence
+  throw in `checkoutKit` would block legitimately-diverged kits (kit contents can
+  change via warehouse/CSV import without touching a project's frozen child-line
+  snapshot — `kitAllocations.ts:18`; the int-test even builds asset-free kits). It
+  guards the `kitSerializedItems` belt, which Phase 3 strips — so the guard lands
+  there, alongside the verification cutover, where a throw is correct rather than a
+  new failure mode on untouched legacy code.
 - **`ConvexError` only**; `ensure*` helpers are already `createIfMissing`-safe.
   Guarded single-row assertions per the parent design's concurrency rule.
 - **Tests:** see the coverage diagram in the eng-review appendix — checkout /
@@ -252,6 +261,11 @@ seeded at creation).
   by backfill). `kitSerializedItems` remains the kit **definition** table (and the
   verification source per the parity-guard decision) — only its use *as a runtime
   fulfillment/asset-flip source* is retired.
+- **Parity guard (codex #9, moved here from Phase 1):** now that the belt is gone
+  and units are the fulfillment source, error at checkout verification if a
+  project's child-line asset set diverges from the live `kitSerializedItems`
+  definition — validate-set == deploy-set by construction. Safe here because the
+  ambiguous dual-flip it used to guard no longer exists.
 - Unblocks the parent design's deferred **`line.assetId` column drop** for kit
   children (now stored on the unit). Coordinate with that design; likely its own
   follow-up PR.

--- a/scripts/convex-backfill-kit-units.ts
+++ b/scripts/convex-backfill-kit-units.ts
@@ -1,0 +1,58 @@
+/**
+ * Kit per-unit fulfillment — Phase 2 backfill driver.
+ * See docs/designs/kit-per-unit-fulfillment.md and convex/backfillKitUnits.ts.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-kit-units.ts          # dry-run
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-kit-units.ts --apply  # writes
+ *
+ * Pages projectLineItems via api.backfillKitUnits.backfillKitUnitsPage until done,
+ * creating a projectLineItemUnit for every unit-less kit MEMBER line and carrying that
+ * line's current lifecycle (deployed / returned / prepped / bulk quantity). Kits added
+ * after Phase 1 already seed their units at kit-add, so this only touches the pre-Phase-1
+ * backlog. Idempotent — safe to re-run.
+ *
+ * A fresh Convex client is fetched per page so the short-lived service token can't
+ * expire mid-run (see the convex-backfill-token-refresh note). No ANALYZE — Convex.
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  console.log("Kit-member unit backfill (Phase 2)");
+  console.log("─".repeat(60));
+  console.log(`Mode: ${apply ? "APPLY (will write units)" : "dry-run"}`);
+  console.log();
+
+  let cursor: string | null = null;
+  let scanned = 0;
+  let created = 0;
+  let page = 0;
+  for (;;) {
+    // Fresh client per page — the service token is short-lived.
+    const convex = await getConvexClient();
+    const r: { scanned: number; created: number; isDone: boolean; continueCursor: string } =
+      await convex.mutation(api.backfillKitUnits.backfillKitUnitsPage, { cursor, apply });
+    scanned += r.scanned;
+    created += r.created;
+    page++;
+    if (r.scanned > 0) {
+      console.log(`  page ${page}: ${apply ? `created ${r.created}` : `would create ${r.scanned}`} unit(s)`);
+    }
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+
+  console.log();
+  console.log(`${scanned} unit-less kit member line(s) found across ${page} page(s).`);
+  if (apply) console.log(`✓ Created ${created} unit row(s).`);
+  else console.log(`(Dry run — re-run with --apply to write ${scanned} unit row(s).)`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("\nBackfill failed:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Combines Phase 1 (write path) + Phase 2 (backfill) of the kit per-unit fulfillment migration into one PR. Design + decisions: `docs/designs/kit-per-unit-fulfillment.md`.

## Why
Kits were the un-migrated island of the fulfillment model: loose/group gear tracks per-unit `projectLineItemUnit` rows (scannable, per-job, reassignable, with history), but kit members carried a serial only on `line.assetId` and `checkoutKit`/`checkinKit` flipped asset status straight from the kit's composition without ever creating unit rows — so members show nothing on the equipment tab. This gives kit members real unit rows, the **data foundation** for surfacing them (Phase 3).

Reviewed via `/plan-eng-review` + codex outside voice before build. Key decisions (all in the design doc): all kits go per-unit (checkMode stays scan-granularity-only); units created at kit-add, not at checkout; **belt owns assets, unit path owns rows** this phase (purely additive on the untouched legacy path); display = one row per member retagged from its unit (Phase 3, no per-unit expansion).

## Phase 1 — write path
- Seed member units at kit-add (serialised + bulk), CONFIRMED.
- Prep tree carries PREP/DEPREP onto units; self-heals pre-change kits.
- Checkout/checkin flip member units (bulk returns full quantity).
- Reverse/force (`undeployKit`, `unreturnKit` clearing `returned*`, `forceReturnKit`, `forceReturnAsset`/`bulk`) flip units — no split-brain.
- Accessories on members deploy/return with the kit, incl. reverse/force.

## Phase 2 — backfill
- `convex/backfillKitUnits.ts`: paginated SERVICE mutation creating units for unit-less kit members added before Phase 1, carrying full lifecycle (deployed/returned/prepped/bulk qty). Idempotent. A Convex mutation (not Prisma/tsx) since units are Convex-native; **no ANALYZE** (Convex table).
- `scripts/convex-backfill-kit-units.ts`: driver, fresh client per page, dry-run default + `--apply`.

## Deploy / run order
Merge, deploy, then **run the backfill** (`scripts/convex-backfill-kit-units.ts --apply`) once — it's idempotent. Kit members remain **invisible on the equipment tab until Phase 3**, so no user-visible change ships here.

## Not in this PR
- **Phase 3** — surface on equipment tab + PDF, strip the `kitSerializedItems` belt + Phase-1 checkin fallback, add the parity guard.
- **Phase 4** — reassign for kit members.

## Testing
- 22 integration tests (`convex/kitPerUnit.test.ts` ×17, `convex/backfillKitUnits.test.ts` ×5). Full convex suite green (**274**). `tsc` clean, 0 new lint errors. Convex-native, one mutation per kit (no new round-trips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)