### PR TITLE
feat(woocommerce): Convex httpAction webhook ingress + processing (Phase 2 gate #6)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3592,6 +3592,38 @@ truth**.
   prod container immediately after deploy** — before any asset/test-tag creation — so
   the atomic counters resume from the stored value rather than re-initialising at 0.
 
+## Phase 2 (WS3) — WooCommerce webhook → Convex httpAction
+
+The public WooCommerce webhook ingress + order processing moved off the Next.js
+route into Convex, so the browser↔Convex-direct architecture doesn't route webhooks
+through Next.js. (Config, order logs, idempotency, and the per-integration HMAC
+secret were already Convex-only.)
+
+- **Ingress** — `convex/http.ts` `httpRouter()` exposes `POST /webhooks/woo` (an
+  `httpAction`) at `…convex.site/webhooks/woo`. It reproduces the Next route
+  step-for-step: 1MB guard, ping bypass, org resolution (`?org=` or the single org),
+  integration-enabled check, **HMAC-SHA256 verify in Web Crypto** (reproduces
+  `verifyWebhookSignature` byte-for-byte — UTF-8 body, base64, length-mismatch → 401),
+  `order.created` topic filter, COMPLETED-log idempotency, then
+  `scheduler.runAfter(0, …)` + immediate 200.
+- **Processing** — `convex/wooCommerceActions.ts` `processOrder` (`internalAction`) is
+  a faithful port of `processWooCommerceOrder`: client match, date extraction, product
+  matching, project + line-item creation, tax recalc, order-log transitions, activity
+  log. Re-asserts `integration.organizationId === orgId` after the async hop.
+- **Auth** — an externally-triggered httpAction / scheduled action has **no SERVICE
+  identity**, so it can't call the service-gated `api.*` CRUD. All DB access goes
+  through **`convex/wooCommerceInternal.ts`** — `internalQuery`/`internalMutation`
+  wrappers that are unreachable from clients by construction (never on the public
+  `api`), each a verbatim copy of its `api.*` twin with the auth guard removed. Recalc
+  reuses the shared pure `recalcProjectTotals` so totals stay byte-identical.
+- **Dual-accept + cutover** — the old Next route is **left intact**; the shared Convex
+  order-log dedup makes running both safe. Ingress guards validated live on prod
+  (ping→200, missing/bad signature→401). **Cutover (follow-up, not in this change):**
+  re-register the WooCommerce webhook URL to the `…convex.site/webhooks/woo` endpoint,
+  soak, then retire the Next route. `dateExtraction` is stored as epoch-ms (Convex
+  rejects `Date` values — a latent bug in the Next original that only fired when
+  date-meta keys were configured).
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -53,6 +53,7 @@ import type * as files from "../files.js";
 import type * as globalSearch from "../globalSearch.js";
 import type * as groupTemplateItems from "../groupTemplateItems.js";
 import type * as groupTemplates from "../groupTemplates.js";
+import type * as http from "../http.js";
 import type * as kitAllocations from "../kitAllocations.js";
 import type * as kitBulkItems from "../kitBulkItems.js";
 import type * as kitCheckItems from "../kitCheckItems.js";
@@ -135,7 +136,9 @@ import type * as warehouseDetail from "../warehouseDetail.js";
 import type * as warehouseList from "../warehouseList.js";
 import type * as warehouseOps from "../warehouseOps.js";
 import type * as webhooks from "../webhooks.js";
+import type * as wooCommerceActions from "../wooCommerceActions.js";
 import type * as wooCommerceIntegrations from "../wooCommerceIntegrations.js";
+import type * as wooCommerceInternal from "../wooCommerceInternal.js";
 import type * as wooCommerceOrderLogs from "../wooCommerceOrderLogs.js";
 
 import type {
@@ -190,6 +193,7 @@ declare const fullApi: ApiFromModules<{
   globalSearch: typeof globalSearch;
   groupTemplateItems: typeof groupTemplateItems;
   groupTemplates: typeof groupTemplates;
+  http: typeof http;
   kitAllocations: typeof kitAllocations;
   kitBulkItems: typeof kitBulkItems;
   kitCheckItems: typeof kitCheckItems;
@@ -272,7 +276,9 @@ declare const fullApi: ApiFromModules<{
   warehouseList: typeof warehouseList;
   warehouseOps: typeof warehouseOps;
   webhooks: typeof webhooks;
+  wooCommerceActions: typeof wooCommerceActions;
   wooCommerceIntegrations: typeof wooCommerceIntegrations;
+  wooCommerceInternal: typeof wooCommerceInternal;
   wooCommerceOrderLogs: typeof wooCommerceOrderLogs;
 }>;
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,186 @@
+import { httpRouter } from "convex/server";
+import { createId } from "@paralleldrive/cuid2";
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+/**
+ * Convex HTTP router — WooCommerce webhook ingress (Convex-native migration).
+ *
+ * Faithful port of the Next.js route `src/app/api/integrations/woocommerce/
+ * webhook/route.ts`. Runs on Convex Cloud; the ORIGINAL Next route is left intact
+ * for dual-accept during the URL swap — the shared Convex order-log dedup makes
+ * running both safe.
+ *
+ * The HMAC scheme reproduces `verifyWebhookSignature` (src/lib/woocommerce-utils.ts)
+ * exactly, in Web Crypto: HMAC-SHA-256 over the UTF-8 raw body bytes, keyed on the
+ * UTF-8 secret bytes, base64-encoded, then constant-time compared to the header.
+ *
+ * AUTH: all DB access goes through UNGUARDED `internalQuery`/`internalMutation`
+ * wrappers in convex/wooCommerceInternal.ts. Those are unreachable from clients by
+ * construction, so — unlike the service-gated `api.*` CRUD — they need no SERVICE
+ * identity, which an externally-triggered HTTP action does not have.
+ */
+
+const MAX_PAYLOAD_SIZE = 1_000_000; // 1MB
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** HMAC-SHA256(secret, message) → standard base64. Mirrors Node's
+ * crypto.createHmac("sha256", secret).update(message).digest("base64"). */
+async function computeHmacBase64(secret: string, message: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(message));
+  const bytes = new Uint8Array(sig);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+/** Constant-time string compare (equal length + XOR fold). Mirrors the outcome of
+ * Node's timingSafeEqual on the two base64 strings (base64 is ASCII), including
+ * treating a length mismatch as "not equal" rather than throwing. */
+function timingSafeEqualStr(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+async function verifyWebhookSignature(
+  rawBody: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  const expected = await computeHmacBase64(secret, rawBody);
+  return timingSafeEqualStr(signature, expected);
+}
+
+const wooWebhook = httpAction(async (ctx, request) => {
+  // 1. Payload size check
+  const contentLength = request.headers.get("content-length");
+  if (contentLength && parseInt(contentLength) > MAX_PAYLOAD_SIZE) {
+    return json({ error: "Payload too large" }, 413);
+  }
+
+  // 2. Read the raw body (needed for HMAC verification)
+  const rawBody = await request.text();
+  if (rawBody.length > MAX_PAYLOAD_SIZE) {
+    return json({ error: "Payload too large" }, 413);
+  }
+
+  // 3. Get headers
+  const signature = request.headers.get("X-WC-Webhook-Signature");
+  const topic = request.headers.get("X-WC-Webhook-Topic");
+
+  // 4. Handle WooCommerce ping (no signature check — no sensitive data).
+  if (topic === "action.woocommerce_webhook_delivery") {
+    return json({ ok: true, ping: true });
+  }
+
+  let parsed: { id?: number; number?: string } | undefined;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    // Not valid JSON — treat as ping if body is empty/minimal
+  }
+  if (!parsed?.id) {
+    return json({ ok: true, ping: true });
+  }
+
+  // 5. Determine org — an explicit ?org= param, else the single org (mirrors the
+  // Next route's getTheOrg()). A missing single org → "No organization configured".
+  let orgId = new URL(request.url).searchParams.get("org");
+  if (!orgId) {
+    const org = await ctx.runQuery(internal.wooCommerceInternal.getSingleOrg, {});
+    if (!org) {
+      return json({ error: "No organization configured" }, 404);
+    }
+    orgId = org.id;
+  }
+
+  // 6. Load the org's integration; require it enabled (mapped isEnabled defaults to
+  // false when absent, matching mapWooCommerceIntegration).
+  const integration = await ctx.runQuery(internal.wooCommerceInternal.getIntegrationByOrg, {
+    orgId,
+  });
+  if (!integration || (integration.isEnabled ?? false) !== true) {
+    return json({ error: "Integration not enabled" }, 404);
+  }
+  const webhookSecret = integration.webhookSecret ?? "";
+
+  // 7. Verify HMAC-SHA256 signature
+  if (!signature) {
+    return json({ error: "Missing signature" }, 401);
+  }
+  try {
+    if (!(await verifyWebhookSignature(rawBody, signature, webhookSecret))) {
+      return json({ error: "Invalid signature" }, 401);
+    }
+  } catch {
+    return json({ error: "Invalid signature" }, 401);
+  }
+
+  const order = parsed as { id: number; number?: string };
+
+  // 9. Store last payload for "Test & Detect".
+  await ctx.runMutation(internal.wooCommerceInternal.updateIntegrationLastPayload, {
+    id: integration.id,
+    lastPayload: order,
+    updatedAt: Date.now(),
+  });
+
+  // 10. Only process order.created topic
+  if (topic && topic !== "order.created") {
+    return json({ ok: true, skipped: true, reason: `Topic ${topic} not handled` });
+  }
+
+  // 11. Idempotency: skip if this order already completed (read-before-write dedup).
+  const existing = await ctx.runQuery(internal.wooCommerceInternal.findCompletedLogByOrder, {
+    orgId,
+    wooOrderId: order.id,
+  });
+  if (existing) {
+    await ctx.runMutation(internal.wooCommerceInternal.createLog, {
+      id: createId(),
+      organizationId: orgId,
+      wooOrderId: order.id,
+      wooOrderNumber: order.number ?? undefined,
+      status: "DUPLICATE",
+      payload: order,
+      createdAt: Date.now(),
+    });
+    return json({ ok: true, duplicate: true });
+  }
+
+  // 12. Process asynchronously — respond 200 immediately (WooCommerce retries on non-200).
+  await ctx.scheduler.runAfter(0, internal.wooCommerceActions.processOrder, {
+    orgId,
+    order,
+    integrationId: integration.id,
+  });
+
+  // 13. Respond 200 immediately
+  return json({ ok: true, received: order.id });
+});
+
+const http = httpRouter();
+
+http.route({
+  path: "/webhooks/woo",
+  method: "POST",
+  handler: wooWebhook,
+});
+
+export default http;

--- a/convex/wooCommerceActions.ts
+++ b/convex/wooCommerceActions.ts
@@ -1,0 +1,810 @@
+import { v, ConvexError } from "convex/values";
+import { createId } from "@paralleldrive/cuid2";
+import { internalAction } from "./_generated/server";
+import type { ActionCtx } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+/**
+ * Convex-native WooCommerce order processing (Convex-native migration).
+ *
+ * Faithful port of `processWooCommerceOrder` + every private helper it transitively
+ * uses from `src/server/woocommerce.ts`. Runs as a scheduled internalAction: the
+ * webhook ingress (convex/http.ts) verifies the HMAC signature and schedules this
+ * with the raw WooCommerce order. Every `convex.mutation(api.X)` in the original is
+ * replaced by `ctx.runMutation(internal.wooCommerceInternal.X)` /
+ * `ctx.runQuery(internal.wooCommerceInternal.X)`.
+ *
+ * AUTH: all DB access goes through UNGUARDED `internalMutation`/`internalQuery`
+ * wrappers in convex/wooCommerceInternal.ts. Those are unreachable from clients by
+ * construction, so — unlike the service-gated `api.*` CRUD — they need no SERVICE
+ * identity, which a webhook-scheduled action does not have. Each wrapper's handler
+ * is a verbatim copy of its `api.*` twin minus the auth guard.
+ *
+ * The RETRY path (retryFailedOrder) intentionally stays server-side in
+ * src/server/woocommerce.ts — this action only handles the create-fresh-log path
+ * the webhook schedules.
+ */
+
+// ─── Types (copied from src/server/woocommerce.ts) ──────────────────────────
+
+interface WooOrder {
+  id: number;
+  number?: string;
+  status?: string;
+  billing: {
+    first_name: string;
+    last_name: string;
+    company?: string;
+    email: string;
+    phone?: string;
+    address_1?: string;
+    address_2?: string;
+    city?: string;
+    state?: string;
+    postcode?: string;
+    country?: string;
+  };
+  customer_note?: string;
+  line_items: Array<{
+    name: string;
+    sku?: string;
+    quantity: number;
+    price: string;
+    meta_data?: Array<{ key: string; value: string }>;
+  }>;
+  meta_data?: Array<{ key: string; value: string }>;
+}
+
+interface WooCommerceIntegrationConfig {
+  id: string;
+  organizationId: string;
+  isEnabled: boolean;
+  webhookSecret: string;
+  productMatchField: string;
+  customFieldKey: string | null;
+  rentalStartKey: string | null;
+  rentalEndKey: string | null;
+  eventStartKey: string | null;
+  deliveryAddressKey: string | null;
+  notesKey: string | null;
+  locationMetaKey: string | null;
+  defaultLocationId: string | null;
+  dateFormat: string;
+  defaultProjectType: string;
+  autoConfirmEnquiry: boolean;
+  notifyUserIds: string[];
+}
+
+/**
+ * Apply the exact defaults `mapWooCommerceIntegration`
+ * (src/lib/woocommerce-integration-read.ts) applies, so the config the ported
+ * helpers see is byte-identical to what the Next route passed.
+ */
+function mapIntegration(d: Record<string, unknown>): WooCommerceIntegrationConfig {
+  return {
+    id: String(d.id),
+    organizationId: String(d.organizationId),
+    isEnabled: (d.isEnabled as boolean | undefined) ?? false,
+    webhookSecret: (d.webhookSecret as string | undefined) ?? "",
+    productMatchField: (d.productMatchField as string | undefined) ?? "sku",
+    customFieldKey: (d.customFieldKey as string | undefined) ?? null,
+    rentalStartKey: (d.rentalStartKey as string | undefined) ?? null,
+    rentalEndKey: (d.rentalEndKey as string | undefined) ?? null,
+    eventStartKey: (d.eventStartKey as string | undefined) ?? null,
+    deliveryAddressKey: (d.deliveryAddressKey as string | undefined) ?? null,
+    notesKey: (d.notesKey as string | undefined) ?? null,
+    locationMetaKey: (d.locationMetaKey as string | undefined) ?? null,
+    defaultLocationId: (d.defaultLocationId as string | undefined) ?? null,
+    dateFormat: (d.dateFormat as string | undefined) ?? "auto",
+    defaultProjectType: (d.defaultProjectType as string | undefined) ?? "DRY_HIRE",
+    autoConfirmEnquiry: (d.autoConfirmEnquiry as boolean | undefined) ?? false,
+    notifyUserIds: (d.notifyUserIds as string[] | undefined) ?? [],
+  };
+}
+
+// ─── Pure helpers (copied verbatim from src/server/woocommerce.ts) ──────────
+
+/** Strip common business suffixes, punctuation, and normalize whitespace */
+function normalizeCompanyName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(
+      /\b(pty\.?\s*ltd\.?|proprietary\s+limited|limited|ltd\.?|inc\.?|incorporated|llc\.?|l\.?l\.?c\.?|corp\.?|corporation|co\.?|company|gmbh|pty|p\/l|group|holdings|enterprises|services|solutions|international|intl\.?|australia|aus|nz|uk|usa)\b/gi,
+      "",
+    )
+    .replace(/[^\w\s]/g, "") // remove punctuation
+    .replace(/\s+/g, " ") // collapse whitespace
+    .trim();
+}
+
+/** Generate character bigrams from a string */
+function getBigrams(str: string): Set<string> {
+  const bigrams = new Set<string>();
+  for (let i = 0; i < str.length - 1; i++) {
+    bigrams.add(str.substring(i, i + 2));
+  }
+  return bigrams;
+}
+
+/** Dice coefficient: 2 * |intersection| / (|A| + |B|) */
+function diceCoefficient(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+
+  let intersection = 0;
+  for (const bigram of a) {
+    if (b.has(bigram)) intersection++;
+  }
+
+  return (2 * intersection) / (a.size + b.size);
+}
+
+/**
+ * Flexible date parse — copied verbatim from src/lib/woocommerce-utils.ts
+ * (`flexibleDateParse`). Convex files can't import from src/.
+ */
+function flexibleDateParse(value: string, preferredFormat: string = "auto"): Date | null {
+  if (!value || !value.trim()) return null;
+  const trimmed = value.trim();
+
+  // Try ISO 8601 first
+  const isoDate = new Date(trimmed);
+  if (preferredFormat === "ISO" && !isNaN(isoDate.getTime())) return isoDate;
+
+  // DD/MM/YYYY or MM/DD/YYYY
+  const ddmmyyyy = trimmed.match(/^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{4})$/);
+  if (ddmmyyyy) {
+    if (preferredFormat === "DD/MM/YYYY" || preferredFormat === "auto") {
+      const d = new Date(Number(ddmmyyyy[3]), Number(ddmmyyyy[2]) - 1, Number(ddmmyyyy[1]));
+      if (!isNaN(d.getTime())) return d;
+    }
+    if (preferredFormat === "MM/DD/YYYY") {
+      const d = new Date(Number(ddmmyyyy[3]), Number(ddmmyyyy[1]) - 1, Number(ddmmyyyy[2]));
+      if (!isNaN(d.getTime())) return d;
+    }
+  }
+
+  // YYYY-MM-DD (ISO date part)
+  const yyyymmdd = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (yyyymmdd) {
+    const d = new Date(Number(yyyymmdd[1]), Number(yyyymmdd[2]) - 1, Number(yyyymmdd[3]));
+    if (!isNaN(d.getTime())) return d;
+  }
+
+  // Natural language: "15 March 2026", "March 15, 2026", etc.
+  const natural = new Date(trimmed);
+  if (!isNaN(natural.getTime())) return natural;
+
+  return null;
+}
+
+interface DateExtractionResult {
+  rentalStart: Date | null;
+  rentalEnd: Date | null;
+  eventStart: Date | null;
+  raw: Record<string, string>;
+}
+
+function extractDates(order: WooOrder, integration: WooCommerceIntegrationConfig): DateExtractionResult {
+  const meta = new Map<string, string>();
+  if (order.meta_data) {
+    for (const m of order.meta_data) {
+      meta.set(m.key, m.value);
+    }
+  }
+
+  const raw: Record<string, string> = {};
+  const format = integration.dateFormat;
+
+  function parseDate(key: string | null): Date | null {
+    if (!key) return null;
+    const value = meta.get(key);
+    if (!value) return null;
+    raw[key] = value;
+    return flexibleDateParse(value, format);
+  }
+
+  return {
+    rentalStart: parseDate(integration.rentalStartKey),
+    rentalEnd: parseDate(integration.rentalEndKey),
+    eventStart: parseDate(integration.eventStartKey),
+    raw,
+  };
+}
+
+function extractNotes(order: WooOrder, integration: WooCommerceIntegrationConfig): string | null {
+  const parts: string[] = [];
+
+  // Customer note from WooCommerce
+  if (order.customer_note) {
+    parts.push(order.customer_note);
+  }
+
+  // Custom notes key from meta
+  if (integration.notesKey) {
+    const meta = order.meta_data?.find((m) => m.key === integration.notesKey);
+    if (meta?.value) {
+      parts.push(meta.value);
+    }
+  }
+
+  // Delivery address from meta
+  if (integration.deliveryAddressKey) {
+    const meta = order.meta_data?.find((m) => m.key === integration.deliveryAddressKey);
+    if (meta?.value) {
+      parts.push(`Delivery address: ${meta.value}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+interface MatchResult {
+  wooProductName: string;
+  wooSku: string | null;
+  wooQuantity: number;
+  wooPrice: number;
+  modelId: string | null;
+  modelName: string | null;
+  matched: boolean;
+}
+
+// ─── ctx-bound helpers ──────────────────────────────────────────────────────
+
+/** Write an activity-log row (native equivalent of the server `logActivity`). */
+async function logActivityConvex(
+  ctx: ActionCtx,
+  entry: {
+    organizationId: string;
+    action: string;
+    entityType: string;
+    entityId: string;
+    entityName: string;
+    summary: string;
+    projectId?: string;
+    metadata?: unknown;
+  },
+): Promise<void> {
+  await ctx.runMutation(internal.wooCommerceInternal.recordActivity, {
+    id: createId(),
+    organizationId: entry.organizationId,
+    userId: "system",
+    userName: "WooCommerce",
+    action: entry.action,
+    entityType: entry.entityType,
+    entityId: entry.entityId,
+    entityName: entry.entityName,
+    summary: entry.summary,
+    ...(entry.projectId ? { projectId: entry.projectId } : {}),
+    ...(entry.metadata !== undefined ? { metadata: entry.metadata } : {}),
+    createdAt: Date.now(),
+  });
+}
+
+type ClientDoc = {
+  id: string;
+  name: string;
+  type?: string;
+  contactEmail?: string;
+  isActive?: boolean;
+};
+
+/**
+ * Fuzzy-match a company name against existing COMPANY clients. (Verbatim logic
+ * from src/server/woocommerce.ts `fuzzyMatchCompany`.)
+ */
+function fuzzyMatchCompany(allClients: ClientDoc[], companyName: string): ClientDoc | null {
+  const candidates = allClients.filter((c) => c.type === "COMPANY" && (c.isActive ?? true));
+  if (candidates.length === 0) return null;
+
+  const normalizedInput = normalizeCompanyName(companyName);
+
+  // Exact normalized match
+  const exact = candidates.find((c) => normalizeCompanyName(c.name) === normalizedInput);
+  if (exact) return exact;
+
+  // Bigram similarity match
+  const inputBigrams = getBigrams(normalizedInput);
+  let bestMatch: { client: ClientDoc; score: number } | null = null;
+
+  for (const candidate of candidates) {
+    const candidateNormalized = normalizeCompanyName(candidate.name);
+    const candidateBigrams = getBigrams(candidateNormalized);
+    const score = diceCoefficient(inputBigrams, candidateBigrams);
+
+    if (score >= 0.7 && (!bestMatch || score > bestMatch.score)) {
+      bestMatch = { client: candidate, score };
+    }
+  }
+
+  return bestMatch ? bestMatch.client : null;
+}
+
+async function findOrCreateClient(
+  ctx: ActionCtx,
+  orgId: string,
+  billing: WooOrder["billing"],
+): Promise<ClientDoc> {
+  const hasCompany = !!billing.company?.trim();
+
+  // Clients live in Convex — fetch the org's clients once and match in memory.
+  const all = (await ctx.runQuery(internal.wooCommerceInternal.listClientsByOrg, { orgId })) as ClientDoc[];
+
+  // 1. Try exact email match first
+  let client: ClientDoc | null =
+    all.find((c) => (c.isActive ?? true) && c.contactEmail === billing.email) ?? null;
+  if (client && hasCompany && client.type === "INDIVIDUAL") {
+    client = null; // skip personal match, fall through to company matching
+  }
+
+  // 2. If company name provided, try fuzzy company matching
+  if (!client && hasCompany) {
+    client = fuzzyMatchCompany(all, billing.company!.trim());
+  }
+
+  // 3. If still no match, create a new client
+  if (!client) {
+    const address = [
+      billing.address_1,
+      billing.address_2,
+      billing.city,
+      billing.state,
+      billing.postcode,
+      billing.country,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    const id = createId();
+    const now = Date.now();
+    const name = hasCompany ? billing.company!.trim() : `${billing.first_name} ${billing.last_name}`;
+    await ctx.runMutation(internal.wooCommerceInternal.createClientIfMissing, {
+      id,
+      organizationId: orgId,
+      name,
+      type: hasCompany ? "COMPANY" : "INDIVIDUAL",
+      contactName: `${billing.first_name} ${billing.last_name}`,
+      contactEmail: billing.email,
+      contactPhone: billing.phone || undefined,
+      billingAddress: address || undefined,
+      tags: ["website-order"],
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    client = (await ctx.runQuery(internal.wooCommerceInternal.getClientById, { id })) as ClientDoc | null;
+    if (!client) throw new ConvexError("Failed to load auto-created client");
+
+    await logActivityConvex(ctx, {
+      organizationId: orgId,
+      action: "CREATE",
+      entityType: "client",
+      entityId: id,
+      entityName: name,
+      summary: `Auto-created client from WooCommerce order`,
+    });
+  }
+
+  return client;
+}
+
+type LocationDoc = { id: string; name: string; address?: string };
+
+async function resolveLocation(
+  ctx: ActionCtx,
+  orgId: string,
+  order: WooOrder,
+  integration: WooCommerceIntegrationConfig,
+): Promise<string | null> {
+  // Try to match from meta field
+  if (integration.locationMetaKey) {
+    const metaValue = order.meta_data?.find((m) => m.key === integration.locationMetaKey)?.value;
+
+    if (metaValue?.trim()) {
+      const locationName = metaValue.trim();
+      const lowerName = locationName.toLowerCase();
+
+      const candidates = (await ctx.runQuery(internal.wooCommerceInternal.listLocationsByOrg, { orgId })) as LocationDoc[];
+
+      // 1. Exact name match (case-insensitive)
+      const exactName = candidates.find((c) => c.name.toLowerCase() === lowerName);
+      if (exactName) return exactName.id;
+
+      // 2. Address match (case-insensitive)
+      const addressMatch = candidates.find(
+        (c) => (c.address?.toLowerCase() ?? "") === lowerName && !!c.address,
+      );
+      if (addressMatch) return addressMatch.id;
+
+      // 3. Fuzzy match against all locations (name + address)
+      const normalizedInput = locationName.toLowerCase().trim();
+      let bestMatch: { id: string; score: number } | null = null;
+
+      for (const candidate of candidates) {
+        const normalizedName = candidate.name.toLowerCase().trim();
+        const normalizedAddress = candidate.address?.toLowerCase().trim() ?? "";
+
+        // Substring match (either direction) on name or address
+        if (
+          normalizedName.includes(normalizedInput) ||
+          normalizedInput.includes(normalizedName) ||
+          (normalizedAddress &&
+            (normalizedAddress.includes(normalizedInput) ||
+              normalizedInput.includes(normalizedAddress)))
+        ) {
+          return candidate.id;
+        }
+
+        // Bigram similarity on name
+        const inputBigrams = getBigrams(normalizedInput);
+        const nameBigrams = getBigrams(normalizedName);
+        const nameScore = diceCoefficient(inputBigrams, nameBigrams);
+
+        // Also try address similarity
+        let addrScore = 0;
+        if (normalizedAddress) {
+          const addrBigrams = getBigrams(normalizedAddress);
+          addrScore = diceCoefficient(inputBigrams, addrBigrams);
+        }
+
+        const bestScore = Math.max(nameScore, addrScore);
+        if (bestScore >= 0.6 && (!bestMatch || bestScore > bestMatch.score)) {
+          bestMatch = { id: candidate.id, score: bestScore };
+        }
+      }
+
+      if (bestMatch) return bestMatch.id;
+
+      // 4. No match — create a new VENUE location.
+      const newLocationId = createId();
+      const now = Date.now();
+      const address =
+        /\d/.test(locationName) || locationName.includes(",") ? locationName : undefined;
+      await ctx.runMutation(internal.wooCommerceInternal.createLocation, {
+        id: newLocationId,
+        organizationId: orgId,
+        name: locationName,
+        type: "VENUE",
+        address,
+        isDefault: false,
+        tags: [],
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await logActivityConvex(ctx, {
+        organizationId: orgId,
+        action: "CREATE",
+        entityType: "location",
+        entityId: newLocationId,
+        entityName: locationName,
+        summary: `Auto-created venue location from WooCommerce order`,
+      });
+
+      return newLocationId;
+    }
+  }
+
+  // Fall back to default location
+  return integration.defaultLocationId || null;
+}
+
+type ModelDoc = {
+  id: string;
+  name?: string;
+  sku?: string;
+  modelNumber?: string;
+  isActive?: boolean;
+};
+
+async function matchProducts(
+  ctx: ActionCtx,
+  orgId: string,
+  lineItems: WooOrder["line_items"],
+  integration: WooCommerceIntegrationConfig,
+): Promise<MatchResult[]> {
+  // Fetch all org models once; each line item matches in JS over this array.
+  const models = (await ctx.runQuery(internal.wooCommerceInternal.listModelsByOrg, { orgId })) as ModelDoc[];
+
+  return lineItems.map((item): MatchResult => {
+    let model: ModelDoc | null = null;
+
+    switch (integration.productMatchField) {
+      case "sku":
+        if (item.sku) {
+          model = models.find((m) => m.sku === item.sku && m.isActive !== false) ?? null;
+          // Fallback to modelNumber if no SKU match
+          if (!model) {
+            model = models.find((m) => m.modelNumber === item.sku && m.isActive !== false) ?? null;
+          }
+        }
+        break;
+      case "custom_field":
+        if (integration.customFieldKey) {
+          const gearflowId = item.meta_data?.find(
+            (m) => m.key === integration.customFieldKey,
+          )?.value;
+          if (gearflowId) {
+            model = models.find((m) => m.id === gearflowId) ?? null;
+          }
+        }
+        break;
+      case "name":
+        model =
+          models.find(
+            (m) =>
+              m.name?.toLowerCase().includes(item.name.toLowerCase()) && m.isActive !== false,
+          ) ?? null;
+        break;
+    }
+
+    return {
+      wooProductName: item.name,
+      wooSku: item.sku ?? null,
+      wooQuantity: item.quantity,
+      wooPrice: parseFloat(item.price),
+      modelId: model?.id ?? null,
+      modelName: model?.name ?? null,
+      matched: !!model,
+    };
+  });
+}
+
+/**
+ * Faithful port of `generateWebOrderProjectNumber` — `WEB-<orderNumber>` with a
+ * base-36 suffix on collision. The original does NOT use the project-number format
+ * engine or org settings; keeping that exactly preserves web-order numbering.
+ */
+async function generateWebOrderProjectNumber(
+  ctx: ActionCtx,
+  orgId: string,
+  order: WooOrder,
+): Promise<string> {
+  const prefix = `WEB-${order.number || order.id}`;
+  // Check if this project number already exists (targeted org+number lookup —
+  // equivalent to the original getProjectsByOrg().find(p.projectNumber === prefix)).
+  const existing = await ctx.runQuery(internal.wooCommerceInternal.getProjectByOrgAndNumber, {
+    organizationId: orgId,
+    projectNumber: prefix,
+  });
+  if (!existing) return prefix;
+  // Append suffix if duplicate
+  return `${prefix}-${Date.now().toString(36).slice(-4)}`;
+}
+
+async function notifyNewWebsiteOrder(
+  ctx: ActionCtx,
+  orgId: string,
+  project: { id: string; projectNumber: string; name: string },
+  client: { name: string },
+  matchedCount: number,
+  totalCount: number,
+  userIds: string[],
+): Promise<void> {
+  const matchStatus =
+    matchedCount === totalCount
+      ? `All ${totalCount} products matched`
+      : `${matchedCount}/${totalCount} products matched`;
+
+  for (const userId of userIds) {
+    await logActivityConvex(ctx, {
+      organizationId: orgId,
+      action: "CREATE",
+      entityType: "notification",
+      entityId: project.id,
+      entityName: project.projectNumber,
+      summary: `New website order: ${project.name} for ${client.name} (${matchStatus})`,
+      projectId: project.id,
+      metadata: { notifyUserId: userId },
+    });
+  }
+}
+
+function errMsg(e: unknown): string {
+  if (e instanceof ConvexError) return typeof e.data === "string" ? e.data : JSON.stringify(e.data);
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+// ─── Scheduled processing action ────────────────────────────────────────────
+
+export const processOrder = internalAction({
+  args: {
+    orgId: v.string(),
+    order: v.any(),
+    integrationId: v.string(),
+  },
+  handler: async (ctx, { orgId, order: rawOrder, integrationId }) => {
+    const order = rawOrder as WooOrder;
+
+    // Load the integration config fresh (mirrors the Next route passing the row).
+    const integrationDoc = await ctx.runQuery(internal.wooCommerceInternal.getIntegrationById, {
+      id: integrationId,
+    });
+    if (!integrationDoc) {
+      throw new ConvexError("WooCommerce integration not found: " + integrationId);
+    }
+    // Defence-in-depth: the httpAction already resolved this integration for `orgId`,
+    // but re-assert org ownership after the async hop so a mid-flight reassignment
+    // can never process an order under the wrong tenant.
+    if ((integrationDoc as { organizationId?: string }).organizationId !== orgId) {
+      throw new ConvexError("WooCommerce integration org mismatch: " + integrationId);
+    }
+    const integration = mapIntegration(integrationDoc as Record<string, unknown>);
+
+    // Create a fresh PROCESSING log; `logId` tracks the flow.
+    const logId = createId();
+    await ctx.runMutation(internal.wooCommerceInternal.createLog, {
+      id: logId,
+      organizationId: orgId,
+      wooOrderId: order.id,
+      wooOrderNumber: order.number ?? undefined,
+      status: "PROCESSING",
+      payload: order,
+      createdAt: Date.now(),
+    });
+
+    try {
+      // 1. Create or find client
+      const client = await findOrCreateClient(ctx, orgId, order.billing);
+
+      // 2. Extract rental dates from order meta
+      const dates = extractDates(order, integration);
+
+      // 3. Match order line items to GearFlow models
+      const matchResults = await matchProducts(ctx, orgId, order.line_items, integration);
+
+      // 4. Resolve location (from meta field or default)
+      const locationId = await resolveLocation(ctx, orgId, order, integration);
+
+      // 5. Generate a project number
+      const projectNumber = await generateWebOrderProjectNumber(ctx, orgId, order);
+
+      // 6. Create the project (createWithUniqueNumber enforces the org+number guard;
+      // on a rare race-clash, append a unique suffix and retry).
+      const projectId = createId();
+      const projectName = order.billing.company
+        ? `${order.billing.company} — Website Order #${order.number || order.id}`
+        : `${order.billing.first_name} ${order.billing.last_name} — Website Order #${order.number || order.id}`;
+      const clientNotes = extractNotes(order, integration);
+      const projectCreatedAt = Date.now();
+      const buildProjectArgs = (num: string) => ({
+        id: projectId,
+        organizationId: orgId,
+        projectNumber: num,
+        name: projectName,
+        clientId: client.id,
+        status: (integration.autoConfirmEnquiry ? "QUOTING" : "ENQUIRY") as never,
+        type: integration.defaultProjectType as never,
+        ...(locationId ? { locationId } : {}),
+        ...(dates.rentalStart ? { rentalStartDate: dates.rentalStart.getTime() } : {}),
+        ...(dates.rentalEnd ? { rentalEndDate: dates.rentalEnd.getTime() } : {}),
+        ...(dates.eventStart ? { eventStartDate: dates.eventStart.getTime() } : {}),
+        ...(clientNotes ? { clientNotes } : {}),
+        tags: ["website-order"],
+        createdAt: projectCreatedAt,
+        updatedAt: projectCreatedAt,
+      });
+      let createResult = await ctx.runMutation(
+        internal.wooCommerceInternal.createProjectWithUniqueNumber,
+        buildProjectArgs(projectNumber),
+      );
+      let finalProjectNumber = projectNumber;
+      if (!createResult.created) {
+        finalProjectNumber = `${projectNumber}-${Date.now().toString(36).slice(-4)}`;
+        createResult = await ctx.runMutation(
+          internal.wooCommerceInternal.createProjectWithUniqueNumber,
+          buildProjectArgs(finalProjectNumber),
+        );
+        if (!createResult.created) {
+          throw new ConvexError("Could not allocate a unique web-order project number");
+        }
+      }
+      const project = await ctx.runQuery(internal.wooCommerceInternal.getProjectByOrgAndNumber, {
+        organizationId: orgId,
+        projectNumber: finalProjectNumber,
+      });
+      if (!project) throw new ConvexError("WooCommerce project create failed");
+
+      // 7. Add line items for matched and unmatched products.
+      const duration =
+        dates.rentalStart && dates.rentalEnd
+          ? Math.max(
+              1,
+              Math.ceil(
+                (dates.rentalEnd.getTime() - dates.rentalStart.getTime()) / (1000 * 60 * 60 * 24),
+              ),
+            )
+          : 1;
+      const nowMs = Date.now();
+      let sortOrder = 0;
+      for (const match of matchResults) {
+        await ctx.runMutation(internal.wooCommerceInternal.createLineItem, {
+          id: createId(),
+          organizationId: orgId,
+          projectId: project.id,
+          type: match.modelId ? "EQUIPMENT" : "MISC",
+          modelId: match.modelId || undefined,
+          description: match.modelId
+            ? undefined
+            : `[WooCommerce] ${match.wooProductName}${match.wooSku ? ` (SKU: ${match.wooSku})` : ""}`,
+          quantity: match.wooQuantity,
+          unitPrice: match.wooPrice,
+          pricingType: "PER_DAY",
+          duration,
+          lineTotal: match.wooPrice * match.wooQuantity,
+          sortOrder: sortOrder++,
+          createdAt: nowMs,
+          updatedAt: nowMs,
+        });
+      }
+
+      // 8. Recalculate project totals (native drop-in for recalculateProjectTotals).
+      const settingsRow = await ctx.runQuery(internal.wooCommerceInternal.getOrgSettingsByOrg, {
+        organizationId: orgId,
+      });
+      const orgDefaultTaxRate =
+        (settingsRow?.defaultTaxRate as number | null | undefined) ?? null;
+      await ctx.runMutation(internal.wooCommerceInternal.recalcProjectTotalsInternal, {
+        projectId: project.id,
+        orgId,
+        orgDefaultTaxRate,
+        now: Date.now(),
+      });
+
+      // 9. Log success
+      const matchedCount = matchResults.filter((m) => m.matched).length;
+      const totalCount = matchResults.length;
+
+      await ctx.runMutation(internal.wooCommerceInternal.updateLog, {
+        id: logId,
+        patch: {
+          status: "COMPLETED",
+          projectId: project.id,
+          clientId: client.id,
+          matchResults: matchResults,
+          // Convex rejects `Date` values — store the extracted dates as epoch ms
+          // (the field is display/debug only). The Next original stored raw Dates,
+          // which only serialised because unconfigured date-keys yield all-null.
+          dateExtraction: {
+            rentalStart: dates.rentalStart ? dates.rentalStart.getTime() : null,
+            rentalEnd: dates.rentalEnd ? dates.rentalEnd.getTime() : null,
+            eventStart: dates.eventStart ? dates.eventStart.getTime() : null,
+          },
+        },
+      });
+
+      // 10. Log activity
+      await logActivityConvex(ctx, {
+        organizationId: orgId,
+        action: "CREATE",
+        entityType: "project",
+        entityId: project.id,
+        entityName: project.projectNumber,
+        summary: `Created project from WooCommerce order #${order.number || order.id} (${matchedCount}/${totalCount} products matched)`,
+        projectId: project.id,
+      });
+
+      // 11. Notify admins
+      if (integration.notifyUserIds.length > 0) {
+        await notifyNewWebsiteOrder(
+          ctx,
+          orgId,
+          project,
+          client,
+          matchedCount,
+          totalCount,
+          integration.notifyUserIds,
+        );
+      }
+    } catch (error) {
+      await ctx.runMutation(internal.wooCommerceInternal.updateLog, {
+        id: logId,
+        patch: {
+          status: "FAILED",
+          errorMessage: errMsg(error),
+        },
+      });
+    }
+  },
+});

--- a/convex/wooCommerceInternal.ts
+++ b/convex/wooCommerceInternal.ts
@@ -1,0 +1,402 @@
+import { v, ConvexError } from "convex/values";
+import { internalQuery, internalMutation } from "./_generated/server";
+import * as enums from "./lib/validators";
+import { bumpCountersForTable } from "./lib/counters";
+import { recalcProjectTotals } from "./lib/recalc";
+import { projectWriteFields } from "./projects";
+
+/**
+ * UNGUARDED internal wrappers for the WooCommerce webhook ingress + order
+ * processing (Convex-native migration).
+ *
+ * `internalQuery` / `internalMutation` are UNREACHABLE from clients by construction
+ * (they never appear on the public `api` — only on `internal`), so — unlike the
+ * service-gated `api.*` CRUD — they carry NO `requireService`: the httpAction
+ * (convex/http.ts) and the scheduled `processOrder` action
+ * (convex/wooCommerceActions.ts) can invoke them with no auth identity. That is the
+ * whole point: a webhook-triggered action has no SERVICE token to present.
+ *
+ * Each handler body below is copied VERBATIM from its service-gated `api.*` twin —
+ * same field validators, same defaults, same return shape — with ONLY the
+ * `requireService(ctx)` (or `requireOrgRead` / `requireOrgReadDoc` /
+ * `requireOrgPermission`) line removed. The recalc math is the shared pure helper
+ * `recalcProjectTotals` (convex/lib/recalc.ts), so totals stay byte-identical.
+ */
+
+// ─── organizations (mirror of src/lib/single-org.ts getTheOrg) ──────────────
+
+/**
+ * The single organization row (or null). This app enforces exactly one org
+ * (src/lib/single-org.ts). Lets the webhook ingress distinguish "No organization
+ * configured" from "Integration not enabled" the way the Next route does.
+ */
+export const getSingleOrg = internalQuery({
+  args: {},
+  handler: async (ctx) => await ctx.db.query("organizations").first(),
+});
+
+// ─── wooCommerceIntegrations ────────────────────────────────────────────────
+
+/** Twin of api.wooCommerceIntegrations.list(orgId)[0] / the getWooCommerceIntegrationByOrg helper. */
+export const getIntegrationByOrg = internalQuery({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) =>
+    await ctx.db
+      .query("wooCommerceIntegrations")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .first(),
+});
+
+/** Twin of api.wooCommerceIntegrations.getById. */
+export const getIntegrationById = internalQuery({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) =>
+    await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique(),
+});
+
+/** Twin of api.wooCommerceIntegrations.update, narrowed to the lastPayload patch the ingress writes. */
+export const updateIntegrationLastPayload = internalMutation({
+  args: { id: v.string(), lastPayload: v.any(), updatedAt: v.number() },
+  handler: async (ctx, { id, lastPayload, updatedAt }) => {
+    const doc = await ctx.db.query("wooCommerceIntegrations").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc) throw new ConvexError("wooCommerceIntegrations not found: " + id);
+    await ctx.db.patch(doc._id, { lastPayload, updatedAt });
+    return doc._id;
+  },
+});
+
+// ─── wooCommerceOrderLogs ───────────────────────────────────────────────────
+
+/** Twin of api.wooCommerceOrderLogs.create. */
+export const createLog = internalMutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    wooOrderId: v.number(),
+    wooOrderNumber: v.optional(v.string()),
+    status: enums.WooOrderLogStatus,
+    projectId: v.optional(v.string()),
+    clientId: v.optional(v.string()),
+    payload: v.any(),
+    errorMessage: v.optional(v.string()),
+    matchResults: v.optional(v.any()),
+    dateExtraction: v.optional(v.any()),
+    createdAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("wooCommerceOrderLogs", args);
+  },
+});
+
+/** Twin of api.wooCommerceOrderLogs.update. */
+export const updateLog = internalMutation({
+  args: {
+    id: v.string(),
+    patch: v.object({
+      organizationId: v.optional(v.string()),
+      wooOrderId: v.optional(v.number()),
+      wooOrderNumber: v.optional(v.string()),
+      status: v.optional(enums.WooOrderLogStatus),
+      projectId: v.optional(v.string()),
+      clientId: v.optional(v.string()),
+      payload: v.optional(v.any()),
+      errorMessage: v.optional(v.string()),
+      matchResults: v.optional(v.any()),
+      dateExtraction: v.optional(v.any()),
+      createdAt: v.optional(v.number()),
+    }),
+  },
+  handler: async (ctx, { id, patch }) => {
+    const doc = await ctx.db.query("wooCommerceOrderLogs").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc) throw new ConvexError("wooCommerceOrderLogs not found: " + id);
+    const safePatch = { ...patch };
+    delete safePatch.organizationId;
+    await ctx.db.patch(doc._id, safePatch);
+    return doc._id;
+  },
+});
+
+/**
+ * The first COMPLETED log for a (org, wooOrderId) — the webhook idempotency check,
+ * replacing findCompletedOrderLog (src/lib/woocommerce-order-logs-read.ts). Uses the
+ * by_wooOrderId index then filters org + status COMPLETED (same result as the helper's
+ * full-org scan + find).
+ */
+export const findCompletedLogByOrder = internalQuery({
+  args: { orgId: v.string(), wooOrderId: v.number() },
+  handler: async (ctx, { orgId, wooOrderId }) => {
+    const rows = await ctx.db
+      .query("wooCommerceOrderLogs")
+      .withIndex("by_wooOrderId", (q) => q.eq("wooOrderId", wooOrderId))
+      .collect();
+    return rows.find((r) => r.organizationId === orgId && r.status === "COMPLETED") ?? null;
+  },
+});
+
+// ─── clients ────────────────────────────────────────────────────────────────
+
+/** Twin of api.clients.list. */
+export const listClientsByOrg = internalQuery({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) =>
+    await ctx.db
+      .query("clients")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect(),
+});
+
+/** Twin of api.clients.getById (minus requireOrgReadDoc). */
+export const getClientById = internalQuery({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) =>
+    await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).unique(),
+});
+
+/** Twin of api.clients.createIfMissing. */
+export const createClientIfMissing = internalMutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    name: v.string(),
+    type: v.optional(enums.ClientType),
+    contactName: v.optional(v.string()),
+    contactEmail: v.optional(v.string()),
+    contactPhone: v.optional(v.string()),
+    billingAddress: v.optional(v.string()),
+    billingLatitude: v.optional(v.number()),
+    billingLongitude: v.optional(v.number()),
+    shippingAddress: v.optional(v.string()),
+    shippingLatitude: v.optional(v.number()),
+    shippingLongitude: v.optional(v.number()),
+    taxId: v.optional(v.string()),
+    paymentTerms: v.optional(v.string()),
+    defaultDiscount: v.optional(v.number()),
+    notes: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    isActive: v.optional(v.boolean()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+    if (existing) return { _id: existing._id, created: false };
+    const _id = await ctx.db.insert("clients", args);
+    return { _id, created: true };
+  },
+});
+
+// ─── locations ──────────────────────────────────────────────────────────────
+
+/** Twin of api.locations.list. */
+export const listLocationsByOrg = internalQuery({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) =>
+    await ctx.db
+      .query("locations")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect(),
+});
+
+/** Twin of api.locations.create. */
+export const createLocation = internalMutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    name: v.string(),
+    address: v.optional(v.string()),
+    latitude: v.optional(v.number()),
+    longitude: v.optional(v.number()),
+    type: v.optional(enums.LocationType),
+    isDefault: v.optional(v.boolean()),
+    parentId: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("locations", args);
+  },
+});
+
+// ─── models ─────────────────────────────────────────────────────────────────
+
+/** Twin of api.models.list. */
+export const listModelsByOrg = internalQuery({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) =>
+    await ctx.db
+      .query("models")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect(),
+});
+
+// ─── projects ───────────────────────────────────────────────────────────────
+
+/** Twin of api.projects.getByOrgAndNumber. */
+export const getProjectByOrgAndNumber = internalQuery({
+  args: { organizationId: v.string(), projectNumber: v.string() },
+  handler: async (ctx, { organizationId, projectNumber }) =>
+    await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId_projectNumber", (q) =>
+        q.eq("organizationId", organizationId).eq("projectNumber", projectNumber),
+      )
+      .unique(),
+});
+
+/** Twin of api.projects.createWithUniqueNumber (verbatim guard + `{created}` return). */
+export const createProjectWithUniqueNumber = internalMutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectNumber: v.string(),
+    name: v.string(),
+    ...projectWriteFields,
+  },
+  handler: async (ctx, args) => {
+    const clash = await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId_projectNumber", (q) =>
+        q.eq("organizationId", args.organizationId).eq("projectNumber", args.projectNumber),
+      )
+      .unique();
+    if (clash) return { created: false, id: clash.id };
+    await ctx.db.insert("projects", args);
+    await bumpCountersForTable(ctx, "projects", null, args);
+    return { created: true, id: args.id };
+  },
+});
+
+// ─── projectLineItems ───────────────────────────────────────────────────────
+
+/** Twin of api.projectLineItems.create (full generated arg validator, plain insert). */
+export const createLineItem = internalMutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    type: v.optional(enums.LineItemType),
+    modelId: v.optional(v.string()),
+    assetId: v.optional(v.string()),
+    bulkAssetId: v.optional(v.string()),
+    kitId: v.optional(v.string()),
+    isKitChild: v.optional(v.boolean()),
+    childKind: v.optional(enums.LineItemChildKind),
+    parentLineItemId: v.optional(v.string()),
+    pricingMode: v.optional(enums.KitPricingMode),
+    description: v.optional(v.string()),
+    quantity: v.optional(v.number()),
+    unitPrice: v.optional(v.number()),
+    pricingType: v.optional(enums.PricingType),
+    duration: v.optional(v.number()),
+    discount: v.optional(v.number()),
+    lineTotal: v.optional(v.number()),
+    priceBreakdown: v.optional(v.string()),
+    priceOverridden: v.optional(v.boolean()),
+    overrideReason: v.optional(v.string()),
+    sortOrder: v.optional(v.number()),
+    groupName: v.optional(v.string()),
+    categoryId: v.optional(v.string()),
+    groupId: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    isOptional: v.optional(v.boolean()),
+    status: v.optional(enums.LineItemStatus),
+    checkedOutQuantity: v.optional(v.number()),
+    returnedQuantity: v.optional(v.number()),
+    assignedQuantity: v.optional(v.number()),
+    packedQuantity: v.optional(v.number()),
+    damagedQuantity: v.optional(v.number()),
+    lostQuantity: v.optional(v.number()),
+    checkedOutAt: v.optional(v.number()),
+    checkedOutById: v.optional(v.string()),
+    returnedAt: v.optional(v.number()),
+    returnedById: v.optional(v.string()),
+    returnCondition: v.optional(enums.ReturnCondition),
+    returnNotes: v.optional(v.string()),
+    prepStatus: v.optional(enums.PrepStatus),
+    prepContainer: v.optional(v.string()),
+    isContainerLineItem: v.optional(v.boolean()),
+    isCustomItem: v.optional(v.boolean()),
+    returnStatus: v.optional(enums.ReturnStatus),
+    showSubhireOnDocs: v.optional(v.boolean()),
+    supplierId: v.optional(v.string()),
+    subhireOrderNumber: v.optional(v.string()),
+    supplierOrderId: v.optional(v.string()),
+    subHireId: v.optional(v.string()),
+    subHireItemId: v.optional(v.string()),
+    subHireGroupId: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("projectLineItems", args);
+  },
+});
+
+// ─── orgSettings ────────────────────────────────────────────────────────────
+
+/** Twin of api.orgSettings.getByOrg. */
+export const getOrgSettingsByOrg = internalQuery({
+  args: { organizationId: v.string() },
+  handler: async (ctx, { organizationId }) =>
+    await ctx.db
+      .query("orgSettings")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+      .unique(),
+});
+
+// ─── recalc (project totals) ────────────────────────────────────────────────
+
+/**
+ * Twin of api.lineItemWrites.recalcNative — reuses the SAME pure math
+ * (recalcProjectTotals), so totals are byte-identical; only the auth guard
+ * (requireOrgPermission) is dropped.
+ */
+export const recalcProjectTotalsInternal = internalMutation({
+  args: {
+    projectId: v.string(),
+    orgId: v.string(),
+    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    now: v.number(),
+  },
+  handler: async (ctx, { projectId, orgId, orgDefaultTaxRate, now }) => {
+    await recalcProjectTotals(ctx, projectId, orgId, orgDefaultTaxRate, now);
+    return { ok: true as const };
+  },
+});
+
+// ─── activity log ───────────────────────────────────────────────────────────
+
+const activityLogFields = {
+  id: v.string(),
+  organizationId: v.string(),
+  action: v.string(),
+  entityType: v.string(),
+  entityId: v.string(),
+  entityName: v.string(),
+  userId: v.optional(v.string()),
+  userName: v.string(),
+  summary: v.string(),
+  details: v.optional(v.any()),
+  metadata: v.optional(v.any()),
+  projectId: v.optional(v.string()),
+  assetId: v.optional(v.string()),
+  kitId: v.optional(v.string()),
+  createdAt: v.number(),
+};
+
+/** Twin of api.activityLogWrites.record (idempotent by cuid). */
+export const recordActivity = internalMutation({
+  args: activityLogFields,
+  handler: async (ctx, entry) => {
+    const existing = await ctx.db
+      .query("activityLogs")
+      .withIndex("by_cuid", (q) => q.eq("id", entry.id))
+      .first();
+    if (existing) return { created: false };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ctx.db.insert("activityLogs", entry as any);
+    return { created: true };
+  },
+});


### PR DESCRIPTION
## Phase 2 gate #6 — WooCommerce → Convex httpAction

Moves the public WooCommerce webhook **ingress + order processing** off the Next.js route into Convex. Config, order logs, idempotency, and the per-integration HMAC secret were already Convex-only; this closes the ingress.

### Files
- **`convex/http.ts`** — `httpRouter` `POST /webhooks/woo` (`httpAction`) at `…convex.site/webhooks/woo`. Faithful port: 1MB guard, ping bypass, org resolve (`?org=` or single org), integration-enabled check, **HMAC-SHA256 verify in Web Crypto** (reproduces `verifyWebhookSignature` byte-for-byte — UTF-8 body, base64, length-mismatch→401), `order.created` filter, COMPLETED-log dedup, `scheduler.runAfter(0,…)` + immediate 200.
- **`convex/wooCommerceActions.ts`** — `processOrder` `internalAction`, faithful port of `processWooCommerceOrder` (client match, date extraction, product matching, project + line items, tax recalc, order-log transitions, activity log).
- **`convex/wooCommerceInternal.ts`** — the key fix: an external-triggered httpAction / scheduled action has **no SERVICE identity**, so it can't call the service-gated `api.*` CRUD. All DB access goes through `internalQuery`/`internalMutation` wrappers (unreachable from clients by construction), each a verbatim copy of its `api.*` twin minus the auth guard. Recalc reuses the shared pure `recalcProjectTotals` → byte-identical totals.

### Correctness (codex-reviewed)
- **dateExtraction** stored as epoch-ms (Convex rejects `Date` values — a latent bug in the Next original that only fired when date-meta keys were configured).
- **Org re-assertion** in `processOrder` after the async hop (defence-in-depth).
- Kept the COMPLETED-only dedup (faithful — the FAILED-retry path depends on it).

### Dual-accept + validation
The old Next route is **left intact**; the shared order-log dedup makes running both safe. Convex functions are additive (already pushed to prod Convex; the new endpoint is inert until Woo is repointed). **Ingress guards validated live on prod:** ping→200, missing-signature→401, bad-signature→401 (no validly-signed order sent → zero side effects).

### ⚠️ Cutover (follow-up, NOT in this PR)
Re-register the WooCommerce webhook URL to `…convex.site/webhooks/woo`, move the secret if needed, soak, then retire the Next route.

tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)