### PR TITLE
feat(warehouse,convex): bulk un-deploy / un-return kits in one array mutation (Phase 3 bulk invariant)

### DIFF
--- a/convex/kitPerUnit.test.ts
+++ b/convex/kitPerUnit.test.ts
@@ -146,6 +146,29 @@ describe("kit per-unit — reverse + force", () => {
     expect(u.returnedQuantity).toBe(0);
   });
 
+  // Bulk single-call (Phase 3): the batch variants do the same per-kit work + report
+  // partial-success. Core behavior is covered above; here we assert the dispatch.
+  test("undeployKitsBatch: undeploys the kit + reports a not-on-project kit as an error", async () => {
+    const t = makeT();
+    await seedKit(t);
+    await co(t);
+    const res = await t.withIdentity(SERVICE).mutation(api.warehouseOps.undeployKitsBatch, { organizationId: ORG, projectId: "p1", userId: USER, kitIds: ["k1", "ghost"], now: NOW });
+    expect(res.succeeded).toEqual(["k1"]);
+    expect(res.errors).toEqual([{ kitId: "ghost", message: "Kit not found on this project" }]);
+    expect(serialUnit(await memberUnits(t)).status).toBe("CONFIRMED");
+  });
+
+  test("unreturnKitsBatch: un-returns the kit in one call", async () => {
+    const t = makeT();
+    await seedKit(t);
+    await co(t);
+    await ci(t, "GOOD");
+    const res = await t.withIdentity(SERVICE).mutation(api.warehouseOps.unreturnKitsBatch, { organizationId: ORG, projectId: "p1", userId: USER, kitIds: ["k1"], now: NOW });
+    expect(res.succeeded).toEqual(["k1"]);
+    expect(res.errors).toEqual([]);
+    expect(serialUnit(await memberUnits(t)).status).toBe("CHECKED_OUT");
+  });
+
   test("forceReturnKit flips member unit → RETURNED", async () => {
     const t = makeT();
     await seedKit(t);

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -793,13 +793,12 @@ export const undeprepLine = mutation({
 });
 
 /** Deployed → Prepped for a whole kit: reverse checkoutKit. */
-export const undeployKit = mutation({
-  args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
-  handler: async (ctx, a) => {
-    await requireService(ctx);
-    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
-    if (!kitLine) throw new ConvexError("Kit not found on this project");
-    const defLoc = await defaultLocationId(ctx, a.organizationId);
+type KitOpArgs = { organizationId: string; projectId: string; userId: string; kitId: string; now: number };
+type KitParentLine = NonNullable<Awaited<ReturnType<typeof kitParentLine>>>;
+
+/** Core of undeployKit for ONE validated kit (parent line found). `defLoc` is passed
+ *  so a batch resolves it once. Returns [kitId, ...nestedKitIds]. */
+async function undeployKitCore(ctx: Ctx, a: KitOpArgs, kitLine: KitParentLine, defLoc: string | null): Promise<string[]> {
     const prepped = { status: "CONFIRMED" as const, prepStatus: "PACKED" as const, checkedOutQuantity: 0, updatedAt: a.now };
 
     const children = await childLines(ctx, kitLine.id, a.organizationId);
@@ -832,19 +831,53 @@ export const undeployKit = mutation({
     await cascadeKitAccessoriesReverse(ctx, kitLine.id, a.organizationId, { fromStatus: "CHECKED_OUT", toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE", locationId: defLoc, clearLoc: true, now: a.now });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Prepped (un-deploy)" });
-    return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
-  },
-});
+    return [a.kitId, ...nestedKitIds];
+}
 
-/** Returned → Deployed for a whole kit: reverse checkinKit. */
-export const unreturnKit = mutation({
+export const undeployKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
     const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
     if (!kitLine) throw new ConvexError("Kit not found on this project");
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
-    const projLoc = project?.locationId ?? null;
+    const defLoc = await defaultLocationId(ctx, a.organizationId);
+    const affectedKitIds = await undeployKitCore(ctx, a, kitLine, defLoc);
+    return { kitId: a.kitId, affectedKitIds };
+  },
+});
+
+/**
+ * Batch un-deploy (bulk single-call invariant, Phase 3): move N kits Deployed→Prepped
+ * in ONE array mutation instead of the client firing one `undeployKit` per kit.
+ * Per-item org+project re-check via `kitParentLine`: a kit not on this org's project is
+ * SKIPPED with an error before any of its writes ({succeeded, errors}). Un-deploy only
+ * RESTORES bulk availability (+1), so a valid kit's core can't underflow — the batch
+ * effectively completes for every eligible kit. (Note: like any Convex mutation this is
+ * ONE transaction, so a genuine mid-execution failure would roll the whole batch back;
+ * the client surfaces the error and the operator retries.) `defLoc` resolved once.
+ */
+export const undeployKitsBatch = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const defLoc = await defaultLocationId(ctx, a.organizationId);
+    const succeeded: string[] = [];
+    const errors: { kitId: string; message: string }[] = [];
+    const affected = new Set<string>();
+    for (const kitId of a.kitIds) {
+      const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
+      if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
+      const aff = await undeployKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, defLoc);
+      succeeded.push(kitId);
+      for (const k of aff) affected.add(k);
+    }
+    return { succeeded, errors, affectedKitIds: [...affected] };
+  },
+});
+
+/** Returned → Deployed for a whole kit: reverse checkinKit. */
+/** Core of unreturnKit for ONE validated kit. `projLoc` passed so a batch resolves it once. */
+async function unreturnKitCore(ctx: Ctx, a: KitOpArgs, kitLine: KitParentLine, projLoc: string | null): Promise<string[]> {
     const deployed = { status: "CHECKED_OUT" as const, returnedQuantity: 0, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now };
 
     const children = (await childLines(ctx, kitLine.id, a.organizationId)).filter((c) => c.status === "RETURNED");
@@ -877,7 +910,49 @@ export const unreturnKit = mutation({
     await cascadeKitAccessoriesReverse(ctx, kitLine.id, a.organizationId, { fromStatus: "RETURNED", toStatus: "CHECKED_OUT", assetStatus: "CHECKED_OUT", locationId: projLoc, clearLoc: false, now: a.now });
 
     await scanLog(ctx, { organizationId: a.organizationId, kitId: a.kitId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Kit moved back to Deployed (un-return)" });
-    return { kitId: a.kitId, affectedKitIds: [a.kitId, ...nestedKitIds] };
+    return [a.kitId, ...nestedKitIds];
+}
+
+export const unreturnKit = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
+    if (!kitLine) throw new ConvexError("Kit not found on this project");
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
+    const projLoc = project?.locationId ?? null;
+    const affectedKitIds = await unreturnKitCore(ctx, a, kitLine, projLoc);
+    return { kitId: a.kitId, affectedKitIds };
+  },
+});
+
+/**
+ * Batch un-return (bulk single-call invariant, Phase 3): move N kits Returned→Deployed
+ * in ONE array mutation instead of one `unreturnKit` per kit. Per-item org+project
+ * re-check via `kitParentLine`: a kit not on this org's project is SKIPPED with an error
+ * before any of its writes ({succeeded, errors}). Un-return RE-CONSUMES bulk availability
+ * (−1), so — unlike un-deploy — a valid kit could in principle underflow; because a
+ * Convex mutation is ONE transaction, such a mid-execution failure rolls the whole batch
+ * back (atomic) rather than leaving it half-applied. The client surfaces the error and
+ * the operator retries. `projLoc` resolved once (all kits share the projectId).
+ */
+export const unreturnKitsBatch = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
+    const projLoc = project?.locationId ?? null;
+    const succeeded: string[] = [];
+    const errors: { kitId: string; message: string }[] = [];
+    const affected = new Set<string>();
+    for (const kitId of a.kitIds) {
+      const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
+      if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
+      const aff = await unreturnKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, projLoc);
+      succeeded.push(kitId);
+      for (const k of aff) affected.add(k);
+    }
+    return { succeeded, errors, affectedKitIds: [...affected] };
   },
 });
 

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -39,8 +39,8 @@ import {
   undeployItems,
   unreturnItems,
   undeprepLine,
-  undeployKit,
-  unreturnKit,
+  undeployKitsBatch,
+  unreturnKitsBatch,
   getAvailableAssetsForModels,
   quickAddAndCheckOut,
   clearPrepContainer,
@@ -812,9 +812,13 @@ function WarehouseProjectPage({
     onSuccess: () => { toast.success("Moved back to Prepped"); invalidate(); },
     onError: (e) => showError(e),
   });
-  const undeployKitMutation = useServerMutation({
-    mutationFn: (kitId: string) => undeployKit(projectId, kitId),
-    onSuccess: () => { toast.success("Kit moved back to Prepped"); invalidate(); },
+  const undeployKitsMutation = useServerMutation<KitBatchResult, string[]>({
+    mutationFn: (kitIds: string[]) => undeployKitsBatch(projectId, kitIds),
+    onSuccess: (res) => {
+      if (res.succeeded.length > 0) toast.success(`Moved ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"} back to Prepped`);
+      if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} skipped: ${res.errors[0].message}`);
+      invalidate();
+    },
     onError: (e) => showError(e),
   });
   const unreturnMutation = useServerMutation({
@@ -823,9 +827,13 @@ function WarehouseProjectPage({
     onSuccess: () => { toast.success("Moved back to Deployed"); invalidate(); },
     onError: (e) => showError(e),
   });
-  const unreturnKitMutation = useServerMutation({
-    mutationFn: (kitId: string) => unreturnKit(projectId, kitId),
-    onSuccess: () => { toast.success("Kit moved back to Deployed"); invalidate(); },
+  const unreturnKitsMutation = useServerMutation<KitBatchResult, string[]>({
+    mutationFn: (kitIds: string[]) => unreturnKitsBatch(projectId, kitIds),
+    onSuccess: (res) => {
+      if (res.succeeded.length > 0) toast.success(`Moved ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"} back to Deployed`);
+      if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} skipped: ${res.errors[0].message}`);
+      invalidate();
+    },
     onError: (e) => showError(e),
   });
   const undeprepMutation = useServerMutation({
@@ -839,7 +847,7 @@ function WarehouseProjectPage({
   const moveBackSelection = (
     ids: Set<string>,
     fireItems: (items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>) => void,
-    fireKit: (kitId: string) => void,
+    fireKits: (kitIds: string[]) => void,
   ) => {
     if (ids.size === 0) return;
     const qtyMap = new Map<string, number>();
@@ -853,7 +861,8 @@ function WarehouseProjectPage({
         qtyMap.set(lineItemId, (qtyMap.get(lineItemId) || 0) + 1);
       }
     }
-    for (const kitId of kitIds) fireKit(kitId);
+    // Bulk single-call: ONE array mutation for all selected kits (was one per kit).
+    if (kitIds.size > 0) fireKits(Array.from(kitIds));
     const items = Array.from(qtyMap.entries()).map(([lineItemId, quantity]) => ({
       lineItemId,
       assetId: lineItems.find((l) => l.id === lineItemId)?.assetId || undefined,
@@ -864,12 +873,12 @@ function WarehouseProjectPage({
 
   // Deployed → Prepped
   const handleUndeploy = (ids: Set<string>) => {
-    moveBackSelection(ids, (items) => undeployMutation.mutate(items), (kitId) => undeployKitMutation.mutate(kitId));
+    moveBackSelection(ids, (items) => undeployMutation.mutate(items), (kitIds) => undeployKitsMutation.mutate(kitIds));
     setSelectedIn(new Set());
   };
   // Returned → Deployed
   const handleUnreturn = (ids: Set<string>) => {
-    moveBackSelection(ids, (items) => unreturnMutation.mutate(items), (kitId) => unreturnKitMutation.mutate(kitId));
+    moveBackSelection(ids, (items) => unreturnMutation.mutate(items), (kitIds) => unreturnKitsMutation.mutate(kitIds));
     setSelectedDeprep(new Set());
   };
 
@@ -2615,7 +2624,7 @@ function WarehouseProjectPage({
           handleDeprep={handleDeprep}
           deprepIsPending={deprepMutation.isPending}
           handleUnreturn={handleUnreturn}
-          unreturnIsPending={unreturnMutation.isPending || unreturnKitMutation.isPending}
+          unreturnIsPending={unreturnMutation.isPending || unreturnKitsMutation.isPending}
           clearContainerMutate={(c) => clearContainerMutation.mutate(c)}
           clearContainerIsPending={clearContainerMutation.isPending}
           checkOutIsPending={checkOutMutation.isPending}
@@ -2650,7 +2659,7 @@ function WarehouseProjectPage({
           handleReturnSelected={handleReturnSelected}
           checkInIsPending={checkInMutation.isPending}
           handleUndeploy={handleUndeploy}
-          undeployIsPending={undeployMutation.isPending || undeployKitMutation.isPending}
+          undeployIsPending={undeployMutation.isPending || undeployKitsMutation.isPending}
           toggleSelection={toggleSelection}
           toggleGroupSelection={toggleGroupSelection}
           toggleAll={toggleAll}

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -600,6 +600,44 @@ export async function unreturnKit(projectId: string, kitId: string) {
   return serialize({ success: true, ...res });
 }
 
+/** Bulk single-call un-deploy: move N kits Deployed→Prepped in ONE array mutation +
+ *  one server round-trip (was one `undeployKit` per selected kit). Partial-success. */
+export async function undeployKitsBatch(projectId: string, kitIds: string[]) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
+  if (kitIds.length === 0) throw new Error("No kits selected");
+  const convex = await getConvexClient();
+  const res = await convex.mutation(api.warehouseOps.undeployKitsBatch, {
+    organizationId, projectId, userId, kitIds, now: Date.now(),
+  });
+  if (res.succeeded.length > 0) {
+    await logActivity({
+      organizationId, userId, userName, action: "UPDATE", entityType: "kit",
+      entityId: res.succeeded[0], entityName: `${res.succeeded.length} kits`,
+      summary: `Moved ${res.succeeded.length} kit(s) back to Prepped (un-deploy)`, projectId,
+    });
+  }
+  return serialize({ success: true, ...res });
+}
+
+/** Bulk single-call un-return: move N kits Returned→Deployed in ONE array mutation +
+ *  one server round-trip (was one `unreturnKit` per selected kit). Partial-success. */
+export async function unreturnKitsBatch(projectId: string, kitIds: string[]) {
+  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
+  if (kitIds.length === 0) throw new Error("No kits selected");
+  const convex = await getConvexClient();
+  const res = await convex.mutation(api.warehouseOps.unreturnKitsBatch, {
+    organizationId, projectId, userId, kitIds, now: Date.now(),
+  });
+  if (res.succeeded.length > 0) {
+    await logActivity({
+      organizationId, userId, userName, action: "UPDATE", entityType: "kit",
+      entityId: res.succeeded[0], entityName: `${res.succeeded.length} kits`,
+      summary: `Moved ${res.succeeded.length} kit(s) back to Deployed (un-return)`, projectId,
+    });
+  }
+  return serialize({ success: true, ...res });
+}
+
 export async function checkOutKit(projectId: string, kitId: string) {
   const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
 


### PR DESCRIPTION
## Phase 3 — bulk single-call invariant (Appendix A)

The warehouse page moved N selected kits Deployed→Prepped / Returned→Deployed by firing **one `undeployKit`/`unreturnKit` server action per kit** (client fan-out in `moveBackSelection`'s loop). Collapsed to **one array mutation per action**.

- **`convex/warehouseOps.ts`** — factored `undeployKit` + `unreturnKit` into `forceReturnKit`-style `undeployKitCore` / `unreturnKitCore` (shared by the singular), added `undeployKitsBatch` / `unreturnKitsBatch`: per-item org+project re-check via `kitParentLine` (a kit not on this project is **skipped with an error before any of its writes**), `defLoc`/`projLoc` resolved once. **Extraction verified behavior-identical** (24 kit-per-unit tests green). Semantics documented honestly: un-deploy only *restores* availability so it completes for every eligible kit; un-return *re-consumes*, and — like any Convex mutation (one transaction) — a mid-execution failure rolls the batch back atomically (operator retries).
- **`src/server/warehouse.ts`** — `undeployKitsBatch` / `unreturnKitsBatch` server actions.
- **warehouse page** — `moveBackSelection` fires **one** batch call for all selected kits; results surface `{succeeded, errors}` via the existing `KitBatchResult` toast pattern (per codex — skipped kits no longer shown as success).

### Verification
- 2 tests added to `kitPerUnit.test.ts` (batch undeploy + not-on-project error, batch unreturn). Full convex suite **green (315)**; `tsc --noEmit` clean. Mutations deployed to prod (additive).
- **Codex-reviewed** (2 rounds): core extraction confirmed identical; fixed client error-surfacing + documented atomic-execution semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)