### PR TITLE
feat(sso): invert pendingSSOApproval to Convex (Phase-1 decommission)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -90,6 +90,7 @@ import type * as notificationDismissals from "../notificationDismissals.js";
 import type * as notificationEmailLogs from "../notificationEmailLogs.js";
 import type * as overbooking from "../overbooking.js";
 import type * as parity from "../parity.js";
+import type * as pendingSSOApprovals from "../pendingSSOApprovals.js";
 import type * as projectCategories from "../projectCategories.js";
 import type * as projectDetail from "../projectDetail.js";
 import type * as projectEquipment from "../projectEquipment.js";
@@ -224,6 +225,7 @@ declare const fullApi: ApiFromModules<{
   notificationEmailLogs: typeof notificationEmailLogs;
   overbooking: typeof overbooking;
   parity: typeof parity;
+  pendingSSOApprovals: typeof pendingSSOApprovals;
   projectCategories: typeof projectCategories;
   projectDetail: typeof projectDetail;
   projectEquipment: typeof projectEquipment;

--- a/convex/pendingSSOApprovals.ts
+++ b/convex/pendingSSOApprovals.ts
@@ -1,0 +1,119 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * PendingSSOApproval — Convex-native domain (Phase-1 decommission; the Postgres
+ * `pending_sso_approval` table is frozen). The SSO approval workflow: an IdP login
+ * under REQUIRE_APPROVAL provisioning enqueues a PENDING row; an org admin
+ * approves (→ creates a Better-Auth member) or rejects it.
+ *
+ * RBAC/validation/audit/member-creation stay in the Next.js server actions
+ * (`src/server/sso.ts`, `src/lib/sso-provisioning.ts`); these are the trusted-backend
+ * SERVICE data layer. The old Prisma `@@unique([organizationId, userId])` is
+ * reproduced by `createForProvisioning`, which is idempotent on (org, userId) inside
+ * a single Convex mutation (transactional → no TOCTOU double-insert).
+ */
+
+/** Pending approvals for an org (the admin review queue), newest first. */
+export const list = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("pendingSSOApprovals")
+      .withIndex("by_organizationId_status", (q) => q.eq("organizationId", orgId).eq("status", "PENDING"))
+      .order("desc")
+      .collect();
+  },
+});
+
+/** Existing approval for (org, user), any status — the provisioning dedup check. */
+export const getByOrgUser = query({
+  args: { orgId: v.string(), userId: v.string() },
+  handler: async (ctx, { orgId, userId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("pendingSSOApprovals")
+      .withIndex("by_organizationId_userId", (q) => q.eq("organizationId", orgId).eq("userId", userId))
+      .unique();
+  },
+});
+
+/**
+ * Enqueue a PENDING approval on SSO login. Idempotent on (org, userId) — mirrors the
+ * old `@@unique` + "create only if none exists" (regardless of the existing row's
+ * status). Returns the existing or newly-created row's id.
+ */
+export const createForProvisioning = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    userId: v.string(),
+    email: v.string(),
+    name: v.optional(v.string()),
+    idpGroups: v.optional(v.array(v.string())),
+    suggestedRole: v.optional(v.string()),
+    providerId: v.string(),
+    createdAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("pendingSSOApprovals")
+      .withIndex("by_organizationId_userId", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", args.userId),
+      )
+      .unique();
+    if (existing) return { id: existing.id, created: false };
+    await ctx.db.insert("pendingSSOApprovals", { ...args, status: "PENDING" });
+    return { id: args.id, created: true };
+  },
+});
+
+/**
+ * Approve/reject: org-guarded, only transitions a currently-PENDING row — this is the
+ * atomic MUTUAL-EXCLUSION gate. A concurrent reject or a double-approve loses here
+ * (throws "not found"), so the caller creates the Better-Auth member AT MOST ONCE and
+ * NEVER after a rejection. Returns the approval's identity fields (userId/email/
+ * suggestedRole) so the server action needs no second read.
+ */
+export const review = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    status: v.union(v.literal("APPROVED"), v.literal("REJECTED")),
+    reviewedById: v.string(),
+    reviewedAt: v.number(),
+    reviewNote: v.optional(v.string()),
+  },
+  handler: async (ctx, { id, orgId, status, reviewedById, reviewedAt, reviewNote }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("pendingSSOApprovals").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId || doc.status !== "PENDING") {
+      throw new ConvexError("Pending approval not found");
+    }
+    await ctx.db.patch(doc._id, { status, reviewedById, reviewedAt, ...(reviewNote ? { reviewNote } : {}) });
+    return { userId: doc.userId, email: doc.email, suggestedRole: doc.suggestedRole ?? null };
+  },
+});
+
+/**
+ * Roll a just-APPROVED approval back to PENDING when the downstream member.create
+ * failed — so an approve never leaves the user "approved but with no membership".
+ * Org-guarded; only reverts an APPROVED row (never undoes a REJECTED decision).
+ */
+export const revertToPending = mutation({
+  args: { id: v.string(), orgId: v.string() },
+  handler: async (ctx, { id, orgId }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("pendingSSOApprovals").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId || doc.status !== "APPROVED") return;
+    await ctx.db.patch(doc._id, {
+      status: "PENDING",
+      reviewedById: undefined,
+      reviewedAt: undefined,
+      reviewNote: undefined,
+    });
+  },
+});

--- a/src/lib/sso-provisioning.ts
+++ b/src/lib/sso-provisioning.ts
@@ -1,4 +1,7 @@
+import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "./prisma";
+import { getConvexClient } from "./convex-client";
+import { api } from "../../convex/_generated/api";
 import { upsertMemberMirrorByOrgUser } from "./member-mirror";
 import type { OrgSSOSettings, SSOGroupMapping } from "./sso-types";
 import type { Organization } from "@/generated/prisma/client";
@@ -233,30 +236,23 @@ export async function handleSSOProvisioning(data: {
   }
 
   if (mode === "REQUIRE_APPROVAL") {
-    // Check if there's already a pending approval
-    const existing = await prisma.pendingSSOApproval.findUnique({
-      where: {
-        organizationId_userId: {
-          organizationId: provider.organizationId,
-          userId: user.id,
-        },
+    // Enqueue a PENDING approval (Convex). Idempotent on (org, userId) inside the
+    // mutation — reproduces the old `@@unique` + "create only if none exists", with
+    // no TOCTOU race (Convex mutations are transactional).
+    await (await getConvexClient()).mutation(
+      api.pendingSSOApprovals.createForProvisioning,
+      {
+        id: createId(),
+        organizationId: provider.organizationId,
+        userId: user.id,
+        email: user.email,
+        name: user.name ?? undefined,
+        idpGroups,
+        suggestedRole: role ?? undefined,
+        providerId: provider.providerId,
+        createdAt: Date.now(),
       },
-    });
-
-    if (!existing) {
-      await prisma.pendingSSOApproval.create({
-        data: {
-          organizationId: provider.organizationId,
-          userId: user.id,
-          email: user.email,
-          name: user.name,
-          idpGroups,
-          suggestedRole: role,
-          providerId: provider.providerId,
-          status: "PENDING",
-        },
-      });
-    }
+    );
 
     // Don't throw — user account exists, they just can't access the org yet.
     // The login flow will detect "no membership" and redirect to /pending-approval.

--- a/src/server/sso.ts
+++ b/src/server/sso.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { sendEmail } from "@/lib/email";
@@ -295,13 +297,18 @@ export async function updateGroupMappings(mappings: SSOGroupMapping[]) {
 export async function getPendingApprovals() {
   const { organizationId } = await getOrgContext();
 
-  const approvals = await prisma.pendingSSOApproval.findMany({
-    where: { organizationId, status: "PENDING" },
-    include: {
-      user: { select: { id: true, name: true, email: true, image: true } },
-    },
-    orderBy: { createdAt: "desc" },
+  // PendingSSOApproval is a Convex domain now. The consumer uses the approval's own
+  // denormalized fields (name/email/suggestedRole/idpGroups/createdAt) — the old
+  // `include: { user }` join was unused, so it's dropped. Coerce optional Convex
+  // fields back to the old non-null shape (idpGroups default [], createdAt → Date).
+  const rows = await (await getConvexClient()).query(api.pendingSSOApprovals.list, {
+    orgId: organizationId,
   });
+  const approvals = rows.map((a) => ({
+    ...a,
+    idpGroups: a.idpGroups ?? [],
+    createdAt: a.createdAt != null ? new Date(a.createdAt) : new Date(0),
+  }));
 
   return serialize(approvals);
 }
@@ -309,31 +316,48 @@ export async function getPendingApprovals() {
 export async function approveSSOUser(approvalId: string, role?: string) {
   const { organizationId, userId, userName } = await requirePermission("orgMembers", "create");
 
-  const approval = await prisma.pendingSSOApproval.findFirst({
-    where: { id: approvalId, organizationId, status: "PENDING" },
-    include: { user: true },
-  });
-  if (!approval) throw new Error("Pending approval not found");
+  const convex = await getConvexClient();
 
-  const assignRole = role || approval.suggestedRole || "member";
+  // CLAIM the approval (PENDING→APPROVED) atomically FIRST. `review` is the single
+  // mutual-exclusion gate: a concurrent reject or a double-approve loses here (throws),
+  // so the member is created at most once and NEVER after a rejection. (Member has no
+  // (org,user) unique constraint, so this — not the DB — is what prevents a double
+  // grant.) On a member.create failure we roll the approval back to PENDING so it never
+  // ends up "approved but with no membership".
+  let claimed: { userId: string; email: string; suggestedRole: string | null };
+  try {
+    claimed = await convex.mutation(api.pendingSSOApprovals.review, {
+      id: approvalId,
+      orgId: organizationId,
+      status: "APPROVED",
+      reviewedById: userId,
+      reviewedAt: Date.now(),
+    });
+  } catch {
+    throw new Error("Pending approval not found");
+  }
 
-  await prisma.$transaction([
-    prisma.member.create({
-      data: {
-        organizationId,
-        userId: approval.userId,
-        role: assignRole,
-      },
-    }),
-    prisma.pendingSSOApproval.update({
-      where: { id: approvalId },
-      data: {
-        status: "APPROVED",
-        reviewedById: userId,
-        reviewedAt: new Date(),
-      },
-    }),
-  ]);
+  const assignRole = role || claimed.suggestedRole || "member";
+
+  // Idempotent member creation: `member` has no (org,user) unique constraint, so guard
+  // against a duplicate across a compensation/retry (or an ambiguous create that
+  // actually committed). Combined with the atomic review gate, this is at-most-once.
+  try {
+    const existingMember = await prisma.member.findFirst({
+      where: { organizationId, userId: claimed.userId },
+      select: { id: true },
+    });
+    if (!existingMember) {
+      await prisma.member.create({
+        data: { organizationId, userId: claimed.userId, role: assignRole },
+      });
+    }
+  } catch (e) {
+    await convex
+      .mutation(api.pendingSSOApprovals.revertToPending, { id: approvalId, orgId: organizationId })
+      .catch(() => {});
+    throw e;
+  }
 
   await logActivity({
     organizationId,
@@ -341,13 +365,13 @@ export async function approveSSOUser(approvalId: string, role?: string) {
     userName,
     action: "CREATE",
     entityType: "member",
-    entityId: approval.userId,
-    entityName: approval.email,
-    summary: `Approved SSO user ${approval.email} with role ${assignRole}`,
+    entityId: claimed.userId,
+    entityName: claimed.email,
+    summary: `Approved SSO user ${claimed.email} with role ${assignRole}`,
   });
 
   // Additive (membership granted): mirror best-effort after the Prisma commit.
-  await upsertMemberMirrorByOrgUser(organizationId, approval.userId);
+  await upsertMemberMirrorByOrgUser(organizationId, claimed.userId);
 
   // Send email notification
   const pName = await getPlatformName();
@@ -356,7 +380,7 @@ export async function approveSSOUser(approvalId: string, role?: string) {
     select: { name: true },
   });
   sendEmail({
-    to: approval.email,
+    to: claimed.email,
     subject: `Your access to ${org?.name || "the organization"} has been approved`,
     html: `
       <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
@@ -378,21 +402,22 @@ export async function approveSSOUser(approvalId: string, role?: string) {
 export async function rejectSSOUser(approvalId: string, note?: string) {
   const { organizationId, userId, userName } = await requirePermission("orgMembers", "create");
 
-  const approval = await prisma.pendingSSOApproval.findFirst({
-    where: { id: approvalId, organizationId, status: "PENDING" },
-    include: { user: true },
-  });
-  if (!approval) throw new Error("Pending approval not found");
-
-  await prisma.pendingSSOApproval.update({
-    where: { id: approvalId },
-    data: {
+  // `review` atomically transitions PENDING→REJECTED (the mutual-exclusion gate) and
+  // returns the approval's identity fields — a concurrent approve that already claimed
+  // it loses here (throws). No separate read needed.
+  let approval: { userId: string; email: string; suggestedRole: string | null };
+  try {
+    approval = await (await getConvexClient()).mutation(api.pendingSSOApprovals.review, {
+      id: approvalId,
+      orgId: organizationId,
       status: "REJECTED",
       reviewedById: userId,
-      reviewedAt: new Date(),
+      reviewedAt: Date.now(),
       reviewNote: note,
-    },
-  });
+    });
+  } catch {
+    throw new Error("Pending approval not found");
+  }
 
   await logActivity({
     organizationId,


### PR DESCRIPTION
## What
Inverts the SSO approval workflow's `pending_sso_approval` from Postgres to the existing Convex `pendingSSOApprovals` table + a new module. 0 prod rows (no backfill); Postgres table frozen. Continues **Phase 1**.

## Auth-flow safety (3 codex rounds)
The old `approveSSOUser` used a single `prisma.$transaction([member.create, approval.update])`. Splitting stores loses that atomicity, so:
- **`review` is the atomic mutual-exclusion gate** (only transitions a PENDING row, org-guarded). approve **claims** the approval (PENDING→APPROVED) **before** creating the member — a concurrent reject or double-approve loses at review. Prevents *approved-despite-reject* and *double-grant* **without** a member unique constraint (there isn't one).
- **Idempotent member creation** (findFirst-then-create) — no duplicate across compensation/retry or an ambiguous commit.
- **Rollback**: on member.create failure the approval reverts to PENDING (never "approved but no access"); `revertToPending` only touches an APPROVED row (never undoes a rejection / cross-org).
- `createForProvisioning` is idempotent on (org,userId) — reproduces the old `@@unique` + "create if none" with no TOCTOU (Convex mutations are transactional).

## Reads
`getPendingApprovals` → Convex list; dropped the **unused** `include:{user}` join; coerces `idpGroups→[]` / `createdAt→Date` so the settings consumer's shape is unchanged.

## Verification
tsc clean; 3 adversarial codex passes (race / duplicate-member / revert-safety all closed). No live IdP to e2e-test; 0 rows so no data risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)