### PR TITLE
feat: maintenance asset-links → single array mutation (bulk single-call)

### DIFF
--- a/convex/maintenanceRecordAssets.ts
+++ b/convex/maintenanceRecordAssets.ts
@@ -103,6 +103,55 @@ export const createIfMissing = mutation({
   },
 });
 
+/**
+ * Create many maintenance→asset links in ONE round trip (bulk single-call invariant —
+ * linking N assets to a record is one user action; the server was looping `create` per
+ * asset). Idempotent per `id`. maintenanceRecordAssets have no org column (they are
+ * parent-scoped), so defense-in-depth: every distinct `maintenanceRecordId` is verified
+ * to belong to `organizationId` before ANY insert (fail-closed via `.unique()`; a bad
+ * parent aborts the whole batch — a record's link set is a single logical write).
+ */
+export const createManyIfMissing = mutation({
+  args: {
+    organizationId: v.string(),
+    links: v.array(
+      v.object({ id: v.string(), maintenanceRecordId: v.string(), assetId: v.string() }),
+    ),
+  },
+  handler: async (ctx, { organizationId, links }) => {
+    await requireService(ctx);
+
+    const verifiedParents = new Map<string, boolean>();
+    for (const link of links) {
+      if (!verifiedParents.has(link.maintenanceRecordId)) {
+        const parent = await ctx.db
+          .query("maintenanceRecords")
+          .withIndex("by_cuid", (q) => q.eq("id", link.maintenanceRecordId))
+          .unique();
+        const ok = !!parent && parent.organizationId === organizationId;
+        verifiedParents.set(link.maintenanceRecordId, ok);
+        if (!ok) {
+          throw new ConvexError(
+            "Forbidden: maintenance record not found in organization: " + link.maintenanceRecordId,
+          );
+        }
+      }
+    }
+
+    let created = 0;
+    for (const link of links) {
+      const existing = await ctx.db
+        .query("maintenanceRecordAssets")
+        .withIndex("by_cuid", (q) => q.eq("id", link.id))
+        .unique();
+      if (existing) continue;
+      await ctx.db.insert("maintenanceRecordAssets", link);
+      created += 1;
+    }
+    return { created };
+  },
+});
+
 export const update = mutation({
   args: {
     id: v.string(),

--- a/convex/maintenanceRecordAssetsCreateMany.test.ts
+++ b/convex/maintenanceRecordAssetsCreateMany.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// maintenanceRecordAssets.createManyIfMissing — bulk single-call for linking N assets
+// to a maintenance record (the server helper was looping `create` per asset). Verifies
+// one array insert, idempotency per id, and per-parent org re-check (the join table has
+// no org column, so a batch referencing another org's record must abort with no insert).
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+const seedRecord = (t: T, id: string, organizationId: string) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("maintenanceRecords", {
+      id,
+      organizationId,
+      type: "REPAIR",
+      status: "SCHEDULED",
+      title: "Fix",
+      reportedById: "u1",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  });
+
+const countLinks = (t: T, recordId: string) =>
+  t.run(async (ctx) =>
+    (await ctx.db.query("maintenanceRecordAssets").withIndex("by_maintenanceRecordId", (q) => q.eq("maintenanceRecordId", recordId)).collect()).length,
+  );
+
+describe("maintenanceRecordAssets.createManyIfMissing", () => {
+  test("links all assets in one call, idempotent per id", async () => {
+    const t = makeT();
+    await seedRecord(t, "mr_1", ORG);
+    const links = [
+      { id: "l_1", maintenanceRecordId: "mr_1", assetId: "a_1" },
+      { id: "l_2", maintenanceRecordId: "mr_1", assetId: "a_2" },
+    ];
+    const first = await t.withIdentity(SERVICE).mutation(api.maintenanceRecordAssets.createManyIfMissing, { organizationId: ORG, links });
+    expect(first.created).toBe(2);
+    expect(await countLinks(t, "mr_1")).toBe(2);
+
+    const second = await t.withIdentity(SERVICE).mutation(api.maintenanceRecordAssets.createManyIfMissing, { organizationId: ORG, links });
+    expect(second.created).toBe(0);
+    expect(await countLinks(t, "mr_1")).toBe(2);
+  });
+
+  test("aborts the whole batch if a record belongs to another org (no partial insert)", async () => {
+    const t = makeT();
+    await seedRecord(t, "mr_ok", ORG);
+    await seedRecord(t, "mr_bad", OTHER);
+    await expect(
+      t.withIdentity(SERVICE).mutation(api.maintenanceRecordAssets.createManyIfMissing, {
+        organizationId: ORG,
+        links: [
+          { id: "l_ok", maintenanceRecordId: "mr_ok", assetId: "a_1" },
+          { id: "l_bad", maintenanceRecordId: "mr_bad", assetId: "a_2" },
+        ],
+      }),
+    ).rejects.toThrow(/Forbidden/);
+    expect(await countLinks(t, "mr_ok")).toBe(0);
+    expect(await countLinks(t, "mr_bad")).toBe(0);
+  });
+
+  test("rejects a non-service caller", async () => {
+    const t = makeT();
+    await seedRecord(t, "mr_1", ORG);
+    await expect(
+      t.withIdentity({ subject: "user_1" }).mutation(api.maintenanceRecordAssets.createManyIfMissing, {
+        organizationId: ORG,
+        links: [{ id: "l_1", maintenanceRecordId: "mr_1", assetId: "a_1" }],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/maintenance-record-asset-read.ts
+++ b/src/lib/maintenance-record-asset-read.ts
@@ -84,19 +84,23 @@ export async function getMaintenanceAssetLinksByAssetIds(
 export async function createMaintenanceAssetLinks(
   maintenanceRecordId: string,
   assetIds: string[],
+  organizationId: string,
 ): Promise<void> {
   if (assetIds.length === 0) return;
   const convex = await getConvexClient();
   const existing = await getMaintenanceAssetLinksByRecordIds([maintenanceRecordId]);
   const have = new Set(existing.map((l) => l.assetId));
   const toCreate = Array.from(new Set(assetIds)).filter((aId) => !have.has(aId));
-  for (const assetId of toCreate) {
-    await convex.mutation(api.maintenanceRecordAssets.create, {
+  if (toCreate.length === 0) return;
+  // ONE array mutation (bulk single-call), org-verified per parent record.
+  await convex.mutation(api.maintenanceRecordAssets.createManyIfMissing, {
+    organizationId,
+    links: toCreate.map((assetId) => ({
       id: createId(),
       maintenanceRecordId,
       assetId,
-    });
-  }
+    })),
+  });
 }
 
 /**

--- a/src/server/check-records.ts
+++ b/src/server/check-records.ts
@@ -208,7 +208,7 @@ async function checkPredictiveMaintenance(
           createdAt: now,
           updatedAt: now,
         });
-        await createMaintenanceAssetLinks(maintenanceId, [assetId]);
+        await createMaintenanceAssetLinks(maintenanceId, [assetId], organizationId);
 
         await logActivity({
           organizationId,

--- a/src/server/maintenance.ts
+++ b/src/server/maintenance.ts
@@ -334,7 +334,7 @@ export async function createMaintenanceRecord(data: MaintenanceFormValues) {
   });
 
   // Convex-only join write (Phase B): link the assets to the new record.
-  await createMaintenanceAssetLinks(newRecordId, assetIds);
+  await createMaintenanceAssetLinks(newRecordId, assetIds, organizationId);
 
   const record = await getMaintenanceRecordById(newRecordId);
 
@@ -445,6 +445,7 @@ export async function updateMaintenanceRecord(
   await createMaintenanceAssetLinks(
     id,
     newAssetIds.filter((aId) => !existingAssetIds.includes(aId)),
+    organizationId,
   );
 
   const record = await getMaintenanceRecordById(id);

--- a/src/server/test-tag-records.ts
+++ b/src/server/test-tag-records.ts
@@ -288,7 +288,7 @@ export async function createTestTagRecord(data: {
         createdAt: now,
         updatedAt: now,
       });
-      await createMaintenanceAssetLinks(maintenanceId, [testTagAsset.assetId]);
+      await createMaintenanceAssetLinks(maintenanceId, [testTagAsset.assetId], organizationId);
       // Mark the linked asset as in maintenance (asset is Convex-only now).
       await convex.mutation(api.assets.patchAsset, {
         id: testTagAsset.assetId,


### PR DESCRIPTION
## What
`createMaintenanceAssetLinks` looped `maintenanceRecordAssets.create` once per asset. Collapsed to **one** `maintenanceRecordAssets.createManyIfMissing` array mutation (Phase 3, WS2 Appendix A).

## Security
The join table has no org column (parent-scoped). The array mutation adds a **per-parent org re-check**: every distinct `maintenanceRecordId` is verified against the caller's `organizationId` before ANY insert (fail-closed via `.unique()`, aborting the batch on mismatch). Idempotent per `id`. Service-gated. `organizationId` threaded through the helper to all 4 call sites.

## Tests
`convex/maintenanceRecordAssetsCreateMany.test.ts` — one-call insert + idempotency, cross-org abort (no partial insert), non-service rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)