### PR TITLE
feat(kits): kit per-unit fulfillment — Phase 3 (surface + strip belt + parity guard)

### DIFF
--- a/FEATUREDOCS/60-assets-on-a-job.md
+++ b/FEATUREDOCS/60-assets-on-a-job.md
@@ -17,8 +17,14 @@ on the container — see also [48](./48-child-assets-accessories.md):
 |---|---|---|
 | Loose / group member, qty 1 | `projectLineItem.assetId` (single) | inline tag next to the name |
 | Loose / group member, qty ≥2 | one `projectLineItemUnit.assetId` per unit | expandable per-unit rows |
-| **Physical kit member** | the kit-child line's `assetId` (mirrors `kitSerializedItems`) | tag on the child row; verified *with* the kit, not scanned per line |
+| **Physical kit member** | one `projectLineItemUnit` per member (seeded at kit-add, like loose gear) | tag + fulfillment badge + history via the same indicator as every line; verified *with* the kit, not scanned per line |
 | Accessory child | `projectLineItemUnit` (`parentUnitAssetId` link) | tag on the child row |
+
+> Physical kit members were migrated onto per-unit `projectLineItemUnit` rows (the
+> kit per-unit fulfillment migration — `docs/designs/kit-per-unit-fulfillment.md`).
+> They still keep `line.assetId` for now, but fulfillment (deploy/return status,
+> history) is driven by the unit. Per-kit-slot reassign is not yet available (the
+> reassign mutation rejects kit children), so their Move control is suppressed.
 
 A **group** (`projectGroups`) is a priced bundle only — it adds nothing to serial
 storage; its members behave exactly like loose lines. Only a **kit** (`kits`, has

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -6,6 +6,7 @@
 // (belt still owns asset status this phase).
 import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
+import { ConvexError } from "convex/values";
 import schema from "./schema";
 import { api } from "./_generated/api";
 
@@ -237,6 +238,29 @@ describe("kit per-unit — accessories on a member", () => {
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKit, { organizationId: ORG, kitId: "k1", userId: USER, now: NOW });
     expect((await accessoryUnits(t))[0].status).toBe("RETURNED");
     expect(await accAssetStatus(t)).toBe("AVAILABLE");
+  });
+});
+
+describe("kit per-unit — composition parity guard (Phase 3)", () => {
+  test("checkout throws KIT_COMPOSITION_DRIFT when the kit definition diverges from the project snapshot", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t); // snapshot child line a1 == definition ks1(a1)
+    // Drift the live definition: add a serialised item not on the project's snapshot.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "A-2", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("kitSerializedItems", { id: "ks2", organizationId: ORG, kitId: "k1", assetId: "a2", addedById: USER });
+    });
+    const err = await co(t).then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(ConvexError);
+    expect((err as ConvexError<{ kind: string }>).data.kind).toBe("KIT_COMPOSITION_DRIFT");
+    // Nothing deployed — the guard runs before any write.
+    expect(await assetStatus(t)).toBe("AVAILABLE");
+  });
+
+  test("checkout succeeds when snapshot and definition match (no false positive)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await expect(co(t)).resolves.toBeTruthy();
   });
 });
 

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -336,6 +336,36 @@ async function childLines(ctx: Ctx, parentId: string, organizationId: string) {
 async function kitSerializedAssetIds(ctx: Ctx, kitId: string): Promise<string[]> {
   return (await ctx.db.query("kitSerializedItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect()).map((k) => k.assetId);
 }
+
+/**
+ * Kit per-unit fulfillment (Phase 3) — composition parity guard.
+ *
+ * A project's kit is a SNAPSHOT (child lines + their units) frozen when the kit
+ * was added; `kitSerializedItems` is the LIVE definition, which can drift
+ * independently (warehouse edits, CSV import). Since Phase 3 the asset flip is
+ * driven by the snapshot (child-line assets), while verification (T&T preflight,
+ * the per-item check flow) still reads the live definition. If the two diverge,
+ * verification validates one asset set and deployment touches another — so we
+ * error and make the operator re-add the kit to resync, rather than silently
+ * deploying an unverified set. Serialised members only (bulk uses availability,
+ * not per-asset status).
+ */
+async function assertKitCompositionParity(ctx: Ctx, kitLineId: string, kitId: string, organizationId: string) {
+  const children = await childLines(ctx, kitLineId, organizationId);
+  const snapshot = new Set(children.filter((c) => !c.kitId && c.assetId).map((c) => c.assetId!));
+  const definition = new Set(await kitSerializedAssetIds(ctx, kitId));
+  const missing = [...definition].filter((id) => !snapshot.has(id));
+  const extra = [...snapshot].filter((id) => !definition.has(id));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new ConvexError({
+      kind: "KIT_COMPOSITION_DRIFT",
+      kitId,
+      message: "This kit's contents changed since it was added to the project. Remove and re-add the kit to resync, then deploy.",
+      missing,
+      extra,
+    });
+  }
+}
 async function collectKitBulkAdjustments(ctx: Ctx, kitId: string, organizationId: string, sign: -1 | 1): Promise<BulkAdjustment[]> {
   const bulks = await ctx.db.query("kitBulkItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect();
   return bulks.filter((b) => b.organizationId === organizationId).map((b) => ({ bulkAssetId: b.bulkAssetId, delta: sign * b.quantity }));
@@ -463,6 +493,13 @@ export const checkoutKit = mutation({
     const nestedKitChildren = children.filter((c) => c.kitId);
     const nestedKitIds = nestedKitChildren.map((c) => c.kitId!) as string[];
 
+    // Parity: the project's kit snapshot (what we deploy) must match the live kit
+    // definition (what T&T verifies) — for this kit and each nested kit.
+    await assertKitCompositionParity(ctx, kitLine.id, a.kitId, a.organizationId);
+    for (const nestedChild of nestedKitChildren) {
+      await assertKitCompositionParity(ctx, nestedChild.id, nestedChild.kitId!, a.organizationId);
+    }
+
     // T&T preflight over this kit + nested kits' permanent composition.
     const ttAssets: string[] = [...(await kitSerializedAssetIds(ctx, a.kitId))];
     const ttBulk: string[] = (await ctx.db.query("kitBulkItems").withIndex("by_kitId", (q) => q.eq("kitId", a.kitId)).collect()).map((b) => b.bulkAssetId);
@@ -480,7 +517,6 @@ export const checkoutKit = mutation({
       for (const gc of await childLines(ctx, nestedChild.id, a.organizationId)) await ctx.db.patch(gc._id, deploy);
       const nk = await kitByCuid(ctx, nestedChild.kitId!);
       if (nk) await ctx.db.patch(nk._id, { status: "CHECKED_OUT", ...(loc ? { locationId: loc } : {}), updatedAt: a.now });
-      await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nestedChild.kitId!), "CHECKED_OUT", loc, false, a.now);
     }
 
     await setAssetsStatus(ctx, children.filter((c) => c.assetId).map((c) => c.assetId!), "CHECKED_OUT", loc, false, a.now);
@@ -491,7 +527,6 @@ export const checkoutKit = mutation({
 
     const kit = await kitByCuid(ctx, a.kitId);
     if (kit) await ctx.db.patch(kit._id, { status: "CHECKED_OUT", ...(loc ? { locationId: loc } : {}), updatedAt: a.now });
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, a.kitId), "CHECKED_OUT", loc, false, a.now);
 
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, -1))];
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, -1)));
@@ -534,7 +569,6 @@ export const checkinKit = mutation({
       for (const gc of (await childLines(ctx, nestedChild.id, a.organizationId)).filter((g) => g.status === "CHECKED_OUT")) await ctx.db.patch(gc._id, ret);
       const nk = await kitByCuid(ctx, nestedChild.kitId!);
       if (nk) await ctx.db.patch(nk._id, { status: newKitStatus, ...(defaultLocationId ? { locationId: defaultLocationId } : {}), updatedAt: a.now });
-      await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nestedChild.kitId!), assetStatus, defaultLocationId, true, a.now);
     }
 
     await setAssetsStatus(ctx, children.filter((c) => c.assetId).map((c) => c.assetId!), assetStatus, defaultLocationId, true, a.now);
@@ -545,7 +579,6 @@ export const checkinKit = mutation({
 
     const kit = await kitByCuid(ctx, a.kitId);
     if (kit) await ctx.db.patch(kit._id, { status: newKitStatus, ...(defaultLocationId ? { locationId: defaultLocationId } : {}), updatedAt: a.now });
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, a.kitId), assetStatus, defaultLocationId, true, a.now);
 
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, 1))];
     for (const nk of nestedKitIds) adjustments.push(...(await collectKitBulkAdjustments(ctx, nk, a.organizationId, 1)));
@@ -760,7 +793,6 @@ export const undeployKit = mutation({
       for (const gc of await childLines(ctx, nestedChild.id, a.organizationId)) await ctx.db.patch(gc._id, prepped);
       const nk = await kitByCuid(ctx, nestedChild.kitId!);
       if (nk) await ctx.db.patch(nk._id, { status: "AVAILABLE", ...(defLoc ? { locationId: defLoc } : {}), updatedAt: a.now });
-      await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nestedChild.kitId!), "AVAILABLE", defLoc, true, a.now);
     }
     await setAssetsStatus(ctx, children.filter((c) => c.assetId).map((c) => c.assetId!), "AVAILABLE", defLoc, true, a.now);
     for (const nestedChild of nestedKitChildren) {
@@ -769,7 +801,6 @@ export const undeployKit = mutation({
     }
     const kit = await kitByCuid(ctx, a.kitId);
     if (kit) await ctx.db.patch(kit._id, { status: "AVAILABLE", ...(defLoc ? { locationId: defLoc } : {}), updatedAt: a.now });
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, a.kitId), "AVAILABLE", defLoc, true, a.now);
 
     // Restore bulk availability the checkout consumed (+1, opposite of checkout's -1).
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, 1))];
@@ -807,7 +838,6 @@ export const unreturnKit = mutation({
       for (const gc of (await childLines(ctx, nestedChild.id, a.organizationId)).filter((g) => g.status === "RETURNED")) await ctx.db.patch(gc._id, deployed);
       const nk = await kitByCuid(ctx, nestedChild.kitId!);
       if (nk) await ctx.db.patch(nk._id, { status: "CHECKED_OUT", ...(projLoc ? { locationId: projLoc } : {}), updatedAt: a.now });
-      await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nestedChild.kitId!), "CHECKED_OUT", projLoc, false, a.now);
     }
     await setAssetsStatus(ctx, children.filter((c) => c.assetId).map((c) => c.assetId!), "CHECKED_OUT", projLoc, false, a.now);
     for (const nestedChild of nestedKitChildren) {
@@ -816,7 +846,6 @@ export const unreturnKit = mutation({
     }
     const kit = await kitByCuid(ctx, a.kitId);
     if (kit) await ctx.db.patch(kit._id, { status: "CHECKED_OUT", ...(projLoc ? { locationId: projLoc } : {}), updatedAt: a.now });
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, a.kitId), "CHECKED_OUT", projLoc, false, a.now);
 
     // Re-consume bulk availability the return restored (-1, opposite of checkin's +1).
     const adjustments: BulkAdjustment[] = [...(await collectKitBulkAdjustments(ctx, a.kitId, a.organizationId, -1))];
@@ -910,7 +939,6 @@ async function restoreKitParentLine(
       if (loc != null) await ctx.db.patch(k._id, { status: "AVAILABLE", locationId: loc, updatedAt: now });
       else { const { _id, _creationTime, locationId: _l, ...rest } = k; await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: now }); }
     }
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, nk), "AVAILABLE", loc, true, now);
   }
   for (const c of children) if (c.status === "CHECKED_OUT") await ctx.db.patch(c._id, FORCE_RET(now));
   await setAssetsStatus(ctx, children.filter((c) => c.assetId).map((c) => c.assetId!), "AVAILABLE", loc, true, now);
@@ -939,7 +967,6 @@ export const forceReturnKit = mutation({
 
     if (loc != null) await ctx.db.patch(kit._id, { status: "AVAILABLE", locationId: loc, updatedAt: a.now });
     else { const { _id, _creationTime, locationId: _l, ...rest } = kit; await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: a.now }); }
-    await setAssetsStatus(ctx, await kitSerializedAssetIds(ctx, a.kitId), "AVAILABLE", loc, true, a.now);
 
     const adjustments: BulkAdjustment[] = [];
     for (const kid of kitsToRestore) adjustments.push(...(await collectKitBulkAdjustments(ctx, kid, a.organizationId, 1)));

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -350,14 +350,25 @@ it true:
 
 ## Implementation status
 
-- **Phase 1 — COMPLETE (2026-07-12).** Seeding, prep tree, checkout/checkin,
-  reverse (undeploy/unreturn), force (forceReturnKit/Asset/bulk), and
-  accessories-on-members all wired unit-only alongside the untouched legacy belt.
-  17 integration tests in `convex/kitPerUnit.test.ts`; full convex suite green
-  (269). `bumpAssetCounters` left unchanged (already idempotent). Kit-edit sync
-  found unnecessary; parity guard moved to Phase 3 (see Phase 1 notes above).
-  Members are **not yet visible** on the equipment tab/PDF — that's Phase 3.
-- **Phase 2 — NEXT.** Backfill kits added before Phase 1.
+- **Phases 1+2 — SHIPPED (2026-07-12, PR #409, merged `facc667f`, deployed).**
+  Write path (seed/prep/checkout/checkin/reverse/force/accessories) + backfill.
+  Backfill RUN on prod: 120 unit rows created. `bumpAssetCounters` left unchanged
+  (already idempotent). Kit-edit sync found unnecessary.
+- **Phase 3 — COMPLETE (2026-07-12).** Two halves:
+  - **Surface:** kit-member rows on the equipment tab (mobile + table) now use the
+    same `LineAssetsIndicator` as every line — tag + fulfillment badge + history —
+    with reassign suppressed (`disableReassign`; per-kit-slot reassign is Phase 4).
+    PDF needed **zero change**: a qty-1 member with one unit renders identically
+    (all per-unit render + `calculateItemHeight` gates are `quantity > 1`); locked
+    by a `getAssetTag` regression + a height-invariance test.
+  - **Strip + guard:** removed the 10 `kitSerializedItems`-driven `setAssetsStatus`
+    belt calls (the definition-driven flip); asset status now flips solely from the
+    project's child-line snapshot (== the units). Added `assertKitCompositionParity`
+    to `checkoutKit` — errors `KIT_COMPOSITION_DRIFT` if the project snapshot
+    diverges from the live kit definition (deploy set != verified set). Child-line
+    flips kept (they mirror the units). 19 kit tests + 3 PDF/UI tests; suite green (276).
+  - **NOT done:** the `line.assetId` column drop for kit children (parent design's
+    deferred follow-up) and **Phase 4** kit-member reassign.
 
 ## Eng-review appendix (2026-07-12)
 

--- a/src/components/projects/__tests__/line-assets-indicator.smoke.test.tsx
+++ b/src/components/projects/__tests__/line-assets-indicator.smoke.test.tsx
@@ -32,6 +32,20 @@ describe("LineAssetsIndicator (smoke)", () => {
     expect(screen.getByRole("button", { name: /2 assets assigned/i })).toBeTruthy();
   });
 
+  it("renders for a kit member with reassign suppressed (disableReassign) without crashing", () => {
+    // Kit members now use the same indicator as every line, but the reassign
+    // mutation rejects kit children — so the Move control is suppressed here.
+    render(
+      <LineAssetsIndicator
+        lineItemId="kc1"
+        modelId="m1"
+        disableReassign
+        units={[{ id: "u1", status: "CHECKED_OUT", asset: { id: "a1", assetTag: "KIT-MEM-1" } }]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /1 asset assigned/i })).toBeTruthy();
+  });
+
   it("renders nothing when the line has no tagged units (keeps the table calm)", () => {
     const { container } = render(
       <LineAssetsIndicator lineItemId="li1" units={[{ id: "u1", status: "CONFIRMED" }]} />,

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -1434,28 +1434,25 @@ export function LineItemRow({
         {/* Expanded child items (kit members / accessories) as nested cards. */}
         {isExpanded && hasChildren && (
           <div className="space-y-1.5">
-            {item.childLineItems!.map((child) => {
-              const childTags = (child.units ?? [])
-                .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
-                .filter((t): t is string => !!t);
-              const tag = childTags[0] ?? child.asset?.assetTag ?? null;
-              const extra = childTags.length > 1 ? ` +${childTags.length - 1}` : "";
-              return (
-                <div key={child.id} className="rounded-[var(--r)] bg-paper-2/40 py-2 pl-6 pr-3">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-table-cell text-ink-2">{child.model?.name ?? child.description ?? "—"}</span>
-                    {tag && <span className="t-mono text-caption text-muted">({tag}{extra})</span>}
-                    {child.childKind === "ACCESSORY" && (
-                      <Badge status="neutral" className="px-1.5 py-0 text-[10px]">Accessory</Badge>
-                    )}
-                  </div>
-                  {child.notes && (
-                    <p className="mt-0.5 truncate text-caption text-muted">{child.notes}</p>
+            {item.childLineItems!.map((child) => (
+              <div key={child.id} className="rounded-[var(--r)] bg-paper-2/40 py-2 pl-6 pr-3">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-table-cell text-ink-2">{child.model?.name ?? child.description ?? "—"}</span>
+                  {/* Kit members / accessories carry their serial on a per-unit row now
+                      — same indicator (tag + fulfillment status + history) as every
+                      other line. Reassign is suppressed: the mutation rejects kit
+                      children (per-kit-slot reassign is Phase 4). */}
+                  <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign />
+                  {child.childKind === "ACCESSORY" && (
+                    <Badge status="neutral" className="px-1.5 py-0 text-[10px]">Accessory</Badge>
                   )}
-                  <MetricLine item={child} showCostColumn={showCostColumn} />
                 </div>
-              );
-            })}
+                {child.notes && (
+                  <p className="mt-0.5 truncate text-caption text-muted">{child.notes}</p>
+                )}
+                <MetricLine item={child} showCostColumn={showCostColumn} />
+              </div>
+            ))}
           </div>
         )}
       </div>
@@ -1728,18 +1725,11 @@ export function LineItemRow({
           <div className={`${childIndent}`}>
             <div className="flex items-center gap-2">
               <span className="text-table-cell text-ink-2">{child.model?.name ?? child.description ?? "—"}</span>
-              {(() => {
-                // Kit members carry their serial on the child line's `asset`
-                // (no unit row); accessories carry it on `units`. Prefer unit
-                // tags, fall back to the line-level asset tag.
-                const childTags = (child.units ?? [])
-                  .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
-                  .filter((t): t is string => !!t);
-                const tag = childTags[0] ?? child.asset?.assetTag ?? null;
-                if (!tag) return null;
-                const extra = childTags.length > 1 ? ` +${childTags.length - 1}` : "";
-                return <span className="t-mono text-caption text-muted">({tag}{extra})</span>;
-              })()}
+              {/* Kit members / accessories now carry their serial on a per-unit
+                  row — same indicator (tag + fulfillment status + history) as every
+                  other line. Reassign is suppressed: the mutation rejects kit
+                  children (per-kit-slot reassign is Phase 4). */}
+              <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign />
               {child.childKind === "ACCESSORY" && (
                 <Badge status="neutral" className="text-[10px] px-1.5 py-0">
                   Accessory

--- a/src/components/projects/line-assets-indicator.tsx
+++ b/src/components/projects/line-assets-indicator.tsx
@@ -55,12 +55,17 @@ export function LineAssetsIndicator({
   lineAssetTag,
   lineItemId,
   modelId,
+  disableReassign = false,
 }: {
   units?: IndicatorUnit[];
   /** Fallback for single-asset legacy lines that carry the tag on the line itself. */
   lineAssetTag?: string | null;
   lineItemId: string;
   modelId?: string | null;
+  /** Suppress the Move control. Kit members bind to their kit slot — the reassign
+   *  mutation rejects kit children — so they view tag/status/history but can't
+   *  reassign until per-kit-slot reassign lands (Phase 4). */
+  disableReassign?: boolean;
 }) {
   const reassignCtx = useReassign();
 
@@ -133,6 +138,7 @@ export function LineAssetsIndicator({
           {entries.map((e, i) => {
             const badge = unitFulfillmentBadge(e.status, e.returnCondition);
             const canReassign =
+              !disableReassign &&
               !!reassignCtx &&
               e.serialised &&
               !!e.unitId &&

--- a/src/lib/equipment-tab-reconstruct.ts
+++ b/src/lib/equipment-tab-reconstruct.ts
@@ -214,8 +214,8 @@ function buildContext(bundle: EquipmentTabBundleData): EquipmentContext {
   // reconstructProjectEquipmentTree does, then index by lineItemId. `expand()`
   // attaches these to every line AND recurses into kit/accessory children, so a
   // multi-qty serialised line expands into per-unit tags and kit-member serials
-  // surface too. Kit members store their serial on `line.assetId` (no unit row),
-  // handled at the render layer.
+  // surface too. Kit members now carry their serial on their own per-unit row
+  // (like loose gear) — the render layer shows tag + fulfillment status from it.
   const units: UnitWithAssetSelect[] = bundle.units.map((u) => {
     const m = mapUnitDoc(u);
     return {

--- a/src/lib/pdfme/plugins/get-asset-tag.test.ts
+++ b/src/lib/pdfme/plugins/get-asset-tag.test.ts
@@ -90,6 +90,19 @@ describe("getAssetTag", () => {
     expect(getAssetTag(li, false)).toBe("CHILD-ASSET");
   });
 
+  it("kit child WITH a unit → the unit's tag, identical to the legacy line.asset (migration is render-neutral)", () => {
+    // Post kit per-unit migration a member carries its serial on a unit row. The
+    // unit's assetId equals the line's, so the resolved tag is the SAME single
+    // string as before — the docket renders identically to pre-migration.
+    const li = lineItem({
+      isKitChild: true,
+      quantity: 1,
+      asset: { assetTag: "CHILD-ASSET" },
+      units: [{ id: "u1", asset: { assetTag: "CHILD-ASSET" }, bulkAsset: null, status: "CHECKED_OUT" }],
+    });
+    expect(getAssetTag(li, false)).toBe("CHILD-ASSET");
+  });
+
   it("falls back to bulkAsset when no units and no asset", () => {
     const li = lineItem({
       bulkAsset: { assetTag: "BULK-CABLE" },

--- a/src/lib/pdfme/section-renderer.test.ts
+++ b/src/lib/pdfme/section-renderer.test.ts
@@ -252,6 +252,27 @@ describe("estimateSectionHeight", () => {
       expect(estimateSectionHeight(section, d)).toBeCloseTo(13.7, 0);
     });
 
+    it("a qty-1 kit member reserves the same height with or without a unit (per-unit migration is height-neutral, no tail-drop)", () => {
+      // The kit per-unit migration gives every kit member a projectLineItemUnit.
+      // A serialised member is qty-1, and the per-unit height branch is gated on
+      // child.quantity > 1 — so a member's single unit must NOT change reserved
+      // height, or the plugin would render rows the calculator didn't reserve and
+      // silently drop tail items (the v0.8.1.1-class bug).
+      const settings: TableSectionSettings = {
+        showGroupHeaders: false, showKitChildren: true, showCheckboxes: false,
+        showConditionColumns: false, showPricing: true, showBadges: true, showNotes: true,
+        showPerUnitCheckboxes: true, showAssetTags: true, showCategories: false, showRowNumbers: false,
+      };
+      const kitParent = (childUnits?: DocumentLineItem["units"]) =>
+        makeLineItem({
+          id: "kit", kitId: "k1", isKitChild: false,
+          childLineItems: [makeLineItem({ id: "m1", isKitChild: true, quantity: 1, asset: { assetTag: "A-1" }, units: childUnits })],
+        });
+      const withoutUnit = estimateSectionHeight(makeSection("table", settings), makeData({ line_items: [kitParent(undefined)] }));
+      const withUnit = estimateSectionHeight(makeSection("table", settings), makeData({ line_items: [kitParent([{ id: "u1", asset: { assetTag: "A-1" }, bulkAsset: null, status: "CHECKED_OUT" }])] }));
+      expect(withUnit).toBeCloseTo(withoutUnit, 5);
+    });
+
     it("includes group-row childLineItems in height (kit-style group parents)", () => {
       // Regression: structureLineItems attaches non-kit group members as
       // childLineItems on the synthetic group row. The plugin renders those


### PR DESCRIPTION
Phase 3 of the kit per-unit fulfillment migration ([design doc](../blob/feat/kit-per-unit-surface/docs/designs/kit-per-unit-fulfillment.md)). Phases 1+2 (write path + backfill) shipped in #409 and the backfill has been run on prod (120 units). This makes kit members **visible** and finishes the cutover.

## 1. Surface on the equipment tab
Kit members now render with the same `LineAssetsIndicator` every other line uses — **tag + fulfillment status badge (Deployed/Returned/…) + movement history** — instead of a bare inline tag with no status. Mobile + table views both updated. Reassign is suppressed via a new `disableReassign` prop, because the reassign mutation rejects kit children (per-kit-slot reassign is Phase 4).

## 2. PDF — zero change needed, locked by tests
A qty-1 kit member with one unit renders **identically** to before: `getAssetTag` prefers units and collapses a single unit to its one tag, and every per-unit render + `calculateItemHeight` branch is gated on `quantity > 1`. Added a `getAssetTag` regression (kit child with a unit → same tag as legacy `line.asset`) and a section-renderer **height-invariance** test (unit present vs absent → identical reserved height — guards the silent tail-drop bug).

## 3. Strip the belt + add the parity guard
- **Removed** the 10 `setAssetsStatus(kitSerializedAssetIds(...))` calls across checkout/checkin/undeploy/unreturn/forceReturn — the *definition-driven* asset flip. Asset status now flips **solely from the project's child-line snapshot** (which mirrors the units), never the live kit definition. The child-line flips (the project's actual member assets) stay.
- **Added** `assertKitCompositionParity` to `checkoutKit`: errors `KIT_COMPOSITION_DRIFT` when a project's kit snapshot diverges from the live `kitSerializedItems` (i.e. the deploy set ≠ the set T&T verifies). `kitSerializedItems` remains the definition + verification source.

## ⚠️ Behavior change to know about
The parity guard **will block checkout of a kit whose definition was edited after it was added to a project** (until the operator removes + re-adds the kit to resync). This is intentional — it prevents deploying an unverified asset set — but if such drift exists on active prod projects, those checkouts will start erroring. If that's a concern we can soften it to a warning; flagging for a conscious call.

## Not in this PR
- `line.assetId` column drop for kit children (parent design's deferred follow-up).
- **Phase 4** — reassign for kit members.

## Testing
- 19 kit integration tests (incl. 2 parity), 3 new PDF/UI tests. Full convex suite green (**276**), affected frontend suites green (122 across 9 files). `tsc` clean, 0 new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)