### PR TITLE
fix(settings,export): close re-audit gaps (sub-hire/prepKit metadata + systemFlags classification)

### DIFF
--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -123,6 +123,31 @@ export const reserveAssetTags = mutation({
   },
 });
 
+// Atomic sub-hire order-number reservation (SH-NNNN), same RMW pattern. Replaces
+// the old `prisma.organization.metadata.subHireOrderCounter` counter so the org row
+// stays auth-only. `floor` seeds the counter to at least this value on the first
+// Convex reservation — used at cutover to carry forward the Postgres counter so
+// numbers never regress into an already-issued range.
+export const reserveSubHireOrderNumber = mutation({
+  args: { organizationId: v.string(), now: v.number(), floor: v.optional(v.number()) },
+  handler: async (ctx, { organizationId, now, floor }) => {
+    await requireService(ctx);
+    const existing = await loadByOrg(ctx, organizationId);
+    const blob = existing?.settings ? safeParse(existing.settings) : {};
+    const stored = (blob.subHireOrderCounter as number) || 0;
+    const current = Math.max(stored, floor ?? 0);
+    const next = current + 1;
+    blob.subHireOrderCounter = next;
+    const settings = JSON.stringify(blob);
+    if (existing) {
+      await ctx.db.patch(existing._id, { settings, updatedAt: now });
+    } else {
+      await ctx.db.insert("orgSettings", { organizationId, settings, createdAt: now, updatedAt: now });
+    }
+    return { orderNumber: `SH-${String(next).padStart(4, "0")}` };
+  },
+});
+
 // Atomic test-tag-id reservation — same pattern, nested `testTag.counter`.
 export const reserveTestTagIds = mutation({
   args: { organizationId: v.string(), count: v.number(), now: v.number() },

--- a/scripts/org-export-tables.ts
+++ b/scripts/org-export-tables.ts
@@ -136,7 +136,9 @@ export const EXCLUDED = {
   // index (by_cuid/by_userId/by_credentialID only), so it's auth, not domain data.
   auth: ["accounts", "backupCodes", "jwkses", "passkeys", "sessions", "twoFactors", "users", "verifications"],
   // Platform/global, not per-org restore state.
-  platform: ["siteSettings", "sentEmails", "organizations"],
+  // systemFlags is a platform-global singleton (the browser-write kill-switch) —
+  // operational state, not per-org domain data.
+  platform: ["siteSettings", "sentEmails", "organizations", "systemFlags"],
   // Ephemeral / live-only presence + preferences — no restore value.
   ephemeral: ["collaborationLocks", "collaborationPresence", "activityEvents", "userNotificationPreferences"],
 } as const;
@@ -170,7 +172,7 @@ export const EXCLUDED_TABLES: string[] = [
 /** Full classified set — the coverage guard asserts this equals the schema. */
 export const CLASSIFIED_TABLES: string[] = [...EXPORTED_TABLES, ...EXCLUDED_TABLES];
 
-export const EXPECTED_TABLE_COUNT = 101;
+export const EXPECTED_TABLE_COUNT = 102;
 
 /**
  * Assert the classification is internally consistent (no dupes, expected total).

--- a/src/lib/org-settings-read.ts
+++ b/src/lib/org-settings-read.ts
@@ -97,6 +97,16 @@ export async function reserveTestTagIdsConvex(organizationId: string, count: num
   return ids;
 }
 
+/** Atomically reserve the next sub-hire order number (SH-NNNN). */
+export async function reserveSubHireOrderNumberConvex(organizationId: string): Promise<string> {
+  const convex = await getConvexClient();
+  const { orderNumber } = await convex.mutation(api.orgSettings.reserveSubHireOrderNumber, {
+    organizationId,
+    now: Date.now(),
+  });
+  return orderNumber;
+}
+
 /** Toggle the API kill-switch; returns the new timestamp (or null). */
 export async function setApiKillSwitchConvex(organizationId: string, enabled: boolean): Promise<Date | null> {
   const convex = await getConvexClient();

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createId } from "@paralleldrive/cuid2";
-import { prisma } from "@/lib/prisma";
+import { readOrgSettingsBlob } from "@/lib/org-settings-read";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
@@ -156,12 +156,9 @@ export async function getCategoryTree() {
 export async function getCaseCategoryIds(): Promise<string[]> {
   const { organizationId } = await getOrgContext();
 
-  // Read prepKitCategoryId from org settings
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { metadata: true },
-  });
-  const settings = org?.metadata ? JSON.parse(org.metadata as string) : {};
+  // prepKitCategoryId lives in the Convex org-settings blob now (org settings were
+  // inverted off the Better Auth org row); reading Postgres metadata would be stale.
+  const settings = await readOrgSettingsBlob(organizationId);
   const rootCatId = settings.prepKitCategoryId;
   if (!rootCatId) return [];
 

--- a/src/server/sub-hires.ts
+++ b/src/server/sub-hires.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { reserveSubHireOrderNumberConvex } from "@/lib/org-settings-read";
 import { addMediaConvex, removeMediaConvex } from "@/lib/media-write";
 import { getConvexClient } from "@/lib/convex-client";
 import { getSubHireMediaFromConvex, withResolvedFile } from "@/lib/media-read";
@@ -58,40 +59,9 @@ const VALID_TRANSITIONS: Record<SubHireStatus, SubHireStatus[]> = {
 
 // ─── Order Number ────────────────────────────────────────────────────────────
 
-interface OrgSettings {
-  [key: string]: unknown;
-  subHireOrderCounter?: number;
-}
-
-async function reserveSubHireOrderNumber(
-  tx: Prisma.TransactionClient,
-  organizationId: string,
-): Promise<string> {
-  const org = await tx.organization.findUnique({
-    where: { id: organizationId },
-  });
-  if (!org) throw new Error("Organization not found");
-
-  let settings: OrgSettings = {};
-  if (org.metadata) {
-    try {
-      settings = JSON.parse(org.metadata);
-    } catch {
-      // ignore
-    }
-  }
-
-  const currentCounter = settings.subHireOrderCounter || 0;
-  const orderNumber = `SH-${String(currentCounter + 1).padStart(4, "0")}`;
-  settings.subHireOrderCounter = currentCounter + 1;
-
-  await tx.organization.update({
-    where: { id: organizationId },
-    data: { metadata: JSON.stringify(settings) },
-  });
-
-  return orderNumber;
-}
+// Sub-hire order-number reservation is a Convex atomic counter now
+// (orgSettings.reserveSubHireOrderNumber) — off the Better Auth org row.
+// See reserveSubHireOrderNumberConvex in org-settings-read.ts.
 
 // ─── Core CRUD ───────────────────────────────────────────────────────────────
 
@@ -303,12 +273,10 @@ export async function createSubHire(input: unknown) {
   const now = Date.now();
   const convex = await getConvexClient();
 
-  // Order-number reservation stays Prisma — it read-modify-writes the org metadata
-  // JSON counter, and `organization` stays Prisma forever. The supplier fetch is
-  // independent of it (and of the create), so run both concurrently instead of
-  // three serial Convex/Postgres round-trips on the create path.
+  // Order-number reservation is a Convex atomic counter; the supplier fetch is
+  // independent, so run both concurrently on the create path.
   const [orderNumber, supplier] = await Promise.all([
-    prisma.$transaction((tx) => reserveSubHireOrderNumber(tx, organizationId)),
+    reserveSubHireOrderNumberConvex(organizationId),
     getSupplierById(data.supplierId),
   ]);
 
@@ -1672,10 +1640,7 @@ export async function duplicateSubHire(sourceId: string) {
     getSubHireItems(sourceId),
   ]);
 
-  // Order-number reservation stays Prisma (org metadata counter).
-  const orderNumber = await prisma.$transaction((tx) =>
-    reserveSubHireOrderNumber(tx, organizationId),
-  );
+  const orderNumber = await reserveSubHireOrderNumberConvex(organizationId);
 
   const convex = await getConvexClient();
   const newId = createId();


### PR DESCRIPTION
Closes the two real gaps the independent re-audit found.

### 1. Gate #1 was PARTIAL — two `organization.metadata` Postgres paths missed
- **`sub-hires.ts`** `reserveSubHireOrderNumber` was an **atomic counter on Postgres `organization.metadata`** (`subHireOrderCounter`) — split-brain vs the Convex orgSettings blob. Moved to a Convex atomic mutation `orgSettings.reserveSubHireOrderNumber` (RMW inside the mutation, with an optional `floor` for cutover safety). **Verified on prod: PG counter == Convex counter == 13**, existing sub-hires SH-0001..SH-0013 → next reservation SH-0014, no reissue. Both call sites now use `reserveSubHireOrderNumberConvex`.
- **`categories.ts`** `getCaseCategoryIds` read `prepKitCategoryId` from **Postgres metadata — stale** after the inversion (writes go to Convex). Now reads `readOrgSettingsBlob`. Dropped the now-unused prisma import.

### 2. Export coverage guard was RED on main
`systemFlags` (PR #447) landed after the export (PR #445), so the schema had **102** tables but the classification expected **101** → `orgExport.test.ts` failed on main (the guard working as designed — no silent drop). Classified `systemFlags` as `EXCLUDED.platform` + bumped `EXPECTED_TABLE_COUNT` to 102. Tests green again.

tsc clean; orgExport + writeGuard tests 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)