### PR TITLE
feat(settings): invert per-org business settings to Convex (Phase 1 WS1)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3556,6 +3556,42 @@ organization writes stay Postgres (Better Auth owns them — Tier E).
   multi-field searches (e.g. the model picker's name+manufacturer) need a second index
   or a denormalized search field before cutover.
 
+## Phase 1 (WS1) — org business settings → Convex
+
+Per-org **business settings** moved off the Better Auth `organization` row into a
+dedicated Convex table so the org row keeps only auth-identity fields (name, slug,
+logo). The three legacy Postgres columns — `metadata` (the `OrgSettings` JSON blob:
+branding, testTag, SSO config, asset-tag + project-number config, ical, tax label,
+timezone…), `defaultTaxRate`, `apiKillSwitchAt` — are now **Convex-only source of
+truth**.
+
+- **Table** (`convex/schema.ts` `orgSettings`, one row per org, `by_organizationId`):
+  `settings` (the JSON blob, verbatim), plus denormalised `defaultTaxRate`,
+  `apiKillSwitchAt`, and `icalToken`. `icalToken` is set **only while the feed is
+  enabled** and indexed (`by_icalToken`) — so the public calendar route resolves a
+  token to a live org with an indexed lookup instead of scanning every org's metadata.
+- **Functions** (`convex/orgSettings.ts`, all SERVICE-gated — RBAC/validation/audit
+  stay in the Next.js server actions for now): `getByOrg`, `getByIcalToken`,
+  `upsertSettings` (full-blob replace), atomic `reserveAssetTags` / `reserveTestTagIds`
+  (counter read-modify-write **inside** the mutation → serializable, no TOCTOU),
+  `setApiKillSwitch`, and `createIfMissing` (backfill).
+- **Server helper** (`src/lib/org-settings-read.ts`): `readOrgSettings` /
+  `readOrgSettingsBlob` / `readOrgDefaultTaxRate` / `saveOrgSettings` /
+  `reserveAssetTagsConvex` / `reserveTestTagIdsConvex` / `setApiKillSwitchConvex` /
+  `orgIdForIcalToken`. `saveOrgSettings` derives the denormalised `icalToken` from the
+  blob (enabled feeds only).
+- **Consumers rewired** off `prisma.organization` metadata/tax/kill-switch reads:
+  `server/settings.ts`, `server/org-calendar.ts`, `server/sso.ts`,
+  `lib/sso-provisioning.ts`, `lib/auth.ts` (SSO test-success flag on login),
+  `server/api-keys.ts` + `lib/api-key.ts` (kill-switch check on every API request),
+  `server/line-items.ts` (org default tax), the iCal feed route + the two crew calendar
+  routes, the test-tag report route + `server/test-tag-assets.ts`, and both PDF
+  doc-data builders. Org **name** reads stay on the Better Auth org row.
+- **Backfill** (`scripts/convex-backfill-org-settings.ts`, idempotent): copies each
+  org's `metadata`/`defaultTaxRate`/`apiKillSwitchAt` into `orgSettings`. **Run in the
+  prod container immediately after deploy** — before any asset/test-tag creation — so
+  the atomic counters resume from the stored value rather than re-initialising at 0.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -88,6 +88,7 @@ import type * as modelMedia from "../modelMedia.js";
 import type * as models from "../models.js";
 import type * as notificationDismissals from "../notificationDismissals.js";
 import type * as notificationEmailLogs from "../notificationEmailLogs.js";
+import type * as orgSettings from "../orgSettings.js";
 import type * as overbooking from "../overbooking.js";
 import type * as parity from "../parity.js";
 import type * as pendingSSOApprovals from "../pendingSSOApprovals.js";
@@ -224,6 +225,7 @@ declare const fullApi: ApiFromModules<{
   models: typeof models;
   notificationDismissals: typeof notificationDismissals;
   notificationEmailLogs: typeof notificationEmailLogs;
+  orgSettings: typeof orgSettings;
   overbooking: typeof overbooking;
   parity: typeof parity;
   pendingSSOApprovals: typeof pendingSSOApprovals;

--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -1,0 +1,228 @@
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+import type { Doc } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+
+/**
+ * Per-org BUSINESS settings — Convex-only source of truth (Phase 1 inversion).
+ *
+ * Replaces the `organization.metadata` JSON blob + `defaultTaxRate` +
+ * `apiKillSwitchAt` columns on the Better Auth `organization` row, so the org
+ * row keeps only auth-identity fields. RBAC/validation/audit stay in the
+ * Next.js server actions (Phase 1), so every function here requires the trusted
+ * backend SERVICE token — browser access is rejected. See FEATUREDOCS/54.
+ *
+ * The `settings` field is the JSON string of the OrgSettings TS shape. Counter
+ * reservation is done INSIDE a mutation (serializable → atomic, no TOCTOU).
+ */
+
+/** Load the (at most one) row for an org, or null. */
+async function loadByOrg(ctx: MutationCtx, organizationId: string): Promise<Doc<"orgSettings"> | null> {
+  return await ctx.db
+    .query("orgSettings")
+    .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+    .unique();
+}
+
+export const getByOrg = query({
+  args: { organizationId: v.string() },
+  handler: async (ctx, { organizationId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("orgSettings")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+      .unique();
+  },
+});
+
+// iCal feed lookup: `icalToken` is denormalised ONLY while the feed is enabled,
+// so a hit here means "valid + live". Returns the row (caller reads its org id).
+export const getByIcalToken = query({
+  args: { token: v.string() },
+  handler: async (ctx, { token }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("orgSettings")
+      .withIndex("by_icalToken", (q) => q.eq("icalToken", token))
+      .first();
+  },
+});
+
+// Full-blob upsert (updateOrganization / ical toggles / SSO writes / login flag).
+// The caller owns the blob shape; it passes the derived denorm values. `null`
+// clears the optional field (undefined → db.patch removes it). Serializable, so
+// concurrent first-time saves can't create two rows (loser retries + patches).
+export const upsertSettings = mutation({
+  args: {
+    organizationId: v.string(),
+    settings: v.string(),
+    defaultTaxRate: v.optional(v.union(v.number(), v.null())),
+    icalToken: v.optional(v.union(v.string(), v.null())),
+    now: v.number(),
+  },
+  handler: async (ctx, { organizationId, settings, defaultTaxRate, icalToken, now }) => {
+    await requireService(ctx);
+    const existing = await loadByOrg(ctx, organizationId);
+
+    // Preserve the reservation counters. They're advanced ONLY by the reserve*
+    // mutations; a full-blob save (settings form / SSO / ical) must never roll a
+    // concurrently-reserved counter backwards, so carry forward max(stored, incoming).
+    const mergedSettings = existing?.settings
+      ? mergeCounters(existing.settings, settings)
+      : settings;
+
+    // undefined arg = leave field unchanged; null = clear (Convex removes an
+    // optional field when patched to undefined); a value sets it.
+    const existingPatch: Record<string, unknown> = { settings: mergedSettings, updatedAt: now };
+    if (defaultTaxRate !== undefined) {
+      existingPatch.defaultTaxRate = defaultTaxRate === null ? undefined : defaultTaxRate;
+    }
+    if (icalToken !== undefined) {
+      existingPatch.icalToken = icalToken === null ? undefined : icalToken;
+    }
+
+    if (existing) {
+      await ctx.db.patch(existing._id, existingPatch);
+      return existing._id;
+    }
+    return await ctx.db.insert("orgSettings", {
+      organizationId,
+      settings: mergedSettings,
+      defaultTaxRate: defaultTaxRate == null ? undefined : defaultTaxRate,
+      icalToken: icalToken == null ? undefined : icalToken,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+// Atomic asset-tag reservation: read-modify-write the counter inside the blob.
+// Creates the row (with defaults) if the org has never saved settings.
+export const reserveAssetTags = mutation({
+  args: { organizationId: v.string(), count: v.number(), now: v.number() },
+  handler: async (ctx, { organizationId, count, now }) => {
+    await requireService(ctx);
+    const existing = await loadByOrg(ctx, organizationId);
+    const blob = existing?.settings ? safeParse(existing.settings) : {};
+    const prefix = (blob.assetTagPrefix as string) || "ASSET";
+    const digits = (blob.assetTagDigits as number) || 4;
+    const current = (blob.assetTagCounter as number) || 0;
+    const tags: string[] = [];
+    for (let i = 1; i <= count; i++) {
+      tags.push(`${prefix}${String(current + i).padStart(digits, "0")}`);
+    }
+    blob.assetTagCounter = current + count;
+    const settings = JSON.stringify(blob);
+    if (existing) {
+      await ctx.db.patch(existing._id, { settings, updatedAt: now });
+    } else {
+      await ctx.db.insert("orgSettings", { organizationId, settings, createdAt: now, updatedAt: now });
+    }
+    return { tags };
+  },
+});
+
+// Atomic test-tag-id reservation — same pattern, nested `testTag.counter`.
+export const reserveTestTagIds = mutation({
+  args: { organizationId: v.string(), count: v.number(), now: v.number() },
+  handler: async (ctx, { organizationId, count, now }) => {
+    await requireService(ctx);
+    const existing = await loadByOrg(ctx, organizationId);
+    const blob = existing?.settings ? safeParse(existing.settings) : {};
+    const tt = (blob.testTag as Record<string, unknown>) || {};
+    const prefix = (tt.prefix as string) || "TT";
+    const digits = (tt.digits as number) || 4;
+    const current = (tt.counter as number) || 0;
+    const ids: string[] = [];
+    for (let i = 1; i <= count; i++) {
+      ids.push(`${prefix}${String(current + i).padStart(digits, "0")}`);
+    }
+    blob.testTag = { ...tt, counter: current + count };
+    const settings = JSON.stringify(blob);
+    if (existing) {
+      await ctx.db.patch(existing._id, { settings, updatedAt: now });
+    } else {
+      await ctx.db.insert("orgSettings", { organizationId, settings, createdAt: now, updatedAt: now });
+    }
+    return { ids };
+  },
+});
+
+// API kill-switch toggle (denormalised timestamp column).
+export const setApiKillSwitch = mutation({
+  args: { organizationId: v.string(), enabled: v.boolean(), now: v.number() },
+  handler: async (ctx, { organizationId, enabled, now }) => {
+    await requireService(ctx);
+    const at = enabled ? now : undefined;
+    const existing = await loadByOrg(ctx, organizationId);
+    if (existing) {
+      await ctx.db.patch(existing._id, { apiKillSwitchAt: at, updatedAt: now });
+    } else {
+      await ctx.db.insert("orgSettings", {
+        organizationId,
+        apiKillSwitchAt: at,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    return { apiKillSwitchAt: at ?? null };
+  },
+});
+
+// Backfill: copy an org's legacy Postgres settings into Convex, idempotently.
+export const createIfMissing = mutation({
+  args: {
+    organizationId: v.string(),
+    settings: v.optional(v.string()),
+    defaultTaxRate: v.optional(v.number()),
+    apiKillSwitchAt: v.optional(v.number()),
+    icalToken: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+    const existing = await loadByOrg(ctx, args.organizationId);
+    if (existing) return { _id: existing._id, created: false };
+    const _id = await ctx.db.insert("orgSettings", args);
+    return { _id, created: true };
+  },
+});
+
+// Corrupt/absent JSON → treat as empty settings (matches the legacy Postgres
+// read path, which caught JSON.parse errors and continued with {}).
+function safeParse(s: string): Record<string, unknown> {
+  try {
+    const v = JSON.parse(s);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+const maxCounter = (a: unknown, b: unknown) => Math.max(Number(a) || 0, Number(b) || 0);
+
+// Carry the stored asset-tag + test-tag counters forward into an incoming blob so
+// a full-blob save can't overwrite a value the reserve* mutations advanced.
+function mergeCounters(storedJson: string, incomingJson: string): string {
+  const stored = safeParse(storedJson);
+  let incoming: Record<string, unknown>;
+  try {
+    const v = JSON.parse(incomingJson);
+    if (!v || typeof v !== "object") return incomingJson;
+    incoming = v as Record<string, unknown>;
+  } catch {
+    return incomingJson;
+  }
+  if (stored.assetTagCounter != null || incoming.assetTagCounter != null) {
+    incoming.assetTagCounter = maxCounter(stored.assetTagCounter, incoming.assetTagCounter);
+  }
+  const storedTT = (stored.testTag as Record<string, unknown> | undefined)?.counter;
+  const incomingTTObj = (incoming.testTag as Record<string, unknown> | undefined) ?? undefined;
+  const incomingTT = incomingTTObj?.counter;
+  if (storedTT != null || incomingTT != null) {
+    incoming.testTag = { ...(incomingTTObj ?? {}), counter: maxCounter(storedTT, incomingTT) };
+  }
+  return JSON.stringify(incoming);
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1471,6 +1471,29 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_credentialID", ["credentialID"]),
 
+  // OrgSettings — per-org BUSINESS settings, migrated OFF the Better Auth
+  // `organizations` row (Phase 1 source-of-truth inversion). The `settings`
+  // field is the JSON blob that used to live in `organization.metadata`
+  // (OrgSettings TS shape: branding, testTag, sso, asset-tag + project-number
+  // config, ical, currency/tax labels, …). Three fields are denormalised out of
+  // the blob for indexed / standalone reads:
+  //   - defaultTaxRate  — read standalone by line-item tax resolution
+  //   - apiKillSwitchAt — the API kill-switch timestamp (ms)
+  //   - icalToken       — SET ONLY WHILE the feed is ENABLED, so a by_icalToken
+  //                       hit means "valid + live" without parsing the blob.
+  // One row per org (by_organizationId). See FEATUREDOCS/54.
+  orgSettings: defineTable({
+    organizationId: v.string(),
+    settings: v.optional(v.string()), // JSON string of the OrgSettings blob
+    defaultTaxRate: v.optional(v.number()),
+    apiKillSwitchAt: v.optional(v.number()),
+    icalToken: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  })
+    .index("by_organizationId", ["organizationId"])
+    .index("by_icalToken", ["icalToken"]),
+
   // SiteSettings
   siteSettings: defineTable({
     id: v.string(),

--- a/scripts/convex-backfill-org-settings.ts
+++ b/scripts/convex-backfill-org-settings.ts
@@ -1,0 +1,62 @@
+/**
+ * One-time (re-runnable) backfill: copy per-org BUSINESS settings off the Better
+ * Auth `organization` row into the Convex `orgSettings` table (Phase 1 inversion).
+ *
+ * Source columns: `metadata` (the OrgSettings JSON blob), `defaultTaxRate`,
+ * `apiKillSwitchAt`. Denormalises `icalToken` ONLY when the feed is enabled (so
+ * the by_icalToken lookup means "valid + live"). Idempotent — `createIfMissing`
+ * skips orgs already present (matched by organizationId), so this is both the
+ * initial load AND a heal path. Run BEFORE the inverted reads go live in prod:
+ *
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-org-settings.ts
+ *
+ * See FEATUREDOCS/54 and docs/convex-native-migration-plan.md (WS1).
+ */
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+async function main() {
+  const orgs = await prisma.organization.findMany({
+    select: { id: true, metadata: true, defaultTaxRate: true, apiKillSwitchAt: true, createdAt: true },
+  });
+  console.log(`Found ${orgs.length} organizations in Prisma.`);
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const org of orgs) {
+    // Derive the denormalised iCal token from the blob (enabled feeds only).
+    let icalToken: string | undefined;
+    if (org.metadata) {
+      try {
+        const blob = JSON.parse(org.metadata) as { icalToken?: string; icalEnabled?: boolean };
+        if (blob.icalEnabled && blob.icalToken) icalToken = blob.icalToken;
+      } catch {
+        // corrupt blob — copy the string verbatim, skip token derivation
+      }
+    }
+
+    // Re-fetch per mutation so a long run keeps a fresh (auto-refreshed) token.
+    const convex = await getConvexClient();
+    const res = await convex.mutation(api.orgSettings.createIfMissing, {
+      organizationId: org.id,
+      settings: org.metadata ?? undefined,
+      defaultTaxRate: org.defaultTaxRate != null ? Number(org.defaultTaxRate) : undefined,
+      apiKillSwitchAt: org.apiKillSwitchAt != null ? org.apiKillSwitchAt.getTime() : undefined,
+      icalToken,
+      createdAt: org.createdAt?.getTime(),
+      updatedAt: Date.now(),
+    });
+    if (res.created) created++;
+    else skipped++;
+  }
+
+  console.log(`\nBackfill complete: ${created} created, ${skipped} already present.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/calendar/[token]/[feed]/route.ts
+++ b/src/app/api/calendar/[token]/[feed]/route.ts
@@ -18,42 +18,34 @@ import {
   buildDateTime,
   type ICalEvent,
 } from "@/lib/ical";
-import type { OrgSettings } from "@/server/settings";
+import { readOrgSettingsBlob, orgIdForIcalToken } from "@/lib/org-settings-read";
 
 const VALID_FEEDS = ["projects", "services", "maintenance", "crew"] as const;
 type FeedType = (typeof VALID_FEEDS)[number];
 
 /**
- * Look up organization by iCal token stored in metadata JSON.
- * Returns null if not found or feed is disabled. Includes the org's
- * configured IANA timezone (default Australia/Sydney) so the iCal feed
- * is anchored correctly.
+ * Look up organization by iCal token. `icalToken` is a denormalised, indexed
+ * lookup key on the Convex `orgSettings` table, SET ONLY while the feed is
+ * enabled — so a hit means "valid + live" (no full-table scan). Org name stays
+ * on the Better Auth org row (Postgres). Returns null if not found/disabled.
+ * Includes the org's configured IANA timezone (default Australia/Sydney).
  */
 async function findOrgByToken(token: string) {
-  // icalToken is stored in Organization.metadata JSON — query all orgs with metadata containing the token
-  const orgs = await prisma.organization.findMany({
-    where: {
-      metadata: { contains: token },
-    },
-    select: { id: true, name: true, metadata: true },
-  });
+  const orgId = await orgIdForIcalToken(token);
+  if (!orgId) return null;
 
-  for (const org of orgs) {
-    if (!org.metadata) continue;
-    try {
-      const settings = JSON.parse(org.metadata) as OrgSettings;
-      if (settings.icalToken === token && settings.icalEnabled) {
-        return {
-          id: org.id,
-          name: org.name,
-          tzid: settings.timezone || "Australia/Sydney",
-        };
-      }
-    } catch {
-      continue;
-    }
-  }
-  return null;
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { id: true, name: true },
+  });
+  if (!org) return null;
+
+  const settings = await readOrgSettingsBlob(orgId);
+  return {
+    id: org.id,
+    name: org.name,
+    tzid: settings.timezone || "Australia/Sydney",
+  };
 }
 
 // ─── Feed Builders ──────────────────────────────────────────────────────────

--- a/src/app/api/crew/calendar/[token]/route.ts
+++ b/src/app/api/crew/calendar/[token]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../../../../../convex/_generated/api";
 import {
@@ -7,7 +6,7 @@ import {
   buildDateTime,
   type ICalEvent,
 } from "@/lib/ical";
-import type { OrgSettings } from "@/server/settings";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { getProjectById } from "@/lib/projects-read";
 import { getCrewRoleMap } from "@/lib/crew-read";
@@ -15,17 +14,8 @@ import { getShiftsByAssignmentIds } from "@/lib/crew-scheduling-read";
 
 /** Read the org's configured IANA timezone (default Australia/Sydney). */
 async function getOrgTimezone(organizationId: string): Promise<string> {
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { metadata: true },
-  });
-  if (!org?.metadata) return "Australia/Sydney";
-  try {
-    const settings = JSON.parse(org.metadata) as OrgSettings;
-    return settings.timezone || "Australia/Sydney";
-  } catch {
-    return "Australia/Sydney";
-  }
+  const settings = await readOrgSettingsBlob(organizationId);
+  return settings.timezone || "Australia/Sydney";
 }
 
 /**

--- a/src/app/api/crew/calendar/assignment/[id]/route.ts
+++ b/src/app/api/crew/calendar/assignment/[id]/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOrgContext } from "@/lib/org-context";
-import { prisma } from "@/lib/prisma";
 import {
   generateVCalendar,
   buildDateTime,
   type ICalEvent,
 } from "@/lib/ical";
-import type { OrgSettings } from "@/server/settings";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getLocationById } from "@/lib/locations-read";
 import { getCrewMemberMap, getCrewRoleMap } from "@/lib/crew-read";
 import { getAssignmentById, getShiftsByAssignmentIds } from "@/lib/crew-scheduling-read";
@@ -26,19 +25,8 @@ export async function GET(
     const { organizationId } = await getOrgContext();
     const { id } = await params;
 
-    const org = await prisma.organization.findUnique({
-      where: { id: organizationId },
-      select: { metadata: true },
-    });
-    let tzid = "Australia/Sydney";
-    if (org?.metadata) {
-      try {
-        const settings = JSON.parse(org.metadata) as OrgSettings;
-        tzid = settings.timezone || "Australia/Sydney";
-      } catch {
-        // ignore
-      }
-    }
+    const orgSettings = await readOrgSettingsBlob(organizationId);
+    const tzid = orgSettings.timezone || "Australia/Sydney";
 
     const assignment = await getAssignmentById(id);
     // Org-scope (replaces the Prisma `where: { id, organizationId }`).

--- a/src/app/api/test-tag-reports/[reportType]/route.tsx
+++ b/src/app/api/test-tag-reports/[reportType]/route.tsx
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireOrganization } from "@/lib/auth-server";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getFileAsDataUri } from "@/lib/storage";
 import { generateTestTagReport } from "@/lib/pdfme/generate-pdf";
 import type { TestTagReportType } from "@/lib/pdfme/types";
@@ -60,11 +61,11 @@ function parseFilters(url: URL): ReportFilters {
 }
 
 async function getOrgData(organizationId: string) {
-  const org = await prisma.organization.findUnique({ where: { id: organizationId } });
-  let orgSettings: Record<string, unknown> = {};
-  if (org?.metadata) {
-    try { orgSettings = JSON.parse(org.metadata); } catch { /* ignore */ }
-  }
+  // Identity (name) from the Better Auth org row; business settings from Convex.
+  const [org, orgSettings] = await Promise.all([
+    prisma.organization.findUnique({ where: { id: organizationId }, select: { name: true } }),
+    readOrgSettingsBlob(organizationId),
+  ]);
   const branding = orgSettings.branding as {
     primaryColor?: string; accentColor?: string; documentColor?: string;
     logoUrl?: string; iconUrl?: string; documentLogoMode?: "logo" | "icon" | "none";

--- a/src/lib/api-key.test.ts
+++ b/src/lib/api-key.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ActorContext } from "./actor-context";
 
-// ApiKey lookup is Convex now; org kill-switch + acting-user name stay on Postgres.
+// ApiKey lookup + org kill-switch are Convex now; org existence + acting-user
+// name stay on Postgres. The Convex query mock dispatches by args shape:
+// `{ tokenHash }` → key lookup, `{ organizationId }` → org-settings (kill switch).
 const getByTokenHash = vi.fn();
+const getOrgSettings = vi.fn();
 const touchLastUsed = vi.fn();
 vi.mock("@/lib/convex-client", () => ({
   getConvexClient: vi.fn(async () => ({
-    query: (_ref: unknown, args: unknown) => getByTokenHash(args),
+    query: (_ref: unknown, args: Record<string, unknown>) => {
+      if (args && "tokenHash" in args) return getByTokenHash(args);
+      if (args && "organizationId" in args) return getOrgSettings(args);
+      return undefined;
+    },
     mutation: (_ref: unknown, args: unknown) => {
       touchLastUsed(args);
       return Promise.resolve();
@@ -50,7 +57,8 @@ function keyRow(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  orgFindUnique.mockResolvedValue({ apiKillSwitchAt: null });
+  orgFindUnique.mockResolvedValue({ id: "org_1" });
+  getOrgSettings.mockResolvedValue({ apiKillSwitchAt: undefined });
   userFindUnique.mockResolvedValue({ name: "Ada" });
 });
 
@@ -166,7 +174,7 @@ describe("getApiKeyActorContext — validation + resolution", () => {
 
   it("rejects every key when the org kill switch is set (ORG_KILL_SWITCH)", async () => {
     getByTokenHash.mockResolvedValue(keyRow());
-    orgFindUnique.mockResolvedValue({ apiKillSwitchAt: new Date() });
+    getOrgSettings.mockResolvedValue({ apiKillSwitchAt: Date.now() });
     await expect(getApiKeyActorContext("x")).rejects.toMatchObject({ code: "ORG_KILL_SWITCH" });
   });
 

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -183,16 +183,20 @@ export async function getApiKeyActorContext(
     }
   }
 
-  // Org kill-switch + acting-user name stay on Postgres (Better-Auth `organization`
-  // / `user`, which remain). apiKillSwitchAt gates ALL keys for the org instantly.
-  const [org, actingUser] = await Promise.all([
+  // Org existence + acting-user name stay on Postgres (Better-Auth `organization`
+  // / `user`, which remain). The kill-switch moved to the Convex org-settings row
+  // (Phase 1 inversion) — it gates ALL keys for the org instantly.
+  const [org, actingUser, orgSettings] = await Promise.all([
     prisma.organization.findUnique({
       where: { id: key.organizationId },
-      select: { apiKillSwitchAt: true },
+      select: { id: true },
     }),
     prisma.user.findUnique({
       where: { id: key.actingUserId },
       select: { name: true },
+    }),
+    (await getConvexClient()).query(api.orgSettings.getByOrg, {
+      organizationId: key.organizationId,
     }),
   ]);
   // FAIL CLOSED: the old Postgres FK cascade auto-deleted a key when its org or acting
@@ -201,7 +205,7 @@ export async function getApiKeyActorContext(
   if (!org) {
     throw new ApiKeyAuthError("INVALID_KEY", "Invalid API key.");
   }
-  if (org.apiKillSwitchAt) {
+  if (orgSettings?.apiKillSwitchAt) {
     throw new ApiKeyAuthError(
       "ORG_KILL_SWITCH",
       "API access is disabled for this organization.",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,6 +10,7 @@ import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
 import { sendEmail } from "./email";
 import { getPlatformName } from "./platform";
 import { getSiteSettingsFromConvex } from "./site-settings-read";
+import { readOrgSettingsBlob, saveOrgSettings } from "./org-settings-read";
 import { handleSSOProvisioning } from "./sso-provisioning";
 import { getTheOrg } from "./single-org";
 import { CONVEX_JWT_AUDIENCE, USER_TOKEN_TTL } from "./convex-auth-constants";
@@ -290,17 +291,11 @@ export const auth = betterAuth({
               select: { organizationId: true },
             });
             if (!ssoProvider?.organizationId) return;
-            const org = await prisma.organization.findUnique({
-              where: { id: ssoProvider.organizationId },
-            });
-            if (!org) return;
-            const settings = org.metadata ? JSON.parse(org.metadata) : {};
+            // SSO config lives in the Convex org-settings blob (source of truth).
+            const settings = await readOrgSettingsBlob(ssoProvider.organizationId);
             if (settings.sso && !settings.sso.ssoTestedSuccessfully) {
               settings.sso.ssoTestedSuccessfully = true;
-              await prisma.organization.update({
-                where: { id: ssoProvider.organizationId },
-                data: { metadata: JSON.stringify(settings) },
-              });
+              await saveOrgSettings(ssoProvider.organizationId, settings);
             }
           } catch {
             // Non-critical — don't block login

--- a/src/lib/org-settings-read.ts
+++ b/src/lib/org-settings-read.ts
@@ -1,0 +1,120 @@
+import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import type { OrgSettings } from "@/server/settings";
+
+/**
+ * Server-side read/write helpers for per-org BUSINESS settings (Phase 1
+ * inversion). `org_settings` is Convex-only source of truth — this replaces the
+ * old `prisma.organization` reads of the `metadata` JSON blob + `defaultTaxRate`
+ * + `apiKillSwitchAt` columns. RBAC/validation/audit stay in the calling server
+ * actions; these helpers only move bytes. See FEATUREDOCS/54.
+ */
+
+export interface OrgSettingsRow {
+  settings: OrgSettings;
+  defaultTaxRate: number | null;
+  apiKillSwitchAt: Date | null;
+}
+
+// Fresh object per call — callers mutate `.settings` in place (ical/SSO flows),
+// so a shared instance would leak settings across organizations.
+function emptyRow(): OrgSettingsRow {
+  return { settings: {}, defaultTaxRate: null, apiKillSwitchAt: null };
+}
+
+function parseBlob(s: string | undefined | null): OrgSettings {
+  if (!s) return {};
+  try {
+    return JSON.parse(s) as OrgSettings;
+  } catch {
+    return {};
+  }
+}
+
+/** Full settings row for an org (blob + denormalised tax/kill-switch columns). */
+export async function readOrgSettings(organizationId: string): Promise<OrgSettingsRow> {
+  const convex = await getConvexClient();
+  const doc = await withConvexReadRetry(() =>
+    convex.query(api.orgSettings.getByOrg, { organizationId }),
+  );
+  if (!doc) return emptyRow();
+  return {
+    settings: parseBlob(doc.settings),
+    defaultTaxRate: doc.defaultTaxRate ?? null,
+    apiKillSwitchAt: doc.apiKillSwitchAt != null ? new Date(doc.apiKillSwitchAt) : null,
+  };
+}
+
+/** Just the parsed settings blob (convenience). */
+export async function readOrgSettingsBlob(organizationId: string): Promise<OrgSettings> {
+  return (await readOrgSettings(organizationId)).settings;
+}
+
+/** The org's default tax rate (or null). Standalone read for line-item tax. */
+export async function readOrgDefaultTaxRate(organizationId: string): Promise<number | null> {
+  return (await readOrgSettings(organizationId)).defaultTaxRate;
+}
+
+/**
+ * Persist the full settings blob (+ optional defaultTaxRate). The denormalised
+ * `icalToken` lookup key is derived here: set only while the feed is enabled.
+ */
+export async function saveOrgSettings(
+  organizationId: string,
+  settings: OrgSettings,
+  defaultTaxRate?: number | null,
+): Promise<void> {
+  const convex = await getConvexClient();
+  const icalToken = settings.icalEnabled && settings.icalToken ? settings.icalToken : null;
+  await convex.mutation(api.orgSettings.upsertSettings, {
+    organizationId,
+    settings: JSON.stringify(settings),
+    defaultTaxRate: defaultTaxRate === undefined ? undefined : defaultTaxRate,
+    icalToken,
+    now: Date.now(),
+  });
+}
+
+/** Atomically reserve N asset tags (increments the counter). */
+export async function reserveAssetTagsConvex(organizationId: string, count: number): Promise<string[]> {
+  const convex = await getConvexClient();
+  const { tags } = await convex.mutation(api.orgSettings.reserveAssetTags, {
+    organizationId,
+    count,
+    now: Date.now(),
+  });
+  return tags;
+}
+
+/** Atomically reserve N test-tag IDs (increments the counter). */
+export async function reserveTestTagIdsConvex(organizationId: string, count: number): Promise<string[]> {
+  const convex = await getConvexClient();
+  const { ids } = await convex.mutation(api.orgSettings.reserveTestTagIds, {
+    organizationId,
+    count,
+    now: Date.now(),
+  });
+  return ids;
+}
+
+/** Toggle the API kill-switch; returns the new timestamp (or null). */
+export async function setApiKillSwitchConvex(organizationId: string, enabled: boolean): Promise<Date | null> {
+  const convex = await getConvexClient();
+  const { apiKillSwitchAt } = await convex.mutation(api.orgSettings.setApiKillSwitch, {
+    organizationId,
+    enabled,
+    now: Date.now(),
+  });
+  return apiKillSwitchAt != null ? new Date(apiKillSwitchAt) : null;
+}
+
+/** Resolve an org id from a live iCal feed token (enabled feeds only). */
+export async function orgIdForIcalToken(token: string): Promise<string | null> {
+  const convex = await getConvexClient();
+  const doc = await withConvexReadRetry(() =>
+    convex.query(api.orgSettings.getByIcalToken, { token }),
+  );
+  if (!doc) return null;
+  const blob = parseBlob(doc.settings);
+  return blob.icalEnabled && blob.icalToken === token ? doc.organizationId : null;
+}

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -6,6 +6,7 @@
 import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../../convex/_generated/api";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getClientById } from "@/lib/clients-read";
 import { getLocationMap } from "@/lib/locations-read";
 import { getSupplierMap } from "@/lib/suppliers-read";
@@ -86,19 +87,14 @@ export async function buildDocumentData(
   // also wants packer order. A separate setting can split them later if a
   // user asks for one without the other.
   const packerSort = expandProjectGroups;
-  // Load org
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-
-  let orgSettings: Record<string, unknown> = {};
-  if (org?.metadata) {
-    try {
-      orgSettings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
+  // Load org identity (name) from Better Auth; business settings from Convex.
+  const [org, orgSettings] = await Promise.all([
+    prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { name: true },
+    }),
+    readOrgSettingsBlob(organizationId) as Promise<Record<string, unknown>>,
+  ]);
 
   const branding = orgSettings.branding as {
     primaryColor?: string;

--- a/src/lib/pdfme/sample-document-data.ts
+++ b/src/lib/pdfme/sample-document-data.ts
@@ -4,6 +4,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { getFileAsDataUri } from "@/lib/storage";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import type { DocumentData, DocumentLineItem, PdfBranding } from "./types";
 
 const DEFAULT_DOC_COLOR = "#0d4f4f";
@@ -15,15 +16,15 @@ const DEFAULT_DOC_COLOR = "#0d4f4f";
 export async function buildSampleDocumentData(
   organizationId: string
 ): Promise<DocumentData> {
-  const org = await prisma.organization.findUniqueOrThrow({
-    where: { id: organizationId },
-  });
+  // Identity (name) from Better Auth; branding/settings from Convex.
+  const [org, meta] = await Promise.all([
+    prisma.organization.findUniqueOrThrow({
+      where: { id: organizationId },
+      select: { name: true },
+    }),
+    readOrgSettingsBlob(organizationId) as Promise<Record<string, unknown>>,
+  ]);
 
-  // Parse org metadata for branding
-  let meta: Record<string, unknown> = {};
-  if (org.metadata) {
-    try { meta = JSON.parse(org.metadata) as Record<string, unknown>; } catch { /* skip */ }
-  }
   const branding = (meta.branding as PdfBranding) || {};
   const docColor = branding.documentColor || DEFAULT_DOC_COLOR;
 

--- a/src/lib/sso-provisioning.ts
+++ b/src/lib/sso-provisioning.ts
@@ -3,8 +3,8 @@ import { prisma } from "./prisma";
 import { getConvexClient } from "./convex-client";
 import { api } from "../../convex/_generated/api";
 import { upsertMemberMirrorByOrgUser } from "./member-mirror";
+import { readOrgSettingsBlob, saveOrgSettings } from "./org-settings-read";
 import type { OrgSSOSettings, SSOGroupMapping } from "./sso-types";
-import type { Organization } from "@/generated/prisma/client";
 
 /**
  * Role hierarchy for resolving multiple group matches.
@@ -93,25 +93,12 @@ function extractIdpGroups(
 }
 
 /**
- * Parse SSO settings from organization metadata JSON.
- */
-function parseSSOSettings(metadata: string | null): OrgSSOSettings | null {
-  if (!metadata) return null;
-  try {
-    const parsed = JSON.parse(metadata);
-    return parsed.sso || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Auto-discover IdP groups: persist any previously-unseen groups to
  * the org's SSO group mappings (with unmapped=true, no role assigned).
  * This lets admins see what groups exist before they map them.
  */
 async function discoverNewGroups(
-  org: Organization,
+  organizationId: string,
   ssoSettings: OrgSSOSettings,
   idpGroups: string[],
   groupValueType: "name" | "id",
@@ -136,17 +123,13 @@ async function discoverNewGroups(
 
   if (newGroups.length === 0) return;
 
-  // Merge and persist
+  // Merge and persist into the Convex org-settings blob (source of truth).
   const updatedMappings = [...existing, ...newGroups];
   try {
-    const metadata = org.metadata ? JSON.parse(org.metadata as string) : {};
-    if (!metadata.sso) metadata.sso = {};
-    metadata.sso.groupMappings = updatedMappings;
-
-    await prisma.organization.update({
-      where: { id: org.id },
-      data: { metadata: JSON.stringify(metadata) },
-    });
+    const settings = await readOrgSettingsBlob(organizationId);
+    if (!settings.sso) settings.sso = {} as OrgSSOSettings;
+    settings.sso.groupMappings = updatedMappings;
+    await saveOrgSettings(organizationId, settings);
   } catch {
     // Non-critical — don't break login if discovery fails
   }
@@ -171,17 +154,20 @@ export async function handleSSOProvisioning(data: {
 
   const org = await prisma.organization.findUnique({
     where: { id: provider.organizationId },
+    select: { id: true },
   });
   if (!org) return;
 
-  const ssoSettings = parseSSOSettings(org.metadata);
+  // SSO config lives in the Convex org-settings blob (source of truth).
+  const settings = await readOrgSettingsBlob(provider.organizationId);
+  const ssoSettings = settings.sso ?? null;
   if (!ssoSettings?.enabled) return;
 
   const providerType = provider.samlConfig ? "saml" : "oidc";
   const idpGroups = extractIdpGroups(userInfo, ssoSettings, providerType);
 
   // Auto-discover new groups from IdP (non-blocking, won't break login)
-  await discoverNewGroups(org, ssoSettings, idpGroups, ssoSettings.groupValueType || "name");
+  await discoverNewGroups(provider.organizationId, ssoSettings, idpGroups, ssoSettings.groupValueType || "name");
 
   const { role } = resolveRoleFromGroups(
     idpGroups,

--- a/src/server/api-keys.test.ts
+++ b/src/server/api-keys.test.ts
@@ -12,14 +12,16 @@ vi.mock("@/lib/api-key", () => ({
 }));
 vi.mock("@/lib/request-actor", () => ({ getAmbientActor: () => undefined }));
 
-// ApiKey is a Convex domain now — mock the Convex client. member/organization stay
-// on Postgres (Better-Auth), so the prisma mock keeps those.
+// ApiKey + org kill-switch (org-settings) are Convex domains now — mock the Convex
+// client. member stays on Postgres (Better-Auth), so the prisma mock keeps that.
 const convexMock = vi.hoisted(() => ({ query: vi.fn(), mutation: vi.fn() }));
-vi.mock("@/lib/convex-client", () => ({ getConvexClient: vi.fn(async () => convexMock) }));
+vi.mock("@/lib/convex-client", () => ({
+  getConvexClient: vi.fn(async () => convexMock),
+  withConvexReadRetry: (fn: () => unknown) => fn(),
+}));
 
 const prismaMock = vi.hoisted(() => ({
   member: { findFirst: vi.fn() },
-  organization: { findUnique: vi.fn(), update: vi.fn() },
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
@@ -82,21 +84,32 @@ describe("revokeApiKey", () => {
 });
 
 describe("setOrgApiKillSwitch", () => {
-  it("sets a timestamp when enabled and clears it when disabled", async () => {
+  it("toggles the kill switch via the Convex org-settings mutation", async () => {
+    convexMock.mutation.mockResolvedValue({ apiKillSwitchAt: Date.now() });
     await setOrgApiKillSwitch(true);
-    expect(prismaMock.organization.update.mock.calls[0][0].data.apiKillSwitchAt).toBeInstanceOf(Date);
+    expect(convexMock.mutation).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: "org_1", enabled: true }),
+    );
 
+    convexMock.mutation.mockResolvedValue({ apiKillSwitchAt: null });
     await setOrgApiKillSwitch(false);
-    expect(prismaMock.organization.update.mock.calls[1][0].data.apiKillSwitchAt).toBeNull();
+    expect(convexMock.mutation).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: "org_1", enabled: false }),
+    );
   });
 });
 
 describe("listApiKeys", () => {
   it("returns keys + kill-switch state without any secret", async () => {
-    convexMock.query.mockResolvedValue([
-      { id: "key_1", prefix: "gf_live_ab", name: "Agent", tokenHash: "hash", actingUserId: "user_1", createdAt: 1000 },
-    ]);
-    prismaMock.organization.findUnique.mockResolvedValue({ apiKillSwitchAt: null });
+    // apiKeys.list → keys; orgSettings.getByOrg (has `organizationId`) → no kill switch.
+    convexMock.query.mockImplementation((_ref: unknown, args: Record<string, unknown>) => {
+      if (args && "organizationId" in args) return Promise.resolve({ apiKillSwitchAt: undefined });
+      return Promise.resolve([
+        { id: "key_1", prefix: "gf_live_ab", name: "Agent", tokenHash: "hash", actingUserId: "user_1", createdAt: 1000 },
+      ]);
+    });
 
     const res = await listApiKeys();
 

--- a/src/server/api-keys.ts
+++ b/src/server/api-keys.ts
@@ -9,6 +9,7 @@ import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { generateApiKey, assertScopesWithinActor } from "@/lib/api-key";
 import { getAmbientActor } from "@/lib/request-actor";
+import { readOrgSettings, setApiKillSwitchConvex } from "@/lib/org-settings-read";
 
 // ApiKey is a Convex domain now (the Postgres `api_key` table is frozen). The
 // Better-Auth `member` (acting-user membership) + `organization` (kill switch) reads
@@ -48,11 +49,8 @@ export async function listApiKeys() {
     orgId: organizationId,
   });
   const keys = rawKeys.map(toKeyRow); // strips tokenHash — never leaves the backend
-  const killSwitch = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { apiKillSwitchAt: true },
-  });
-  return serialize({ keys, apiKillSwitchAt: killSwitch?.apiKillSwitchAt ?? null });
+  const { apiKillSwitchAt } = await readOrgSettings(organizationId);
+  return serialize({ keys, apiKillSwitchAt });
 }
 
 /**
@@ -175,10 +173,7 @@ export async function setOrgApiKillSwitch(enabled: boolean) {
     "update",
   );
 
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { apiKillSwitchAt: enabled ? new Date() : null },
-  });
+  const apiKillSwitchAt = await setApiKillSwitchConvex(organizationId, enabled);
 
   await logActivity({
     organizationId,
@@ -193,5 +188,5 @@ export async function setOrgApiKillSwitch(enabled: boolean) {
       : "Disabled org-wide API kill switch (keys re-enabled)",
   });
 
-  return serialize({ apiKillSwitchAt: enabled ? new Date() : null });
+  return serialize({ apiKillSwitchAt });
 }

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { readOrgDefaultTaxRate } from "@/lib/org-settings-read";
 import {
   lineItemSchema,
   customLineItemSchema,
@@ -38,11 +38,8 @@ import { getAssignmentsByProject } from "@/lib/crew-scheduling-read";
  * their in-transaction recalc uses the authoritative rate for the no-override fallback.
  */
 async function orgDefaultTaxRateFor(orgId: string): Promise<number | null> {
-  const org = await prisma.organization.findUnique({
-    where: { id: orgId },
-    select: { defaultTaxRate: true },
-  });
-  return org?.defaultTaxRate != null ? Number(org.defaultTaxRate) : null;
+  // Org default tax lives in the Convex org-settings row (Phase 1 inversion).
+  return readOrgDefaultTaxRate(orgId);
 }
 
 /**
@@ -1638,15 +1635,13 @@ export async function recalculateProjectTotals(projectId: string) {
   // wave (was ~5 SEQUENTIAL round-trips: groups/lines → services → assignments →
   // subHires → a conditional org-tax read). This is the common write-latency tail.
   const needsOrgTax = project.taxRate == null;
-  const [groups, projectLines, allOrgServices, assignments, allSubHires, orgTaxRow] = await Promise.all([
+  const [groups, projectLines, allOrgServices, assignments, allSubHires, orgDefaultTaxRate] = await Promise.all([
     convex.query(api.projectGroups.listByProject, { projectId, orgId }),
     convex.query(api.projectLineItems.listByProject, { projectId, orgId }),
     getProjectServicesByOrg(orgId),
     getAssignmentsByProject(projectId, orgId),
     getSubHiresByProject(projectId, orgId),
-    needsOrgTax
-      ? prisma.organization.findUnique({ where: { id: orgId }, select: { defaultTaxRate: true } })
-      : Promise.resolve(null),
+    needsOrgTax ? orgDefaultTaxRateFor(orgId) : Promise.resolve(null),
   ]);
 
   // 1. Equipment revenue from groups: bundle price × quantity, PLUS any
@@ -1756,8 +1751,8 @@ export async function recalculateProjectTotals(projectId: string) {
   let taxRate = 10;
   if (project.taxRate != null) {
     taxRate = Number(project.taxRate);
-  } else if (orgTaxRow?.defaultTaxRate != null) {
-    taxRate = Number(orgTaxRow.defaultTaxRate);
+  } else if (orgDefaultTaxRate != null) {
+    taxRate = Number(orgDefaultTaxRate);
   }
 
   const taxAmount = roundCurrency(taxableAmount * (taxRate / 100));

--- a/src/server/org-calendar.ts
+++ b/src/server/org-calendar.ts
@@ -5,32 +5,25 @@ import { prisma } from "@/lib/prisma";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
-import type { OrgSettings } from "./settings";
+import { readOrgSettingsBlob, saveOrgSettings } from "@/lib/org-settings-read";
 
 function generateToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
-async function getSettingsForOrg(organizationId: string) {
+// Org name for the activity log (identity stays on the Better Auth org row).
+async function getOrgName(organizationId: string): Promise<string> {
   const org = await prisma.organization.findUnique({
     where: { id: organizationId },
+    select: { name: true },
   });
   if (!org) throw new Error("Organization not found");
-
-  let settings: OrgSettings = {};
-  if (org.metadata) {
-    try {
-      settings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
-  return { org, settings };
+  return org.name;
 }
 
 export async function getOrgIcalSettings() {
   const { organizationId } = await getOrgContext();
-  const { settings } = await getSettingsForOrg(organizationId);
+  const settings = await readOrgSettingsBlob(organizationId);
 
   return serialize({
     icalEnabled: settings.icalEnabled || false,
@@ -44,16 +37,12 @@ export async function enableOrgIcalFeed() {
     "update"
   );
 
-  const { org, settings } = await getSettingsForOrg(organizationId);
+  const settings = await readOrgSettingsBlob(organizationId);
 
   const token = settings.icalToken || generateToken();
   settings.icalToken = token;
   settings.icalEnabled = true;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   await logActivity({
     organizationId,
@@ -62,7 +51,7 @@ export async function enableOrgIcalFeed() {
     action: "UPDATE",
     entityType: "settings",
     entityId: organizationId,
-    entityName: org.name,
+    entityName: await getOrgName(organizationId),
     summary: "Enabled organization calendar feeds",
   });
 
@@ -75,14 +64,10 @@ export async function disableOrgIcalFeed() {
     "update"
   );
 
-  const { org, settings } = await getSettingsForOrg(organizationId);
+  const settings = await readOrgSettingsBlob(organizationId);
 
   settings.icalEnabled = false;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   await logActivity({
     organizationId,
@@ -91,7 +76,7 @@ export async function disableOrgIcalFeed() {
     action: "UPDATE",
     entityType: "settings",
     entityId: organizationId,
-    entityName: org.name,
+    entityName: await getOrgName(organizationId),
     summary: "Disabled organization calendar feeds",
   });
 
@@ -104,16 +89,12 @@ export async function regenerateOrgIcalToken() {
     "update"
   );
 
-  const { org, settings } = await getSettingsForOrg(organizationId);
+  const settings = await readOrgSettingsBlob(organizationId);
 
   const token = generateToken();
   settings.icalToken = token;
   settings.icalEnabled = true;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   await logActivity({
     organizationId,
@@ -122,7 +103,7 @@ export async function regenerateOrgIcalToken() {
     action: "UPDATE",
     entityType: "settings",
     entityId: organizationId,
-    entityName: org.name,
+    entityName: await getOrgName(organizationId),
     summary: "Regenerated organization calendar feed token",
   });
 

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -7,6 +7,13 @@ import { sendEmail } from "@/lib/email";
 import { getPlatformName } from "@/lib/platform";
 import { logActivity } from "@/lib/activity-log";
 import { upsertMemberMirrorById, removeMemberMirror } from "@/lib/member-mirror";
+import {
+  readOrgSettings,
+  readOrgSettingsBlob,
+  saveOrgSettings,
+  reserveAssetTagsConvex,
+  reserveTestTagIdsConvex,
+} from "@/lib/org-settings-read";
 import { env } from "@/env";
 import type { OrgSSOSettings } from "@/lib/sso-types";
 import { validateProjectNumberFormat, type IncrementReset } from "@/lib/project-number";
@@ -72,16 +79,11 @@ export async function getOrganization() {
 
   if (!org) throw new Error("Organization not found");
 
-  let settings: OrgSettings = {};
-  if (org.metadata) {
-    try {
-      settings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
+  // Business settings are Convex-only now (blob + defaultTaxRate); the Postgres
+  // columns are frozen/legacy. Identity fields (name/slug/logo) stay on the org row.
+  const { settings, defaultTaxRate } = await readOrgSettings(organizationId);
 
-  return serialize({ ...org, settings });
+  return serialize({ ...org, defaultTaxRate, settings });
 }
 
 export async function updateOrganization(data: {
@@ -99,16 +101,13 @@ export async function updateOrganization(data: {
     if (err) throw new Error(`Project number format: ${err}`);
   }
 
+  // Identity (name) stays on the Better Auth org row; business settings + tax
+  // rate go to Convex (source of truth).
   const updated = await prisma.organization.update({
     where: { id: organizationId },
-    data: {
-      name: data.name,
-      metadata: JSON.stringify(data.settings),
-      ...(data.defaultTaxRate !== undefined && {
-        defaultTaxRate: data.defaultTaxRate,
-      }),
-    },
+    data: { name: data.name },
   });
+  await saveOrgSettings(organizationId, data.settings, data.defaultTaxRate);
 
   await logActivity({
     organizationId,
@@ -121,39 +120,21 @@ export async function updateOrganization(data: {
     summary: `Updated organization settings`,
   });
 
-  return serialize(updated);
+  return serialize({ ...updated, settings: data.settings, defaultTaxRate: data.defaultTaxRate });
 }
 
 /** Get org-level T&T settings (for fallback defaults). */
 export async function getOrgTestTagSettings(): Promise<TestTagSettings> {
   const { organizationId } = await getOrgContext();
-  const org = await prisma.organization.findUnique({ where: { id: organizationId } });
-  if (!org?.metadata) return {};
-  try {
-    const settings = JSON.parse(org.metadata) as OrgSettings;
-    return settings.testTag || {};
-  } catch {
-    return {};
-  }
+  const settings = await readOrgSettingsBlob(organizationId);
+  return settings.testTag || {};
 }
 
 /** Read-only preview of the next N asset tags — does NOT increment the counter. */
 export async function peekNextAssetTags(count = 1): Promise<string[]> {
   const { organizationId } = await getOrgContext();
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
-  let settings: OrgSettings = {};
-  if (org.metadata) {
-    try {
-      settings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
+  const settings = await readOrgSettingsBlob(organizationId);
 
   const prefix = settings.assetTagPrefix || "ASSET";
   const digits = settings.assetTagDigits || 4;
@@ -169,59 +150,15 @@ export async function peekNextAssetTags(count = 1): Promise<string[]> {
 /** Atomically reserve N asset tags — increments the counter. Call only at creation time. */
 export async function reserveAssetTags(count = 1): Promise<string[]> {
   const { organizationId } = await getOrgContext();
-
-  return prisma.$transaction(async (tx) => {
-    const org = await tx.organization.findUnique({
-      where: { id: organizationId },
-    });
-    if (!org) throw new Error("Organization not found");
-
-    let settings: OrgSettings = {};
-    if (org.metadata) {
-      try {
-        settings = JSON.parse(org.metadata);
-      } catch {
-        // ignore
-      }
-    }
-
-    const prefix = settings.assetTagPrefix || "ASSET";
-    const digits = settings.assetTagDigits || 4;
-    const currentCounter = settings.assetTagCounter || 0;
-
-    const tags: string[] = [];
-    for (let i = 1; i <= count; i++) {
-      tags.push(`${prefix}${String(currentCounter + i).padStart(digits, "0")}`);
-    }
-
-    settings.assetTagCounter = currentCounter + count;
-
-    await tx.organization.update({
-      where: { id: organizationId },
-      data: { metadata: JSON.stringify(settings) },
-    });
-
-    return tags;
-  });
+  // Atomic in a single Convex mutation (serializable → no read-modify-write race).
+  return reserveAssetTagsConvex(organizationId, count);
 }
 
 /** Read-only preview of the next N test tag IDs — does NOT increment the counter. */
 export async function peekNextTestTagIds(count = 1): Promise<string[]> {
   const { organizationId } = await getOrgContext();
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
-  let settings: OrgSettings = {};
-  if (org.metadata) {
-    try {
-      settings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
+  const settings = await readOrgSettingsBlob(organizationId);
 
   const tt = settings.testTag || {};
   const prefix = tt.prefix || "TT";
@@ -238,41 +175,8 @@ export async function peekNextTestTagIds(count = 1): Promise<string[]> {
 /** Atomically reserve N test tag IDs — increments the counter. Call only at creation time. */
 export async function reserveTestTagIds(count = 1): Promise<string[]> {
   const { organizationId } = await getOrgContext();
-
-  return prisma.$transaction(async (tx) => {
-    const org = await tx.organization.findUnique({
-      where: { id: organizationId },
-    });
-    if (!org) throw new Error("Organization not found");
-
-    let settings: OrgSettings = {};
-    if (org.metadata) {
-      try {
-        settings = JSON.parse(org.metadata);
-      } catch {
-        // ignore
-      }
-    }
-
-    const tt = settings.testTag || {};
-    const prefix = tt.prefix || "TT";
-    const digits = tt.digits || 4;
-    const currentCounter = tt.counter || 0;
-
-    const ids: string[] = [];
-    for (let i = 1; i <= count; i++) {
-      ids.push(`${prefix}${String(currentCounter + i).padStart(digits, "0")}`);
-    }
-
-    settings.testTag = { ...tt, counter: currentCounter + count };
-
-    await tx.organization.update({
-      where: { id: organizationId },
-      data: { metadata: JSON.stringify(settings) },
-    });
-
-    return ids;
-  });
+  // Atomic in a single Convex mutation (serializable → no read-modify-write race).
+  return reserveTestTagIdsConvex(organizationId, count);
 }
 
 /** @deprecated Use peekNextAssetTags for preview, reserveAssetTags for creation */

--- a/src/server/sso.ts
+++ b/src/server/sso.ts
@@ -11,18 +11,10 @@ import { logActivity } from "@/lib/activity-log";
 import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
 import { DEFAULT_SSO_SETTINGS, type OrgSSOSettings, type SSOGroupMapping } from "@/lib/sso-types";
 import { env } from "@/env";
+import { readOrgSettingsBlob, saveOrgSettings } from "@/lib/org-settings-read";
 import type { OrgSettings } from "./settings";
 
 // ─── Read helpers ────────────────────────────────────────────────────────────
-
-function parseOrgSettings(metadata: string | null): OrgSettings {
-  if (!metadata) return {};
-  try {
-    return JSON.parse(metadata);
-  } catch {
-    return {};
-  }
-}
 
 function getSSOFromSettings(settings: OrgSettings): OrgSSOSettings {
   return { ...DEFAULT_SSO_SETTINGS, ...settings.sso };
@@ -33,13 +25,15 @@ function getSSOFromSettings(settings: OrgSettings): OrgSSOSettings {
 export async function getSSOSettings() {
   const { organizationId } = await getOrgContext();
 
+  // Identity (slug/name/logo) stays on the Better Auth org row; SSO config is
+  // in the Convex org-settings blob.
   const org = await prisma.organization.findUnique({
     where: { id: organizationId },
-    select: { metadata: true, slug: true, name: true, logo: true },
+    select: { slug: true, name: true, logo: true },
   });
   if (!org) throw new Error("Organization not found");
 
-  const settings = parseOrgSettings(org.metadata);
+  const settings = await readOrgSettingsBlob(organizationId);
   const sso = getSSOFromSettings(settings);
 
   return serialize({ sso, orgSlug: org.slug, orgName: org.name, orgLogo: org.logo });
@@ -48,12 +42,7 @@ export async function getSSOSettings() {
 export async function updateSSOSettings(data: Partial<OrgSSOSettings>) {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
-  const settings = parseOrgSettings(org.metadata);
+  const settings = await readOrgSettingsBlob(organizationId);
   const currentSSO = getSSOFromSettings(settings);
 
   // Enforce: can't enable enforceSSO without successful test
@@ -63,11 +52,7 @@ export async function updateSSOSettings(data: Partial<OrgSSOSettings>) {
 
   const updatedSSO = { ...currentSSO, ...data };
   settings.sso = updatedSSO;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   await logActivity({
     organizationId,
@@ -223,12 +208,7 @@ export async function updateSSOProviderMeta(
 ) {
   const { organizationId } = await requirePermission("orgSettings", "update");
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
-  const settings = parseOrgSettings(org.metadata);
+  const settings = await readOrgSettingsBlob(organizationId);
   const sso = getSSOFromSettings(settings);
 
   if (!sso.providerMeta) sso.providerMeta = {};
@@ -237,11 +217,7 @@ export async function updateSSOProviderMeta(
     icon: meta.icon || "key",
   };
   settings.sso = sso;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   return { success: true };
 }
@@ -251,21 +227,12 @@ export async function updateSSOProviderMeta(
 export async function updateGroupMappings(mappings: SSOGroupMapping[]) {
   const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
   // Group mappings target built-in roles only (custom roles were removed).
-  const settings = parseOrgSettings(org.metadata);
+  const settings = await readOrgSettingsBlob(organizationId);
   const sso = getSSOFromSettings(settings);
   sso.groupMappings = mappings;
   settings.sso = sso;
-
-  await prisma.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
+  await saveOrgSettings(organizationId, settings);
 
   await logActivity({
     organizationId,
@@ -455,12 +422,12 @@ export async function rejectSSOUser(approvalId: string, note?: string) {
 export async function getOrgLoginInfo(orgSlug: string) {
   const org = await prisma.organization.findUnique({
     where: { slug: orgSlug },
-    select: { id: true, name: true, slug: true, logo: true, metadata: true },
+    select: { id: true, name: true, slug: true, logo: true },
   });
 
   if (!org) return null;
 
-  const settings = parseOrgSettings(org.metadata);
+  const settings = await readOrgSettingsBlob(org.id);
   const sso = settings.sso;
 
   // Get SSO providers for this org

--- a/src/server/test-tag-assets.ts
+++ b/src/server/test-tag-assets.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { reserveTestTagIds, peekNextTestTagIds, getOrgTestTagSettings } from "@/server/settings";
@@ -436,17 +436,9 @@ export async function getTestTagDashboardStats() {
 
   const now = new Date();
 
-  // Get org settings for dueSoonThreshold
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-  });
-  let dueSoonDays = 14;
-  if (org?.metadata) {
-    try {
-      const settings = JSON.parse(org.metadata);
-      dueSoonDays = settings.testTag?.dueSoonThresholdDays || 14;
-    } catch { /* ignore */ }
-  }
+  // Get org settings for dueSoonThreshold (Convex org-settings blob).
+  const settings = await readOrgSettingsBlob(organizationId);
+  const dueSoonDays = settings.testTag?.dueSoonThresholdDays || 14;
 
   const dueSoonDate = new Date(now);
   dueSoonDate.setDate(dueSoonDate.getDate() + dueSoonDays);


### PR DESCRIPTION
## Phase 1 (WS1) — org business settings → Convex

Moves per-org **business settings** off the Better Auth `organization` row into a dedicated Convex `orgSettings` table, so the org row keeps only auth-identity fields (name/slug/logo). The legacy Postgres columns become **Convex-only source of truth**:
- `metadata` (the `OrgSettings` JSON blob — branding, testTag, SSO config, asset-tag + project-number config, ical, tax label, timezone…)
- `defaultTaxRate`
- `apiKillSwitchAt`

### What's here
- **`convex/orgSettings.ts`** (SERVICE-gated — RBAC/validation/audit stay in the Next.js server actions for now): `getByOrg`, `getByIcalToken`, `upsertSettings`, atomic `reserveAssetTags`/`reserveTestTagIds` (counter read-modify-write **inside** the mutation → serializable, no TOCTOU), `setApiKillSwitch`, `createIfMissing`.
- **Denormalised `icalToken`** (indexed `by_icalToken`, set only while the feed is enabled) → the public calendar route resolves a token with an index hit instead of scanning every org's metadata.
- **`src/lib/org-settings-read.ts`** — shared server read/write helpers.
- **Consumers rewired** off `prisma.organization` metadata/tax/kill-switch reads: `settings`, `org-calendar`, `sso`, `sso-provisioning`, `auth` (login SSO-tested flag), `api-keys` + `api-key` (kill-switch on every API request), `line-items` (org default tax), the iCal + two crew calendar routes, the test-tag report route + `test-tag-assets`, and both PDF doc-data builders. Org **name** stays on the Better Auth org row.
- **`scripts/convex-backfill-org-settings.ts`** — idempotent prod backfill.

### Correctness (codex-reviewed, 4 issues fixed)
1. Missing-org reads now return a **fresh** row (was a shared mutable object → cross-org leak).
2. `upsertSettings` only patches `defaultTaxRate`/`icalToken` when the arg is supplied (`undefined`=leave, `null`=clear) — a blob-only save no longer wipes the tax rate.
3. `safeParse` returns `{}` on corrupt JSON (matches the legacy Postgres read path) instead of throwing.
4. `upsertSettings` carries the stored asset-tag/test-tag **counters** forward (`max(stored, incoming)`) so a settings save can't roll back a concurrent reservation.

### ⚠️ Deploy step
Convex functions + schema are additive (already pushed to prod Convex; nothing reads them until this merges). **After the app container is live, run the backfill inside it before any asset/test-tag creation** so the atomic counters resume from the stored value instead of re-initialising at 0:
```
pnpm tsx scripts/convex-backfill-org-settings.ts
```

tsc + lint clean; full unit suite (3150) green; api-key(s) tests updated for the Convex kill-switch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)