### PR TITLE
feat(warehouse,convex): bulk single-call for 3 warehouse-page fan-outs (review M1)

### DIFF
--- a/convex/checkRecordOps.ts
+++ b/convex/checkRecordOps.ts
@@ -254,6 +254,35 @@ export const prepKitChildren = mutation({
   },
 });
 
+/**
+ * Batch kit prep (bulk single-call invariant, Phase 3): prep N kit trees in ONE
+ * array mutation instead of the client firing one `prepKitChildren` per kit.
+ * Per-item org+project re-check via the parent's `by_cuid` fetch (a GLOBAL index,
+ * so a kit not on this org's project is SKIPPED with a per-item error before any
+ * of its writes — {succeeded, errors}, mirroring undeployKitsBatch). Each eligible
+ * parent runs the identical `setKitTreePrep(... "PREP")` the singular does. Like any
+ * Convex mutation this is ONE transaction; setKitTreePrep only flips prep state
+ * (no inventory consumption) so a valid kit's core can't fail on a resource guard.
+ */
+export const prepKitsBatch = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), parentLineItemIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const succeeded: string[] = [];
+    const errors: { lineItemId: string; message: string }[] = [];
+    for (const parentLineItemId of a.parentLineItemIds) {
+      const parent = await lineByCuid(ctx, parentLineItemId);
+      if (!parent || parent.projectId !== a.projectId || parent.organizationId !== a.organizationId) {
+        errors.push({ lineItemId: parentLineItemId, message: "Kit line item not found" });
+        continue;
+      }
+      await setKitTreePrep(ctx, parentLineItemId, a.organizationId, a.now, "PREP");
+      succeeded.push(parentLineItemId);
+    }
+    return { succeeded, errors };
+  },
+});
+
 export const deprepKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), parentLineItemId: v.string(), now: v.number() },
   handler: async (ctx, a) => {

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -1323,6 +1323,49 @@ export const syncContainerStatus = mutation({
   },
 });
 
+/**
+ * Batch container roll-up (bulk single-call invariant, Phase 3): sync N containers
+ * in ONE array mutation instead of the client firing one `syncContainerStatus` per
+ * container after a bulk checkout/checkin. The project's lines are read ONCE and
+ * bucketed by `prepContainer` (the singular re-scanned by_projectId every call);
+ * every line carries exactly one prepContainer, so the buckets are disjoint and a
+ * prior container's patch can't stale another's snapshot — identical to N singular
+ * calls. Each container runs the singular's rollup logic (flip the container line +
+ * its asset when all contents are uniformly deployed/returned). Org scoping is
+ * inherent (by_projectId scan filtered to organizationId).
+ */
+export const syncContainersBatch = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), containerNames: v.array(v.string()), userId: v.string(), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    const allLines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
+      .filter((l) => l.organizationId === a.organizationId);
+    const results: Array<{ containerName: string; updated: boolean; status?: string }> = [];
+    for (const containerName of a.containerNames) {
+      const lines = allLines.filter((l) => l.prepContainer === containerName);
+      const containerLI = lines.find((l) => l.isContainerLineItem);
+      if (!containerLI) { results.push({ containerName, updated: false }); continue; }
+      const contents = lines.filter((l) => !l.isContainerLineItem);
+      if (contents.length === 0) { results.push({ containerName, updated: false }); continue; }
+      const allDeployed = contents.every((i) => i.status === "CHECKED_OUT");
+      const allReturned = contents.every((i) => i.status === "RETURNED");
+      const allDeployedFlag = allDeployed && containerLI.status !== "CHECKED_OUT";
+      const allReturnedFlag = allReturned && containerLI.status !== "RETURNED";
+      if (!allDeployedFlag && !allReturnedFlag) { results.push({ containerName, updated: false }); continue; }
+      if (allDeployedFlag) {
+        await ctx.db.patch(containerLI._id, { status: "CHECKED_OUT", checkedOutQuantity: containerLI.quantity ?? 1, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
+      } else {
+        await ctx.db.patch(containerLI._id, { status: "RETURNED", returnedQuantity: 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD", updatedAt: a.now });
+      }
+      if (containerLI.assetId) {
+        await setAssetsStatus(ctx, [containerLI.assetId], allDeployedFlag ? "CHECKED_OUT" : "AVAILABLE", null, false, a.now);
+      }
+      results.push({ containerName, updated: true, status: allDeployedFlag ? "CHECKED_OUT" : "RETURNED" });
+    }
+    return { results };
+  },
+});
+
 // ── Bulk check-in (Group G) ───────────────────────────────────────────────────
 
 export const checkInBulkTotals = mutation({

--- a/convex/warehousePageBatch.test.ts
+++ b/convex/warehousePageBatch.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+//
+// Warehouse-page bulk single-call invariant (Phase 3): the two array mutations that
+// collapse warehouse-page client fan-outs into one call —
+//  - checkRecordOps.prepKitsBatch  (was one prepKitChildren per kit)
+//  - warehouseOps.syncContainersBatch (was one syncContainerStatus per container)
+// Small hand-seeded fixtures isolate the batch dispatch / per-item validation /
+// partial-success (the full kit-tree + container semantics are covered elsewhere).
+import { convexTest } from "convex-test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+type T = ReturnType<typeof makeT>;
+
+const baseLine = (id: string, extra: Record<string, unknown>) => ({
+  id,
+  organizationId: ORG,
+  projectId: "p1",
+  type: "EQUIPMENT" as const,
+  quantity: 1,
+  sortOrder: 0,
+  status: "CONFIRMED" as const,
+  checkedOutQuantity: 0,
+  prepStatus: "PENDING" as const,
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...extra,
+});
+
+const lineById = (t: T, id: string) =>
+  t.run(async (ctx) => (await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique()));
+
+// ── prepKitsBatch ─────────────────────────────────────────────────────────────
+
+describe("checkRecordOps.prepKitsBatch — bulk single-call + partial-success", () => {
+  async function seedKits(t: T) {
+    await t.run(async (ctx) => {
+      // Kit 1: parent kl1 + child c1 (both PENDING).
+      await ctx.db.insert("projectLineItems", baseLine("kl1", { kitId: "k1", isKitChild: false }));
+      await ctx.db.insert("projectLineItems", baseLine("c1", { parentLineItemId: "kl1", isKitChild: true }));
+      // Kit 2: parent kl2 + child c2.
+      await ctx.db.insert("projectLineItems", baseLine("kl2", { kitId: "k2", isKitChild: false }));
+      await ctx.db.insert("projectLineItems", baseLine("c2", { parentLineItemId: "kl2", isKitChild: true }));
+      // Cross-project parent (same org, different project) — must be skipped.
+      await ctx.db.insert("projectLineItems", { ...baseLine("klX", { kitId: "kx", isKitChild: false }), projectId: "p2" });
+    });
+  }
+
+  test("preps every eligible kit tree; skips cross-project / missing with per-item errors", async () => {
+    const t = makeT();
+    await seedKits(t);
+
+    const res = await t.withIdentity(SERVICE).mutation(api.checkRecordOps.prepKitsBatch, {
+      organizationId: ORG,
+      projectId: "p1",
+      parentLineItemIds: ["kl1", "kl2", "klX", "ghost"],
+      now: NOW,
+    });
+
+    expect([...res.succeeded].sort()).toEqual(["kl1", "kl2"]);
+    expect(res.errors.map((e) => e.lineItemId).sort()).toEqual(["ghost", "klX"]);
+
+    // Both eligible kit trees (parents + children) flipped to CONFIRMED / PACKED.
+    for (const id of ["kl1", "c1", "kl2", "c2"]) {
+      const line = await lineById(t, id);
+      expect(line?.status).toBe("CONFIRMED");
+      expect(line?.prepStatus).toBe("PACKED");
+    }
+    // The cross-project kit is untouched.
+    expect((await lineById(t, "klX"))?.prepStatus).toBe("PENDING");
+  });
+
+  test("a cross-org parent id can't be prepped through another org's batch", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { ...baseLine("klO", { kitId: "ko", isKitChild: false }), organizationId: OTHER });
+    });
+
+    const res = await t.withIdentity(SERVICE).mutation(api.checkRecordOps.prepKitsBatch, {
+      organizationId: ORG,
+      projectId: "p1",
+      parentLineItemIds: ["klO"],
+      now: NOW,
+    });
+
+    expect(res.succeeded).toEqual([]);
+    expect(res.errors).toEqual([{ lineItemId: "klO", message: "Kit line item not found" }]);
+    expect((await lineById(t, "klO"))?.prepStatus).toBe("PENDING");
+  });
+
+  test("a non-service (user) token cannot call the batch", async () => {
+    const t = makeT();
+    await seedKits(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: ORG }).mutation(api.checkRecordOps.prepKitsBatch, {
+        organizationId: ORG,
+        projectId: "p1",
+        parentLineItemIds: ["kl1"],
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});
+
+// ── syncContainersBatch ────────────────────────────────────────────────────────
+
+describe("warehouseOps.syncContainersBatch — bulk single-call container roll-up", () => {
+  async function seedContainers(t: T) {
+    await t.run(async (ctx) => {
+      // Container C1: container line (CONFIRMED) + all-deployed contents → should flip CHECKED_OUT.
+      await ctx.db.insert("projectLineItems", baseLine("c1li", { prepContainer: "C1", isContainerLineItem: true }));
+      await ctx.db.insert("projectLineItems", baseLine("c1a", { prepContainer: "C1", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", baseLine("c1b", { prepContainer: "C1", status: "CHECKED_OUT" }));
+      // Container C2: container line + all-returned contents → should flip RETURNED.
+      await ctx.db.insert("projectLineItems", baseLine("c2li", { prepContainer: "C2", isContainerLineItem: true, status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", baseLine("c2a", { prepContainer: "C2", status: "RETURNED" }));
+      // Container C3: mixed contents → no change.
+      await ctx.db.insert("projectLineItems", baseLine("c3li", { prepContainer: "C3", isContainerLineItem: true }));
+      await ctx.db.insert("projectLineItems", baseLine("c3a", { prepContainer: "C3", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", baseLine("c3b", { prepContainer: "C3", status: "CONFIRMED" }));
+      // Cross-org line sharing the C1 name — must NOT be swept into this org's rollup.
+      await ctx.db.insert("projectLineItems", { ...baseLine("cxli", { prepContainer: "C1", isContainerLineItem: true, status: "CONFIRMED" }), organizationId: OTHER });
+    });
+  }
+
+  test("rolls up N containers in one call — deployed→CHECKED_OUT, returned→RETURNED, mixed→no-op", async () => {
+    const t = makeT();
+    await seedContainers(t);
+
+    const res = await t.withIdentity(SERVICE).mutation(api.warehouseOps.syncContainersBatch, {
+      organizationId: ORG,
+      projectId: "p1",
+      containerNames: ["C1", "C2", "C3", "Cghost"],
+      userId: USER,
+      now: NOW,
+    });
+
+    const byName = new Map(res.results.map((r) => [r.containerName, r]));
+    expect(byName.get("C1")).toEqual({ containerName: "C1", updated: true, status: "CHECKED_OUT" });
+    expect(byName.get("C2")).toEqual({ containerName: "C2", updated: true, status: "RETURNED" });
+    expect(byName.get("C3")).toEqual({ containerName: "C3", updated: false });
+    expect(byName.get("Cghost")).toEqual({ containerName: "Cghost", updated: false });
+
+    expect((await lineById(t, "c1li"))?.status).toBe("CHECKED_OUT");
+    expect((await lineById(t, "c2li"))?.status).toBe("RETURNED");
+    expect((await lineById(t, "c3li"))?.status).toBe("CONFIRMED");
+    // The other org's identically-named container line is untouched.
+    expect((await lineById(t, "cxli"))?.status).toBe("CONFIRMED");
+  });
+
+  test("a non-service (user) token cannot call the batch", async () => {
+    const t = makeT();
+    await seedContainers(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: ORG }).mutation(api.warehouseOps.syncContainersBatch, {
+        organizationId: ORG,
+        projectId: "p1",
+        containerNames: ["C1"],
+        userId: USER,
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -45,7 +45,7 @@ import {
   quickAddAndCheckOut,
   clearPrepContainer,
   ensureContainerOnProject,
-  syncContainerStatus,
+  syncContainersBatch,
 } from "@/server/warehouse";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -117,6 +117,7 @@ import {
   deprepKit,
   deprepItemsBatch,
   prepKitChildren,
+  prepKitsBatch,
   completeCheckAndPack,
   completeCheckAndFlag,
   unpackItem,
@@ -685,11 +686,12 @@ function WarehouseProjectPage({
   const checkOutMutation = useServerMutation({
     mutationFn: async (params: { items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>; includeAccessories?: boolean }) => {
       const result = await checkOutItems(projectId, params.items, params.includeAccessories);
-      // Sync container status for affected containers
+      // Sync container status for affected containers — ONE batch call (was one
+      // round-trip per container).
       const containers = new Set(
         params.items.map((i) => lineItems.find((l) => l.id === i.lineItemId)?.prepContainer).filter(Boolean) as string[]
       );
-      for (const c of containers) await syncContainerStatus(projectId, c);
+      if (containers.size > 0) await syncContainersBatch(projectId, [...containers]);
       return result;
     },
     onSuccess: invalidate,
@@ -701,11 +703,12 @@ function WarehouseProjectPage({
       items: Array<{ lineItemId: string; assetId?: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING"; quantity?: number; notes?: string }>;
     }) => {
       const result = await checkInItems(projectId, data.items);
-      // Sync container status for affected containers
+      // Sync container status for affected containers — ONE batch call (was one
+      // round-trip per container).
       const containers = new Set(
         data.items.map((i) => lineItems.find((l) => l.id === i.lineItemId)?.prepContainer).filter(Boolean) as string[]
       );
-      for (const c of containers) await syncContainerStatus(projectId, c);
+      if (containers.size > 0) await syncContainersBatch(projectId, [...containers]);
       return result;
     },
     onSuccess: () => {
@@ -1817,7 +1820,11 @@ function WarehouseProjectPage({
         }
       }
 
-      // Prep kits — check verification first, then check flow or direct prep
+      // Prep kits — check verification first, then check flow or direct prep.
+      // Kits that go straight to direct prep (fully verified + no interactive check
+      // flow) are collected and prepped in ONE batch call after the loop, instead
+      // of firing one prepKitChildren round-trip per kit.
+      const directPrepKits: Array<{ id: string; name: string }> = [];
       for (const kitItemId of kitLineItemIds) {
         const li = lineItems.find((l) => l.id === kitItemId);
         if (li?.kitId) {
@@ -1842,14 +1849,24 @@ function WarehouseProjectPage({
           // Fully verified (or no verifiable items) — proceed
           const started = startKitCheckFlow(li.kitId, li, "PREP");
           if (!started) {
-            prepKitChildren(projectId, li.id)
-              .then(() => {
-                toast.success(`Kit prepped: ${li.description || li.kit?.name || "Kit"}`);
-                invalidate();
-              })
-              .catch((e) => showError(e, { fallbackTitle: "Failed to prep kit" }));
+            directPrepKits.push({ id: li.id, name: li.description || li.kit?.name || "Kit" });
           }
         }
+      }
+      if (directPrepKits.length > 0) {
+        prepKitsBatch(projectId, directPrepKits.map((k) => k.id))
+          .then((res) => {
+            const ok = res.succeeded.length;
+            const failed = res.errors.length;
+            if (ok > 0) {
+              toast.success(ok === 1 ? `Kit prepped: ${directPrepKits[0].name}` : `Prepped ${ok} kits`);
+            }
+            if (failed > 0) {
+              toast.error(`${failed} kit${failed === 1 ? "" : "s"} skipped`);
+            }
+            invalidate();
+          })
+          .catch((e) => showError(e, { fallbackTitle: "Failed to prep kit" }));
       }
 
       // Build check queue for bulk items with checks, and prep directly for those without
@@ -2760,11 +2777,10 @@ function WarehouseProjectPage({
                   size="sm"
                   onClick={() => {
                     if (kitConfirm.action === "deploy") {
-                      // Prep verified children
-                      Promise.all(
-                        kitConfirm.verifiedIds.map((id) =>
-                          prepItemDirect(projectId, id)
-                        )
+                      // Prep verified children — ONE batch call (was N round-trips).
+                      prepItemsBatch(
+                        projectId,
+                        kitConfirm.verifiedIds.map((id) => ({ lineItemId: id }))
                       ).then(() => {
                         toast.success(`Prepped ${kitConfirm.verifiedCount} verified items`);
                         invalidate();

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -826,6 +826,92 @@ export async function prepKitChildren(
   return serialize({ success: true });
 }
 
+/**
+ * Bulk single-call kit prep (Phase 3 bulk invariant): prep N kit trees in ONE
+ * server round-trip + ONE atomic Convex mutation (`prepKitsBatch`). Replaces the
+ * warehouse "Prep Selected" loop that fired one `prepKitChildren` round-trip per
+ * kit. The blocking-comment gate mirrors `prepKitChildren`'s per-kit check but
+ * reads the project summary + line groups ONCE. Per-kit org/project validation is
+ * the MUTATION's job — a kit not on this org's project surfaces in `res.errors`
+ * (partial-success) instead of sinking the rest. Returns succeeded parent line ids
+ * + per-kit errors.
+ */
+export async function prepKitsBatch(
+  projectId: string,
+  parentLineItemIds: string[]
+) {
+  const { organizationId, userId, userName } = await requirePermission(
+    "warehouse",
+    "check_out"
+  );
+  const unique = [...new Set(parentLineItemIds)];
+  if (unique.length === 0) return serialize({ succeeded: [] as string[], errors: [] as { lineItemId: string; message: string }[] });
+
+  const convex = await getConvexClient();
+
+  // Blocking-comment gate — one project summary + one line-groups read (was a
+  // per-kit assertNoBlockingComments in the singular). A project-level blocker
+  // (or a blocker on any prepped kit line / its group) fails the whole batch, just
+  // as the old loop threw on the first blocked kit.
+  const [summary, lineDocs] = await Promise.all([
+    getProjectBlockingSummary(organizationId, projectId),
+    convex.query(api.projectLineItems.listByIds, { ids: unique, orgId: organizationId }),
+  ]);
+  // Scope the gate to THIS org+project — listByIds is a global-index read, so a
+  // foreign/cross-project id must not feed its groupId to the project's blocking gate
+  // (it would falsely abort the whole batch). Cross-project/foreign ids fall through
+  // to the mutation, which skips them per-item with an error (partial-success).
+  const inProject = lineDocs.filter((l) => l.projectId === projectId && l.organizationId === organizationId);
+  const groupById = new Map(inProject.map((l) => [l.id, l.groupId ?? null]));
+  const kitIdByLine = new Map(inProject.map((l) => [l.id, l.kitId ?? null]));
+  for (const lineItemId of unique) {
+    if (!groupById.has(lineItemId)) continue; // not in this project → mutation handles it
+    const gate = evaluateBlockingGate(summary, {
+      lineItemId,
+      groupId: groupById.get(lineItemId) ?? null,
+      actionLabel: "prep this kit",
+    });
+    if (gate.blocked) throw new Error(gate.message);
+  }
+
+  // ONE atomic array mutation preps every kit tree (partial-success on org/project).
+  const { succeeded, errors } = await convex.mutation(api.checkRecordOps.prepKitsBatch, {
+    organizationId,
+    projectId,
+    parentLineItemIds: unique,
+    now: Date.now(),
+  });
+
+  // One audit row per prepped kit (kit name via the parent line's kitId), matching
+  // the single prepKitChildren's per-kit log.
+  const kitIds = [...new Set(succeeded.map((id: string) => kitIdByLine.get(id)).filter((x): x is string => !!x))];
+  const kitNameById = new Map<string, string>();
+  await Promise.all(
+    kitIds.map(async (kid) => {
+      const kit = await convex.query(api.kits.getById, { id: kid });
+      if (kit) kitNameById.set(kid, kit.name);
+    }),
+  );
+  await logActivityMany(
+    succeeded.map((lineItemId: string) => {
+      const kid = kitIdByLine.get(lineItemId);
+      return {
+        organizationId,
+        userId,
+        userName,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: lineItemId,
+        entityName: (kid && kitNameById.get(kid)) || "Kit",
+        summary: "Kit prepped (checks completed)",
+        projectId,
+      };
+    }),
+  );
+
+  return serialize({ succeeded, errors });
+}
+
 export async function unpackItem(projectId: string, lineItemId: string) {
   const { organizationId, userId, userName } = await requirePermission(
     "warehouse",

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -963,6 +963,30 @@ export async function syncContainerStatus(projectId: string, containerName: stri
   return serialize(res);
 }
 
+/**
+ * Bulk single-call container sync (Phase 3 bulk invariant): roll up N containers in
+ * ONE Convex array mutation + ONE server round-trip — replaces the client's
+ * `for (const c of containers) await syncContainerStatus(...)` loop that fired one
+ * round-trip per affected container after a bulk checkout/check-in. Container names
+ * are deduped; the mutation reports each container's rollup result.
+ */
+export async function syncContainersBatch(projectId: string, containerNames: string[]) {
+  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
+  const unique = [...new Set(containerNames)];
+  if (unique.length === 0) return serialize({ results: [] as Array<{ containerName: string; updated: boolean; status?: string }> });
+
+  const convex = await getConvexClient();
+  const res = await convex.mutation(api.warehouseOps.syncContainersBatch, {
+    organizationId,
+    projectId,
+    containerNames: unique,
+    userId,
+    now: Date.now(),
+  });
+
+  return serialize(res);
+}
+
 type AvailableAssetRow = {
   id: string;
   assetTag: string;


### PR DESCRIPTION
Converts the last warehouse-page client fan-outs (kit-verify, prep-kits, container-sync) to single array mutations. New `checkRecordOps.prepKitsBatch` + `warehouseOps.syncContainersBatch` (per-item org re-check, partial-success); kit-verify reuses the existing `prepItemsBatch`.

Tests: `warehousePageBatch.test.ts` (5). Full suite green (333); tsc clean. **Codex-reviewed** — fixed the blocking-gate project-scoping + the page now surfaces `{succeeded,errors}`. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)