### PR TITLE
feat: T&T sub-tests → single array mutation (bulk single-call)

### DIFF
--- a/convex/subTestRecords.ts
+++ b/convex/subTestRecords.ts
@@ -54,26 +54,79 @@ export const listByRecordIds = query({
   },
 });
 
+const subTestFields = {
+  id: v.string(),
+  testTagRecordId: v.string(),
+  label: v.string(),
+  sortOrder: v.optional(v.number()),
+  result: v.optional(enums.TestResult),
+  earthContinuityResult: v.optional(enums.TestResult),
+  earthContinuityReading: v.optional(v.number()),
+  insulationResult: v.optional(enums.TestResult),
+  insulationReading: v.optional(v.number()),
+  leakageCurrentResult: v.optional(enums.TestResult),
+  leakageCurrentReading: v.optional(v.number()),
+  polarityResult: v.optional(enums.TestResult),
+  notes: v.optional(v.string()),
+  createdAt: v.optional(v.number()),
+};
+
 export const create = mutation({
-  args: {
-    id: v.string(),
-    testTagRecordId: v.string(),
-    label: v.string(),
-    sortOrder: v.optional(v.number()),
-    result: v.optional(enums.TestResult),
-    earthContinuityResult: v.optional(enums.TestResult),
-    earthContinuityReading: v.optional(v.number()),
-    insulationResult: v.optional(enums.TestResult),
-    insulationReading: v.optional(v.number()),
-    leakageCurrentResult: v.optional(enums.TestResult),
-    leakageCurrentReading: v.optional(v.number()),
-    polarityResult: v.optional(enums.TestResult),
-    notes: v.optional(v.string()),
-    createdAt: v.optional(v.number()),
-  },
+  args: subTestFields,
   handler: async (ctx, args) => {
     await requireService(ctx);
     return await ctx.db.insert("subTestRecords", args);
+  },
+});
+
+/**
+ * Insert many sub-test records in ONE round trip (bulk single-call invariant —
+ * a T&T record's sub-tests are all created from one form submit; the server was
+ * looping `createIfMissing` per sub-test). Idempotent per `id` (safe on retry).
+ *
+ * subTestRecords have no org column — they are parent-scoped — so defense-in-depth:
+ * every distinct `testTagRecordId` is verified to belong to `organizationId` before
+ * ANY insert (one parent lookup per distinct record, cached). A record that doesn't
+ * match the caller's org aborts the whole batch (transactional: one record's
+ * sub-tests are a single logical set).
+ */
+export const createManyIfMissing = mutation({
+  args: {
+    organizationId: v.string(),
+    records: v.array(v.object(subTestFields)),
+  },
+  handler: async (ctx, { organizationId, records }) => {
+    await requireService(ctx);
+
+    // Per-parent org re-check (by_cuid is a GLOBAL index) — cache by parent id.
+    const verifiedParents = new Map<string, boolean>();
+    for (const rec of records) {
+      if (!verifiedParents.has(rec.testTagRecordId)) {
+        const parent = await ctx.db
+          .query("testTagRecords")
+          .withIndex("by_cuid", (q) => q.eq("id", rec.testTagRecordId))
+          .unique(); // fail-closed on the (impossible) duplicate-cuid case, matching getById/createIfMissing
+        const ok = !!parent && parent.organizationId === organizationId;
+        verifiedParents.set(rec.testTagRecordId, ok);
+        if (!ok) {
+          throw new ConvexError(
+            "Forbidden: test record not found in organization: " + rec.testTagRecordId,
+          );
+        }
+      }
+    }
+
+    let created = 0;
+    for (const args of records) {
+      const existing = await ctx.db
+        .query("subTestRecords")
+        .withIndex("by_cuid", (q) => q.eq("id", args.id))
+        .unique();
+      if (existing) continue;
+      await ctx.db.insert("subTestRecords", args);
+      created += 1;
+    }
+    return { created };
   },
 });
 

--- a/convex/subTestRecordsCreateMany.test.ts
+++ b/convex/subTestRecordsCreateMany.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+//
+// subTestRecords.createManyIfMissing — bulk single-call for a T&T record's sub-tests
+// (the server was looping createIfMissing per sub-test). Verifies: one array insert,
+// idempotent per id, and per-parent org re-check (subTestRecords are parent-scoped, no
+// org column — a batch referencing another org's record must abort).
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const seedRecord = (t: T, id: string, organizationId: string) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("testTagRecords", {
+      id,
+      organizationId,
+      testTagAssetId: "tta_1",
+      testDate: NOW,
+      testedById: "u1",
+      testerName: "Tester",
+      nextDueDate: NOW,
+    });
+  });
+
+const countSubTests = (t: T, recordId: string) =>
+  t.run(async (ctx) =>
+    (await ctx.db.query("subTestRecords").withIndex("by_testTagRecordId", (q) => q.eq("testTagRecordId", recordId)).collect()).length,
+  );
+
+describe("subTestRecords.createManyIfMissing", () => {
+  test("inserts all sub-tests in one call, idempotent per id", async () => {
+    const t = makeT();
+    await seedRecord(t, "rec_1", ORG);
+    const records = [
+      { id: "st_1", testTagRecordId: "rec_1", label: "A", createdAt: NOW },
+      { id: "st_2", testTagRecordId: "rec_1", label: "B", createdAt: NOW },
+    ];
+    const first = await t.withIdentity(SERVICE).mutation(api.subTestRecords.createManyIfMissing, { organizationId: ORG, records });
+    expect(first.created).toBe(2);
+    expect(await countSubTests(t, "rec_1")).toBe(2);
+
+    // Re-run (retry) — no duplicates.
+    const second = await t.withIdentity(SERVICE).mutation(api.subTestRecords.createManyIfMissing, { organizationId: ORG, records });
+    expect(second.created).toBe(0);
+    expect(await countSubTests(t, "rec_1")).toBe(2);
+  });
+
+  test("aborts the whole batch if any record belongs to another org (no partial insert)", async () => {
+    const t = makeT();
+    await seedRecord(t, "rec_ok", ORG);
+    await seedRecord(t, "rec_bad", OTHER);
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.subTestRecords.createManyIfMissing, {
+        organizationId: ORG,
+        records: [
+          { id: "st_a", testTagRecordId: "rec_ok", label: "A", createdAt: NOW },
+          { id: "st_b", testTagRecordId: "rec_bad", label: "B", createdAt: NOW },
+        ],
+      }),
+    ).rejects.toThrow(/Forbidden/);
+    // Verification happens up-front, before any insert → nothing written.
+    expect(await countSubTests(t, "rec_ok")).toBe(0);
+    expect(await countSubTests(t, "rec_bad")).toBe(0);
+  });
+
+  test("rejects a non-service (browser) caller", async () => {
+    const t = makeT();
+    await seedRecord(t, "rec_1", ORG);
+    await expect(
+      t.withIdentity({ subject: "user_1" }).mutation(api.subTestRecords.createManyIfMissing, {
+        organizationId: ORG,
+        records: [{ id: "st_1", testTagRecordId: "rec_1", label: "A", createdAt: NOW }],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/server/test-tag-records.ts
+++ b/src/server/test-tag-records.ts
@@ -226,10 +226,11 @@ export async function createTestTagRecord(data: {
     updatedAt: now,
   });
 
-  // Write sub-test records to Convex.
+  // Write sub-test records to Convex in ONE array mutation (bulk single-call).
   if (data.subTests && data.subTests.length > 0) {
-    for (const st of data.subTests) {
-      await convex.mutation(api.subTestRecords.createIfMissing, {
+    await convex.mutation(api.subTestRecords.createManyIfMissing, {
+      organizationId,
+      records: data.subTests.map((st) => ({
         id: createId(),
         testTagRecordId: recordId,
         label: st.label,
@@ -244,8 +245,8 @@ export async function createTestTagRecord(data: {
         polarityResult: st.polarityResult || "NOT_APPLICABLE",
         ...(st.notes && { notes: st.notes }),
         createdAt: now,
-      });
-    }
+      })),
+    });
   }
 
   // Update parent TestTagAsset scalars in Convex.


### PR DESCRIPTION
## What
The `createTestTagRecord` server action looped `subTestRecords.createIfMissing` once per sub-test. Collapsed to **one** `subTestRecords.createManyIfMissing` array mutation — closing a remaining bulk single-call gap (Phase 3, WS2 Appendix A).

## Security
subTestRecords have no org column (parent-scoped). The array mutation adds a **per-parent org re-check**: every distinct `testTagRecordId` is verified to belong to the supplied `organizationId` before ANY insert (fail-closed via `.unique()`, aborting the whole batch on mismatch). Idempotent per `id` (safe on retry). Service-gated (`requireService`).

## Tests
`convex/subTestRecordsCreateMany.test.ts` — one-call insert + idempotency, cross-org abort (no partial insert), non-service rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)