### PR TITLE
feat(api-keys): invert apiKey to Convex (Phase-1 decommission)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as activityLog from "../activityLog.js";
 import type * as activityLogWrites from "../activityLogWrites.js";
+import type * as apiKeys from "../apiKeys.js";
 import type * as assetBulkChildren from "../assetBulkChildren.js";
 import type * as assetDetail from "../assetDetail.js";
 import type * as assetMedia from "../assetMedia.js";
@@ -143,6 +144,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   activityLog: typeof activityLog;
   activityLogWrites: typeof activityLogWrites;
+  apiKeys: typeof apiKeys;
   assetBulkChildren: typeof assetBulkChildren;
   assetDetail: typeof assetDetail;
   assetMedia: typeof assetMedia;

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -1,0 +1,110 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * ApiKey (agent-accessible API/MCP access keys) — Convex-native domain (Phase-1
+ * decommission; the Postgres `api_key` table is frozen). RBAC/validation/audit stay
+ * in the Next.js server actions (`src/server/api-keys.ts`) + the request-auth path
+ * (`src/lib/api-key.ts`); these functions are the trusted-backend SERVICE data layer.
+ *
+ * `getByTokenHash` is the request-auth hot path: the raw token hashes to `tokenHash`,
+ * which is the credential, so a GLOBAL lookup by hash is correct (like by_cuid) — the
+ * returned key carries its own `organizationId`. The org kill-switch + acting-user
+ * name are still read from Postgres (Better-Auth `organization`/`user`, which stay).
+ */
+
+export const list = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("apiKeys")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getByTokenHash = query({
+  args: { tokenHash: v.string() },
+  handler: async (ctx, { tokenHash }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("apiKeys")
+      .withIndex("by_tokenHash", (q) => q.eq("tokenHash", tokenHash))
+      .unique();
+  },
+});
+
+const writeArgs = {
+  id: v.string(),
+  organizationId: v.string(),
+  name: v.string(),
+  prefix: v.string(),
+  tokenHash: v.string(),
+  scopes: v.optional(v.string()),
+  isActive: v.optional(v.boolean()),
+  actingUserId: v.string(),
+  createdById: v.string(),
+  expiresAt: v.optional(v.number()),
+  lastUsedAt: v.optional(v.number()),
+  lastRotatedAt: v.optional(v.number()),
+  revokedAt: v.optional(v.number()),
+  createdAt: v.optional(v.number()),
+};
+
+export const create = mutation({
+  args: writeArgs,
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    // by_cuid / by_tokenHash are non-unique Convex indexes — a duplicate would make
+    // the `.unique()` reads in getByTokenHash/revoke throw a cardinality error and
+    // break auth/revoke. Guard at creation (Postgres had PK + UNIQUE constraints).
+    const dupId = await ctx.db.query("apiKeys").withIndex("by_cuid", (q) => q.eq("id", args.id)).first();
+    if (dupId) throw new ConvexError("apiKey id collision: " + args.id);
+    const dupHash = await ctx.db.query("apiKeys").withIndex("by_tokenHash", (q) => q.eq("tokenHash", args.tokenHash)).first();
+    if (dupHash) throw new ConvexError("apiKey tokenHash collision");
+    return await ctx.db.insert("apiKeys", args);
+  },
+});
+
+export const createIfMissing = mutation({
+  args: writeArgs,
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("apiKeys")
+      .withIndex("by_cuid", (q) => q.eq("id", args.id))
+      .unique();
+    if (existing) return { _id: existing._id, created: false };
+    // Same tokenHash under a DIFFERENT id would break the .unique() auth lookup —
+    // reject rather than insert a colliding hash (idempotent by id, guarded by hash).
+    const dupHash = await ctx.db.query("apiKeys").withIndex("by_tokenHash", (q) => q.eq("tokenHash", args.tokenHash)).first();
+    if (dupHash) throw new ConvexError("apiKey tokenHash collision (different id)");
+    const _id = await ctx.db.insert("apiKeys", args);
+    return { _id, created: true };
+  },
+});
+
+/** Revoke a single key (org-guarded): deactivate + stamp revokedAt. Idempotent. */
+export const revoke = mutation({
+  args: { id: v.string(), orgId: v.string() },
+  handler: async (ctx, { id, orgId }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("apiKeys").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId) throw new ConvexError("apiKey not found: " + id);
+    await ctx.db.patch(doc._id, { isActive: false, revokedAt: Date.now() });
+    return { id: doc.id, name: doc.name };
+  },
+});
+
+/** Best-effort last-used stamp (observability). Never gates auth. */
+export const touchLastUsed = mutation({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("apiKeys").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (doc) await ctx.db.patch(doc._id, { lastUsedAt: Date.now() });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -206,6 +206,30 @@ export default defineSchema({
     .index("by_organizationId_userId", ["organizationId", "userId"])
     .index("by_organizationId_status", ["organizationId", "status"]),
 
+  // ApiKey — agent-accessible API/MCP access keys (docs/designs/api-mcp-agent-access.md).
+  // `by_tokenHash` is the auth verify path (the token IS the credential, so a global
+  // lookup by hash is correct — like by_cuid; the found key carries its own orgId).
+  apiKeys: defineTable({
+    id: v.string(),
+    organizationId: v.string(),
+    name: v.string(),
+    prefix: v.string(),
+    tokenHash: v.string(),
+    scopes: v.optional(v.string()),
+    isActive: v.optional(v.boolean()),
+    actingUserId: v.string(),
+    createdById: v.string(),
+    expiresAt: v.optional(v.number()),
+    lastUsedAt: v.optional(v.number()),
+    lastRotatedAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+    createdAt: v.optional(v.number()),
+  })
+    .index("by_cuid", ["id"])
+    .index("by_organizationId", ["organizationId"])
+    .index("by_tokenHash", ["tokenHash"])
+    .index("by_actingUserId", ["actingUserId"]),
+
   // Category
   categories: defineTable({
     id: v.string(),

--- a/prisma/migrations/20260713120000_drop_api_idempotency_apikey_fk/migration.sql
+++ b/prisma/migrations/20260713120000_drop_api_idempotency_apikey_fk/migration.sql
@@ -1,0 +1,12 @@
+-- Drop the api_idempotency -> api_key FK constraint.
+--
+-- ApiKey inverted to Convex (Phase-1 decommission): new keys are created in Convex
+-- ONLY, so there is no matching frozen Postgres api_key row for their id. The
+-- api_idempotency ledger (still on Postgres) references apiKeyId; with the FK in
+-- place, every idempotency insert for a NEW key would violate the constraint and
+-- fail — and the reserve path swallows that failure, letting a retry re-apply a
+-- stock-moving write. Dropping the constraint makes apiKeyId a plain external id
+-- (matching how every other decommissioned cross-store FK was handled). The
+-- api_idempotency table itself stays on Postgres for now; its full inversion to
+-- Convex is a follow-up.
+ALTER TABLE "api_idempotency" DROP CONSTRAINT IF EXISTS "api_idempotency_apiKeyId_fkey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2861,8 +2861,6 @@ model ApiKey {
   revokedAt     DateTime? // Set on single-key revocation (isActive also flipped false)
   createdAt     DateTime  @default(now())
 
-  idempotencyRecords ApiIdempotency[]
-
   @@index([organizationId])
   @@index([actingUserId])
   @@map("api_key")
@@ -2875,8 +2873,9 @@ model ApiKey {
 model ApiIdempotency {
   id             String   @id @default(cuid())
   organizationId String
+  // apiKeyId is a plain external id now — ApiKey is a Convex domain, so the FK to
+  // api_key was dropped (migration 20260713120000). No Prisma relation.
   apiKeyId       String
-  apiKey         ApiKey   @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
   key            String // client-provided idempotency key
   verb           String // capability verb, e.g. "reserve_items"
   result         String // JSON-serialized result returned on replay

--- a/src/lib/api-key.test.ts
+++ b/src/lib/api-key.test.ts
@@ -1,14 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ActorContext } from "./actor-context";
 
-const apiKeyFindUnique = vi.fn();
-const apiKeyUpdate = vi.fn();
+// ApiKey lookup is Convex now; org kill-switch + acting-user name stay on Postgres.
+const getByTokenHash = vi.fn();
+const touchLastUsed = vi.fn();
+vi.mock("@/lib/convex-client", () => ({
+  getConvexClient: vi.fn(async () => ({
+    query: (_ref: unknown, args: unknown) => getByTokenHash(args),
+    mutation: (_ref: unknown, args: unknown) => {
+      touchLastUsed(args);
+      return Promise.resolve();
+    },
+  })),
+}));
+const orgFindUnique = vi.fn();
+const userFindUnique = vi.fn();
 vi.mock("@/lib/prisma", () => ({
   prisma: {
-    apiKey: {
-      findUnique: (...a: unknown[]) => apiKeyFindUnique(...a),
-      update: (...a: unknown[]) => apiKeyUpdate(...a),
-    },
+    organization: { findUnique: (...a: unknown[]) => orgFindUnique(...a) },
+    user: { findUnique: (...a: unknown[]) => userFindUnique(...a) },
   },
 }));
 
@@ -24,24 +34,24 @@ import {
   assertScopesWithinActor,
 } from "@/lib/api-key";
 
+// A Convex-shaped apiKey doc (epoch-ms dates; org/user resolved separately).
 function keyRow(overrides: Record<string, unknown> = {}) {
   return {
     id: "key_1",
     organizationId: "org_1",
     actingUserId: "user_1",
     isActive: true,
-    revokedAt: null,
-    expiresAt: null,
+    revokedAt: undefined,
+    expiresAt: undefined,
     scopes: '["assets:read","project:manage_line_items"]',
-    actingUser: { name: "Ada" },
-    organization: { apiKillSwitchAt: null },
     ...overrides,
   };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  apiKeyUpdate.mockResolvedValue({});
+  orgFindUnique.mockResolvedValue({ apiKillSwitchAt: null });
+  userFindUnique.mockResolvedValue({ name: "Ada" });
 });
 
 describe("hashApiKey / generateApiKey", () => {
@@ -116,7 +126,7 @@ describe("requireApiScope — the key-scope half of the intersection", () => {
 
 describe("getApiKeyActorContext — validation + resolution", () => {
   it("resolves a valid key to an apiKey ActorContext with its scopes", async () => {
-    apiKeyFindUnique.mockResolvedValue(keyRow());
+    getByTokenHash.mockResolvedValue(keyRow());
 
     const actor = await getApiKeyActorContext("gf_live_whatever");
 
@@ -129,34 +139,47 @@ describe("getApiKeyActorContext — validation + resolution", () => {
       scopes: ["assets:read", "project:manage_line_items"],
     });
     // Looked up by hash, not raw token.
-    expect(apiKeyFindUnique).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { tokenHash: hashApiKey("gf_live_whatever") } }),
-    );
+    expect(getByTokenHash).toHaveBeenCalledWith({ tokenHash: hashApiKey("gf_live_whatever") });
   });
 
   it("rejects an unknown key (INVALID_KEY)", async () => {
-    apiKeyFindUnique.mockResolvedValue(null);
+    getByTokenHash.mockResolvedValue(null);
     await expect(getApiKeyActorContext("nope")).rejects.toMatchObject({ code: "INVALID_KEY" });
   });
 
   it("rejects an inactive or revoked key (KEY_INACTIVE)", async () => {
-    apiKeyFindUnique.mockResolvedValue(keyRow({ revokedAt: new Date() }));
+    getByTokenHash.mockResolvedValue(keyRow({ revokedAt: Date.now() }));
     await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "KEY_INACTIVE" });
 
-    apiKeyFindUnique.mockResolvedValue(keyRow({ isActive: false }));
+    getByTokenHash.mockResolvedValue(keyRow({ isActive: false }));
     await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "KEY_INACTIVE" });
   });
 
-  it("rejects an expired key (KEY_EXPIRED)", async () => {
-    apiKeyFindUnique.mockResolvedValue(keyRow({ expiresAt: new Date(Date.now() - 1000) }));
+  it("rejects an expired key — including a non-finite stored expiry (KEY_EXPIRED)", async () => {
+    getByTokenHash.mockResolvedValue(keyRow({ expiresAt: Date.now() - 1000 }));
+    await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "KEY_EXPIRED" });
+
+    // Fail closed: a garbage (NaN) stored expiry must reject, not read as "no expiry".
+    getByTokenHash.mockResolvedValue(keyRow({ expiresAt: NaN }));
     await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "KEY_EXPIRED" });
   });
 
   it("rejects every key when the org kill switch is set (ORG_KILL_SWITCH)", async () => {
-    apiKeyFindUnique.mockResolvedValue(
-      keyRow({ organization: { apiKillSwitchAt: new Date() } }),
-    );
+    getByTokenHash.mockResolvedValue(keyRow());
+    orgFindUnique.mockResolvedValue({ apiKillSwitchAt: new Date() });
     await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "ORG_KILL_SWITCH" });
+  });
+
+  it("fails closed when the key's org no longer exists (INVALID_KEY)", async () => {
+    getByTokenHash.mockResolvedValue(keyRow());
+    orgFindUnique.mockResolvedValue(null);
+    await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "INVALID_KEY" });
+  });
+
+  it("fails closed when the acting user no longer exists (KEY_INACTIVE)", async () => {
+    getByTokenHash.mockResolvedValue(keyRow());
+    userFindUnique.mockResolvedValue(null);
+    await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "KEY_INACTIVE" });
   });
 });
 

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -1,5 +1,7 @@
 import { createHash, randomBytes } from "crypto";
 import { prisma } from "./prisma";
+import { getConvexClient } from "./convex-client";
+import { api } from "../../convex/_generated/api";
 import type { ActorContext } from "./actor-context";
 
 /**
@@ -162,13 +164,9 @@ export async function getApiKeyActorContext(
 ): Promise<ActorContext> {
   const tokenHash = hashApiKey(rawToken);
 
-  const key = await prisma.apiKey.findUnique({
-    where: { tokenHash },
-    include: {
-      actingUser: { select: { name: true } },
-      organization: { select: { apiKillSwitchAt: true } },
-    },
-  });
+  // ApiKey lookup is Convex-native now (by_tokenHash — the token IS the credential).
+  const convex = await getConvexClient();
+  const key = await convex.query(api.apiKeys.getByTokenHash, { tokenHash });
 
   if (!key) {
     throw new ApiKeyAuthError("INVALID_KEY", "Invalid API key.");
@@ -176,27 +174,55 @@ export async function getApiKeyActorContext(
   if (!key.isActive || key.revokedAt) {
     throw new ApiKeyAuthError("KEY_INACTIVE", "This API key has been revoked.");
   }
-  if (key.expiresAt && key.expiresAt.getTime() <= Date.now()) {
-    throw new ApiKeyAuthError("KEY_EXPIRED", "This API key has expired.");
+  // A present `expiresAt` must be finite and in the future. A non-finite stored value
+  // (NaN/Infinity) is treated as expired — fail closed, never "no expiry". Absent
+  // (`undefined`) means no expiry.
+  if (key.expiresAt != null) {
+    if (!Number.isFinite(key.expiresAt) || key.expiresAt <= Date.now()) {
+      throw new ApiKeyAuthError("KEY_EXPIRED", "This API key has expired.");
+    }
   }
-  if (key.organization.apiKillSwitchAt) {
+
+  // Org kill-switch + acting-user name stay on Postgres (Better-Auth `organization`
+  // / `user`, which remain). apiKillSwitchAt gates ALL keys for the org instantly.
+  const [org, actingUser] = await Promise.all([
+    prisma.organization.findUnique({
+      where: { id: key.organizationId },
+      select: { apiKillSwitchAt: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: key.actingUserId },
+      select: { name: true },
+    }),
+  ]);
+  // FAIL CLOSED: the old Postgres FK cascade auto-deleted a key when its org or acting
+  // user was deleted. Convex has no cascade, so a key can outlive them — reject rather
+  // than authenticate a phantom actor against a missing org/user.
+  if (!org) {
+    throw new ApiKeyAuthError("INVALID_KEY", "Invalid API key.");
+  }
+  if (org.apiKillSwitchAt) {
     throw new ApiKeyAuthError(
       "ORG_KILL_SWITCH",
       "API access is disabled for this organization.",
     );
   }
+  if (!actingUser) {
+    throw new ApiKeyAuthError(
+      "KEY_INACTIVE",
+      "This API key's acting user no longer exists.",
+    );
+  }
 
   // Best-effort last-used stamp for observability. Never block or fail auth on it.
-  prisma.apiKey
-    .update({ where: { id: key.id }, data: { lastUsedAt: new Date() } })
-    .catch(() => {});
+  convex.mutation(api.apiKeys.touchLastUsed, { id: key.id }).catch(() => {});
 
   return {
     organizationId: key.organizationId,
     userId: key.actingUserId,
-    userName: key.actingUser.name || "API key",
+    userName: actingUser.name || "API key",
     actorType: "apiKey",
     apiKeyId: key.id,
-    scopes: parseScopes(key.scopes),
+    scopes: parseScopes(key.scopes ?? "[]"),
   };
 }

--- a/src/server/api-keys.test.ts
+++ b/src/server/api-keys.test.ts
@@ -8,10 +8,16 @@ vi.mock("@/lib/org-context", () => ({
 vi.mock("@/lib/activity-log", () => ({ logActivity: vi.fn(async () => {}) }));
 vi.mock("@/lib/api-key", () => ({
   generateApiKey: () => ({ raw: "gf_live_SECRET", prefix: "gf_live_ab", tokenHash: "hash_of_secret" }),
+  assertScopesWithinActor: vi.fn(),
 }));
+vi.mock("@/lib/request-actor", () => ({ getAmbientActor: () => undefined }));
+
+// ApiKey is a Convex domain now — mock the Convex client. member/organization stay
+// on Postgres (Better-Auth), so the prisma mock keeps those.
+const convexMock = vi.hoisted(() => ({ query: vi.fn(), mutation: vi.fn() }));
+vi.mock("@/lib/convex-client", () => ({ getConvexClient: vi.fn(async () => convexMock) }));
 
 const prismaMock = vi.hoisted(() => ({
-  apiKey: { create: vi.fn(), findMany: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
   member: { findFirst: vi.fn() },
   organization: { findUnique: vi.fn(), update: vi.fn() },
 }));
@@ -23,19 +29,23 @@ import { logActivity } from "@/lib/activity-log";
 beforeEach(() => {
   vi.clearAllMocks();
   prismaMock.member.findFirst.mockResolvedValue({ id: "mem_1" });
-  prismaMock.apiKey.create.mockResolvedValue({ id: "key_1", name: "Agent", prefix: "gf_live_ab" });
+  convexMock.mutation.mockResolvedValue({ id: "key_1", name: "Agent" });
+  convexMock.query.mockResolvedValue([]);
 });
 
 describe("createApiKey", () => {
-  it("stores only the hash, returns the raw secret once, and audits", async () => {
+  it("stores only the hash via Convex, returns the raw secret once, and audits", async () => {
     const res = await createApiKey({ name: "Agent", scopes: ["project:manage_line_items"] });
 
     expect(res.token).toBe("gf_live_SECRET");
-    const createArg = prismaMock.apiKey.create.mock.calls[0][0];
-    expect(createArg.data.tokenHash).toBe("hash_of_secret");
-    expect(createArg.data.token).toBeUndefined(); // raw secret is never persisted
-    expect(createArg.data.scopes).toBe('["project:manage_line_items"]');
-    expect(createArg.data.actingUserId).toBe("user_1"); // defaults to creator
+    // The single create mutation's payload
+    const createArg = convexMock.mutation.mock.calls[0][1] as Record<string, unknown>;
+    expect(createArg.tokenHash).toBe("hash_of_secret");
+    expect(createArg.token).toBeUndefined(); // raw secret is never persisted
+    expect(createArg.scopes).toBe('["project:manage_line_items"]');
+    expect(createArg.actingUserId).toBe("user_1"); // defaults to creator
+    // never round-trips the secret back to the client
+    expect(res.key).not.toHaveProperty("tokenHash");
     expect(logActivity).toHaveBeenCalledWith(
       expect.objectContaining({ entityType: "apiKey", action: "create" }),
     );
@@ -46,7 +56,7 @@ describe("createApiKey", () => {
     await expect(
       createApiKey({ name: "X", scopes: [], actingUserId: "outsider" }),
     ).rejects.toThrow(/member of this organization/i);
-    expect(prismaMock.apiKey.create).not.toHaveBeenCalled();
+    expect(convexMock.mutation).not.toHaveBeenCalled();
   });
 
   it("requires a name", async () => {
@@ -55,17 +65,18 @@ describe("createApiKey", () => {
 });
 
 describe("revokeApiKey", () => {
-  it("deactivates + stamps revokedAt and audits", async () => {
-    prismaMock.apiKey.findFirst.mockResolvedValue({ id: "key_1", name: "Agent" });
+  it("revokes via the org-guarded Convex mutation and audits", async () => {
+    convexMock.mutation.mockResolvedValue({ id: "key_1", name: "Agent" });
     await revokeApiKey("key_1");
-    const updateArg = prismaMock.apiKey.update.mock.calls[0][0];
-    expect(updateArg.data.isActive).toBe(false);
-    expect(updateArg.data.revokedAt).toBeInstanceOf(Date);
+    expect(convexMock.mutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: "key_1", orgId: "org_1" }),
+    );
     expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({ action: "delete" }));
   });
 
-  it("throws when the key is not in this org", async () => {
-    prismaMock.apiKey.findFirst.mockResolvedValue(null);
+  it("throws when the Convex mutation rejects (key not in this org)", async () => {
+    convexMock.mutation.mockRejectedValue(new Error("apiKey not found"));
     await expect(revokeApiKey("nope")).rejects.toThrow(/not found/i);
   });
 });
@@ -82,7 +93,9 @@ describe("setOrgApiKillSwitch", () => {
 
 describe("listApiKeys", () => {
   it("returns keys + kill-switch state without any secret", async () => {
-    prismaMock.apiKey.findMany.mockResolvedValue([{ id: "key_1", prefix: "gf_live_ab", name: "Agent" }]);
+    convexMock.query.mockResolvedValue([
+      { id: "key_1", prefix: "gf_live_ab", name: "Agent", tokenHash: "hash", actingUserId: "user_1", createdAt: 1000 },
+    ]);
     prismaMock.organization.findUnique.mockResolvedValue({ apiKillSwitchAt: null });
 
     const res = await listApiKeys();

--- a/src/server/api-keys.ts
+++ b/src/server/api-keys.ts
@@ -1,11 +1,38 @@
 "use server";
 
+import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { generateApiKey, assertScopesWithinActor } from "@/lib/api-key";
 import { getAmbientActor } from "@/lib/request-actor";
+
+// ApiKey is a Convex domain now (the Postgres `api_key` table is frozen). The
+// Better-Auth `member` (acting-user membership) + `organization` (kill switch) reads
+// below stay on Postgres by design. Convex stores date fields as epoch-ms; map them
+// back to Date so the serialized shape matches the old Prisma `select`.
+type ConvexApiKey = {
+  id: string; name: string; prefix: string; scopes?: string; isActive?: boolean;
+  actingUserId: string; expiresAt?: number; lastUsedAt?: number;
+  lastRotatedAt?: number; revokedAt?: number; createdAt?: number;
+};
+function toKeyRow(k: ConvexApiKey) {
+  const d = (n: number | undefined | null) => (n != null ? new Date(n) : null);
+  return {
+    id: k.id, name: k.name, prefix: k.prefix,
+    scopes: k.scopes ?? "[]",
+    isActive: k.isActive ?? true,
+    actingUserId: k.actingUserId,
+    expiresAt: d(k.expiresAt),
+    lastUsedAt: d(k.lastUsedAt),
+    lastRotatedAt: d(k.lastRotatedAt),
+    revokedAt: d(k.revokedAt),
+    createdAt: k.createdAt != null ? new Date(k.createdAt) : new Date(0),
+  };
+}
 
 /**
  * Management for agent-accessible API keys (docs/designs/api-mcp-agent-access.md).
@@ -14,28 +41,13 @@ import { getAmbientActor } from "@/lib/request-actor";
  * creation — only its SHA-256 hash is ever stored.
  */
 
-const READ_SHAPE = {
-  id: true,
-  name: true,
-  prefix: true,
-  scopes: true,
-  isActive: true,
-  actingUserId: true,
-  expiresAt: true,
-  lastUsedAt: true,
-  lastRotatedAt: true,
-  revokedAt: true,
-  createdAt: true,
-} as const;
-
 /** List this org's API keys (never returns a secret — only the display prefix). */
 export async function listApiKeys() {
   const { organizationId } = await getOrgContext();
-  const keys = await prisma.apiKey.findMany({
-    where: { organizationId },
-    select: READ_SHAPE,
-    orderBy: { createdAt: "desc" },
+  const rawKeys = await (await getConvexClient()).query(api.apiKeys.list, {
+    orgId: organizationId,
   });
+  const keys = rawKeys.map(toKeyRow); // strips tokenHash — never leaves the backend
   const killSwitch = await prisma.organization.findUnique({
     where: { id: organizationId },
     select: { apiKillSwitchAt: true },
@@ -80,18 +92,28 @@ export async function createApiKey(input: {
 
   const { raw, prefix, tokenHash } = generateApiKey();
 
-  const created = await prisma.apiKey.create({
-    data: {
-      organizationId,
-      name,
-      prefix,
-      tokenHash,
-      scopes: JSON.stringify(scopes),
-      actingUserId,
-      createdById: userId,
-      expiresAt: input.expiresAt ? new Date(input.expiresAt) : null,
-    },
-    select: READ_SHAPE,
+  const id = createId();
+  const now = Date.now();
+  const expiresAtMs = input.expiresAt ? new Date(input.expiresAt).getTime() : undefined;
+  if (expiresAtMs !== undefined && !Number.isFinite(expiresAtMs)) {
+    throw new Error("Invalid expiry date.");
+  }
+  await (await getConvexClient()).mutation(api.apiKeys.create, {
+    id,
+    organizationId,
+    name,
+    prefix,
+    tokenHash,
+    scopes: JSON.stringify(scopes),
+    isActive: true,
+    actingUserId,
+    createdById: userId,
+    expiresAt: expiresAtMs,
+    createdAt: now,
+  });
+  const created = toKeyRow({
+    id, name, prefix, scopes: JSON.stringify(scopes), isActive: true,
+    actingUserId, expiresAt: expiresAtMs, createdAt: now,
   });
 
   await logActivity({
@@ -117,16 +139,17 @@ export async function revokeApiKey(id: string) {
     "update",
   );
 
-  const key = await prisma.apiKey.findFirst({
-    where: { id, organizationId },
-    select: { id: true, name: true },
-  });
-  if (!key) throw new Error("API key not found.");
-
-  await prisma.apiKey.update({
-    where: { id },
-    data: { isActive: false, revokedAt: new Date() },
-  });
+  let key: { id: string; name: string };
+  try {
+    key = await (await getConvexClient()).mutation(api.apiKeys.revoke, {
+      id,
+      orgId: organizationId,
+    });
+  } catch {
+    // Convex throws ConvexError("apiKey not found") when the key is missing or
+    // belongs to another org — same 404 semantics as the old org-scoped findFirst.
+    throw new Error("API key not found.");
+  }
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## What
Inverts agent API/MCP access keys (`api_key`) from Postgres to a new Convex `apiKeys` table. Postgres table frozen. Part of finishing **Phase 1** (Convex = source of truth for all domain data).

## Auth-critical, so heavily hardened (3 codex rounds)
- **Verify path** (`getApiKeyActorContext`): key lookup → Convex `by_tokenHash`; org kill-switch + acting-user name stay on Postgres (Better-Auth). **Fails closed** on: missing key / inactive / revoked / expired (incl. non-finite stored expiry) / kill-switch / **missing org** / **missing user** — Convex has no FK cascade, so a key can outlive its org/user.
- **create/createIfMissing** guard duplicate `id` AND `tokenHash` (Convex indexes are non-unique; a dup would break the `.unique()` auth lookup → credential-specific DoS).
- **revoke** is org-guarded in the mutation (a key from another org 404s).
- `tokenHash` never leaves the backend (list/create map via `toKeyRow`).

## api_idempotency FK
New keys are Convex-only → the Postgres `api_idempotency.apiKeyId` FK would fail every idempotency insert for a new key (and the reserve path swallows that → **duplicate stock writes**). Migration `20260713120000` **drops the FK**; `apiKeyId` is a plain external id; Prisma relations removed to match. The ledger table stays on Postgres for now — full inversion is a follow-up.

## Verification
- 1 prod key backfilled (`createIfMissing`); **verify path validated against prod Convex** (getByTokenHash returns the key, all auth fields match Postgres).
- 30 unit tests (both api-key test files rewritten to mock Convex + Postgres org/user); tsc clean; 3 adversarial codex passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)