### PR TITLE
feat(activity-log): Convex-only audit log (drop Postgres dual-write)

### DIFF
--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,7 +1,4 @@
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
-import type { Prisma } from "@/generated/prisma/client";
-import { nativeActivityWrites } from "@/lib/native-writes";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -22,53 +19,32 @@ interface LogActivityInput {
 }
 
 export async function logActivity(input: LogActivityInput): Promise<void> {
-  // One shared id + timestamp so the Postgres row and the Convex mirror row match
-  // exactly (the mirror is idempotent by this cuid).
+  // Convex-only now (the Postgres `activity_log` table is frozen; the activity-log
+  // screens read Convex `activityLogs`). Best-effort — audit must never break the write
+  // that produced it. Idempotent by this cuid. The 5 inverted domains write Convex
+  // atomically in-mutation and skip logActivity, so there's no double-count.
   const id = createId();
-  const createdAt = new Date();
-
-  // Postgres write (unchanged behaviour — best-effort, never throws).
   try {
-    await prisma.activityLog.create({
-      data: {
-        id,
-        createdAt,
-        ...input,
-        details: input.details as unknown as Prisma.InputJsonValue,
-        metadata: input.metadata as unknown as Prisma.InputJsonValue,
-      },
+    const convex = await getConvexClient();
+    await convex.mutation(api.activityLogWrites.record, {
+      id,
+      organizationId: input.organizationId,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      entityName: input.entityName,
+      userId: input.userId,
+      userName: input.userName,
+      summary: input.summary,
+      details: input.details,
+      metadata: input.metadata,
+      projectId: input.projectId,
+      assetId: input.assetId,
+      kitId: input.kitId,
+      createdAt: Date.now(),
     });
   } catch (error) {
-    console.error("Failed to log activity:", error);
-  }
-
-  // Phase 5c: mirror into Convex `activityLogs` so the activity-log screens can read
-  // natively with the COMPLETE cross-domain history. Best-effort — audit must never
-  // break a write. The 5 inverted domains write Convex atomically in-mutation and skip
-  // logActivity, so there's no double-count.
-  if (nativeActivityWrites()) {
-    try {
-      const convex = await getConvexClient();
-      await convex.mutation(api.activityLogWrites.record, {
-        id,
-        organizationId: input.organizationId,
-        action: input.action,
-        entityType: input.entityType,
-        entityId: input.entityId,
-        entityName: input.entityName,
-        userId: input.userId,
-        userName: input.userName,
-        summary: input.summary,
-        details: input.details,
-        metadata: input.metadata,
-        projectId: input.projectId,
-        assetId: input.assetId,
-        kitId: input.kitId,
-        createdAt: createdAt.getTime(),
-      });
-    } catch (error) {
-      console.error("Failed to mirror activity to Convex:", error);
-    }
+    console.error("Failed to record activity to Convex:", error);
   }
 }
 
@@ -82,48 +58,33 @@ export async function logActivity(input: LogActivityInput): Promise<void> {
  */
 export async function logActivityMany(inputs: LogActivityInput[]): Promise<void> {
   if (inputs.length === 0) return;
-  const createdAt = new Date();
+  const createdAt = Date.now();
   const rows = inputs.map((input) => ({ id: createId(), createdAt, ...input }));
 
-  // ONE Postgres insert for all N rows (was N sequential creates).
+  // ONE Convex mutation for all N rows (Convex-only; audit is best-effort, never throws).
   try {
-    await prisma.activityLog.createMany({
-      data: rows.map((r) => ({
-        ...r,
-        details: r.details as unknown as Prisma.InputJsonValue,
-        metadata: r.metadata as unknown as Prisma.InputJsonValue,
+    const convex = await getConvexClient();
+    await convex.mutation(api.activityLogWrites.recordMany, {
+      rows: rows.map((r) => ({
+        id: r.id,
+        organizationId: r.organizationId,
+        action: r.action,
+        entityType: r.entityType,
+        entityId: r.entityId,
+        entityName: r.entityName,
+        userId: r.userId,
+        userName: r.userName,
+        summary: r.summary,
+        details: r.details,
+        metadata: r.metadata,
+        projectId: r.projectId,
+        assetId: r.assetId,
+        kitId: r.kitId,
+        createdAt: r.createdAt,
       })),
     });
   } catch (error) {
-    console.error("Failed to log activity batch:", error);
-  }
-
-  // ONE Convex mirror mutation for all N (was N sequential `record` calls).
-  if (nativeActivityWrites()) {
-    try {
-      const convex = await getConvexClient();
-      await convex.mutation(api.activityLogWrites.recordMany, {
-        rows: rows.map((r) => ({
-          id: r.id,
-          organizationId: r.organizationId,
-          action: r.action,
-          entityType: r.entityType,
-          entityId: r.entityId,
-          entityName: r.entityName,
-          userId: r.userId,
-          userName: r.userName,
-          summary: r.summary,
-          details: r.details,
-          metadata: r.metadata,
-          projectId: r.projectId,
-          assetId: r.assetId,
-          kitId: r.kitId,
-          createdAt: r.createdAt.getTime(),
-        })),
-      });
-    } catch (error) {
-      console.error("Failed to mirror activity batch to Convex:", error);
-    }
+    console.error("Failed to record activity batch to Convex:", error);
   }
 }
 

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -36,22 +36,8 @@ export const nativeLineItemWrites = (): boolean =>
 export const nativeRecalc = (): boolean =>
   process.env.NATIVE_RECALC === "true";
 
-/**
- * Audit-log Phase 5c cutover (two independent flags so the write can lead the read):
- * - `NATIVE_ACTIVITY_WRITES` — `logActivity` ALSO mirrors each row into Convex
- *   `activityLogs` (via `api.activityLogWrites.record`), giving Convex the COMPLETE
- *   history across all domains, not just the 5 inverted ones. Keeps the Postgres write
- *   too (dual-write) so the read can fall back instantly.
- * - `NATIVE_ACTIVITY_READS` — the activity-log screens read Convex `activityLogs`
- *   instead of Postgres. Only flip AFTER writes have run long enough to backfill, or
- *   after a one-off backfill; otherwise the screen shows a truncated history.
- * Both default OFF.
- */
-export const nativeActivityWrites = (): boolean =>
-  process.env.NATIVE_ACTIVITY_WRITES === "true";
-
-export const nativeActivityReads = (): boolean =>
-  process.env.NATIVE_ACTIVITY_READS === "true";
+// Audit log is now Convex-only (write + read); the NATIVE_ACTIVITY_WRITES/READS
+// cutover flags were removed once the Postgres activity_log table was frozen.
 
 /**
  * Phase 6b — route post-write email side-effects through the Convex durable,

--- a/src/server/activity-log.ts
+++ b/src/server/activity-log.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import { prisma } from "@/lib/prisma";
 import { getOrgContext } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
-import { nativeActivityReads } from "@/lib/native-writes";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -52,70 +50,25 @@ export async function getActivityLogs(filters: ActivityLogFilters = {}) {
     order = "desc",
   } = filters;
 
-  // Phase 5c: native Convex read (complete cross-domain history via the logActivity
-  // mirror). Same shape as the Prisma path so the screen is agnostic.
-  if (nativeActivityReads()) {
-    const convex = await getConvexClient();
-    const result = await convex.query(api.activityLog.list, {
-      orgId: organizationId,
-      page,
-      pageSize,
-      sort,
-      order,
-      entityType,
-      action,
-      userId,
-      entityId,
-      projectId,
-      assetId,
-      search,
-      startDateMs: startMs(startDate),
-      endDateMs: endMs(endDate),
-    });
-    return serialize(result);
-  }
-
-  const where: Record<string, unknown> = { organizationId };
-
-  if (entityType) where.entityType = entityType;
-  if (action) where.action = action;
-  if (userId) where.userId = userId;
-  if (entityId) where.entityId = entityId;
-  if (projectId) where.projectId = projectId;
-  if (assetId) where.assetId = assetId;
-  if (search) where.summary = { contains: search, mode: "insensitive" };
-
-  if (startDate || endDate) {
-    const dateFilter: Record<string, Date> = {};
-    if (startDate) dateFilter.gte = new Date(startDate);
-    if (endDate) {
-      const end = new Date(endDate);
-      end.setHours(23, 59, 59, 999);
-      dateFilter.lte = end;
-    }
-    where.createdAt = dateFilter;
-  }
-
-  const [items, total] = await Promise.all([
-    prisma.activityLog.findMany({
-      where,
-      include: {
-        user: { select: { id: true, name: true, image: true } },
-      },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-      orderBy: { [sort]: order },
-    }),
-    prisma.activityLog.count({ where }),
-  ]);
-
-  return serialize({
-    items,
-    total,
+  // Convex-only (complete cross-domain history; the Postgres activity_log is frozen).
+  const convex = await getConvexClient();
+  const result = await convex.query(api.activityLog.list, {
+    orgId: organizationId,
     page,
     pageSize,
-    totalPages: Math.ceil(total / pageSize),
+    sort,
+    order,
+    entityType,
+    action,
+    userId,
+    entityId,
+    projectId,
+    assetId,
+    search,
+    startDateMs: startMs(startDate),
+    endDateMs: endMs(endDate),
   });
+  return serialize(result);
 }
 
 export async function getEntityActivityLog(
@@ -125,32 +78,14 @@ export async function getEntityActivityLog(
 ) {
   const { organizationId } = await getOrgContext();
 
-  if (nativeActivityReads()) {
-    const convex = await getConvexClient();
-    const result = await convex.query(api.activityLog.listByEntity, {
-      orgId: organizationId,
-      entityType,
-      entityId,
-      limit,
-    });
-    return serialize(result);
-  }
-
-  const where = { organizationId, entityType, entityId };
-
-  const [items, total] = await Promise.all([
-    prisma.activityLog.findMany({
-      where,
-      include: {
-        user: { select: { id: true, name: true, image: true } },
-      },
-      orderBy: { createdAt: "desc" },
-      take: limit,
-    }),
-    prisma.activityLog.count({ where }),
-  ]);
-
-  return serialize({ items, total });
+  const convex = await getConvexClient();
+  const result = await convex.query(api.activityLog.listByEntity, {
+    orgId: organizationId,
+    entityType,
+    entityId,
+    limit,
+  });
+  return serialize(result);
 }
 
 export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
@@ -175,42 +110,17 @@ export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
     details?: unknown;
   }>;
 
-  if (nativeActivityReads()) {
-    const convex = await getConvexClient();
-    items = await convex.query(api.activityLog.exportRows, {
-      orgId: organizationId,
-      entityType,
-      entityId,
-      action,
-      userId,
-      search,
-      startDateMs: startMs(startDate),
-      endDateMs: endMs(endDate),
-    });
-  } else {
-    const where: Record<string, unknown> = { organizationId };
-    if (entityType) where.entityType = entityType;
-    if (entityId) where.entityId = entityId;
-    if (action) where.action = action;
-    if (userId) where.userId = userId;
-    if (search) where.summary = { contains: search, mode: "insensitive" };
-    if (startDate || endDate) {
-      const dateFilter: Record<string, Date> = {};
-      if (startDate) dateFilter.gte = new Date(startDate);
-      if (endDate) {
-        const end = new Date(endDate);
-        end.setHours(23, 59, 59, 999);
-        dateFilter.lte = end;
-      }
-      where.createdAt = dateFilter;
-    }
-
-    items = await prisma.activityLog.findMany({
-      where,
-      orderBy: { createdAt: "desc" },
-      take: 10000,
-    });
-  }
+  const convex = await getConvexClient();
+  items = await convex.query(api.activityLog.exportRows, {
+    orgId: organizationId,
+    entityType,
+    entityId,
+    action,
+    userId,
+    search,
+    startDateMs: startMs(startDate),
+    endDateMs: endMs(endDate),
+  });
 
   const escape = (s: string) => {
     if (s.includes(",") || s.includes('"') || s.includes("\n")) {

--- a/src/server/activity-log.ts
+++ b/src/server/activity-log.ts
@@ -100,7 +100,8 @@ export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
     endDate,
   } = filters;
 
-  let items: Array<{
+  const convex = await getConvexClient();
+  const items: Array<{
     createdAt: string | Date;
     userName: string;
     action: string;
@@ -108,10 +109,7 @@ export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
     entityName: string;
     summary: string;
     details?: unknown;
-  }>;
-
-  const convex = await getConvexClient();
-  items = await convex.query(api.activityLog.exportRows, {
+  }> = await convex.query(api.activityLog.exportRows, {
     orgId: organizationId,
     entityType,
     entityId,


### PR DESCRIPTION
## What
The audit log was the **last dual-write domain**. Inverts it to Convex-only, completing the 'Postgres for Better Auth only' goal.

- **Backfilled** all **5092** prod Postgres rows → Convex first (idempotent by cuid — only **1** was new; the mirror had carried the rest). Convex holds the complete history.
- `logActivity`/`logActivityMany`: Convex-only writes, unconditional, still **best-effort** (audit never breaks the write — same contract).
- Reads (`getActivityLogs`/`getEntityActivityLog`/`exportActivityLogCSV`): Convex-only; dropped the Postgres branches.
- Removed the `NATIVE_ACTIVITY_WRITES`/`READS` cutover flags.

Postgres `activity_log` is now frozen (Phase-4 DROP candidate).

## Verification
Backfill run against prod (5092 rows, Convex complete). tsc clean; full suite **3150/3150**; codex — no audit-loss or shape regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)