### PR TITLE
feat(kits): kit per-unit fulfillment — Phase 2 (backfill)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as assetScanLogs from "../assetScanLogs.js";
 import type * as assetWrites from "../assetWrites.js";
 import type * as assets from "../assets.js";
 import type * as availabilityCheck from "../availabilityCheck.js";
+import type * as backfillKitUnits from "../backfillKitUnits.js";
 import type * as brandTemplates from "../brandTemplates.js";
 import type * as bulkAssets from "../bulkAssets.js";
 import type * as categories from "../categories.js";
@@ -147,6 +148,7 @@ declare const fullApi: ApiFromModules<{
   assetWrites: typeof assetWrites;
   assets: typeof assets;
   availabilityCheck: typeof availabilityCheck;
+  backfillKitUnits: typeof backfillKitUnits;
   brandTemplates: typeof brandTemplates;
   bulkAssets: typeof bulkAssets;
   categories: typeof categories;

--- a/convex/backfillKitUnits.test.ts
+++ b/convex/backfillKitUnits.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+//
+// Kit per-unit fulfillment — Phase 2 backfill (docs/designs/kit-per-unit-fulfillment.md).
+// Verifies unit-less kit member child lines get a unit carrying the line's current
+// lifecycle, idempotently, while loose / accessory / nested / already-seeded lines are
+// left alone.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+/** A pre-change kit member child line (no unit). */
+function kitChild(id: string, extra: Record<string, unknown>) {
+  return { id, organizationId: ORG, projectId: "p1", type: "EQUIPMENT" as const, isKitChild: true, parentLineItemId: "kl1", createdAt: NOW, updatedAt: NOW, ...extra };
+}
+
+async function runBackfill(t: T, apply = true) {
+  let cursor: string | null = null;
+  let scanned = 0;
+  let created = 0;
+  for (;;) {
+    const r: { scanned: number; created: number; isDone: boolean; continueCursor: string } = await t.withIdentity(SERVICE).mutation(api.backfillKitUnits.backfillKitUnitsPage, { cursor, apply });
+    scanned += r.scanned;
+    created += r.created;
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+  return { scanned, created };
+}
+const unitsFor = (t: T, lineId: string) => t.run(async (ctx) => ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", lineId)).collect());
+
+describe("backfillKitUnits — carries line lifecycle", () => {
+  test("deployed / returned / prepped / bulk members each backfill at the right stage", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT", checkedOutAt: NOW, checkedOutById: USER }));
+      await ctx.db.insert("projectLineItems", kitChild("ret", { assetId: "aRet", status: "RETURNED", returnedAt: NOW, returnedById: USER, returnCondition: "DAMAGED" }));
+      await ctx.db.insert("projectLineItems", kitChild("prep", { assetId: "aPrep", status: "CONFIRMED", prepStatus: "PACKED", prepContainer: "Case 3" }));
+      await ctx.db.insert("projectLineItems", kitChild("bulk", { bulkAssetId: "b1", quantity: 3, status: "CHECKED_OUT", checkedOutAt: NOW, checkedOutById: USER }));
+    });
+    const { created } = await runBackfill(t);
+    expect(created).toBe(4);
+
+    const [out] = await unitsFor(t, "out");
+    expect(out.status).toBe("CHECKED_OUT");
+    expect(out.assetId).toBe("aOut");
+    expect(out.checkedOutById).toBe(USER);
+    expect(out.returnedQuantity).toBe(0);
+
+    const [ret] = await unitsFor(t, "ret");
+    expect(ret.status).toBe("RETURNED");
+    expect(ret.returnCondition).toBe("DAMAGED");
+    expect(ret.returnedQuantity).toBe(1);
+
+    const [prep] = await unitsFor(t, "prep");
+    expect(prep.status).toBe("CONFIRMED");
+    expect(prep.prepStatus).toBe("PACKED");
+    expect(prep.prepContainer).toBe("Case 3");
+
+    const [bulk] = await unitsFor(t, "bulk");
+    expect(bulk.bulkAssetId).toBe("b1");
+    expect(bulk.quantity).toBe(3);
+    expect(bulk.status).toBe("CHECKED_OUT");
+  });
+});
+
+describe("backfillKitUnits — idempotent + dry-run", () => {
+  test("re-running the backfill creates nothing new", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT" })); });
+    expect((await runBackfill(t)).created).toBe(1);
+    expect((await runBackfill(t)).created).toBe(0);
+    expect(await unitsFor(t, "out")).toHaveLength(1);
+  });
+
+  test("dry-run scans but writes nothing", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", kitChild("out", { assetId: "aOut", status: "CHECKED_OUT" })); });
+    const { scanned, created } = await runBackfill(t, false);
+    expect(scanned).toBe(1);
+    expect(created).toBe(0);
+    expect(await unitsFor(t, "out")).toHaveLength(0);
+  });
+
+  test("a member already seeded (Phase 1) keeps its live unit, untouched", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", kitChild("seeded", { assetId: "aS", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItemUnits", { id: "liveU", organizationId: ORG, lineItemId: "seeded", assetId: "aS", ordinal: 1, status: "CHECKED_OUT", checkedOutById: "someone", createdAt: NOW, updatedAt: NOW });
+    });
+    expect((await runBackfill(t)).created).toBe(0);
+    const units = await unitsFor(t, "seeded");
+    expect(units).toHaveLength(1);
+    expect(units[0].id).toBe("liveU");
+    expect(units[0].checkedOutById).toBe("someone"); // not clobbered
+  });
+});
+
+describe("backfillKitUnits — leaves non-kit-member lines alone", () => {
+  test("loose, accessory, nested-kit-parent, and asset-free lines are skipped", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "loose", organizationId: ORG, projectId: "p1", type: "EQUIPMENT" as const, isKitChild: false, assetId: "aL", status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", kitChild("acc", { assetId: "aAcc", childKind: "ACCESSORY", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", kitChild("nested", { kitId: "k2", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", kitChild("svc", { status: "CONFIRMED" })); // no asset/bulk
+    });
+    const { scanned, created } = await runBackfill(t);
+    expect(scanned).toBe(0);
+    expect(created).toBe(0);
+    for (const id of ["loose", "acc", "nested", "svc"]) expect(await unitsFor(t, id)).toHaveLength(0);
+  });
+});

--- a/convex/backfillKitUnits.ts
+++ b/convex/backfillKitUnits.ts
@@ -1,0 +1,75 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+import { ensureBulkUnit, ensureSerialisedUnit } from "./lib/fulfillment";
+
+/**
+ * Kit per-unit fulfillment — Phase 2 backfill.
+ * See docs/designs/kit-per-unit-fulfillment.md.
+ *
+ * Kits added AFTER Phase 1 seed their member units at kit-add (createKitLineItemCore);
+ * kits added before it have none. This pages the projectLineItems table and, for every
+ * unit-less kit MEMBER child line — a serialised or bulk member, NOT a nested-kit parent
+ * (no own units) and NOT an accessory (already unit-backed) — creates the unit carrying
+ * the line's CURRENT lifecycle, so a deployed / returned / prepped member backfills at
+ * the right stage rather than bare CONFIRMED (codex #8).
+ *
+ * SERVICE-only. Idempotent: a member that already has its unit (Phase-1 seed or a prior
+ * run) is skipped, so re-runs are safe and never clobber live state. `apply=false` is a
+ * dry-run that only counts. Paginated because one query can't scan a large table.
+ *
+ * NB: NO `ANALYZE` — projectLineItemUnits is a Convex table (ANALYZE is Postgres-only;
+ * the CLAUDE.md ANALYZE rule is for Prisma bulk migrations).
+ *
+ * Driver: scripts/convex-backfill-kit-units.ts (pages the cursor until isDone).
+ */
+export const backfillKitUnitsPage = mutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    apply: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, { cursor, apply, numItems }) => {
+    await requireService(ctx);
+    const res = await ctx.db.query("projectLineItems").paginate({ cursor, numItems: numItems ?? 300 });
+
+    let scanned = 0;
+    let created = 0;
+    for (const line of res.page) {
+      if (!line.isKitChild || line.childKind === "ACCESSORY" || line.kitId) continue;
+      const isBulk = !!line.bulkAssetId;
+      if (!line.assetId && !isBulk) continue;
+      // Already seeded (Phase 1) or backfilled by a prior run? Skip — never clobber
+      // live state. A kit member line carries exactly one unit, so any unit = done.
+      const already = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", line.id)).first();
+      if (already) continue;
+      scanned++; // a member that NEEDS a unit
+      if (!apply) continue;
+
+      const ensured = isBulk
+        ? await ensureBulkUnit(ctx, { organizationId: line.organizationId, lineItemId: line.id, bulkAssetId: line.bulkAssetId!, quantity: line.quantity ?? 1 })
+        : await ensureSerialisedUnit(ctx, { organizationId: line.organizationId, lineItemId: line.id, assetId: line.assetId! });
+      // Idempotent guard against a concurrent writer that seeded since the check.
+      if (!ensured.created) continue;
+
+      const u = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", ensured.id)).unique();
+      if (!u) continue;
+      await ctx.db.patch(u._id, {
+        status: line.status ?? "CONFIRMED",
+        returnedQuantity: isBulk ? (line.returnedQuantity ?? 0) : line.status === "RETURNED" ? 1 : 0,
+        ...(line.prepStatus !== undefined ? { prepStatus: line.prepStatus } : {}),
+        ...(line.prepContainer !== undefined ? { prepContainer: line.prepContainer } : {}),
+        ...(line.checkedOutAt !== undefined ? { checkedOutAt: line.checkedOutAt } : {}),
+        ...(line.checkedOutById !== undefined ? { checkedOutById: line.checkedOutById } : {}),
+        ...(line.returnedAt !== undefined ? { returnedAt: line.returnedAt } : {}),
+        ...(line.returnedById !== undefined ? { returnedById: line.returnedById } : {}),
+        ...(line.returnCondition !== undefined ? { returnCondition: line.returnCondition } : {}),
+        ...(line.returnStatus !== undefined ? { returnStatus: line.returnStatus } : {}),
+        ...(line.returnNotes !== undefined ? { returnNotes: line.returnNotes } : {}),
+        updatedAt: line.updatedAt ?? Date.now(),
+      });
+      created++;
+    }
+    return { scanned, created, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});

--- a/scripts/convex-backfill-kit-units.ts
+++ b/scripts/convex-backfill-kit-units.ts
@@ -1,0 +1,58 @@
+/**
+ * Kit per-unit fulfillment — Phase 2 backfill driver.
+ * See docs/designs/kit-per-unit-fulfillment.md and convex/backfillKitUnits.ts.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-kit-units.ts          # dry-run
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-kit-units.ts --apply  # writes
+ *
+ * Pages projectLineItems via api.backfillKitUnits.backfillKitUnitsPage until done,
+ * creating a projectLineItemUnit for every unit-less kit MEMBER line and carrying that
+ * line's current lifecycle (deployed / returned / prepped / bulk quantity). Kits added
+ * after Phase 1 already seed their units at kit-add, so this only touches the pre-Phase-1
+ * backlog. Idempotent — safe to re-run.
+ *
+ * A fresh Convex client is fetched per page so the short-lived service token can't
+ * expire mid-run (see the convex-backfill-token-refresh note). No ANALYZE — Convex.
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  console.log("Kit-member unit backfill (Phase 2)");
+  console.log("─".repeat(60));
+  console.log(`Mode: ${apply ? "APPLY (will write units)" : "dry-run"}`);
+  console.log();
+
+  let cursor: string | null = null;
+  let scanned = 0;
+  let created = 0;
+  let page = 0;
+  for (;;) {
+    // Fresh client per page — the service token is short-lived.
+    const convex = await getConvexClient();
+    const r: { scanned: number; created: number; isDone: boolean; continueCursor: string } =
+      await convex.mutation(api.backfillKitUnits.backfillKitUnitsPage, { cursor, apply });
+    scanned += r.scanned;
+    created += r.created;
+    page++;
+    if (r.scanned > 0) {
+      console.log(`  page ${page}: ${apply ? `created ${r.created}` : `would create ${r.scanned}`} unit(s)`);
+    }
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+
+  console.log();
+  console.log(`${scanned} unit-less kit member line(s) found across ${page} page(s).`);
+  if (apply) console.log(`✓ Created ${created} unit row(s).`);
+  else console.log(`(Dry run — re-run with --apply to write ${scanned} unit row(s).)`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("\nBackfill failed:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## What & why

Phase 2 of the kit per-unit fulfillment migration ([design doc](https://github.com/TwoToned/gearflow/blob/feat/kit-per-unit-fulfillment/docs/designs/kit-per-unit-fulfillment.md)). Phase 1 (#409) seeds member units at kit-add for **new** kits; this backfills **kits added before Phase 1**, which have no member units.

## What's in this PR

- **`convex/backfillKitUnits.ts`** — a paginated, SERVICE-only mutation. For every unit-less kit **member** child line (serialised or bulk; not a nested-kit parent, not an accessory), it creates the `projectLineItemUnit` carrying the line's **current lifecycle** — a CHECKED_OUT line → CHECKED_OUT unit with `checkedOut*`, RETURNED → RETURNED with `returned*`, prepped → `prepStatus: PACKED`, bulk → quantity + `returnedQuantity` — so members backfill at the right stage, not bare CONFIRMED (codex #8). Idempotent existence pre-check; never clobbers a live/seeded unit.
- **`scripts/convex-backfill-kit-units.ts`** — driver: pages the cursor until done, **fresh Convex client per page** (short-lived service token), dry-run default + `--apply`.

Notes:
- **A Convex mutation, not a `tsx`/Prisma script** — units are Convex-native now; a Prisma backfill would write a table nothing reads (codex #7).
- **No `ANALYZE`** — `projectLineItemUnits` is a Convex table (the CLAUDE.md ANALYZE rule is Prisma/Postgres-only).

## ⚠️ Deploy order
Code-independent of #409 (only uses the pre-existing `ensure*` helpers), so it can merge in any order. But **run the backfill only after #409 is deployed** — otherwise new kits still won't seed units and coverage is incomplete. It's idempotent, so re-running after #409 lands is safe. Nothing reads kit-member units until **Phase 3**, so this is non-destructive.

## Testing
- 5 tests (`convex/backfillKitUnits.test.ts`): carries deployed/returned/prepped/bulk state; idempotent re-run; dry-run writes nothing; skips loose/accessory/nested/asset-free lines; leaves an already-seeded member untouched.
- Full convex suite green (257). `tsc` clean, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)