### PR TITLE
feat(convex): bulk single-call for services-crew + T&T (review M1)

### DIFF
--- a/convex/testTagAssets.ts
+++ b/convex/testTagAssets.ts
@@ -181,6 +181,82 @@ export const createIfMissing = mutation({
   },
 });
 
+/**
+ * Create N test tag assets in ONE array mutation (bulk single-call invariant,
+ * Phase 3) — replaces the server firing one `createIfMissing` round-trip per
+ * reserved tag id when batch-creating from a bulk asset. `organizationId` is
+ * stamped from the ARG onto every row (a caller can't smuggle a per-row org),
+ * and each row is inserted only if its id is new (idempotent on retry).
+ * Returns how many were created.
+ */
+export const createManyIfMissing = mutation({
+  args: {
+    organizationId: v.string(),
+    rows: v.array(
+      v.object({
+        id: v.string(),
+        testTagId: v.string(),
+        description: v.string(),
+        equipmentClass: v.optional(enums.EquipmentClass),
+        applianceType: v.optional(enums.ApplianceType),
+        make: v.optional(v.string()),
+        modelName: v.optional(v.string()),
+        serialNumber: v.optional(v.string()),
+        location: v.optional(v.string()),
+        testIntervalMonths: v.optional(v.number()),
+        status: v.optional(enums.TestTagStatus),
+        lastTestDate: v.optional(v.number()),
+        nextDueDate: v.optional(v.number()),
+        notes: v.optional(v.string()),
+        assetId: v.optional(v.string()),
+        bulkAssetId: v.optional(v.string()),
+        testProfileId: v.optional(v.string()),
+        outletCount: v.optional(v.number()),
+        isActive: v.optional(v.boolean()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (ctx, { organizationId, rows }) => {
+    await requireService(ctx);
+    let created = 0;
+    for (const r of rows) {
+      const existing = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", r.id)).unique();
+      if (existing) continue;
+      await ctx.db.insert("testTagAssets", { ...r, organizationId });
+      created++;
+    }
+    return { created };
+  },
+});
+
+/**
+ * Retire N test tag assets in ONE array mutation (bulk single-call invariant,
+ * Phase 3) — replaces the server firing one `update` round-trip per orphaned /
+ * dangling id in the backfill sweep. Each id is fetched via the GLOBAL by_cuid
+ * index and re-checked against the arg `organizationId` (skip on missing OR
+ * cross-tenant), then patched to RETIRED/inactive. Returns how many were retired.
+ */
+export const retireMany = mutation({
+  args: {
+    organizationId: v.string(),
+    ids: v.array(v.string()),
+    now: v.number(),
+  },
+  handler: async (ctx, { organizationId, ids, now }) => {
+    await requireService(ctx);
+    let retired = 0;
+    for (const id of ids) {
+      const doc = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (!doc || doc.organizationId !== organizationId) continue;
+      await ctx.db.patch(doc._id, { status: "RETIRED", isActive: false, updatedAt: now });
+      retired++;
+    }
+    return { retired };
+  },
+});
+
 export const update = mutation({
   args: {
     id: v.string(),

--- a/convex/testTagBatch.test.ts
+++ b/convex/testTagBatch.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+//
+// testTagAssets.createManyIfMissing + testTagAssets.retireMany — the Phase 3 bulk
+// single-call invariants for Test & Tag (Appendix A*):
+//  - createManyIfMissing: N reserved-tag assets created in ONE array mutation (was one
+//    createIfMissing round-trip per id). organizationId is stamped from the arg (no
+//    per-row cross-tenant smuggling); dedups by id.
+//  - retireMany: N orphaned/dangling assets retired in ONE array mutation (was one
+//    update round-trip per id) with a per-item organizationId re-check on the GLOBAL
+//    by_cuid index (cross-org rows skipped).
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const rowById = (t: T, id: string) =>
+  t.run(async (ctx) => (await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique()));
+
+describe("testTagAssets.createManyIfMissing — bulk single-call", () => {
+  test("creates new assets, skips an existing id, stamps organizationId from the arg", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("testTagAssets", {
+        id: "tt-existing", organizationId: ORG, testTagId: "TT-000", description: "seed",
+        status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW,
+      });
+    });
+
+    const { created } = await t.withIdentity(SERVICE).mutation(api.testTagAssets.createManyIfMissing, {
+      organizationId: ORG,
+      rows: [
+        { id: "tt-existing", testTagId: "TT-000", description: "dupe", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW }, // already there → skip
+        { id: "tt1", testTagId: "TT-001", description: "Drill", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", testIntervalMonths: 3, bulkAssetId: "bulk1", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW },
+        { id: "tt2", testTagId: "TT-002", description: "Lead", equipmentClass: "LEAD_CORD_ASSEMBLY", applianceType: "EXTENSION_LEAD", testIntervalMonths: 3, bulkAssetId: "bulk1", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    expect(created).toBe(2);
+    const tt1 = await rowById(t, "tt1");
+    expect(tt1?.organizationId).toBe(ORG); // stamped from the arg
+    expect(tt1?.testTagId).toBe("TT-001");
+    expect(tt1?.bulkAssetId).toBe("bulk1");
+    expect((await rowById(t, "tt2"))?.equipmentClass).toBe("LEAD_CORD_ASSEMBLY");
+
+    // Exactly one row for the pre-existing id (no duplicate insert).
+    const dupes = await t.run(async (ctx) =>
+      (await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", "tt-existing")).collect()).length,
+    );
+    expect(dupes).toBe(1);
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.testTagAssets.createManyIfMissing, {
+        organizationId: ORG,
+        rows: [{ id: "x", testTagId: "TT-X", description: "no", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW }],
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});
+
+async function seedForRetire(t: T) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("testTagAssets", { id: "r1", organizationId: ORG, testTagId: "TT-R1", description: "orphan", status: "NOT_YET_TESTED", isActive: true, createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("testTagAssets", { id: "r2", organizationId: ORG, testTagId: "TT-R2", description: "dangling", status: "CURRENT", isActive: true, createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("testTagAssets", { id: "rx", organizationId: OTHER, testTagId: "TT-RX", description: "other org", status: "CURRENT", isActive: true, createdAt: NOW, updatedAt: NOW });
+  });
+}
+
+describe("testTagAssets.retireMany — bulk single-call + per-item org re-check", () => {
+  test("retires in-org assets, skips cross-org, skips missing", async () => {
+    const t = makeT();
+    await seedForRetire(t);
+
+    const { retired } = await t.withIdentity(SERVICE).mutation(api.testTagAssets.retireMany, {
+      organizationId: ORG,
+      ids: ["r1", "r2", "rx", "does-not-exist"],
+      now: NOW + 1,
+    });
+
+    expect(retired).toBe(2);
+    const r1 = await rowById(t, "r1");
+    expect(r1?.status).toBe("RETIRED");
+    expect(r1?.isActive).toBe(false);
+    expect(r1?.updatedAt).toBe(NOW + 1);
+    expect((await rowById(t, "r2"))?.status).toBe("RETIRED");
+    // cross-org row untouched (per-item org re-check on a GLOBAL by_cuid).
+    const rx = await rowById(t, "rx");
+    expect(rx?.status).toBe("CURRENT");
+    expect(rx?.isActive).toBe(true);
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await seedForRetire(t);
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.testTagAssets.retireMany, {
+        organizationId: ORG,
+        ids: ["r1"],
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -606,10 +606,20 @@ export async function updateServiceCrewStatus(
       if (status === "CANCELLED") return !["COMPLETED", "CANCELLED"].includes(a.status);
       return true;
     });
-    for (const a of targets) {
-      await convex.mutation(api.crewAssignments.patchAssignment, { id: a.id, set: { status } });
+    // Bulk single-call: ONE array mutation instead of one patchAssignment per target
+    // (mirrors updateAssignmentStatus' first-transition CONFIRMED stamp per row).
+    if (targets.length > 0) {
+      const { updated } = await convex.mutation(api.crewAssignments.patchManyStatus, {
+        ids: targets.map((a) => a.id),
+        orgId: organizationId,
+        status: status as "PENDING" | "OFFERED" | "ACCEPTED" | "CONFIRMED" | "DECLINED" | "CANCELLED" | "COMPLETED",
+        confirmedById: userId,
+        now: Date.now(),
+      });
+      updatedCount = updated;
+    } else {
+      updatedCount = 0;
     }
-    updatedCount = targets.length;
   }
 
   const statusLabels: Record<string, string> = {

--- a/src/server/test-tag-assets.ts
+++ b/src/server/test-tag-assets.ts
@@ -311,28 +311,24 @@ export async function createTestTagAssetsFromBulk(data: {
   const convex = await getConvexClient();
   const now = Date.now();
 
-  const createdIds: string[] = [];
-  for (const testTagId of ids) {
-    const id = createId();
-    await convex.mutation(api.testTagAssets.createIfMissing, {
-      id,
-      organizationId,
-      testTagId,
-      description: data.description,
-      equipmentClass: (data.equipmentClass as "CLASS_I" | "CLASS_II" | "CLASS_II_DOUBLE_INSULATED" | "LEAD_CORD_ASSEMBLY") || "CLASS_I",
-      applianceType: (data.applianceType as "APPLIANCE" | "CORD_SET" | "EXTENSION_LEAD" | "POWER_BOARD" | "RCD_PORTABLE" | "RCD_FIXED" | "THREE_PHASE" | "OTHER") || "APPLIANCE",
-      ...(data.make && { make: data.make }),
-      ...(data.modelName && { modelName: data.modelName }),
-      ...(data.location && { location: data.location }),
-      testIntervalMonths: data.testIntervalMonths || 3,
-      bulkAssetId: data.bulkAssetId,
-      status: "NOT_YET_TESTED",
-      isActive: true,
-      createdAt: now,
-      updatedAt: now,
-    });
-    createdIds.push(id);
-  }
+  const rows = ids.map((testTagId) => ({
+    id: createId(),
+    testTagId,
+    description: data.description,
+    equipmentClass: (data.equipmentClass as "CLASS_I" | "CLASS_II" | "CLASS_II_DOUBLE_INSULATED" | "LEAD_CORD_ASSEMBLY") || "CLASS_I",
+    applianceType: (data.applianceType as "APPLIANCE" | "CORD_SET" | "EXTENSION_LEAD" | "POWER_BOARD" | "RCD_PORTABLE" | "RCD_FIXED" | "THREE_PHASE" | "OTHER") || "APPLIANCE",
+    ...(data.make && { make: data.make }),
+    ...(data.modelName && { modelName: data.modelName }),
+    ...(data.location && { location: data.location }),
+    testIntervalMonths: data.testIntervalMonths || 3,
+    bulkAssetId: data.bulkAssetId,
+    status: "NOT_YET_TESTED" as const,
+    isActive: true,
+    createdAt: now,
+    updatedAt: now,
+  }));
+  await convex.mutation(api.testTagAssets.createManyIfMissing, { organizationId, rows });
+  const createdIds = rows.map((r) => r.id);
 
   await logActivity({
     organizationId,
@@ -555,15 +551,12 @@ export async function backfillTestTagAssets() {
   );
 
   const retireIds = [...new Set([...orphaned.map((o) => o.id), ...dangling.map((d) => d.id)])];
-  let retired = 0;
   const now = Date.now();
-  for (const retireId of retireIds) {
-    await convex.mutation(api.testTagAssets.update, {
-      id: retireId,
-      patch: { status: "RETIRED", isActive: false, updatedAt: now },
-    });
-    retired++;
-  }
+  const { retired } = await convex.mutation(api.testTagAssets.retireMany, {
+    organizationId,
+    ids: retireIds,
+    now,
+  });
 
   if (unlinkedAssets.length === 0) return { created: 0, retired };
 


### PR DESCRIPTION
Phase-3 bulk single-call invariant (Appendix A*) — three server-side per-item Convex loops → single array mutations:
- **services confirm/cancel-all crew**: per-target `patchAssignment` loop → one `crewAssignments.patchManyStatus` (already existed).
- **T&T batch-create + bulk-retire**: new `testTagAssets.createManyIfMissing` (org from arg, dedup by id) + `retireMany` (per-item org re-check).

Tests: `testTagBatch.test.ts`. Full suite green (326); tsc clean; **codex CLEAN**. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)