### PR TITLE
feat(export): versioned, validated whole-org export (Phase 2 gate #7)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3624,6 +3624,40 @@ secret were already Convex-only.)
   rejects `Date` values — a latent bug in the Next original that only fired when
   date-meta keys were configured).
 
+## Phase 2 (WS3) — versioned whole-org export
+
+A **semantic per-org export** (gate: a validated, versioned artifact before the
+irreversible Phase-4 `DROP TABLE` — distinct from the raw full-deployment Convex
+snapshot backup, which captures bytes but not org-scoped structure).
+
+- **`convex/orgExport.ts`** (service-gated) — generic paginated readers over any
+  table by name: `exportTablePage` (DIRECT, via `by_organizationId`),
+  `scanTableFiltered` (org-column, no index), `childRowsByParentIds` (parent-join
+  children), `getOrgRow`, `countTable` (independent re-count for validation).
+- **`scripts/org-export-tables.ts`** — the authoritative classification of all 101
+  tables, shared by the exporter and the coverage test, with a hard guard: a new
+  unclassified schema table makes the build **fail** (no silent drop). Buckets:
+  **DIRECT (75)** org-indexed; **FILTER (4)** org-column scan — `storedFiles` +
+  `comments`/`commentThreads`/`reviewMarkers` (which carry a direct `orgId` but only a
+  composite index); **PARENT_JOIN (7)** children collected via their org-scoped parent
+  (`subHireItems`/`subHireGroups`→subHires, `supplierOrderItems`→supplierOrders,
+  `crewShifts`→crewAssignments, `maintenanceRecordAssets`→maintenanceRecords,
+  `subTestRecords`→testTagRecords, `categorySlots`→projectCategories); **EXCLUDED (15)**
+  — Better Auth (8, incl. `passkeys` — a WebAuthn credential with no org index),
+  platform (3: `siteSettings`, `sentEmails`, `organizations` — the last exported
+  separately as `orgRow`), ephemeral (4: collaboration presence/locks, `activityEvents`,
+  `userNotificationPreferences`).
+- **`scripts/export-org.ts`** — assembles a versioned artifact
+  `{ schemaVersion, exportedAt, organizationId, orgRow, tables, fileManifest, counts,
+  coverage }`, pages every exported table fully, builds the file manifest from
+  `storedFiles` + `*Media`, then runs an **independent re-count validation** (exits
+  non-zero on any mismatch). Org identity comes from Postgres/Better Auth when the
+  Convex `organizations` mirror is empty (identity is deliberately not mirrored).
+- **Validated live on prod:** all 86 exported tables, 11,186 domain rows, re-count
+  matched for every table; 6.9 MB artifact; coverage 86 + 15 = 101.
+- **`convex/orgExport.test.ts`** — parses the live schema and asserts
+  classified ∪ = 101 (fails on an unclassified new table).
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -89,6 +89,7 @@ import type * as modelMedia from "../modelMedia.js";
 import type * as models from "../models.js";
 import type * as notificationDismissals from "../notificationDismissals.js";
 import type * as notificationEmailLogs from "../notificationEmailLogs.js";
+import type * as orgExport from "../orgExport.js";
 import type * as orgSettings from "../orgSettings.js";
 import type * as overbooking from "../overbooking.js";
 import type * as parity from "../parity.js";
@@ -229,6 +230,7 @@ declare const fullApi: ApiFromModules<{
   models: typeof models;
   notificationDismissals: typeof notificationDismissals;
   notificationEmailLogs: typeof notificationEmailLogs;
+  orgExport: typeof orgExport;
   orgSettings: typeof orgSettings;
   overbooking: typeof overbooking;
   parity: typeof parity;

--- a/convex/orgExport.test.ts
+++ b/convex/orgExport.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import {
+  CLASSIFIED_TABLES,
+  EXPORTED_TABLES,
+  EXCLUDED_TABLES,
+  EXPECTED_TABLE_COUNT,
+  assertClassificationIntegrity,
+  assertCoverage,
+} from "../scripts/org-export-tables";
+
+// The live table set, straight from the compiled schema (not a hand-copied list).
+const SCHEMA_TABLES = Object.keys(schema.tables);
+
+describe("org export coverage", () => {
+  test("schema has the expected number of tables", () => {
+    expect(SCHEMA_TABLES.length).toBe(EXPECTED_TABLE_COUNT);
+  });
+
+  test("classification is internally consistent (no dupes, correct total)", () => {
+    expect(() => assertClassificationIntegrity()).not.toThrow();
+    expect(new Set(CLASSIFIED_TABLES).size).toBe(EXPECTED_TABLE_COUNT);
+  });
+
+  test("classified set exactly equals the schema table set", () => {
+    const classified = new Set(CLASSIFIED_TABLES);
+    const schemaSet = new Set(SCHEMA_TABLES);
+
+    const unclassified = SCHEMA_TABLES.filter((t) => !classified.has(t));
+    const phantom = CLASSIFIED_TABLES.filter((t) => !schemaSet.has(t));
+
+    // Precise failure messages so a future new table points at the fix.
+    expect(unclassified, `Unclassified schema tables: ${unclassified.join(", ")}`).toEqual([]);
+    expect(phantom, `Classified but not in schema: ${phantom.join(", ")}`).toEqual([]);
+  });
+
+  test("assertCoverage passes against the real schema", () => {
+    expect(() => assertCoverage(SCHEMA_TABLES)).not.toThrow();
+  });
+
+  test("assertCoverage FAILS when the schema grows an unclassified table", () => {
+    expect(() => assertCoverage([...SCHEMA_TABLES, "someBrandNewTable"])).toThrow(
+      /Unclassified schema table/,
+    );
+  });
+
+  test("exported ∪ excluded partition (no table both exported and excluded)", () => {
+    const exported = new Set(EXPORTED_TABLES);
+    const overlap = EXCLUDED_TABLES.filter((t) => exported.has(t));
+    expect(overlap, `Tables in both exported and excluded: ${overlap.join(", ")}`).toEqual([]);
+  });
+});

--- a/convex/orgExport.ts
+++ b/convex/orgExport.ts
@@ -1,0 +1,151 @@
+/**
+ * Semantic per-org export (READ-ONLY) — the migration-gate safety + portability
+ * artifact. Distinct from the raw full-deployment snapshot: this is a versioned,
+ * validated, org-scoped dump assembled by `scripts/export-org.ts`.
+ *
+ * Every query here is SERVICE-GATED (`requireService`). The table name is passed
+ * as a string and cast — these are deliberately GENERIC readers so the script can
+ * drive all 76 direct + filtered + parent-join tables through one code path. The
+ * authoritative table classification lives in `scripts/org-export-tables.ts`
+ * (shared with the coverage test); this file stays dumb on purpose.
+ *
+ * Throws `ConvexError` (never plain `Error`) so the payload survives the prod
+ * boundary instead of being masked to InternalServerError. See convex/lib/auth.ts.
+ */
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import type { TableNames } from "./_generated/dataModel";
+import { requireService } from "./lib/auth";
+
+// Loose query-builder type: the generic table name is a runtime string, so the
+// per-table index/field names can't be statically checked. We cast at the call
+// site; these aliases keep the casts readable and localised.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyQuery = any;
+
+const CURSOR = v.union(v.string(), v.null());
+
+/**
+ * Generic paginated read for a DIRECT table (one with a `by_organizationId`
+ * index). Page via that index; the script loops on `continueCursor` until
+ * `isDone`.
+ */
+export const exportTablePage = query({
+  args: { table: v.string(), orgId: v.string(), cursor: CURSOR, numItems: v.number() },
+  handler: async (ctx, { table, orgId, cursor, numItems }) => {
+    await requireService(ctx);
+    const q = ctx.db.query(table as TableNames) as AnyQuery;
+    const res = await q
+      .withIndex("by_organizationId", (qb: AnyQuery) => qb.eq("organizationId", orgId))
+      .paginate({ cursor, numItems });
+    return { page: res.page, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});
+
+/**
+ * Generic paginated read for a table with an org column but NO
+ * `by_organizationId` index: full-table scan + `.filter()` on the given org
+ * field (default `organizationId`). Used for `storedFiles` (field
+ * `organizationId`) and the collaboration tables `commentThreads` / `comments` /
+ * `reviewMarkers` (field `orgId`). A page may return fewer than `numItems`
+ * matching rows — the script loops until `isDone`.
+ */
+export const scanTableFiltered = query({
+  args: {
+    table: v.string(),
+    orgId: v.string(),
+    orgField: v.optional(v.string()),
+    cursor: CURSOR,
+    numItems: v.number(),
+  },
+  handler: async (ctx, { table, orgId, orgField, cursor, numItems }) => {
+    await requireService(ctx);
+    const field = orgField ?? "organizationId";
+    const q = ctx.db.query(table as TableNames) as AnyQuery;
+    const res = await q
+      .filter((qb: AnyQuery) => qb.eq(qb.field(field), orgId))
+      .paginate({ cursor, numItems });
+    return { page: res.page, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});
+
+/**
+ * Collect PARENT-JOIN children (rows with no org column) whose FK ∈ the given
+ * parent-id batch. `indexName` is the child's single-field index on `parentField`
+ * (e.g. `by_orderId` / `orderId`). The script chunks `parentIds` to bound each
+ * call. Children of a single org are small, so a per-parent `.collect()` is safe.
+ */
+export const childRowsByParentIds = query({
+  args: {
+    table: v.string(),
+    indexName: v.string(),
+    parentField: v.string(),
+    parentIds: v.array(v.string()),
+  },
+  handler: async (ctx, { table, indexName, parentField, parentIds }) => {
+    await requireService(ctx);
+    const out: unknown[] = [];
+    for (const pid of parentIds) {
+      const q = ctx.db.query(table as TableNames) as AnyQuery;
+      const rows = await q
+        .withIndex(indexName, (qb: AnyQuery) => qb.eq(parentField, pid))
+        .collect();
+      out.push(...rows);
+    }
+    return out;
+  },
+});
+
+/** The single `organizations` row, exported separately as `orgRow`. */
+export const getOrgRow = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("organizations")
+      .withIndex("by_cuid", (qb) => qb.eq("id", orgId))
+      .unique();
+  },
+});
+
+/**
+ * All organization ids. The script uses this to default to the single org (and
+ * to fail loudly if the deployment unexpectedly holds more than one).
+ */
+export const listOrgIds = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireService(ctx);
+    const orgs = await ctx.db.query("organizations").collect();
+    return orgs.map((o) => o.id);
+  },
+});
+
+/**
+ * Independent paginated COUNT used by the post-write validation pass. Mirrors the
+ * two paginated read shapes (direct index vs filtered scan) but returns only page
+ * counts, so the script sums them without re-materialising every row. A count
+ * that disagrees with the exported row count means the export loop dropped or
+ * duplicated a page — the script exits non-zero.
+ */
+export const countTable = query({
+  args: {
+    table: v.string(),
+    orgId: v.string(),
+    orgField: v.optional(v.string()),
+    cursor: CURSOR,
+    numItems: v.number(),
+  },
+  handler: async (ctx, { table, orgId, orgField, cursor, numItems }) => {
+    await requireService(ctx);
+    const q = ctx.db.query(table as TableNames) as AnyQuery;
+    let scoped: AnyQuery;
+    if (orgField) {
+      scoped = q.filter((qb: AnyQuery) => qb.eq(qb.field(orgField), orgId));
+    } else {
+      scoped = q.withIndex("by_organizationId", (qb: AnyQuery) => qb.eq("organizationId", orgId));
+    }
+    const res = await scoped.paginate({ cursor, numItems });
+    return { count: res.page.length, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});

--- a/scripts/export-org.ts
+++ b/scripts/export-org.ts
@@ -1,0 +1,299 @@
+/**
+ * Semantic, versioned, validated WHOLE-ORG export (READ-ONLY — no mutations).
+ *
+ * The migration-gate safety + portability artifact: a per-org semantic dump,
+ * distinct from the raw full-deployment Convex snapshot. Every one of the 101
+ * schema tables is either exported or EXPLICITLY excluded with a reason — a new
+ * unclassified schema table makes this FAIL (see scripts/org-export-tables.ts),
+ * never silently drop.
+ *
+ * Usage:
+ *   pnpm tsx --env-file=.env --env-file=.env.local scripts/export-org.ts [orgId] [--out <path>]
+ *
+ * Defaults: orgId = the single org in the deployment; out = ./org-export-<orgId>-<stamp>.json
+ *
+ * Token refresh: `getConvexClient()` is re-fetched per round-trip so a long run
+ * keeps a fresh service token (5-min TTL). See scripts/convex-backfill-activity-log.ts.
+ */
+import { writeFileSync } from "node:fs";
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+import convexSchema from "../convex/schema";
+import {
+  SCHEMA_VERSION,
+  DIRECT_TABLES,
+  FILTER_TABLES,
+  PARENT_JOIN,
+  EXCLUDED,
+  MEDIA_TABLES,
+  EXPORTED_TABLES,
+  EXPECTED_TABLE_COUNT,
+  assertCoverage,
+} from "./org-export-tables";
+
+const PAGE = 500;
+const PARENT_CHUNK = 50; // parent ids per childRowsByParentIds call
+
+type Row = Record<string, unknown>;
+type PageResult = { page: Row[]; isDone: boolean; continueCursor: string };
+type CountResult = { count: number; isDone: boolean; continueCursor: string };
+
+function parseArgs(argv: string[]): { orgId?: string; out?: string } {
+  const out: { orgId?: string; out?: string } = {};
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") {
+      out.out = argv[++i];
+    } else {
+      rest.push(argv[i]);
+    }
+  }
+  if (rest[0]) out.orgId = rest[0];
+  return out;
+}
+
+/** Page a DIRECT table (by_organizationId) fully. */
+async function readDirect(table: string, orgId: string): Promise<Row[]> {
+  const rows: Row[] = [];
+  let cursor: string | null = null;
+  for (;;) {
+    const convex = await getConvexClient();
+    const res: PageResult = await convex.query(api.orgExport.exportTablePage, {
+      table,
+      orgId,
+      cursor,
+      numItems: PAGE,
+    });
+    rows.push(...res.page);
+    if (res.isDone) break;
+    cursor = res.continueCursor;
+  }
+  return rows;
+}
+
+/** Page a FILTER table (org column, no index) fully. */
+async function readFiltered(table: string, orgId: string, orgField: string): Promise<Row[]> {
+  const rows: Row[] = [];
+  let cursor: string | null = null;
+  for (;;) {
+    const convex = await getConvexClient();
+    const res: PageResult = await convex.query(api.orgExport.scanTableFiltered, {
+      table,
+      orgId,
+      orgField,
+      cursor,
+      numItems: PAGE,
+    });
+    rows.push(...res.page);
+    if (res.isDone) break;
+    cursor = res.continueCursor;
+  }
+  return rows;
+}
+
+/** Collect PARENT_JOIN children by chunking parent cuid ids. */
+async function readChildren(
+  table: string,
+  indexName: string,
+  parentField: string,
+  parentIds: string[],
+): Promise<Row[]> {
+  const rows: Row[] = [];
+  for (let i = 0; i < parentIds.length; i += PARENT_CHUNK) {
+    const chunk = parentIds.slice(i, i + PARENT_CHUNK);
+    const convex = await getConvexClient();
+    const res = (await convex.query(api.orgExport.childRowsByParentIds, {
+      table,
+      indexName,
+      parentField,
+      parentIds: chunk,
+    })) as Row[];
+    rows.push(...res);
+  }
+  return rows;
+}
+
+/** Paginated independent count for a DIRECT / FILTER table. */
+async function countPaginated(table: string, orgId: string, orgField?: string): Promise<number> {
+  let total = 0;
+  let cursor: string | null = null;
+  for (;;) {
+    const convex = await getConvexClient();
+    const res: CountResult = await convex.query(api.orgExport.countTable, {
+      table,
+      orgId,
+      orgField,
+      cursor,
+      numItems: PAGE,
+    });
+    total += res.count;
+    if (res.isDone) break;
+    cursor = res.continueCursor;
+  }
+  return total;
+}
+
+async function main() {
+  const { orgId: argOrg, out: argOut } = parseArgs(process.argv.slice(2));
+
+  // ---- Coverage guard (fail loudly on any unclassified schema table) --------
+  const schemaTables = Object.keys(convexSchema.tables);
+  assertCoverage(schemaTables);
+  if (schemaTables.length !== EXPECTED_TABLE_COUNT) {
+    throw new Error(
+      `Schema has ${schemaTables.length} tables, classification expects ${EXPECTED_TABLE_COUNT}. ` +
+        `Reconcile scripts/org-export-tables.ts before exporting.`,
+    );
+  }
+  console.log(`Coverage OK: all ${schemaTables.length} schema tables classified.`);
+
+  // ---- Resolve org ----------------------------------------------------------
+  let orgId = argOrg;
+  if (!orgId) {
+    const convex = await getConvexClient();
+    const ids = await convex.query(api.orgExport.listOrgIds, {});
+    if (ids.length === 0) throw new Error("No organizations in the deployment — nothing to export.");
+    if (ids.length > 1) {
+      throw new Error(
+        `Deployment holds ${ids.length} organizations (${ids.join(", ")}). ` +
+          `Pass an explicit orgId: scripts/export-org.ts <orgId>`,
+      );
+    }
+    orgId = ids[0];
+  }
+  console.log(`Exporting organization: ${orgId}`);
+
+  const convex0 = await getConvexClient();
+  let orgRow: unknown = await convex0.query(api.orgExport.getOrgRow, { orgId });
+  if (!orgRow) {
+    // Org IDENTITY lives in Postgres (Better Auth) — it is deliberately NOT mirrored
+    // into the Convex `organizations` table. Pull the identity label from the
+    // authoritative source so the export header is complete; the DOMAIN data below is
+    // all Convex, keyed by organizationId.
+    const pgOrg = await prisma.organization.findUnique({ where: { id: orgId } });
+    if (!pgOrg) {
+      throw new Error(`Organization not found in Convex mirror or Postgres: ${orgId}`);
+    }
+    orgRow = {
+      id: pgOrg.id,
+      name: pgOrg.name,
+      slug: pgOrg.slug,
+      createdAt: pgOrg.createdAt?.getTime?.() ?? null,
+      _identitySource: "postgres-betterauth",
+    };
+  }
+
+  const tables: Record<string, Row[]> = {};
+
+  // ---- DIRECT ---------------------------------------------------------------
+  for (const table of DIRECT_TABLES) {
+    tables[table] = await readDirect(table, orgId);
+    console.log(`  DIRECT  ${table}: ${tables[table].length}`);
+  }
+
+  // ---- FILTER ---------------------------------------------------------------
+  for (const { table, orgField } of FILTER_TABLES) {
+    tables[table] = await readFiltered(table, orgId, orgField);
+    console.log(`  FILTER  ${table} (${orgField}): ${tables[table].length}`);
+  }
+
+  // ---- PARENT_JOIN ----------------------------------------------------------
+  for (const { table, parentTable, index, field } of PARENT_JOIN) {
+    const parents = tables[parentTable];
+    if (!parents) throw new Error(`Parent table ${parentTable} not exported before child ${table}`);
+    const parentIds = parents.map((r) => r.id as string).filter(Boolean);
+    tables[table] = await readChildren(table, index, field, parentIds);
+    console.log(`  CHILD   ${table} (via ${parentTable}.${field}, ${parentIds.length} parents): ${tables[table].length}`);
+  }
+
+  // ---- File manifest --------------------------------------------------------
+  type ManifestEntry = { storageId: string; table: string; refId: string; contentType?: string; size?: number };
+  const fileManifest: ManifestEntry[] = [];
+  for (const r of tables.storedFiles ?? []) {
+    if (typeof r.storageId === "string") {
+      fileManifest.push({ storageId: r.storageId, table: "storedFiles", refId: r.storageId });
+    }
+  }
+  for (const { table, refField } of MEDIA_TABLES) {
+    for (const r of tables[table] ?? []) {
+      // Media rows reference a fileUploads row via `fileId` (the portable file
+      // handle) and their owning entity via `refField`.
+      if (typeof r.fileId === "string") {
+        fileManifest.push({ storageId: r.fileId, table, refId: (r[refField] as string) ?? "" });
+      }
+    }
+  }
+
+  // ---- Counts + coverage ----------------------------------------------------
+  const counts: Record<string, number> = {};
+  for (const t of EXPORTED_TABLES) counts[t] = (tables[t] ?? []).length;
+
+  const artifact = {
+    schemaVersion: SCHEMA_VERSION,
+    exportedAt: Date.now(),
+    organizationId: orgId,
+    orgRow,
+    tables,
+    fileManifest,
+    counts,
+    coverage: {
+      total: EXPECTED_TABLE_COUNT,
+      exported: EXPORTED_TABLES,
+      excluded: {
+        auth: EXCLUDED.auth,
+        platform: EXCLUDED.platform,
+        ephemeral: EXCLUDED.ephemeral,
+      },
+    },
+  };
+
+  const stamp = new Date(artifact.exportedAt).toISOString().replace(/[:.]/g, "-");
+  const outPath = argOut ?? `./org-export-${orgId}-${stamp}.json`;
+  writeFileSync(outPath, JSON.stringify(artifact, null, 2));
+  const totalRows = Object.values(counts).reduce((a, b) => a + b, 0);
+  console.log(`\nWrote ${outPath} — ${EXPORTED_TABLES.length} tables, ${totalRows} rows, ${fileManifest.length} file refs.`);
+
+  // ---- Validation pass (independent re-count) -------------------------------
+  console.log(`\nValidating counts…`);
+  const mismatches: string[] = [];
+
+  for (const table of DIRECT_TABLES) {
+    const recount = await countPaginated(table, orgId);
+    if (recount !== counts[table]) {
+      mismatches.push(`${table}: exported ${counts[table]} ≠ recount ${recount}`);
+    }
+  }
+  for (const { table, orgField } of FILTER_TABLES) {
+    const recount = await countPaginated(table, orgId, orgField);
+    if (recount !== counts[table]) {
+      mismatches.push(`${table}: exported ${counts[table]} ≠ recount ${recount}`);
+    }
+  }
+  for (const { table, parentTable, index, field } of PARENT_JOIN) {
+    const parentIds = (tables[parentTable] ?? []).map((r) => r.id as string).filter(Boolean);
+    const recount = (await readChildren(table, index, field, parentIds)).length;
+    if (recount !== counts[table]) {
+      mismatches.push(`${table}: exported ${counts[table]} ≠ recount ${recount}`);
+    }
+  }
+
+  console.log(`\nPer-table counts:`);
+  for (const t of EXPORTED_TABLES) console.log(`  ${t}: ${counts[t]}`);
+  console.log(`  TOTAL: ${totalRows}`);
+
+  if (mismatches.length) {
+    console.error(`\nVALIDATION FAILED — ${mismatches.length} mismatch(es):`);
+    for (const m of mismatches) console.error(`  ✗ ${m}`);
+    process.exit(1);
+  }
+  console.log(`\nValidation OK: all ${EXPORTED_TABLES.length} exported table counts match.`);
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (err) => {
+    console.error(err);
+    await prisma.$disconnect().catch(() => {});
+    process.exit(1);
+  });

--- a/scripts/org-export-tables.ts
+++ b/scripts/org-export-tables.ts
@@ -1,0 +1,220 @@
+/**
+ * AUTHORITATIVE table classification for the semantic per-org export.
+ *
+ * Shared by `scripts/export-org.ts` (the exporter) and `convex/orgExport.test.ts`
+ * (the coverage guard). The "no silent caps" contract: every one of the Convex
+ * schema's tables must appear in exactly one bucket below. The coverage test
+ * parses `convex/schema.ts` and fails if the schema grows a table this file
+ * doesn't classify — so a new table makes the build FAIL, never silently drop.
+ *
+ * Buckets
+ * -------
+ *  • DIRECT_TABLES     — has a `by_organizationId` index; page via that index.
+ *  • FILTER_TABLES     — has an org column but NO `by_organizationId` index; export
+ *                        by full-table scan + `.filter()` on the named org field.
+ *                        Covers `storedFiles` (organizationId) AND the three
+ *                        collaboration tables commentThreads/comments/reviewMarkers,
+ *                        which carry a direct `orgId` field. (The task listed those
+ *                        three under "parent-join", but each has its own org field,
+ *                        so a filtered scan on `orgId` is exact and does NOT depend
+ *                        on which parent entities were exported — the cleanest
+ *                        resolution. Documented here + in the exporter.)
+ *  • PARENT_JOIN       — true children with NO org column; collect via their
+ *                        org-scoped parent's cuid ids over the child's FK index.
+ *  • EXCLUDED          — auth / platform-global / ephemeral, each with a reason.
+ *                        `organizations` is exported separately as `orgRow`.
+ */
+
+export const SCHEMA_VERSION = "1";
+
+/** 76 tables, each with a `by_organizationId` index. */
+export const DIRECT_TABLES = [
+  "activityLogs",
+  "apiKeys",
+  "assetBulkChildren",
+  "assetMedia",
+  "assets",
+  "assetScanLogs",
+  "brandTemplates",
+  "bulkAssets",
+  "categories",
+  "checkItems",
+  "checkRecords",
+  "clientMedia",
+  "clients",
+  "crewAssignments",
+  "crewAvailabilities",
+  "crewMembers",
+  "crewRoles",
+  "crewSkills",
+  "crewTimeEntries",
+  "customFieldDefinitions",
+  "dashboardCounters",
+  "documentTemplates",
+  "fileUploads",
+  "groupTemplateItems",
+  "groupTemplates",
+  "invitations",
+  "kitBulkItems",
+  "kitCheckItems",
+  "kitMedia",
+  "kitRevenueAllocations",
+  "kits",
+  "kitSerializedItems",
+  "lineItemMergeMaps",
+  "locationMedia",
+  "locations",
+  "maintenanceRecords",
+  "members",
+  "modelBulkAccessories",
+  "modelCheckItems",
+  "modelMedia",
+  "models",
+  "notificationDismissals",
+  "notificationEmailLogs",
+  "orgSettings",
+  "pendingSSOApprovals",
+  "projectCategories",
+  "projectGroups",
+  "projectLineItems",
+  "projectLineItemUnits",
+  "projectManagers",
+  "projectMedia",
+  "projectModelRevenues",
+  "projectNumberSequences",
+  "projects",
+  "projectServices",
+  "projectTasks",
+  "savedTableViews",
+  "sectionPresets",
+  "serviceTemplates",
+  "ssoProviders",
+  "subHireMedia",
+  "subHires",
+  "supplierModelRates",
+  "supplierOrders",
+  "suppliers",
+  "testProfiles",
+  "testTagAssets",
+  "testTagAuditorTokens",
+  "testTagRecords",
+  "warehouseCloses",
+  "warehouseDashboardTokens",
+  "webhookDeliveries",
+  "webhooks",
+  "wooCommerceIntegrations",
+  "wooCommerceOrderLogs",
+] as const;
+
+/** Tables with an org column but no `by_organizationId` index → filtered scan. */
+export const FILTER_TABLES = [
+  { table: "storedFiles", orgField: "organizationId" },
+  { table: "commentThreads", orgField: "orgId" },
+  { table: "comments", orgField: "orgId" },
+  { table: "reviewMarkers", orgField: "orgId" },
+] as const;
+
+/**
+ * Children with no org column. `field` is the FK on the child; `index` is the
+ * child's single-field index on that FK; `parentTable` supplies the org-scoped
+ * cuid ids we join against (parent already exported via DIRECT).
+ */
+export const PARENT_JOIN = [
+  { table: "supplierOrderItems", parentTable: "supplierOrders", index: "by_orderId", field: "orderId" },
+  { table: "subHireItems", parentTable: "subHires", index: "by_subHireId", field: "subHireId" },
+  { table: "subHireGroups", parentTable: "subHires", index: "by_subHireId", field: "subHireId" },
+  { table: "crewShifts", parentTable: "crewAssignments", index: "by_assignmentId", field: "assignmentId" },
+  { table: "maintenanceRecordAssets", parentTable: "maintenanceRecords", index: "by_maintenanceRecordId", field: "maintenanceRecordId" },
+  { table: "subTestRecords", parentTable: "testTagRecords", index: "by_testTagRecordId", field: "testTagRecordId" },
+  { table: "categorySlots", parentTable: "projectCategories", index: "by_projectCategoryId", field: "projectCategoryId" },
+] as const;
+
+/** Excluded with reason. `organizations` handled separately as `orgRow`. */
+export const EXCLUDED = {
+  // Better Auth machinery — credentials/sessions, not domain data.
+  // passkeys is a Better Auth WebAuthn credential — it has NO by_organizationId
+  // index (by_cuid/by_userId/by_credentialID only), so it's auth, not domain data.
+  auth: ["accounts", "backupCodes", "jwkses", "passkeys", "sessions", "twoFactors", "users", "verifications"],
+  // Platform/global, not per-org restore state.
+  platform: ["siteSettings", "sentEmails", "organizations"],
+  // Ephemeral / live-only presence + preferences — no restore value.
+  ephemeral: ["collaborationLocks", "collaborationPresence", "activityEvents", "userNotificationPreferences"],
+} as const;
+
+/**
+ * `*Media` tables (all also in DIRECT) plus their owning entity ref field. Used
+ * to build the file manifest alongside `storedFiles`.
+ */
+export const MEDIA_TABLES = [
+  { table: "modelMedia", refField: "modelId" },
+  { table: "assetMedia", refField: "assetId" },
+  { table: "kitMedia", refField: "kitId" },
+  { table: "projectMedia", refField: "projectId" },
+  { table: "clientMedia", refField: "clientId" },
+  { table: "locationMedia", refField: "locationId" },
+  { table: "subHireMedia", refField: "subHireId" },
+] as const;
+
+export const EXPORTED_TABLES: string[] = [
+  ...DIRECT_TABLES,
+  ...FILTER_TABLES.map((f) => f.table),
+  ...PARENT_JOIN.map((p) => p.table),
+];
+
+export const EXCLUDED_TABLES: string[] = [
+  ...EXCLUDED.auth,
+  ...EXCLUDED.platform,
+  ...EXCLUDED.ephemeral,
+];
+
+/** Full classified set — the coverage guard asserts this equals the schema. */
+export const CLASSIFIED_TABLES: string[] = [...EXPORTED_TABLES, ...EXCLUDED_TABLES];
+
+export const EXPECTED_TABLE_COUNT = 101;
+
+/**
+ * Assert the classification is internally consistent (no dupes, expected total).
+ * Throws with a precise message. Returns the classified set on success.
+ */
+export function assertClassificationIntegrity(): string[] {
+  const seen = new Set<string>();
+  const dupes: string[] = [];
+  for (const t of CLASSIFIED_TABLES) {
+    if (seen.has(t)) dupes.push(t);
+    seen.add(t);
+  }
+  if (dupes.length) {
+    throw new Error(`org-export classification has duplicate tables: ${dupes.join(", ")}`);
+  }
+  if (seen.size !== EXPECTED_TABLE_COUNT) {
+    throw new Error(
+      `org-export classification covers ${seen.size} tables, expected ${EXPECTED_TABLE_COUNT}. ` +
+        `Every schema table must be classified (DIRECT / FILTER / PARENT_JOIN / EXCLUDED).`,
+    );
+  }
+  return CLASSIFIED_TABLES;
+}
+
+/**
+ * Coverage guard against the live schema table list: throws if any schema table
+ * is unclassified, or any classified name is not in the schema.
+ */
+export function assertCoverage(schemaTables: string[]): void {
+  assertClassificationIntegrity();
+  const classified = new Set(CLASSIFIED_TABLES);
+  const schema = new Set(schemaTables);
+
+  const unclassified = schemaTables.filter((t) => !classified.has(t));
+  if (unclassified.length) {
+    throw new Error(
+      `Unclassified schema table(s) — export would SILENTLY DROP data: ${unclassified.join(", ")}. ` +
+        `Add each to scripts/org-export-tables.ts (DIRECT / FILTER / PARENT_JOIN / EXCLUDED).`,
+    );
+  }
+  const phantom = CLASSIFIED_TABLES.filter((t) => !schema.has(t));
+  if (phantom.length) {
+    throw new Error(
+      `Classified table(s) not present in convex/schema.ts (stale classification): ${phantom.join(", ")}.`,
+    );
+  }
+}


### PR DESCRIPTION
## Phase 2 gate #7 — versioned whole-org export

A **semantic per-org export** as a pre-DROP safety + portability artifact (distinct from the raw full-deployment Convex snapshot backup — that captures bytes, this captures org-scoped structure). Gate #7: "reporting + whole-org export built and validated → before the drop."

### What's here
- **`convex/orgExport.ts`** (service-gated) — generic paginated readers over any table by name: `exportTablePage` (DIRECT via `by_organizationId`), `scanTableFiltered` (org-column, no index), `childRowsByParentIds` (parent-join), `getOrgRow`, `countTable` (independent re-count).
- **`scripts/org-export-tables.ts`** — the authoritative classification of all **101** tables, shared by the exporter and the coverage test. **Hard guard: a new unclassified schema table fails the build (no silent drop).** DIRECT 75 / FILTER 4 / PARENT_JOIN 7 / EXCLUDED 15.
- **`scripts/export-org.ts`** — assembles a versioned artifact (`schemaVersion`, `orgRow`, `tables`, `fileManifest`, `counts`, `coverage`), pages every table fully, then runs an **independent re-count validation** (exits non-zero on any mismatch). Org identity falls back to Postgres/Better Auth (the Convex `organizations` mirror is intentionally not populated).
- **`convex/orgExport.test.ts`** — asserts classified ∪ = 101 (fails on an unclassified new table).

### Fix found during live validation
`passkeys` was mis-classified as DIRECT — it's a Better Auth WebAuthn credential with **no `by_organizationId` index** (the false positive came from an adjacent doc-comment). Moved to EXCLUDED (auth).

### Validated live on prod
All **86 exported tables**, **11,186 domain rows**, **independent re-count matched for every table**, 6.9 MB artifact. Coverage: 86 exported + 15 excluded (auth/platform/ephemeral) = 101.

tsc + coverage test (6/6) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)