### PR TITLE
feat(convex): projectLineItems.createMany for Woo order ingest (review M1)

### DIFF
--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -230,6 +230,92 @@ export const createIfMissing = mutation({
   },
 });
 
+/**
+ * Create N project line items in ONE array mutation (bulk single-call invariant,
+ * Phase 3) — replaces the WooCommerce order-ingest server loop firing one `create`
+ * per matched product (N round-trips). `organizationId` is stamped from the ARG
+ * onto every row (a caller can't smuggle a per-row org), and each row is inserted
+ * only if its id is new (idempotent on retry). Mirrors
+ * modelCheckItems.createManyIfMissing. Returns how many were created.
+ */
+export const createMany = mutation({
+  args: {
+    organizationId: v.string(),
+    rows: v.array(
+      v.object({
+        id: v.string(),
+        projectId: v.string(),
+        type: v.optional(enums.LineItemType),
+        modelId: v.optional(v.string()),
+        assetId: v.optional(v.string()),
+        bulkAssetId: v.optional(v.string()),
+        kitId: v.optional(v.string()),
+        isKitChild: v.optional(v.boolean()),
+        childKind: v.optional(enums.LineItemChildKind),
+        parentLineItemId: v.optional(v.string()),
+        pricingMode: v.optional(enums.KitPricingMode),
+        description: v.optional(v.string()),
+        quantity: v.optional(v.number()),
+        unitPrice: v.optional(v.number()),
+        pricingType: v.optional(enums.PricingType),
+        duration: v.optional(v.number()),
+        discount: v.optional(v.number()),
+        lineTotal: v.optional(v.number()),
+        priceBreakdown: v.optional(v.string()),
+        priceOverridden: v.optional(v.boolean()),
+        overrideReason: v.optional(v.string()),
+        sortOrder: v.optional(v.number()),
+        groupName: v.optional(v.string()),
+        categoryId: v.optional(v.string()),
+        groupId: v.optional(v.string()),
+        notes: v.optional(v.string()),
+        isOptional: v.optional(v.boolean()),
+        status: v.optional(enums.LineItemStatus),
+        checkedOutQuantity: v.optional(v.number()),
+        returnedQuantity: v.optional(v.number()),
+        assignedQuantity: v.optional(v.number()),
+        packedQuantity: v.optional(v.number()),
+        damagedQuantity: v.optional(v.number()),
+        lostQuantity: v.optional(v.number()),
+        checkedOutAt: v.optional(v.number()),
+        checkedOutById: v.optional(v.string()),
+        returnedAt: v.optional(v.number()),
+        returnedById: v.optional(v.string()),
+        returnCondition: v.optional(enums.ReturnCondition),
+        returnNotes: v.optional(v.string()),
+        prepStatus: v.optional(enums.PrepStatus),
+        prepContainer: v.optional(v.string()),
+        isContainerLineItem: v.optional(v.boolean()),
+        isCustomItem: v.optional(v.boolean()),
+        returnStatus: v.optional(enums.ReturnStatus),
+        showSubhireOnDocs: v.optional(v.boolean()),
+        supplierId: v.optional(v.string()),
+        subhireOrderNumber: v.optional(v.string()),
+        supplierOrderId: v.optional(v.string()),
+        subHireId: v.optional(v.string()),
+        subHireItemId: v.optional(v.string()),
+        subHireGroupId: v.optional(v.string()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (ctx, { organizationId, rows }) => {
+    await requireService(ctx);
+    let created = 0;
+    for (const r of rows) {
+      const existing = await ctx.db
+        .query("projectLineItems")
+        .withIndex("by_cuid", (q) => q.eq("id", r.id))
+        .unique();
+      if (existing) continue;
+      await ctx.db.insert("projectLineItems", { ...r, organizationId });
+      created++;
+    }
+    return { created };
+  },
+});
+
 export const update = mutation({
   args: {
     id: v.string(),

--- a/convex/projectLineItemsCreateMany.test.ts
+++ b/convex/projectLineItemsCreateMany.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+//
+// projectLineItems.createMany — the Phase 3 bulk single-call invariant for the
+// WooCommerce order-ingest server loop: N project line items created in ONE array
+// mutation (was one `create` round-trip per matched product). organizationId is
+// stamped from the arg (no per-row cross-tenant smuggling); dedups by id.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const rowById = (t: T, id: string) =>
+  t.run(async (ctx) => (await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique()));
+
+describe("projectLineItems.createMany — bulk single-call", () => {
+  test("creates new rows, skips an existing id, stamps organizationId from the arg", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li-existing", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+    });
+
+    const { created } = await t.withIdentity(SERVICE).mutation(api.projectLineItems.createMany, {
+      organizationId: ORG,
+      rows: [
+        { id: "li-existing", projectId: "p1", type: "EQUIPMENT", sortOrder: 0, createdAt: NOW, updatedAt: NOW }, // already there → skip
+        { id: "li1", projectId: "p1", type: "EQUIPMENT", modelId: "m1", quantity: 2, unitPrice: 10, pricingType: "PER_DAY", duration: 3, lineTotal: 20, sortOrder: 1, createdAt: NOW, updatedAt: NOW },
+        { id: "li2", projectId: "p1", type: "MISC", description: "[WooCommerce] Widget", quantity: 1, unitPrice: 5, sortOrder: 2, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    expect(created).toBe(2);
+    const li1 = await rowById(t, "li1");
+    expect(li1?.organizationId).toBe(ORG); // stamped from the arg
+    expect(li1?.projectId).toBe("p1");
+    expect(li1?.modelId).toBe("m1");
+    expect(li1?.quantity).toBe(2);
+    expect(li1?.sortOrder).toBe(1);
+    const li2 = await rowById(t, "li2");
+    expect(li2?.organizationId).toBe(ORG);
+    expect(li2?.type).toBe("MISC");
+    expect(li2?.description).toBe("[WooCommerce] Widget");
+
+    // Exactly one row for the pre-existing id (no duplicate insert).
+    const dupes = await t.run(async (ctx) =>
+      (await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li-existing")).collect()).length,
+    );
+    expect(dupes).toBe(1);
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.projectLineItems.createMany, {
+        organizationId: ORG,
+        rows: [{ id: "x", projectId: "p1" }],
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -372,31 +372,35 @@ export async function processWooCommerceOrder(
     if (!project) throw new Error("WooCommerce project create failed");
 
     // 7. Add line items for matched and unmatched products.
-    // projectLineItem is Convex-only — write each line via api.projectLineItems.create
-    // (full-field generated mutation) with an explicit cuid + sortOrder.
+    // projectLineItem is Convex-only. Build every row in memory and write them all in
+    // ONE array mutation (api.projectLineItems.createMany) instead of one round-trip
+    // per matched product (bulk single-call invariant, Phase 3). organizationId is
+    // stamped from the mutation arg, not per-row.
     const duration = dates.rentalStart && dates.rentalEnd
       ? Math.max(1, Math.ceil((dates.rentalEnd.getTime() - dates.rentalStart.getTime()) / (1000 * 60 * 60 * 24)))
       : 1;
     const nowMs = Date.now();
-    let sortOrder = 0;
-    for (const match of matchResults) {
-      await convex.mutation(api.projectLineItems.create, {
-        id: createId(),
+    const lineItemRows = matchResults.map((match, sortOrder) => ({
+      id: createId(),
+      projectId: project.id,
+      type: (match.modelId ? "EQUIPMENT" : "MISC") as never,
+      modelId: match.modelId || undefined,
+      description: match.modelId
+        ? undefined
+        : `[WooCommerce] ${match.wooProductName}${match.wooSku ? ` (SKU: ${match.wooSku})` : ""}`,
+      quantity: match.wooQuantity,
+      unitPrice: match.wooPrice,
+      pricingType: "PER_DAY" as never,
+      duration,
+      lineTotal: match.wooPrice * match.wooQuantity,
+      sortOrder,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+    }));
+    if (lineItemRows.length > 0) {
+      await convex.mutation(api.projectLineItems.createMany, {
         organizationId: orgId,
-        projectId: project.id,
-        type: match.modelId ? "EQUIPMENT" : "MISC",
-        modelId: match.modelId || undefined,
-        description: match.modelId
-          ? undefined
-          : `[WooCommerce] ${match.wooProductName}${match.wooSku ? ` (SKU: ${match.wooSku})` : ""}`,
-        quantity: match.wooQuantity,
-        unitPrice: match.wooPrice,
-        pricingType: "PER_DAY",
-        duration,
-        lineTotal: match.wooPrice * match.wooQuantity,
-        sortOrder: sortOrder++,
-        createdAt: nowMs,
-        updatedAt: nowMs,
+        rows: lineItemRows,
       });
     }
 


### PR DESCRIPTION
Phase-3 bulk single-call (Appendix A*): WooCommerce order ingest created line items via a per-item `convex.mutation(create)` loop → new `projectLineItems.createMany` (org from arg, dedup by id, service-gated), called once. Test added. Full suite green (335); tsc clean; **codex CLEAN**. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)