### PR TITLE
feat(webhooks): invert webhook + delivery queue to Convex (Phase-1 decommission)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -133,6 +133,7 @@ import type * as warehouseDashboardTokens from "../warehouseDashboardTokens.js";
 import type * as warehouseDetail from "../warehouseDetail.js";
 import type * as warehouseList from "../warehouseList.js";
 import type * as warehouseOps from "../warehouseOps.js";
+import type * as webhooks from "../webhooks.js";
 import type * as wooCommerceIntegrations from "../wooCommerceIntegrations.js";
 import type * as wooCommerceOrderLogs from "../wooCommerceOrderLogs.js";
 
@@ -268,6 +269,7 @@ declare const fullApi: ApiFromModules<{
   warehouseDetail: typeof warehouseDetail;
   warehouseList: typeof warehouseList;
   warehouseOps: typeof warehouseOps;
+  webhooks: typeof webhooks;
   wooCommerceIntegrations: typeof wooCommerceIntegrations;
   wooCommerceOrderLogs: typeof wooCommerceOrderLogs;
 }>;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -230,6 +230,51 @@ export default defineSchema({
     .index("by_tokenHash", ["tokenHash"])
     .index("by_actingUserId", ["actingUserId"]),
 
+  // Webhook — outbound event endpoints (docs/designs/webhooks.md). The delivery
+  // WORKER (HTTP send, HMAC signing, cron) stays in Next.js server code; only the
+  // data lives here.
+  webhooks: defineTable({
+    id: v.string(),
+    organizationId: v.string(),
+    description: v.string(),
+    url: v.string(),
+    events: v.optional(v.string()), // JSON array of event names, default "[]"
+    secret: v.string(),
+    previousSecret: v.optional(v.string()),
+    previousSecretExpiresAt: v.optional(v.number()),
+    isActive: v.optional(v.boolean()),
+    disabledAt: v.optional(v.number()),
+    consecutiveFailures: v.optional(v.number()),
+    lastDeliveryAt: v.optional(v.number()),
+    createdById: v.string(),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  })
+    .index("by_cuid", ["id"])
+    .index("by_organizationId", ["organizationId"]),
+
+  // WebhookDelivery — the delivery queue + operator-facing delivery log.
+  // `by_status_nextAttemptAt` is the worker's claim query (PENDING + backoff elapsed);
+  // it is a GLOBAL scan (the cron worker processes all orgs).
+  webhookDeliveries: defineTable({
+    id: v.string(),
+    organizationId: v.string(),
+    webhookId: v.string(),
+    event: v.string(),
+    payload: v.string(),
+    status: v.optional(v.string()), // "PENDING" | "SUCCEEDED" | "FAILED"
+    attempts: v.optional(v.number()),
+    nextAttemptAt: v.optional(v.number()),
+    responseStatus: v.optional(v.number()),
+    lastError: v.optional(v.string()),
+    deliveredAt: v.optional(v.number()),
+    createdAt: v.optional(v.number()),
+  })
+    .index("by_cuid", ["id"])
+    .index("by_organizationId", ["organizationId"])
+    .index("by_webhookId", ["webhookId"])
+    .index("by_status_nextAttemptAt", ["status", "nextAttemptAt"]),
+
   // Category
   categories: defineTable({
     id: v.string(),

--- a/convex/webhooks.ts
+++ b/convex/webhooks.ts
@@ -1,0 +1,340 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * Webhook + WebhookDelivery — Convex-native domain (Phase-1 decommission; the Postgres
+ * `webhook` / `webhook_delivery` tables are frozen). This module is ONLY the data
+ * layer: the delivery worker (HTTP send, HMAC signing, SSRF guard, cron) stays in
+ * Next.js server code (`src/lib/webhooks/*`, `src/server/webhooks.ts`), calling these
+ * with the trusted-backend SERVICE token. See docs/designs/webhooks.md.
+ *
+ * The queue's atomic claim (`claimDelivery`) is a transactional Convex mutation —
+ * cleaner than the old Postgres `updateMany` optimistic lock and race-free by
+ * construction (Convex mutations are serializable).
+ */
+
+// ── Webhook config ───────────────────────────────────────────────────────────
+
+/** This org's endpoints (server strips the secret via READ_SHAPE). */
+export const list = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("webhooks")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .order("desc")
+      .collect();
+  },
+});
+
+/** Active endpoints subscribed to events — the emit() subscription read. */
+export const activeSubscriptions = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    const rows = await ctx.db
+      .query("webhooks")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    return rows
+      .filter((w) => w.isActive === true)
+      .map((w) => ({ id: w.id, events: w.events ?? "[]" }));
+  },
+});
+
+const webhookWriteArgs = {
+  id: v.string(),
+  organizationId: v.string(),
+  description: v.string(),
+  url: v.string(),
+  events: v.optional(v.string()),
+  secret: v.string(),
+  isActive: v.optional(v.boolean()),
+  consecutiveFailures: v.optional(v.number()),
+  createdById: v.string(),
+  createdAt: v.optional(v.number()),
+  updatedAt: v.optional(v.number()),
+  previousSecret: v.optional(v.string()),
+  previousSecretExpiresAt: v.optional(v.number()),
+  disabledAt: v.optional(v.number()),
+  lastDeliveryAt: v.optional(v.number()),
+};
+
+export const create = mutation({
+  args: webhookWriteArgs,
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    return await ctx.db.insert("webhooks", args);
+  },
+});
+
+export const createIfMissing = mutation({
+  args: webhookWriteArgs,
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db.query("webhooks").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+    if (existing) return { _id: existing._id, created: false };
+    const _id = await ctx.db.insert("webhooks", args);
+    return { _id, created: true };
+  },
+});
+
+/** Org-guarded webhook fetch — returns null if missing/other-org. */
+async function ownedWebhook(ctx: MutationCtx, id: string, orgId: string) {
+  const doc = await ctx.db.query("webhooks").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+  if (!doc || doc.organizationId !== orgId) return null;
+  return doc;
+}
+
+export const update = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    patch: v.object({
+      description: v.optional(v.string()),
+      events: v.optional(v.string()),
+      isActive: v.optional(v.boolean()),
+      disabledAt: v.optional(v.union(v.number(), v.null())),
+      consecutiveFailures: v.optional(v.number()),
+    }),
+  },
+  handler: async (ctx, { id, orgId, patch }) => {
+    await requireService(ctx);
+    const doc = await ownedWebhook(ctx, id, orgId);
+    if (!doc) throw new ConvexError("Webhook endpoint not found");
+    // Map an explicit null (clear disabledAt) to undefined (Convex removes the field).
+    const applied: Record<string, unknown> = { ...patch };
+    if (patch.disabledAt === null) applied.disabledAt = undefined;
+    await ctx.db.patch(doc._id, applied);
+    return await ctx.db.get(doc._id); // fresh doc for the server response + audit
+  },
+});
+
+export const rotateSecret = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    secret: v.string(),
+    previousSecretExpiresAt: v.number(),
+  },
+  handler: async (ctx, { id, orgId, secret, previousSecretExpiresAt }) => {
+    await requireService(ctx);
+    const doc = await ownedWebhook(ctx, id, orgId);
+    if (!doc) throw new ConvexError("Webhook endpoint not found");
+    // previousSecret is the CURRENT secret — read internally so the server never has to
+    // round-trip the live secret out of the backend.
+    await ctx.db.patch(doc._id, { secret, previousSecret: doc.secret, previousSecretExpiresAt });
+    return { id: doc.id, description: doc.description };
+  },
+});
+
+/** Delete an endpoint AND its deliveries (the old FK cascade, re-implemented). */
+export const remove = mutation({
+  args: { id: v.string(), orgId: v.string() },
+  handler: async (ctx, { id, orgId }) => {
+    await requireService(ctx);
+    const doc = await ownedWebhook(ctx, id, orgId);
+    if (!doc) throw new ConvexError("Webhook endpoint not found");
+    // Bounded delete: cap the delivery-log cascade so a huge history can't blow the
+    // Convex per-mutation write limit and fail the endpoint deletion (the Postgres FK
+    // cascade had no such cap). Any remainder becomes an orphan that dueDeliveries +
+    // the worker fail out of the queue; SUCCEEDED/FAILED rows just age out. 4000 « 16k.
+    const deliveries = await ctx.db
+      .query("webhookDeliveries")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", id))
+      .take(4000);
+    for (const d of deliveries) await ctx.db.delete(d._id);
+    await ctx.db.delete(doc._id);
+    return { id: doc.id, description: doc.description };
+  },
+});
+
+// ── Delivery queue ───────────────────────────────────────────────────────────
+
+/** Recent deliveries for one endpoint (self-serve debugging), newest first. */
+export const deliveries = query({
+  args: { orgId: v.string(), webhookId: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { orgId, webhookId, limit }) => {
+    await requireService(ctx);
+    const rows = await ctx.db
+      .query("webhookDeliveries")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", webhookId))
+      .order("desc")
+      .collect();
+    return rows
+      .filter((d) => d.organizationId === orgId)
+      .slice(0, Math.min(limit ?? 50, 200));
+  },
+});
+
+/** Enqueue N deliveries (one per matching endpoint) — the emit() write. */
+export const enqueueDeliveries = mutation({
+  args: {
+    deliveries: v.array(
+      v.object({
+        id: v.string(),
+        organizationId: v.string(),
+        webhookId: v.string(),
+        event: v.string(),
+        payload: v.string(),
+        createdAt: v.number(),
+        nextAttemptAt: v.number(),
+      }),
+    ),
+  },
+  handler: async (ctx, { deliveries }) => {
+    await requireService(ctx);
+    for (const d of deliveries) {
+      await ctx.db.insert("webhookDeliveries", { ...d, status: "PENDING", attempts: 0 });
+    }
+    return { enqueued: deliveries.length };
+  },
+});
+
+/**
+ * Global claim query for the worker: PENDING deliveries whose backoff has elapsed,
+ * each joined to its webhook. Service-only (the cron worker is system-wide).
+ */
+export const dueDeliveries = query({
+  args: { now: v.number(), limit: v.optional(v.number()) },
+  handler: async (ctx, { now, limit }) => {
+    await requireService(ctx);
+    const due = await ctx.db
+      .query("webhookDeliveries")
+      .withIndex("by_status_nextAttemptAt", (q) => q.eq("status", "PENDING").lte("nextAttemptAt", now))
+      .order("asc")
+      .take(limit ?? 50);
+    const out = [];
+    for (const d of due) {
+      const base = {
+        id: d.id,
+        organizationId: d.organizationId,
+        event: d.event,
+        payload: d.payload,
+        attempts: d.attempts ?? 0,
+        nextAttemptAt: d.nextAttemptAt ?? 0,
+        createdAt: d.createdAt ?? 0,
+      };
+      const webhook = await ctx.db.query("webhooks").withIndex("by_cuid", (q) => q.eq("id", d.webhookId)).unique();
+      // Orphan (webhook deleted after this row was enqueued, past remove()'s cascade):
+      // return it with webhook=null so the worker can FAIL it out of the PENDING queue.
+      // If we skipped it, an always-"due" orphan would starve the batch limit forever.
+      if (!webhook) {
+        out.push({ ...base, webhook: null });
+        continue;
+      }
+      out.push({
+        ...base,
+        webhook: {
+          id: webhook.id,
+          url: webhook.url,
+          secret: webhook.secret,
+          previousSecret: webhook.previousSecret ?? null,
+          previousSecretExpiresAt: webhook.previousSecretExpiresAt ?? null,
+          isActive: webhook.isActive === true,
+        },
+      });
+    }
+    return out;
+  },
+});
+
+/**
+ * Atomically CLAIM a due delivery (transactional — replaces the Postgres `updateMany`
+ * optimistic lock). Only claims a still-PENDING, still-due row; bumps attempts and
+ * pushes nextAttemptAt out by the lease so a concurrent worker's due-filter misses it.
+ */
+export const claimDelivery = mutation({
+  args: { id: v.string(), now: v.number(), leaseMs: v.number() },
+  handler: async (ctx, { id, now, leaseMs }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("webhookDeliveries").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.status !== "PENDING" || (doc.nextAttemptAt ?? 0) > now) {
+      return { claimed: false, attempts: doc?.attempts ?? 0 };
+    }
+    // Lease from CLAIM time (server Date.now()), not the batch's `now` — a sequential
+    // batch's later claims must still get a full lease. `attempts` doubles as the
+    // fencing token: the completion mutations only write if it's unchanged.
+    const attempts = (doc.attempts ?? 0) + 1;
+    await ctx.db.patch(doc._id, { attempts, nextAttemptAt: Date.now() + leaseMs });
+    return { claimed: true, attempts };
+  },
+});
+
+/**
+ * A delivery whose endpoint was disabled/deleted after enqueue — mark FAILED, don't
+ * send. FENCED (expectedAttempts + still-PENDING): if another worker already claimed
+ * this row (attempts bumped) or completed it, this is a no-op — never clobber it.
+ */
+export const markEndpointDisabled = mutation({
+  args: { deliveryId: v.string(), lastError: v.string(), expectedAttempts: v.number() },
+  handler: async (ctx, { deliveryId, lastError, expectedAttempts }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("webhookDeliveries").withIndex("by_cuid", (q) => q.eq("id", deliveryId)).unique();
+    if (!doc || doc.status !== "PENDING" || (doc.attempts ?? 0) !== expectedAttempts) return;
+    await ctx.db.patch(doc._id, { status: "FAILED", lastError });
+  },
+});
+
+/**
+ * Successful delivery: mark SUCCEEDED + reset the endpoint's failure counter.
+ * FENCED by `expectedAttempts`: a stale worker whose lease expired (and whose row was
+ * re-claimed → attempts bumped) is a no-op, so it can't overwrite the newer attempt.
+ */
+export const markSucceeded = mutation({
+  args: { deliveryId: v.string(), webhookId: v.string(), responseStatus: v.number(), deliveredAt: v.number(), expectedAttempts: v.number() },
+  handler: async (ctx, { deliveryId, webhookId, responseStatus, deliveredAt, expectedAttempts }) => {
+    await requireService(ctx);
+    const d = await ctx.db.query("webhookDeliveries").withIndex("by_cuid", (q) => q.eq("id", deliveryId)).unique();
+    if (!d || d.attempts !== expectedAttempts) return; // stale worker — a newer claim owns this row
+    await ctx.db.patch(d._id, { status: "SUCCEEDED", responseStatus, deliveredAt, lastError: undefined });
+    const w = await ctx.db.query("webhooks").withIndex("by_cuid", (q) => q.eq("id", webhookId)).unique();
+    if (w) await ctx.db.patch(w._id, { consecutiveFailures: 0, lastDeliveryAt: deliveredAt });
+  },
+});
+
+/**
+ * Failed attempt: record the outcome + backoff on the delivery, bump the endpoint's
+ * consecutiveFailures, and auto-disable it on HTTP 410 or once it crosses the
+ * threshold. Encapsulates deliver.ts's failure branch atomically.
+ */
+export const markFailed = mutation({
+  args: {
+    deliveryId: v.string(),
+    webhookId: v.string(),
+    deliveryStatus: v.string(), // "PENDING" | "FAILED"
+    responseStatus: v.optional(v.number()),
+    lastError: v.string(),
+    nextAttemptAt: v.number(),
+    now: v.number(),
+    gone: v.boolean(),
+    autoDisableAfter: v.number(),
+    expectedAttempts: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const d = await ctx.db.query("webhookDeliveries").withIndex("by_cuid", (q) => q.eq("id", args.deliveryId)).unique();
+    // FENCED: a stale worker (lease expired, row re-claimed) is a no-op — it must not
+    // flip a newer attempt's outcome or double-count the endpoint's failures.
+    if (!d || d.attempts !== args.expectedAttempts) return;
+    await ctx.db.patch(d._id, {
+      status: args.deliveryStatus,
+      responseStatus: args.responseStatus,
+      lastError: args.lastError,
+      nextAttemptAt: args.nextAttemptAt,
+    });
+    const w = await ctx.db.query("webhooks").withIndex("by_cuid", (q) => q.eq("id", args.webhookId)).unique();
+    if (w) {
+      const consecutiveFailures = (w.consecutiveFailures ?? 0) + 1;
+      const disable = args.gone || consecutiveFailures >= args.autoDisableAfter;
+      await ctx.db.patch(w._id, {
+        consecutiveFailures,
+        lastDeliveryAt: args.now,
+        ...(disable ? { isActive: false, disabledAt: args.now } : {}),
+      });
+    }
+  },
+});

--- a/src/lib/webhooks/deliver.test.ts
+++ b/src/lib/webhooks/deliver.test.ts
@@ -1,19 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { verifyWebhookSignature } from "./sign";
 
-const findMany = vi.hoisted(() => vi.fn());
-const deliveryUpdate = vi.hoisted(() => vi.fn());
-const deliveryUpdateMany = vi.hoisted(() => vi.fn());
-const webhookUpdate = vi.hoisted(() => vi.fn());
-const transaction = vi.hoisted(() => vi.fn());
+// Webhook data is Convex now. Route the mocked client's mutations by a distinguishing
+// arg key (the vi.mock factory can't reference the imported `api`).
+const dueDeliveries = vi.hoisted(() => vi.fn());
+const claimDelivery = vi.hoisted(() => vi.fn());
+const markSucceeded = vi.hoisted(() => vi.fn());
+const markFailed = vi.hoisted(() => vi.fn());
+const markEndpointDisabled = vi.hoisted(() => vi.fn());
 
 vi.mock("./resolve-guard", () => ({ hostResolvesToPrivate: vi.fn().mockResolvedValue(false) }));
-vi.mock("../prisma", () => ({
-  prisma: {
-    webhookDelivery: { findMany, update: deliveryUpdate, updateMany: deliveryUpdateMany },
-    webhook: { update: webhookUpdate },
-    $transaction: transaction,
-  },
+vi.mock("../convex-client", () => ({
+  getConvexClient: vi.fn(async () => ({
+    query: (_ref: unknown, args: Record<string, unknown>) => dueDeliveries(args),
+    mutation: (_ref: unknown, args: Record<string, unknown>) => {
+      if ("leaseMs" in args) return claimDelivery(args);
+      if ("deliveredAt" in args) return markSucceeded(args);
+      if ("autoDisableAfter" in args) return markFailed(args);
+      if ("lastError" in args && !("webhookId" in args)) return markEndpointDisabled(args);
+      return Promise.resolve();
+    },
+  })),
 }));
 
 const { deliverPendingWebhooks, MAX_ATTEMPTS, AUTO_DISABLE_AFTER } = await import("./deliver");
@@ -27,7 +34,8 @@ const row = (over: Record<string, unknown> = {}) => ({
   event: "project.status_changed",
   payload: JSON.stringify({ projectId: "p1", from: "QUOTE", to: "CONFIRMED" }),
   attempts: 0,
-  createdAt: NOW,
+  nextAttemptAt: NOW.getTime(),
+  createdAt: NOW.getTime(),
   webhook: { id: "wh_1", url: "https://hooks.example.com/x", secret: SECRET, previousSecret: null, previousSecretExpiresAt: null, isActive: true },
   ...over,
 });
@@ -36,15 +44,16 @@ const okResponse = (status = 200) => ({ status }) as Response;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  deliveryUpdate.mockResolvedValue({});
-  deliveryUpdateMany.mockResolvedValue({ count: 1 });
-  webhookUpdate.mockResolvedValue({ consecutiveFailures: 1 });
-  transaction.mockResolvedValue([]);
+  // Default: claim succeeds, bumping attempts to (row.attempts + 1).
+  claimDelivery.mockImplementation((args: { id: string }) => Promise.resolve({ claimed: true, attempts: 1 }));
+  markSucceeded.mockResolvedValue(undefined);
+  markFailed.mockResolvedValue(undefined);
+  markEndpointDisabled.mockResolvedValue(undefined);
 });
 
 describe("deliverPendingWebhooks — success", () => {
   it("POSTs a signed, verifiable envelope and marks the delivery succeeded", async () => {
-    findMany.mockResolvedValue([row()]);
+    dueDeliveries.mockResolvedValue([row()]);
     const fetchImpl = vi.fn().mockResolvedValue(okResponse());
 
     const res = await deliverPendingWebhooks({ fetchImpl, now: NOW });
@@ -57,7 +66,6 @@ describe("deliverPendingWebhooks — success", () => {
     expect(headers["X-GearFlow-Event"]).toBe("project.status_changed");
     expect(headers["X-GearFlow-Delivery-Id"]).toBe("whd_1");
 
-    // The consumer can verify exactly the bytes we sent.
     expect(
       verifyWebhookSignature({
         rawBody: init.body as string,
@@ -67,7 +75,6 @@ describe("deliverPendingWebhooks — success", () => {
       }),
     ).toEqual({ valid: true });
 
-    // The envelope carries the delivery id, so a retry is dedupable.
     const envelope = JSON.parse(init.body as string);
     expect(envelope).toMatchObject({
       id: "whd_1",
@@ -77,29 +84,31 @@ describe("deliverPendingWebhooks — success", () => {
       data: { projectId: "p1", from: "QUOTE", to: "CONFIRMED" },
     });
 
-    // Success resets the failure streak.
-    expect(transaction).toHaveBeenCalled();
+    // Success path records via markSucceeded (resets the failure streak inside the mutation).
+    expect(markSucceeded).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveryId: "whd_1", webhookId: "wh_1", responseStatus: 200 }),
+    );
   });
 
   it("treats any 2xx as success", async () => {
-    findMany.mockResolvedValue([row()]);
+    dueDeliveries.mockResolvedValue([row()]);
     const res = await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(204)), now: NOW });
     expect(res.succeeded).toBe(1);
   });
 });
 
 describe("deliverPendingWebhooks — retries", () => {
-  it("claims the row atomically (increment attempts) BEFORE sending", async () => {
-    findMany.mockResolvedValue([row({ attempts: 0 })]);
+  it("claims the row atomically BEFORE sending", async () => {
+    dueDeliveries.mockResolvedValue([row({ attempts: 0 })]);
     await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse()), now: NOW });
-    const claim = deliveryUpdateMany.mock.calls[0][0];
-    expect(claim.where).toMatchObject({ id: "whd_1", status: "PENDING" });
-    expect(claim.data.attempts).toEqual({ increment: 1 });
+    expect(claimDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "whd_1", now: NOW.getTime() }),
+    );
   });
 
   it("does NOT send when the claim is lost to a concurrent worker", async () => {
-    findMany.mockResolvedValue([row({ attempts: 0 })]);
-    deliveryUpdateMany.mockResolvedValue({ count: 0 }); // someone else claimed it
+    dueDeliveries.mockResolvedValue([row({ attempts: 0 })]);
+    claimDelivery.mockResolvedValue({ claimed: false, attempts: 0 });
     const fetchImpl = vi.fn();
     const res = await deliverPendingWebhooks({ fetchImpl, now: NOW });
     expect(fetchImpl).not.toHaveBeenCalled();
@@ -107,106 +116,104 @@ describe("deliverPendingWebhooks — retries", () => {
   });
 
   it("schedules exponential backoff and stays PENDING while attempts remain", async () => {
-    findMany.mockResolvedValue([row({ attempts: 2 })]); // claim -> attempts 3
+    dueDeliveries.mockResolvedValue([row({ attempts: 2 })]);
+    claimDelivery.mockResolvedValue({ claimed: true, attempts: 3 }); // claim -> attempts 3
     await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(500)), now: NOW });
 
-    const data = deliveryUpdate.mock.calls[0][0].data;
-    expect(data.status).toBe("PENDING");
-    expect(data.lastError).toBe("HTTP 500");
-    // The claim already bumped attempts to 3; the failure write must not bump it again.
-    expect(data.attempts).toBeUndefined();
-    // attempt 3 -> 2^2 = 4 minutes
-    expect(new Date(data.nextAttemptAt).getTime() - NOW.getTime()).toBe(4 * 60_000);
+    const args = markFailed.mock.calls[0][0];
+    expect(args.deliveryStatus).toBe("PENDING");
+    expect(args.lastError).toBe("HTTP 500");
+    // attempt 3 -> 2^2 = 4 minutes (epoch ms)
+    expect(args.nextAttemptAt - NOW.getTime()).toBe(4 * 60_000);
   });
 
   it("does not follow redirects — a 3xx is a failed delivery, never an internal hop", async () => {
-    findMany.mockResolvedValue([row()]);
+    dueDeliveries.mockResolvedValue([row()]);
     const fetchImpl = vi.fn().mockResolvedValue(okResponse(302));
     await deliverPendingWebhooks({ fetchImpl, now: NOW });
     expect(fetchImpl.mock.calls[0][1].redirect).toBe("manual");
-    // 302 is not 2xx, so it is recorded as a failure.
-    expect(deliveryUpdate.mock.calls[0][0].data.status).toBe("PENDING");
-    expect(deliveryUpdate.mock.calls[0][0].data.lastError).toBe("HTTP 302");
+    expect(markFailed.mock.calls[0][0].deliveryStatus).toBe("PENDING");
+    expect(markFailed.mock.calls[0][0].lastError).toBe("HTTP 302");
   });
 
   it("gives up after MAX_ATTEMPTS", async () => {
-    findMany.mockResolvedValue([row({ attempts: MAX_ATTEMPTS - 1 })]); // claim -> MAX_ATTEMPTS
+    dueDeliveries.mockResolvedValue([row({ attempts: MAX_ATTEMPTS - 1 })]);
+    claimDelivery.mockResolvedValue({ claimed: true, attempts: MAX_ATTEMPTS });
     const res = await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(500)), now: NOW });
 
-    expect(deliveryUpdate.mock.calls[0][0].data.status).toBe("FAILED");
+    expect(markFailed.mock.calls[0][0].deliveryStatus).toBe("FAILED");
     expect(res.failed).toBe(1);
   });
 
   it("records a network error rather than throwing", async () => {
-    findMany.mockResolvedValue([row()]);
+    dueDeliveries.mockResolvedValue([row()]);
     const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     const res = await deliverPendingWebhooks({ fetchImpl, now: NOW });
 
     expect(res.processed).toBe(1);
-    expect(deliveryUpdate.mock.calls[0][0].data.lastError).toContain("ECONNREFUSED");
-    expect(deliveryUpdate.mock.calls[0][0].data.status).toBe("PENDING");
+    expect(markFailed.mock.calls[0][0].lastError).toContain("ECONNREFUSED");
+    expect(markFailed.mock.calls[0][0].deliveryStatus).toBe("PENDING");
   });
 });
 
 describe("deliverPendingWebhooks — endpoint health", () => {
-  it("honours 410 Gone: fails immediately and disables the endpoint", async () => {
-    findMany.mockResolvedValue([row()]);
+  it("honours 410 Gone: fails immediately and signals disable (gone=true)", async () => {
+    dueDeliveries.mockResolvedValue([row()]);
     await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(410)), now: NOW });
 
-    // No further retries for a consumer that said "stop".
-    expect(deliveryUpdate.mock.calls[0][0].data.status).toBe("FAILED");
-    const disable = webhookUpdate.mock.calls.find((c) => c[0].data.isActive === false);
-    expect(disable).toBeTruthy();
-    expect(disable![0].data.disabledAt).toEqual(NOW);
+    // 410 → exhausted FAILED + gone=true, which the markFailed mutation acts on to disable.
+    expect(markFailed.mock.calls[0][0].deliveryStatus).toBe("FAILED");
+    expect(markFailed.mock.calls[0][0].gone).toBe(true);
   });
 
-  it("auto-disables a dead endpoint after AUTO_DISABLE_AFTER consecutive failures", async () => {
-    findMany.mockResolvedValue([row()]);
-    webhookUpdate.mockResolvedValueOnce({ consecutiveFailures: AUTO_DISABLE_AFTER });
-
+  it("passes the auto-disable threshold to markFailed on every failure", async () => {
+    dueDeliveries.mockResolvedValue([row()]);
     await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(500)), now: NOW });
-
-    expect(webhookUpdate.mock.calls.some((c) => c[0].data.isActive === false)).toBe(true);
+    // The disable decision (consecutiveFailures >= threshold) is made atomically inside
+    // the Convex markFailed mutation; the worker's job is to pass the threshold + gone.
+    expect(markFailed.mock.calls[0][0].autoDisableAfter).toBe(AUTO_DISABLE_AFTER);
+    expect(markFailed.mock.calls[0][0].gone).toBe(false);
   });
 
-  it("does NOT disable while below the threshold", async () => {
-    findMany.mockResolvedValue([row()]);
-    webhookUpdate.mockResolvedValueOnce({ consecutiveFailures: AUTO_DISABLE_AFTER - 1 });
+  it("fails out an orphaned delivery whose endpoint was deleted (no starvation)", async () => {
+    dueDeliveries.mockResolvedValue([row({ webhook: null })]);
+    const fetchImpl = vi.fn();
 
-    await deliverPendingWebhooks({ fetchImpl: vi.fn().mockResolvedValue(okResponse(500)), now: NOW });
+    const res = await deliverPendingWebhooks({ fetchImpl, now: NOW });
 
-    expect(webhookUpdate.mock.calls.some((c) => c[0].data.isActive === false)).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(claimDelivery).not.toHaveBeenCalled();
+    expect(res.failed).toBe(1);
+    expect(markEndpointDisabled.mock.calls[0][0].lastError).toContain("no longer exists");
   });
 
   it("skips a delivery whose endpoint was disabled after it was enqueued", async () => {
-    findMany.mockResolvedValue([row({ webhook: { id: "wh_1", url: "https://x", secret: SECRET, isActive: false } })]);
+    dueDeliveries.mockResolvedValue([row({ webhook: { id: "wh_1", url: "https://x", secret: SECRET, previousSecret: null, previousSecretExpiresAt: null, isActive: false } })]);
     const fetchImpl = vi.fn();
 
     const res = await deliverPendingWebhooks({ fetchImpl, now: NOW });
 
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(res.failed).toBe(1);
-    expect(deliveryUpdate.mock.calls[0][0].data.lastError).toContain("disabled");
+    expect(markEndpointDisabled.mock.calls[0][0].lastError).toContain("disabled");
+    expect(claimDelivery).not.toHaveBeenCalled();
   });
 });
 
 describe("deliverPendingWebhooks — claiming", () => {
-  it("only claims pending rows whose backoff has elapsed", async () => {
-    findMany.mockResolvedValue([]);
+  it("queries due deliveries at `now`", async () => {
+    dueDeliveries.mockResolvedValue([]);
     await deliverPendingWebhooks({ now: NOW, fetchImpl: vi.fn() });
-    expect(findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { status: "PENDING", nextAttemptAt: { lte: NOW } },
-      }),
+    expect(dueDeliveries).toHaveBeenCalledWith(
+      expect.objectContaining({ now: NOW.getTime() }),
     );
   });
 });
 
 describe("deliverPendingWebhooks — secret rotation", () => {
   it("signs with both secrets during the grace window, so an un-rotated consumer verifies", async () => {
-    const { verifyWebhookSignature } = await import("./sign");
-    const future = new Date(NOW.getTime() + 30 * 60_000);
-    findMany.mockResolvedValue([
+    const future = NOW.getTime() + 30 * 60_000;
+    dueDeliveries.mockResolvedValue([
       row({ webhook: { id: "wh_1", url: "https://x/h", secret: "whsec_new", previousSecret: "whsec_old", previousSecretExpiresAt: future, isActive: true } }),
     ]);
     const fetchImpl = vi.fn().mockResolvedValue(okResponse());
@@ -221,8 +228,8 @@ describe("deliverPendingWebhooks — secret rotation", () => {
   });
 
   it("drops the previous secret once its grace window has expired", async () => {
-    const past = new Date(NOW.getTime() - 60_000);
-    findMany.mockResolvedValue([
+    const past = NOW.getTime() - 60_000;
+    dueDeliveries.mockResolvedValue([
       row({ webhook: { id: "wh_1", url: "https://x/h", secret: "whsec_new", previousSecret: "whsec_old", previousSecretExpiresAt: past, isActive: true } }),
     ]);
     const fetchImpl = vi.fn().mockResolvedValue(okResponse());

--- a/src/lib/webhooks/deliver.ts
+++ b/src/lib/webhooks/deliver.ts
@@ -1,4 +1,5 @@
-import { prisma } from "../prisma";
+import { getConvexClient } from "../convex-client";
+import { api } from "../../../convex/_generated/api";
 import { buildEnvelope, type WebhookEvent } from "./events";
 import { signWebhookPayload } from "./sign";
 import { hostResolvesToPrivate } from "./resolve-guard";
@@ -46,24 +47,25 @@ async function attemptOne(
     event: string;
     payload: string;
     attempts: number;
-    createdAt: Date;
+    createdAt: number; // epoch ms (Convex)
     webhook: {
       id: string;
       url: string;
       secret: string;
       previousSecret: string | null;
-      previousSecretExpiresAt: Date | null;
+      previousSecretExpiresAt: number | null; // epoch ms (Convex)
     };
   },
   doFetch: FetchLike,
   now: Date,
 ): Promise<DeliveryOutcome> {
+  const convex = await getConvexClient();
   const envelope = buildEnvelope({
     deliveryId: delivery.id,
     event: delivery.event as WebhookEvent,
     organizationId: delivery.organizationId,
     data: JSON.parse(delivery.payload) as Record<string, unknown>,
-    createdAt: delivery.createdAt,
+    createdAt: new Date(delivery.createdAt),
   });
 
   // Sign exactly the bytes we send. Re-serializing on the consumer's side would
@@ -78,7 +80,7 @@ async function attemptOne(
   const previousStillValid =
     delivery.webhook.previousSecret &&
     delivery.webhook.previousSecretExpiresAt &&
-    delivery.webhook.previousSecretExpiresAt > now;
+    delivery.webhook.previousSecretExpiresAt > now.getTime();
   if (previousStillValid) secrets.push(delivery.webhook.previousSecret!);
 
   const signature = signWebhookPayload(rawBody, secrets, timestamp);
@@ -129,46 +131,34 @@ async function attemptOne(
   const gone = responseStatus === 410;
 
   if (ok) {
-    await prisma.$transaction([
-      prisma.webhookDelivery.update({
-        where: { id: delivery.id },
-        data: { status: "SUCCEEDED", responseStatus, deliveredAt: now, lastError: null },
-      }),
-      prisma.webhook.update({
-        where: { id: delivery.webhook.id },
-        data: { consecutiveFailures: 0, lastDeliveryAt: now },
-      }),
-    ]);
+    await convex.mutation(api.webhooks.markSucceeded, {
+      deliveryId: delivery.id,
+      webhookId: delivery.webhook.id,
+      responseStatus: responseStatus!,
+      deliveredAt: now.getTime(),
+      expectedAttempts: attempts,
+    });
     return { deliveryId: delivery.id, status: "SUCCEEDED", responseStatus };
   }
 
   const exhausted = attempts >= MAX_ATTEMPTS || gone;
   const failureMessage = error ?? `HTTP ${responseStatus}`;
 
-  const webhook = await prisma.webhook.update({
-    where: { id: delivery.webhook.id },
-    data: { consecutiveFailures: { increment: 1 }, lastDeliveryAt: now },
-    select: { consecutiveFailures: true },
+  // One atomic mutation: record the delivery outcome + backoff, bump the endpoint's
+  // consecutiveFailures, and auto-disable on 410 or once it crosses the threshold.
+  await convex.mutation(api.webhooks.markFailed, {
+    deliveryId: delivery.id,
+    webhookId: delivery.webhook.id,
+    deliveryStatus: exhausted ? "FAILED" : "PENDING",
+    ...(responseStatus !== undefined ? { responseStatus } : {}),
+    lastError: failureMessage,
+    // Overwrites the claim lease with the real backoff.
+    nextAttemptAt: exhausted ? now.getTime() : now.getTime() + backoffMs(attempts),
+    now: now.getTime(),
+    gone,
+    autoDisableAfter: AUTO_DISABLE_AFTER,
+    expectedAttempts: attempts,
   });
-
-  await prisma.webhookDelivery.update({
-    where: { id: delivery.id },
-    data: {
-      status: exhausted ? "FAILED" : "PENDING",
-      responseStatus,
-      lastError: failureMessage,
-      // Overwrites the claim lease with the real backoff.
-      nextAttemptAt: exhausted ? now : new Date(now.getTime() + backoffMs(attempts)),
-    },
-  });
-
-  // A dead endpoint must stop generating load forever. The operator re-enables it.
-  if (gone || webhook.consecutiveFailures >= AUTO_DISABLE_AFTER) {
-    await prisma.webhook.update({
-      where: { id: delivery.webhook.id },
-      data: { isActive: false, disabledAt: now },
-    });
-  }
 
   return {
     deliveryId: delivery.id,
@@ -188,56 +178,59 @@ export async function deliverPendingWebhooks(opts: {
   fetchImpl?: FetchLike;
   now?: Date;
 } = {}): Promise<{ processed: number; succeeded: number; failed: number; outcomes: DeliveryOutcome[] }> {
-  const now = opts.now ?? new Date();
+  // Batch time bounds the due-query (a single consistent snapshot of "what's due").
+  // Per-delivery work uses a FRESH timestamp (unless a time is injected for tests), so
+  // a later delivery in a slow sequential batch gets current signatures + backoff, not
+  // the stale batch-start time.
+  const batchNow = opts.now ?? new Date();
   const doFetch = opts.fetchImpl ?? ((url, init) => fetch(url, init));
+  const convex = await getConvexClient();
 
-  const due = await prisma.webhookDelivery.findMany({
-    where: { status: "PENDING", nextAttemptAt: { lte: now } },
-    orderBy: { nextAttemptAt: "asc" },
-    take: opts.limit ?? 50,
-    include: {
-      webhook: {
-        select: {
-          id: true,
-          url: true,
-          secret: true,
-          previousSecret: true,
-          previousSecretExpiresAt: true,
-          isActive: true,
-        },
-      },
-    },
+  const due = await convex.query(api.webhooks.dueDeliveries, {
+    now: batchNow.getTime(),
+    limit: opts.limit ?? 50,
   });
 
   const outcomes: DeliveryOutcome[] = [];
   for (const delivery of due) {
+    const now = opts.now ?? new Date();
+
+    // Orphan: the endpoint was deleted after this row was enqueued. Fail it out of the
+    // queue so it can't sit forever "due" and starve the batch. Fenced by attempts.
+    if (!delivery.webhook) {
+      await convex.mutation(api.webhooks.markEndpointDisabled, {
+        deliveryId: delivery.id,
+        lastError: "Endpoint no longer exists.",
+        expectedAttempts: delivery.attempts,
+      });
+      outcomes.push({ deliveryId: delivery.id, status: "FAILED", error: "endpoint deleted" });
+      continue;
+    }
+
     // The endpoint was disabled after this row was enqueued. Don't deliver it.
     if (!delivery.webhook.isActive) {
-      await prisma.webhookDelivery.update({
-        where: { id: delivery.id },
-        data: { status: "FAILED", lastError: "Endpoint disabled before delivery." },
+      await convex.mutation(api.webhooks.markEndpointDisabled, {
+        deliveryId: delivery.id,
+        lastError: "Endpoint disabled before delivery.",
+        expectedAttempts: delivery.attempts,
       });
       outcomes.push({ deliveryId: delivery.id, status: "FAILED", error: "endpoint disabled" });
       continue;
     }
 
-    // CLAIM the row before sending. The cron worker and every emit fire-and-forget
-    // kick select the same PENDING rows; without an atomic claim they would both POST
-    // it and both write attempts=1 (last-writer-wins), so a failing endpoint would
-    // retry past MAX_ATTEMPTS and consumers would see duplicate bursts.
-    //
-    // Pushing `nextAttemptAt` out by the lease is what makes the claim exclusive: a
-    // concurrent worker's `nextAttemptAt <= now` filter no longer matches the row.
-    const lease = new Date(now.getTime() + LEASE_MS);
-    const claim = await prisma.webhookDelivery.updateMany({
-      where: { id: delivery.id, status: "PENDING", nextAttemptAt: { lte: now } },
-      data: { attempts: { increment: 1 }, nextAttemptAt: lease },
+    // CLAIM the row before sending — an atomic, transactional Convex mutation (replaces
+    // the Postgres updateMany optimistic lock). The cron worker and every emit
+    // fire-and-forget kick select the same PENDING rows; the claim bumps attempts and
+    // pushes nextAttemptAt out by the lease, so a concurrent worker's due-filter misses
+    // it. claim.claimed=false → someone else owns this attempt.
+    const claim = await convex.mutation(api.webhooks.claimDelivery, {
+      id: delivery.id,
+      now: now.getTime(),
+      leaseMs: LEASE_MS,
     });
-    if (claim.count === 0) continue; // someone else owns this attempt
+    if (!claim.claimed) continue;
 
-    outcomes.push(
-      await attemptOne({ ...delivery, attempts: delivery.attempts + 1 }, doFetch, now),
-    );
+    outcomes.push(await attemptOne({ ...delivery, attempts: claim.attempts }, doFetch, now));
   }
 
   return {

--- a/src/lib/webhooks/emit.test.ts
+++ b/src/lib/webhooks/emit.test.ts
@@ -1,25 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const webhookFindMany = vi.hoisted(() => vi.fn());
-const deliveryCreateMany = vi.hoisted(() => vi.fn());
+// Webhook data is Convex now.
+const activeSubscriptions = vi.hoisted(() => vi.fn());
+const enqueueDeliveries = vi.hoisted(() => vi.fn());
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    webhook: { findMany: webhookFindMany },
-    webhookDelivery: { createMany: deliveryCreateMany },
-  },
+vi.mock("../convex-client", () => ({
+  getConvexClient: vi.fn(async () => ({
+    query: (_ref: unknown, args: Record<string, unknown>) => activeSubscriptions(args),
+    mutation: (_ref: unknown, args: Record<string, unknown>) => enqueueDeliveries(args),
+  })),
 }));
+// The fire-and-forget delivery kick is irrelevant to enqueue behaviour.
+vi.mock("./deliver", () => ({ deliverPendingWebhooks: vi.fn().mockResolvedValue({}) }));
 
 const { emitWebhookEvent } = await import("./emit");
 
 beforeEach(() => {
   vi.clearAllMocks();
-  deliveryCreateMany.mockResolvedValue({ count: 1 });
+  enqueueDeliveries.mockResolvedValue({ enqueued: 1 });
 });
 
 describe("emitWebhookEvent", () => {
   it("enqueues one delivery per subscribed endpoint", async () => {
-    webhookFindMany.mockResolvedValue([
+    activeSubscriptions.mockResolvedValue([
       { id: "wh_1", events: JSON.stringify(["project.status_changed", "line_item.added"]) },
       { id: "wh_2", events: JSON.stringify(["project.status_changed"]) },
     ]);
@@ -27,46 +30,50 @@ describe("emitWebhookEvent", () => {
     const res = await emitWebhookEvent("org_1", "project.status_changed", { projectId: "p1" });
 
     expect(res.enqueued).toBe(2);
-    expect(deliveryCreateMany).toHaveBeenCalledWith({
-      data: [
-        { organizationId: "org_1", webhookId: "wh_1", event: "project.status_changed", payload: '{"projectId":"p1"}' },
-        { organizationId: "org_1", webhookId: "wh_2", event: "project.status_changed", payload: '{"projectId":"p1"}' },
-      ],
-    });
+    const arg = enqueueDeliveries.mock.calls[0][0] as {
+      deliveries: Array<{ id: string; organizationId: string; webhookId: string; event: string; payload: string }>;
+    };
+    expect(arg.deliveries).toHaveLength(2);
+    // Each delivery targets a subscribed endpoint with the same event + payload; the id
+    // is a freshly-minted cuid (stable envelope id), so assert structurally.
+    expect(arg.deliveries.map((d) => d.webhookId)).toEqual(["wh_1", "wh_2"]);
+    for (const d of arg.deliveries) {
+      expect(d).toMatchObject({ organizationId: "org_1", event: "project.status_changed", payload: '{"projectId":"p1"}' });
+      expect(typeof d.id).toBe("string");
+      expect(d.id.length).toBeGreaterThan(0);
+    }
   });
 
   it("ignores endpoints not subscribed to the event", async () => {
-    webhookFindMany.mockResolvedValue([{ id: "wh_1", events: JSON.stringify(["maintenance.created"]) }]);
+    activeSubscriptions.mockResolvedValue([{ id: "wh_1", events: JSON.stringify(["maintenance.created"]) }]);
 
     const res = await emitWebhookEvent("org_1", "project.status_changed", {});
 
     expect(res.enqueued).toBe(0);
-    expect(deliveryCreateMany).not.toHaveBeenCalled();
+    expect(enqueueDeliveries).not.toHaveBeenCalled();
   });
 
-  it("only considers active endpoints of this org", async () => {
-    webhookFindMany.mockResolvedValue([]);
+  it("only considers this org's active endpoints", async () => {
+    activeSubscriptions.mockResolvedValue([]);
     await emitWebhookEvent("org_1", "line_item.added", {});
-    expect(webhookFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { organizationId: "org_1", isActive: true } }),
-    );
+    expect(activeSubscriptions).toHaveBeenCalledWith({ orgId: "org_1" });
   });
 
   it("tolerates a garbage events column instead of throwing", async () => {
-    webhookFindMany.mockResolvedValue([{ id: "wh_1", events: "not json" }]);
+    activeSubscriptions.mockResolvedValue([{ id: "wh_1", events: "not json" }]);
     await expect(emitWebhookEvent("org_1", "line_item.added", {})).resolves.toEqual({ enqueued: 0 });
   });
 
   it("NEVER throws — a webhook must not roll back the write that produced it", async () => {
-    webhookFindMany.mockRejectedValue(new Error("database is on fire"));
+    activeSubscriptions.mockRejectedValue(new Error("backend is on fire"));
     await expect(emitWebhookEvent("org_1", "warehouse.checked_out", {})).resolves.toEqual({
       enqueued: 0,
     });
   });
 
   it("never throws when the enqueue itself fails", async () => {
-    webhookFindMany.mockResolvedValue([{ id: "wh_1", events: JSON.stringify(["line_item.added"]) }]);
-    deliveryCreateMany.mockRejectedValue(new Error("unique violation"));
+    activeSubscriptions.mockResolvedValue([{ id: "wh_1", events: JSON.stringify(["line_item.added"]) }]);
+    enqueueDeliveries.mockRejectedValue(new Error("write failed"));
     await expect(emitWebhookEvent("org_1", "line_item.added", {})).resolves.toEqual({ enqueued: 0 });
   });
 });

--- a/src/lib/webhooks/emit.ts
+++ b/src/lib/webhooks/emit.ts
@@ -1,4 +1,6 @@
-import { prisma } from "../prisma";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "../convex-client";
+import { api } from "../../../convex/_generated/api";
 import { parseEvents, type WebhookEvent } from "./events";
 
 /**
@@ -21,23 +23,27 @@ export async function emitWebhookEvent(
   data: Record<string, unknown>,
 ): Promise<{ enqueued: number }> {
   try {
-    const subscriptions = await prisma.webhook.findMany({
-      where: { organizationId, isActive: true },
-      select: { id: true, events: true },
-    });
+    const convex = await getConvexClient();
+    const subscriptions = await convex.query(api.webhooks.activeSubscriptions, { orgId: organizationId });
 
     const matching = subscriptions.filter((w) => parseEvents(w.events).includes(event));
     if (matching.length === 0) return { enqueued: 0 };
 
     // The payload stored here is NOT the final body — the envelope needs the delivery
-    // id, which only exists once the row does. `deliverPendingWebhooks` builds the
-    // envelope from this `data` plus the row's id and createdAt.
-    await prisma.webhookDelivery.createMany({
-      data: matching.map((w) => ({
+    // id, which we mint here (createId) so it's stable. `deliverPendingWebhooks` builds
+    // the envelope from this `data` plus the row's id and createdAt. nextAttemptAt=now
+    // so the row is immediately due.
+    const now = Date.now();
+    const payload = JSON.stringify(data);
+    await convex.mutation(api.webhooks.enqueueDeliveries, {
+      deliveries: matching.map((w) => ({
+        id: createId(),
         organizationId,
         webhookId: w.id,
         event,
-        payload: JSON.stringify(data),
+        payload,
+        createdAt: now,
+        nextAttemptAt: now,
       })),
     });
 

--- a/src/server/webhooks.ts
+++ b/src/server/webhooks.ts
@@ -1,6 +1,8 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
+import { createId } from "@paralleldrive/cuid2";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
@@ -8,6 +10,38 @@ import { generateWebhookSecret } from "@/lib/webhooks/sign";
 import { validateWebhookUrl } from "@/lib/webhooks/url";
 import { WEBHOOK_EVENTS, WEBHOOK_EVENT_DESCRIPTIONS, isWebhookEvent } from "@/lib/webhooks/events";
 import { UserFacingError } from "@/lib/errors";
+
+// Webhook is a Convex domain now (the Postgres `webhook`/`webhook_delivery` tables are
+// frozen). Convex stores dates as epoch-ms; these mappers restore the old Prisma
+// `select` shapes (Date fields, secret never leaked).
+const d = (n: number | null | undefined) => (n != null ? new Date(n) : null);
+type ConvexWebhook = {
+  id: string; description: string; url: string; events?: string; isActive?: boolean;
+  disabledAt?: number; consecutiveFailures?: number; lastDeliveryAt?: number; createdAt?: number;
+};
+function toWebhookRow(w: ConvexWebhook) {
+  return {
+    id: w.id, description: w.description, url: w.url,
+    events: w.events ?? "[]",
+    isActive: w.isActive ?? true,
+    disabledAt: d(w.disabledAt),
+    consecutiveFailures: w.consecutiveFailures ?? 0,
+    lastDeliveryAt: d(w.lastDeliveryAt),
+    createdAt: w.createdAt != null ? new Date(w.createdAt) : new Date(0),
+  };
+}
+type ConvexDelivery = {
+  id: string; event: string; status?: string; attempts?: number; responseStatus?: number;
+  lastError?: string; nextAttemptAt?: number; deliveredAt?: number; createdAt?: number;
+};
+function toDeliveryRow(x: ConvexDelivery) {
+  return {
+    id: x.id, event: x.event, status: x.status ?? "PENDING", attempts: x.attempts ?? 0,
+    responseStatus: x.responseStatus ?? null, lastError: x.lastError ?? null,
+    nextAttemptAt: d(x.nextAttemptAt), deliveredAt: d(x.deliveredAt),
+    createdAt: x.createdAt != null ? new Date(x.createdAt) : new Date(0),
+  };
+}
 
 /**
  * Webhook endpoint management. Creating, rotating and deleting an endpoint are
@@ -17,18 +51,6 @@ import { UserFacingError } from "@/lib/errors";
  *
  * See docs/designs/webhooks.md.
  */
-
-const READ_SHAPE = {
-  id: true,
-  description: true,
-  url: true,
-  events: true,
-  isActive: true,
-  disabledAt: true,
-  consecutiveFailures: true,
-  lastDeliveryAt: true,
-  createdAt: true,
-} as const;
 
 /** The events an endpoint can subscribe to, with descriptions. Read-only. */
 export async function getWebhookEvents() {
@@ -44,33 +66,20 @@ export async function getWebhookEvents() {
 /** List this org's endpoints. Never returns a secret. */
 export async function getWebhooks() {
   const { organizationId } = await getOrgContext();
-  const webhooks = await prisma.webhook.findMany({
-    where: { organizationId },
-    select: READ_SHAPE,
-    orderBy: { createdAt: "desc" },
-  });
+  const rows = await (await getConvexClient()).query(api.webhooks.list, { orgId: organizationId });
+  const webhooks = rows.map(toWebhookRow); // strips secret
   return serialize({ webhooks });
 }
 
 /** Recent delivery attempts for one endpoint — the self-serve debugging surface. */
 export async function getWebhookDeliveries(webhookId: string, limit?: number) {
   const { organizationId } = await getOrgContext();
-  const deliveries = await prisma.webhookDelivery.findMany({
-    where: { webhookId, organizationId },
-    orderBy: { createdAt: "desc" },
-    take: Math.min(limit ?? 50, 200),
-    select: {
-      id: true,
-      event: true,
-      status: true,
-      attempts: true,
-      responseStatus: true,
-      lastError: true,
-      nextAttemptAt: true,
-      deliveredAt: true,
-      createdAt: true,
-    },
+  const rows = await (await getConvexClient()).query(api.webhooks.deliveries, {
+    orgId: organizationId,
+    webhookId,
+    limit,
   });
+  const deliveries = rows.map(toDeliveryRow);
   return serialize({ deliveries });
 }
 
@@ -126,16 +135,24 @@ export async function createWebhook(input: {
   const events = assertEvents(input.events);
   const secret = generateWebhookSecret();
 
-  const created = await prisma.webhook.create({
-    data: {
-      organizationId,
-      description,
-      url: input.url,
-      events: JSON.stringify(events),
-      secret,
-      createdById: userId,
-    },
-    select: READ_SHAPE,
+  const id = createId();
+  const now = Date.now();
+  await (await getConvexClient()).mutation(api.webhooks.create, {
+    id,
+    organizationId,
+    description,
+    url: input.url,
+    events: JSON.stringify(events),
+    secret,
+    isActive: true,
+    consecutiveFailures: 0,
+    createdById: userId,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const created = toWebhookRow({
+    id, description, url: input.url, events: JSON.stringify(events),
+    isActive: true, consecutiveFailures: 0, createdAt: now,
   });
 
   await logActivity({
@@ -160,25 +177,34 @@ export async function updateWebhook(
 ) {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
-  const existing = await prisma.webhook.findFirst({ where: { id, organizationId } });
-  if (!existing) throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
+  // Build the patch; the Convex `update` mutation org-guards + returns the fresh doc.
+  const patch: {
+    description?: string;
+    events?: string;
+    isActive?: boolean;
+    disabledAt?: number | null;
+    consecutiveFailures?: number;
+  } = {};
+  if (input.description) patch.description = input.description.trim();
+  if (input.events) patch.events = JSON.stringify(assertEvents(input.events));
+  if (input.isActive !== undefined) {
+    // Re-enabling clears the auto-disable state so a fixed endpoint resumes cleanly.
+    patch.isActive = input.isActive;
+    patch.disabledAt = input.isActive ? null : Date.now();
+    if (input.isActive) patch.consecutiveFailures = 0;
+  }
 
-  const updated = await prisma.webhook.update({
-    where: { id },
-    data: {
-      ...(input.description ? { description: input.description.trim() } : {}),
-      ...(input.events ? { events: JSON.stringify(assertEvents(input.events)) } : {}),
-      // Re-enabling clears the auto-disable state, so a fixed endpoint resumes cleanly.
-      ...(input.isActive !== undefined
-        ? {
-            isActive: input.isActive,
-            disabledAt: input.isActive ? null : new Date(),
-            consecutiveFailures: input.isActive ? 0 : existing.consecutiveFailures,
-          }
-        : {}),
-    },
-    select: READ_SHAPE,
-  });
+  let updatedDoc;
+  try {
+    updatedDoc = await (await getConvexClient()).mutation(api.webhooks.update, {
+      id,
+      orgId: organizationId,
+      patch,
+    });
+  } catch {
+    throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
+  }
+  const updated = toWebhookRow(updatedDoc as ConvexWebhook);
 
   await logActivity({
     organizationId,
@@ -201,20 +227,22 @@ export async function updateWebhook(
 export async function rotateWebhookSecret(id: string, graceMinutes?: number) {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
-  const existing = await prisma.webhook.findFirst({ where: { id, organizationId } });
-  if (!existing) throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
-
   const secret = generateWebhookSecret();
   const grace = Math.min(Math.max(graceMinutes ?? 60, 0), 24 * 60);
 
-  await prisma.webhook.update({
-    where: { id },
-    data: {
+  // The mutation org-guards, sets previousSecret from the current secret internally,
+  // and returns the endpoint's description for the audit line.
+  let rotated: { id: string; description: string };
+  try {
+    rotated = await (await getConvexClient()).mutation(api.webhooks.rotateSecret, {
+      id,
+      orgId: organizationId,
       secret,
-      previousSecret: existing.secret,
-      previousSecretExpiresAt: new Date(Date.now() + grace * 60_000),
-    },
-  });
+      previousSecretExpiresAt: Date.now() + grace * 60_000,
+    });
+  } catch {
+    throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
+  }
 
   await logActivity({
     organizationId,
@@ -223,8 +251,8 @@ export async function rotateWebhookSecret(id: string, graceMinutes?: number) {
     action: "update",
     entityType: "webhook",
     entityId: id,
-    entityName: existing.description,
-    summary: `Rotated the signing secret for "${existing.description}"`,
+    entityName: rotated.description,
+    summary: `Rotated the signing secret for "${rotated.description}"`,
     metadata: { graceMinutes: grace },
   });
 
@@ -235,10 +263,16 @@ export async function rotateWebhookSecret(id: string, graceMinutes?: number) {
 export async function deleteWebhook(id: string) {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
-  const existing = await prisma.webhook.findFirst({ where: { id, organizationId } });
-  if (!existing) throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
-
-  await prisma.webhook.delete({ where: { id } });
+  // Convex remove org-guards, cascades the delivery log, and returns the description.
+  let removed: { id: string; description: string };
+  try {
+    removed = await (await getConvexClient()).mutation(api.webhooks.remove, {
+      id,
+      orgId: organizationId,
+    });
+  } catch {
+    throw new UserFacingError({ code: "NOT_FOUND", title: "Not found", message: "Webhook endpoint not found." });
+  }
 
   await logActivity({
     organizationId,
@@ -247,8 +281,8 @@ export async function deleteWebhook(id: string) {
     action: "delete",
     entityType: "webhook",
     entityId: id,
-    entityName: existing.description,
-    summary: `Deleted webhook endpoint "${existing.description}"`,
+    entityName: removed.description,
+    summary: `Deleted webhook endpoint "${removed.description}"`,
   });
 
   return serialize({ success: true });


### PR DESCRIPTION
## What
Inverts the last Postgres domain in this area: `webhook` config + the `webhookDelivery` queue → Convex (source of truth). Postgres tables frozen; **0 prod rows** (no backfill). The delivery **worker** (HTTP/HMAC/SSRF/cron) stays in Next.js — only the data layer moved, consistent with every other inversion. Completes **Phase 1** except the final `customRole` drop.

## Concurrency hardening (2 codex rounds — better than the original)
- **claimDelivery**: transactional atomic claim replacing the Postgres `updateMany` optimistic lock; leases from server `Date.now()` at claim time.
- **All completion mutations fenced by `expectedAttempts`** (= the claim's bumped attempts): a stale worker whose lease expired and whose row was re-claimed is a **no-op** — can't overwrite a newer attempt or double-count failures. *The original worker had no fencing at all.*
- **markFailed** encapsulates the failure branch atomically (backoff + endpoint failure-count + auto-disable on 410 / threshold).
- **Orphan handling**: `dueDeliveries` returns deleted-endpoint deliveries (webhook=null); the worker fails them out so they can't starve the batch limit.
- Per-attempt timestamps in a sequential batch (fresh signatures/backoff); injected time preserved for tests.

## Known scale note (documented)
`remove()`'s cascade is bounded to `take(4000)` so a huge delivery history can't exceed the Convex per-mutation write limit and *fail the deletion*; stragglers age out of the PENDING queue via the orphan path. A paginated retention job is a follow-up (moot at 0 rows).

## Verification
tsc clean; **71 webhook unit tests** (deliver/emit rewritten to mock Convex + a new orphan-starvation test; sign/url/resolve-guard unchanged). 2 adversarial codex passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)