### PR TITLE
fix(convex,security): per-item org re-check on reorder* mutations (cross-tenant write hole)

### DIFF
--- a/convex/categorySlots.ts
+++ b/convex/categorySlots.ts
@@ -127,6 +127,7 @@ export const remove = mutation({
  */
 export const reorderSlots = mutation({
   args: {
+    orgId: v.string(),
     categoryId: v.string(),
     items: v.array(v.object({
       kind: v.union(v.literal("projectGroup"), v.literal("subHireGroup")),
@@ -136,8 +137,13 @@ export const reorderSlots = mutation({
     })),
     now: v.number(),
   },
-  handler: async (ctx, { categoryId, items, now }) => {
+  handler: async (ctx, { orgId, categoryId, items, now }) => {
     await requireService(ctx);
+    // categorySlots has no org column, so scope to the caller's org via the category:
+    // a cross-org / missing category is a no-op, so a caller can't reorder (or create)
+    // slots under another org's category (by_cuid is a GLOBAL index).
+    const category = await ctx.db.query("projectCategories").withIndex("by_cuid", (q) => q.eq("id", categoryId)).unique();
+    if (!category || category.organizationId !== orgId) return;
     const catSlots = await ctx.db
       .query("categorySlots")
       .withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", categoryId))

--- a/convex/modelMedia.ts
+++ b/convex/modelMedia.ts
@@ -139,15 +139,16 @@ export const setPrimary = mutation({
 
 // Atomic reorder: set sortOrder = array index (replaces the Prisma update-per-id tx).
 export const reorder = mutation({
-  args: { orderedIds: v.array(v.string()) },
-  handler: async (ctx, { orderedIds }) => {
+  args: { orgId: v.string(), orderedIds: v.array(v.string()) },
+  handler: async (ctx, { orgId, orderedIds }) => {
     await requireService(ctx);
     for (let i = 0; i < orderedIds.length; i++) {
       const doc = await ctx.db
         .query("modelMedia")
         .withIndex("by_cuid", (q) => q.eq("id", orderedIds[i]))
         .unique();
-      if (doc) await ctx.db.patch(doc._id, { sortOrder: i });
+      // Per-item org re-check (by_cuid is a GLOBAL index).
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: i });
     }
   },
 });

--- a/convex/projectCategories.ts
+++ b/convex/projectCategories.ts
@@ -158,15 +158,16 @@ export const createAtEnd = mutation({
  * against the winner's writes).
  */
 export const reorder = mutation({
-  args: { orderedIds: v.array(v.string()), now: v.number() },
-  handler: async (ctx, { orderedIds, now }) => {
+  args: { orgId: v.string(), orderedIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, { orgId, orderedIds, now }) => {
     await requireService(ctx);
     for (let i = 0; i < orderedIds.length; i++) {
       const doc = await ctx.db
         .query("projectCategories")
         .withIndex("by_cuid", (q) => q.eq("id", orderedIds[i]))
         .unique();
-      if (doc) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
+      // Per-item org re-check (by_cuid is a GLOBAL index).
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
     }
   },
 });

--- a/convex/projectGroups.ts
+++ b/convex/projectGroups.ts
@@ -197,15 +197,16 @@ export const createAtEnd = mutation({
  * Atomic reorder within a category: sortOrder = index for each id, one transaction.
  */
 export const reorder = mutation({
-  args: { orderedIds: v.array(v.string()), now: v.number() },
-  handler: async (ctx, { orderedIds, now }) => {
+  args: { orgId: v.string(), orderedIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, { orgId, orderedIds, now }) => {
     await requireService(ctx);
     for (let i = 0; i < orderedIds.length; i++) {
       const doc = await ctx.db
         .query("projectGroups")
         .withIndex("by_cuid", (q) => q.eq("id", orderedIds[i]))
         .unique();
-      if (doc) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
+      // Per-item org re-check (by_cuid is a GLOBAL index).
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: i, updatedAt: now });
     }
   },
 });

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -687,14 +687,17 @@ export const patchMany = mutation({
 /** Atomic reorder: assign sortOrder = index (+ optional groupName) per id. */
 export const reorderLineItems = mutation({
   args: {
+    orgId: v.string(),
     items: v.array(v.object({ id: v.string(), sortOrder: v.number(), groupName: v.optional(v.string()) })),
     now: v.number(),
   },
-  handler: async (ctx, { items, now }) => {
+  handler: async (ctx, { orgId, items, now }) => {
     await requireService(ctx);
     for (const it of items) {
       const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
-      if (doc) await ctx.db.patch(doc._id, { sortOrder: it.sortOrder, groupName: it.groupName, updatedAt: now });
+      // Per-item org re-check: by_cuid is a GLOBAL index, so without this a caller
+      // could reorder another org's line items (mirrors reorderNative's guard).
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: it.sortOrder, groupName: it.groupName, updatedAt: now });
     }
   },
 });

--- a/convex/reorderOrgCheck.test.ts
+++ b/convex/reorderOrgCheck.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+//
+// Per-item org re-check on the reorder* mutations (Phase 3 security baseline). These
+// service-gated array mutations fetch rows by the GLOBAL by_cuid index and patch
+// sortOrder; without an org re-check a caller could reorder ANOTHER org's rows. Each
+// now takes `orgId` and skips a row whose organizationId differs. (Surfaced by the
+// independent adversarial re-audit; fixed to match reorderNative's guard.)
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const sortOrder = (t: T, table: "projectLineItems" | "projectGroups" | "projectCategories" | "modelMedia", id: string) =>
+  t.run(async (ctx) => (await ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).unique())?.sortOrder);
+
+describe("reorder* mutations — per-item org re-check (no cross-tenant reorder)", () => {
+  test("reorderLineItems: patches in-org, skips a cross-org id", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li_a", organizationId: ORG, projectId: "p1", sortOrder: 0 });
+      await ctx.db.insert("projectLineItems", { id: "li_b", organizationId: OTHER, projectId: "p9", sortOrder: 0 });
+    });
+    await t.withIdentity(SERVICE).mutation(api.projectLineItems.reorderLineItems, {
+      orgId: ORG,
+      items: [{ id: "li_a", sortOrder: 5 }, { id: "li_b", sortOrder: 99 }],
+      now: NOW,
+    });
+    expect(await sortOrder(t, "projectLineItems", "li_a")).toBe(5); // in-org applied
+    expect(await sortOrder(t, "projectLineItems", "li_b")).toBe(0); // cross-org untouched
+  });
+
+  test("projectGroups.reorder + projectCategories.reorder skip cross-org", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectGroups", { id: "g_x", organizationId: OTHER, projectId: "p9", title: "X", sortOrder: 0 });
+      await ctx.db.insert("projectCategories", { id: "c_x", organizationId: OTHER, projectId: "p9", name: "X", sortOrder: 0 });
+    });
+    await t.withIdentity(SERVICE).mutation(api.projectGroups.reorder, { orgId: ORG, orderedIds: ["g_x"], now: NOW });
+    await t.withIdentity(SERVICE).mutation(api.projectCategories.reorder, { orgId: ORG, orderedIds: ["c_x"], now: NOW });
+    expect(await sortOrder(t, "projectGroups", "g_x")).toBe(0);
+    expect(await sortOrder(t, "projectCategories", "c_x")).toBe(0);
+  });
+
+  test("modelMedia.reorder skips a cross-org id", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("modelMedia", { id: "mm_x", organizationId: OTHER, modelId: "m9", fileId: "f9", sortOrder: 0 });
+    });
+    await t.withIdentity(SERVICE).mutation(api.modelMedia.reorder, { orgId: ORG, orderedIds: ["mm_x"] });
+    expect(await sortOrder(t, "modelMedia", "mm_x")).toBe(0);
+  });
+
+  test("categorySlots.reorderSlots no-ops for a cross-org category", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      // category belongs to OTHER org; a slot exists under it.
+      await ctx.db.insert("projectCategories", { id: "cat_x", organizationId: OTHER, projectId: "p9", name: "X", sortOrder: 0 });
+      await ctx.db.insert("categorySlots", { id: "slot_x", projectCategoryId: "cat_x", projectGroupId: "g1", sortOrder: 0 });
+    });
+    await t.withIdentity(SERVICE).mutation(api.categorySlots.reorderSlots, {
+      orgId: ORG, // caller is org_1, category is org_other → no-op
+      categoryId: "cat_x",
+      items: [{ kind: "projectGroup", groupId: "g1", sortOrder: 7, newSlotId: "slot_x" }],
+      now: NOW,
+    });
+    const slot = await t.run(async (ctx) => ctx.db.query("categorySlots").withIndex("by_cuid", (q) => q.eq("id", "slot_x")).unique());
+    expect(slot?.sortOrder).toBe(0); // untouched — cross-org category rejected
+  });
+});

--- a/src/lib/media-write.ts
+++ b/src/lib/media-write.ts
@@ -171,10 +171,11 @@ export async function setPrimaryPhotoConvex(
   await convex.mutation(spec.convex.setPrimary, { parentId: opts.parentId, mediaId: opts.mediaId } as AnyArgs);
 }
 
-/** Reorder a parent's media by the given id order (atomic Convex mutation). */
-export async function reorderMediaConvex(kind: MediaKind, orderedIds: string[]): Promise<void> {
+/** Reorder a parent's media by the given id order (atomic Convex mutation). `orgId`
+ *  scopes the per-item org re-check in the mutation (by_cuid is a GLOBAL index). */
+export async function reorderMediaConvex(kind: MediaKind, orderedIds: string[], orgId: string): Promise<void> {
   const spec = MEDIA_SPECS[kind];
   if (!spec.convex.reorder) throw new Error(`${kind} media has no reorder`);
   const convex = await getConvexClient();
-  await convex.mutation(spec.convex.reorder, { orderedIds } as AnyArgs);
+  await convex.mutation(spec.convex.reorder, { orgId, orderedIds } as AnyArgs);
 }

--- a/src/server/category-slots.ts
+++ b/src/server/category-slots.ts
@@ -524,6 +524,7 @@ export async function reorderMixedGroupsInCategory(
 
   const now = Date.now();
   await client.mutation(api.categorySlots.reorderSlots, {
+    orgId: organizationId,
     categoryId: parsed.categoryId,
     items: sortedByPrefixedId.map(({ prefixedId, displayIndex }) => {
       const parsedSlot = parseSlotId(prefixedId)!;

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1289,6 +1289,7 @@ export async function reorderLineItems(
     });
   } else {
     await reorderConvex.mutation(api.projectLineItems.reorderLineItems, {
+      orgId: reorderOrgId,
       items,
       now: Date.now(),
     });

--- a/src/server/model-media.ts
+++ b/src/server/model-media.ts
@@ -49,7 +49,7 @@ export async function reorderModelMedia(modelId: string, orderedIds: string[]) {
   const { organizationId } = await getOrgContext();
   const model = await getModelById(modelId);
   if (!model || model.organizationId !== organizationId) throw new Error("Model not found");
-  await reorderMediaConvex("model", orderedIds);
+  await reorderMediaConvex("model", orderedIds, organizationId);
 }
 
 export async function getModelMedia(modelId: string) {

--- a/src/server/project-categories.ts
+++ b/src/server/project-categories.ts
@@ -480,11 +480,11 @@ export async function reorderProjectCategories(
   projectId: string,
   orderedIds: string[],
 ) {
-  await requirePermission("project", "manage_line_items");
+  const { organizationId } = await requirePermission("project", "manage_line_items");
   const client = await getConvexClient();
 
   // Atomic reorder: contiguous sortOrder guaranteed in one transaction.
-  await client.mutation(api.projectCategories.reorder, { orderedIds, now: Date.now() });
+  await client.mutation(api.projectCategories.reorder, { orgId: organizationId, orderedIds, now: Date.now() });
 
   return serialize({ success: true });
 }

--- a/src/server/project-groups.ts
+++ b/src/server/project-groups.ts
@@ -529,11 +529,11 @@ export async function reorderProjectGroups(
   categoryId: string,
   orderedIds: string[]
 ) {
-  await requirePermission("project", "manage_line_items");
+  const { organizationId } = await requirePermission("project", "manage_line_items");
   const client = await getConvexClient();
 
   // Atomic reorder within the category: contiguous sortOrder in one transaction.
-  await client.mutation(api.projectGroups.reorder, { orderedIds, now: Date.now() });
+  await client.mutation(api.projectGroups.reorder, { orgId: organizationId, orderedIds, now: Date.now() });
 
   return serialize({ success: true });
 }


### PR DESCRIPTION
## Security fix — surfaced by the Phase-3 independent adversarial re-audit

Five service-gated `reorder*` array mutations fetched rows by the **GLOBAL `by_cuid` index** and patched `sortOrder` with **no per-item `organizationId` re-check**. The server actions pass **client-supplied ids without org-scoping** them, so a member of org A could reorder (overwrite `sortOrder`/`groupName` on) **org B's** line items / groups / categories / model media — a real cross-tenant write (non-destructive presentation fields, but wrong). The guarded native sibling `lineItemWrites.reorderNative` already had the check, but it's behind a flag that **defaults OFF**, so the unguarded legacy path is the one live in prod.

### Fix (mirrors `reorderNative`)
Each mutation takes an `orgId` arg and skips a row whose `doc.organizationId !== orgId`:
- `projectLineItems.reorderLineItems`
- `projectGroups.reorder`
- `projectCategories.reorder`
- `modelMedia.reorder`
- `categorySlots.reorderSlots` — has no org column, so it scopes via the parent `projectCategory`'s org (no-op if the category isn't the caller's).

All server-action callers (`line-items`, `project-groups`, `project-categories`, `model-media` via `reorderMediaConvex`, `category-slots`) pass `orgId` from `requirePermission`/`getOrgContext`.

### Verification
- New `convex/reorderOrgCheck.test.ts`: cross-org reorder is a **no-op** for all 5; in-org still applies.
- Full convex suite **green (319)**; `tsc --noEmit` clean. Mutations deployed to prod (additive; the flag-off legacy path is now guarded).
- **Codex: CLEAN.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)