### PR TITLE
feat(crew,convex): crew-member delete cascade as array mutations (Phase 3 bulk invariant)

### DIFF
--- a/convex/crewAvailabilities.ts
+++ b/convex/crewAvailabilities.ts
@@ -139,3 +139,26 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+/**
+ * Delete N availability rows in ONE array mutation (bulk single-call invariant) —
+ * replaces the server firing one `remove` per row in a crew-member delete cascade.
+ * `organizationId` is OPTIONAL on this table, so we skip only a row whose org is
+ * PRESENT and MISMATCHED (a genuine cross-tenant id); null-org rows are deleted (they
+ * match the old delete-by-id behavior and belong to the member being removed).
+ */
+export const removeMany = mutation({
+  args: { organizationId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { organizationId, ids }) => {
+    await requireService(ctx);
+    let deleted = 0;
+    for (const id of ids) {
+      const doc = await ctx.db.query("crewAvailabilities").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (!doc) continue;
+      if (doc.organizationId != null && doc.organizationId !== organizationId) continue;
+      await ctx.db.delete(doc._id);
+      deleted++;
+    }
+    return { deleted };
+  },
+});

--- a/convex/crewCascadeRemoveMany.test.ts
+++ b/convex/crewCascadeRemoveMany.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+//
+// crewTimeEntries.removeMany + crewAvailabilities.removeMany — the Phase 3 bulk
+// single-call invariant for the crew-member delete cascade (Appendix A*): N rows
+// deleted in ONE array mutation (was one round-trip per row) with a per-item org
+// re-check. crewAvailabilities.organizationId is OPTIONAL → null-org rows are deleted.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const has = (t: T, table: "crewTimeEntries" | "crewAvailabilities", id: string) =>
+  t.run(async (ctx) => (await ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).unique()) != null);
+
+describe("crewTimeEntries.removeMany — org-checked bulk delete", () => {
+  test("deletes in-org entries, skips missing + cross-org", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      const te = (id: string, org: string) => ctx.db.insert("crewTimeEntries", { id, organizationId: org, crewMemberId: "c1", date: NOW, startTime: "09:00", endTime: "17:00" });
+      await te("t1", ORG); await te("t2", ORG); await te("tx", OTHER);
+    });
+
+    const res = await t.withIdentity(SERVICE).mutation(api.crewTimeEntries.removeMany, {
+      organizationId: ORG, ids: ["t1", "t2", "tx", "ghost"],
+    });
+
+    expect(res.deleted).toBe(2);
+    expect(await has(t, "crewTimeEntries", "t1")).toBe(false);
+    expect(await has(t, "crewTimeEntries", "t2")).toBe(false);
+    expect(await has(t, "crewTimeEntries", "tx")).toBe(true); // cross-org untouched
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.crewTimeEntries.removeMany, { organizationId: ORG, ids: [] }),
+    ).rejects.toThrow(/server/i);
+  });
+});
+
+describe("crewAvailabilities.removeMany — optional-org bulk delete", () => {
+  test("deletes in-org + null-org rows, skips a present-but-mismatched org", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("crewAvailabilities", { id: "av1", organizationId: ORG, crewMemberId: "c1", startDate: NOW, endDate: NOW + 1 });
+      await ctx.db.insert("crewAvailabilities", { id: "av2", crewMemberId: "c1", startDate: NOW, endDate: NOW + 1 }); // null org — the member's own row
+      await ctx.db.insert("crewAvailabilities", { id: "avx", organizationId: OTHER, crewMemberId: "c1", startDate: NOW, endDate: NOW + 1 });
+    });
+
+    const res = await t.withIdentity(SERVICE).mutation(api.crewAvailabilities.removeMany, {
+      organizationId: ORG, ids: ["av1", "av2", "avx"],
+    });
+
+    expect(res.deleted).toBe(2); // av1 (in-org) + av2 (null org)
+    expect(await has(t, "crewAvailabilities", "av1")).toBe(false);
+    expect(await has(t, "crewAvailabilities", "av2")).toBe(false);
+    expect(await has(t, "crewAvailabilities", "avx")).toBe(true); // present + mismatched org → kept
+  });
+});

--- a/convex/crewTimeEntries.ts
+++ b/convex/crewTimeEntries.ts
@@ -167,6 +167,27 @@ export const remove = mutation({
 });
 
 /**
+ * Delete N time entries in ONE array mutation (bulk single-call invariant) — replaces
+ * the server firing one `remove` per entry in a crew-member delete cascade. Per-item
+ * `organizationId` re-check (by_cuid is a GLOBAL index); a missing / cross-org id is
+ * skipped (idempotent — a row an assignment-cascade already deleted is just absent).
+ */
+export const removeMany = mutation({
+  args: { organizationId: v.string(), ids: v.array(v.string()) },
+  handler: async (ctx, { organizationId, ids }) => {
+    await requireService(ctx);
+    let deleted = 0;
+    for (const id of ids) {
+      const doc = await ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (!doc || doc.organizationId !== organizationId) continue;
+      await ctx.db.delete(doc._id);
+      deleted++;
+    }
+    return { deleted };
+  },
+});
+
+/**
  * Bulk status transition (bulk single-call invariant, Phase 3): apply ONE shared `set`
  * to N time entries in a single array mutation — replaces the server firing one
  * `patchTimeEntry` round-trip per entry (submit / approve N timesheets). Guards each

--- a/src/server/crew.ts
+++ b/src/server/crew.ts
@@ -409,13 +409,22 @@ export async function deleteCrewMember(id: string) {
   } else {
     await convex.mutation(api.crewMembers.remove, { id });
   }
-  // Within each set the rows are distinct, so parallelize each. Keep the three
-  // sets SEQUENTIAL: an assignment's deleteCascade can remove its linked time
-  // entries, so the assignments must finish before the time-entry removals run
-  // (preserves the original ordering; avoids removing an already-gone row).
-  await Promise.all(memberAssignments.map((a) => convex.mutation(api.crewAssignments.deleteCascade, { id: a.id })));
-  await Promise.all(orgTimeEntries.map((t) => convex.mutation(api.crewTimeEntries.remove, { id: t.id })));
-  await Promise.all(memberAvailability.map((av) => convex.mutation(api.crewAvailabilities.remove, { id: av.id })));
+  // Each set is now ONE array mutation (was one round-trip per row). Keep the three
+  // SEQUENTIAL: an assignment's cascade also removes its linked time entries, so the
+  // assignment deletes must finish before the standalone-time-entry deletes run
+  // (removeMany is idempotent — an already-gone row is skipped, not an error).
+  await convex.mutation(api.crewAssignments.deleteManyCascade, {
+    orgId: organizationId,
+    ids: memberAssignments.map((a) => a.id),
+  });
+  await convex.mutation(api.crewTimeEntries.removeMany, {
+    organizationId,
+    ids: orgTimeEntries.map((t) => t.id),
+  });
+  await convex.mutation(api.crewAvailabilities.removeMany, {
+    organizationId,
+    ids: memberAvailability.map((av) => av.id),
+  });
 
   if (!nativeCrewWrites()) {
     await logActivity({


### PR DESCRIPTION
## Phase 3 — bulk single-call invariant (Appendix A*)

`deleteCrewMember` cascaded its children via **three `Promise.all(N convex.mutation)` loops** — one round-trip per assignment / time-entry / availability. Collapsed each set to **one array mutation**.

- **`convex/crewTimeEntries.ts` `removeMany`** — strict per-item org re-check (`organizationId` required); missing/cross-org ids skipped (idempotent).
- **`convex/crewAvailabilities.ts` `removeMany`** — `organizationId` is **optional**, so it deletes in-org + null-org rows (the member's own, matching the old delete-by-id behavior) and skips only a **present-but-mismatched** org (cross-tenant).
- **`crewAssignments.deleteManyCascade`** (already existed) replaces the assignment loop.
- **`src/server/crew.ts`** — 3 sequential array-mutation calls (was 3× `Promise.all(N)`); order preserved (assignments cascade first — they also delete linked time entries — then standalone time entries, then availabilities). `removeMany` is idempotent, so a row an assignment-cascade already removed is skipped, not an error.

### Verification
- New `convex/crewCascadeRemoveMany.test.ts`: org-checked delete, null-org availability deleted, cross-org kept, service-gate.
- Full convex suite **green (311)**; `tsc --noEmit` clean. Mutations deployed to prod (additive).
- **Codex: CLEAN.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)