### PR TITLE
perf(convex): cut overbooking.bundle Database I/O (Phase 0)

### DIFF
--- a/convex/overbooking.ts
+++ b/convex/overbooking.ts
@@ -22,20 +22,34 @@ export const bundle = query({
       throw new ConvexError("overbooking.bundle: too many modelIds (" + unique.length + " > 1000)");
     }
 
-    const [lineItemGroups, assetGroups, bulkGroups, projects, models] = await Promise.all([
+    const [lineItemGroups, assetGroups, bulkGroups] = await Promise.all([
       Promise.all(unique.map((mid) => ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
       Promise.all(unique.map((mid) => ctx.db.query("assets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
       Promise.all(unique.map((mid) => ctx.db.query("bulkAssets").withIndex("by_modelId", (q) => q.eq("modelId", mid)).collect())),
-      ctx.db.query("projects").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
-      ctx.db.query("models").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
+    ]);
+
+    const lineItems = lineItemGroups.flat().filter((r) => r.organizationId === orgId);
+    const assets = assetGroups.flat().filter((r) => r.organizationId === orgId);
+    const bulkAssets = bulkGroups.flat().filter((r) => r.organizationId === orgId);
+
+    // REFERENCED-ONLY reads (NOT whole-table). The consumer (reconstructOverbookedStatus)
+    // looks projects/models up BY ID — so it only needs the projects these line items
+    // belong to (for the date-window join) and the passed models (for the stock
+    // breakdown). Previously this .collect()'d EVERY project + EVERY model in the org
+    // and, being a reactive subscription, re-read both whole tables on ANY project/model
+    // write org-wide — the dominant Database-I/O cost. by_cuid is global, so re-check org.
+    const projectIds = [...new Set(lineItems.map((li) => li.projectId))];
+    const [projectDocs, modelDocs] = await Promise.all([
+      Promise.all(projectIds.map((pid) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique())),
+      Promise.all(unique.map((mid) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", mid)).unique())),
     ]);
 
     return {
-      lineItems: lineItemGroups.flat().filter((r) => r.organizationId === orgId),
-      assets: assetGroups.flat().filter((r) => r.organizationId === orgId),
-      bulkAssets: bulkGroups.flat().filter((r) => r.organizationId === orgId),
-      projects,
-      models,
+      lineItems,
+      assets,
+      bulkAssets,
+      projects: projectDocs.filter((p): p is NonNullable<typeof p> => !!p && p.organizationId === orgId),
+      models: modelDocs.filter((m): m is NonNullable<typeof m> => !!m && m.organizationId === orgId),
     };
   },
 });

--- a/src/hooks/use-native-equipment-tab.ts
+++ b/src/hooks/use-native-equipment-tab.ts
@@ -78,7 +78,11 @@ export function useNativeEquipmentTab(
   const project = useProject(enabled ? projectId : undefined);
 
   // Overbooked: referenced models from the FLAT non-cancelled line items (mirrors
-  // getProjectOverbookedStatus's modelIds). Skip the subscription when none.
+  // getProjectOverbookedStatus's modelIds AND relevantOverbookModelIds). Skip the
+  // subscription when none. `.sort()` matches relevantOverbookModelIds so the
+  // overbooking.bundle args are byte-identical to useNativeProjectDetail's on the
+  // same page → Convex's query cache serves ONE subscription instead of two
+  // (halves this query's Database I/O). See relevantOverbookModelIds.
   const modelIds = useMemo(() => {
     if (!bundle) return undefined;
     return [
@@ -87,7 +91,7 @@ export function useNativeEquipmentTab(
           .filter((li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null)
           .map((li) => li.modelId!),
       ),
-    ];
+    ].sort();
   }, [bundle]);
   const overbooking = useAuthedQuery(
     api.overbooking.bundle,

--- a/src/lib/overbooking-core.ts
+++ b/src/lib/overbooking-core.ts
@@ -175,13 +175,21 @@ export type OverbookingBundleData = FunctionReturnType<typeof api.overbooking.bu
  * needs (mirrors the server's modelIds derivation).
  */
 export function relevantOverbookModelIds(lineItems: OverbookLineItem[]): string[] {
+  // Sorted so the returned array is DETERMINISTIC for a given set of models.
+  // The overbooking.bundle subscription is keyed on this array; two hooks on the
+  // project-detail page (useNativeProjectDetail + useNativeEquipmentTab) derive it
+  // from different bundles, and Convex's query cache only dedupes byte-identical
+  // args — insertion-order differences would spawn a SECOND subscription that
+  // re-reads the whole org-wide booking set (doubling Database I/O). Sorting makes
+  // both args identical so the cache serves ONE subscription. Order does not affect
+  // the query result (it re-dedupes modelIds and computes order-independently).
   return [
     ...new Set(
       lineItems
         .filter((li) => li.modelId && li.status !== "CANCELLED" && li.subHireId == null)
         .map((li) => li.modelId!),
     ),
-  ];
+  ].sort();
 }
 
 /**


### PR DESCRIPTION
## Phase 0 — DB I/O efficiency, slice 1

Prod Convex **Database I/O was 5.6× over quota** (5.58 GB / 1 GB) on tiny data (1 org, 3 users) — pure query inefficiency. `overbooking.bundle` was the #1 consumer (19K calls). Two behaviour-preserving fixes:

- **Referenced-only reads** (`convex/overbooking.ts`): it no longer `.collect()`s the whole org `projects` + `models` tables on every call. It point-reads only the projects the line items reference + the passed `modelIds` (`by_cuid`). As a reactive subscription it stops re-reading both whole tables on *any* project/model write org-wide — the dominant I/O cost.
- **Dedupe the double subscription** (`overbooking-core.ts`, `use-native-equipment-tab.ts`): the two project-detail hooks now emit sorted, byte-identical `modelIds`, so Convex's query cache serves **one** subscription instead of two.

### Safety
- Behaviour-preserving: consumers look projects/models up **by id** (`reconstructOverbookedStatus`, `indexProjectsById`, `new Map(models)`), never iterate the full set. Verified by `tsc` + an independent codex review (PASS).
- `projectLineItems.projectId` is required, so no referenced project is missed.

### Rollout
Ships Convex + image via CI. Expected: large drop in Database I/O on the dashboard after deploy. First slice of the efficiency standard in `docs/convex-native-migration-plan.md` Appendix B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)