### PR TITLE
fix(convex,security): harden the *Writes browser-direct surface (review H1 + M2)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_rateLimiter from "../lib/rateLimiter.js";
 import type * as lib_recalc from "../lib/recalc.js";
+import type * as lib_sanitizeSet from "../lib/sanitizeSet.js";
 import type * as lib_searchScore from "../lib/searchScore.js";
 import type * as lib_shardedCounter from "../lib/shardedCounter.js";
 import type * as lib_testtag from "../lib/testtag.js";
@@ -219,6 +220,7 @@ declare const fullApi: ApiFromModules<{
   "lib/permissionsCore": typeof lib_permissionsCore;
   "lib/rateLimiter": typeof lib_rateLimiter;
   "lib/recalc": typeof lib_recalc;
+  "lib/sanitizeSet": typeof lib_sanitizeSet;
   "lib/searchScore": typeof lib_searchScore;
   "lib/shardedCounter": typeof lib_shardedCounter;
   "lib/testtag": typeof lib_testtag;

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -97,6 +97,8 @@ export const archiveNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgPermission(ctx, orgId, "asset", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -157,6 +159,8 @@ export const deleteNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgPermission(ctx, orgId, "asset", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -304,6 +308,8 @@ export const createNative = mutation({
   },
   handler: async (ctx, args) => {
     const { actor: suppliedActor, auditId, ...fields } = args;
+    await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgPermission(ctx, fields.organizationId, "asset", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -359,6 +365,8 @@ export const updateNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, set, clear, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "asset"); // browser-direct kill-switch
+    await enforceBrowserWriteLimit(ctx); // per-user browser-direct budget
     await requireOrgPermission(ctx, orgId, "asset", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 

--- a/convex/crewWrites.test.ts
+++ b/convex/crewWrites.test.ts
@@ -1,14 +1,17 @@
 // @vitest-environment node
 import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 import schema from "./schema";
 import { api } from "./_generated/api";
 
 const modules = import.meta.glob("./**/*.ts");
-// Counted crew writes go through the sharded counter component (gate #3); mount it.
+// Crew mutations enforce a browser write limit (rate-limiter component) and counted
+// crew writes go through the sharded counter component (gate #3); mount both.
 function makeT() {
   const tc = convexTest(schema, modules);
+  registerRateLimiter(tc, "rateLimiter");
   registerShardedCounter(tc, "shardedCounter");
   return tc;
 }

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -1,6 +1,9 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { writeActivityLog } from "./lib/audit";
 import { bumpCrewMemberCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -56,6 +59,8 @@ export const createNative = mutation({
   },
   handler: async (ctx, args) => {
     const { actor: suppliedActor, auditId, ...fields } = args;
+    await assertWritesEnabled(ctx, "crew");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "crew", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -100,6 +105,8 @@ export const updateNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, set, clear, entityName, details, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "crew");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "crew", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -109,12 +116,13 @@ export const updateNative = mutation({
 
     // Apply set (+ clear-to-null) — the patchMember pattern.
     const NEVER_CLEAR = new Set(["id", "organizationId"]);
+    const setObj = sanitizeClientSet(set); // strip organizationId/id — no cross-tenant reassign
     if (clear.length === 0) {
-      await ctx.db.patch(doc._id, set as Record<string, unknown>);
-      await bumpCrewMemberCounters(ctx, orgId, doc, { ...doc, ...(set as Record<string, unknown>) });
+      await ctx.db.patch(doc._id, setObj);
+      await bumpCrewMemberCounters(ctx, orgId, doc, { ...doc, ...setObj });
     } else {
       const { _id, _creationTime, ...rest } = doc;
-      const merged: Record<string, unknown> = { ...rest, ...(set as Record<string, unknown>) };
+      const merged: Record<string, unknown> = { ...rest, ...setObj };
       for (const k of clear) {
         if (NEVER_CLEAR.has(k)) continue;
         delete merged[k];
@@ -157,6 +165,8 @@ export const deleteNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, name, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "crew");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "crew", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).first();

--- a/convex/kitWrites.test.ts
+++ b/convex/kitWrites.test.ts
@@ -3,8 +3,18 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 
 const modules = import.meta.glob("./**/*.ts");
+// Mount both components: the rate limiter (enforceBrowserWriteLimit) and the sharded
+// counter (counted writes). Both are required whenever a kit mutation runs with a USER identity.
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
@@ -37,7 +47,7 @@ describe("kitWrites.createNative", () => {
   };
 
   test("a manager creates a kit + writes the CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "manager" });
     });
@@ -53,7 +63,7 @@ describe("kitWrites.createNative", () => {
   });
 
   test("rejects a duplicate asset tag", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t); // KIT-1
     await expect(
       t.withIdentity(SERVICE).mutation(api.kitWrites.createNative, { ...createArgs, assetTag: "KIT-1" }),
@@ -61,7 +71,7 @@ describe("kitWrites.createNative", () => {
   });
 
   test("a viewer is denied (kit:create)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "viewer" });
     });
@@ -75,7 +85,7 @@ describe("kitWrites.updateNative", () => {
   const updArgs = { id: "k1", orgId: ORG, patch: { name: "Renamed", status: "IN_MAINTENANCE" as const, updatedAt: NOW }, actor: ACTOR, auditId: "log1", now: NOW };
 
   test("applies patch + writes the UPDATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.withIdentity(SERVICE).mutation(api.kitWrites.updateNative, updArgs);
     await t.run(async (ctx) => {
@@ -88,7 +98,7 @@ describe("kitWrites.updateNative", () => {
   });
 
   test("rejects a tag change that collides", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("kits", { id: "k2", organizationId: ORG, assetTag: "TAKEN", name: "Other", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -99,7 +109,7 @@ describe("kitWrites.updateNative", () => {
   });
 
   test("a viewer is denied (kit:update)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, "viewer");
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.kitWrites.updateNative, updArgs),
@@ -109,7 +119,7 @@ describe("kitWrites.updateNative", () => {
 
 describe("kitWrites.updateNotesNative", () => {
   test("patches notes + audit; clears on null", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t);
     await t.withIdentity(SERVICE).mutation(api.kitWrites.updateNotesNative, { id: "k1", orgId: ORG, notes: "spare fuse inside", actor: ACTOR, auditId: "log1", now: NOW });
     await t.run(async (ctx) => {
@@ -127,7 +137,7 @@ describe("kitWrites.updateNotesNative", () => {
 describe("kitWrites.archiveNative / deleteNative", () => {
   const args = { id: "k1", orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW };
   test("owner archives an AVAILABLE kit + releases members + audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, "owner");
     await t.run(async (ctx) => { await ctx.db.insert("kitSerializedItems", { id: "ks1", organizationId: ORG, kitId: "k1", assetId: "a1", addedById: USER }); });
     await t.withIdentity(asUser(ORG)).mutation(api.kitWrites.archiveNative, args);
@@ -142,7 +152,7 @@ describe("kitWrites.archiveNative / deleteNative", () => {
     });
   });
   test("owner deletes an AVAILABLE kit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, "owner");
     await t.withIdentity(asUser(ORG)).mutation(api.kitWrites.deleteNative, args);
     await t.run(async (ctx) => {
@@ -150,12 +160,12 @@ describe("kitWrites.archiveNative / deleteNative", () => {
     });
   });
   test("blocks archive of a non-AVAILABLE kit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
     await expect(t.withIdentity(SERVICE).mutation(api.kitWrites.archiveNative, args)).rejects.toThrow(/AVAILABLE/i);
   });
   test("a manager (no kit:delete) is denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await seedKit(t, "manager");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.kitWrites.deleteNative, args)).rejects.toThrow(/insufficient permissions/i);
   });

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -3,6 +3,7 @@ import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { writeActivityLog } from "./lib/audit";
 import { releaseKitMembers } from "./kits";
 import * as enums from "./lib/validators";
@@ -81,6 +82,8 @@ export const createNative = mutation({
   },
   handler: async (ctx, args) => {
     const { actor: suppliedActor, auditId, ...fields } = args;
+    await assertWritesEnabled(ctx, "kit");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "kit", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -128,6 +131,8 @@ export const updateNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, patch, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "kit");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "kit", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -150,7 +155,7 @@ export const updateNative = mutation({
       }
     }
 
-    await ctx.db.patch(doc._id, patch);
+    await ctx.db.patch(doc._id, sanitizeClientSet(patch)); // strip organizationId/id — no cross-tenant reassign
 
     const finalTag = patch.assetTag ?? doc.assetTag;
     await writeActivityLog(ctx, {
@@ -220,6 +225,8 @@ export const updateNotesNative = mutation({
 export const archiveNative = mutation({
   args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
   handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "kit");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "kit", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
@@ -239,6 +246,8 @@ export const archiveNative = mutation({
 export const deleteNative = mutation({
   args: { id: v.string(), orgId: v.string(), actor: actorValidator, auditId: v.string(), now: v.number() },
   handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "kit");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "kit", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();

--- a/convex/lib/sanitizeSet.ts
+++ b/convex/lib/sanitizeSet.ts
@@ -1,0 +1,23 @@
+/**
+ * Strip the keys a client must NEVER be able to change on a doc via a `set: v.any()`
+ * (or `patch: v.any()`) browser-direct patch/replace — the tenant anchor
+ * (`organizationId`) and the immutable cuid (`id`), plus any per-entity immutable
+ * fields (e.g. a line item's `projectId`).
+ *
+ * Without this, a `set: v.any()` on a user-callable `*Writes` mutation lets a member
+ * of org A reassign a row into org B (`set:{organizationId:"B"}`) — the up-front
+ * `doc.organizationId === orgId` re-check passes (the doc is still in A) and then the
+ * raw patch overwrites the field. Phase-3 security baseline: strict field validation
+ * so clients can't smuggle data. Use this at every raw-apply site that has no explicit
+ * field validator.
+ */
+export function sanitizeClientSet(
+  set: unknown,
+  extraImmutable: readonly string[] = [],
+): Record<string, unknown> {
+  const out = { ...(set as Record<string, unknown> | null | undefined) } as Record<string, unknown>;
+  delete out.organizationId;
+  delete out.id;
+  for (const k of extraImmutable) delete out[k];
+  return out;
+}

--- a/convex/lib/writeGuard.test.ts
+++ b/convex/lib/writeGuard.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect } from "vitest";
 import { ConvexError } from "convex/values";
 import { assertWritesEnabled } from "./writeGuard";
 
-// Minimal MutationCtx stub — assertWritesEnabled only touches ctx.db.query(...).first().
+// Minimal MutationCtx stub — assertWritesEnabled touches ctx.auth.getUserIdentity()
+// (service bypass) then ctx.db.query(...).first() (the flag). `identity` defaults to
+// null (anonymous/user path → gated by the flag).
 type Flag = {
   writesDisabled?: boolean;
   disabledReason?: string;
   disabledDomains?: string[];
 } | null;
+const SERVICE = { subject: "gearflow-service", svc: true };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ctxWith = (flag: Flag): any => ({
+const ctxWith = (flag: Flag, identity: any = null): any => ({
+  auth: { getUserIdentity: async () => identity },
   db: { query: () => ({ first: async () => flag }) },
 });
 
@@ -39,5 +43,16 @@ describe("assertWritesEnabled", () => {
   it("global switch beats domain scoping (kills everything)", async () => {
     const flag = { writesDisabled: true, disabledDomains: ["asset"] };
     await expect(assertWritesEnabled(ctxWith(flag), "dashboard")).rejects.toThrow(/temporarily disabled/);
+  });
+
+  it("SERVICE token bypasses the kill-switch (server-routed writes are not gated)", async () => {
+    // Even with the global switch on, a service-token (trusted backend) write proceeds.
+    await expect(
+      assertWritesEnabled(ctxWith({ writesDisabled: true, disabledReason: "incident" }, SERVICE)),
+    ).resolves.toBeUndefined();
+    // And a disabled domain doesn't stop the service path either.
+    await expect(
+      assertWritesEnabled(ctxWith({ writesDisabled: false, disabledDomains: ["asset"] }, SERVICE), "asset"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/convex/lib/writeGuard.ts
+++ b/convex/lib/writeGuard.ts
@@ -1,5 +1,6 @@
 import { ConvexError } from "convex/values";
 import type { MutationCtx } from "../_generated/server";
+import { getAuthContext } from "./auth";
 
 /**
  * Emergency brake for the browser-direct mutation surface (Phase 3 kill-switch).
@@ -7,15 +8,21 @@ import type { MutationCtx } from "../_generated/server";
  * Every browser-direct (public) mutation must call this FIRST. When the
  * `systemFlags` singleton has `writesDisabled` (or lists the mutation's `domain`
  * in `disabledDomains`), it throws — so an abusive/runaway client can be cut off
- * INSTANTLY via `systemFlags.setWrites`, with no redeploy. Server-routed
- * (service-token) writes are the trusted backend and are NOT gated here; they have
- * their own env-flag controls.
+ * INSTANTLY via `systemFlags.setWrites`, with no redeploy.
+ *
+ * Server-routed (SERVICE-token) writes are the trusted backend and are NOT gated —
+ * the kill-switch targets the BROWSER-DIRECT (user-token) surface only, so flipping
+ * it cuts off an abusive client without taking down the server-mediated write path.
+ * (This matters now that the guard is applied to mutations reachable by BOTH a user
+ * token and the service token.)
  *
  * The read is one indexed-free `first()` on a single-row table (negligible), and
  * it joins the mutation's transaction read-set — so flipping the flag deterministically
  * takes effect on the next write.
  */
 export async function assertWritesEnabled(ctx: MutationCtx, domain?: string): Promise<void> {
+  const auth = await getAuthContext(ctx);
+  if (auth?.kind === "service") return; // trusted backend — not gated by the browser kill-switch
   const flags = await ctx.db.query("systemFlags").first();
   if (!flags) return; // no row → writes enabled (default)
   if (flags.writesDisabled) {

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -3,8 +3,19 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
 import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 
 const modules = import.meta.glob("./**/*.ts");
+// Mount both components: the rate limiter (enforceBrowserWriteLimit on line-item
+// mutations) and the sharded counter (mounted for safety — other convex modules in
+// the same test glob need it).
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
 const ORG = "org_1";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
@@ -19,7 +30,7 @@ async function member(t: ReturnType<typeof convexTest>, role: string) {
 
 describe("lineItemWrites.removeNative", () => {
   test("member removes a leaf line + its units + DELETE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
@@ -39,7 +50,7 @@ describe("lineItemWrites.removeNative", () => {
   });
 
   test("cascade-removes children (+ their units)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Kit", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
       await ctx.db.insert("projectLineItems", { id: "child1", organizationId: ORG, projectId: "p1", parentLineItemId: "li1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "KIT" });
@@ -55,7 +66,7 @@ describe("lineItemWrites.removeNative", () => {
   });
 
   test("blocks removing a kit child directly (KIT_CHILD)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "KIT" });
     });
@@ -63,7 +74,7 @@ describe("lineItemWrites.removeNative", () => {
   });
 
   test("blocks removing an accessory child directly (ACCESSORY_CHILD)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: true, childKind: "ACCESSORY" });
     });
@@ -71,7 +82,7 @@ describe("lineItemWrites.removeNative", () => {
   });
 
   test("a viewer is denied (project:manage_line_items)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
@@ -83,7 +94,7 @@ describe("lineItemWrites.removeNative", () => {
 describe("lineItemWrites.patchNative", () => {
   const pargs = { id: "li1", orgId: ORG, orgDefaultTaxRate: null, entityName: "Light", actor: ACTOR, auditId: "log1", now: NOW };
   test("member patches fields + UPDATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", quantity: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
@@ -99,7 +110,7 @@ describe("lineItemWrites.patchNative", () => {
     });
   });
   test("clear removes a field", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", notes: "x", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
     });
@@ -110,7 +121,7 @@ describe("lineItemWrites.patchNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
@@ -120,7 +131,7 @@ describe("lineItemWrites.patchNative", () => {
 describe("lineItemWrites.addCustomNative", () => {
   const cargs = { id: "cust1", organizationId: ORG, projectId: "p1", fields: { description: "Rigging labour", quantity: 1, unitPrice: 200 }, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
   test("member adds a custom line (sortOrder computed) + CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "existing", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 4 });
@@ -136,7 +147,7 @@ describe("lineItemWrites.addCustomNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, cargs)).rejects.toThrow(/insufficient permissions/i);
   });
@@ -145,7 +156,7 @@ describe("lineItemWrites.addCustomNative", () => {
 describe("lineItemWrites.addNative", () => {
   const aargs = { id: "new1", organizationId: ORG, projectId: "p1", fields: { type: "EQUIPMENT" as const, description: "PAR Can", quantity: 2, unitPrice: 15 }, includeAccessories: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
   test("member adds an inventory line (sortOrder in-mutation) + CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "e", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 2 });
@@ -162,7 +173,7 @@ describe("lineItemWrites.addNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs)).rejects.toThrow(/insufficient permissions/i);
   });
@@ -171,7 +182,7 @@ describe("lineItemWrites.addNative", () => {
 describe("lineItemWrites.addKitNative", () => {
   const kargs = { id: "kl1", organizationId: ORG, projectId: "p1", kitId: "k1", pricingMode: "KIT_PRICE" as const, unitPrice: 500, kitLabel: "KIT-1 - Lighting", orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
   test("member adds a kit (parent + member child lines) + CREATE audit", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
@@ -193,7 +204,7 @@ describe("lineItemWrites.addKitNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs)).rejects.toThrow(/insufficient permissions/i);
@@ -202,7 +213,7 @@ describe("lineItemWrites.addKitNative", () => {
 
 describe("lineItemWrites.reorderNative", () => {
   test("member reorders lines (sortOrder/groupName) + org-scoped", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 0 });
@@ -221,7 +232,7 @@ describe("lineItemWrites.reorderNative", () => {
     });
   });
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, { orgId: ORG, items: [], now: NOW })).rejects.toThrow(/insufficient permissions/i);
   });
@@ -229,7 +240,7 @@ describe("lineItemWrites.reorderNative", () => {
 
 describe("lineItemWrites.recalcNative", () => {
   test("member recomputes + persists project totals (one round-trip)", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "member");
     await t.run(async (ctx) => {
       await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, taxRate: 10, discountPercent: 0, createdAt: NOW, updatedAt: NOW });
@@ -244,7 +255,7 @@ describe("lineItemWrites.recalcNative", () => {
   });
 
   test("viewer denied", async () => {
-    const t = convexTest(schema, modules);
+    const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.recalcNative, { projectId: "p1", orgId: ORG, orgDefaultTaxRate: null, now: NOW })).rejects.toThrow(/insufficient permissions/i);
   });

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -3,6 +3,9 @@ import { mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
@@ -48,6 +51,8 @@ export const removeNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -116,6 +121,8 @@ export const patchNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, orgDefaultTaxRate, set, clear, entityName, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -123,11 +130,12 @@ export const patchNative = mutation({
     if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
+    const setObj = sanitizeClientSet(set, ["projectId"]); // strip organizationId/id/projectId
     if (clear.length === 0) {
-      await ctx.db.patch(doc._id, set as Record<string, unknown>);
+      await ctx.db.patch(doc._id, setObj);
     } else {
       const { _id, _creationTime, ...rest } = doc;
-      const merged: Record<string, unknown> = { ...rest, ...(set as Record<string, unknown>) };
+      const merged: Record<string, unknown> = { ...rest, ...setObj };
       for (const k of clear) {
         if (LINE_NEVER_CLEAR.has(k)) continue;
         delete merged[k];
@@ -197,6 +205,8 @@ export const addCustomNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, organizationId, projectId, fields, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -275,6 +285,8 @@ export const addNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -349,6 +361,8 @@ export const addKitNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, kitLabel, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -388,6 +402,8 @@ export const reorderNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { orgId, items, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     for (const it of items) {
       const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).first();
@@ -421,6 +437,8 @@ export const recalcNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { projectId, orgId, orgDefaultTaxRate, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     await recalcProjectTotals(ctx, projectId, orgId, orgDefaultTaxRate, now);
     return { ok: true as const };

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -5,6 +5,7 @@ import type { MutationCtx } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import { ensureBulkUnit, ensureSerialisedUnit, expandAccessoryChildLines, syncLineItemRollup } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
 import * as enums from "./lib/validators";
 
 /**
@@ -665,7 +666,7 @@ export const patchMany = mutation({
     for (const it of items) {
       const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
       if (!doc || doc.organizationId !== orgId) { skipped++; continue; }
-      const set = it.set as Record<string, unknown>;
+      const set = sanitizeClientSet(it.set, ["projectId"]); // strip organizationId/id/projectId
       if (it.clear.length === 0) {
         await ctx.db.patch(doc._id, set);
       } else {

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -159,6 +159,7 @@ export const updateMany = mutation({
       if (!doc || doc.organizationId !== orgId) { skipped++; continue; }
       const applied: Record<string, unknown> = { ...p, updatedAt: now };
       delete applied.organizationId;
+      delete applied.id;
       if (p.status !== undefined && p.status !== doc.status) {
         applied.completedAt = p.status === "DONE" ? now : null;
       }

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
 import { describe, test, expect } from "vitest";
 import schema from "./schema";
@@ -7,8 +8,10 @@ import { api } from "./_generated/api";
 
 const modules = import.meta.glob("./**/*.ts");
 // Counted project writes go through the sharded counter component (gate #3); mount it.
+// enforceBrowserWriteLimit goes through the rate-limiter component; mount it too.
 function makeT() {
   const tc = convexTest(schema, modules);
+  registerRateLimiter(tc, "rateLimiter");
   registerShardedCounter(tc, "shardedCounter");
   return tc;
 }

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -1,6 +1,9 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { writeActivityLog } from "./lib/audit";
 import { bumpProjectCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -34,6 +37,8 @@ export const updateStatusNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, status, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -78,6 +83,8 @@ export const updateNotesNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, field, notes, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -115,6 +122,8 @@ export const archiveNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -163,6 +172,8 @@ export const updateNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, set, clear, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -170,7 +181,7 @@ export const updateNative = mutation({
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
-    const setObj = (set ?? {}) as Record<string, unknown>;
+    const setObj = sanitizeClientSet(set); // strip organizationId/id — no cross-tenant reassign
     if (clear.length === 0) {
       await ctx.db.patch(project._id, setObj);
       await bumpProjectCounters(ctx, orgId, project, { ...project, ...setObj });
@@ -223,6 +234,8 @@ export const createNative = mutation({
   },
   handler: async (ctx, args) => {
     const { actor: suppliedActor, auditId, ...fields } = args;
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "project", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -273,6 +286,8 @@ export const deleteNative = mutation({
     now: v.number(),
   },
   handler: async (ctx, { id, orgId, freedAssets, freedKits, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();

--- a/convex/sanitizeSet.test.ts
+++ b/convex/sanitizeSet.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+//
+// H1 security fix: a user-callable `set: v.any()` (or `patch` that includes
+// organizationId) must NOT let a caller reassign a row into another org. sanitizeSet
+// strips organizationId/id; the mutation applies the sanitized set.
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+
+describe("sanitizeClientSet (unit)", () => {
+  test("strips organizationId + id + extras, keeps other fields", () => {
+    expect(sanitizeClientSet({ organizationId: "B", id: "x", projectId: "p", name: "ok" }, ["projectId"]))
+      .toEqual({ name: "ok" });
+    expect(sanitizeClientSet(null)).toEqual({});
+    expect(sanitizeClientSet({ notes: "n" })).toEqual({ notes: "n" });
+  });
+});
+
+describe("projectWrites.updateNative — no cross-tenant reassign via set:v.any (H1)", () => {
+  test("set:{organizationId:'org_other'} does NOT move the project; other fields still apply", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Old", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "owner" });
+    });
+
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, {
+      id: "p1",
+      orgId: ORG,
+      set: { organizationId: OTHER, id: "hacked", name: "New" }, // hostile fields
+      clear: [],
+      actor: { userId: USER, userName: "U" },
+      auditId: "a1",
+      now: NOW,
+    });
+
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).unique());
+    expect(p?.organizationId).toBe(ORG); // NOT reassigned to org_other
+    expect(p?.id).toBe("p1"); // id not rewritten
+    expect(p?.name).toBe("New"); // legitimate field still applied
+  });
+});


### PR DESCRIPTION
Fixes the Phase-3 review's **H1 (HIGH cross-tenant write)** + **M2 (kill-switch/rate-limiter coverage)** across the whole `*Writes` surface, plus a latent kill-switch bug codex found.

## H1 — cross-tenant / arbitrary-field write via `set: v.any()`
A user-callable `updateNative`/`patchNative` applied a client `set` raw, so a member of org A could reassign a row into org B (`set:{organizationId:"B"}`) — the org re-check passes (doc still in A) then the raw patch overwrites the anchor. Also bypasses the server-side pricing/availability guards.
- New `convex/lib/sanitizeSet.ts` strips `organizationId`/`id` (+ per-entity immutable keys like `projectId`) from any client set/patch.
- Wired into `projectWrites.updateNative`, `lineItemWrites.patchNative`, `crewWrites.updateNative`, `kitWrites.updateNative` (its `kitPatch` validator included `organizationId`), + service-gated `projectLineItems.patchMany` / `projectTasks.updateMany`.

## M2 — kill-switch + rate-limiter coverage
Added `assertWritesEnabled` + `enforceBrowserWriteLimit` to **all 26** user-callable `*Writes` mutations (was 3), so the emergency brake + per-user budget cover the whole browser-direct surface.

## Kill-switch service bypass (codex, HIGH)
`assertWritesEnabled` now bypasses SERVICE tokens — its docstring always said server-routed writes aren't gated but the code never checked. Latent until M2 applied it broadly; without the fix, flipping the kill-switch would take down the server-mediated write path too.

### Verification
New `sanitizeSet.test.ts` (unit + a mutation-level proof `set:{organizationId:'other'}` does NOT reassign), `writeGuard.test.ts` +service-bypass, 4 `*Writes` test files mount the components. Full convex suite **green (322)**; tsc clean; **codex CLEAN**. Deployed to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)