### PR TITLE
feat(convex,security): resolveActor pins audit identity for browser-direct mutations

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3699,6 +3699,30 @@ before Phase 3 goes live. Full runbook: [`docs/convex-observability-runbook.md`]
   anomaly alerts already emit: auth-mirror drift (reconcile cron), WooCommerce `FAILED`
   order logs, webhook-delivery stalls.
 
+## Phase 3 (WS2) — browser-direct security baseline
+
+Phase 3 wires the browser straight to Convex mutations, so **the mutation is now the
+security boundary** (no server action in front). The baseline hardening lands as
+shared infra before any domain goes browser-direct.
+
+- **`resolveActor(ctx, supplied)`** (`convex/lib/auth.ts`) — the actor-spoofing fix.
+  Every `*Writes.ts` mutation takes a client-supplied `actor` (`{userId, userName}`)
+  used for the audit trail, and those mutations are **public** (a user token with the
+  role passes `requireOrgPermission`), so a caller could attribute a write to **any**
+  userId. `resolveActor` pins attribution to the **verified token identity**:
+  - **service token** → trusts `supplied` verbatim (the trusted backend already
+    authenticated the end-user and passes their id/name);
+  - **user token** → `userId` is overwritten with the token subject (unspoofable);
+    `userName` is resolved from the `users` mirror, falling back to the verified
+    userId — **never** the client-supplied label;
+  - **anonymous** → rejected.
+
+  Wired into all 24 handlers across `assetWrites`/`kitWrites`/`crewWrites`/
+  `projectWrites`/`lineItemWrites` (each destructures `actor: suppliedActor` then
+  `const actor = await resolveActor(ctx, suppliedActor)`). Unit-tested in
+  `convex/resolveActor.test.ts`. **Every new mutation that takes an `actor` arg MUST
+  resolve it through this.**
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -1,6 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
-import { requireOrgPermission } from "./lib/auth";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { writeActivityLog } from "./lib/audit";
 import { bumpAssetCounters } from "./lib/counters";
@@ -43,9 +43,10 @@ export const updateNotesNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, notes, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, notes, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
     await requireOrgPermission(ctx, orgId, "asset", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const asset = await ctx.db
       .query("assets")
@@ -93,8 +94,9 @@ export const archiveNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "asset", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const asset = await ctx.db
       .query("assets")
@@ -152,8 +154,9 @@ export const deleteNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "asset", "delete");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const asset = await ctx.db
       .query("assets")
@@ -298,8 +301,9 @@ export const createNative = mutation({
     auditId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { actor, auditId, ...fields } = args;
+    const { actor: suppliedActor, auditId, ...fields } = args;
     await requireOrgPermission(ctx, fields.organizationId, "asset", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const dup = await ctx.db
       .query("assets")
@@ -352,8 +356,9 @@ export const updateNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, set, clear, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, set, clear, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "asset", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError("Asset not found: " + id);

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -1,6 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
-import { requireOrgPermission } from "./lib/auth";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import { bumpCrewMemberCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -55,8 +55,9 @@ export const createNative = mutation({
     auditId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { actor, auditId, ...fields } = args;
+    const { actor: suppliedActor, auditId, ...fields } = args;
     await requireOrgPermission(ctx, fields.organizationId, "crew", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     // Idempotent by cuid (mirror convention — a retried create can't duplicate).
     const existing = await ctx.db
@@ -98,8 +99,9 @@ export const updateNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, set, clear, entityName, details, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, set, clear, entityName, details, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "crew", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError("Crew member not found: " + id);
@@ -154,8 +156,9 @@ export const deleteNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, name, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, name, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "crew", "delete");
+    const actor = await resolveActor(ctx, suppliedActor);
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "Crew member not found." });
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -1,6 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
-import { requireOrgPermission } from "./lib/auth";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import { releaseKitMembers } from "./kits";
 import * as enums from "./lib/validators";
@@ -78,8 +78,9 @@ export const createNative = mutation({
     auditId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { actor, auditId, ...fields } = args;
+    const { actor: suppliedActor, auditId, ...fields } = args;
     await requireOrgPermission(ctx, fields.organizationId, "kit", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const dup = await ctx.db
       .query("kits")
@@ -124,8 +125,9 @@ export const updateNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, patch, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, patch, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "kit", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError("Kit not found: " + id);
@@ -176,8 +178,9 @@ export const updateNotesNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, notes, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, notes, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "kit", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError("Kit not found: " + id);
@@ -212,8 +215,9 @@ export const updateNotesNative = mutation({
  */
 export const archiveNative = mutation({
   args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
-  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "kit", "delete");
+    const actor = await resolveActor(ctx, suppliedActor);
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
     if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be archived" });
@@ -230,8 +234,9 @@ export const archiveNative = mutation({
 
 export const deleteNative = mutation({
   args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
-  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "kit", "delete");
+    const actor = await resolveActor(ctx, suppliedActor);
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
     if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be deleted" });

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -189,3 +189,53 @@ export async function requireOrgPermission(
     throw new ConvexError(orgPermissionMessage(decision));
   }
 }
+
+// ─── Actor identity (Phase 3 — browser-direct security baseline) ────────────
+//
+// The `actor` mutation arg (userId + userName for the audit trail) is
+// CLIENT-SUPPLIED, and every `*Writes.ts` mutation is PUBLIC and reachable by a
+// user token (requireOrgPermission permits a member with the role). So a caller
+// can attribute a write to ANY userId in the activity log — a real spoofing hole
+// that becomes load-bearing the moment writes go browser-direct. `resolveActor`
+// is the fix: it pins attribution to the VERIFIED token identity.
+//
+//   • SERVICE token — the trusted Next.js backend already authenticated the real
+//     end-user and passes their id/name; a service call has no user identity of
+//     its own, so `supplied` is trusted verbatim.
+//   • USER token — `userId` is OVERWRITTEN with the token subject (unspoofable);
+//     `userName` is resolved from the `users` mirror, falling back to the supplied
+//     label (display-only — once userId is pinned, the label can't forge attribution).
+//   • No identity — reject.
+//
+// Every mutation that takes an `actor` arg MUST resolve it through this before
+// using it for the audit trail. Accepts QueryCtx or MutationCtx (uses ctx.auth +
+// ctx.db.query only).
+
+export interface Actor {
+  userId: string;
+  userName: string;
+}
+
+export async function resolveActor(
+  ctx: QueryCtx | MutationCtx,
+  supplied: Actor,
+): Promise<Actor> {
+  const auth = await getAuthContext(ctx);
+  if (!auth) throw new ConvexError("Unauthorized: authentication required.");
+  if (auth.kind === "service") return supplied;
+
+  // User token: the verified subject is the ONLY trustworthy attribution. Resolve
+  // the display name from the users mirror; if the mirror row is missing (rare —
+  // members+users are mirrored together, and a member row already passed RBAC),
+  // fall back to the verified userId, NEVER the client-supplied label (which the
+  // caller could set to impersonate someone in the "by …" audit attribution). The
+  // activity UI joins the users row for the pretty name anyway.
+  const userRow = await ctx.db
+    .query("users")
+    .withIndex("by_cuid", (q) => q.eq("id", auth.userId))
+    .first();
+  return {
+    userId: auth.userId,
+    userName: userRow?.name ?? auth.userId,
+  };
+}

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -2,7 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
-import { requireOrgPermission } from "./lib/auth";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
@@ -47,8 +47,9 @@ export const removeNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, orgDefaultTaxRate, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!line) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
@@ -114,8 +115,9 @@ export const patchNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, orgDefaultTaxRate, set, clear, entityName, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, orgDefaultTaxRate, set, clear, entityName, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
@@ -194,8 +196,9 @@ export const addCustomNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, fields, orgDefaultTaxRate, actor, auditId, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, fields, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const sortOrder = await nextLineSort(ctx, projectId, organizationId);
     await ctx.db.insert("projectLineItems", {
@@ -271,8 +274,9 @@ export const addNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, orgDefaultTaxRate, actor, auditId, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     // Mirrors createLineItem exactly (sortOrder in-mutation, no TOCTOU; permanent
     // accessories expanded as child lines atomically via the shared helper).
@@ -344,8 +348,9 @@ export const addKitNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, kitLabel, orgDefaultTaxRate, actor, auditId, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, kitLabel, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     await createKitLineItemCore(ctx, {
       id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, now,

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -1,6 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
-import { requireOrgPermission } from "./lib/auth";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { writeActivityLog } from "./lib/audit";
 import { bumpProjectCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -33,8 +33,9 @@ export const updateStatusNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, status, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, status, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
@@ -76,8 +77,9 @@ export const updateNotesNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, field, notes, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, field, notes, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
@@ -112,8 +114,9 @@ export const archiveNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
@@ -159,8 +162,9 @@ export const updateNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, set, clear, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, set, clear, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
@@ -218,8 +222,9 @@ export const createNative = mutation({
     auditId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { actor, auditId, ...fields } = args;
+    const { actor: suppliedActor, auditId, ...fields } = args;
     await requireOrgPermission(ctx, fields.organizationId, "project", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
 
     const clash = await ctx.db
       .query("projects")
@@ -267,8 +272,9 @@ export const deleteNative = mutation({
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, freedAssets, freedKits, actor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, freedAssets, freedKits, actor: suppliedActor, auditId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "delete");
+    const actor = await resolveActor(ctx, suppliedActor);
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");

--- a/convex/resolveActor.test.ts
+++ b/convex/resolveActor.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { resolveActor } from "./lib/auth";
+
+// resolveActor is the Phase-3 browser-direct security baseline: the `actor` arg
+// every *Writes.ts mutation takes is CLIENT-SUPPLIED, so a user token calling the
+// (public) mutation directly could attribute the audit row to anyone. resolveActor
+// pins attribution to the VERIFIED token identity. These tests exercise the helper
+// directly via an inline `run` (it's a lib fn, not a Convex function).
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+
+describe("resolveActor — actor-spoofing baseline (Phase 3)", () => {
+  test("service token trusts the supplied actor verbatim", async () => {
+    // The trusted backend already authenticated the end-user and passes their id.
+    const t = convexTest(schema, modules);
+    const out = await t
+      .withIdentity(SERVICE)
+      .run(async (ctx) =>
+        resolveActor(ctx, { userId: "someone_else", userName: "Server Passed" }),
+      );
+    expect(out).toEqual({ userId: "someone_else", userName: "Server Passed" });
+  });
+
+  test("user token OVERWRITES a spoofed userId with the verified subject", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", { id: USER, name: "Alice", email: "a@x.com" });
+    });
+    const out = await t
+      .withIdentity(asUser(ORG))
+      .run(async (ctx) =>
+        resolveActor(ctx, { userId: "victim_id", userName: "Impersonated" }),
+      );
+    // userId is pinned to the token subject (spoof rejected); userName is resolved
+    // from the users mirror, not the client-supplied label.
+    expect(out).toEqual({ userId: USER, userName: "Alice" });
+  });
+
+  test("user token with no mirror row falls back to the verified userId, NOT the supplied label", async () => {
+    const t = convexTest(schema, modules);
+    const out = await t
+      .withIdentity(asUser(ORG))
+      .run(async (ctx) =>
+        resolveActor(ctx, { userId: "victim_id", userName: "Impersonated" }),
+      );
+    // Client-supplied userName is discarded — attribution can't be forged even
+    // when the users mirror is briefly lagging.
+    expect(out).toEqual({ userId: USER, userName: USER });
+  });
+
+  test("no identity is rejected", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.run(async (ctx) => resolveActor(ctx, { userId: USER, userName: "x" })),
+    ).rejects.toThrow(/authentication required/i);
+  });
+});


### PR DESCRIPTION
## Phase 3 (WS2) — browser-direct security baseline, PR 1/N

The Convex-native Phase 3 migration wires the browser straight to Convex mutations, so **the mutation is now the security boundary** (no server action in front). This is the first shared-infra hardening: close the **actor-spoofing hole**.

### The hole (already live)
Every `*Writes.ts` mutation takes a **client-supplied** `actor` (`{userId, userName}`) that feeds the audit trail, and those mutations are **public** — a user token with the role already passes `requireOrgPermission` and can call them directly. So a caller can attribute activity-log rows to **any** userId. The official client just happens to route through the trusted service token today; the hole becomes load-bearing the moment writes go browser-direct.

### The fix — `resolveActor(ctx, supplied)` (`convex/lib/auth.ts`)
- **service token** → trusts `supplied` verbatim (trusted backend already authenticated the end-user and passes their id/name);
- **user token** → `userId` is **overwritten** with the verified token subject (unspoofable); `userName` resolved from the `users` mirror, falling back to the verified userId — **never** the client label;
- **anonymous** → rejected.

Wired into **all 24 handlers** across `asset`/`kit`/`crew`/`project`/`lineItem` Writes (each destructures `actor: suppliedActor` → `const actor = await resolveActor(ctx, suppliedActor)`; every downstream audit write uses the resolved identity).

### Verification
- New unit tests `convex/resolveActor.test.ts`: spoofed userId rejected, service verbatim, mirror-miss falls back to verified userId (not the client label), anon rejected.
- All existing `*Writes` tests green (**76 passing**). `tsc --noEmit` clean (0 errors).
- Convex fns deployed to prod (additive — signatures unchanged; a no-op for the live service-token path, closes the hole for any user-token caller).
- **Codex-reviewed**: flagged the `userName` fallback still trusting the client label on a mirror miss → fixed to fall back to the verified userId.

Additive + backward-compatible. Next PRs: rate limiter + `internal*`/`returns`-validator sweep, then Aggregate/sharded counters (gate #3) before high-write domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)