### PR TITLE
feat(kits,convex): bulk single-call force-return (Phase 3 bulk invariant)

### DIFF
--- a/convex/forceReturnKitsBatch.test.ts
+++ b/convex/forceReturnKitsBatch.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// forceReturnKitsBatch — the Phase 3 bulk single-call invariant for kit force-return
+// (Appendix A): N kits force-returned in ONE array mutation with partial-success + a
+// per-item organizationId re-check. Uses kits with no project lines so the batch's
+// dispatch/validation is isolated (the full restore path is covered by kitPerUnit.test).
+import { convexTest } from "convex-test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+
+const kitDoc = (id: string, org: string, status: "AVAILABLE" | "CHECKED_OUT") => ({
+  id, organizationId: org, assetTag: id.toUpperCase(), name: id,
+  status, condition: "GOOD" as const, isActive: true, createdAt: NOW, updatedAt: NOW,
+});
+
+async function seed(t: ReturnType<typeof makeT>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("kits", kitDoc("k1", ORG, "CHECKED_OUT"));
+    await ctx.db.insert("kits", kitDoc("k2", ORG, "CHECKED_OUT"));
+    await ctx.db.insert("kits", kitDoc("k3", ORG, "AVAILABLE")); // nothing to return
+    await ctx.db.insert("kits", kitDoc("kx", OTHER, "CHECKED_OUT")); // another org
+  });
+}
+
+const kitStatus = (t: ReturnType<typeof makeT>, id: string) =>
+  t.run(async (ctx) => (await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())?.status);
+
+describe("forceReturnKitsBatch — bulk single-call + partial-success", () => {
+  test("returns the checked-out kits; skips already-available / missing / cross-org with errors", async () => {
+    const t = makeT();
+    await seed(t);
+
+    const res = await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKitsBatch, {
+      organizationId: ORG,
+      kitIds: ["k1", "k2", "k3", "kx", "ghost"],
+      userId: USER,
+      now: NOW,
+    });
+
+    expect([...res.succeeded].sort()).toEqual(["k1", "k2"]);
+    expect(res.errors.map((e) => e.kitId).sort()).toEqual(["ghost", "k3", "kx"]);
+
+    // The valid checked-out kits are now available…
+    expect(await kitStatus(t, "k1")).toBe("AVAILABLE");
+    expect(await kitStatus(t, "k2")).toBe("AVAILABLE");
+    // …and the cross-org kit is untouched (per-item org re-check on a GLOBAL by_cuid).
+    expect(await kitStatus(t, "kx")).toBe("CHECKED_OUT");
+  });
+
+  test("a cross-org kit id can't be force-returned through another org's batch", async () => {
+    const t = makeT();
+    await seed(t);
+
+    const res = await t.withIdentity(SERVICE).mutation(api.warehouseOps.forceReturnKitsBatch, {
+      organizationId: ORG,
+      kitIds: ["kx"],
+      userId: USER,
+      now: NOW,
+    });
+
+    expect(res.succeeded).toEqual([]);
+    expect(res.errors).toEqual([{ kitId: "kx", error: "Kit not found" }]);
+    expect(await kitStatus(t, "kx")).toBe("CHECKED_OUT");
+  });
+
+  test("a non-service (user) token cannot call the batch", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: ORG }).mutation(api.warehouseOps.forceReturnKitsBatch, {
+        organizationId: ORG,
+        kitIds: ["k1"],
+        userId: USER,
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -964,6 +964,43 @@ async function restoreKitParentLine(
   if (parent.status === "CHECKED_OUT") await ctx.db.patch(parent._id, FORCE_RET(now));
 }
 
+/**
+ * Core force-return for ONE already-validated (existing, in-org, non-AVAILABLE) kit:
+ * restore every parent line + children/grandchildren, nested kits + their assets,
+ * member units + accessories, bulk quantities, and the root kit. `loc` (the default
+ * location) is PASSED so a batch resolves it once. Returns the set of kit ids it
+ * restored (incl. nested kits). Guards live in the callers so the singular can throw
+ * while the batch collects per-item errors.
+ */
+async function forceReturnKitCore(
+  ctx: Ctx,
+  organizationId: string,
+  kit: NonNullable<Awaited<ReturnType<typeof kitByCuid>>>,
+  userId: string,
+  now: number,
+  loc: string | null,
+): Promise<string[]> {
+  const kitsToRestore = new Set<string>([kit.id]);
+
+  const parents = (await ctx.db.query("projectLineItems").withIndex("by_kitId", (q) => q.eq("kitId", kit.id)).collect())
+    .filter((l) => l.organizationId === organizationId && !l.isKitChild);
+  for (const p of parents) {
+    await restoreKitParentLine(ctx, p, organizationId, loc, now, kitsToRestore);
+    // Kit per-unit: flip this kit's CHECKED_OUT member units → RETURNED (and its
+    // accessories) so a force-return doesn't leave members stuck deployed.
+    await patchKitMemberUnits(ctx, p.id, organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: now, returnedById: userId, returnCondition: "GOOD" }), now);
+    await cascadeKitAccessoriesIn(ctx, p.id, organizationId, { projectId: p.projectId, userId, defaultLocationId: loc, returnCondition: "GOOD" });
+  }
+
+  if (loc != null) await ctx.db.patch(kit._id, { status: "AVAILABLE", locationId: loc, updatedAt: now });
+  else { const { _id, _creationTime, locationId: _l, ...rest } = kit; await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: now }); }
+
+  const adjustments: BulkAdjustment[] = [];
+  for (const kid of kitsToRestore) adjustments.push(...(await collectKitBulkAdjustments(ctx, kid, organizationId, 1)));
+  if (adjustments.length > 0) await adjustBulkAvailability(ctx, organizationId, coalesceAdjustments(adjustments));
+  return [...kitsToRestore];
+}
+
 export const forceReturnKit = mutation({
   args: { organizationId: v.string(), kitId: v.string(), userId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
@@ -972,25 +1009,36 @@ export const forceReturnKit = mutation({
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     if (kit.status === "AVAILABLE") throw new ConvexError("Kit is already available");
     const loc = await defaultLocationId(ctx, a.organizationId);
-    const kitsToRestore = new Set<string>([a.kitId]);
+    const affectedKitIds = await forceReturnKitCore(ctx, a.organizationId, kit, a.userId, a.now, loc);
+    return { success: true, affectedKitIds };
+  },
+});
 
-    const parents = (await ctx.db.query("projectLineItems").withIndex("by_kitId", (q) => q.eq("kitId", a.kitId)).collect())
-      .filter((l) => l.organizationId === a.organizationId && !l.isKitChild);
-    for (const p of parents) {
-      await restoreKitParentLine(ctx, p, a.organizationId, loc, a.now, kitsToRestore);
-      // Kit per-unit: flip this kit's CHECKED_OUT member units → RETURNED (and its
-      // accessories) so a force-return doesn't leave members stuck deployed.
-      await patchKitMemberUnits(ctx, p.id, a.organizationId, ["CHECKED_OUT"], (u) => ({ status: "RETURNED", returnedQuantity: u.quantity ?? 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD" }), a.now);
-      await cascadeKitAccessoriesIn(ctx, p.id, a.organizationId, { projectId: p.projectId, userId: a.userId, defaultLocationId: loc, returnCondition: "GOOD" });
+/**
+ * Batch force-return (bulk single-call invariant, Phase 3): force-return N kits in
+ * ONE Convex array mutation instead of the client firing one server round-trip per
+ * kit. Partial-success ({succeeded, errors}) — a missing / cross-org / already-AVAILABLE
+ * kit is skipped with an error and can't abort the batch. Per-item `organizationId`
+ * re-check (`by_cuid` is a GLOBAL index → a cross-tenant id must be rejected). `loc`
+ * is resolved once for the whole batch.
+ */
+export const forceReturnKitsBatch = mutation({
+  args: { organizationId: v.string(), kitIds: v.array(v.string()), userId: v.string(), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const loc = await defaultLocationId(ctx, a.organizationId);
+    const succeeded: string[] = [];
+    const errors: { kitId: string; error: string }[] = [];
+    const affected = new Set<string>();
+    for (const kitId of a.kitIds) {
+      const kit = await kitByCuid(ctx, kitId);
+      if (!kit || kit.organizationId !== a.organizationId) { errors.push({ kitId, error: "Kit not found" }); continue; }
+      if (kit.status === "AVAILABLE") { errors.push({ kitId, error: "Kit is already available" }); continue; }
+      const aff = await forceReturnKitCore(ctx, a.organizationId, kit, a.userId, a.now, loc);
+      succeeded.push(kitId);
+      for (const k of aff) affected.add(k);
     }
-
-    if (loc != null) await ctx.db.patch(kit._id, { status: "AVAILABLE", locationId: loc, updatedAt: a.now });
-    else { const { _id, _creationTime, locationId: _l, ...rest } = kit; await ctx.db.replace(_id, { ...rest, status: "AVAILABLE", updatedAt: a.now }); }
-
-    const adjustments: BulkAdjustment[] = [];
-    for (const kid of kitsToRestore) adjustments.push(...(await collectKitBulkAdjustments(ctx, kid, a.organizationId, 1)));
-    if (adjustments.length > 0) await adjustBulkAvailability(ctx, a.organizationId, coalesceAdjustments(adjustments));
-    return { success: true, affectedKitIds: [...kitsToRestore] };
+    return { succeeded, errors, affectedKitIds: [...affected] };
   },
 });
 

--- a/docs/convex-native-migration-plan.md
+++ b/docs/convex-native-migration-plan.md
@@ -213,7 +213,7 @@ Assets bulk-edit + force-return; **all line-item bulk** (delete/edit/move + all 
 ### Fix: client fan-out, N round-trips (Class B)
 | Surface | File | Fix |
 |---|---|---|
-| `/kits` bulk force-return | `kits/page.tsx:177` `for(id) forceReturnKit` | author `forceReturnKitsBatch` array mutation |
+| ~~`/kits` bulk force-return~~ **DONE** | `kits/page.tsx` | `forceReturnKitsBatch` array mutation (partial-success + per-item org re-check) + `forceReturnKits` server action; page calls it once |
 | Warehouse prep **kits** | `warehouse/[projectId]/page.tsx:1804` | `prepKitsBatch` |
 | Warehouse undeploy **kits** | `page.tsx:864` | `undeployKitsBatch` |
 | Warehouse unreturn **kits** | `page.tsx:853` | `unreturnKitsBatch` |

--- a/src/app/(app)/kits/page.tsx
+++ b/src/app/(app)/kits/page.tsx
@@ -12,7 +12,7 @@ import { useServerQuery } from "@/hooks/use-server-query";
 import { useKits } from "@/hooks/use-kits";
 import { useCategories } from "@/hooks/use-categories";
 import { useLocations } from "@/hooks/use-locations";
-import { forceReturnKit } from "@/server/warehouse";
+import { forceReturnKits } from "@/server/warehouse";
 import { useTablePreferences } from "@/lib/use-table-preferences";
 import { Button } from "@/components/ui/button";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
@@ -172,17 +172,10 @@ export default function KitsPage() {
 
   const forceReturnMutation = useServerMutation({
     mutationFn: async () => {
-      const ids = Array.from(selectedIds);
-      let count = 0;
-      for (const id of ids) {
-        try {
-          await forceReturnKit(id);
-          count++;
-        } catch {
-          // skip kits that are already available
-        }
-      }
-      return count;
+      // Bulk single-call: ONE array mutation (partial-success) instead of a
+      // per-kit server round-trip. Returns the count actually force-returned.
+      const res = await forceReturnKits(Array.from(selectedIds));
+      return res.count;
     },
     onSuccess: (count) => {
       toast.success(`Force returned ${count} kits to available`);

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -14,7 +14,7 @@ import { api } from "../../convex/_generated/api";
 import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import { getModelCheckItemCountMap } from "@/lib/line-item-tree-read";
 import { buildWarehouseLineItems, buildPullSheetLineItems } from "@/lib/project-line-item-read";
-import { getKitById, getKitByAssetTag } from "@/lib/kits-read";
+import { getKitById, getKitByAssetTag, getKitsByIds } from "@/lib/kits-read";
 import { getActiveAssetsByModel, getAssetById, getAssetByAssetTag, getAssetsByOrg, getAssetsByIds, getBulkAssetsByIds, getBulkAssetByAssetTag } from "@/lib/assets-read";
 import { getProjectById, getProjectByIdMapped, getProjectsByOrg } from "@/lib/projects-read";
 
@@ -1158,6 +1158,51 @@ export async function forceReturnKit(kitId: string) {
   });
 
   return serialize({ success: true });
+}
+
+/**
+ * Bulk single-call force-return (Phase 3 bulk invariant): force-return N kits in ONE
+ * Convex array mutation + ONE server round-trip — replaces the client firing one
+ * `forceReturnKit` per selected kit. Partial-success: already-available / missing kits
+ * are skipped, the rest still return. Selection is validated + named via ONE org-scoped
+ * Convex read (`getKitsByIds`).
+ */
+export async function forceReturnKits(kitIds: string[]) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
+
+  if (kitIds.length === 0) throw new Error("No kits selected");
+
+  // Names for the audit log only (org-scoped read; missing / cross-org ids just have
+  // no name). Per-item validation + partial-success are the MUTATION's job — pass the
+  // whole selection so already-available / missing / cross-org kits surface in
+  // `res.errors` instead of being silently pre-filtered (an all-invalid selection
+  // then returns { count: 0, errors } rather than throwing).
+  const kits = await getKitsByIds(organizationId, kitIds);
+  const nameById = new Map(kits.map((k) => [k.id, `${k.assetTag} - ${k.name}`]));
+
+  // ONE atomic array mutation (partial-success) — no client fan-out.
+  const convex = await getConvexClient();
+  const res = await convex.mutation(api.warehouseOps.forceReturnKitsBatch, {
+    organizationId,
+    kitIds,
+    userId,
+    now: Date.now(),
+  });
+
+  if (res.succeeded.length > 0) {
+    await logActivity({
+      organizationId,
+      userId,
+      userName,
+      action: "FORCE_RETURN",
+      entityType: "kit",
+      entityId: res.succeeded[0],
+      entityName: res.succeeded.map((id) => nameById.get(id) ?? id).join(", "),
+      summary: `Bulk force returned ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"} and contents to available`,
+    });
+  }
+
+  return serialize({ count: res.succeeded.length, succeeded: res.succeeded, errors: res.errors });
 }
 
 export async function bulkForceReturnAssets(assetIds: string[]) {


### PR DESCRIPTION
## Phase 3 — kit domain, bulk single-call invariant (Appendix A)

The `/kits` multi-select **force return** fired **one `forceReturnKit` server action per selected kit** (client fan-out, N round-trips). This collapses it to **one array mutation + one server round-trip**, per the enforced bulk single-call invariant.

### Changes
- **`convex/warehouseOps.ts`** — factored the kit-restore logic into `forceReturnKitCore` (shared by the singular `forceReturnKit`), added **`forceReturnKitsBatch`**: one array mutation over `kitIds` with **partial-success** (`{succeeded, errors}`) and a **per-item `organizationId` re-check** (`by_cuid` is a GLOBAL index → a cross-tenant id is rejected, never force-returned through another org's batch). Default location resolved once for the batch.
- **`src/server/warehouse.ts`** — `forceReturnKits(kitIds)` server action: validates/names via one org-scoped `getKitsByIds` read, calls the batch mutation once, logs one summary activity. Passes the **full** selection so already-available / missing / cross-org kits surface in `res.errors` (per codex — no pre-filter; an all-invalid selection returns `{count:0, errors}` instead of throwing).
- **`/kits` page** now calls `forceReturnKits(ids)` once (was a per-kit loop).

### Verification
- New `convex/forceReturnKitsBatch.test.ts`: partial-success (returns checked-out kits, skips already-available/missing/cross-org with errors), cross-org re-check, service-gate.
- Full convex suite **green (303)**; `tsc --noEmit` clean. Mutation deployed to prod (additive).
- **Codex-reviewed**: `forceReturnKitCore` refactor behavior-identical to the singular; transaction rollback + tenant re-check + `requireService` sound; fixed the pre-filter so partial-success errors aren't hidden.

Appendix A `/kits` bulk force-return → **done**. Next kit-domain bulk gaps (warehouse prep/undeploy/unreturn kits) sequence with the warehouse domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)