### PR TITLE
perf(convex): referenced-only project reads (Phase 0)

### DIFF
--- a/convex/availabilityCheck.ts
+++ b/convex/availabilityCheck.ts
@@ -18,18 +18,28 @@ export const checkBundle = query({
   handler: async (ctx, { modelId, orgId }) => {
     await requireService(ctx);
 
-    const [modelDoc, assetsRaw, bulksRaw, lineRaw, projects, accessories] = await Promise.all([
+    const [modelDoc, assetsRaw, bulksRaw, lineRaw, accessories] = await Promise.all([
       ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", modelId)).unique(),
       ctx.db.query("assets").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
       ctx.db.query("bulkAssets").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
       ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
-      ctx.db.query("projects").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
       ctx.db
         .query("modelBulkAccessories")
         .withIndex("by_modelId", (q) => q.eq("modelId", modelId))
         .filter((q) => q.eq(q.field("organizationId"), orgId))
         .collect(),
     ]);
+
+    // projectLineItems.listByModelId org-filters; match it.
+    const lines = lineRaw.filter((r) => r.organizationId === orgId);
+    // REFERENCED-ONLY projects: the consumer (line-items.ts) builds a projectById
+    // map and looks each line's project up by id, so it only needs the projects
+    // these line items reference — not the whole org projects table this previously
+    // .collect()'d on every availability check. by_cuid is global → org-recheck.
+    const projectIds = [...new Set(lines.map((li) => li.projectId))];
+    const projectDocs = await Promise.all(
+      projectIds.map((pid) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique()),
+    );
 
     return {
       // getModelById did not org-filter; we do (org-correct + closes a cross-org
@@ -38,9 +48,8 @@ export const checkBundle = query({
       // getActiveAssetsByModel / getActiveBulkAssetsByModel: isActive !== false.
       activeAssets: assetsRaw.filter((a) => a.isActive !== false),
       activeBulkAssets: bulksRaw.filter((b) => b.isActive !== false),
-      // projectLineItems.listByModelId org-filters; match it.
-      lines: lineRaw.filter((r) => r.organizationId === orgId),
-      projects,
+      lines,
+      projects: projectDocs.filter((p): p is NonNullable<typeof p> => !!p && p.organizationId === orgId),
       bulkAccessoryCount: accessories.length,
     };
   },

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -719,9 +719,17 @@ export const swapLineItemAsset = mutation({
     const startMs = project?.rentalStartDate ?? null;
     const endMs = project?.rentalEndDate ?? null;
     if (startMs != null && endMs != null) {
-      const projects = await ctx.db.query("projects").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
+      // Range-scan only projects that could overlap [startMs, endMs] — an
+      // overlapping project must have rentalStartDate <= endMs — instead of
+      // collecting the whole org projects table on every asset reassign. The JS
+      // e >= startMs check completes the overlap test; null-start projects are
+      // outside the range = correctly skipped (the old loop skipped them too).
       const overlapping = new Set<string>();
-      for (const p of projects) {
+      for await (const p of ctx.db
+        .query("projects")
+        .withIndex("by_organizationId_rentalStartDate", (q) =>
+          q.eq("organizationId", a.organizationId).lte("rentalStartDate", endMs),
+        )) {
         if (p.isTemplate) continue;
         if (DEAD_PROJECT_STATUSES.has(p.status ?? "")) continue;
         const s = p.rentalStartDate ?? null;


### PR DESCRIPTION
## Phase 0 — DB I/O efficiency, slice 3

Two hot paths `.collect()`d the **whole org projects table** on every call:

- **`swapLineItemAsset`** (per asset reassign) — now range-scans `by_organizationId_rentalStartDate` (`rentalStartDate <= endMs`, the only projects that can overlap the window) instead of all org projects. The existing JS `end >= startMs` completes the overlap test.
- **`availabilityCheck.checkBundle`** (per availability check) — now point-reads only the projects the model's line items reference (the consumer builds a `projectById` map and looks up by id), not the whole org projects table.

### Safety
Behavior-preserving. Verified by `tsc` + independent codex review — **PASS on both** (overlap set and projectById lookups identical; null-start projects excluded as before). Appendix B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)