### PR TITLE
fix: RVLT Flow bug & UX sweep (8 issues)

### DIFF
--- a/FEATUREDOCS/08-assets.md
+++ b/FEATUREDOCS/08-assets.md
@@ -5,6 +5,22 @@
 2. **Bulk** (`BulkAsset`): Quantity-tracked, `totalQuantity`/`availableQuantity`
 3. **Kit** (`Kit`): Container of serialized + bulk assets (see [kits.md](./09-kits.md))
 
+### ⚠️ Stock-type resolution — `model.assetType` may be absent on the Convex mirror
+`Model.assetType` is `v.optional` in the Convex schema, so older / backfilled model
+docs read back `undefined`. Every stock/availability computation used to coerce it
+with `assetType ?? "SERIALIZED"` — which sent a genuine BULK model down the
+serialized branch of `computeStockBreakdown` (`totalStock = assets.length = 0`, since
+a bulk model has no serialized assets), so **every bulk line showed "0 available"**
+and was spuriously overbooked. Use **`resolveModelAssetType(assetType, hasBulkAssets)`**
+(`src/lib/overbooking-core.ts`) instead of the `?? "SERIALIZED"` default at every
+stock site: it returns a present value unchanged and falls back to `BULK` only when
+the model has active bulk assets. Applied at all five computation sites —
+`overbooking-core.ts` (`reconstructOverbookedStatus`), `line-items.ts` (`addLineItem`
+/ `updateLineItem` / `checkAvailability`), and `server/availability.ts` (calendar
+stock). Regression: `overbooking-core.test.ts`. Follow-up (durable, needs a prod
+backfill): always-write `assetType` on the model mirror so no consumer has to guess —
+`models-read.ts` mapping a lone doc still can't resolve without the bulk-asset signal.
+
 ## Auto-Incrementing Tags
 Stored in `Organization.metadata` JSON:
 ```json

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -119,6 +119,18 @@ marginPercent = margin / total × 100
   Uncategorized as a destination. `createProjectGroup` scopes its
   `sortOrder` aggregate by `projectId` so each project's Uncategorized
   zone has its own sequence.
+- **Moving a line item into an uncategorized-zone group:** the
+  `MoveItemToGroupDialog` builds its target list from BOTH `categories[]`
+  (categorized groups) AND a separate `uncategorizedGroups` prop
+  (`native.uncategorizedProjectGroups`). Earlier it was only fed
+  `categories[]`, so uncategorized-zone groups were never offered as move
+  targets — and a project whose ONLY groups were uncategorized showed the
+  false "no groups exist" empty state (read as "can't move into an empty /
+  newly-created group"; the real discriminator was *uncategorized*, not
+  *empty*). The submit path forwards `categoryId: null` for those targets,
+  which `moveLineItemToGroup` / `moveLineItemsToGroup` already accept. Server
+  side needs no change. Smoke test:
+  `__tests__/move-item-to-group-dialog.smoke.test.tsx`.
 - `suggestedPrice` auto-calculated from tracked assets' rates inside the group
 - User can override `price` or accept the suggestion with one click
 - Assets inside a group are for **tracking only** — never shown on quotes

--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -111,6 +111,28 @@ tags" and all jump over). Now these lines track prep **per unit**, exactly like 
 - Bulk items display as expandable groups with individual unit rows (Unit 1, Unit 2, etc.) — each unit gets its own check dialog
 - `deprepItem()` reverses prep: clears `prepStatus` to PENDING (split items stay as independent line items)
 
+#### ⚠️ Tagged-bulk quantity — the ONE unit carries the packed count (don't overwrite it)
+A **tagged** bulk line (`bulkAssetId` set) keeps exactly ONE `projectLineItemUnit`
+per `(line, bulkAsset)` whose `quantity` is the total packed/checked-out count; the
+line's `checkedOutQuantity`/`packedQuantity`/`returnedQuantity` rollups are *derived*
+from it by `syncLineItemRollup` → `computeRollupCounters`. Bug history (issue #8):
+`prepUnit`'s bulk branch OVERWROTE that unit's `quantity` to `args.quantity` on every
+call, and the client expanded a bulk prep into N `{quantity: 1}` entries — so a
+16-unit prep collapsed the unit to `quantity: 1` ("16 on the job, shows qty 1").
+That cascaded: deploy → `checkedOutQuantity: 1`, and the return path decremented 1 at
+a time (return had to be clicked 16×). Fixes:
+- `prepUnit` bulk branch **accumulates** (`existing.quantity + addQty`), capped at the
+  line's ordered `quantity` — correct whether the caller sends one aggregate entry or
+  N per-unit entries, and for incremental prep. The warehouse page now sends ONE
+  aggregate entry per bulk line.
+- `warehouseOps.checkoutKit` deploys each line at its **own** `quantity`, not a
+  hardcoded `1` (a bulk kit member of qty 16 was rolling up as 1).
+- `returnLineUnits`' bulk branch defaults `quantity` to the **full remaining**
+  checked-out quantity (was `?? 1`), so one return action brings back all 16; an
+  explicit `quantity` is still honoured for partial returns.
+- Regression: `convex/bulk-fulfillment-quantity.test.ts` drives prep → return through
+  the real `prepUnit`/`returnLineUnits` with a `convex-test` harness.
+
 ### Deploy Tab
 - Shows items with `prepStatus=PACKED` and `quantity > 0` (prepped but not yet deployed)
 - **Move to Pick (deprep) button** — a secondary `variant="line"` button next to Deploy that

--- a/FEATUREDOCS/37-check-items.md
+++ b/FEATUREDOCS/37-check-items.md
@@ -113,18 +113,47 @@ The warehouse page builds a **check queue** when prepping or returning multiple 
 
 When a check queue completes (single item or multi-item), `finishCheckQueue` returns focus to the correct scan input via `requestAnimationFrame` (PREP → main scan input, RETURN → return-tab scan input, RETURN-with-fromDeprep → deploy-tab scan input). This lets barcode scanners flow scan-to-scan without a mouse click between checks. The `requestAnimationFrame` delay lets the Sheet focus trap release before the refocus runs, avoiding a race.
 
-### Deprep Check Gate (inbound symmetry)
+### ⚠️ Which transition fires a check — one policy, `transitionNeedsCheck`
+
+The "does this transition need a check?" decision was copy-pasted across ~7 handlers
+in `warehouse/[projectId]/page.tsx` (each re-deriving `modelCheckItems > 0` and
+branching on context), which let coverage drift per transition. It now lives in ONE
+place: [`src/lib/warehouse-check-policy.ts`](../src/lib/warehouse-check-policy.ts) —
+`transitionNeedsCheck(context, { hasCheckItems, fromDeprep })`, plus
+`lineHasModelChecks(li)` / `kitHasChecks(kit)` (the deduped inline gates). Every
+trigger site routes through it (`startKitCheckFlow` has the central kit guard).
+Cross-transition test: `warehouse-check-policy.test.ts`.
+
+**Policy (product decision 2026-07): checks fire at PREP and DE-PREP only.**
 
 Outbound flow: `pick/prep → CHECK → deploy (staging) → on truck`.
 Inbound flow: `truck → return → deploy (staging) → CHECK → pick/prep (inventory)`.
 
-The Deploy tab is the staging ground on both sides of the truck. The check always happens at the inventory↔staging boundary. On the inbound side, that means a second RETURN-context check runs at **deprep time** in addition to the existing return-scan check (additive, dual-check). Implementation:
+- **PREP** (Pick → Prep): the outbound gate — a check runs when the model/kit has
+  check items. (Deploy / checkout fires NO check; prep is the gate.)
+- **DE-PREP** (shelf-in, `fromDeprep: true`, `context: "RETURN"`): the inbound gate —
+  a check runs at the inventory↔staging boundary as gear is stowed.
+- **Return-scan** (truck-in, `context: "RETURN"`, no `fromDeprep`): **no check.**
+  Previously an additive "dual-check" also ran here; per the product decision the
+  return check now runs *only* at de-prep, so the single-item scan, the batch
+  "Return Selected", and kit return-scans all return directly (`checkInMutation` /
+  `kitCheckInMutation` / `kitBatchInMutation`) without opening the form.
 
-- `handleDeprep` in `src/app/(app)/warehouse/[projectId]/page.tsx` intercepts deprep clicks for returned items (`status === "RETURNED"`, `prepStatus === "PACKED"`) whose model has check items, and builds a check queue with `fromDeprep: true, context: "RETURN"`.
-- On submit, the queue dispatches to `completeCheckAndDeprep` (not `completeCheckAndStore`) which writes RETURN-context `CheckRecord` rows and resets `prepStatus=PENDING` in one transaction — without changing `status` (already RETURNED).
-- Items that were never deployed (outbound deprep) or whose model has no check items bypass the form and call `deprepItem` directly.
-- Flagged/damaged items (`prepStatus !== "PACKED"`) also bypass the form and deprep directly — the return-scan check already captured the fault, and a second pass would be duplicate noise.
-- Kit deprep respects `KitCheckMode` via `startKitCheckFlow(..., fromDeprep=true)`. `KIT_LEVEL` kits get one kit-level check; `PER_ITEM` kits get a queue entry per child. When the queue finishes, `finishCheckQueue` calls `deprepKit` instead of `kitCheckInMutation`.
+Implementation of the de-prep gate:
+- `handleDeprep` intercepts deprep clicks for returned items (`status === "RETURNED"`,
+  `prepStatus === "PACKED"`) whose model has check items, and builds a check queue
+  with `fromDeprep: true, context: "RETURN"`.
+- On submit, the queue dispatches to `completeCheckAndDeprep` (not
+  `completeCheckAndStore`) which writes RETURN-context `CheckRecord` rows and resets
+  `prepStatus=PENDING` in one transaction — without changing `status` (already RETURNED).
+- Items never deployed (outbound deprep) or whose model has no check items bypass the
+  form and call `deprepItem` directly.
+- Flagged/damaged items (`prepStatus !== "PACKED"`) also bypass the form and deprep
+  directly — they route to a fault workflow rather than the standard shelf-in check.
+- Kit deprep respects `KitCheckMode` via `startKitCheckFlow(..., fromDeprep=true)`.
+  `KIT_LEVEL` kits get one kit-level check; `PER_ITEM` kits get a queue entry per
+  child. When the queue finishes, `finishCheckQueue` calls `deprepKit` instead of
+  `kitCheckInMutation`.
 
 ### Bulk Items in Check Queue
 - Each selected bulk unit generates a separate `CheckQueueItem` entry

--- a/FEATUREDOCS/51-project-numbering.md
+++ b/FEATUREDOCS/51-project-numbering.md
@@ -61,6 +61,24 @@ the counter again (capped at 50 attempts).
 - Project create form: when auto-numbering is on, the Project Code field is optional with an
   `Auto: <next>` placeholder and a "Leave blank to auto-generate" hint.
 
+## Duplicate-code validation (inline field error)
+The `@@unique([organizationId, projectNumber])` invariant is enforced by
+`createWithUniqueNumber` on insert; `createProject` turns the `{ created: false }`
+result into a `DUPLICATE_PROJECT_CODE` `UserFacingError` with `field: "projectNumber"`.
+**But a thrown server-action error is masked in production** to the generic
+"An error occurred in the Server Components render" string — its `message`/`field`
+never reach the client — so relying on the throw gave no usable inline error. Two-part fix:
+- `checkProjectNumberAvailable(projectNumber, excludeProjectId?)` — a RETURN-value
+  action (`{ available }`) the create/edit wizard calls before submit. Return values
+  serialize across the boundary intact, so the wizard raises a client-side
+  `field`-tagged error and `form.setError("projectNumber", …)` (jumping to step 0). The
+  create/update throws remain the authoritative integrity backstop and feed the API
+  error envelope (`toApiError` in `src/lib/api/dispatch.ts` handles `UserFacingError`).
+- `updateProject` gained the same duplicate guard (it previously patched
+  `projectNumber` blindly — editing a code to one a sibling already used silently
+  produced two projects sharing a number). Checked only when the number actually
+  changes, excluding the project's own row.
+
 ## Tests
 - `project-number.test.ts` — 12 pure-engine tests (render, scopeKey, validation, tz).
 - `project-numbering.int.test.ts` — 7 integration tests (sequential allocation, padding/literal,

--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -2858,6 +2858,26 @@ re-introduce a Prisma fallback: a *map miss* still yields `null` (mirror-freshne
 invariant preserved); only a *thrown* transient error is retried. Regression tests:
 `src/lib/convex-client.test.ts`, `src/lib/convex-auth-guards.test.ts`.
 
+**2a. The projects domain itself was the gap (spurious "Server Components render"
+error on mutations).** The *keystone* read modules — `projects-read.ts`
+(`getProjectsByOrg` / `getProjectById` / `getProjectIdsForManager` / `getCallSheetData`),
+`project-managers-read.ts` (`getProjectManagerRows`), and the project-detail bundle
+in `project-line-item-read.ts` (`buildProjectEquipmentTree`) — were the only read
+helpers *not* wrapped in `withConvexReadRetry`, even though every project **write**
+action (`createProject`/`updateProject`/`updateProjectStatus`/…) ends with a
+`getProjectByIdMapped` **read-back**. A token-refresh-boundary blip on that read-back
+rejected an action whose write had *already committed* — so the row existed (~80% of
+the time) yet the client showed the masked "An error occurred in the Server
+Components render" (an unhandled server-action rejection, not a real render error).
+Fix: wrap those reads in `withConvexReadRetry` (same rule — reads only), plus
+failure-isolate the genuinely post-commit side-effects: `updateProject`'s
+`recalculateProjectTotals` is now wrapped in try/catch (totals are derived and
+self-heal), and the pre-write diff reads in `setProjectManagers` /
+`removeProjectManager` retry so the wizard's post-create manager sync can't fail the
+whole create on a blip. Note `logActivity` was *already* failure-isolated
+(`src/lib/activity-log.ts` swallows both the Postgres write and the Convex mirror) —
+it was never the culprit.
+
 ## Phase A — read-rewiring (domain-only decommission)
 
 Moving every remaining Prisma **domain read** to Convex, one surface per PR. Full

--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -1389,7 +1389,21 @@ only (toast / close dialog / `router.refresh()`). Hardened (codex): in-flight
 **counter** so `isPending` survives overlapping calls (`remove.mutate(id)` per
 row), latest-call-wins `data`/`error`, callback errors logged not merged with the
 mutation error, options ref updated in an effect (react-compiler), unmount-guarded.
-11 unit tests.
+13 unit tests.
+
+**⚠️ Stale-navigation guard: `onSuccess`/`onSettled` are gated on still-mounted.**
+~24 call sites navigate in `onSuccess` (`router.push(...)` after a create/delete).
+If the user leaves the page while the mutation is in flight, an *ungated* `onSuccess`
+fires `router.push` on the now-unmounted view and **snaps them back** to the
+entity/list page. So the hook skips `onSuccess`/`onSettled` when `mountedRef` is
+false — a successful mutation on a torn-down view has nothing to do (toasts/nav/reset
+are all view-local; the Convex subscription already pushed the data). `onError` stays
+**ungated** (a failure toast is worth showing even after unmount, and `onError` never
+navigates). Note this is a deliberate divergence from React Query, which runs
+mutation callbacks regardless of mount state. The same class of bug in raw
+`.then()`/`setTimeout` redirects (onboarding / register / invite pages) is guarded
+with a local `cancelled` flag / `clearTimeout` on unmount. Reads (`useServerQuery`,
+`command-search`) were already unmount-guarded.
 
 **The unit of conversion is a DATUM, not a file (the critical safety rule).** A
 writer can drop a datum's invalidation only once **every reader of that datum** is

--- a/FEATUREDOCS/59-bulk-operations.md
+++ b/FEATUREDOCS/59-bulk-operations.md
@@ -98,6 +98,35 @@ props).
 - `bulk-edit-line-items-dialog.smoke.test.tsx` — jsdom render + enable-toggle
   gating (per the CLAUDE.md rule that new overlay UI gets a render smoke test).
 
+## Warehouse batch ops — audit + check-record round-trip collapse
+
+Bulk warehouse actions (check-out / return / prep / deprep / kit batch) had already
+collapsed their *state* mutations into single atomic Convex calls, but two sequential
+per-item loops remained on the hot paths and made them feel one-item-at-a-time:
+
+1. **Per-item `logActivity`** — every batch action looped `await logActivity(...)`
+   (one Postgres insert + one Convex mirror mutation *per item*) after the batched
+   state write. Now `logActivityMany(inputs)` (`src/lib/activity-log.ts`) writes all
+   N audit rows in ONE `prisma.createMany` + ONE `api.activityLogWrites.recordMany`
+   mutation. One audit row per item is preserved (per-item granularity intact) — only
+   the transport is batched. Applied in `warehouse.ts` (`checkOutItems`,
+   `checkInItems`, `undeployItems`, `unreturnItems`, `checkOutKitsBatch`,
+   `checkInKitsBatch`) and `check-records.ts` (`prepItemsBatch`, `deprepItemsBatch`).
+2. **Per-record check-write** — `writeCheckRecordsToConvex` fired one
+   `checkRecords.createIfMissing` per record; a check submission is (N line items × M
+   check items) records. Now one `api.checkRecords.createManyIfMissing` batched
+   mutation (still idempotent per cuid, one doc per record).
+3. **Kit batch loops** — `checkOutKitsBatch` / `checkInKitsBatch` ran one serial
+   Convex round-trip per kit. Now `Promise.allSettled` fires them concurrently; each
+   kit keeps its own atomic mutation/transaction so **per-kit error isolation is
+   preserved** (a failing kit doesn't abort the rest), and the audit is written via
+   `logActivityMany`. Caveat: concurrent kit ops on the SAME project touch shared line
+   rollups → Convex may OCC-retry (auto-retried, stays correct; minor contention on
+   very large same-project batches).
+
+New Convex mutations: `activityLogWrites.recordMany`, `checkRecords.createManyIfMissing`
+— both loop `insert`/`createIfMissing` internally in one transaction.
+
 ## Follow-ups
 
 - **Integration tests** for the batch server actions (mirroring

--- a/convex/activityLogWrites.ts
+++ b/convex/activityLogWrites.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation } from "./_generated/server";
+import { mutation, type MutationCtx } from "./_generated/server";
 import { requireService } from "./lib/auth";
 
 /**
@@ -16,32 +16,62 @@ import { requireService } from "./lib/auth";
  * Date.now()) so the Convex row matches the Postgres row exactly. Service-token only —
  * `logActivity` calls it via the server's `getConvexClient()`.
  */
+const activityLogFields = {
+  id: v.string(),
+  organizationId: v.string(),
+  action: v.string(),
+  entityType: v.string(),
+  entityId: v.string(),
+  entityName: v.string(),
+  userId: v.optional(v.string()),
+  userName: v.string(),
+  summary: v.string(),
+  details: v.optional(v.any()),
+  metadata: v.optional(v.any()),
+  projectId: v.optional(v.string()),
+  assetId: v.optional(v.string()),
+  kitId: v.optional(v.string()),
+  createdAt: v.number(),
+};
+
+async function insertIfMissing(
+  ctx: MutationCtx,
+  entry: { id: string } & Record<string, unknown>,
+): Promise<boolean> {
+  const existing = await ctx.db
+    .query("activityLogs")
+    .withIndex("by_cuid", (q) => q.eq("id", entry.id))
+    .first();
+  if (existing) return false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await ctx.db.insert("activityLogs", entry as any);
+  return true;
+}
+
 export const record = mutation({
-  args: {
-    id: v.string(),
-    organizationId: v.string(),
-    action: v.string(),
-    entityType: v.string(),
-    entityId: v.string(),
-    entityName: v.string(),
-    userId: v.optional(v.string()),
-    userName: v.string(),
-    summary: v.string(),
-    details: v.optional(v.any()),
-    metadata: v.optional(v.any()),
-    projectId: v.optional(v.string()),
-    assetId: v.optional(v.string()),
-    kitId: v.optional(v.string()),
-    createdAt: v.number(),
-  },
+  args: activityLogFields,
   handler: async (ctx, entry) => {
     await requireService(ctx);
-    const existing = await ctx.db
-      .query("activityLogs")
-      .withIndex("by_cuid", (q) => q.eq("id", entry.id))
-      .first();
-    if (existing) return { created: false as const };
-    await ctx.db.insert("activityLogs", { ...entry });
-    return { created: true as const };
+    const created = await insertIfMissing(ctx, entry);
+    return { created };
+  },
+});
+
+/**
+ * Batched sibling of `record`: mirror N audit rows in ONE Convex round-trip instead
+ * of N. Used by `logActivityMany` (src/lib/activity-log.ts) so a bulk warehouse
+ * action (check-out / return / prep / deprep of a batch) writes its per-item audit
+ * entries without a network round-trip per item. Still idempotent per cuid — one
+ * doc per row, so audit granularity is identical to N separate `record` calls.
+ */
+export const recordMany = mutation({
+  args: { rows: v.array(v.object(activityLogFields)) },
+  handler: async (ctx, { rows }) => {
+    await requireService(ctx);
+    let created = 0;
+    for (const entry of rows) {
+      if (await insertIfMissing(ctx, entry)) created += 1;
+    }
+    return { created };
   },
 });

--- a/convex/bulk-fulfillment-quantity.test.ts
+++ b/convex/bulk-fulfillment-quantity.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { prepUnit, returnLineUnits } from "./lib/fulfillment";
+
+type T = TestConvex<typeof schema>;
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const NOW = 1_700_000_000_000;
+
+/**
+ * Regression for the bulk-asset quantity bug (issue #8): prep must NOT collapse a
+ * bulk line's packed quantity to 1, and a return must default to the full remaining
+ * checked-out quantity (not 1, which forced "click return 16 times").
+ */
+
+async function seedBulkLine(t: T, opts: { orderedQuantity: number }) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", {
+      id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig",
+      status: "PREPPING", isTemplate: false, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("projectLineItems", {
+      id: "bl", organizationId: ORG, projectId: "p1", type: "EQUIPMENT",
+      status: "CONFIRMED", isKitChild: false, isOptional: false,
+      bulkAssetId: "ba1", quantity: opts.orderedQuantity, sortOrder: 0,
+      createdAt: NOW, updatedAt: NOW,
+    });
+  });
+}
+
+const readBulkUnit = (t: T) =>
+  t.run(async (ctx) =>
+    (await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", "bl")).collect())
+      .find((u) => u.bulkAssetId === "ba1"),
+  );
+
+describe("bulk fulfillment quantity", () => {
+  test("prep accumulates to the full quantity even when expanded into qty-1 calls", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 16 });
+
+    // Simulate the OLD client behaviour: 16 separate qty-1 prep calls. With the fix
+    // these accumulate onto the single (line, bulkAsset) unit instead of overwriting
+    // it to 1 (last-write-wins), so the unit ends at 16 — not 1.
+    for (let i = 0; i < 16; i++) {
+      await t.run((ctx) =>
+        prepUnit(ctx, { organizationId: ORG, lineItemId: "bl", bulkAssetId: "ba1", quantity: 1 }),
+      );
+    }
+
+    const unit = await readBulkUnit(t);
+    expect(unit?.quantity).toBe(16);
+    expect(unit?.prepStatus).toBe("PACKED");
+  });
+
+  test("prep caps accumulation at the line's ordered quantity", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 10 });
+    // One aggregate prep of the full quantity.
+    await t.run((ctx) =>
+      prepUnit(ctx, { organizationId: ORG, lineItemId: "bl", bulkAssetId: "ba1", quantity: 10 }),
+    );
+    // A stray extra prep must not push it past the ordered quantity.
+    await t.run((ctx) =>
+      prepUnit(ctx, { organizationId: ORG, lineItemId: "bl", bulkAssetId: "ba1", quantity: 5 }),
+    );
+    const unit = await readBulkUnit(t);
+    expect(unit?.quantity).toBe(10);
+  });
+
+  test("return with no explicit quantity returns the FULL remaining checked-out quantity", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 16 });
+    // A bulk unit deployed with 16 on the job.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 16, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+
+    const result = await t.run((ctx) =>
+      returnLineUnits(ctx, {
+        organizationId: ORG, projectId: "p1", lineItemId: "bl", bulkAssetId: "ba1",
+        returnCondition: "GOOD", userId: "user_1", defaultLocationId: null,
+        // quantity intentionally omitted — must default to the full remaining 16.
+      }),
+    );
+
+    expect(result.unitsFlipped).toBeGreaterThan(0);
+    const unit = await readBulkUnit(t);
+    expect(unit?.returnedQuantity).toBe(16);
+    expect(unit?.status).toBe("RETURNED");
+  });
+
+  test("return still honours an explicit partial quantity", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 16 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 16, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    await t.run((ctx) =>
+      returnLineUnits(ctx, {
+        organizationId: ORG, projectId: "p1", lineItemId: "bl", bulkAssetId: "ba1",
+        returnCondition: "GOOD", userId: "user_1", defaultLocationId: null, quantity: 5,
+      }),
+    );
+    const unit = await readBulkUnit(t);
+    expect(unit?.returnedQuantity).toBe(5);
+    expect(unit?.status).toBe("CHECKED_OUT"); // not fully returned
+  });
+});

--- a/convex/checkRecords.ts
+++ b/convex/checkRecords.ts
@@ -93,32 +93,56 @@ export const create = mutation({
   },
 });
 
+const checkRecordFields = {
+  id: v.string(),
+  organizationId: v.string(),
+  context: enums.CheckContext,
+  lineItemId: v.optional(v.string()),
+  lineItemUnitId: v.optional(v.string()),
+  assetId: v.optional(v.string()),
+  bulkAssetId: v.optional(v.string()),
+  kitId: v.optional(v.string()),
+  checkItemId: v.string(),
+  checkItemLabelSnapshot: v.string(),
+  checkItemTypeSnapshot: enums.CheckItemType,
+  result: enums.CheckResult,
+  value: v.optional(v.string()),
+  notes: v.optional(v.string()),
+  photos: v.optional(v.array(v.string())),
+  performedById: v.string(),
+  performedAt: v.optional(v.number()),
+};
+
 export const createIfMissing = mutation({
-  args: {
-    id: v.string(),
-    organizationId: v.string(),
-    context: enums.CheckContext,
-    lineItemId: v.optional(v.string()),
-    lineItemUnitId: v.optional(v.string()),
-    assetId: v.optional(v.string()),
-    bulkAssetId: v.optional(v.string()),
-    kitId: v.optional(v.string()),
-    checkItemId: v.string(),
-    checkItemLabelSnapshot: v.string(),
-    checkItemTypeSnapshot: enums.CheckItemType,
-    result: enums.CheckResult,
-    value: v.optional(v.string()),
-    notes: v.optional(v.string()),
-    photos: v.optional(v.array(v.string())),
-    performedById: v.string(),
-    performedAt: v.optional(v.number()),
-  },
+  args: checkRecordFields,
   handler: async (ctx, args) => {
     await requireService(ctx);
     const existing = await ctx.db.query("checkRecords").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("checkRecords", args);
     return { _id, created: true };
+  },
+});
+
+/**
+ * Batched sibling of `createIfMissing`: insert N check records in ONE Convex
+ * round-trip instead of N. A single check submission produces (N line items × M
+ * check items) records; `writeCheckRecordsToConvex` used to fire one mutation per
+ * record. Still idempotent per cuid (CLAUDE.md rule — never `create`, always
+ * check-then-insert on by_cuid), one doc per record.
+ */
+export const createManyIfMissing = mutation({
+  args: { records: v.array(v.object(checkRecordFields)) },
+  handler: async (ctx, { records }) => {
+    await requireService(ctx);
+    let created = 0;
+    for (const args of records) {
+      const existing = await ctx.db.query("checkRecords").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+      if (existing) continue;
+      await ctx.db.insert("checkRecords", args);
+      created += 1;
+    }
+    return { created };
   },
 });
 

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -242,10 +242,14 @@ export async function returnLineUnits(
   // 2. Bulk line return
   const targetBulkId = args.bulkAssetId || lineItem.bulkAssetId || null;
   if (targetBulkId) {
-    const returnQty = args.quantity ?? 1;
     const bulkUnits = units
       .filter((u) => u.bulkAssetId === targetBulkId && u.status === "CHECKED_OUT")
       .sort((a, b) => a.ordinal - b.ordinal);
+    // Default to the FULL remaining checked-out quantity, not 1. The old `?? 1`
+    // meant one click returned a single unit, forcing "click return 16 times" for a
+    // 16-unit bulk line. When the caller passes an explicit quantity, honour it.
+    const totalRemaining = bulkUnits.reduce((sum, u) => sum + ((u.quantity ?? 0) - (u.returnedQuantity ?? 0)), 0);
+    const returnQty = args.quantity ?? totalRemaining;
     let remaining = returnQty;
     for (const unit of bulkUnits) {
       if (remaining <= 0) break;
@@ -646,16 +650,36 @@ export async function prepUnit(
       }
     }
   } else if (args.bulkAssetId) {
-    const { id } = await ensureBulkUnit(ctx, { organizationId: args.organizationId, lineItemId: args.lineItemId, bulkAssetId: args.bulkAssetId, quantity: args.quantity ?? 1 });
-    const u = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (u) {
-      await ctx.db.patch(u._id, {
+    // A bulk line keeps ONE unit per (line, bulkAsset) carrying the packed quantity.
+    // The old code OVERWROTE that unit's quantity to args.quantity on every call, so
+    // when the client expanded a bulk prep into N `{quantity: 1}` entries the unit
+    // collapsed to 1 (last write wins) — the "16 on the job but shows qty 1" bug.
+    // ACCUMULATE instead (capped at the line's ordered quantity): correct whether
+    // the caller sends one aggregate entry or N per-unit entries, and correct for
+    // incremental prep (prep 3, then 5 more → 8).
+    const addQty = args.quantity ?? 1;
+    const line = await lineDocByCuid(ctx, args.lineItemId);
+    const ordered = line?.quantity ?? addQty;
+    const existing = (await lineUnits(ctx, args.lineItemId)).find((un) => un.bulkAssetId === args.bulkAssetId);
+    if (existing) {
+      await ctx.db.patch(existing._id, {
         status: "CONFIRMED",
         prepStatus: "PACKED",
-        ...(args.quantity !== undefined ? { quantity: args.quantity } : {}),
+        quantity: Math.min(ordered, (existing.quantity ?? 0) + addQty),
         ...(args.prepContainer !== undefined ? { prepContainer: args.prepContainer ?? undefined } : {}),
         updatedAt: now,
       });
+    } else {
+      const { id } = await ensureBulkUnit(ctx, { organizationId: args.organizationId, lineItemId: args.lineItemId, bulkAssetId: args.bulkAssetId, quantity: Math.min(ordered, addQty) });
+      const u = await ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (u) {
+        await ctx.db.patch(u._id, {
+          status: "CONFIRMED",
+          prepStatus: "PACKED",
+          ...(args.prepContainer !== undefined ? { prepContainer: args.prepContainer ?? undefined } : {}),
+          updatedAt: now,
+        });
+      }
     }
   } else {
     const line = await lineDocByCuid(ctx, args.lineItemId);

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -472,12 +472,16 @@ export const checkoutKit = mutation({
     }
     await assertTestTagAllowsCheckout(ctx, a.organizationId, { assetIds: ttAssets, bulkAssetIds: ttBulk });
 
-    const deploy = { status: "CHECKED_OUT" as const, checkedOutQuantity: 1, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now };
-    await ctx.db.patch(kitLine._id, deploy);
-    for (const c of children) await ctx.db.patch(c._id, deploy);
+    // checkedOutQuantity must be the LINE's own quantity, not a hardcoded 1 — a bulk
+    // kit member with quantity 16 was rolling up as "1 on the job", which then let the
+    // return path decrement only 1 at a time. Each line deploys its full quantity.
+    const deployBase = { status: "CHECKED_OUT" as const, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now };
+    const deployLine = (line: { quantity?: number }) => ({ ...deployBase, checkedOutQuantity: line.quantity ?? 1 });
+    await ctx.db.patch(kitLine._id, deployLine(kitLine));
+    for (const c of children) await ctx.db.patch(c._id, deployLine(c));
 
     for (const nestedChild of nestedKitChildren) {
-      for (const gc of await childLines(ctx, nestedChild.id, a.organizationId)) await ctx.db.patch(gc._id, deploy);
+      for (const gc of await childLines(ctx, nestedChild.id, a.organizationId)) await ctx.db.patch(gc._id, deployLine(gc));
       const nk = await kitByCuid(ctx, nestedChild.kitId!);
       if (nk) await ctx.db.patch(nk._id, { status: "CHECKED_OUT", ...(loc ? { locationId: loc } : {}), updatedAt: a.now });
       await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nestedChild.kitId!), "CHECKED_OUT", loc, false, a.now);
@@ -1023,7 +1027,7 @@ export const syncContainerStatus = mutation({
     const allReturnedFlag = allReturned && containerLI.status !== "RETURNED";
     if (!allDeployedFlag && !allReturnedFlag) return { updated: false };
     if (allDeployedFlag) {
-      await ctx.db.patch(containerLI._id, { status: "CHECKED_OUT", checkedOutQuantity: 1, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
+      await ctx.db.patch(containerLI._id, { status: "CHECKED_OUT", checkedOutQuantity: containerLI.quantity ?? 1, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
     } else {
       await ctx.db.patch(containerLI._id, { status: "RETURNED", returnedQuantity: 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD", updatedAt: a.now });
     }

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -1870,9 +1870,10 @@ function WarehouseProjectPage({
       }
 
       // Accumulate every no-check prep (bulk units + ready serialised) into one
-      // batch call fired below. Bulk items expand to one qty-1 entry per unit —
-      // exactly the sequence the old per-unit prepItemDirect loop produced (each
-      // still splits off its own line item server-side).
+      // batch call fired below. Send ONE entry per bulk line carrying the full
+      // selected quantity — the bulk unit tracks total packed quantity (prepUnit
+      // accumulates, capped at the ordered quantity). The old per-unit qty-1 expansion
+      // is what collapsed the bulk unit to quantity 1 ("16 on the job, shows 1").
       const directPrepItems: Array<{
         lineItemId: string;
         assetId?: string;
@@ -1880,13 +1881,11 @@ function WarehouseProjectPage({
         prepContainer?: string | null;
       }> = [];
       for (const bi of bulkNoCheckItems) {
-        for (let i = 0; i < bi.quantity; i++) {
-          directPrepItems.push({
-            lineItemId: bi.lineItemId,
-            quantity: 1,
-            prepContainer: selectedContainer || null,
-          });
-        }
+        directPrepItems.push({
+          lineItemId: bi.lineItemId,
+          quantity: bi.quantity,
+          prepContainer: selectedContainer || null,
+        });
       }
 
       // Build check queue for ready items with checks

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -26,6 +26,7 @@ import {
 import { toast } from "sonner";
 import { showError } from "@/lib/show-error";
 import { focusRing } from "@/lib/utils";
+import { transitionNeedsCheck, lineHasModelChecks, kitHasChecks } from "@/lib/warehouse-check-policy";
 
 import {
   lookupAssetForScan,
@@ -591,13 +592,16 @@ function WarehouseProjectPage({
     const kit = kitLi.kit;
     if (!kit) return false;
 
+    // Central policy gate: a plain return-scan (truck-in) never fires a check — the
+    // return check runs only at de-prep (fromDeprep). PREP and de-prep proceed.
+    if (!transitionNeedsCheck(context, { hasCheckItems: true, fromDeprep })) return false;
+
     const checkMode = kit.checkMode || "KIT_LEVEL";
     const children = (kitLi.childLineItems || []) as LineItem[];
 
     if (checkMode === "KIT_LEVEL") {
       // Kit-level: check the kit once using its own check items
-      const hasKitChecks = kit._count?.kitCheckItems && kit._count.kitCheckItems > 0;
-      if (!hasKitChecks) return false;
+      if (!kitHasChecks(kit)) return false;
 
       const queue: CheckQueueItem[] = [{
         context,
@@ -622,8 +626,7 @@ function WarehouseProjectPage({
         if (context === "RETURN" && !fromDeprep && child.status !== "CHECKED_OUT") continue;
         if (context === "RETURN" && fromDeprep && child.status === "CANCELLED") continue;
 
-        const hasModelChecks = child.model?._count?.modelCheckItems && child.model._count.modelCheckItems > 0;
-        if (!hasModelChecks || !child.modelId) continue;
+        if (!lineHasModelChecks(child) || !child.modelId) continue;
 
         // For serialized items, one queue entry per child
         // For bulk items, expand per quantity
@@ -725,7 +728,7 @@ function WarehouseProjectPage({
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const li = result as any;
-      const hasChecks = li?.model?._count?.modelCheckItems > 0;
+      const hasChecks = transitionNeedsCheck("PREP", { hasCheckItems: lineHasModelChecks(li) });
 
       if (hasChecks && li.modelId) {
         // Route through check queue — pull first, then open check form
@@ -975,7 +978,7 @@ function WarehouseProjectPage({
 
         // Check if model has check items — if so, open check form for prep
         const matchedLi = lineItems.find((l) => l.id === result.lineItemId);
-        const hasChecks = matchedLi?.model?._count?.modelCheckItems && matchedLi.model._count.modelCheckItems > 0;
+        const hasChecks = transitionNeedsCheck("PREP", { hasCheckItems: lineHasModelChecks(matchedLi) });
 
         if (hasChecks && matchedLi?.modelId) {
           // Pull item first, then open check form (prep flow)
@@ -1204,11 +1207,16 @@ function WarehouseProjectPage({
       }
 
       if (result.found && result.lineItemId) {
-        // Check if model has check items — if so, open check form
+        // A return-scan (truck-in) never opens a check form — the return check runs
+        // only at de-prep (shelf-in). transitionNeedsCheck("RETURN", …) returns false
+        // here, so this collapses to the direct check-in below.
         const matchedLi = lineItems.find((l) => l.id === result.lineItemId);
-        const hasChecks = matchedLi?.model?._count?.modelCheckItems && matchedLi.model._count.modelCheckItems > 0;
+        const needsReturnCheck = transitionNeedsCheck("RETURN", {
+          hasCheckItems: lineHasModelChecks(matchedLi),
+          fromDeprep: false,
+        });
 
-        if (hasChecks && matchedLi?.modelId) {
+        if (needsReturnCheck && matchedLi?.modelId) {
           // Unpack item first, then open check form
           unpackItem(projectId, result.lineItemId).catch(() => {});
           setCheckFormData({
@@ -1843,7 +1851,7 @@ function WarehouseProjectPage({
       const bulkNoCheckItems: typeof bulkItems = [];
       for (const bi of bulkItems) {
         const li = lineItems.find((l) => l.id === bi.lineItemId);
-        const hasChecks = li?.model?._count?.modelCheckItems && li.model._count.modelCheckItems > 0;
+        const hasChecks = transitionNeedsCheck("PREP", { hasCheckItems: lineHasModelChecks(li) });
         if (hasChecks && li?.modelId) {
           for (let i = 0; i < bi.quantity; i++) {
             bulkCheckQueue.push({
@@ -1886,7 +1894,7 @@ function WarehouseProjectPage({
       const readyNoCheckItems: typeof readyItems = [];
       for (const item of readyItems) {
         const li = lineItems.find((l) => l.id === item.lineItemId);
-        const hasChecks = li?.model?._count?.modelCheckItems && li.model._count.modelCheckItems > 0;
+        const hasChecks = transitionNeedsCheck("PREP", { hasCheckItems: lineHasModelChecks(li) });
         if (hasChecks && li?.modelId) {
           readyCheckQueue.push({
             context: "PREP" as const,
@@ -2011,8 +2019,7 @@ function WarehouseProjectPage({
       const needsCheck =
         li?.status === "RETURNED" &&
         li.prepStatus === "PACKED" &&
-        !!li.model?._count?.modelCheckItems &&
-        li.model._count.modelCheckItems > 0 &&
+        transitionNeedsCheck("RETURN", { hasCheckItems: lineHasModelChecks(li), fromDeprep: true }) &&
         !!li.modelId;
       if (needsCheck && li) {
         for (let i = 0; i < count; i++) {
@@ -2044,8 +2051,7 @@ function WarehouseProjectPage({
         const needsCheck =
           li?.status === "RETURNED" &&
           li.prepStatus === "PACKED" &&
-          !!li.model?._count?.modelCheckItems &&
-          li.model._count.modelCheckItems > 0 &&
+          transitionNeedsCheck("RETURN", { hasCheckItems: lineHasModelChecks(li), fromDeprep: true }) &&
           !!li.modelId;
         if (needsCheck && li) {
           checkQueueBuild.push({
@@ -2114,7 +2120,7 @@ function WarehouseProjectPage({
     const bulkNoChecks: typeof assetPickerBulkItems = [];
     for (const bi of assetPickerBulkItems) {
       const li = lineItems.find((l) => l.id === bi.lineItemId);
-      if (li?.model?._count?.modelCheckItems && li.model._count.modelCheckItems > 0 && li.modelId) {
+      if (li && transitionNeedsCheck("PREP", { hasCheckItems: lineHasModelChecks(li) }) && li.modelId) {
         for (let i = 0; i < bi.quantity; i++) {
           bulkCheckQueue.push({
             context: "PREP" as const,
@@ -2265,7 +2271,10 @@ function WarehouseProjectPage({
       const withoutCheckItems: typeof items = [];
 
       for (const { item, li } of returnLineItems) {
-        const hasChecks = li?.model?._count?.modelCheckItems && li.model._count.modelCheckItems > 0 && li?.modelId;
+        // Batch "Return Selected" is a return-scan (truck-in) → no check (de-prep only).
+        const hasChecks =
+          transitionNeedsCheck("RETURN", { hasCheckItems: lineHasModelChecks(li), fromDeprep: false }) &&
+          li?.modelId;
         if (hasChecks) {
           const isBulk = !!li.bulkAssetId || (!li.assetId && li.quantity > 1);
           const count = isBulk ? item.quantity : 1;

--- a/src/app/(auth)/invite/[id]/page.tsx
+++ b/src/app/(auth)/invite/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
+import { useState, useEffect, useRef, use } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { authClient, organization } from "@/lib/auth-client";
@@ -21,11 +21,19 @@ export default function InviteAcceptPage({
   const [accepted, setAccepted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+  // Track the post-accept redirect timer so it's cleared on unmount — otherwise a
+  // user who navigates away in the 1.5s window still gets pushed to /dashboard.
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     authClient.getSession().then((session) => {
-      setIsAuthenticated(!!session.data?.user);
+      if (!cancelled) setIsAuthenticated(!!session.data?.user);
     });
+    return () => {
+      cancelled = true;
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
+    };
   }, []);
 
   const handleAccept = async () => {
@@ -45,7 +53,7 @@ export default function InviteAcceptPage({
       if (orgData) {
         await organization.setActive({ organizationId: orgData.id });
       }
-      setTimeout(() => router.push("/dashboard"), 1500);
+      redirectTimerRef.current = setTimeout(() => router.push("/dashboard"), 1500);
     } catch {
       setError("Something went wrong. Please try again.");
     } finally {

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -24,11 +24,17 @@ export default function OnboardingPage() {
   const [slug, setSlug] = useState("");
   const [loading, setLoading] = useState(false);
 
-  // Redirect away if an org already exists
+  // Redirect away if an org already exists. Guard on a cancelled flag: if the user
+  // navigates away before this async check resolves, the late resolve must not fire
+  // router.replace and snap them back to /dashboard.
   useEffect(() => {
+    let cancelled = false;
     getTheOrgId().then((org) => {
-      if (org) router.replace("/dashboard");
+      if (!cancelled && org) router.replace("/dashboard");
     });
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   const handleNameChange = (value: string) => {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -32,18 +32,22 @@ function RegisterContent() {
       .catch(() => setPolicy("OPEN"));
   }, []);
 
-  // Prefill email from invitation
+  // Prefill email from invitation. Guard on cancelled so a late resolve doesn't
+  // setState on an unmounted view.
   useEffect(() => {
-    if (inviteId) {
-      import("@/server/invitations").then(({ getInvitationEmail }) => {
-        getInvitationEmail(inviteId).then((invEmail) => {
-          if (invEmail) {
-            setEmail(invEmail);
-            setInviteEmailLocked(true);
-          }
-        });
+    if (!inviteId) return;
+    let cancelled = false;
+    import("@/server/invitations").then(({ getInvitationEmail }) => {
+      getInvitationEmail(inviteId).then((invEmail) => {
+        if (!cancelled && invEmail) {
+          setEmail(invEmail);
+          setInviteEmailLocked(true);
+        }
       });
-    }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [inviteId]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/components/projects/__tests__/move-item-to-group-dialog.smoke.test.tsx
+++ b/src/components/projects/__tests__/move-item-to-group-dialog.smoke.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+import { MoveItemToGroupDialog } from "../move-item-to-group-dialog";
+import type { CategoryData } from "../equipment-rows";
+
+const baseProps = {
+  lineItemId: "li1",
+  isPending: false,
+  onClose: () => {},
+};
+
+describe("MoveItemToGroupDialog — can move into uncategorized-zone groups (issue #4)", () => {
+  it("offers an uncategorized group as a target and submits categoryId=null", () => {
+    const onSubmit = vi.fn();
+    // The ONLY groups in this project live in the Uncategorized zone (no category).
+    render(
+      <MoveItemToGroupDialog
+        {...baseProps}
+        categories={[] as unknown as CategoryData[]}
+        uncategorizedGroups={[{ id: "g_orphan", title: "Staging" }]}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Not the "no groups exist" empty state — the picker + Move button render.
+    expect(screen.queryByText(/no groups in this project yet/i)).toBeNull();
+    const option = screen.getByRole("option", { name: /Uncategorized > Staging/ }) as HTMLOptionElement;
+    expect(option.value).toBe("g_orphan");
+
+    fireEvent.click(screen.getByRole("button", { name: /^move$/i }));
+    expect(onSubmit).toHaveBeenCalledWith("li1", { categoryId: null, groupId: "g_orphan" });
+  });
+
+  it("lists both categorized and uncategorized groups together", () => {
+    render(
+      <MoveItemToGroupDialog
+        {...baseProps}
+        categories={[
+          { id: "cat1", name: "Lighting", groups: [{ id: "g1", title: "Front Truss" }] },
+        ] as unknown as CategoryData[]}
+        uncategorizedGroups={[{ id: "g_orphan", title: "Staging" }]}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("option", { name: /Lighting > Front Truss/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Uncategorized > Staging/ })).toBeTruthy();
+  });
+});

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1657,6 +1657,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         lineItemId={moveItemToGroup?.lineItemId ?? null}
         initialGroupId={moveItemToGroup?.initialGroupId}
         categories={typedCategories}
+        uncategorizedGroups={orphanProjectGroups.map((g) => ({ id: g.id, title: g.title }))}
         isPending={moveLineItemMut.isPending}
         onClose={() => setMoveItemToGroup(null)}
         onSubmit={(lineItemId, target) =>
@@ -1699,6 +1700,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
       <MoveItemToGroupDialog
         lineItemId={bulkMoveGroupOpen ? "__bulk__" : null}
         categories={typedCategories}
+        uncategorizedGroups={orphanProjectGroups.map((g) => ({ id: g.id, title: g.title }))}
         isPending={bulkMoveMut.isPending}
         onClose={() => setBulkMoveGroupOpen(false)}
         onSubmit={(_id, target) =>

--- a/src/components/projects/move-item-to-group-dialog.tsx
+++ b/src/components/projects/move-item-to-group-dialog.tsx
@@ -34,8 +34,9 @@ import type { CategoryData } from "./equipment-rows";
 
 export interface MoveItemToGroupTarget {
   /** The owning category of the picked group — kept in sync with
-   *  `groupId` so the line item's `categoryId` follows its group. */
-  categoryId: string;
+   *  `groupId` so the line item's `categoryId` follows its group.
+   *  `null` when the target is an uncategorized-zone group (no category). */
+  categoryId: string | null;
   groupId: string;
 }
 
@@ -45,6 +46,11 @@ interface MoveItemToGroupDialogProps {
    *  the first available group. */
   initialGroupId?: string;
   categories: CategoryData[];
+  /** Groups living in the "Uncategorized" zone (categoryId === null). These are
+   *  NOT under any `categories[]` entry, so without them the picker silently
+   *  omits every uncategorized-zone group as a move target — and if a project's
+   *  ONLY groups are uncategorized, the picker falsely claimed "no groups exist". */
+  uncategorizedGroups?: { id: string; title: string }[];
   isPending: boolean;
   onClose: () => void;
   onSubmit: (lineItemId: string, target: MoveItemToGroupTarget) => void;
@@ -69,24 +75,33 @@ function MoveItemToGroupDialogBody({
   lineItemId,
   initialGroupId,
   categories,
+  uncategorizedGroups,
   isPending,
   onClose,
   onSubmit,
 }: MoveItemToGroupDialogProps) {
   // Flatten all groups with their owning category id so the picker
   // can label each option `<cat> > <group>` AND submit the right
-  // categoryId without a second lookup.
+  // categoryId without a second lookup. Uncategorized-zone groups
+  // (categoryId === null) are appended so they're selectable targets too.
   const flatGroups = useMemo(
-    () =>
-      categories.flatMap((cat) =>
+    () => [
+      ...categories.flatMap((cat) =>
         cat.groups.map((g) => ({
-          categoryId: cat.id,
+          categoryId: cat.id as string | null,
           categoryName: cat.name,
           groupId: g.id,
           groupTitle: g.title,
         })),
       ),
-    [categories],
+      ...(uncategorizedGroups ?? []).map((g) => ({
+        categoryId: null,
+        categoryName: "Uncategorized",
+        groupId: g.id,
+        groupTitle: g.title,
+      })),
+    ],
+    [categories, uncategorizedGroups],
   );
 
   const firstGroupId = flatGroups[0]?.groupId ?? "";
@@ -135,6 +150,15 @@ function MoveItemToGroupDialogBody({
                   ))}
                 </optgroup>
               ) : null,
+            )}
+            {uncategorizedGroups && uncategorizedGroups.length > 0 && (
+              <optgroup label="Uncategorized">
+                {uncategorizedGroups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    Uncategorized &gt; {g.title}
+                  </option>
+                ))}
+              </optgroup>
             )}
           </select>
         </div>

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -17,7 +17,7 @@ import {
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { projectSchema, type ProjectFormValues } from "@/lib/validations/project";
-import { createProject, updateProject, peekNextProjectNumber } from "@/server/projects";
+import { createProject, updateProject, peekNextProjectNumber, checkProjectNumberAvailable } from "@/server/projects";
 import { setProjectManagers } from "@/server/project-managers";
 import { useClientSearch, useClient } from "@/hooks/use-clients";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -202,6 +202,23 @@ export function ProjectWizard({
 
   const mutation = useServerMutation({
     mutationFn: async (data: ProjectFormValues) => {
+      // Inline duplicate-code guard: a thrown DUPLICATE_PROJECT_CODE error is
+      // masked to the generic "Server Components render" string in production, so
+      // check availability up-front (a return value survives the boundary) and
+      // raise a client-side error tagged with the field for an inline message.
+      if (!isTemplate && data.projectNumber?.trim()) {
+        const { available } = await checkProjectNumberAvailable(
+          data.projectNumber.trim(),
+          project?.id,
+        );
+        if (!available) {
+          throw Object.assign(
+            new Error(`Project code "${data.projectNumber.trim()}" is already in use.`),
+            { field: "projectNumber" as const },
+          );
+        }
+      }
+
       const result = project
         ? await updateProject(project.id, data)
         : await createProject({ ...data, isTemplate });
@@ -229,7 +246,18 @@ export function ProjectWizard({
       );
       router.push(`/projects/${result.id}`);
     },
-    onError: (e) => toast.error(e.message),
+    onError: (e) => {
+      // A field-tagged error (e.g. duplicate project code) surfaces inline on the
+      // right input; projectNumber lives on step 0, so make it visible first.
+      const field = (e as { field?: string }).field;
+      if (field) {
+        setStep(0);
+        form.setError(field as "projectNumber", { type: "server", message: e.message });
+        form.setFocus(field as "projectNumber");
+        return;
+      }
+      toast.error(e.message);
+    },
   });
 
   const next = async () => {

--- a/src/hooks/use-server-mutation.test.tsx
+++ b/src/hooks/use-server-mutation.test.tsx
@@ -216,4 +216,44 @@ describe("useServerMutation", () => {
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1); // latest callback used
   });
+
+  it("does NOT run onSuccess/onSettled after the view unmounts (no snap-back nav)", async () => {
+    // Simulates: user fires a create, then navigates away before it resolves.
+    // onSuccess (which ~24 call sites use to router.push) must not run on the
+    // torn-down view and yank the user back.
+    let resolveFn!: (v: string) => void;
+    const pending = new Promise<string>((res) => { resolveFn = res; });
+    const onSuccess = vi.fn();
+    const onSettled = vi.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useServerMutation<string, void>({ mutationFn: () => pending, onSuccess, onSettled })
+    );
+
+    let call!: Promise<string>;
+    act(() => { call = result.current.mutateAsync(); });
+    unmount(); // leave the page while the mutation is in flight
+    await act(async () => { resolveFn("done"); await call; });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it("still runs onError after unmount (failure toasts survive, they never navigate)", async () => {
+    let rejectFn!: (e: Error) => void;
+    const pending = new Promise<string>((_res, rej) => { rejectFn = rej; });
+    const onError = vi.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useServerMutation<string, void>({ mutationFn: () => pending, onError })
+    );
+
+    let call!: Promise<string>;
+    act(() => { call = result.current.mutateAsync().catch(() => "caught"); });
+    unmount();
+    await act(async () => { rejectFn(new Error("boom")); await call; });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
 });

--- a/src/hooks/use-server-mutation.ts
+++ b/src/hooks/use-server-mutation.ts
@@ -112,6 +112,10 @@ export function useServerMutation<TData = unknown, TVariables = void>(
       const settle = async (data: TData | undefined, error: Error | null) => {
         inFlightRef.current -= 1;
         if (mountedRef.current && inFlightRef.current === 0) setIsPending(false);
+        // onSettled is success-path cleanup (close dialog, reset, navigate). If the
+        // view already unmounted, its work is moot — and skipping it avoids a
+        // post-unmount navigation. See onSuccess note below.
+        if (!mountedRef.current) return;
         await runCallback(
           opts.onSettled
             ? () => opts.onSettled!(data, error, variables)
@@ -125,14 +129,24 @@ export function useServerMutation<TData = unknown, TVariables = void>(
           setData(result);
           setError(null);
         }
-        await runCallback(
-          opts.onSuccess ? () => opts.onSuccess!(result, variables) : undefined
-        );
+        // Gate onSuccess on still-mounted. ~24 call sites navigate in onSuccess
+        // (`router.push(...)`); if the user left the page while the mutation was in
+        // flight, an ungated onSuccess fires router.push on the now-unmounted view
+        // and SNAPS them back to the entity/list page. A successful mutation on a
+        // torn-down view has nothing to do (its toasts/nav/reset are all view-local;
+        // the Convex subscription already pushed the data), so skipping is safe.
+        if (mountedRef.current) {
+          await runCallback(
+            opts.onSuccess ? () => opts.onSuccess!(result, variables) : undefined
+          );
+        }
         await settle(result, null);
         return result;
       } catch (e) {
         const err = toError(e);
         if (mountedRef.current && callId === callSeqRef.current) setError(err);
+        // onError stays ungated: a failure toast is still worth showing even if the
+        // triggering view unmounted, and onError never navigates.
         await runCallback(
           opts.onError ? () => opts.onError!(err, variables) : undefined
         );

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -72,6 +72,61 @@ export async function logActivity(input: LogActivityInput): Promise<void> {
   }
 }
 
+/**
+ * Batched sibling of {@link logActivity}: write N audit rows in ONE Postgres insert
+ * + ONE Convex mirror mutation instead of N sequential round-trips. Use from bulk
+ * warehouse actions (check-out / return / prep / deprep of a batch) that previously
+ * looped `await logActivity(...)` per item — the dominant tax on those paths. Each
+ * input still produces exactly one audit row (per-item granularity preserved); only
+ * the transport is batched. Best-effort, like logActivity — audit never breaks a write.
+ */
+export async function logActivityMany(inputs: LogActivityInput[]): Promise<void> {
+  if (inputs.length === 0) return;
+  const createdAt = new Date();
+  const rows = inputs.map((input) => ({ id: createId(), createdAt, ...input }));
+
+  // ONE Postgres insert for all N rows (was N sequential creates).
+  try {
+    await prisma.activityLog.createMany({
+      data: rows.map((r) => ({
+        ...r,
+        details: r.details as unknown as Prisma.InputJsonValue,
+        metadata: r.metadata as unknown as Prisma.InputJsonValue,
+      })),
+    });
+  } catch (error) {
+    console.error("Failed to log activity batch:", error);
+  }
+
+  // ONE Convex mirror mutation for all N (was N sequential `record` calls).
+  if (nativeActivityWrites()) {
+    try {
+      const convex = await getConvexClient();
+      await convex.mutation(api.activityLogWrites.recordMany, {
+        rows: rows.map((r) => ({
+          id: r.id,
+          organizationId: r.organizationId,
+          action: r.action,
+          entityType: r.entityType,
+          entityId: r.entityId,
+          entityName: r.entityName,
+          userId: r.userId,
+          userName: r.userName,
+          summary: r.summary,
+          details: r.details,
+          metadata: r.metadata,
+          projectId: r.projectId,
+          assetId: r.assetId,
+          kitId: r.kitId,
+          createdAt: r.createdAt.getTime(),
+        })),
+      });
+    } catch (error) {
+      console.error("Failed to mirror activity batch to Convex:", error);
+    }
+  }
+}
+
 export function buildChanges(
   before: Record<string, unknown>,
   after: Record<string, unknown>,

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -2,6 +2,7 @@ import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import {
   computeStockBreakdown,
+  resolveModelAssetType,
   reconstructOverbookedStatus,
   type OverbookedInfo,
   type OverbookLineItem,
@@ -10,7 +11,7 @@ import {
 // Re-exported for back-compat: the pure stock-breakdown + overbooked types moved
 // into the client-safe overbooking-core (so the native read layer can run the
 // same math client-side); server callers keep importing them from here.
-export { computeStockBreakdown };
+export { computeStockBreakdown, resolveModelAssetType };
 export type { OverbookedInfo };
 
 /**

--- a/src/lib/overbooking-core.test.ts
+++ b/src/lib/overbooking-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   reconstructOverbookedStatus,
+  resolveModelAssetType,
   type OverbookingBundleData,
   type OverbookLineItem,
 } from "./overbooking-core";
@@ -221,5 +222,39 @@ describe("reconstructOverbookedStatus", () => {
     const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
     expect(map.get("kc")).toMatchObject({ overBy: 1 });
     expect(map.get("kp")).toMatchObject({ overBy: 1, inherited: true, hasOverbookedChildren: true });
+  });
+
+  it("counts bulk stock for a BULK model whose assetType mirror field is absent", () => {
+    // Regression: older/backfilled Convex model docs read back assetType === undefined.
+    // Defaulting to SERIALIZED made totalStock = assets.length = 0 → every bulk line
+    // showed "0 available" and was spuriously overbooked. With the bulk-asset signal,
+    // the model resolves to BULK and its 10-unit stock is counted.
+    const items: OverbookLineItem[] = [
+      { id: "li1", modelId: "m1", quantity: 6, isKitChild: false, parentLineItemId: null, kitId: null, status: "QUOTED" },
+    ];
+    const bundle = makeBundle({
+      // assetType intentionally omitted (undefined) — the mirror gap this fixes.
+      models: [{ id: "m1", organizationId: ORG } as unknown as ReturnType<typeof model>],
+      bulkAssets: [bulk({ id: "b1", modelId: "m1", totalQuantity: 10 })],
+      projects: [project({ id: THIS_PROJECT, start: WINDOW_START.getTime(), end: WINDOW_END.getTime() })],
+      lineItems: [bundleLineItem({ id: "li1", projectId: THIS_PROJECT, modelId: "m1", quantity: 6 })],
+    });
+    // 6 booked against 10 bulk units → within stock, NOT overbooked.
+    const map = reconstructOverbookedStatus(bundle, items, WINDOW_START, WINDOW_END, THIS_PROJECT);
+    expect(map.has("li1")).toBe(false);
+  });
+});
+
+describe("resolveModelAssetType", () => {
+  it("returns a present value unchanged", () => {
+    expect(resolveModelAssetType("SERIALIZED", true)).toBe("SERIALIZED");
+    expect(resolveModelAssetType("BULK", false)).toBe("BULK");
+  });
+  it("falls back to BULK when assetType is absent but bulk assets exist", () => {
+    expect(resolveModelAssetType(undefined, true)).toBe("BULK");
+    expect(resolveModelAssetType(null, true)).toBe("BULK");
+  });
+  it("falls back to SERIALIZED when assetType is absent and there are no bulk assets", () => {
+    expect(resolveModelAssetType(undefined, false)).toBe("SERIALIZED");
   });
 });

--- a/src/lib/overbooking-core.ts
+++ b/src/lib/overbooking-core.ts
@@ -33,6 +33,24 @@ import { mapLineItemDoc } from "@/lib/project-equipment-reconstruct";
  * includes assets that are in maintenance / lost / retired and will overstate
  * what can actually be booked.
  */
+/**
+ * Resolve a model's stock type when the Convex `assetType` mirror field may be
+ * absent. `assetType` is `v.optional` in the Convex schema, so older / backfilled
+ * model docs read back `undefined`. Blindly defaulting to `"SERIALIZED"` made a
+ * genuine BULK model take the serialized branch of `computeStockBreakdown` —
+ * `totalStock = assets.length = 0` (a bulk model has no serialized assets) — so
+ * every bulk line showed "0 available". Fall back to `"BULK"` when the model has
+ * any active bulk asset. A present value is returned unchanged, so this is a
+ * strictly-safe replacement for `assetType ?? "SERIALIZED"` at every stock site.
+ */
+export function resolveModelAssetType(
+  assetType: string | null | undefined,
+  hasBulkAssets: boolean,
+): "SERIALIZED" | "BULK" {
+  if (assetType === "BULK" || assetType === "SERIALIZED") return assetType;
+  return hasBulkAssets ? "BULK" : "SERIALIZED";
+}
+
 export function computeStockBreakdown(model: {
   assetType: "SERIALIZED" | "BULK";
   assets: { status: string }[];
@@ -244,7 +262,7 @@ export function reconstructOverbookedStatus(
     const m = convexModelMap.get(modelId);
     if (!m) continue;
     const modelForBreakdown = {
-      assetType: (m.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
+      assetType: resolveModelAssetType(m.assetType, (bulkMap.get(modelId)?.length ?? 0) > 0),
       assets: (assetMap.get(modelId) ?? []).map((a) => ({ status: a.status ?? "AVAILABLE" })),
       bulkAssets: (bulkMap.get(modelId) ?? []).map((ba) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
     };

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -1,4 +1,4 @@
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import {
@@ -343,8 +343,11 @@ export async function buildProjectEquipmentTree(
   // assets/bulks/kits + the org's models/suppliers/categories, all inside a single
   // Convex query (backend-local reads). Was ~10 separate server→Convex queries in 3
   // sequential waves — the round-trip count was the latency, not the payload.
-  const convex = await getConvexClient();
-  const bundleData = await convex.query(api.projectEquipment.bundle, { projectId, orgId: organizationId });
+  // withConvexReadRetry: this bundle feeds the high-traffic project-detail page;
+  // a transient blip must not take the whole page down (matches every other read domain).
+  const bundleData = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.projectEquipment.bundle, { projectId, orgId: organizationId }),
+  );
 
   // The reconstruction is PURE and now lives in the client-safe
   // project-equipment-reconstruct.ts (so the native read-layer cutover can run it

--- a/src/lib/project-managers-read.ts
+++ b/src/lib/project-managers-read.ts
@@ -1,4 +1,4 @@
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 
@@ -54,7 +54,8 @@ export async function getProjectManagerRows(
   organizationId: string,
   projectId: string,
 ): Promise<ProjectManagerRow[]> {
-  const client = await getConvexClient();
-  const docs = await client.query(api.projectManagers.list, { orgId: organizationId });
+  const docs = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.projectManagers.list, { orgId: organizationId }),
+  );
   return filterAndSortManagers(docs, projectId, organizationId);
 }

--- a/src/lib/projects-read.ts
+++ b/src/lib/projects-read.ts
@@ -1,4 +1,4 @@
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import type { ProjectStatus, ProjectType, RentalPeriod } from "@/generated/prisma/client";
@@ -8,11 +8,18 @@ export type ConvexProjectService = Doc<"projectServices">;
 export type ConvexCrewAssignment = Doc<"crewAssignments">;
 
 export async function getProjectsByOrg(orgId: string): Promise<ConvexProject[]> {
-  return await (await getConvexClient()).query(api.projects.list, { orgId });
+  // Wrapped in withConvexReadRetry (like every other read domain): a transient
+  // Convex blip — cold start, JWKS hiccup, service-token refresh boundary — must
+  // not take down the projects list or reject an already-committed write via its
+  // post-commit read-back. Reads are idempotent, so one retry absorbs the blip.
+  return withConvexReadRetry(async () => (await getConvexClient()).query(api.projects.list, { orgId }));
 }
 
 export async function getProjectById(id: string): Promise<ConvexProject | null> {
-  return await (await getConvexClient()).query(api.projects.getById, { id });
+  // See getProjectsByOrg — this is the read-back used by every project write
+  // action (via getProjectByIdMapped); an unretried blip here is what surfaced as
+  // the spurious "Server Components render" error after a successful create/update.
+  return withConvexReadRetry(async () => (await getConvexClient()).query(api.projects.getById, { id }));
 }
 
 // ─── Prisma-row-shaped mapping (for consumers that read the project scalars) ─────
@@ -136,8 +143,9 @@ export async function getProjectByIdMapped(id: string, orgId: string): Promise<P
 
 /** Returns the set of projectIds where userId appears as a project manager. */
 export async function getProjectIdsForManager(orgId: string, userId: string): Promise<Set<string>> {
-  const client = await getConvexClient();
-  const entries = await client.query(api.projectManagers.list, { orgId });
+  const entries = await withConvexReadRetry(async () =>
+    (await getConvexClient()).query(api.projectManagers.list, { orgId }),
+  );
   return new Set(entries.filter((e) => e.userId === userId).map((e) => e.projectId));
 }
 
@@ -210,12 +218,14 @@ export async function getCallSheetData(
   orgId: string,
   projectId: string,
 ): Promise<{ milestones: CallSheetMilestoneDates; serviceDates: CallSheetServiceDate[] } | null> {
-  const client = await getConvexClient();
-  const [project, services, assignments] = await Promise.all([
-    client.query(api.projects.getById, { id: projectId }),
-    client.query(api.projectServices.listByProject, { projectId, orgId }),
-    client.query(api.crewAssignments.listByProject, { projectId, orgId }),
-  ]);
+  const [project, services, assignments] = await withConvexReadRetry(async () => {
+    const client = await getConvexClient();
+    return Promise.all([
+      client.query(api.projects.getById, { id: projectId }),
+      client.query(api.projectServices.listByProject, { projectId, orgId }),
+      client.query(api.crewAssignments.listByProject, { projectId, orgId }),
+    ]);
+  });
   if (!project || project.organizationId !== orgId) return null;
   return {
     milestones: mapCallSheetMilestoneDates(project),

--- a/src/lib/warehouse-check-policy.test.ts
+++ b/src/lib/warehouse-check-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  transitionNeedsCheck,
+  lineHasModelChecks,
+  kitHasChecks,
+} from "./warehouse-check-policy";
+
+describe("transitionNeedsCheck — cross-transition policy", () => {
+  it("PREP fires a check when the model/kit has check items", () => {
+    expect(transitionNeedsCheck("PREP", { hasCheckItems: true })).toBe(true);
+    expect(transitionNeedsCheck("PREP", { hasCheckItems: true, fromDeprep: false })).toBe(true);
+  });
+
+  it("RETURN at DE-PREP (fromDeprep) fires a check when there are check items", () => {
+    expect(transitionNeedsCheck("RETURN", { hasCheckItems: true, fromDeprep: true })).toBe(true);
+  });
+
+  it("RETURN at return-scan (truck-in) NEVER fires a check", () => {
+    // Product decision: the return check runs only at de-prep, not at return-scan.
+    expect(transitionNeedsCheck("RETURN", { hasCheckItems: true })).toBe(false);
+    expect(transitionNeedsCheck("RETURN", { hasCheckItems: true, fromDeprep: false })).toBe(false);
+  });
+
+  it("never fires when the model/kit has no check items, regardless of transition", () => {
+    expect(transitionNeedsCheck("PREP", { hasCheckItems: false })).toBe(false);
+    expect(transitionNeedsCheck("RETURN", { hasCheckItems: false, fromDeprep: true })).toBe(false);
+    expect(transitionNeedsCheck("RETURN", { hasCheckItems: false, fromDeprep: false })).toBe(false);
+  });
+
+  // A single table asserting every (context, fromDeprep) combination — the one place
+  // a future transition change is visible.
+  it.each([
+    ["PREP", undefined, true],
+    ["PREP", false, true],
+    ["RETURN", true, true],
+    ["RETURN", false, false],
+    ["RETURN", undefined, false],
+  ] as const)("context=%s fromDeprep=%s → %s (with check items)", (context, fromDeprep, expected) => {
+    expect(transitionNeedsCheck(context, { hasCheckItems: true, fromDeprep })).toBe(expected);
+  });
+});
+
+describe("lineHasModelChecks / kitHasChecks", () => {
+  it("lineHasModelChecks is true only for a positive count", () => {
+    expect(lineHasModelChecks({ model: { _count: { modelCheckItems: 2 } } })).toBe(true);
+    expect(lineHasModelChecks({ model: { _count: { modelCheckItems: 0 } } })).toBe(false);
+    expect(lineHasModelChecks({ model: { _count: null } })).toBe(false);
+    expect(lineHasModelChecks({ model: null })).toBe(false);
+    expect(lineHasModelChecks(null)).toBe(false);
+    expect(lineHasModelChecks(undefined)).toBe(false);
+  });
+
+  it("kitHasChecks is true only for a positive count", () => {
+    expect(kitHasChecks({ _count: { kitCheckItems: 1 } })).toBe(true);
+    expect(kitHasChecks({ _count: { kitCheckItems: 0 } })).toBe(false);
+    expect(kitHasChecks({ _count: null })).toBe(false);
+    expect(kitHasChecks(null)).toBe(false);
+  });
+});

--- a/src/lib/warehouse-check-policy.ts
+++ b/src/lib/warehouse-check-policy.ts
@@ -1,0 +1,46 @@
+/**
+ * Central policy for "does this warehouse transition fire an equipment check?"
+ *
+ * The gating logic used to be copy-pasted across ~7 handlers in the warehouse
+ * page (each re-deriving `model._count.modelCheckItems > 0` and branching on
+ * context), which is exactly why check coverage drifted per transition. This
+ * module is the single source of truth. Callers pass the transition + whether the
+ * model/kit carries check items; the policy decides.
+ *
+ * Policy (product decision 2026-07):
+ * - **PREP** (Pick → Prep): fire a check when the model/kit has check items. This
+ *   is THE outbound gate — items are verified once, at prep.
+ * - **RETURN at DE-PREP** (shelf-in, `fromDeprep: true`): fire a check when the
+ *   model/kit has check items. This is the condition check as gear is stowed.
+ * - **RETURN at return-scan** (truck-in, `fromDeprep` false/absent): **no check.**
+ *   The return check fires only at de-prep, not when the item first comes back.
+ * - **Deploy** (Prep → Checked-out): no check (prep is the gate) — there is no
+ *   `CheckContext` for it, so it simply never calls this.
+ */
+export type CheckContext = "PREP" | "RETURN";
+
+export function transitionNeedsCheck(
+  context: CheckContext,
+  opts: { hasCheckItems: boolean; fromDeprep?: boolean },
+): boolean {
+  if (!opts.hasCheckItems) return false;
+  if (context === "PREP") return true;
+  // context === "RETURN": only at de-prep (shelf-in), never at return-scan (truck-in).
+  return opts.fromDeprep === true;
+}
+
+/** True when a line's model carries ≥1 check item (dedupes the ~7 inline copies). */
+export function lineHasModelChecks(
+  li: { model?: { _count?: { modelCheckItems?: number } | null } | null } | null | undefined,
+): boolean {
+  const n = li?.model?._count?.modelCheckItems;
+  return typeof n === "number" && n > 0;
+}
+
+/** True when a kit carries ≥1 kit-level check item. */
+export function kitHasChecks(
+  kit: { _count?: { kitCheckItems?: number } | null } | null | undefined,
+): boolean {
+  const n = kit?._count?.kitCheckItems;
+  return typeof n === "number" && n > 0;
+}

--- a/src/server/availability.ts
+++ b/src/server/availability.ts
@@ -6,6 +6,7 @@ import { getClientMap } from "@/lib/clients-read";
 import { getModelById } from "@/lib/models-read";
 import { getActiveAssetsByModel, getActiveBulkAssetsByModel, type ConvexAsset, type ConvexBulkAsset } from "@/lib/assets-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
+import { resolveModelAssetType } from "@/lib/overbooking-core";
 import {
   getOrgLineItems,
   getOrgLineItemUnits,
@@ -94,7 +95,7 @@ export async function getModelBookings(
   let totalStock = 0;
   let effectiveStock = 0;
   if (model) {
-    if ((model.assetType ?? "SERIALIZED") === "SERIALIZED") {
+    if (resolveModelAssetType(model.assetType, activeBulkAssets.length > 0) === "SERIALIZED") {
       totalStock = activeAssets.length;
       const unavailable = activeAssets.filter(
         (a: ConvexAsset) => a.status === "IN_MAINTENANCE" || a.status === "LOST" || a.status === "RETIRED"

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -4,7 +4,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
-import { logActivity } from "@/lib/activity-log";
+import { logActivity, logActivityMany } from "@/lib/activity-log";
 import { assertNoBlockingComments, getProjectBlockingSummary } from "@/lib/blocking-comments-read";
 import { evaluateBlockingGate } from "@/lib/blocking-comments-gate";
 import { getModelMap, getModelById, type ConvexModel } from "@/lib/models-read";
@@ -124,11 +124,13 @@ async function saveCheckRecords(
 
 /** Write Phase-B check records to Convex after the Prisma tx commits. */
 async function writeCheckRecordsToConvex(records: CheckRecordDoc[]) {
+  if (records.length === 0) return;
   const convex = await getConvexClient();
-  for (const r of records) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await convex.mutation(api.checkRecords.createIfMissing, r as any);
-  }
+  // ONE batched mutation instead of one round-trip per record. A single check
+  // submission produces (N line items × M check items) records — the per-record
+  // loop was the "checks feel sequential" tax. Still idempotent per cuid inside.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await convex.mutation(api.checkRecords.createManyIfMissing, { records: records as any });
 }
 
 /** After saving FAIL records, check if predictive maintenance should trigger */
@@ -461,21 +463,25 @@ export async function prepItemsBatch(
     rows.filter((r): r is NonNullable<typeof r> => r != null).map((r) => ({ ...r, modelId: r.modelId ?? null })),
   );
   const lineById = new Map(grafted.map((g) => [g.id, g]));
-  for (const item of items) {
-    const line = lineById.get(item.lineItemId);
-    await logActivity({
-      organizationId,
-      userId,
-      userName,
-      action: "UPDATE",
-      entityType: "asset",
-      entityId: item.lineItemId,
-      entityName: line?.model?.name || "Line item",
-      summary: "Prepped item (no checks required)",
-      projectId,
-      assetId: item.assetId || line?.assetId || undefined,
-    });
-  }
+  // One audit row per prepped item (matches prepItemDirect), written in ONE batch
+  // instead of N sequential inserts.
+  await logActivityMany(
+    items.map((item) => {
+      const line = lineById.get(item.lineItemId);
+      return {
+        organizationId,
+        userId,
+        userName,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: item.lineItemId,
+        entityName: line?.model?.name || "Line item",
+        summary: "Prepped item (no checks required)",
+        projectId,
+        assetId: item.assetId || line?.assetId || undefined,
+      };
+    }),
+  );
 
   return serialize(grafted);
 }
@@ -728,23 +734,25 @@ export async function deprepItemsBatch(
     }),
   );
 
-  for (const op of ops) {
-    const line = lineById.get(op.lineItemId);
-    if (op.isKit) {
-      const kitName = line?.kitId ? kitNameById.get(line.kitId) : undefined;
-      await logActivity({
-        organizationId,
-        userId,
-        userName,
-        action: "UPDATE",
-        entityType: "asset",
-        entityId: op.lineItemId,
-        entityName: kitName || "Kit",
-        summary: "Removed kit from prep",
-        projectId,
-      });
-    } else {
-      await logActivity({
+  // One audit row per deprepped item/kit, written in ONE batch instead of N.
+  await logActivityMany(
+    ops.map((op) => {
+      const line = lineById.get(op.lineItemId);
+      if (op.isKit) {
+        const kitName = line?.kitId ? kitNameById.get(line.kitId) : undefined;
+        return {
+          organizationId,
+          userId,
+          userName,
+          action: "UPDATE",
+          entityType: "asset",
+          entityId: op.lineItemId,
+          entityName: kitName || "Kit",
+          summary: "Removed kit from prep",
+          projectId,
+        };
+      }
+      return {
         organizationId,
         userId,
         userName,
@@ -755,9 +763,9 @@ export async function deprepItemsBatch(
         summary: "Removed item from prep",
         projectId,
         assetId: line?.assetId || undefined,
-      });
-    }
-  }
+      };
+    }),
+  );
 
   return serialize({ ids: distinctIds });
 }

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -20,7 +20,7 @@ import { roundCurrency } from "@/lib/formatters";
 import { calculateSuggestedPrice } from "./project-groups";
 import { UserFacingError } from "@/lib/errors";
 import { emitWebhookEvent } from "@/lib/webhooks/emit";
-import { computeStockBreakdown } from "@/lib/availability";
+import { computeStockBreakdown, resolveModelAssetType } from "@/lib/availability";
 import { isStaleRevision } from "@/lib/collaboration-conflict";
 import { writeCollabActivityEvent } from "@/lib/collaboration-activity";
 import { getModelById, getModelWithCategoryMap } from "@/lib/models-read";
@@ -194,7 +194,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
       // only check this project's existing bookings since other quotes are drafts.
       if (model) {
         const modelForBreakdown = {
-          assetType: (model.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
+          assetType: resolveModelAssetType(model.assetType, activeBulkAssets.length > 0),
           assets: activeAssets.map((a: ConvexAsset) => ({ status: a.status ?? "AVAILABLE" })),
           bulkAssets: activeBulkAssets.map((ba: ConvexBulkAsset) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
         };
@@ -589,7 +589,7 @@ export async function updateLineItem(
 
     if (model) {
       const modelForBreakdown = {
-        assetType: (model.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
+        assetType: resolveModelAssetType(model.assetType, activeBulkAssets.length > 0),
         assets: activeAssets.map((a: ConvexAsset) => ({ status: a.status ?? "AVAILABLE" })),
         bulkAssets: activeBulkAssets.map((ba: ConvexBulkAsset) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
       };
@@ -1332,7 +1332,7 @@ export async function checkAvailability(
   }
 
   const modelForBreakdown = {
-    assetType: (model.assetType ?? "SERIALIZED") as "SERIALIZED" | "BULK",
+    assetType: resolveModelAssetType(model.assetType, activeBulkAssets.length > 0),
     assets: activeAssets.map((a: ConvexAsset) => ({ status: a.status ?? "AVAILABLE" })),
     bulkAssets: activeBulkAssets.map((ba: ConvexBulkAsset) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
   };

--- a/src/server/project-managers.ts
+++ b/src/server/project-managers.ts
@@ -3,7 +3,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/org-context";
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
@@ -96,10 +96,11 @@ export async function setProjectManagers(projectId: string, userIds: string[]) {
 
   const desired = [...new Set(userIds)];
   const convex = await getConvexClient();
-  const current = await convex.query(api.projectManagers.listByProject, {
-    projectId,
-    orgId: organizationId,
-  });
+  // Pre-write diff read — retry a transient blip so the wizard's post-create
+  // manager sync doesn't spuriously fail after the project already committed.
+  const current = await withConvexReadRetry(() =>
+    convex.query(api.projectManagers.listByProject, { projectId, orgId: organizationId }),
+  );
   const currentUserIds = new Set(current.map((r) => r.userId));
   const desiredSet = new Set(desired);
 
@@ -179,10 +180,9 @@ export async function removeProjectManager(projectId: string, userId: string) {
   );
 
   const convex = await getConvexClient();
-  const pmRows = await convex.query(api.projectManagers.listByProject, {
-    projectId,
-    orgId: organizationId,
-  });
+  const pmRows = await withConvexReadRetry(() =>
+    convex.query(api.projectManagers.listByProject, { projectId, orgId: organizationId }),
+  );
   const manager = pmRows.find((r) => r.userId === userId && r.organizationId === organizationId);
 
   if (!manager) {

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -28,7 +28,7 @@ import { computeOverbookedStatus } from "@/lib/availability";
 import { recalculateProjectTotals } from "@/server/line-items";
 import { logActivity } from "@/lib/activity-log";
 import { getKitSerializedItemsByOrg } from "@/lib/kits-read";
-import { getConvexClient } from "@/lib/convex-client";
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { getProjectMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { api } from "../../convex/_generated/api";
 import { getAssignmentsByProject } from "@/lib/crew-scheduling-read";
@@ -663,6 +663,31 @@ export async function createProject(data: ProjectFormValues & { isTemplate?: boo
   return serialize(result);
 }
 
+/**
+ * Return-value availability check for a project code (the
+ * `@@unique([organizationId, projectNumber])` guard). The create/edit wizard calls
+ * this before submit to show an INLINE error on the projectNumber field.
+ *
+ * Why a RETURN value and not the thrown `DUPLICATE_PROJECT_CODE` UserFacingError:
+ * Next masks a thrown server-action error in production to the generic
+ * "An error occurred in the Server Components render" string — its `message`/`field`
+ * never reach the client. A returned value serializes intact. The create/update
+ * throws remain the authoritative integrity backstop (and the API-envelope path).
+ */
+export async function checkProjectNumberAvailable(
+  projectNumber: string,
+  excludeProjectId?: string,
+): Promise<{ available: boolean }> {
+  const { organizationId } = await getOrgContext();
+  const trimmed = projectNumber.trim();
+  if (!trimmed) return { available: true };
+  const convex = await getConvexClient();
+  const clash = await withConvexReadRetry(() =>
+    convex.query(api.projects.getByOrgAndNumber, { organizationId, projectNumber: trimmed }),
+  );
+  return { available: !clash || clash.id === excludeProjectId };
+}
+
 export async function updateProject(id: string, data: ProjectFormValues) {
   const { organizationId, userId, userName } = await requirePermission("project", "update");
   const parsed = projectSchema.parse(data);
@@ -681,6 +706,31 @@ export async function updateProject(id: string, data: ProjectFormValues) {
     await assertNoBlockingComments(organizationId, id, {
       actionLabel: `move this project to ${String(parsed.status).toLowerCase().replaceAll("_", " ")}`,
     });
+  }
+
+  // Duplicate-code integrity guard. createProject enforces the
+  // @@unique([organizationId, projectNumber]) invariant at insert, but the edit
+  // path patched projectNumber blindly — editing a code to one a sibling already
+  // uses silently produced two projects sharing a number. Only check when the
+  // number actually changes. (The wizard also checks availability up-front via
+  // checkProjectNumberAvailable for an inline field error; this catches the edit
+  // race and any non-wizard caller, and feeds the API error envelope.)
+  if (parsed.projectNumber && before && parsed.projectNumber !== before.projectNumber) {
+    const dupCheck = await getConvexClient();
+    const clash = await withConvexReadRetry(() =>
+      dupCheck.query(api.projects.getByOrgAndNumber, {
+        organizationId,
+        projectNumber: parsed.projectNumber!,
+      }),
+    );
+    if (clash && clash.id !== id) {
+      throw new UserFacingError({
+        code: "DUPLICATE_PROJECT_CODE",
+        title: "Project code already in use",
+        message: `A ${before.isTemplate ? "template" : "project"} with code "${parsed.projectNumber}" already exists.`,
+        field: "projectNumber",
+      });
+    }
   }
 
   // project is Convex-only — patch via api.projects.patchProject. Value→set,

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -746,9 +746,16 @@ export async function updateProject(id: string, data: ProjectFormValues) {
     });
   }
 
-  // Recalculate totals if tax rate changed
+  // Recalculate totals if tax rate changed. Best-effort: the project patch already
+  // committed, so a transient recalc failure must not reject an otherwise-successful
+  // update (that surfaced as the spurious "Server Components render" error). Totals
+  // are derived and self-heal on the next line-item write / recalc.
   if (parsed.taxRate !== undefined) {
-    await recalculateProjectTotals(id);
+    try {
+      await recalculateProjectTotals(id);
+    } catch (e) {
+      console.error("post-update recalc failed (non-fatal):", e);
+    }
   }
 
   const updated = await getProjectByIdMapped(id, organizationId);

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -8,7 +8,7 @@ import { getModelById, getModelMap } from "@/lib/models-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { serialize } from "@/lib/serialize";
 import { computeOverbookedStatus } from "@/lib/availability";
-import { logActivity } from "@/lib/activity-log";
+import { logActivity, logActivityMany } from "@/lib/activity-log";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
@@ -352,8 +352,8 @@ export async function checkOutItems(
     now: Date.now(),
   });
 
-  for (const item of items) {
-    await logActivity({
+  await logActivityMany(
+    items.map((item) => ({
       organizationId,
       userId,
       userName,
@@ -364,8 +364,8 @@ export async function checkOutItems(
       summary: `Checked out item on project`,
       projectId,
       assetId: item.assetId,
-    });
-  }
+    })),
+  );
 
   // Re-read the updated lines and graft the Convex model doc for the return.
   const rows = await Promise.all(
@@ -442,8 +442,8 @@ export async function checkInItems(
     now: Date.now(),
   });
 
-  for (const item of items) {
-    await logActivity({
+  await logActivityMany(
+    items.map((item) => ({
       organizationId,
       userId,
       userName,
@@ -453,8 +453,8 @@ export async function checkInItems(
       entityName: `Line item ${item.lineItemId}`,
       summary: `Checked in item on project (condition: ${item.returnCondition})`,
       projectId,
-    });
-  }
+    })),
+  );
 
   // Re-read the updated lines and graft the Convex model doc for the return.
   const rows = await Promise.all(
@@ -479,13 +479,13 @@ export async function undeployItems(
     items: items.map((i) => ({ lineItemId: i.lineItemId, assetId: i.assetId, quantity: i.quantity })),
     now: Date.now(),
   });
-  for (const item of items) {
-    await logActivity({
+  await logActivityMany(
+    items.map((item) => ({
       organizationId, userId, userName, action: "UPDATE", entityType: "asset",
       entityId: item.assetId || item.lineItemId, entityName: `Line item ${item.lineItemId}`,
       summary: "Moved item back to Prepped (un-deploy)", projectId, assetId: item.assetId,
-    });
-  }
+    })),
+  );
   const rows = await Promise.all(
     res.updatedLineIds.map((id: string) => convex.query(api.projectLineItems.getById, { id })),
   );
@@ -506,13 +506,13 @@ export async function unreturnItems(
     items: items.map((i) => ({ lineItemId: i.lineItemId, assetId: i.assetId, quantity: i.quantity })),
     now: Date.now(),
   });
-  for (const item of items) {
-    await logActivity({
+  await logActivityMany(
+    items.map((item) => ({
       organizationId, userId, userName, action: "UPDATE", entityType: "asset",
       entityId: item.assetId || item.lineItemId, entityName: `Line item ${item.lineItemId}`,
       summary: "Moved item back to Deployed (un-return)", projectId, assetId: item.assetId,
-    });
-  }
+    })),
+  );
   const rows = await Promise.all(
     res.updatedLineIds.map((id: string) => convex.query(api.projectLineItems.getById, { id })),
   );
@@ -655,20 +655,26 @@ export async function checkOutKitsBatch(projectId: string, kitIds: string[]) {
 
   const convex = await getConvexClient();
   const now = Date.now();
+  // Fire every kit's atomic checkout concurrently (was one serial round-trip per
+  // kit). Each kit stays in its own Convex mutation/transaction, so per-kit error
+  // isolation is preserved; allSettled collects successes + failures without one
+  // failing kit aborting the rest. (Concurrent checkouts on the SAME project touch
+  // shared line rollups → Convex may OCC-retry; it auto-retries, so it stays correct.)
+  const results = await Promise.allSettled(
+    unique.map((kitId) => convex.mutation(api.warehouseOps.checkoutKit, { organizationId, projectId, userId, kitId, now })),
+  );
   const succeeded: string[] = [];
   const errors: { kitId: string; message: string }[] = [];
-  for (const kitId of unique) {
-    try {
-      await convex.mutation(api.warehouseOps.checkoutKit, { organizationId, projectId, userId, kitId, now });
-      succeeded.push(kitId);
-      await logActivity({
-        organizationId, userId, userName, action: "CHECK_OUT", entityType: "kit",
-        entityId: kitId, entityName: `Kit ${kitId}`, summary: "Checked out kit with all contents", projectId, kitId,
-      });
-    } catch (e) {
-      errors.push({ kitId, message: e instanceof Error ? e.message : String(e) });
-    }
-  }
+  results.forEach((r, i) => {
+    if (r.status === "fulfilled") succeeded.push(unique[i]);
+    else errors.push({ kitId: unique[i], message: r.reason instanceof Error ? r.reason.message : String(r.reason) });
+  });
+  await logActivityMany(
+    succeeded.map((kitId) => ({
+      organizationId, userId, userName, action: "CHECK_OUT", entityType: "kit",
+      entityId: kitId, entityName: `Kit ${kitId}`, summary: "Checked out kit with all contents", projectId, kitId,
+    })),
+  );
   return serialize({ succeeded, errors });
 }
 
@@ -692,20 +698,27 @@ export async function checkInKitsBatch(
 
   const convex = await getConvexClient();
   const now = Date.now();
+  // Concurrent per-kit check-in (see checkOutKitsBatch for the isolation rationale).
+  const results = await Promise.allSettled(
+    uniqueKits.map((k) =>
+      convex.mutation(api.warehouseOps.checkinKit, { organizationId, projectId, userId, kitId: k.kitId, returnCondition: k.returnCondition, now })
+        .then(() => k),
+    ),
+  );
   const succeeded: string[] = [];
   const errors: { kitId: string; message: string }[] = [];
-  for (const { kitId, returnCondition } of uniqueKits) {
-    try {
-      await convex.mutation(api.warehouseOps.checkinKit, { organizationId, projectId, userId, kitId, returnCondition, now });
-      succeeded.push(kitId);
-      await logActivity({
+  results.forEach((r, i) => {
+    if (r.status === "fulfilled") succeeded.push(uniqueKits[i].kitId);
+    else errors.push({ kitId: uniqueKits[i].kitId, message: r.reason instanceof Error ? r.reason.message : String(r.reason) });
+  });
+  await logActivityMany(
+    uniqueKits
+      .filter((k) => succeeded.includes(k.kitId))
+      .map((k) => ({
         organizationId, userId, userName, action: "CHECK_IN", entityType: "kit",
-        entityId: kitId, entityName: `Kit ${kitId}`, summary: `Checked in kit (condition: ${returnCondition})`, projectId, kitId,
-      });
-    } catch (e) {
-      errors.push({ kitId, message: e instanceof Error ? e.message : String(e) });
-    }
-  }
+        entityId: k.kitId, entityName: `Kit ${k.kitId}`, summary: `Checked in kit (condition: ${k.returnCondition})`, projectId, kitId: k.kitId,
+      })),
+  );
   return serialize({ succeeded, errors });
 }
 


### PR DESCRIPTION
Fixes 8 bug/UX issues across projects, warehouse, and navigation. Each was investigated against the real code first — several root causes differed from the original reports (noted below). One atomic commit per issue.

## Issues

**1 — Spurious "Server Components render" error on mutations** (`5e4ad946`)
Not the post-commit mirror/log pattern (already failure-isolated). The projects-domain read modules (`projects-read`, `project-managers-read`, the project-detail bundle) were the *only* reads missing `withConvexReadRetry`; a token-refresh blip on a write's post-commit read-back rejected an already-committed write → the masked error. Wrapped those reads + isolated `updateProject`'s recalc.

**2 — Duplicate project code shows no inline error** (`69a1be42`)
The server already threw the right error, but Next masks thrown server-action errors in prod, so the field never reached the form. Added a return-value `checkProjectNumberAvailable` for an inline error, and closed a real data-integrity gap — `updateProject` had no duplicate check, so editing a code to a taken one silently created two projects sharing a number.

**3 — Bulk assets always show 0 available** (`016acec9`)
`model.assetType ?? "SERIALIZED"` mis-resolved bulk models whose Convex mirror field is absent → `totalStock = 0`. Found **5** affected computation sites (not 2); added a shared `resolveModelAssetType`.

**4 — Can't move items into an empty/new group** (`80dd53ae`)
UI-only: the "Move to group" picker was never fed uncategorized-zone groups. "Empty" was incidental — the real discriminator was *uncategorized*. Server already accepted `categoryId: null`.

**5 — Stale navigation snaps back after in-flight load** (`a8e6280a`)
Reads were already guarded; `useServerMutation` ran nav callbacks (`onSuccess`/`onSettled`) after unmount, so leaving a page mid-mutation yanked you back. Gated those on mount (kept `onError`), plus fixed 3 unguarded auth-page `.then()`/timer redirects.

**6 — Checks only fire on two transitions** (`ec8c2931`)
Design ambiguity, resolved by product decision: checks already fired on prep + both return points. Removed the return-scan (truck-in) check so checks fire at **PREP and DE-PREP only**, and centralized the copy-pasted gating into one `transitionNeedsCheck` policy + cross-transition test.

**7 — Bulk warehouse ops extremely slow** (`b9ef011b`)
Sequential per-item `logActivity` + per-record check writes. Added `logActivityMany` + batched Convex mutations (`recordMany`, `createManyIfMissing`); parallelized the kit batch loops with `Promise.allSettled` (per-kit error isolation preserved).

**8 — Bulk asset quantities stuck at 1** (`a914cda1`)
`prepUnit` overwrote the single bulk unit's quantity to 1 (client expanded prep into N qty-1 calls); `checkoutKit`/return hardcoded `1`. Now prep accumulates (capped at ordered qty), checkout uses each line's own quantity, and return defaults to the full remaining quantity. Line rollups derive from unit quantity, so the whole chain follows. Covered by a `convex-test` prep→return regression suite.

## Verification
- `tsc --noEmit` clean
- Full unit suite: **195 files / 3150 tests passing** (5 new/updated test files)
- ESLint: 0 errors
- Convex function changes (issues 7 & 8) deploy via the normal pipeline / PR preview — not pushed to shared dev from the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
