### PR TITLE
docs(search): validate global search vs real queries + BM25 decision (Phase 2 gate #4)

### DIFF
--- a/docs/convex-search-decision.md
+++ b/docs/convex-search-decision.md
@@ -1,0 +1,76 @@
+# Global search — design decision + validation (hard gate §4.4)
+
+Hard gate: **Convex search validated against real queries — before the drop
+(search breaks otherwise).** This documents what shipped (`#432`), why it's a
+range-scan rather than BM25, the SCAN_CAP limitation, the live validation, and the
+trigger to migrate to search-indexes.
+
+## What shipped
+
+`convex/globalSearch.ts` `search({ orgId, query })` — one backend-local query that
+**range-scans each of 15 org-scoped entities** (`models, kits, assets, bulkAssets,
+projects, clients, suppliers, locations, categories, maintenanceRecords, crewMembers,
+crewRoles, checkItems, groupTemplates, subHires`) via `by_organizationId`, plus child
+drills, then ranks in JS with `convex/lib/searchScore.ts` — a **pg_trgm-parity**
+scorer (exact/normalized substring + trigram Jaccard similarity ≥ 0.15 + tag match,
+`GREATEST`-style best-field rank). It replaced the frozen-Postgres `pg_trgm`
+`globalSearch` engine that was reading stale rows (the live command-palette bug).
+
+## Range-scan vs BM25 search-indexes — the decision
+
+**Chosen: range-scan + JS trigram scorer. Not: Convex `searchIndex` (BM25).**
+
+- **Why range-scan now.** Convex `searchIndex` is single-field, single-table, and
+  BM25-ranked — it does **not** reproduce pg_trgm fuzzy similarity, and a federated
+  14-entity/multi-field palette would need *many* indexes plus a separate merge/rank
+  pass anyway. The range-scan keeps **exact behavioural parity** with the old
+  pg_trgm engine (same threshold, same cross-field `GREATEST` rank, same child
+  drills) — parity was the requirement, since the palette + the MCP `search` tool
+  both depend on it. It is one round-trip, org-scoped, and reactive.
+- **The cost.** O(rows-per-entity) per search, JS-side. Fine while entities are
+  small; linear growth is the ceiling.
+
+## SCAN_CAP limitation (explicit — no silent cap)
+
+Each entity scan is bounded by **`SCAN_CAP = 5000`** (`convex/globalSearch.ts:45`).
+A tenant with >5000 rows in one searched entity would search only the first 5000 of
+that entity — a silent recall gap. This is documented in-code and here.
+
+**Current headroom (prod, verified via the whole-org export counts):** the largest
+*searched* entity is `assets` at **112** rows (models 61, projects 44, clients 37 …)
+— all **~45× under** SCAN_CAP. It is not close to tripping. (High-row tables like
+`activityLogs`/`checkRecords` are **not** searched.)
+
+## Live validation (gate evidence)
+
+`scripts/validate-search.ts` is a repeatable, data-driven harness: it pulls a real
+entity name per type, derives a query term, and asserts the entity is found — plus
+data-agnostic invariants. Run against **prod** (`docker exec <app> npx tsx
+scripts/validate-search.ts <orgId>`):
+
+```
+models:    "EWDX"     (EW-DX EM 2 Dante)  → 30 hits, target FOUND ✓
+clients:   "UNSW"     (UNSW MTS)          → 7 hits,  target FOUND ✓
+projects:  "Drum"     (Drum Shield Hire)  → 14 hits, target FOUND ✓
+suppliers: "Resolution"(Resolution X)     → 5 hits,  target FOUND ✓
+assets:    "TTP00062"                     → 34 hits, target FOUND ✓
+min-length 1-char → 0 ✓   gibberish → 0 (no false positives) ✓
+org isolation: real term under a bogus org → 0 (no cross-tenant leak) ✓
+latency ~524ms (warm, 15-entity scan)
+```
+
+Earlier (#432) manual validation also confirmed manufacturer matches (QSC→K10.2),
+parent/child drills (assets under a model, project under a client), and sub-hire
+item-desc drills — and that the JS trigram impl reproduces a pg_trgm fuzzy hit
+(`Yamaha`→a client whose `contactName` trigram-matched, exactly as the old SQL did).
+
+## Migration trigger → BM25 search-indexes
+
+Move a given entity to a Convex `searchIndex` when **either**:
+1. its row count approaches **SCAN_CAP/2 (~2500)** — recall risk + scan cost, **or**
+2. warm search latency exceeds **~1s** attributable to that entity's scan.
+
+Migration is per-entity and incremental: add a `searchIndex` on the entity's search
+field(s), swap that entity's `orgScan` for a `withSearchIndex` read, keep the JS
+merge/rank for the rest. The harness above guards against a regression during the
+swap. Until a trigger fires, the range-scan is the correct, parity-preserving choice.

--- a/scripts/validate-search.ts
+++ b/scripts/validate-search.ts
@@ -1,0 +1,95 @@
+/**
+ * Global-search validation harness (gate: "Convex search validated against real
+ * queries — before the drop"). Repeatable + data-driven: derives real query terms
+ * from live org data, asserts each entity is found, and checks the invariants that
+ * must hold regardless of data (org isolation, no false positives, min-length).
+ *
+ * Search is `convex/globalSearch.ts` — org-scoped range scans (SCAN_CAP=5000) + a
+ * pg_trgm-parity JS trigram/substring scorer (`convex/lib/searchScore.ts`). See
+ * docs/convex-search-decision.md for the range-scan-vs-BM25 decision + SCAN_CAP.
+ *
+ *   docker exec <app> npx tsx scripts/validate-search.ts [orgId]
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+type Result = { type: string; id: string; label?: string; title?: string; name?: string };
+
+async function searchTop(orgId: string, query: string): Promise<Result[]> {
+  const convex = await getConvexClient();
+  const { results } = await convex.query(api.globalSearch.search, { orgId, query });
+  return results as Result[];
+}
+
+async function firstRowName(orgId: string, table: string): Promise<{ id: string; name: string } | null> {
+  const convex = await getConvexClient();
+  const page = await convex.query(api.orgExport.exportTablePage, { table, orgId, cursor: null, numItems: 1 });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = (page.page as any[])[0];
+  if (!row) return null;
+  const name = row.name ?? row.title ?? row.assetTag ?? null;
+  return name ? { id: row.id, name: String(name) } : null;
+}
+
+const failures: string[] = [];
+const ok = (cond: boolean, msg: string) => {
+  console.log(`  ${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures.push(msg);
+};
+
+async function main() {
+  const orgId = process.argv[2];
+  if (!orgId) throw new Error("Usage: validate-search.ts <orgId>");
+  console.log(`Validating global search for org ${orgId}\n`);
+
+  // ── Data-driven correctness: real entity → derived term → must be found ──────
+  console.log("Data-driven (real entity name → search → found):");
+  for (const table of ["models", "clients", "projects", "suppliers", "assets"]) {
+    const row = await firstRowName(orgId, table);
+    if (!row) {
+      console.log(`  – ${table}: no rows, skipped`);
+      continue;
+    }
+    // Use the FULL first word (≥2 alnum chars) as the term — specific enough that
+    // the target entity ranks in the results (a short prefix can match many rows and
+    // push the exact target below the per-entity result cap: a harness artifact, not
+    // a search bug).
+    const term = row.name.split(/\s+/).find((w) => w.replace(/[^a-zA-Z0-9]/g, "").length >= 2) ?? row.name;
+    const q = term.replace(/[^a-zA-Z0-9]/g, "");
+    const hits = await searchTop(orgId, q);
+    const found = hits.some((h) => h.id === row.id);
+    ok(found, `${table}: "${q}" (from "${row.name}") → ${hits.length} hits, target ${found ? "FOUND" : "MISSING"}`);
+  }
+
+  // ── Invariants (data-agnostic) ──────────────────────────────────────────────
+  console.log("\nInvariants:");
+  ok((await searchTop(orgId, "a")).length === 0, 'min-length: 1-char "a" → 0 results');
+  ok((await searchTop(orgId, "zzqxjkwvbmp")).length === 0, 'no false positives: gibberish → 0 results');
+
+  // Org isolation: a real term under a BOGUS org must return nothing (no cross-tenant leak).
+  const realRow = await firstRowName(orgId, "models");
+  if (realRow) {
+    const term = realRow.name.replace(/[^a-zA-Z0-9]/g, "").slice(0, 5);
+    const leak = await searchTop("org_does_not_exist_zzz", term);
+    ok(leak.length === 0, `org isolation: "${term}" under a bogus org → ${leak.length} results (expect 0)`);
+  }
+
+  // Latency sample
+  const t0 = Date.now();
+  await searchTop(orgId, "e");
+  const t1 = Date.now();
+  await searchTop(orgId, "pro");
+  console.log(`\nLatency: ~${Date.now() - t1}ms (warm single-term scan across 15 entities).`);
+
+  if (failures.length) {
+    console.error(`\nSEARCH VALIDATION FAILED — ${failures.length} check(s):`);
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("\nSEARCH VALIDATION OK.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Phase 2 gate #4 — Convex search validated against real queries

Formalizes the search hard gate: *validated against real queries; range-scan-vs-BM25 decision documented; SCAN_CAP limitation stated.* The engine itself shipped in #432 (replacing the frozen-Postgres pg_trgm palette bug); this closes the validation gate.

### What's here
- **`scripts/validate-search.ts`** — a **repeatable, data-driven** harness: pulls a real entity name per type from live data, derives a query term, and asserts the entity is found — plus data-agnostic invariants (min-length → 0, gibberish → 0 false positives, **org isolation**: a real term under a bogus org → 0, no cross-tenant leak).
- **`docs/convex-search-decision.md`** — the decision + evidence:
  - **range-scan + pg_trgm-parity JS scorer** over BM25 `searchIndex` (behavioural parity with the old engine was the requirement — the palette + MCP `search` tool depend on it).
  - **SCAN_CAP=5000 limitation** stated explicitly: the largest *searched* entity is `assets` at **112** rows (~45× under the cap; high-row tables like activityLogs aren't searched).
  - **live validation evidence** + a per-entity **BM25 migration trigger** (row count ~2500, or >1s latency).

### Validated live on prod
`models/clients/projects/suppliers/assets` all FOUND; min-length/false-positive/org-isolation invariants pass; ~524ms; exit 0.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)