### PR TITLE
feat(convex,security): rate limiter for the browser-direct mutation surface

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3723,6 +3723,26 @@ shared infra before any domain goes browser-direct.
   `convex/resolveActor.test.ts`. **Every new mutation that takes an `actor` arg MUST
   resolve it through this.**
 
+- **Rate limiter** (`@convex-dev/rate-limiter` component) — replaces the implicit
+  throttling the server-action tier used to give; once the browser calls mutations
+  directly there is nothing in front of the public surface. `convex/convex.config.ts`
+  registers the component (the app's first Convex component); `convex/lib/rateLimiter.ts`
+  defines a per-user `browserWrite` token bucket (300/min sustained, 100-op burst) and
+  `enforceBrowserWriteLimit(ctx)`:
+  - **USER token** → consumes the budget, keyed on the **verified token subject**
+    (unspoofable); throws a `ConvexError` (`kind: "RateLimited"`, with `retryAfter`)
+    once exhausted;
+  - **SERVICE / anonymous** → no-op (the trusted backend does its own throttling and
+    runs legitimate bulk/backfill; anonymous is rejected by the mutation's auth guard).
+
+  A bulk action is ONE array mutation, so it costs one token regardless of item count.
+  Call `enforceBrowserWriteLimit(ctx)` FIRST in every browser-direct mutation, alongside
+  `assertWritesEnabled`. Wired into the 2 live browser-direct mutations
+  (`assetWrites.updateNotesNative`, `dashboardCounters.reconcileIfStale`); the convention
+  extends to each new one. Tests: `convex/rateLimiter.test.ts` (exhaustion, service
+  exemption, per-user keying). **Convex-test callers must mount the component** via
+  `register(t, "rateLimiter")` from `@convex-dev/rate-limiter/test`.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -72,6 +72,7 @@ import type * as lib_fulfillment from "../lib/fulfillment.js";
 import type * as lib_inventory from "../lib/inventory.js";
 import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
+import type * as lib_rateLimiter from "../lib/rateLimiter.js";
 import type * as lib_recalc from "../lib/recalc.js";
 import type * as lib_searchScore from "../lib/searchScore.js";
 import type * as lib_testtag from "../lib/testtag.js";
@@ -215,6 +216,7 @@ declare const fullApi: ApiFromModules<{
   "lib/inventory": typeof lib_inventory;
   "lib/lineItemUnits": typeof lib_lineItemUnits;
   "lib/permissionsCore": typeof lib_permissionsCore;
+  "lib/rateLimiter": typeof lib_rateLimiter;
   "lib/recalc": typeof lib_recalc;
   "lib/searchScore": typeof lib_searchScore;
   "lib/testtag": typeof lib_testtag;
@@ -314,4 +316,6 @@ export declare const internal: FilterApi<
   FunctionReference<any, "internal">
 >;
 
-export declare const components: {};
+export declare const components: {
+  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
+};

--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -3,8 +3,16 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 
 const modules = import.meta.glob("./**/*.ts");
+// enforceBrowserWriteLimit (updateNotesNative) calls the rate-limiter component for
+// user tokens; mount it so those paths resolve in tests. Service-token calls no-op.
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
@@ -43,7 +51,7 @@ async function seedAsset(t: ReturnType<typeof convexTest>, role?: string, orgOfA
 
 describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
   test("service identity is allowed and patches notes + writes the audit row (5c)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     const res = await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNotesNative, baseArgs);
     expect(res.ok).toBe(true);
@@ -66,14 +74,14 @@ describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
   });
 
   test("a member (has asset:update) is allowed", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "member");
     const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, baseArgs);
     expect(res.ok).toBe(true);
   });
 
   test("a viewer (read-only) is denied asset:update", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "viewer");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, baseArgs),
@@ -81,7 +89,7 @@ describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
   });
 
   test("a non-member is denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t); // no member row
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, baseArgs),
@@ -89,7 +97,7 @@ describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
   });
 
   test("a user whose token org != the requested org is denied (org-scoping)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "member");
     await expect(
       t.withIdentity(asUser("org_other")).mutation(api.assetWrites.updateNotesNative, baseArgs),
@@ -97,7 +105,7 @@ describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
   });
 
   test("clears notes when null", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNotesNative, { ...baseArgs, notes: null });
     await t.run(async (ctx) => {
@@ -109,7 +117,7 @@ describe("assetWrites.updateNotesNative — RBAC (5a)", () => {
 
 describe("assetWrites.updateNotesNative — invariants (5b)", () => {
   test("rejects when the asset belongs to a different org than requested", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     // Caller is a service token (RBAC passes), but the asset row is in another org.
     await seedAsset(t, undefined, "org_other");
     await expect(
@@ -118,7 +126,7 @@ describe("assetWrites.updateNotesNative — invariants (5b)", () => {
   });
 
   test("throws a ConvexError when the asset is missing", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await expect(
       t.withIdentity(SERVICE).mutation(api.assetWrites.updateNotesNative, baseArgs),
     ).rejects.toThrow(/not found/i);
@@ -129,7 +137,7 @@ const archiveArgs = { id: "a1", orgId: ORG, actor: ACTOR, auditId: "log1", now: 
 
 describe("assetWrites.archiveNative", () => {
   test("retires the asset + linked T&T and writes an audit row", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("testTagAssets", { id: "tt1", organizationId: ORG, assetId: "a1", testTagId: "TAG-1", description: "TAG-1", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -148,7 +156,7 @@ describe("assetWrites.archiveNative", () => {
   });
 
   test("a viewer is denied (asset:update)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "viewer");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.archiveNative, archiveArgs),
@@ -160,7 +168,7 @@ const deleteArgs = { id: "a1", orgId: ORG, actor: ACTOR, auditId: "log1", now: N
 
 describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
   test("owner deletes a free asset + writes the DELETE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "owner");
     const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.deleteNative, deleteArgs);
     expect(res.id).toBe("a1");
@@ -173,7 +181,7 @@ describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
   });
 
   test("a manager (no asset:delete) is denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "manager");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.deleteNative, deleteArgs),
@@ -181,7 +189,7 @@ describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
   });
 
   test("blocked when referenced by a project line item (ASSET_IN_USE)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", assetId: "a1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
@@ -192,7 +200,7 @@ describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
   });
 
   test("blocked when the asset is a kit member (ASSET_IN_KIT)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER });
@@ -203,7 +211,7 @@ describe("assetWrites.deleteNative — RBAC + orphan guards (5b)", () => {
   });
 
   test("blocked when the asset has accessory children (ASSET_HAS_ACCESSORIES)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "child", organizationId: ORG, modelId: "m1", assetTag: "CHILD", parentAssetId: "a1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -222,7 +230,7 @@ describe("assetWrites.createNative", () => {
   };
 
   test("member creates an asset + writes the CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
     });
@@ -237,7 +245,7 @@ describe("assetWrites.createNative", () => {
   });
 
   test("rejects a duplicate asset tag (DUPLICATE_ASSET_TAG)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t); // seeds TAG-1
     await expect(
       t.withIdentity(SERVICE).mutation(api.assetWrites.createNative, { ...createArgs, assetTag: "TAG-1" }),
@@ -245,7 +253,7 @@ describe("assetWrites.createNative", () => {
   });
 
   test("a viewer is denied (asset:create)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "viewer" });
     });
@@ -259,7 +267,7 @@ describe("assetWrites.updateNative", () => {
   const updArgs = { id: "a1", orgId: ORG, set: { assetTag: "TAG-1", status: "IN_MAINTENANCE" as const, updatedAt: NOW }, clear: [] as string[], actor: ACTOR, auditId: "log1", now: NOW };
 
   test("applies set + writes the UPDATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t);
     await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNative, updArgs);
     await t.run(async (ctx) => {
@@ -271,7 +279,7 @@ describe("assetWrites.updateNative", () => {
   });
 
   test("clear removes an optional field", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "TAG-1", status: "AVAILABLE", condition: "GOOD", isActive: true, notes: "old", createdAt: NOW, updatedAt: NOW });
     });
@@ -283,7 +291,7 @@ describe("assetWrites.updateNative", () => {
   });
 
   test("rejects a tag change that collides with another asset (DUPLICATE_ASSET_TAG)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t); // a1 / TAG-1
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "TAKEN", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -294,7 +302,7 @@ describe("assetWrites.updateNative", () => {
   });
 
   test("a viewer is denied (asset:update)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedAsset(t, "viewer");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNative, updArgs),

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -2,6 +2,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { bumpAssetCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -45,6 +46,7 @@ export const updateNotesNative = mutation({
   },
   handler: async (ctx, { id, orgId, notes, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgPermission(ctx, orgId, "asset", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,13 @@
+import { defineApp } from "convex/server";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config";
+
+// Convex component registry (Phase 3 — browser-direct security baseline).
+//
+// The rate limiter replaces the implicit throttling the server-action tier used to
+// give: once the browser calls mutations directly, a runaway or abusive client can
+// hammer the public mutation surface with nothing in front of it. `components.rateLimiter`
+// is consumed via convex/lib/rateLimiter.ts.
+const app = defineApp();
+app.use(rateLimiter);
+
+export default app;

--- a/convex/dashboardCounters.test.ts
+++ b/convex/dashboardCounters.test.ts
@@ -3,9 +3,17 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 
 // import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
 const modules = import.meta.glob("./**/*.ts");
+// enforceBrowserWriteLimit (reconcileIfStale) calls the rate-limiter component for
+// user tokens; mount it so those paths resolve in tests. Service-token calls no-op.
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const SERVICE = { subject: "gearflow-service", svc: true };
@@ -72,7 +80,7 @@ async function seed(t: ReturnType<typeof convexTest>) {
 
 describe("dashboardCounters", () => {
   test("reconcile computes the six counters from source", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     const values = await t.withIdentity(SERVICE).mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
     expect(values).toEqual({
@@ -86,7 +94,7 @@ describe("dashboardCounters", () => {
   });
 
   test("dashboardStats.bundle returns the 7 stats (counters + date-derived)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     await t.withIdentity(SERVICE).mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
     const stats = await t.withIdentity(asUser(ORG)).query(api.dashboardStats.bundle, { orgId: ORG, now: NOW });
@@ -103,7 +111,7 @@ describe("dashboardCounters", () => {
   });
 
   test("bump adjusts a single field and clamps at 0", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     await t.withIdentity(SERVICE).mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
     await t.withIdentity(SERVICE).mutation(api.dashboardCounters.bump, { orgId: ORG, field: "checkedOutAssets", delta: 1, now: NOW + 1 });
@@ -116,7 +124,7 @@ describe("dashboardCounters", () => {
   });
 
   test("reconcileIfStale is a no-op while fresh, recomputes when stale", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     await t.withIdentity(SERVICE).mutation(api.dashboardCounters.reconcile, { orgId: ORG, now: NOW });
     // Within maxAge → no-op.
@@ -128,7 +136,7 @@ describe("dashboardCounters", () => {
   });
 
   test("dashboardStats denies a non-member", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await expect(
       t.withIdentity(asUser("other")).query(api.dashboardStats.bundle, { orgId: ORG, now: NOW }),
     ).rejects.toThrow();
@@ -138,7 +146,7 @@ describe("dashboardCounters", () => {
   // the generated + custom mutations) must keep the counter row EQUAL to the
   // authoritative reconcile recompute after an arbitrary sequence of writes.
   test("counters stay equal to the reconcile recompute after a write sequence", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     const svc = t.withIdentity(SERVICE);
     // Backfill so the row exists — per-write deltas require it (an absent row is
@@ -186,7 +194,7 @@ describe("dashboardCounters", () => {
   });
 
   test("a per-write delta against a not-yet-backfilled org is skipped (reconcile seeds it)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seed(t);
     const svc = t.withIdentity(SERVICE);
     // No reconcile yet → row absent. A counted write must NOT create a partial row

--- a/convex/dashboardCounters.ts
+++ b/convex/dashboardCounters.ts
@@ -3,6 +3,7 @@ import { mutation, query } from "./_generated/server";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { requireService, requireOrgRead } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 
 /**
  * Denormalised dashboard stat counters (Phase 3). One `dashboardCounters` row per
@@ -110,6 +111,7 @@ export const reconcileIfStale = mutation({
   args: { orgId: v.string(), now: v.number(), maxAgeMs: v.number() },
   handler: async (ctx, { orgId, now, maxAgeMs }) => {
     await assertWritesEnabled(ctx, "dashboard"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgRead(ctx, orgId);
     const existing = await ctx.db
       .query("dashboardCounters")

--- a/convex/lib/rateLimiter.ts
+++ b/convex/lib/rateLimiter.ts
@@ -1,0 +1,41 @@
+import { RateLimiter, MINUTE } from "@convex-dev/rate-limiter";
+import { components } from "../_generated/api";
+import type { MutationCtx } from "../_generated/server";
+import { getAuthContext } from "./auth";
+
+/**
+ * Rate limiting for the browser-direct mutation surface (Phase 3 security baseline).
+ *
+ * Once the browser calls Convex mutations directly there is no server-action tier in
+ * front to throttle abuse, so a runaway/hostile USER token could hammer the public
+ * mutation surface. This caps sustained per-user write rate while still allowing
+ * legitimate bursts (rapid optimistic edits; a bulk action is ONE array mutation, so
+ * it costs one token regardless of item count).
+ *
+ * SERVICE-token (trusted backend) writes are NOT limited — the server does its own
+ * throttling and runs legitimate bulk/backfill operations.
+ *
+ * `limit(..., { throws: true })` throws a `ConvexError` whose payload has
+ * `kind: "RateLimited"` (detectable client-side via `isRateLimitError`) plus a
+ * `retryAfter` — that payload survives the production boundary, unlike a plain Error.
+ */
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  // Per-user browser-direct write budget. Token bucket = burst up to `capacity`,
+  // refilling at `rate` per `period`. 300/min sustained (5/s) with a 100-op burst
+  // comfortably covers rapid optimistic editing yet stops a runaway client loop.
+  browserWrite: { kind: "token bucket", rate: 300, period: MINUTE, capacity: 100 },
+});
+
+/**
+ * Enforce the per-user browser-direct write budget for USER-token callers only.
+ * No-op for service/anonymous (service = trusted backend; anonymous is rejected by
+ * the mutation's own auth guard). Keyed on the VERIFIED token subject — a client
+ * can't dodge its budget by supplying a different id. Throws when the budget is
+ * exceeded. Call it FIRST in every browser-direct mutation, alongside
+ * `assertWritesEnabled`.
+ */
+export async function enforceBrowserWriteLimit(ctx: MutationCtx): Promise<void> {
+  const auth = await getAuthContext(ctx);
+  if (!auth || auth.kind !== "user") return;
+  await rateLimiter.limit(ctx, "browserWrite", { key: auth.userId, throws: true });
+}

--- a/convex/rateLimiter.test.ts
+++ b/convex/rateLimiter.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+// Exercises enforceBrowserWriteLimit through the real browser-direct mutation
+// (assetWrites.updateNotesNative), which calls it for user tokens. The rate-limiter
+// component must be mounted via registerRateLimiter.
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const asUser = (orgId: string, subject = USER) => ({ subject, orgId });
+
+// browserWrite bucket capacity (convex/lib/rateLimiter.ts). The (capacity+1)-th
+// write in a burst is rejected.
+const CAPACITY = 100;
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
+
+async function seedAssetAndMember(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("assets", {
+      id: "a1",
+      organizationId: ORG,
+      modelId: "m1",
+      assetTag: "TAG-1",
+      status: "AVAILABLE",
+      condition: "GOOD",
+      isActive: true,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+  });
+}
+
+const notesArgs = (i: number) => ({
+  id: "a1",
+  orgId: ORG,
+  notes: `n${i}`,
+  actor: { userId: USER, userName: "Alice" },
+  auditId: `log_${i}`,
+  now: NOW + i,
+});
+
+describe("enforceBrowserWriteLimit — per-user browser-direct budget", () => {
+  test("a user token is rejected once its burst budget is exhausted", async () => {
+    const t = makeT();
+    await seedAssetAndMember(t);
+    // The first `capacity` writes in a burst succeed…
+    for (let i = 0; i < CAPACITY; i++) {
+      const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, notesArgs(i));
+      expect(res.ok).toBe(true);
+    }
+    // …the next one is rate-limited (ConvexError, kind: RateLimited).
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, notesArgs(CAPACITY)),
+    ).rejects.toThrow(/rate/i);
+  });
+
+  test("a service token is never rate-limited", async () => {
+    const t = makeT();
+    await seedAssetAndMember(t);
+    // Well beyond the user bucket capacity — the trusted backend is exempt.
+    for (let i = 0; i < CAPACITY + 25; i++) {
+      const res = await t.withIdentity(SERVICE).mutation(api.assetWrites.updateNotesNative, notesArgs(i));
+      expect(res.ok).toBe(true);
+    }
+  });
+
+  test("the budget is per-user — one user's burst does not limit another", async () => {
+    const t = makeT();
+    await seedAssetAndMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem2", organizationId: ORG, userId: "user_2", role: "member" });
+    });
+    // Drain user_1's bucket.
+    for (let i = 0; i < CAPACITY; i++) {
+      await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, notesArgs(i));
+    }
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNotesNative, notesArgs(CAPACITY)),
+    ).rejects.toThrow(/rate/i);
+    // user_2 still has a full bucket.
+    const res = await t
+      .withIdentity(asUser(ORG, "user_2"))
+      .mutation(api.assetWrites.updateNotesNative, { ...notesArgs(999), actor: { userId: "user_2", userName: "Bob" } });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@base-ui/react": "^1.5.0",
     "@better-auth/passkey": "^1.6.15",
     "@better-auth/sso": "^1.6.15",
+    "@convex-dev/rate-limiter": "^0.3.2",
     "@ducanh2912/next-pwa": "^10.2.9",
     "@hookform/resolvers": "^5.4.0",
     "@paralleldrive/cuid2": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@better-auth/sso':
         specifier: ^1.6.15
         version: 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.15(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(magicast@0.5.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(magicast@0.5.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.5(zod@4.4.3))
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.40.0(react@19.2.7))(react@19.2.7)
       '@ducanh2912/next-pwa':
         specifier: ^10.2.9
         version: 10.2.9(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(webpack@5.105.4(lightningcss@1.32.0))
@@ -941,6 +944,15 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@convex-dev/rate-limiter@0.3.2':
+    resolution: {integrity: sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==}
+    peerDependencies:
+      convex: ^1.24.8
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -8135,6 +8147,12 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@convex-dev/rate-limiter@0.3.2(convex@1.40.0(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      convex: 1.40.0(react@19.2.7)
+    optionalDependencies:
+      react: 19.2.7
 
   '@csstools/color-helpers@6.0.2': {}
 


### PR DESCRIPTION
## Phase 3 (WS2) — browser-direct security baseline, PR 2/N

Once the browser calls Convex mutations directly there is no server-action tier in front to throttle abuse. This adds the **`@convex-dev/rate-limiter`** component (the app's first Convex component) as shared security-baseline infra.

### What
- **`convex/convex.config.ts`** — registers the `rateLimiter` component.
- **`convex/lib/rateLimiter.ts`** — a per-user `browserWrite` token bucket (**300/min** sustained, **100-op** burst) and `enforceBrowserWriteLimit(ctx)`:
  - **USER token** → consumes the budget, keyed on the **verified token subject** (unspoofable); throws `ConvexError` (`kind:"RateLimited"`, with `retryAfter`) once exhausted;
  - **SERVICE / anonymous** → no-op (trusted backend does its own throttling + legitimate bulk/backfill; anon is rejected by the mutation's own auth guard).
  - A bulk action is **one** array mutation → costs one token regardless of item count.
- Wired into the **2 live browser-direct mutations** (`assetWrites.updateNotesNative`, `dashboardCounters.reconcileIfStale`), alongside `assertWritesEnabled`. The convention extends to each new browser-direct mutation.

### Verification
- New `convex/rateLimiter.test.ts`: exhaustion after capacity, service-token exemption, per-user keying (one user's burst doesn't limit another).
- Existing `assetWrites`/`dashboardCounters` user-token tests now mount the component via `register(t, "rateLimiter")` from `@convex-dev/rate-limiter/test` (a `makeT()` helper). **32 affected tests green**; `tsc --noEmit` clean.
- `reconcileIfStale`'s client caller already swallows errors (`.catch(() => {})`), so a rate-limit rejection can't surface. Legit use can't approach 300/min anyway (client throttles reconcile to ~1h).
- Component deployed to prod (additive — doesn't touch the live service-routed write path).
- **Codex-reviewed: CLEAN.**

Additive + backward-compatible. Next: `internal*`/`returns`-validator sweep, then Aggregate/sharded counters (gate #3) before high-write domains go browser-direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)