### PR TITLE
perf(convex): index optimizations — fileUploads scan + sortOrder O(N^2) (Phase 0)

### DIFF
--- a/convex/fileUploads.ts
+++ b/convex/fileUploads.ts
@@ -40,8 +40,12 @@ export const getByThumbnailUrl = query({
   args: { thumbnailUrl: v.string() },
   handler: async (ctx, { thumbnailUrl }) => {
     await requireService(ctx);
-    const docs = await ctx.db.query("fileUploads").collect();
-    return docs.find((d) => d.thumbnailUrl === thumbnailUrl) ?? null;
+    // Point-lookup via by_thumbnailUrl instead of scanning the whole (cross-org)
+    // fileUploads table. .first() matches the old .find() (first/only match).
+    return await ctx.db
+      .query("fileUploads")
+      .withIndex("by_thumbnailUrl", (q) => q.eq("thumbnailUrl", thumbnailUrl))
+      .first();
   },
 });
 

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -154,11 +154,14 @@ export const patchNative = mutation({
 
 /** Next sort order for a project's lines (replica of nextLineSort). */
 async function nextLineSort(ctx: MutationCtx, projectId: string, organizationId: string): Promise<number> {
-  const lines = await ctx.db
+  // desc-first on by_projectId_sortOrder (1 doc) instead of collecting all the
+  // project's lines to reduce the max (O(N) per add, O(N^2) across a bulk add).
+  const top = await ctx.db
     .query("projectLineItems")
-    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-    .collect();
-  return lines.filter((l) => l.organizationId === organizationId).reduce((m, l) => Math.max(m, l.sortOrder ?? -1), -1) + 1;
+    .withIndex("by_projectId_sortOrder", (q) => q.eq("projectId", projectId))
+    .order("desc")
+    .first();
+  return ((top && top.organizationId === organizationId ? top.sortOrder : undefined) ?? -1) + 1;
 }
 
 /**

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -318,13 +318,15 @@ export const remove = mutation({
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function nextLineSort(ctx: MutationCtx, projectId: string, organizationId: string): Promise<number> {
-  const lines = await ctx.db
+  // Max sortOrder for the project = desc-first on by_projectId_sortOrder (1 doc),
+  // instead of collecting ALL the project's lines to reduce the max (O(N) per add,
+  // O(N^2) across a bulk add). projectId is org-scoped, so the org check is defensive.
+  const top = await ctx.db
     .query("projectLineItems")
-    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-    .collect();
-  return lines
-    .filter((l) => l.organizationId === organizationId)
-    .reduce((m, l) => Math.max(m, l.sortOrder ?? -1), -1) + 1;
+    .withIndex("by_projectId_sortOrder", (q) => q.eq("projectId", projectId))
+    .order("desc")
+    .first();
+  return ((top && top.organizationId === organizationId ? top.sortOrder : undefined) ?? -1) + 1;
 }
 
 async function deleteLineWithUnits(ctx: MutationCtx, lineDocId: import("./_generated/dataModel").Id<"projectLineItems">, lineCuid: string) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -864,6 +864,10 @@ export default defineSchema({
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
     .index("by_projectId", ["projectId"])
+    // Composite: max(sortOrder) for a project via .order("desc").first() (1 doc)
+    // instead of collecting ALL of a project's lines to reduce the max (O(N) per
+    // add, O(N^2) across a bulk add). Used by nextLineSort.
+    .index("by_projectId_sortOrder", ["projectId", "sortOrder"])
     // Composite: range-scan a project's lines by status (e.g. CHECKED_OUT) instead
     // of collecting ALL of a project's lines and JS-filtering. Used by
     // warehouseOps.checkInBulkTotals (the hottest status-filtered read).
@@ -1104,7 +1108,10 @@ export default defineSchema({
   })
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
-    .index("by_uploadedById", ["uploadedById"]),
+    .index("by_uploadedById", ["uploadedById"])
+    // Point-lookup a fileUpload by its thumbnailUrl instead of scanning the whole
+    // (cross-org) table. Used by getByThumbnailUrl.
+    .index("by_thumbnailUrl", ["thumbnailUrl"]),
 
   // ModelMedia
   modelMedia: defineTable({


### PR DESCRIPTION
## Phase 0 — DB I/O efficiency, slice 4

Two additive indexes + the reads that use them:

- **`fileUploads.getByThumbnailUrl`** — was a full-table, cross-org `.collect().find()`; now a `by_thumbnailUrl` point-lookup.
- **`nextLineSort`** — collected **all** of a project's line items to reduce `max(sortOrder)` (O(N) per add, **O(N²) across a bulk add**); now a `by_projectId_sortOrder` descending `.first()` (1 doc).

### Safety
Additive indexes (Convex backfills them on deploy — no data migration). Behavior-preserving: verified `tsc` + independent codex — **PASS on both swaps and the schema** (desc-first == max-reduce+1 for empty/undefined/normal cases; `.first()` == `.find()`). Appendix B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)