### PR TITLE
feat(convex): bulk single-call for reorder family + service crew-assign (review round-2)

### DIFF
--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -387,3 +387,57 @@ export const createServiceAssignment = mutation({
     return { created: true, id: args.id };
   },
 });
+
+/**
+ * Create N service-derived crew assignments in ONE array mutation (bulk single-call
+ * invariant, Phase 3) — replaces the server firing one `createServiceAssignment` per
+ * selected crew member when assigning multiple crew to a service (N round-trips).
+ * `organizationId` is stamped from the ARG onto every row (a caller can't smuggle a
+ * per-row org). Each row honours the same partial-unique
+ * `(projectId, crewMemberId, serviceId)` invariant as the single mutation: an existing
+ * row for that triple is skipped (idempotent on retry). Returns how many were created.
+ */
+export const createManyServiceAssignments = mutation({
+  args: {
+    organizationId: v.string(),
+    rows: v.array(
+      v.object({
+        id: v.string(),
+        projectId: v.string(),
+        crewMemberId: v.string(),
+        serviceId: v.string(),
+        crewRoleId: v.optional(v.string()),
+        status: v.optional(enums.AssignmentStatus),
+        phase: v.optional(enums.ProjectPhase),
+        startDate: v.optional(v.number()),
+        startTime: v.optional(v.string()),
+        endDate: v.optional(v.number()),
+        endTime: v.optional(v.string()),
+        rateOverride: v.optional(v.number()),
+        rateType: v.optional(enums.CrewRateType),
+        estimatedHours: v.optional(v.number()),
+        estimatedCost: v.optional(v.number()),
+        notes: v.optional(v.string()),
+        createdAt: v.optional(v.number()),
+        updatedAt: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (ctx, { organizationId, rows }) => {
+    await requireService(ctx);
+    let created = 0;
+    for (const r of rows) {
+      const dupe = await ctx.db
+        .query("crewAssignments")
+        .withIndex("by_serviceId", (q) => q.eq("serviceId", r.serviceId))
+        .filter((q) => q.and(q.eq(q.field("projectId"), r.projectId), q.eq(q.field("crewMemberId"), r.crewMemberId)))
+        .first();
+      if (dupe) continue;
+      const doc = { ...r, organizationId };
+      await ctx.db.insert("crewAssignments", doc);
+      await bumpCountersForTable(ctx, "crewAssignments", null, doc);
+      created++;
+    }
+    return { created };
+  },
+});

--- a/convex/kitCheckItems.ts
+++ b/convex/kitCheckItems.ts
@@ -135,3 +135,23 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+/**
+ * Atomic drag-reorder: assign sortOrder = index for each assignment id in `orderedIds`,
+ * in ONE mutation round-trip (was a `Promise.all` firing one read + one `update` per
+ * item). The caller resolves (kit, checkItem) → row id once via listByKitId, then passes
+ * the row ids in display order. Per-item org re-check: by_cuid is a GLOBAL index, so the
+ * `doc.organizationId === orgId` skip prevents reordering another org's rows.
+ */
+export const reorderMany = mutation({
+  // Explicit {id, sortOrder} pairs (not array-index) so the caller can resolve/filter
+  // ids without compressing the sort positions of the survivors.
+  args: { orgId: v.string(), items: v.array(v.object({ id: v.string(), sortOrder: v.number() })) },
+  handler: async (ctx, { orgId, items }) => {
+    await requireService(ctx);
+    for (const it of items) {
+      const doc = await ctx.db.query("kitCheckItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: it.sortOrder }); // per-item org re-check
+    }
+  },
+});

--- a/convex/modelCheckItems.ts
+++ b/convex/modelCheckItems.ts
@@ -188,3 +188,23 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+/**
+ * Atomic drag-reorder: assign sortOrder = index for each assignment id in `orderedIds`,
+ * in ONE mutation round-trip (was a `Promise.all` firing one read + one `update` per
+ * item). The caller resolves (model, checkItem) → row id once via listByModel, then
+ * passes the row ids in display order. Per-item org re-check: by_cuid is a GLOBAL index,
+ * so the `doc.organizationId === orgId` skip prevents reordering another org's rows.
+ */
+export const reorderMany = mutation({
+  // Explicit {id, sortOrder} pairs (not array-index) so the caller can resolve/filter
+  // ids without compressing the sort positions of the survivors.
+  args: { orgId: v.string(), items: v.array(v.object({ id: v.string(), sortOrder: v.number() })) },
+  handler: async (ctx, { orgId, items }) => {
+    await requireService(ctx);
+    for (const it of items) {
+      const doc = await ctx.db.query("modelCheckItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: it.sortOrder }); // per-item org re-check
+    }
+  },
+});

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -189,3 +189,20 @@ export const removeMany = mutation({
     return { deleted, skipped, projectIds: [...projectIds] };
   },
 });
+
+/**
+ * Atomic drag-reorder: assign sortOrder = index for each id in `orderedIds`, in ONE
+ * mutation round-trip (was a server loop firing one `update` per task). Per-item org
+ * re-check: by_cuid is a GLOBAL index, so without the `doc.organizationId === orgId`
+ * skip a caller could reorder another org's tasks (mirrors reorderLineItems' guard).
+ */
+export const reorderMany = mutation({
+  args: { orgId: v.string(), orderedIds: v.array(v.string()), now: v.number() },
+  handler: async (ctx, { orgId, orderedIds, now }) => {
+    await requireService(ctx);
+    for (let index = 0; index < orderedIds.length; index++) {
+      const doc = await ctx.db.query("projectTasks").withIndex("by_cuid", (q) => q.eq("id", orderedIds[index])).unique();
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: index, updatedAt: now });
+    }
+  },
+});

--- a/convex/review2Bulk.test.ts
+++ b/convex/review2Bulk.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+//
+// Phase 3 bulk single-call invariant — review2 batch (review2/bulk). Converts the
+// last multi-select server fan-outs into single array mutations:
+//   • *.reorderMany  — drag-reorder N rows in ONE call, sortOrder = index, with a
+//     per-item org re-check (by_cuid is a GLOBAL index — a caller must not be able to
+//     reorder another org's rows). Representative table: projectTasks.
+//   • crewAssignments.createManyServiceAssignments — assign N crew to a service in ONE
+//     call; organizationId stamped from the arg, (project, member, service) dedup.
+// Mirrors reorderOrgCheck.test.ts / modelCheckItemsCreateMany.test.ts.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+// createManyServiceAssignments bumps the sharded dashboard counter on every insert —
+// mount the component (same as dashboardCounters.test.ts) or the write throws.
+const makeT = () => {
+  const t = convexTest(schema, modules);
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+};
+type T = ReturnType<typeof makeT>;
+
+const taskSort = (t: T, id: string) =>
+  t.run(async (ctx) => (await ctx.db.query("projectTasks").withIndex("by_cuid", (q) => q.eq("id", id)).unique())?.sortOrder);
+
+describe("projectTasks.reorderMany — bulk drag-reorder, per-item org re-check", () => {
+  test("sets sortOrder = index for in-org rows, skips a cross-org id", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectTasks", { id: "t_a", organizationId: ORG, projectId: "p1", title: "A", sortOrder: 9 });
+      await ctx.db.insert("projectTasks", { id: "t_b", organizationId: ORG, projectId: "p1", title: "B", sortOrder: 9 });
+      await ctx.db.insert("projectTasks", { id: "t_x", organizationId: OTHER, projectId: "p9", title: "X", sortOrder: 9 });
+    });
+    // Desired display order: b, a — and a cross-org id that must be ignored.
+    await t.withIdentity(SERVICE).mutation(api.projectTasks.reorderMany, {
+      orgId: ORG,
+      orderedIds: ["t_b", "t_a", "t_x"],
+      now: NOW,
+    });
+    expect(await taskSort(t, "t_b")).toBe(0); // in-org, index 0
+    expect(await taskSort(t, "t_a")).toBe(1); // in-org, index 1
+    expect(await taskSort(t, "t_x")).toBe(9); // cross-org, untouched
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.projectTasks.reorderMany, {
+        orgId: ORG,
+        orderedIds: ["t_a"],
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});
+
+describe("crewAssignments.createManyServiceAssignments — bulk single-call", () => {
+  const rowById = (t: T, id: string) =>
+    t.run(async (ctx) => (await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique()));
+
+  test("creates new rows, stamps org from the arg, dedups (project, member, service)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      // Pre-existing assignment for (p1, m1, svc1) — must NOT be duplicated.
+      await ctx.db.insert("crewAssignments", {
+        id: "ca-existing", organizationId: ORG, projectId: "p1", crewMemberId: "m1", serviceId: "svc1", status: "PENDING",
+      });
+    });
+
+    const { created } = await t.withIdentity(SERVICE).mutation(api.crewAssignments.createManyServiceAssignments, {
+      organizationId: ORG,
+      rows: [
+        { id: "ca-dupe", projectId: "p1", crewMemberId: "m1", serviceId: "svc1", status: "PENDING" }, // dupe triple → skip
+        { id: "ca1", projectId: "p1", crewMemberId: "m2", serviceId: "svc1", status: "PENDING" },
+        { id: "ca2", projectId: "p1", crewMemberId: "m3", serviceId: "svc1", phase: "EVENT", status: "PENDING" },
+      ],
+    });
+
+    expect(created).toBe(2);
+    expect((await rowById(t, "ca-dupe"))).toBeNull(); // triple already existed → not inserted
+    const ca1 = await rowById(t, "ca1");
+    expect(ca1?.organizationId).toBe(ORG); // stamped from the arg
+    expect(ca1?.crewMemberId).toBe("m2");
+    expect((await rowById(t, "ca2"))?.phase).toBe("EVENT");
+
+    // Exactly one row survives for the pre-existing triple.
+    const dupes = await t.run(async (ctx) =>
+      (await ctx.db.query("crewAssignments").withIndex("by_serviceId", (q) => q.eq("serviceId", "svc1")).collect())
+        .filter((r) => r.projectId === "p1" && r.crewMemberId === "m1").length,
+    );
+    expect(dupes).toBe(1);
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.crewAssignments.createManyServiceAssignments, {
+        organizationId: ORG,
+        rows: [{ id: "x", projectId: "p1", crewMemberId: "m1", serviceId: "svc1" }],
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});

--- a/src/server/check-items.ts
+++ b/src/server/check-items.ts
@@ -325,14 +325,16 @@ export async function reorderModelCheckItems(
   const parsed = reorderModelCheckItemsSchema.parse(data);
 
   const convex = await getConvexClient();
-  // Each (model, checkItem) row is independent — resolve + patch them all
-  // concurrently (was a sequential read+update per item).
-  await Promise.all(
-    parsed.orderedCheckItemIds.map(async (checkItemId, index) => {
-      const row = await convex.query(api.modelCheckItems.getByModelAndCheckItem, { orgId: organizationId, modelId: parsed.modelId, checkItemId });
-      if (row) await convex.mutation(api.modelCheckItems.update, { id: row.id, patch: { sortOrder: index } });
-    }),
-  );
+  // Resolve (model, checkItem) → row id ONCE via listByModel, then patch sortOrder for
+  // all rows in a single array mutation (was one read + one update round-trip per item).
+  const rows = await convex.query(api.modelCheckItems.listByModel, { orgId: organizationId, modelId: parsed.modelId });
+  const rowIdByCheckItem = new Map(rows.map((r) => [r.checkItemId, r.id]));
+  // Keep each row's ORIGINAL position (index in orderedCheckItemIds) as its sortOrder,
+  // so a dropped/unresolved id doesn't compress the survivors' positions.
+  const items = parsed.orderedCheckItemIds
+    .map((checkItemId, sortOrder) => ({ id: rowIdByCheckItem.get(checkItemId), sortOrder }))
+    .filter((r): r is { id: string; sortOrder: number } => r.id != null);
+  await convex.mutation(api.modelCheckItems.reorderMany, { orgId: organizationId, items });
 
   return { success: true };
 }
@@ -503,13 +505,15 @@ export async function reorderKitCheckItems(
   const { organizationId } = await requirePermission("checkItem", "update");
 
   const convex = await getConvexClient();
-  // Each (kit, checkItem) row is independent — resolve + patch concurrently.
-  await Promise.all(
-    orderedCheckItemIds.map(async (checkItemId, index) => {
-      const row = await convex.query(api.kitCheckItems.getByKitAndCheckItem, { orgId: organizationId, kitId, checkItemId });
-      if (row) await convex.mutation(api.kitCheckItems.update, { id: row.id, patch: { sortOrder: index } });
-    }),
-  );
+  // Resolve (kit, checkItem) → row id ONCE via listByKitId, then patch sortOrder for all
+  // rows in a single array mutation (was one read + one update round-trip per item).
+  const rows = await convex.query(api.kitCheckItems.listByKitId, { orgId: organizationId, kitId });
+  const rowIdByCheckItem = new Map(rows.map((r) => [r.checkItemId, r.id]));
+  // Keep each row's ORIGINAL position as its sortOrder (no compression on drop).
+  const items = orderedCheckItemIds
+    .map((checkItemId, sortOrder) => ({ id: rowIdByCheckItem.get(checkItemId), sortOrder }))
+    .filter((r): r is { id: string; sortOrder: number } => r.id != null);
+  await convex.mutation(api.kitCheckItems.reorderMany, { orgId: organizationId, items });
 
   return { success: true };
 }

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -224,24 +224,26 @@ export async function createProjectService(
     );
     const convex = await getConvexClient();
     const now = Date.now();
-    for (const crewMemberId of parsed.crewMemberIds) {
-      await convex.mutation(api.crewAssignments.createServiceAssignment, {
-        id: createId(),
-        organizationId,
-        projectId,
-        crewMemberId,
-        serviceId: service.id,
-        phase,
-        status: "PENDING",
-        ...(parsed.crewRoleId ? { crewRoleId: parsed.crewRoleId } : {}),
-        ...(serviceDate ? { startDate: serviceDate.getTime() } : {}),
-        ...(crewStart ? { startTime: crewStart } : {}),
-        ...(serviceEndDate ? { endDate: serviceEndDate.getTime() } : {}),
-        ...(crewEnd ? { endTime: crewEnd } : {}),
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+    // Build every crew row up front, then insert them in ONE array mutation (was one
+    // createServiceAssignment round-trip per crew member). organizationId is stamped
+    // from the arg inside Convex; the partial-unique (project, member, service)
+    // invariant is re-enforced per row there.
+    const rows = parsed.crewMemberIds.map((crewMemberId) => ({
+      id: createId(),
+      projectId,
+      crewMemberId,
+      serviceId: service.id,
+      phase,
+      status: "PENDING" as const,
+      ...(parsed.crewRoleId ? { crewRoleId: parsed.crewRoleId } : {}),
+      ...(serviceDate ? { startDate: serviceDate.getTime() } : {}),
+      ...(crewStart ? { startTime: crewStart } : {}),
+      ...(serviceEndDate ? { endDate: serviceEndDate.getTime() } : {}),
+      ...(crewEnd ? { endTime: crewEnd } : {}),
+      createdAt: now,
+      updatedAt: now,
+    }));
+    await convex.mutation(api.crewAssignments.createManyServiceAssignments, { organizationId, rows });
   }
 
   // Always recalculate project totals — service charge/cost affects financials
@@ -346,8 +348,13 @@ export async function updateProjectService(
     const existingMemberIds = new Set(existingAssignments.map((a) => a.crewMemberId));
     const desiredMemberIds = new Set(parsed.crewMemberIds);
 
-    for (const a of existingAssignments.filter((a) => !desiredMemberIds.has(a.crewMemberId))) {
-      await convex.mutation(api.crewAssignments.deleteCascade, { id: a.id });
+    // Remove de-selected members' assignments in ONE cascade mutation (was one
+    // deleteCascade round-trip per removed member). Org re-checked per row in Convex.
+    const removeIds = existingAssignments
+      .filter((a) => !desiredMemberIds.has(a.crewMemberId))
+      .map((a) => a.id);
+    if (removeIds.length > 0) {
+      await convex.mutation(api.crewAssignments.deleteManyCascade, { ids: removeIds, orgId: organizationId });
     }
 
     const { crewStart, crewEnd } = deriveCrewTimes(
@@ -357,15 +364,17 @@ export async function updateProjectService(
       parsed.type,
     );
     const now = Date.now();
-    for (const crewMemberId of parsed.crewMemberIds.filter((m) => !existingMemberIds.has(m))) {
-      await convex.mutation(api.crewAssignments.createServiceAssignment, {
+    // Add newly-selected members in ONE array mutation (was one createServiceAssignment
+    // round-trip per added member). Partial-unique re-enforced per row in Convex.
+    const addRows = parsed.crewMemberIds
+      .filter((m) => !existingMemberIds.has(m))
+      .map((crewMemberId) => ({
         id: createId(),
-        organizationId,
         projectId: existing.projectId,
         crewMemberId,
         serviceId: id,
         phase,
-        status: "PENDING",
+        status: "PENDING" as const,
         ...(parsed.crewRoleId ? { crewRoleId: parsed.crewRoleId } : {}),
         ...(serviceDate ? { startDate: serviceDate.getTime() } : {}),
         ...(crewStart ? { startTime: crewStart } : {}),
@@ -373,9 +382,15 @@ export async function updateProjectService(
         ...(crewEnd ? { endTime: crewEnd } : {}),
         createdAt: now,
         updatedAt: now,
-      });
+      }));
+    if (addRows.length > 0) {
+      await convex.mutation(api.crewAssignments.createManyServiceAssignments, { organizationId, rows: addRows });
     }
 
+    // Role-change patch on surviving assignments stays a per-row loop: it's a
+    // patch-WITH-CLEAR (null crewRoleId → field removed), which no batch mutation
+    // expresses (patchManyStatus only sets status). Only fires when the role changed,
+    // so it's a bounded, rarely-hit fan-out — left as-is deliberately.
     if (parsed.crewRoleId !== existing.crewRoleId) {
       for (const a of existingAssignments.filter((a) => desiredMemberIds.has(a.crewMemberId))) {
         await convex.mutation(api.crewAssignments.patchAssignment, {

--- a/src/server/project-tasks.ts
+++ b/src/server/project-tasks.ts
@@ -411,13 +411,13 @@ export async function reorderProjectTasks(projectId: string, orderedIds: string[
   const { organizationId } = await requirePermission("project", "update");
 
   const convex = await getConvexClient();
-  const now = Date.now();
-  for (let index = 0; index < orderedIds.length; index++) {
-    await convex.mutation(api.projectTasks.update, {
-      id: orderedIds[index],
-      patch: { sortOrder: index, updatedAt: now },
-    });
-  }
+  // Single array mutation: sortOrder = index for every id, org re-checked per row
+  // inside Convex (was one `update` round-trip per task).
+  await convex.mutation(api.projectTasks.reorderMany, {
+    orgId: organizationId,
+    orderedIds,
+    now: Date.now(),
+  });
 }
 
 export async function getMyOpenTasks(limit = 25) {


### PR DESCRIPTION
Round-2 re-audit found 4 more multi-select fan-outs → single array mutations, each with a per-item org re-check:
- `projectTasks.reorderMany` (had **no** org check before), `modelCheckItems.reorderMany`, `kitCheckItems.reorderMany` (explicit {id,sortOrder} so filtering resolved ids doesn't compress positions — per codex).
- `crewAssignments.createManyServiceAssignments` (org from arg, dedup) for the service crew create/add loops; remove loop uses `deleteManyCascade`. Role-change patch-with-clear loop left (bounded, no batch expresses field-clear).

Tests: `review2Bulk.test.ts`. Suite green (339); tsc clean; **codex CLEAN**. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)