### PR TITLE
feat(convex): custom-field reorder + service-delete cascade → single array calls (review round-3)

### DIFF
--- a/convex/customFieldDefinitions.ts
+++ b/convex/customFieldDefinitions.ts
@@ -118,3 +118,26 @@ export const remove = mutation({
     await ctx.db.delete(doc._id);
   },
 });
+
+/**
+ * Atomic drag-reorder: assign each definition's sortOrder in ONE mutation round-trip
+ * (was a server-side `Promise.all` firing one getById + one update per row = 2N calls).
+ * Explicit {id, sortOrder} pairs (not array-index) so the caller can filter foreign/
+ * unresolved ids without compressing the survivors' positions. Per-item org re-check:
+ * by_cuid is a GLOBAL index, so the `doc.organizationId === orgId` skip stops a caller
+ * reordering another org's definitions (mirrors modelCheckItems.reorderMany).
+ */
+export const reorderMany = mutation({
+  args: {
+    orgId: v.string(),
+    items: v.array(v.object({ id: v.string(), sortOrder: v.number() })),
+    now: v.number(),
+  },
+  handler: async (ctx, { orgId, items, now }) => {
+    await requireService(ctx);
+    for (const it of items) {
+      const doc = await ctx.db.query("customFieldDefinitions").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
+      if (doc && doc.organizationId === orgId) await ctx.db.patch(doc._id, { sortOrder: it.sortOrder, updatedAt: now }); // per-item org re-check
+    }
+  },
+});

--- a/convex/review2Bulk.test.ts
+++ b/convex/review2Bulk.test.ts
@@ -62,6 +62,41 @@ describe("projectTasks.reorderMany — bulk drag-reorder, per-item org re-check"
   });
 });
 
+describe("customFieldDefinitions.reorderMany — {id,sortOrder} pairs, per-item org re-check", () => {
+  const cfSort = (t: T, id: string) =>
+    t.run(async (ctx) => (await ctx.db.query("customFieldDefinitions").withIndex("by_cuid", (q) => q.eq("id", id)).unique())?.sortOrder);
+
+  test("applies explicit sortOrder for in-org rows, skips a cross-org id without compressing positions", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customFieldDefinitions", { id: "cf_a", organizationId: ORG, label: "A", fieldKey: "a", sortOrder: 5 });
+      await ctx.db.insert("customFieldDefinitions", { id: "cf_b", organizationId: ORG, label: "B", fieldKey: "b", sortOrder: 5 });
+      await ctx.db.insert("customFieldDefinitions", { id: "cf_x", organizationId: OTHER, label: "X", fieldKey: "x", sortOrder: 5 });
+    });
+    // The server filters foreign ids out but keeps explicit sortOrder so survivors
+    // don't shift: cf_a→0, cf_x (cross-org, dropped by server) would be 1, cf_b→2.
+    await t.withIdentity(SERVICE).mutation(api.customFieldDefinitions.reorderMany, {
+      orgId: ORG,
+      items: [{ id: "cf_a", sortOrder: 0 }, { id: "cf_b", sortOrder: 2 }, { id: "cf_x", sortOrder: 3 }],
+      now: NOW,
+    });
+    expect(await cfSort(t, "cf_a")).toBe(0);
+    expect(await cfSort(t, "cf_b")).toBe(2); // position preserved, not compressed to 1
+    expect(await cfSort(t, "cf_x")).toBe(5); // cross-org, untouched
+  });
+
+  test("a non-service token cannot call it", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.customFieldDefinitions.reorderMany, {
+        orgId: ORG,
+        items: [{ id: "cf_a", sortOrder: 0 }],
+        now: NOW,
+      }),
+    ).rejects.toThrow(/server/i);
+  });
+});
+
 describe("crewAssignments.createManyServiceAssignments — bulk single-call", () => {
   const rowById = (t: T, id: string) =>
     t.run(async (ctx) => (await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique()));

--- a/src/server/custom-fields.ts
+++ b/src/server/custom-fields.ts
@@ -237,21 +237,15 @@ export async function reorderCustomFieldDefinitions(orderedIds: string[]) {
   const { organizationId } = await requirePermission("orgSettings", "update");
   const convex = await getConvexClient();
   const now = Date.now();
-  // Convex-only: patch each definition's sortOrder. The old Prisma `updateMany`
-  // `where: { id, organizationId }` silently skipped foreign ids; replicate that
-  // org-guard by verifying ownership per id (the reorder list is small) so a
-  // stray/foreign id is a no-op rather than touching another org's row.
-  // Each definition is independent — verify ownership + patch sortOrder for all
-  // ids concurrently (was a sequential read+update per id).
-  await Promise.all(
-    orderedIds.map(async (id, idx) => {
-      const doc = await convex.query(api.customFieldDefinitions.getById, { id });
-      if (!doc || doc.organizationId !== organizationId) return;
-      await convex.mutation(api.customFieldDefinitions.update, {
-        id,
-        patch: { sortOrder: idx, updatedAt: now },
-      });
-    }),
-  );
+  // Convex-only, ONE round-trip: reorderMany loops server-side and verifies each
+  // row's org (by_cuid is a GLOBAL index) so a stray/foreign id is a no-op rather
+  // than touching another org's row — replicating the old Prisma `updateMany`
+  // `where: { id, organizationId }` guard. Explicit sortOrder = display index.
+  const items = orderedIds.map((id, sortOrder) => ({ id, sortOrder }));
+  await convex.mutation(api.customFieldDefinitions.reorderMany, {
+    orgId: organizationId,
+    items,
+    now,
+  });
   return { ok: true };
 }

--- a/src/server/project-services.ts
+++ b/src/server/project-services.ts
@@ -447,8 +447,13 @@ export async function deleteProjectService(id: string) {
       .catch(() => {});
   }
   await convex.mutation(api.projectServices.remove, { id });
-  for (const a of serviceAssignments) {
-    await convex.mutation(api.crewAssignments.deleteCascade, { id: a.id });
+  if (serviceAssignments.length > 0) {
+    // ONE array mutation instead of one deleteCascade per assignment; org-scoped per
+    // row inside Convex (by_cuid is global — foreign ids skipped).
+    await convex.mutation(api.crewAssignments.deleteManyCascade, {
+      ids: serviceAssignments.map((a) => a.id),
+      orgId: organizationId,
+    });
   }
 
   await recalculateProjectTotals(service.projectId);


### PR DESCRIPTION
Round-3 independent re-audit (security boundary + bulk invariant). **Security audit: CLEAN** — no cross-tenant hole in the mutation layer. Bulk audit found the last two fan-outs:

- `reorderCustomFieldDefinitions` (settings drag-reorder) was **2N** round-trips (getById+update per id) with **no** batch mutation → added `customFieldDefinitions.reorderMany` ({id,sortOrder} pairs, requireService-gated, per-item org re-check) called **once**. Explicit sortOrder so filtering foreign ids doesn't compress survivors.
- `deleteProjectService` cascade looped `deleteCascade` per assignment → one `deleteManyCascade({ids,orgId})` (batch already existed).

Test: `review2Bulk.test.ts` position-preservation + service gating. Suite green (340); tsc clean; **codex CLEAN**. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)