### PR TITLE
feat(convex,perf): sharded dashboard counters — gate #3 (hot-row OCC contention)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3743,6 +3743,30 @@ shared infra before any domain goes browser-direct.
   exemption, per-user keying). **Convex-test callers must mount the component** via
   `register(t, "rateLimiter")` from `@convex-dev/rate-limiter/test`.
 
+- **Sharded dashboard counters (gate #3)** — `@convex-dev/sharded-counter`. Removes
+  hot-row OCC contention before high-write domains (warehouse/line-item/asset) go
+  browser-direct. The six per-org dashboard tallies were maintained by read-then-patching
+  a **single** `dashboardCounters` row on every counted asset/bulk/project/crew write —
+  a contention point under concurrent browser-direct writes. Now:
+  - `convex/lib/shardedCounter.ts` — a `ShardedCounter` (4 shards, key `${orgId}:${field}`)
+    with `addToCounter` (per-write delta, no hot row), `readCounter` (sum shards, clamp ≥0),
+    `setCounter` (reset+add to an absolute value).
+  - `convex/lib/counters.ts` `applyDelta` → sharded `add` (no row read/patch; clamp on read).
+  - `convex/dashboardCounters.ts`: `reconcile` SETS each sharded counter to the source
+    recompute and stamps the row's `shardsSeededAt`; `readCounterValues` sums shards;
+    `getByOrg`/`dashboardStats.bundle` read sharded values; `bump` is a pure sharded add.
+  - **Readiness gates on `shardsSeededAt`, NOT row existence** — a legacy pre-migration
+    row has unseeded shards, so it reads as not-ready and the client
+    (`useNativeDashboardStats`) shows a **loading** state (not wrong-zeros).
+    `reconcileIfStale` also reconciles when `!shardsSeededAt`, so the migration **self-heals
+    on first dashboard view**; the client hook bounded-retries a failed backstop reconcile.
+  - The `dashboardCounters` ROW is retained as the reconcile snapshot + `updatedAt` freshness
+    + `shardsSeededAt` ready marker; the **live truth is the sharded sum**.
+  - **Prod backfilled + parity-verified** (`scripts/verify-sharded-counters.ts`, run
+    in-container): sharded read == source recompute (112/4/159/3/6/1). Convex-test callers of
+    counted mutations must mount the component via `register(t, "shardedCounter")` from
+    `@convex-dev/sharded-counter/test`.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -75,6 +75,7 @@ import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_rateLimiter from "../lib/rateLimiter.js";
 import type * as lib_recalc from "../lib/recalc.js";
 import type * as lib_searchScore from "../lib/searchScore.js";
+import type * as lib_shardedCounter from "../lib/shardedCounter.js";
 import type * as lib_testtag from "../lib/testtag.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as lib_writeGuard from "../lib/writeGuard.js";
@@ -219,6 +220,7 @@ declare const fullApi: ApiFromModules<{
   "lib/rateLimiter": typeof lib_rateLimiter;
   "lib/recalc": typeof lib_recalc;
   "lib/searchScore": typeof lib_searchScore;
+  "lib/shardedCounter": typeof lib_shardedCounter;
   "lib/testtag": typeof lib_testtag;
   "lib/validators": typeof lib_validators;
   "lib/writeGuard": typeof lib_writeGuard;
@@ -318,4 +320,5 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
+  shardedCounter: import("@convex-dev/sharded-counter/_generated/component.js").ComponentApi<"shardedCounter">;
 };

--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -4,13 +4,15 @@ import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 
 const modules = import.meta.glob("./**/*.ts");
-// enforceBrowserWriteLimit (updateNotesNative) calls the rate-limiter component for
-// user tokens; mount it so those paths resolve in tests. Service-token calls no-op.
+// Mount both components: the rate limiter (updateNotesNative) and the sharded counter
+// (create/archive/delete go through bumpAssetCounters → the sharded counter, gate #3).
 function makeT() {
   const t = convexTest(schema, modules);
   registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
   return t;
 }
 const ORG = "org_1";

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,13 +1,18 @@
 import { defineApp } from "convex/server";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
+import shardedCounter from "@convex-dev/sharded-counter/convex.config";
 
-// Convex component registry (Phase 3 — browser-direct security baseline).
+// Convex component registry (Phase 3 — browser-direct security baseline + gate #3).
 //
-// The rate limiter replaces the implicit throttling the server-action tier used to
-// give: once the browser calls mutations directly, a runaway or abusive client can
-// hammer the public mutation surface with nothing in front of it. `components.rateLimiter`
-// is consumed via convex/lib/rateLimiter.ts.
+// - rateLimiter: replaces the implicit throttling the server-action tier used to
+//   give — once the browser calls mutations directly a runaway/abusive client can
+//   hammer the public mutation surface with nothing in front of it. Consumed via
+//   convex/lib/rateLimiter.ts.
+// - shardedCounter (gate #3): removes hot-row OCC contention on the per-write
+//   dashboard-counter delta path before high-write domains (warehouse/line-item/
+//   asset) go browser-direct. Consumed via convex/lib/shardedCounter.ts.
 const app = defineApp();
 app.use(rateLimiter);
+app.use(shardedCounter);
 
 export default app;

--- a/convex/crewWrites.test.ts
+++ b/convex/crewWrites.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment node
 import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 import schema from "./schema";
 import { api } from "./_generated/api";
 
 const modules = import.meta.glob("./**/*.ts");
+// Counted crew writes go through the sharded counter component (gate #3); mount it.
+function makeT() {
+  const tc = convexTest(schema, modules);
+  registerShardedCounter(tc, "shardedCounter");
+  return tc;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
@@ -27,7 +34,7 @@ describe("crewWrites.createNative", () => {
   const createArgs = { id: "c1", organizationId: ORG, firstName: "Ada", lastName: "Lovelace", status: "ACTIVE" as const, createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1" };
 
   test("a manager creates a crew member + CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "manager");
     const res = await t.withIdentity(asUser(ORG)).mutation(api.crewWrites.createNative, createArgs);
     expect(res.id).toBe("c1");
@@ -41,7 +48,7 @@ describe("crewWrites.createNative", () => {
   });
 
   test("idempotent by cuid (retried create doesn't duplicate)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedCrew(t); // c1 already exists
     await t.withIdentity(SERVICE).mutation(api.crewWrites.createNative, { ...createArgs, auditId: "log2" });
     await t.run(async (ctx) => {
@@ -52,7 +59,7 @@ describe("crewWrites.createNative", () => {
   });
 
   test("a member (crew:read only) is denied create", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.crewWrites.createNative, createArgs),
@@ -64,7 +71,7 @@ describe("crewWrites.updateNative", () => {
   const updArgs = { id: "c1", orgId: ORG, set: { firstName: "Robert", updatedAt: NOW }, clear: [] as string[], entityName: "Robert Ryan", actor: ACTOR, auditId: "log1", now: NOW };
 
   test("applies set + UPDATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedCrew(t);
     await t.withIdentity(SERVICE).mutation(api.crewWrites.updateNative, updArgs);
     await t.run(async (ctx) => {
@@ -76,7 +83,7 @@ describe("crewWrites.updateNative", () => {
   });
 
   test("clear removes a field", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedCrew(t);
     await t.withIdentity(SERVICE).mutation(api.crewWrites.updateNative, { ...updArgs, set: { updatedAt: NOW }, clear: ["notes"] });
     await t.run(async (ctx) => {
@@ -86,7 +93,7 @@ describe("crewWrites.updateNative", () => {
   });
 
   test("a member is denied update", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedCrew(t);
     await member(t, "member");
     await expect(
@@ -98,7 +105,7 @@ describe("crewWrites.updateNative", () => {
 describe("crewWrites.deleteNative", () => {
   const dargs = { id: "c1", orgId: ORG, name: "Bob Ryan", actor: ACTOR, auditId: "log1", now: NOW };
   test("owner deletes a crew member + DELETE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "owner"); await seedCrew(t);
     await t.withIdentity(asUser(ORG)).mutation(api.crewWrites.deleteNative, dargs);
     await t.run(async (ctx) => {
@@ -108,7 +115,7 @@ describe("crewWrites.deleteNative", () => {
     });
   });
   test("a member (no crew:delete) is denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member"); await seedCrew(t);
     await expect(t.withIdentity(asUser(ORG)).mutation(api.crewWrites.deleteNative, dargs)).rejects.toThrow(/insufficient permissions/i);
   });

--- a/convex/dashboardCounters.test.ts
+++ b/convex/dashboardCounters.test.ts
@@ -4,14 +4,16 @@ import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 
 // import.meta.glob typed via convex/import-meta-glob.d.ts (see convex/rbac.test.ts).
 const modules = import.meta.glob("./**/*.ts");
-// enforceBrowserWriteLimit (reconcileIfStale) calls the rate-limiter component for
-// user tokens; mount it so those paths resolve in tests. Service-token calls no-op.
+// Mount both Convex components: the rate limiter (reconcileIfStale) and the sharded
+// counter (every counted write + reconcile/bump goes through it — gate #3).
 function makeT() {
   const t = convexTest(schema, modules);
   registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
   return t;
 }
 const ORG = "org_1";
@@ -193,12 +195,13 @@ describe("dashboardCounters", () => {
     }).toEqual(recomputed);
   });
 
-  test("a per-write delta against a not-yet-backfilled org is skipped (reconcile seeds it)", async () => {
+  test("a per-write delta before backfill leaves getByOrg null until reconcile seeds the row", async () => {
     const t = makeT();
     await seed(t);
     const svc = t.withIdentity(SERVICE);
-    // No reconcile yet → row absent. A counted write must NOT create a partial row
-    // (a delta can't reconstruct the pre-existing population).
+    // No reconcile yet → no counter row. A counted write bumps the sharded counter,
+    // but getByOrg gates on the row (which reconcile creates) so it stays null until
+    // then; reconcile's absolute SET overwrites any pre-backfill sharded delta.
     await svc.mutation(api.assets.create, { id: "a9", organizationId: ORG, modelId: "m1", assetTag: "a9", status: "AVAILABLE", isActive: true });
     const before = await t.withIdentity(asUser(ORG)).query(api.dashboardCounters.getByOrg, { orgId: ORG });
     expect(before).toBeNull();

--- a/convex/dashboardCounters.ts
+++ b/convex/dashboardCounters.ts
@@ -4,6 +4,7 @@ import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { requireService, requireOrgRead } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { setCounter, addToCounter, readCounter } from "./lib/shardedCounter";
 
 /**
  * Denormalised dashboard stat counters (Phase 3). One `dashboardCounters` row per
@@ -73,18 +74,44 @@ export async function computeCounters(ctx: QueryCtx, orgId: string): Promise<Cou
   };
 }
 
+export const ZERO_COUNTERS: CounterValues = {
+  activeAssets: 0, checkedOutAssets: 0, bulkQuantity: 0,
+  activeProjects: 0, activeCrew: 0, pendingCrewOffers: 0,
+};
+
 async function reconcileOrg(ctx: MutationCtx, orgId: string, now: number): Promise<CounterValues> {
   const values = await computeCounters(ctx, orgId);
+  // SET each sharded counter to the absolute source recompute (the live truth).
+  for (const field of COUNTER_FIELDS) {
+    await setCounter(ctx, orgId, field, values[field]);
+  }
+  // The row is the reconcile snapshot + `updatedAt` freshness marker + `shardsSeededAt`
+  // ready marker (set here, once shards are seeded). The LIVE counts are the sharded
+  // sums above — the row's snapshot is only for parity/debug.
   const existing = await ctx.db
     .query("dashboardCounters")
     .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
     .first();
   if (existing) {
-    await ctx.db.patch(existing._id, { ...values, updatedAt: now });
+    await ctx.db.patch(existing._id, { ...values, updatedAt: now, shardsSeededAt: now });
   } else {
-    await ctx.db.insert("dashboardCounters", { organizationId: orgId, ...values, updatedAt: now });
+    await ctx.db.insert("dashboardCounters", { organizationId: orgId, ...values, updatedAt: now, shardsSeededAt: now });
   }
   return values;
+}
+
+/**
+ * Read the six LIVE counter values for an org from the sharded counters (each summed
+ * across its shards, clamped ≥0). This is the source of truth between reconciles.
+ */
+export async function readCounterValues(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+): Promise<CounterValues> {
+  const entries = await Promise.all(
+    COUNTER_FIELDS.map(async (f) => [f, await readCounter(ctx, orgId, f)] as const),
+  );
+  return Object.fromEntries(entries) as unknown as CounterValues;
 }
 
 /** Recompute + persist all six counters for an org (backfill + drift correction). */
@@ -117,8 +144,12 @@ export const reconcileIfStale = mutation({
       .query("dashboardCounters")
       .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
       .first();
-    if (existing && existing.updatedAt > now - maxAgeMs) {
-      return { reconciled: false }; // still fresh — cheap no-op
+    // Reconcile when missing, stale, OR the sharded counters were never seeded (a
+    // legacy pre-migration row: fresh `updatedAt` but no `shardsSeededAt`). The last
+    // case makes the migration self-heal on first dashboard view — no manual backfill
+    // required — and until it runs the org reads as not-ready (client shows a loading state).
+    if (existing && existing.shardsSeededAt && existing.updatedAt > now - maxAgeMs) {
+      return { reconciled: false }; // still fresh + seeded — cheap no-op
     }
     await reconcileOrg(ctx, orgId, now);
     return { reconciled: true };
@@ -126,49 +157,42 @@ export const reconcileIfStale = mutation({
 });
 
 /**
- * Incremental adjust of a single counter field by `delta` (the write-path hook).
- * Idempotency is NOT guaranteed (it's additive) — `reconcile` is the drift
- * backstop. Clamps at 0 so a double-decrement can't go negative. Creates the row
- * (zeroed) on first bump so a fresh org still tracks.
+ * Legacy single-field delta entry point (service-only), retained for the reconcile
+ * parity test + any future service hook. A PURE sharded increment — clamping moves to
+ * the read (`readCounter`) and `reconcile` sets the absolute value. bump does NOT touch
+ * the row's `updatedAt` / `shardsSeededAt` markers: marking ready here would expose
+ * partial counts, and advancing freshness would indefinitely postpone reconcile's
+ * drift-correction (reconcile is the ONLY writer that seeds shards + sets shardsSeededAt).
+ * `now` is accepted for the stable public contract but unused.
  */
 export const bump = mutation({
   args: { orgId: v.string(), field: v.string(), delta: v.number(), now: v.number() },
-  handler: async (ctx, { orgId, field, delta, now }) => {
+  handler: async (ctx, { orgId, field, delta }) => {
     await requireService(ctx);
     if (!(COUNTER_FIELDS as readonly string[]).includes(field)) {
       return; // unknown field — ignore (forward-compat)
     }
-    const existing = await ctx.db
-      .query("dashboardCounters")
-      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
-      .first();
-    if (existing) {
-      const current = (existing as unknown as Record<string, number>)[field] ?? 0;
-      await ctx.db.patch(existing._id, { [field]: Math.max(0, current + delta), updatedAt: now });
-    } else {
-      // Seed a zeroed row, then apply the delta to the one field.
-      const zero: CounterValues = {
-        activeAssets: 0, checkedOutAssets: 0, bulkQuantity: 0,
-        activeProjects: 0, activeCrew: 0, pendingCrewOffers: 0,
-      };
-      await ctx.db.insert("dashboardCounters", {
-        organizationId: orgId,
-        ...zero,
-        [field]: Math.max(0, delta),
-        updatedAt: now,
-      });
-    }
+    await addToCounter(ctx, orgId, field, delta);
   },
 });
 
-/** Read the counter row for an org (browser-safe; org-scoped). */
+/**
+ * Read an org's counters (browser-safe; org-scoped). Returns the LIVE sharded sums
+ * plus the row's `updatedAt`; returns null when the org has never been reconciled
+ * (no row / unseeded shards = not ready → the client shows a loading state).
+ */
 export const getByOrg = query({
   args: { orgId: v.string() },
   handler: async (ctx, { orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    const row = await ctx.db
       .query("dashboardCounters")
       .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
       .first();
+    // Not ready until the shards are seeded (a legacy row exists but has unseeded
+    // shards → its sharded sums would be wrong-zeros). Client treats null as loading.
+    if (!row?.shardsSeededAt) return null;
+    const values = await readCounterValues(ctx, orgId);
+    return { organizationId: orgId, ...values, updatedAt: row.updatedAt };
   },
 });

--- a/convex/dashboardStats.ts
+++ b/convex/dashboardStats.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { requireOrgRead } from "./lib/auth";
+import { readCounterValues, ZERO_COUNTERS } from "./dashboardCounters";
 
 /**
  * BROWSER-facing native replacement for getDashboardStats (Phase 3). Returns the
@@ -24,10 +25,17 @@ export const bundle = query({
   handler: async (ctx, { orgId, now }) => {
     await requireOrgRead(ctx, orgId);
 
-    const counter = await ctx.db
+    // `countersReady` = the SHARDED counters have been seeded (row.shardsSeededAt),
+    // NOT mere row existence — a legacy pre-migration row exists but its shards are
+    // unseeded, so its sums would be wrong-zeros. When not ready, return zeros +
+    // countersReady:false; the client (useNativeDashboardStats) treats that as a
+    // loading state (StatTile skeletons) rather than showing the zeros.
+    const counterRow = await ctx.db
       .query("dashboardCounters")
       .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
       .first();
+    const ready = counterRow?.shardsSeededAt != null;
+    const counter = ready ? await readCounterValues(ctx, orgId) : ZERO_COUNTERS;
 
     // ── Date-derived: maintenanceDue (open + scheduledDate arrived) ──
     const maintenance = await ctx.db
@@ -70,16 +78,16 @@ export const bundle = query({
     }
 
     return {
-      totalAssets: (counter?.activeAssets ?? 0) + (counter?.bulkQuantity ?? 0),
-      checkedOutAssets: counter?.checkedOutAssets ?? 0,
-      activeProjects: counter?.activeProjects ?? 0,
-      activeCrew: counter?.activeCrew ?? 0,
-      pendingCrewOffers: counter?.pendingCrewOffers ?? 0,
+      totalAssets: counter.activeAssets + counter.bulkQuantity,
+      checkedOutAssets: counter.checkedOutAssets,
+      activeProjects: counter.activeProjects,
+      activeCrew: counter.activeCrew,
+      pendingCrewOffers: counter.pendingCrewOffers,
       maintenanceDue,
       overdueReturns,
-      // True until the first reconcile/backfill has populated the counter row, so
-      // the client can fall back to the server-action stats if needed.
-      countersReady: counter != null,
+      // False until the sharded counters are seeded, so the client shows a loading
+      // state instead of wrong-zeros mid-migration (see useNativeDashboardStats).
+      countersReady: ready,
     };
   },
 });

--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -5,6 +5,7 @@
 // every warehouse kit operation, while the legacy line/asset path keeps working
 // (belt still owns asset status this phase).
 import { convexTest } from "convex-test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 import { describe, test, expect } from "vitest";
 import { ConvexError } from "convex/values";
 import schema from "./schema";
@@ -17,7 +18,11 @@ const NOW = 1_700_000_000_000;
 const SERVICE = { subject: "gearflow-service", svc: true };
 // Infer the schema-typed tester from a real call (so ctx.db inside t.run knows
 // our indexes); manually applying the generic trips convexTest's constraint.
-const makeT = () => convexTest(schema, modules);
+const makeT = () => {
+  const tc = convexTest(schema, modules);
+  registerShardedCounter(tc, "shardedCounter");
+  return tc;
+};
 type T = ReturnType<typeof makeT>;
 
 /** Seed a kit (serialised member A-1, optional bulk member B-1 qty 3) and build
@@ -57,7 +62,7 @@ const ci = (t: T, cond: "GOOD" | "DAMAGED" | "MISSING" = "GOOD") => t.withIdenti
 
 describe("kit per-unit — seeding", () => {
   test("createKitLineItem seeds one CONFIRMED unit per serialised member", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     const units = await memberUnits(t);
     expect(units).toHaveLength(1);
@@ -66,7 +71,7 @@ describe("kit per-unit — seeding", () => {
   });
 
   test("bulk member seeds one unit carrying its quantity", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, { bulk: true });
     const units = await memberUnits(t);
     expect(units).toHaveLength(2);
@@ -77,7 +82,7 @@ describe("kit per-unit — seeding", () => {
 
 describe("kit per-unit — checkout / checkin", () => {
   test("checkout flips member unit → CHECKED_OUT and the belt still flips the asset", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     expect(serialUnit(await memberUnits(t)).status).toBe("CHECKED_OUT");
@@ -86,7 +91,7 @@ describe("kit per-unit — checkout / checkin", () => {
   });
 
   test("checkin flips CHECKED_OUT member unit → RETURNED with return stamps", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await ci(t, "GOOD");
@@ -98,7 +103,7 @@ describe("kit per-unit — checkout / checkin", () => {
   });
 
   test("bulk member returns its full quantity", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, { bulk: true });
     await co(t);
     expect(bulkUnit(await memberUnits(t)).status).toBe("CHECKED_OUT");
@@ -109,7 +114,7 @@ describe("kit per-unit — checkout / checkin", () => {
   });
 
   test("DAMAGED checkin records the condition on the unit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await ci(t, "DAMAGED");
@@ -119,7 +124,7 @@ describe("kit per-unit — checkout / checkin", () => {
 
 describe("kit per-unit — reverse + force", () => {
   test("undeployKit: CHECKED_OUT unit → CONFIRMED (re-packed)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.undeployKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
@@ -129,7 +134,7 @@ describe("kit per-unit — reverse + force", () => {
   });
 
   test("unreturnKit: RETURNED unit → CHECKED_OUT and clears return stamps", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await ci(t, "GOOD");
@@ -142,7 +147,7 @@ describe("kit per-unit — reverse + force", () => {
   });
 
   test("forceReturnKit flips member unit → RETURNED", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKit, { organizationId: ORG, kitId: "k1", userId: USER, now: NOW });
@@ -150,7 +155,7 @@ describe("kit per-unit — reverse + force", () => {
   });
 
   test("forceReturnAsset flips the kit member's unit → RETURNED (no split-brain)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnAsset, { organizationId: ORG, assetId: "a1", userId: USER, now: NOW });
@@ -160,7 +165,7 @@ describe("kit per-unit — reverse + force", () => {
 
 describe("kit per-unit — prep tree", () => {
   test("prepKitChildren packs member units; deprepKit resets them to PENDING", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.withIdentity(SERVICE).mutation(api.checkRecordOps.prepKitChildren, { organizationId: ORG, projectId: "p1", parentLineItemId: "kl1", now: NOW });
     expect(serialUnit(await memberUnits(t)).prepStatus).toBe("PACKED");
@@ -169,7 +174,7 @@ describe("kit per-unit — prep tree", () => {
   });
 
   test("deprep does not delete a RETURNED member unit (history survives)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await co(t);
     await ci(t, "GOOD");
@@ -202,7 +207,7 @@ describe("kit per-unit — accessories on a member", () => {
   const accAssetStatus = (t: T) => t.run(async (ctx) => (await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "acc1")).unique())?.status);
 
   test("checkout deploys the member's accessory unit + asset", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithAccessory(t);
     await co(t);
     const us = await accessoryUnits(t);
@@ -213,7 +218,7 @@ describe("kit per-unit — accessories on a member", () => {
   });
 
   test("checkin returns the member's accessory unit + asset", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithAccessory(t);
     await co(t);
     await ci(t, "GOOD");
@@ -223,7 +228,7 @@ describe("kit per-unit — accessories on a member", () => {
   });
 
   test("undeployKit reverses the accessory back to prepped (not stranded deployed)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithAccessory(t);
     await co(t);
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.undeployKit, { organizationId: ORG, projectId: "p1", userId: USER, kitId: "k1", now: NOW });
@@ -232,7 +237,7 @@ describe("kit per-unit — accessories on a member", () => {
   });
 
   test("forceReturnKit returns the member's accessory (no stuck asset)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithAccessory(t);
     await co(t);
     await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKit, { organizationId: ORG, kitId: "k1", userId: USER, now: NOW });
@@ -243,7 +248,7 @@ describe("kit per-unit — accessories on a member", () => {
 
 describe("kit per-unit — composition parity guard (Phase 3)", () => {
   test("checkout throws KIT_COMPOSITION_DRIFT when the kit definition diverges from the project snapshot", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t); // snapshot child line a1 == definition ks1(a1)
     // Drift the live definition: add a serialised item not on the project's snapshot.
     await t.run(async (ctx) => {
@@ -258,7 +263,7 @@ describe("kit per-unit — composition parity guard (Phase 3)", () => {
   });
 
   test("checkout succeeds when snapshot and definition match (no false positive)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await expect(co(t)).resolves.toBeTruthy();
   });
@@ -278,7 +283,7 @@ describe("kit per-unit — member serial reassign (Phase 4)", () => {
     t.run(async (ctx) => (await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", lineItemId)).unique())?.assetId);
 
   test("swaps the member's serial on the unit AND its child line (pre-deployment)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithSpare(t);
     const u0 = await memberUnit(t);
     const res = await reassign(t, u0.id as string, "a2");
@@ -289,7 +294,7 @@ describe("kit per-unit — member serial reassign (Phase 4)", () => {
   });
 
   test("after a same-model swap, checkout passes the (model-based) parity guard and deploys the new serial", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithSpare(t);
     await reassign(t, (await memberUnit(t)).id as string, "a2");
     await expect(co(t)).resolves.toBeTruthy();
@@ -298,14 +303,14 @@ describe("kit per-unit — member serial reassign (Phase 4)", () => {
   });
 
   test("rejects reassign once the member is deployed", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKitWithSpare(t);
     await co(t);
     await expect(reassign(t, (await memberUnit(t)).id as string, "a2")).rejects.toThrow(/deployed/i);
   });
 
   test("rejects a different-model replacement", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Other", createdAt: NOW, updatedAt: NOW });
@@ -315,7 +320,7 @@ describe("kit per-unit — member serial reassign (Phase 4)", () => {
   });
 
   test("rejects an unavailable replacement", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "A-2", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -326,7 +331,7 @@ describe("kit per-unit — member serial reassign (Phase 4)", () => {
 
 describe("kit per-unit — pre-change kit (no units)", () => {
   test("checkinKit does not throw and creates no units for a unit-less kit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     // A kit deployed before the migration: parent + child line, CHECKED_OUT, NO units.
     await t.run(async (ctx) => {
       await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });

--- a/convex/lib/counters.ts
+++ b/convex/lib/counters.ts
@@ -1,4 +1,5 @@
 import type { MutationCtx } from "../_generated/server";
+import { addToCounter } from "./shardedCounter";
 
 /**
  * Write-path maintenance for the six denormalised dashboard counters
@@ -16,12 +17,13 @@ import type { MutationCtx } from "../_generated/server";
  * longer the PRIMARY freshness mechanism (the client now throttles reconcile to a
  * long window — see src/hooks/use-native-dashboard.ts).
  *
- * The counter row is created + seeded ONLY by reconcile / backfill (an accurate
- * full recompute). A delta against a MISSING row is skipped: a delta can't
- * reconstruct the pre-existing population, so we let the next reconcile create it
- * correctly. In prod the backfill (`pnpm convex:backfill:dashboard-counters`) runs
- * before NEXT_PUBLIC_NATIVE_DASHBOARD is flipped, so the row exists; a brand-new
- * org's row is created on its first dashboard view (reconcileIfStale).
+ * Deltas are applied to the SHARDED counter (convex/lib/shardedCounter.ts, gate #3),
+ * not a single hot row — so concurrent counted writes from browser-direct high-write
+ * domains don't contend. A delta always lands (no "row missing" skip); the sharded
+ * counter accumulates from 0. For an EXISTING org the one-time backfill (`reconcile`)
+ * SETS each counter to the absolute source recompute right after deploy, so any delta
+ * that raced ahead of the backfill is corrected; a brand-new org accumulates from 0
+ * correctly and is snapshot on its first dashboard view (reconcileIfStale).
  */
 
 const ACTIVE_PROJECT_STATUSES = new Set(["CONFIRMED", "PREPPING", "CHECKED_OUT", "ON_SITE"]);
@@ -38,35 +40,19 @@ type CounterField =
 type Delta = Partial<Record<CounterField, number>>;
 
 /**
- * Apply a signed delta to an org's counter row, clamped at 0 (a double-decrement
- * can't go negative). No-op when every field is 0, and when the row doesn't exist
- * yet (see the file header). Does NOT touch `updatedAt` — that field tracks the
- * last reconcile, which is what `reconcileIfStale` gates its drift-backstop on.
+ * Apply a signed delta to an org's counters via the SHARDED counter (gate #3) — no
+ * hot-row read/patch, so concurrent counted writes don't contend on a single row.
+ * Each field's increment lands on one shard. Clamping-at-0 moves to the READ side
+ * (`readCounter`) and the `reconcile` absolute-set; a transient negative can't stick.
+ * Does NOT touch the `dashboardCounters` row `updatedAt` — that tracks the last
+ * reconcile, which is what `reconcileIfStale` gates its drift-backstop on.
  */
 async function applyDelta(ctx: MutationCtx, orgId: string, delta: Delta): Promise<void> {
-  let changed = false;
-  for (const key in delta) {
-    if (delta[key as CounterField]) {
-      changed = true;
-      break;
-    }
-  }
-  if (!changed) return;
-
-  const row = await ctx.db
-    .query("dashboardCounters")
-    .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
-    .first();
-  if (!row) return; // not yet backfilled — reconcile will create it accurately
-
-  const patch: Record<string, number> = {};
   for (const key in delta) {
     const d = delta[key as CounterField];
     if (!d) continue;
-    const cur = (row as unknown as Record<string, number>)[key] ?? 0;
-    patch[key] = Math.max(0, cur + d);
+    await addToCounter(ctx, orgId, key, d);
   }
-  await ctx.db.patch(row._id, patch);
 }
 
 // ── Per-entity counter contribution (MUST match computeCounters predicates) ──

--- a/convex/lib/shardedCounter.ts
+++ b/convex/lib/shardedCounter.ts
@@ -1,0 +1,77 @@
+import { ShardedCounter } from "@convex-dev/sharded-counter";
+import { components } from "../_generated/api";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+
+/**
+ * Sharded dashboard counters (Phase 3, gate #3).
+ *
+ * The six per-org dashboard tallies (convex/dashboardCounters.ts) were maintained by
+ * read-then-patching a SINGLE `dashboardCounters` row on every counted asset / bulk /
+ * project / crew write. That single row is a hot-row OCC-contention point the moment
+ * high-write domains (warehouse checkout/checkin, line-items, bulk) go browser-direct
+ * with concurrency: two concurrent mutations both patch the row → the second conflicts
+ * and Convex retries the whole mutation.
+ *
+ * A sharded counter spreads each (org, field) count across N shard docs; a write hits
+ * one random shard, so concurrent writes rarely collide. Reads sum the shards.
+ *
+ * SHARD COUNT: 4 (vs the component default 16). The counts are small integers read on
+ * the dashboard bundle — which ALREADY collects whole-org projects + maintenance for
+ * its date-derived metrics — so a handful of extra tiny shard reads is noise, while 4
+ * shards still gives ~4× write throughput. Bumping this later only helps throughput;
+ * it needs a `rebalance` to redistribute existing counts across the new shards.
+ *
+ * The `dashboardCounters` ROW is retained as the reconcile snapshot + `updatedAt`
+ * freshness marker (reconcileIfStale gates on it) + the "countersReady" signal — but
+ * the LIVE truth is the sharded sum, not the row's stale-between-reconciles fields.
+ */
+export const dashboardCounter = new ShardedCounter(components.shardedCounter, {
+  defaultShards: 4,
+});
+
+/** Sharded-counter key for one org's one counter field. */
+export function counterKey(orgId: string, field: string): string {
+  return `${orgId}:${field}`;
+}
+
+/**
+ * Apply a signed delta to an org's sharded counter for `field`. No hot-row read —
+ * the increment lands on one shard. Unlike the old row patch this does NOT clamp at
+ * 0 (a sharded counter has no single value to clamp); a transient negative is clamped
+ * on READ and corrected by the next `reconcile` (which sets the absolute value).
+ */
+export async function addToCounter(
+  ctx: MutationCtx,
+  orgId: string,
+  field: string,
+  delta: number,
+): Promise<void> {
+  if (!delta) return;
+  await dashboardCounter.add(ctx, counterKey(orgId, field), delta);
+}
+
+/** Read one org's one counter field (sum of shards), clamped at 0. */
+export async function readCounter(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  field: string,
+): Promise<number> {
+  const n = await dashboardCounter.count(ctx, counterKey(orgId, field));
+  return Math.max(0, n);
+}
+
+/**
+ * Set an org's one counter field to an ABSOLUTE value (reconcile / backfill): clear
+ * the shards then seed the value. Used by the drift backstop + the one-time backfill
+ * so the sharded truth matches a fresh source recompute.
+ */
+export async function setCounter(
+  ctx: MutationCtx,
+  orgId: string,
+  field: string,
+  value: number,
+): Promise<void> {
+  const key = counterKey(orgId, field);
+  await dashboardCounter.reset(ctx, key);
+  if (value) await dashboardCounter.add(ctx, key, value);
+}

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment node
 import { convexTest } from "convex-test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
 
 const modules = import.meta.glob("./**/*.ts");
+// Counted project writes go through the sharded counter component (gate #3); mount it.
+function makeT() {
+  const tc = convexTest(schema, modules);
+  registerShardedCounter(tc, "shardedCounter");
+  return tc;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
@@ -23,7 +30,7 @@ describe("projectWrites.updateStatusNative", () => {
   const args = { id: "p1", orgId: ORG, status: "PREPPING" as const, actor: ACTOR, auditId: "log1", now: NOW };
 
   test("member changes status + STATUS_CHANGE audit (from/to)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "member");
     await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args);
     await t.run(async (ctx) => {
@@ -36,7 +43,7 @@ describe("projectWrites.updateStatusNative", () => {
   });
 
   test("rejects a template (TEMPLATE_STATUS)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, undefined, true);
     await expect(
       t.withIdentity(SERVICE).mutation(api.projectWrites.updateStatusNative, args),
@@ -44,7 +51,7 @@ describe("projectWrites.updateStatusNative", () => {
   });
 
   test("a viewer is denied (project:update)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "viewer");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args),
@@ -54,7 +61,7 @@ describe("projectWrites.updateStatusNative", () => {
 
 describe("projectWrites.updateNotesNative", () => {
   test("patches a whitelisted notes field + audit; clears on null", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t);
     await t.withIdentity(SERVICE).mutation(api.projectWrites.updateNotesNative, { id: "p1", orgId: ORG, field: "crewNotes", notes: "load in 6am", actor: ACTOR, auditId: "log1", now: NOW });
     await t.run(async (ctx) => {
@@ -71,7 +78,7 @@ describe("projectWrites.updateNotesNative", () => {
 
 describe("projectWrites.archiveNative", () => {
   test("sets status CANCELLED + audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t);
     await t.withIdentity(SERVICE).mutation(api.projectWrites.archiveNative, { id: "p1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW });
     await t.run(async (ctx) => {
@@ -84,7 +91,7 @@ describe("projectWrites.archiveNative", () => {
 describe("projectWrites.updateNative", () => {
   const uargs = { id: "p1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
   test("member patches fields + UPDATE audit (label from doc)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "member");
     await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { name: "Renamed Gig", taxRate: 10, updatedAt: NOW }, clear: [] });
     await t.run(async (ctx) => {
@@ -97,7 +104,7 @@ describe("projectWrites.updateNative", () => {
     });
   });
   test("clear removes a field", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, clientNotes: "x", createdAt: NOW, updatedAt: NOW });
     });
@@ -108,7 +115,7 @@ describe("projectWrites.updateNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
   });
@@ -117,7 +124,7 @@ describe("projectWrites.updateNative", () => {
 describe("projectWrites.createNative", () => {
   const cargs = { id: "np1", organizationId: ORG, projectNumber: "P-100", name: "New Gig", isTemplate: false, createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1" };
   test("member creates a project + CREATE audit (created:true)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
     const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs);
     expect(res).toEqual({ created: true, id: "np1" });
@@ -129,7 +136,7 @@ describe("projectWrites.createNative", () => {
     });
   });
   test("returns created:false + no insert/audit on a number clash", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projects", { id: "existing", organizationId: ORG, projectNumber: "P-100", name: "Taken", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
     });
@@ -143,7 +150,7 @@ describe("projectWrites.createNative", () => {
     });
   });
   test("a viewer is denied (project:create)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "viewer" }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs)).rejects.toThrow(/insufficient permissions/i);
   });
@@ -152,7 +159,7 @@ describe("projectWrites.createNative", () => {
 describe("projectWrites.deleteNative", () => {
   const dargs = { id: "p1", orgId: ORG, freedAssets: 2, freedKits: 1, actor: ACTOR, auditId: "log1", now: NOW };
   test("owner deletes project + DELETE audit (freed counts)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "owner");
     await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs);
     await t.run(async (ctx) => {
@@ -163,7 +170,7 @@ describe("projectWrites.deleteNative", () => {
     });
   });
   test("a member (no project:delete) is denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedProject(t, "member");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs)).rejects.toThrow(/insufficient permissions/i);
   });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2323,6 +2323,8 @@ export default defineSchema({
   // moment a date passes).
   dashboardCounters: defineTable({
     organizationId: v.string(),
+    // Reconcile SNAPSHOT of the six counters (the LIVE truth is the sharded counter,
+    // convex/lib/shardedCounter.ts — this row is the freshness/ready marker).
     activeAssets: v.number(),
     checkedOutAssets: v.number(),
     bulkQuantity: v.number(),
@@ -2330,6 +2332,11 @@ export default defineSchema({
     activeCrew: v.number(),
     pendingCrewOffers: v.number(),
     updatedAt: v.number(),
+    // Set by reconcile once the SHARDED counters are seeded from a source recompute
+    // (gate #3). "Ready" gates on this, NOT row existence: a legacy pre-migration row
+    // exists but has unseeded shards, so it must read as not-ready (client falls back
+    // a loading state) until reconcileIfStale re-seeds on first view.
+    shardsSeededAt: v.optional(v.number()),
   }).index("by_organizationId", ["organizationId"]),
 
 });

--- a/convex/writeParity.test.ts
+++ b/convex/writeParity.test.ts
@@ -3,6 +3,7 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 
 /**
  * Write-parity gate (design doc Phase 5): for each domain, the NATIVE mutation must
@@ -13,6 +14,12 @@ import { api } from "./_generated/api";
  */
 
 const modules = import.meta.glob("./**/*.ts");
+// Counted writes go through the sharded counter component (gate #3); mount it.
+function makeT() {
+  const tc = convexTest(schema, modules);
+  registerShardedCounter(tc, "shardedCounter");
+  return tc;
+}
 const ORG = "org_1";
 const NOW = 1_700_000_000_000;
 const SERVICE = { subject: "gearflow-service", svc: true };
@@ -41,7 +48,7 @@ describe("write-parity: assets", () => {
   };
 
   test("createNative == assets.create (same resulting doc)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     // Distinct tags (native has a dup-guard the service mutation lacks); exclude the tag.
     await t.withIdentity(SERVICE).mutation(api.assets.create, { id: "svc", ...baseFields, assetTag: "TAG-S" });
     await t.withIdentity(SERVICE).mutation(api.assetWrites.createNative, { id: "nat", ...baseFields, assetTag: "TAG-N", actor: ACTOR, auditId: "log1" });
@@ -53,7 +60,7 @@ describe("write-parity: assets", () => {
   });
 
   test("updateNative(set/clear) == patchAsset (same resulting doc)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "svc", ...baseFields, notes: "old", assetTag: "A" });
       await ctx.db.insert("assets", { id: "nat", ...baseFields, notes: "old", assetTag: "B" });
@@ -70,7 +77,7 @@ describe("write-parity: assets", () => {
   });
 
   test("deleteNative == assets.remove (both gone)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "svc", ...baseFields, assetTag: "A" });
       await ctx.db.insert("assets", { id: "nat", ...baseFields, assetTag: "B" });
@@ -86,7 +93,7 @@ describe("write-parity: line-items", () => {
   const fields = { type: "EQUIPMENT" as const, modelId: "m1", description: "Light", quantity: 2, unitPrice: 15 };
 
   test("addNative == createLineItem (same resulting parent line)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.withIdentity(SERVICE).mutation(api.projectLineItems.createLineItem, { id: "svc", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, now: NOW });
     await t.withIdentity(SERVICE).mutation(api.lineItemWrites.addNative, { id: "nat", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW });
     const svc = normalize(await readByCuid(t, "projectLineItems", "svc"));
@@ -98,7 +105,7 @@ describe("write-parity: line-items", () => {
   });
 
   test("removeNative == removeLineItemCascade (both gone)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "svc", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
       await ctx.db.insert("projectLineItems", { id: "nat", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
@@ -114,7 +121,7 @@ describe("write-parity: projects", () => {
   const fields = { name: "Gig", status: "CONFIRMED" as const, isTemplate: false, createdAt: NOW, updatedAt: NOW };
 
   test("createNative == createWithUniqueNumber (same resulting doc)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.withIdentity(SERVICE).mutation(api.projects.createWithUniqueNumber, { id: "svc", organizationId: ORG, projectNumber: "P-1", ...fields });
     await t.withIdentity(SERVICE).mutation(api.projectWrites.createNative, { id: "nat", organizationId: ORG, projectNumber: "P-2", ...fields, actor: ACTOR, auditId: "log1" });
     const svc = normalize(await readByCuid(t, "projects", "svc"));

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@better-auth/passkey": "^1.6.15",
     "@better-auth/sso": "^1.6.15",
     "@convex-dev/rate-limiter": "^0.3.2",
+    "@convex-dev/sharded-counter": "^0.2.1",
     "@ducanh2912/next-pwa": "^10.2.9",
     "@hookform/resolvers": "^5.4.0",
     "@paralleldrive/cuid2": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
         version: 0.3.2(convex@1.40.0(react@19.2.7))(react@19.2.7)
+      '@convex-dev/sharded-counter':
+        specifier: ^0.2.1
+        version: 0.2.1(convex@1.40.0(react@19.2.7))
       '@ducanh2912/next-pwa':
         specifier: ^10.2.9
         version: 10.2.9(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(webpack@5.105.4(lightningcss@1.32.0))
@@ -953,6 +956,11 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+
+  '@convex-dev/sharded-counter@0.2.1':
+    resolution: {integrity: sha512-JbHBuULFftOBAWa1XPgqFglKlSXntuQ6XIQm6KUcVoh+l2+3s5nbngGDIXmzAeLdD1pkKz53ldGfeA+hdgQHeQ==}
+    peerDependencies:
+      convex: ^1.24.8
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -8153,6 +8161,10 @@ snapshots:
       convex: 1.40.0(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
+
+  '@convex-dev/sharded-counter@0.2.1(convex@1.40.0(react@19.2.7))':
+    dependencies:
+      convex: 1.40.0(react@19.2.7)
 
   '@csstools/color-helpers@6.0.2': {}
 

--- a/scripts/verify-sharded-counters.ts
+++ b/scripts/verify-sharded-counters.ts
@@ -1,0 +1,61 @@
+/**
+ * Parity check for the sharded dashboard counters (Phase 3, gate #3).
+ *
+ * For every org: reconcile (recomputes the six counters from source AND sets the
+ * sharded counters to those absolute values) → then read them back through
+ * `getByOrg` (which SUMS the shards). The sharded read must equal the source
+ * recompute, proving the sharded write + read paths agree on real prod data.
+ *
+ * Run in the prod app container (the worktree service token isn't trusted by prod
+ * Convex):
+ *   docker exec <cid> sh -lc 'cd /app && npx tsx scripts/verify-sharded-counters.ts'
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { prisma } from "@/lib/prisma";
+import { api } from "../convex/_generated/api";
+
+const FIELDS = [
+  "activeAssets",
+  "checkedOutAssets",
+  "bulkQuantity",
+  "activeProjects",
+  "activeCrew",
+  "pendingCrewOffers",
+] as const;
+
+async function main() {
+  const convex = await getConvexClient();
+  const now = Date.now();
+  const orgs = await prisma.organization.findMany({ select: { id: true, name: true } });
+  console.log(`Checking ${orgs.length} organization(s).\n`);
+
+  let bad = 0;
+  for (const org of orgs) {
+    const source = await convex.mutation(api.dashboardCounters.reconcile, { orgId: org.id, now });
+    const read = (await convex.query(api.dashboardCounters.getByOrg, { orgId: org.id })) as
+      | Record<string, number>
+      | null;
+    const mismatched = FIELDS.filter((f) => (read?.[f] ?? null) !== source[f]);
+    const ok = read != null && mismatched.length === 0;
+    if (!ok) bad++;
+    const shardedView = read ? Object.fromEntries(FIELDS.map((f) => [f, read[f]])) : null;
+    console.log(
+      `${ok ? "OK " : "BAD"} ${org.name} (${org.id})\n    source recompute: ${JSON.stringify(source)}\n    sharded read    : ${JSON.stringify(shardedView)}${
+        ok ? "" : `\n    MISMATCH fields : ${mismatched.join(", ")}`
+      }`,
+    );
+  }
+
+  console.log(
+    bad === 0
+      ? "\nPARITY OK: sharded read == source recompute for every org."
+      : `\nPARITY FAIL: ${bad} org(s) mismatched.`,
+  );
+  await prisma.$disconnect();
+  process.exit(bad === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/hooks/use-native-dashboard.ts
+++ b/src/hooks/use-native-dashboard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useConvexAuth, useMutation } from "convex/react";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { api } from "../../convex/_generated/api";
@@ -50,21 +50,39 @@ export function useNativeDashboardStats(
   // the date-derived metrics each minute) — queries can't read the clock themselves.
   const nowBucket = enabled ? Math.floor(Date.now() / MINUTE) * MINUTE : 0;
 
-  const data = useAuthedQuery(
+  const raw = useAuthedQuery(
     api.dashboardStats.bundle,
     enabled ? { orgId: orgId!, now: nowBucket } : "skip",
   ) as NativeDashboardStats | undefined;
+  // `countersReady === false` means the sharded counters aren't seeded yet (a brand-new
+  // org, or the one-time gate-#3 migration window on a legacy row) — the counts would be
+  // wrong-zeros. Treat that as still-loading (StatTiles show skeletons) rather than
+  // surfacing zeros; the reconcileIfStale effect below seeds them and the reactive query
+  // re-runs with real values. A reconciled empty org has countersReady=true (legit zeros).
+  const data = raw?.countersReady === false ? undefined : raw;
 
   const { isAuthenticated } = useConvexAuth();
   const reconcileIfStale = useMutation(api.dashboardCounters.reconcileIfStale);
-  const firedFor = useRef<string | null>(null);
+  // Retry counter (a dep of the effect) so a FAILED backstop reconcile can be
+  // re-attempted — otherwise a transient failure on an UNSEEDED org would leave the
+  // dashboard stuck on skeletons (countersReady never flips). A seeded org resolves
+  // on the first success and never re-fires.
+  const [retry, setRetry] = useState(0);
   useEffect(() => {
-    if (!enabled || !isAuthenticated || !orgId || firedFor.current === orgId) return;
-    firedFor.current = orgId;
+    if (!enabled || !isAuthenticated || !orgId) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     // Best-effort drift backstop: reconcile only if the row is stale by the long
-    // backstop window (per-write deltas keep it fresh in between). ≤ once/hour/org.
-    void reconcileIfStale({ orgId, now: Date.now(), maxAgeMs: RECONCILE_BACKSTOP_MS }).catch(() => {});
-  }, [enabled, isAuthenticated, orgId, reconcileIfStale]);
+    // backstop window (per-write deltas keep it fresh in between), OR the shards are
+    // unseeded (self-heals the gate-#3 migration on first view). ≤ once/hour/org.
+    void reconcileIfStale({ orgId, now: Date.now(), maxAgeMs: RECONCILE_BACKSTOP_MS }).catch(() => {
+      if (retry < 3) timer = setTimeout(() => setRetry((n) => n + 1), 4000);
+    });
+    // Clear the pending retry on unmount / dep change (no setState after unmount).
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+    // `retry` is intentionally a dep: bumping it re-runs the backstop after a failure.
+  }, [enabled, isAuthenticated, orgId, reconcileIfStale, retry]);
 
   return { data, isLoading: enabled && data === undefined };
 }


### PR DESCRIPTION
## Phase 3 — gate #3 (Aggregate/sharded counters)

Hard gate before high-write domains go browser-direct. The six per-org dashboard tallies were maintained by read-then-patching a **single** `dashboardCounters` row on every counted asset/bulk/project/crew write — a hot-row OCC-contention point once concurrent browser-direct writes (warehouse checkout/checkin, line-items, bulk) hit it. Migrated to **`@convex-dev/sharded-counter`** (the app's 2nd Convex component).

### Design
- `convex/lib/shardedCounter.ts` — `ShardedCounter` (4 shards, key `${orgId}:${field}`): `addToCounter` (per-write delta, no hot row), `readCounter` (sum shards, clamp ≥0), `setCounter` (reset+add absolute).
- `convex/lib/counters.ts` `applyDelta` → sharded `add` (no row read/patch).
- `convex/dashboardCounters.ts`: `reconcile` SETS each sharded counter to the source recompute + stamps `shardsSeededAt`; `readCounterValues` sums shards; `getByOrg` + `dashboardStats.bundle` read sharded; `bump` is a pure sharded add.
- The `dashboardCounters` **row** is retained as the reconcile snapshot + `updatedAt` freshness + `shardsSeededAt` ready marker; the **live truth is the sharded sum**.

### Safe migration (codex-hardened, 4 rounds)
- **Readiness gates on `shardsSeededAt`, not row existence** — a legacy pre-migration row has unseeded shards, so it reads not-ready and the client (`useNativeDashboardStats`) shows a **loading** state, never wrong-zeros.
- `reconcileIfStale` reconciles when `!shardsSeededAt` → **self-heals on first dashboard view**; the client hook **bounded-retries** a failed backstop reconcile (with timer cleanup).
- `bump` no longer touches freshness/ready markers (no partial-ready, no postponed drift-correction).

### Verification
- **Prod backfilled + parity-verified in-container** (`scripts/verify-sharded-counters.ts`): sharded read == source recompute (**112 / 4 / 159 / 3 / 6 / 1**).
- Full convex suite **green (300)**; `tsc --noEmit` clean. 6 test files mount the component via `register(t, "shardedCounter")` from `@convex-dev/sharded-counter/test`.
- Convex fns + component + schema (`shardsSeededAt`) deployed to prod (additive).

Next: per-domain two-hop conversions (kit → crew → project → line-item → asset → warehouse); the high-write domains are now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)