### PR TITLE
feat(kits): kit per-unit fulfillment — Phase 4 (member serial reassign)

### DIFF
--- a/FEATUREDOCS/60-assets-on-a-job.md
+++ b/FEATUREDOCS/60-assets-on-a-job.md
@@ -23,8 +23,10 @@ on the container — see also [48](./48-child-assets-accessories.md):
 > Physical kit members were migrated onto per-unit `projectLineItemUnit` rows (the
 > kit per-unit fulfillment migration — `docs/designs/kit-per-unit-fulfillment.md`).
 > They still keep `line.assetId` for now, but fulfillment (deploy/return status,
-> history) is driven by the unit. Per-kit-slot reassign is not yet available (the
-> reassign mutation rejects kit children), so their Move control is suppressed.
+> history) is driven by the unit. A kit member binds to its slot, so instead of the
+> loose "Move to another line" it offers **"Swap"** — pick a same-model available
+> serial (before deployment). See `reassignKitMemberSerial` + the model-based kit
+> composition parity guard.
 
 A **group** (`projectGroups`) is a priced bundle only — it adds nothing to serial
 storage; its members behave exactly like loose lines. Only a **kit** (`kits`, has

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -264,6 +264,66 @@ describe("kit per-unit — composition parity guard (Phase 3)", () => {
   });
 });
 
+describe("kit per-unit — member serial reassign (Phase 4)", () => {
+  async function seedKitWithSpare(t: T) {
+    await seedKit(t); // member a1 (model m1) on kit k1 / project p1
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "A-2", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+  }
+  const memberUnit = async (t: T) => (await memberUnits(t))[0];
+  const reassign = (t: T, unitId: string, newAssetId: string) =>
+    t.withIdentity(SERVICE).mutation(api.warehouseOps.reassignKitMemberSerial, { organizationId: ORG, unitId, newAssetId });
+  const childAssetId = (t: T, lineItemId: string) =>
+    t.run(async (ctx) => (await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", lineItemId)).unique())?.assetId);
+
+  test("swaps the member's serial on the unit AND its child line (pre-deployment)", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithSpare(t);
+    const u0 = await memberUnit(t);
+    const res = await reassign(t, u0.id as string, "a2");
+    expect(res.moved).toBe(true);
+    const u = await memberUnit(t);
+    expect(u.assetId).toBe("a2");
+    expect(await childAssetId(t, u.lineItemId as string)).toBe("a2");
+  });
+
+  test("after a same-model swap, checkout passes the (model-based) parity guard and deploys the new serial", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithSpare(t);
+    await reassign(t, (await memberUnit(t)).id as string, "a2");
+    await expect(co(t)).resolves.toBeTruthy();
+    const a2 = await t.run(async (ctx) => (await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a2")).unique())?.status);
+    expect(a2).toBe("CHECKED_OUT");
+  });
+
+  test("rejects reassign once the member is deployed", async () => {
+    const t = convexTest(schema, modules);
+    await seedKitWithSpare(t);
+    await co(t);
+    await expect(reassign(t, (await memberUnit(t)).id as string, "a2")).rejects.toThrow(/deployed/i);
+  });
+
+  test("rejects a different-model replacement", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Other", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "aX", organizationId: ORG, modelId: "m2", assetTag: "X-1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(reassign(t, (await memberUnit(t)).id as string, "aX")).rejects.toThrow(/same model/i);
+  });
+
+  test("rejects an unavailable replacement", async () => {
+    const t = convexTest(schema, modules);
+    await seedKit(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "A-2", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(reassign(t, (await memberUnit(t)).id as string, "a2")).rejects.toThrow(/not available/i);
+  });
+});
+
 describe("kit per-unit — pre-change kit (no units)", () => {
   test("checkinKit does not throw and creates no units for a unit-less kit", async () => {
     const t = convexTest(schema, modules);

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -349,20 +349,35 @@ async function kitSerializedAssetIds(ctx: Ctx, kitId: string): Promise<string[]>
  * error and make the operator re-add the kit to resync, rather than silently
  * deploying an unverified set. Serialised members only (bulk uses availability,
  * not per-asset status).
+ *
+ * Compared by MODEL + quantity, not exact serial: a per-job serial substitution
+ * (kit-member reassign, Phase 4) legitimately points a member at a different
+ * same-model asset, so exact-serial parity would false-positive. The guard's real
+ * job is STRUCTURAL drift — a member added/removed, or a model changed. Actual
+ * serials are still verified by tag-scan at checkout (T&T + the check flow).
  */
+async function kitModelCounts(ctx: Ctx, assetIds: string[]): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  for (const id of assetIds) {
+    const a = await assetByCuid(ctx, id);
+    const model = a?.modelId ?? `__no-model:${id}`;
+    counts.set(model, (counts.get(model) ?? 0) + 1);
+  }
+  return counts;
+}
+
 async function assertKitCompositionParity(ctx: Ctx, kitLineId: string, kitId: string, organizationId: string) {
   const children = await childLines(ctx, kitLineId, organizationId);
-  const snapshot = new Set(children.filter((c) => !c.kitId && c.assetId).map((c) => c.assetId!));
-  const definition = new Set(await kitSerializedAssetIds(ctx, kitId));
-  const missing = [...definition].filter((id) => !snapshot.has(id));
-  const extra = [...snapshot].filter((id) => !definition.has(id));
-  if (missing.length > 0 || extra.length > 0) {
+  const snapshot = await kitModelCounts(ctx, children.filter((c) => !c.kitId && c.assetId).map((c) => c.assetId!));
+  const definition = await kitModelCounts(ctx, await kitSerializedAssetIds(ctx, kitId));
+  const models = new Set([...snapshot.keys(), ...definition.keys()]);
+  const driftModels = [...models].filter((m) => (snapshot.get(m) ?? 0) !== (definition.get(m) ?? 0));
+  if (driftModels.length > 0) {
     throw new ConvexError({
       kind: "KIT_COMPOSITION_DRIFT",
       kitId,
-      message: "This kit's contents changed since it was added to the project. Remove and re-add the kit to resync, then deploy.",
-      missing,
-      extra,
+      message: "This kit's contents (models/quantities) changed since it was added to the project. Remove and re-add the kit to resync, then deploy.",
+      driftModels,
     });
   }
 }
@@ -1236,5 +1251,61 @@ export const reassignSerialisedUnit = mutation({
       fromLineItemId: sourceLineId,
       toLineItemId: targetLineItemId,
     };
+  },
+});
+
+/**
+ * Kit-member serial reassign (Phase 4). A kit member is bound to its kit slot, so
+ * "reassign" here means SWAP which physical serial fills that slot on this job —
+ * point the member's unit (and its snapshot child line) at a different same-model
+ * AVAILABLE asset — NOT move it to another line (that's reassignSerialisedUnit for
+ * loose gear). The kit DEFINITION (kitSerializedItems) is shared across projects
+ * and is never touched; only this project's snapshot changes. The parity guard is
+ * model-based, so a same-model swap doesn't trip it.
+ *
+ * Before deployment only: once the member is CHECKED_OUT the asset is physically
+ * out, so a swap would be a physical return+redeploy (out of scope — un-deploy the
+ * kit first). Pre-deployment neither asset's status changes (both stay AVAILABLE
+ * until checkout), so this is a pure pointer swap.
+ */
+export const reassignKitMemberSerial = mutation({
+  args: { organizationId: v.string(), unitId: v.string(), newAssetId: v.string() },
+  handler: async (ctx, { organizationId, unitId, newAssetId }) => {
+    await requireService(ctx);
+    const unit = await unitByCuid(ctx, unitId);
+    if (!unit || unit.organizationId !== organizationId) throw new ConvexError("Unit not found in this organization");
+    if (!unit.assetId) throw new ConvexError("Only serialised (asset-tagged) members can be reassigned");
+    if (unit.status === "CHECKED_OUT") throw new ConvexError("This member is deployed — un-deploy the kit before swapping its serial");
+    if (unit.status === "RETURNED" || unit.status === "CANCELLED") throw new ConvexError("Returned units are history and can't be reassigned");
+    if (unit.assetId === newAssetId) return { moved: false as const };
+
+    const line = await lineByCuid(ctx, unit.lineItemId);
+    if (!line) throw new ConvexError("Line not found");
+    if (!line.isKitChild) throw new ConvexError("Loose gear reassigns by line — use reassignSerialisedUnit");
+
+    const [current, next] = await Promise.all([assetByCuid(ctx, unit.assetId), assetByCuid(ctx, newAssetId)]);
+    if (!current) throw new ConvexError("Current asset not found");
+    if (!next || next.organizationId !== organizationId) throw new ConvexError("Replacement asset not found in this organization");
+    if (!next.modelId || next.modelId !== current.modelId) throw new ConvexError("Replacement must be the same model");
+    if (next.status !== "AVAILABLE") throw new ConvexError(`${next.assetTag} is not available`);
+    if (next.isActive === false) throw new ConvexError(`${next.assetTag} is retired`);
+
+    // The replacement must not already fill another live member of THIS kit.
+    if (line.parentLineItemId) {
+      for (const sib of await childLines(ctx, line.parentLineItemId, organizationId)) {
+        const sibUnits = await lineUnits(ctx, sib.id);
+        if (sibUnits.some((u) => u.assetId === newAssetId && u.status !== "CANCELLED" && u.status !== "RETURNED")) {
+          throw new ConvexError(`${next.assetTag} is already assigned to this kit`);
+        }
+      }
+    }
+
+    const now = Date.now();
+    // Swap the serial on both the unit and its snapshot child line. Pre-deployment
+    // neither asset's status changes (both AVAILABLE until checkout).
+    await ctx.db.patch(unit._id, { assetId: newAssetId, updatedAt: now });
+    await ctx.db.patch(line._id, { assetId: newAssetId, updatedAt: now });
+    await syncLineItemRollup(ctx, line.id);
+    return { moved: true as const, fromAssetTag: current.assetTag, toAssetTag: next.assetTag, lineItemId: line.id };
   },
 });

--- a/docs/designs/kit-per-unit-fulfillment.md
+++ b/docs/designs/kit-per-unit-fulfillment.md
@@ -270,13 +270,30 @@ seeded at creation).
   children (now stored on the unit). Coordinate with that design; likely its own
   follow-up PR.
 
-### Phase 4 (follow-up, scoped separately) — reassign for kit members
-Today `reassignSerialisedUnit` blocks kit children
-(`warehouseOps.ts:1046`). A kit member's identity is tied to its kit slot, so
-"reassign" means **swap which serial fills a same-model slot within the same
-kit**, not move it to a loose line. Decide the guard model (same-kit +
-same-model slot) before enabling. **Out of scope for Phases 1–3**; visibility +
-per-unit lifecycle + history land first.
+### Phase 4 — reassign for kit members — COMPLETE (2026-07-12)
+A kit member binds to its kit slot, so "reassign" = **swap which serial fills
+that slot on this job** (point the member's unit + snapshot child line at a
+different same-model AVAILABLE asset), NOT move to a loose line. The shared kit
+definition (`kitSerializedItems`) is never touched — only this project's snapshot.
+
+- **`reassignKitMemberSerial`** mutation (`warehouseOps.ts`) — **before deployment
+  only** (member not CHECKED_OUT); pre-deployment it's a pure pointer swap (no
+  asset-status change). Guards: serialised, kit child, not deployed, same model,
+  replacement AVAILABLE + not already in this kit. Server action with
+  `requirePermission` + `logActivity`.
+- **Parity guard relaxed to model-based** — this was the key coupling: an exact-
+  serial guard would false-positive on every swap, so `assertKitCompositionParity`
+  now compares **models + quantities**. A same-model swap passes; structural drift
+  (member added/removed, wrong model) still errors. Actual serials are still
+  verified by tag-scan at checkout (T&T).
+- **UI** — kit-member rows get a **"Swap"** control on `LineAssetsIndicator`
+  (new `kitMember` prop): pick a same-model available serial (sourced via
+  `assets.listByModelIds` for the kit-member models, exposed on the reassign
+  context as `serialsByModel`). Loose-gear "Move" stays suppressed for kit members;
+  accessories stay fully suppressed (`disableReassign`).
+
+Still deferred: the `line.assetId` column drop for kit children (parent design's
+follow-up).
 
 ## Performance — Convex-native, one call per kit operation (hard invariant)
 

--- a/src/components/projects/__tests__/line-assets-indicator.smoke.test.tsx
+++ b/src/components/projects/__tests__/line-assets-indicator.smoke.test.tsx
@@ -32,15 +32,15 @@ describe("LineAssetsIndicator (smoke)", () => {
     expect(screen.getByRole("button", { name: /2 assets assigned/i })).toBeTruthy();
   });
 
-  it("renders for a kit member with reassign suppressed (disableReassign) without crashing", () => {
-    // Kit members now use the same indicator as every line, but the reassign
-    // mutation rejects kit children — so the Move control is suppressed here.
+  it("renders a kit member (kitMember) without crashing — swap flow, no loose Move", () => {
+    // Kit members use the same indicator as every line, but swap their SERIAL
+    // (same-model available asset) rather than move to another line.
     render(
       <LineAssetsIndicator
         lineItemId="kc1"
         modelId="m1"
-        disableReassign
-        units={[{ id: "u1", status: "CHECKED_OUT", asset: { id: "a1", assetTag: "KIT-MEM-1" } }]}
+        kitMember
+        units={[{ id: "u1", status: "CONFIRMED", asset: { id: "a1", assetTag: "KIT-MEM-1" } }]}
       />,
     );
     expect(screen.getByRole("button", { name: /1 asset assigned/i })).toBeTruthy();

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -1442,7 +1442,7 @@ export function LineItemRow({
                       — same indicator (tag + fulfillment status + history) as every
                       other line. Reassign is suppressed: the mutation rejects kit
                       children (per-kit-slot reassign is Phase 4). */}
-                  <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign />
+                  <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign={child.childKind === "ACCESSORY"} kitMember={child.childKind !== "ACCESSORY"} />
                   {child.childKind === "ACCESSORY" && (
                     <Badge status="neutral" className="px-1.5 py-0 text-[10px]">Accessory</Badge>
                   )}
@@ -1729,7 +1729,7 @@ export function LineItemRow({
                   row — same indicator (tag + fulfillment status + history) as every
                   other line. Reassign is suppressed: the mutation rejects kit
                   children (per-kit-slot reassign is Phase 4). */}
-              <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign />
+              <LineAssetsIndicator units={child.units} lineAssetTag={child.asset?.assetTag} lineItemId={child.id} modelId={child.modelId} disableReassign={child.childKind === "ACCESSORY"} kitMember={child.childKind !== "ACCESSORY"} />
               {child.childKind === "ACCESSORY" && (
                 <Badge status="neutral" className="text-[10px] px-1.5 py-0">
                   Accessory

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -117,8 +117,8 @@ import {
   type MixedGroupSlot,
   type OverbookedInfo,
 } from "./equipment-rows";
-import { ReassignProvider, type ReassignTarget } from "./reassign-context";
-import { reassignLineItemUnit } from "@/server/warehouse";
+import { ReassignProvider, type ReassignTarget, type ReassignSerial } from "./reassign-context";
+import { reassignLineItemUnit, reassignKitMemberSerial } from "@/server/warehouse";
 import { useSelection } from "./use-selection";
 import { targetKey } from "@/lib/collaboration-targets";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -376,13 +376,65 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
     [projectId],
   );
 
+  // Kit-member reassign (Phase 4): a member swaps its SERIAL (a same-model
+  // AVAILABLE asset), not its line. Gather the models present as kit members, load
+  // available inventory for just those models, and expose a serials-by-model map +
+  // swap handler alongside the loose-gear line targets.
+  const kitMemberModelIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    const scan = (line: LineItemData) => {
+      for (const c of line.childLineItems ?? []) {
+        if (c.isKitChild && c.childKind !== "ACCESSORY" && c.modelId) ids.add(c.modelId);
+      }
+    };
+    for (const cat of categories as CategoryData[]) {
+      for (const li of cat.lineItems ?? []) scan(li);
+      for (const g of cat.groups ?? []) for (const li of g.lineItems ?? []) scan(li);
+    }
+    for (const li of uncategorizedItems as LineItemData[]) scan(li);
+    for (const g of uncategorizedProjectGroups as GroupData[]) for (const li of g.lineItems ?? []) scan(li);
+    return [...ids];
+  }, [categories, uncategorizedItems, uncategorizedProjectGroups]);
+
+  const availableKitAssets = useAuthedQuery(
+    api.assets.listByModelIds,
+    orgId && kitMemberModelIds.length > 0 ? { orgId, modelIds: kitMemberModelIds } : "skip",
+  );
+
+  const reassignSerialsByModel = React.useMemo(() => {
+    const map = new Map<string, ReassignSerial[]>();
+    for (const a of availableKitAssets ?? []) {
+      if (a.status !== "AVAILABLE" || a.isActive === false || !a.modelId || !a.assetTag) continue;
+      const arr = map.get(a.modelId) ?? [];
+      arr.push({ assetId: a.id, assetTag: a.assetTag });
+      map.set(a.modelId, arr);
+    }
+    for (const arr of map.values()) arr.sort((x, y) => x.assetTag.localeCompare(y.assetTag));
+    return map;
+  }, [availableKitAssets]);
+
+  const handleReassignKitMember = useCallback(
+    (unitId: string, newAssetId: string) => {
+      setReassignPendingUnitId(unitId);
+      reassignKitMemberSerial(projectId, unitId, newAssetId)
+        .then((res) => {
+          if (res.moved) toast.success(`Swapped kit serial to ${res.toAssetTag ?? "the new asset"}`);
+        })
+        .catch((e: unknown) => toast.error(e instanceof Error ? e.message : "Couldn't swap that serial"))
+        .finally(() => setReassignPendingUnitId(null));
+    },
+    [projectId],
+  );
+
   const reassignValue = React.useMemo(
     () => ({
       targetsByModel: reassignTargetsByModel,
       reassign: handleReassignUnit,
       pendingUnitId: reassignPendingUnitId,
+      serialsByModel: reassignSerialsByModel,
+      reassignKitMember: handleReassignKitMember,
     }),
-    [reassignTargetsByModel, handleReassignUnit, reassignPendingUnitId],
+    [reassignTargetsByModel, handleReassignUnit, reassignPendingUnitId, reassignSerialsByModel, handleReassignKitMember],
   );
   const overbookedMap = native.overbookedMap;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/projects/line-assets-indicator.tsx
+++ b/src/components/projects/line-assets-indicator.tsx
@@ -56,16 +56,19 @@ export function LineAssetsIndicator({
   lineItemId,
   modelId,
   disableReassign = false,
+  kitMember = false,
 }: {
   units?: IndicatorUnit[];
   /** Fallback for single-asset legacy lines that carry the tag on the line itself. */
   lineAssetTag?: string | null;
   lineItemId: string;
   modelId?: string | null;
-  /** Suppress the Move control. Kit members bind to their kit slot — the reassign
-   *  mutation rejects kit children — so they view tag/status/history but can't
-   *  reassign until per-kit-slot reassign lands (Phase 4). */
+  /** Suppress the loose "Move to another line" control (read-only consumers). */
   disableReassign?: boolean;
+  /** This line is a kit member: it binds to its kit slot, so instead of moving to
+   *  another line it offers "Swap serial" — pick a same-model AVAILABLE asset
+   *  (Phase 4). Only before deployment. */
+  kitMember?: boolean;
 }) {
   const reassignCtx = useReassign();
 
@@ -92,6 +95,9 @@ export function LineAssetsIndicator({
   const targets = reassignCtx
     ? (reassignCtx.targetsByModel.get(modelId ?? "") ?? []).filter((t) => t.id !== lineItemId)
     : [];
+  // Kit members swap their serial (same-model available inventory), not their line.
+  const swapSerials =
+    kitMember && reassignCtx?.serialsByModel ? (reassignCtx.serialsByModel.get(modelId ?? "") ?? []) : [];
 
   return (
     <Popover>
@@ -137,14 +143,25 @@ export function LineAssetsIndicator({
         <div className="space-y-0.5 p-1.5">
           {entries.map((e, i) => {
             const badge = unitFulfillmentBadge(e.status, e.returnCondition);
+            const deployedOrGone = e.status === "CHECKED_OUT" || e.status === "RETURNED" || e.status === "CANCELLED";
             const canReassign =
               !disableReassign &&
+              !kitMember &&
               !!reassignCtx &&
               e.serialised &&
               !!e.unitId &&
               e.status !== "RETURNED" &&
               e.status !== "CANCELLED" &&
               targets.length > 0;
+            // Kit member, not yet deployed: offer same-model available serials to swap in.
+            const swapOptions = swapSerials.filter((s) => s.assetId !== e.assetId);
+            const canSwap =
+              kitMember &&
+              !!reassignCtx?.reassignKitMember &&
+              e.serialised &&
+              !!e.unitId &&
+              !deployedOrGone &&
+              swapOptions.length > 0;
             return (
               <div key={i} className="flex items-center justify-between gap-2 rounded-sm px-1.5 py-1">
                 <div className="flex min-w-0 items-center gap-1.5">
@@ -180,6 +197,33 @@ export function LineAssetsIndicator({
                             >
                               {t.label}
                               {t.full ? " · full" : ""}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                  {canSwap && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={reassignCtx!.pendingUnitId === e.unitId}
+                          className="h-7 px-2 text-caption text-muted hover:text-ink"
+                        >
+                          {reassignCtx!.pendingUnitId === e.unitId ? "Swapping…" : "Swap"}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
+                        <DropdownMenuGroup>
+                          <DropdownMenuLabel>Swap {e.tag} for…</DropdownMenuLabel>
+                          {swapOptions.map((s) => (
+                            <DropdownMenuItem
+                              key={s.assetId}
+                              onClick={() => reassignCtx!.reassignKitMember!(e.unitId, s.assetId)}
+                            >
+                              {s.assetTag}
                             </DropdownMenuItem>
                           ))}
                         </DropdownMenuGroup>

--- a/src/components/projects/reassign-context.tsx
+++ b/src/components/projects/reassign-context.tsx
@@ -20,6 +20,12 @@ export interface ReassignTarget {
   full: boolean;
 }
 
+/** An available same-model serial a kit member can be swapped to (Phase 4). */
+export interface ReassignSerial {
+  assetId: string;
+  assetTag: string;
+}
+
 export interface ReassignContextValue {
   /** modelId → candidate target lines on this project (same model). */
   targetsByModel: Map<string, ReassignTarget[]>;
@@ -28,6 +34,12 @@ export interface ReassignContextValue {
   reassign: (unitId: string, targetLineItemId: string) => void;
   /** Unit currently mid-move (disables its control). */
   pendingUnitId: string | null;
+  /** modelId → AVAILABLE inventory serials a kit member can swap to. A kit member
+   *  binds to its slot, so it swaps its SERIAL (same-model available asset) rather
+   *  than moving to another line. Absent on read-only consumers. */
+  serialsByModel?: Map<string, ReassignSerial[]>;
+  /** Swap which serial fills a kit member's slot on this job. */
+  reassignKitMember?: (unitId: string, newAssetId: string) => void;
 }
 
 const ReassignContext = createContext<ReassignContextValue | null>(null);

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -418,6 +418,40 @@ export async function reassignLineItemUnit(
   return serialize(res);
 }
 
+/**
+ * Swap which physical serial fills a kit member's slot on this job (Phase 4).
+ * Distinct from reassignLineItemUnit: kit members bind to their slot, so we swap
+ * the member's asset rather than move it to another line. The live subscription
+ * reflects the swap; no revalidate.
+ */
+export async function reassignKitMemberSerial(
+  projectId: string,
+  unitId: string,
+  newAssetId: string,
+) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
+  const convex = await getConvexClient();
+  const res = await convex.mutation(api.warehouseOps.reassignKitMemberSerial, {
+    organizationId,
+    unitId,
+    newAssetId,
+  });
+  if (res.moved) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "UPDATE",
+      entityType: "asset",
+      entityId: res.toAssetTag ?? newAssetId,
+      entityName: res.toAssetTag ? `Asset ${res.toAssetTag}` : `Asset ${newAssetId}`,
+      summary: `Swapped kit member ${res.fromAssetTag ?? "serial"} → ${res.toAssetTag ?? newAssetId}`,
+      projectId,
+    });
+  }
+  return serialize(res);
+}
+
 export async function checkInItems(
   projectId: string,
   items: Array<{


### PR DESCRIPTION
Phase 4 (final phase) of the kit per-unit fulfillment migration ([design doc](../blob/feat/kit-member-reassign/docs/designs/kit-per-unit-fulfillment.md)). Phases 1-3 shipped in #409 + #414. This lets you correct which physical serial fills a kit member's slot on a job.

## What it does
A kit member binds to its kit slot, so "reassign" ≠ the loose-gear move. It's a **serial swap**: point the member's unit + snapshot child line at a different **same-model AVAILABLE** asset. The shared kit definition (`kitSerializedItems`) is never touched — only this project's snapshot.

- **`reassignKitMemberSerial`** mutation — before-deployment only (member not `CHECKED_OUT`); pre-deployment it's a pure pointer swap (no asset-status change). Guards: serialised, kit child, not deployed, same model, replacement available + not already in this kit. Server action with `requirePermission` + `logActivity`.
- **UI** — kit-member rows get a **"Swap"** control on `LineAssetsIndicator` (new `kitMember` prop): pick a same-model available serial, sourced via `assets.listByModelIds` for the kit-member models (exposed on the reassign context as `serialsByModel`). Loose "Move" stays suppressed for kit members; accessories stay fully suppressed.

## Key coupling: the #414 parity guard is relaxed to model-based
This is the important part. A serial swap makes the project snapshot diverge from the kit definition **by serial** — the exact-serial parity guard I shipped in #414 would reject it. So `assertKitCompositionParity` now compares **models + quantities**, not exact serials:
- A same-model swap **passes** (right models, right count).
- Structural drift (member added/removed, different model) **still errors** `KIT_COMPOSITION_DRIFT`.
- Actual serials are still verified by tag-scan at checkout (T&T + the check flow).

This is arguably the more correct guard — it catches structural problems while allowing legitimate per-job substitution. (You approved this relaxation.)

## Not in this PR
- `line.assetId` column drop for kit children (parent design's deferred follow-up).
- Post-deployment serial swap (a physical return+redeploy) — deliberately scoped out.

## Testing
- 5 new reassign integration tests (swap on unit+child line; **swap-then-checkout passes the model-based parity guard**; rejects when deployed / different model / unavailable). Full convex suite green (**285**). Component/UI suites green. `tsc` clean, 0 new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)