### PR TITLE
feat(storage): move file storage to Convex (retire Garage/S3)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -49,6 +49,7 @@ import type * as emailActions from "../emailActions.js";
 import type * as emails from "../emails.js";
 import type * as equipmentTab from "../equipmentTab.js";
 import type * as fileUploads from "../fileUploads.js";
+import type * as files from "../files.js";
 import type * as globalSearch from "../globalSearch.js";
 import type * as groupTemplateItems from "../groupTemplateItems.js";
 import type * as groupTemplates from "../groupTemplates.js";
@@ -184,6 +185,7 @@ declare const fullApi: ApiFromModules<{
   emails: typeof emails;
   equipmentTab: typeof equipmentTab;
   fileUploads: typeof fileUploads;
+  files: typeof files;
   globalSearch: typeof globalSearch;
   groupTemplateItems: typeof groupTemplateItems;
   groupTemplates: typeof groupTemplates;

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,0 +1,88 @@
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { requireService } from "./lib/auth";
+
+/**
+ * Convex file storage (replaces the self-hosted Garage/S3 box). The bytes live in
+ * Convex `_storage`; this module manages the org-association records (`storedFiles`)
+ * that the `/api/files` proxy uses to authorise a serve — preserving the old per-org
+ * access model without S3's org-prefixed keys.
+ *
+ * All SERVICE-gated: the Next.js server (`src/lib/storage.ts`) is the only caller,
+ * via the service token. Uploads go: server → generateUploadUrl → POST bytes to that
+ * URL → register(storageId, org). Serves go: server → getServeInfo → stream getUrl.
+ */
+
+/** Mint a one-time upload URL. The server POSTs the file bytes to it and gets a storageId. */
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await requireService(ctx);
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+/** Record a freshly-uploaded file's org association (idempotent by storageId). */
+export const register = mutation({
+  args: {
+    storageId: v.string(),
+    organizationId: v.string(),
+    folder: v.optional(v.string()),
+    fileName: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await ctx.db
+      .query("storedFiles")
+      .withIndex("by_storageId", (q) => q.eq("storageId", args.storageId))
+      .unique();
+    if (existing) return;
+    await ctx.db.insert("storedFiles", args);
+  },
+});
+
+/**
+ * Serve info for the proxy: the file's org (for the auth check), a short-lived
+ * download URL, and content metadata. Null if the storageId has no record (deny).
+ */
+export const getServeInfo = query({
+  args: { storageId: v.string() },
+  handler: async (ctx, { storageId }) => {
+    await requireService(ctx);
+    const rec = await ctx.db
+      .query("storedFiles")
+      .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+      .unique();
+    if (!rec) return null;
+    const url = await ctx.storage.getUrl(storageId as Id<"_storage">);
+    if (!url) return null; // bytes gone
+    const meta = await ctx.db.system.get(storageId as Id<"_storage">);
+    return {
+      organizationId: rec.organizationId,
+      url,
+      contentType: meta?.contentType ?? null,
+      size: meta?.size ?? null,
+      fileName: rec.fileName ?? null,
+    };
+  },
+});
+
+/** Delete a file: its bytes + its org record. Idempotent. */
+export const deleteFile = mutation({
+  args: { storageId: v.string() },
+  handler: async (ctx, { storageId }) => {
+    await requireService(ctx);
+    const rec = await ctx.db
+      .query("storedFiles")
+      .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+      .unique();
+    if (rec) await ctx.db.delete(rec._id);
+    try {
+      await ctx.storage.delete(storageId as Id<"_storage">);
+    } catch {
+      // already gone — idempotent
+    }
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -214,6 +214,20 @@ export default defineSchema({
     .index("by_tokenHash", ["tokenHash"])
     .index("by_actingUserId", ["actingUserId"]),
 
+  // StoredFile — the org-association for a Convex-storage file (the byte store is
+  // Convex `_storage`). The /api/files proxy authorises a serve by looking up this
+  // record's org (replacing the old S3 org-prefixed-key path auth). organizationId
+  // "avatars" = global (user avatars, viewable by any authed user); any other value =
+  // org-scoped (only that org's members). See src/lib/storage.ts.
+  storedFiles: defineTable({
+    storageId: v.string(),
+    organizationId: v.string(),
+    folder: v.optional(v.string()),
+    fileName: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+  })
+    .index("by_storageId", ["storageId"]),
+
   // Webhook — outbound event endpoints (docs/designs/webhooks.md). The delivery
   // WORKER (HTTP send, HMAC signing, cron) stays in Next.js server code; only the
   // data lives here.

--- a/src/app/api/files/[...path]/route.ts
+++ b/src/app/api/files/[...path]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireOrganization } from "@/lib/auth-server";
-import { getFromS3 } from "@/lib/storage";
+import { getServeInfo } from "@/lib/storage";
 
 export const runtime = "nodejs";
 
 export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
+  _request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
 ) {
   let session;
   try {
@@ -19,57 +19,44 @@ export async function GET(
   const { path } = await params;
   const storageKey = path.join("/");
 
-  // Defense-in-depth: reject path traversal and null bytes
-  if (storageKey.includes("..") || storageKey.includes("\0") || storageKey.includes("//")) {
+  if (storageKey.includes("\0")) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Allow avatar paths (global, not org-scoped)
-  const isAvatarPath = storageKey.startsWith("avatars/");
-
-  // Verify the file belongs to the requesting user's organization (or is an avatar)
-  if (!isAvatarPath && !storageKey.startsWith(organizationId + "/")) {
+  // Record-based auth (replaces the old S3 org-prefixed-key path check): look up the
+  // file's org. "avatars" = global (any authed user); otherwise the caller's org must
+  // match. A missing record → 404.
+  const info = await getServeInfo(storageKey);
+  if (!info) {
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+  if (info.organizationId !== "avatars" && info.organizationId !== organizationId) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   try {
-    const response = await getFromS3(storageKey);
-
-    if (!response.Body) {
+    const upstream = await fetch(info.url);
+    if (!upstream.ok || !upstream.body) {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
 
-    const contentType = response.ContentType || "application/octet-stream";
+    const contentType = info.contentType || "application/octet-stream";
     const isImage = contentType.startsWith("image/");
 
-    // Convert the S3 readable stream to a web ReadableStream
-    const stream = response.Body.transformToWebStream();
-
-    const headers: Record<string, string> = {
-      "Content-Type": contentType,
-    };
-
+    const headers: Record<string, string> = { "Content-Type": contentType };
     if (isImage) {
       headers["Cache-Control"] = "public, max-age=31536000, immutable";
     } else {
-      // Extract filename from key for Content-Disposition
-      const fileName = storageKey.split("/").pop() || "download";
-      // Remove UUID prefix (first 8 chars + dash)
-      let cleanName = fileName.replace(/^[a-f0-9]+-/, "");
-      // Sanitize: remove CRLF, quotes, path separators, and traversal sequences
-      cleanName = cleanName.replace(/[\r\n"\\/:]/g, "_").replace(/\.\./g, "_");
-      cleanName = cleanName.replace(/^\.+/, ""); // Remove leading dots
+      let cleanName = (info.fileName || "download").replace(/[\r\n"\\/:]/g, "_").replace(/\.\./g, "_");
+      cleanName = cleanName.replace(/^\.+/, "");
       if (!cleanName) cleanName = "download";
       const encodedName = encodeURIComponent(cleanName);
       headers["Content-Disposition"] = `inline; filename="${cleanName}"; filename*=UTF-8''${encodedName}`;
       headers["Cache-Control"] = "private, max-age=3600";
     }
+    if (info.size) headers["Content-Length"] = String(info.size);
 
-    if (response.ContentLength) {
-      headers["Content-Length"] = String(response.ContentLength);
-    }
-
-    return new NextResponse(stream, { headers });
+    return new NextResponse(upstream.body, { headers });
   } catch (error) {
     console.error("File serve error:", error);
     return NextResponse.json({ error: "File not found" }, { status: 404 });

--- a/src/lib/media-write.ts
+++ b/src/lib/media-write.ts
@@ -1,6 +1,6 @@
 import { createId } from "@paralleldrive/cuid2";
 import { getConvexClient } from "@/lib/convex-client";
-import { deleteFromS3 } from "@/lib/storage";
+import { deleteFromS3, storageKeyFromUrl } from "@/lib/storage";
 import { mapGalleryFile, type GalleryFile } from "@/lib/media-read";
 import { MEDIA_SPECS, type MediaKind } from "@/lib/media-specs";
 import { api } from "../../convex/_generated/api";
@@ -120,8 +120,12 @@ export async function removeMediaConvex(
   if (fileDoc) {
     try {
       await deleteFromS3(fileDoc.storageKey);
+      // The thumbnail is a separate Convex storage object with its OWN opaque id —
+      // extract it from thumbnailUrl (/api/files/{thumbStorageId}), not by rewriting
+      // the original key (which only worked for the old S3 path scheme).
       if (fileDoc.thumbnailUrl) {
-        await deleteFromS3(fileDoc.storageKey.replace(/(\.[^.]+)$/, "_thumb.jpg"));
+        const thumbKey = storageKeyFromUrl(fileDoc.thumbnailUrl);
+        if (thumbKey) await deleteFromS3(thumbKey);
       }
     } catch {
       // best-effort S3 cleanup

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,54 +1,22 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  DeleteObjectCommand,
-  GetObjectCommand,
-  HeadBucketCommand,
-  CreateBucketCommand,
-} from "@aws-sdk/client-s3";
-import { randomUUID } from "crypto";
-import { env } from "@/env";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
 
-let s3Client: S3Client | null = null;
-
-function getS3Client(): S3Client {
-  if (s3Client) return s3Client;
-
-  const config: ConstructorParameters<typeof S3Client>[0] = {
-    region: env.S3_REGION,
-    credentials: {
-      accessKeyId: env.S3_ACCESS_KEY_ID,
-      secretAccessKey: env.S3_SECRET_ACCESS_KEY,
-    },
-  };
-
-  if (env.S3_ENDPOINT) {
-    config.endpoint = env.S3_ENDPOINT;
-    config.forcePathStyle = true; // Required for MinIO / R2
-  }
-
-  s3Client = new S3Client(config);
-  return s3Client;
-}
-
-function getBucket(): string {
-  return env.S3_BUCKET;
-}
+/**
+ * File storage on Convex `_storage` (replaces the self-hosted Garage/S3 box). The
+ * public API shape (uploadToS3 / deleteFromS3 / getProxyUrl / getFileAsDataUri) is
+ * kept so callers don't change — the "storageKey" is now a Convex storageId, and the
+ * `/api/files/{storageId}` proxy authorises a serve via the file's `storedFiles` org
+ * record (see convex/files.ts + the /api/files route). Uploads are server-side: mint a
+ * Convex upload URL, POST the bytes to it, then register the org association.
+ */
 
 export interface UploadResult {
   storageKey: string;
   url: string;
 }
 
-export async function ensureBucket(): Promise<void> {
-  const client = getS3Client();
-  const bucket = getBucket();
-  try {
-    await client.send(new HeadBucketCommand({ Bucket: bucket }));
-  } catch {
-    await client.send(new CreateBucketCommand({ Bucket: bucket }));
-  }
-}
+/** No-op — Convex storage needs no bucket. Retained so existing callers don't change. */
+export async function ensureBucket(): Promise<void> {}
 
 export async function uploadToS3(
   file: Buffer,
@@ -58,54 +26,47 @@ export async function uploadToS3(
     entityId: string;
     fileName: string;
     mimeType: string;
-  }
+  },
 ): Promise<UploadResult> {
-  const client = getS3Client();
-  const bucket = getBucket();
+  const convex = await getConvexClient();
+  const uploadUrl = await convex.mutation(api.files.generateUploadUrl, {});
+  const res = await fetch(uploadUrl, {
+    method: "POST",
+    headers: { "Content-Type": options.mimeType },
+    // Buffer isn't in the DOM BodyInit types; a plain Uint8Array view is.
+    body: new Uint8Array(file),
+  });
+  if (!res.ok) throw new Error(`Convex storage upload failed: ${res.status}`);
+  const { storageId } = (await res.json()) as { storageId: string };
 
-  const safeName = options.fileName.replace(/[^a-zA-Z0-9._-]/g, "-");
-  const uuid = randomUUID().split("-")[0];
-  const storageKey = `${options.organizationId}/${options.folder}/${options.entityId}/${uuid}-${safeName}`;
+  await convex.mutation(api.files.register, {
+    storageId,
+    organizationId: options.organizationId,
+    folder: options.folder,
+    fileName: options.fileName,
+    createdAt: Date.now(),
+  });
 
-  await client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: storageKey,
-      Body: file,
-      ContentType: options.mimeType,
-    })
-  );
-
-  return {
-    storageKey,
-    url: `/api/files/${storageKey}`,
-  };
+  return { storageKey: storageId, url: `/api/files/${storageId}` };
 }
 
 export async function deleteFromS3(storageKey: string): Promise<void> {
-  const client = getS3Client();
-  const bucket = getBucket();
-
-  await client.send(
-    new DeleteObjectCommand({
-      Bucket: bucket,
-      Key: storageKey,
-    })
-  );
+  const convex = await getConvexClient();
+  await convex.mutation(api.files.deleteFile, { storageId: storageKey });
 }
 
-export async function getFromS3(storageKey: string) {
-  const client = getS3Client();
-  const bucket = getBucket();
+export interface ServeInfo {
+  organizationId: string;
+  url: string;
+  contentType: string | null;
+  size: number | null;
+  fileName: string | null;
+}
 
-  const response = await client.send(
-    new GetObjectCommand({
-      Bucket: bucket,
-      Key: storageKey,
-    })
-  );
-
-  return response;
+/** Auth + streaming info for the /api/files proxy. Null → the storageId has no record. */
+export async function getServeInfo(storageKey: string): Promise<ServeInfo | null> {
+  const convex = await getConvexClient();
+  return await convex.query(api.files.getServeInfo, { storageId: storageKey });
 }
 
 export function getProxyUrl(storageKey: string): string {
@@ -120,54 +81,18 @@ export function storageKeyFromUrl(proxyUrl: string): string | null {
   return proxyUrl.slice(idx + prefix.length);
 }
 
-/** Read a file from S3 and return it as a base64 data URI */
+/** Read a file (by proxy URL) and return it as a base64 data URI (for PDF embedding). */
 export async function getFileAsDataUri(proxyUrl: string): Promise<string | null> {
   const key = storageKeyFromUrl(proxyUrl);
   if (!key) return null;
-
-  // Try the key directly first
-  const result = await fetchS3AsDataUri(key);
-  if (result) return result;
-
-  // If the URL was a thumbnail, try to find the original
-  if (proxyUrl.includes("_thumb")) {
-    // Strategy 1: strip _thumb suffix to reconstruct the original key
-    const thumbKey = storageKeyFromUrl(proxyUrl);
-    if (thumbKey) {
-      const originalKey = thumbKey.replace(/_thumb(\.[^.]+)$/, "$1");
-      if (originalKey !== thumbKey) {
-        const originalResult = await fetchS3AsDataUri(originalKey);
-        if (originalResult) return originalResult;
-      }
-    }
-
-    // Strategy 2: look up the FileUpload record by thumbnailUrl. file_upload is
-    // Convex-only — query by thumbnailUrl via the service token (no orgId in this
-    // path, so the Convex query is cross-org, mirroring the old global findFirst).
-    try {
-      const { getConvexClient } = await import("@/lib/convex-client");
-      const { api } = await import("../../convex/_generated/api");
-      const record = await (await getConvexClient()).query(api.fileUploads.getByThumbnailUrl, {
-        thumbnailUrl: proxyUrl,
-      });
-      if (record) {
-        return fetchS3AsDataUri(record.storageKey);
-      }
-    } catch {
-      // Lookup failed, give up
-    }
-  }
-
-  return null;
-}
-
-async function fetchS3AsDataUri(key: string): Promise<string | null> {
+  const info = await getServeInfo(key);
+  if (!info) return null;
   try {
-    const response = await getFromS3(key);
-    if (!response.Body) return null;
-    const bytes = await response.Body.transformToByteArray();
-    const contentType = response.ContentType || "image/png";
-    return `data:${contentType};base64,${Buffer.from(bytes).toString("base64")}`;
+    const res = await fetch(info.url);
+    if (!res.ok) return null;
+    const bytes = Buffer.from(await res.arrayBuffer());
+    const contentType = info.contentType || "image/png";
+    return `data:${contentType};base64,${bytes.toString("base64")}`;
   } catch {
     return null;
   }


### PR DESCRIPTION
## What
**Phase 2.** Replaces the self-hosted Garage/S3 box with **Convex `_storage`** for file bytes. Prod Garage is **empty (0 objects)** → no byte migration.

- `convex/files.ts` + `storedFiles` table: `generateUploadUrl`/`register`/`getServeInfo`/`deleteFile` (SERVICE-gated). `storedFiles` holds the **org association per storageId** (Convex ids are opaque — no S3 prefix to authorise from).
- `src/lib/storage.ts`: rewritten to Convex, **same public API** so the ~6 callers don't change.
- `/api/files` serve route: **record-based auth** (look up the file's org) replacing the S3-key-prefix check — server-controlled, stronger. `"avatars"` = global (user avatars); else the caller's org must match. Streams via a short-lived Convex `getUrl`.
- `media-write`: thumbnail deletion uses the thumb's own storageId from `thumbnailUrl`.

## Security (chosen model: keep per-org auth)
Codex confirmed **no cross-org read / no auth bypass** (record check > caller-controlled prefix; `"avatars"` can't collide with a cuid org). **Validated end-to-end on prod Convex storage**: upload → register → serve-auth (org match; cross-org 403) → **bytes match** → delete → gone.

## Notes
- Pre-existing `fileUpload` records point at now-absent Garage bytes and already 404'd (0 objects) — no regression, nothing to migrate.
- **Retiring the Garage container + S3 env/deps is a follow-up** once this is live-confirmed.

## Verification
tsc clean; full suite **3150/3150**; codex-reviewed; live round-trip on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)