### PR TITLE
feat: activity-log reads → browser-direct (file trimmed to CSV export)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -28,7 +28,7 @@ The surface is arranged in two tiers, because 537 tools would overwhelm any agen
 `get_project`, `create_project`, `search_assets`, `get_asset`, `list_models`,
 `list_kits`, `get_kit`, `check_availability`, `global_search`, `scan_lookup`,
 `list_clients`, `create_client`, `list_crew`, `list_locations`, `list_suppliers`,
-`get_pull_sheet`, `get_project_tasks`, `get_activity_log`,
+`get_pull_sheet`, `get_project_tasks`,
 `reserve_items`, `whoami`, and the tier-2 tools below. Use these first — they are
 easier to call correctly.
 

--- a/src/app/(app)/activity/page.tsx
+++ b/src/app/(app)/activity/page.tsx
@@ -2,14 +2,13 @@
 
 import { useState, Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { useServerQuery } from "@/hooks/use-server-query";
+import { useActivityLogs } from "@/hooks/use-activity-log";
 import { Download } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
 
-import { getActivityLogs, exportActivityLogCSV } from "@/server/activity-log";
+import { exportActivityLogCSV } from "@/server/activity-log";
 import { useTablePreferences } from "@/lib/use-table-preferences";
-import { useActiveOrganization } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
@@ -119,8 +118,6 @@ function useActivityColumns(): ColumnDef<AnyLog>[] {
 }
 
 function ActivityLogContent() {
-  const { data: activeOrg } = useActiveOrganization();
-  const orgId = activeOrg?.id;
 
   const searchParams = useSearchParams();
   const urlEntityType = searchParams.get("entityType") || undefined;
@@ -154,11 +151,7 @@ function ActivityLogContent() {
     order: sortOrder,
   };
 
-  const { data, isLoading } = useServerQuery({
-    queryKey: ["activity-logs", orgId, queryFilters],
-    queryFn: () => getActivityLogs(queryFilters),
-    enabled: !!orgId,
-  });
+  const { data, isLoading } = useActivityLogs(queryFilters);
 
   const items = (data?.items || []) as AnyLog[];
   const total = data?.total || 0;

--- a/src/components/activity/activity-timeline.tsx
+++ b/src/components/activity/activity-timeline.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useServerQuery } from "@/hooks/use-server-query";
-import { getEntityActivityLog } from "@/server/activity-log";
-import { useActiveOrganization } from "@/lib/auth-client";
+import { useEntityActivityLog } from "@/hooks/use-activity-log";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { EmptyState } from "@/components/ui/empty-state";
 
@@ -25,14 +23,7 @@ interface ActivityTimelineProps {
 }
 
 export function ActivityTimeline({ entityType, entityId, limit = 5 }: ActivityTimelineProps) {
-  const { data: activeOrg } = useActiveOrganization();
-  const orgId = activeOrg?.id;
-
-  const { data, isLoading } = useServerQuery({
-    queryKey: ["entity-activity", orgId, entityType, entityId, limit],
-    queryFn: () => getEntityActivityLog(entityType, entityId, limit),
-    enabled: !!entityId,
-  });
+  const { data, isLoading } = useEntityActivityLog(entityType, entityId, limit);
 
   const items = (data?.items ?? []) as Record<string, unknown>[];
   const total = data?.total ?? 0;

--- a/src/hooks/use-activity-log.ts
+++ b/src/hooks/use-activity-log.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { api } from "../../convex/_generated/api";
+import { type ActivityLogFilters, startMs, endMs } from "@/lib/activity-log-filters";
+
+/**
+ * Browser-direct activity-log reads (Phase 3 — replaces the getActivityLogs /
+ * getEntityActivityLog server actions). `api.activityLog.list` / `listByEntity` are
+ * browser-callable (`requireOrgRead`). The date→ms coercion the server action did
+ * moves here. (CSV export stays server-only.)
+ */
+
+export function useActivityLogs(filters: ActivityLogFilters = {}) {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const {
+    page = 1,
+    pageSize = 50,
+    entityType,
+    action,
+    userId,
+    entityId,
+    projectId,
+    assetId,
+    search,
+    startDate,
+    endDate,
+    sort = "createdAt",
+    order = "desc",
+  } = filters;
+
+  const data = useAuthedQuery(
+    api.activityLog.list,
+    orgId
+      ? {
+          orgId,
+          page,
+          pageSize,
+          sort,
+          order,
+          entityType,
+          action,
+          userId,
+          entityId,
+          projectId,
+          assetId,
+          search,
+          startDateMs: startMs(startDate),
+          endDateMs: endMs(endDate),
+        }
+      : "skip",
+  );
+  return { data, isLoading: data === undefined };
+}
+
+export function useEntityActivityLog(entityType: string, entityId: string, limit = 5) {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const data = useAuthedQuery(
+    api.activityLog.listByEntity,
+    orgId && entityId ? { orgId, entityType, entityId, limit } : "skip",
+  );
+  return { data, isLoading: data === undefined };
+}

--- a/src/lib/activity-log-filters.ts
+++ b/src/lib/activity-log-filters.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared activity-log filter shape + date coercion. Plain module (not "use server")
+ * so both the browser-direct read hook (`use-activity-log.ts`) and the server-only CSV
+ * export (`src/server/activity-log.ts`) can import it.
+ */
+
+export interface ActivityLogFilters {
+  page?: number;
+  pageSize?: number;
+  entityType?: string;
+  action?: string;
+  userId?: string;
+  entityId?: string;
+  projectId?: string;
+  assetId?: string;
+  search?: string;
+  startDate?: string | Date;
+  endDate?: string | Date;
+  sort?: string;
+  order?: "asc" | "desc";
+}
+
+/** Filter date → epoch ms. */
+export function startMs(d?: string | Date): number | undefined {
+  return d != null ? new Date(d).getTime() : undefined;
+}
+
+/** endDate is pushed to end-of-day (Prisma parity). */
+export function endMs(d?: string | Date): number | undefined {
+  if (d == null) return undefined;
+  const end = new Date(d);
+  end.setHours(23, 59, 59, 999);
+  return end.getTime();
+}

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -39,9 +39,7 @@ export interface OperationMeta {
 }
 
 export const OPERATIONS: Record<string, OperationMeta> = {
-  "activity-log.exportActivityLogCSV": { name: "activity-log.exportActivityLogCSV", module: "activity-log", fn: "exportActivityLogCSV", kind: "read", resource: "reports", action: "read", scope: "reports:read", params: [{ name: "filters", type: "ActivityLogFilters", optional: true }], dangerous: false, summary: "" },
-  "activity-log.getActivityLogs": { name: "activity-log.getActivityLogs", module: "activity-log", fn: "getActivityLogs", kind: "read", resource: "reports", action: "read", scope: "reports:read", params: [{ name: "filters", type: "ActivityLogFilters", optional: true }], dangerous: false, summary: "" },
-  "activity-log.getEntityActivityLog": { name: "activity-log.getEntityActivityLog", module: "activity-log", fn: "getEntityActivityLog", kind: "read", resource: "reports", action: "read", scope: "reports:read", params: [{ name: "entityType", type: "string", optional: false }, { name: "entityId", type: "string", optional: false }, { name: "limit", type: "unknown", optional: true }], dangerous: false, summary: "" },
+  "activity-log.exportActivityLogCSV": { name: "activity-log.exportActivityLogCSV", module: "activity-log", fn: "exportActivityLogCSV", kind: "read", resource: "reports", action: "read", scope: "reports:read", params: [{ name: "filters", type: "ActivityLogFilters", optional: true }], dangerous: false, summary: "Activity-log CSV export (KEEP-SERVER-ONLY — Node string generation). The" },
   "api-keys.createApiKey": { name: "api-keys.createApiKey", module: "api-keys", fn: "createApiKey", kind: "write", resource: "orgSettings", action: "update", scope: "orgSettings:update", params: [{ name: "input", type: "{ name: string; scopes: string[]; actingUserId?: string; expiresAt?: Date | string | null; }", optional: false }], dangerous: true, summary: "Mint a new key. Returns the raw token ONCE — show it to the user immediately;" },
   "api-keys.listApiKeys": { name: "api-keys.listApiKeys", module: "api-keys", fn: "listApiKeys", kind: "read", resource: "orgSettings", action: "read", scope: "orgSettings:read", params: [], dangerous: false, summary: "Management for agent-accessible API keys (docs/designs/api-mcp-agent-access.md)." },
   "api-keys.revokeApiKey": { name: "api-keys.revokeApiKey", module: "api-keys", fn: "revokeApiKey", kind: "write", resource: "orgSettings", action: "update", scope: "orgSettings:update", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "Revoke a single key (deactivate + stamp revokedAt). Idempotent. */" },
@@ -4283,4 +4281,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 527;
+export const OPERATION_COUNT = 525;

--- a/src/lib/api/mcp-tools.ts
+++ b/src/lib/api/mcp-tools.ts
@@ -322,21 +322,6 @@ export const CURATED_TOOLS: CuratedTool[] = [
       required: ["projectId"],
     },
   },
-  {
-    name: "get_activity_log",
-    operation: "activity-log.getActivityLogs",
-    description:
-      "Audit trail of who changed what, when. Read-only. Useful for answering 'what happened to this booking'. Required scope: reports:read.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        filters: {
-          type: "object",
-          description: "Optional filters: { entityType?, entityId?, userId?, action?, limit? }",
-        },
-      },
-    },
-  },
 ];
 
 /**

--- a/src/lib/api/openapi.test.ts
+++ b/src/lib/api/openapi.test.ts
@@ -42,8 +42,8 @@ describe("OpenAPI document", () => {
   });
 
   it("does not pretend to have a schema it lacks", () => {
-    // activity-log.getActivityLogs takes ActivityLogFilters, a plain interface.
-    const post = doc.paths["/api/v1/ops/activity-log.getActivityLogs"].post!;
+    // activity-log.exportActivityLogCSV takes ActivityLogFilters, a plain interface.
+    const post = doc.paths["/api/v1/ops/activity-log.exportActivityLogCSV"].post!;
     const body = post.requestBody as {
       content: { "application/json": { schema: { properties: { arguments: { properties: Record<string, { description?: string }> } } } } };
     };

--- a/src/lib/api/tool-aliases.ts
+++ b/src/lib/api/tool-aliases.ts
@@ -38,7 +38,6 @@ export const TOOL_ALIASES: Record<string, string> = {
   get_pull_sheet: "warehouse.getProjectPullSheet",
   get_available_assets_for_model: "warehouse.getAvailableAssetsForModel",
   get_project_tasks: "project-tasks.getProjectTasks",
-  get_activity_log: "activity-log.getActivityLogs",
 };
 
 /** operation name → MCP tool name (inverse of {@link TOOL_ALIASES}). */

--- a/src/server/activity-log.ts
+++ b/src/server/activity-log.ts
@@ -1,104 +1,19 @@
 "use server";
 
 import { getOrgContext } from "@/lib/org-context";
-import { serialize } from "@/lib/serialize";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
+import { type ActivityLogFilters, startMs, endMs } from "@/lib/activity-log-filters";
 
-interface ActivityLogFilters {
-  page?: number;
-  pageSize?: number;
-  entityType?: string;
-  action?: string;
-  userId?: string;
-  entityId?: string;
-  projectId?: string;
-  assetId?: string;
-  search?: string;
-  startDate?: string | Date;
-  endDate?: string | Date;
-  sort?: string;
-  order?: "asc" | "desc";
-}
-
-/** Convert a filter date to epoch ms; endDate is pushed to end-of-day (Prisma parity). */
-function startMs(d?: string | Date): number | undefined {
-  return d != null ? new Date(d).getTime() : undefined;
-}
-function endMs(d?: string | Date): number | undefined {
-  if (d == null) return undefined;
-  const end = new Date(d);
-  end.setHours(23, 59, 59, 999);
-  return end.getTime();
-}
-
-export async function getActivityLogs(filters: ActivityLogFilters = {}) {
-  const { organizationId } = await getOrgContext();
-  const {
-    page = 1,
-    pageSize = 50,
-    entityType,
-    action,
-    userId,
-    entityId,
-    projectId,
-    assetId,
-    search,
-    startDate,
-    endDate,
-    sort = "createdAt",
-    order = "desc",
-  } = filters;
-
-  // Convex-only (complete cross-domain history; the Postgres activity_log is frozen).
-  const convex = await getConvexClient();
-  const result = await convex.query(api.activityLog.list, {
-    orgId: organizationId,
-    page,
-    pageSize,
-    sort,
-    order,
-    entityType,
-    action,
-    userId,
-    entityId,
-    projectId,
-    assetId,
-    search,
-    startDateMs: startMs(startDate),
-    endDateMs: endMs(endDate),
-  });
-  return serialize(result);
-}
-
-export async function getEntityActivityLog(
-  entityType: string,
-  entityId: string,
-  limit = 5,
-) {
-  const { organizationId } = await getOrgContext();
-
-  const convex = await getConvexClient();
-  const result = await convex.query(api.activityLog.listByEntity, {
-    orgId: organizationId,
-    entityType,
-    entityId,
-    limit,
-  });
-  return serialize(result);
-}
-
+/**
+ * Activity-log CSV export (KEEP-SERVER-ONLY — Node string generation). The
+ * getActivityLogs / getEntityActivityLog READS moved browser-direct
+ * (`src/hooks/use-activity-log.ts` → `api.activityLog.list` / `listByEntity`); only
+ * the CSV serialization stays server-side per the DoD's Node-bound exclusion.
+ */
 export async function exportActivityLogCSV(filters: ActivityLogFilters = {}) {
   const { organizationId } = await getOrgContext();
-  const {
-    entityType,
-    entityId,
-    action,
-    userId,
-    search,
-    startDate,
-    endDate,
-  } = filters;
+  const { entityType, entityId, action, userId, search, startDate, endDate } = filters;
 
   const convex = await getConvexClient();
   const items: Array<{


### PR DESCRIPTION
Re-homes the two activity-log READS browser-direct (`use-activity-log.ts` over `api.activityLog.list`/`listByEntity`); moves shared filter types/date-coercion to a lib module; trims `src/server/activity-log.ts` to just `exportActivityLogCSV` (CSV = keep-server). Consumers rewired; `get_activity_log` MCP tool/alias/llms.txt removed; registry regenerated; openapi test repointed at the kept CSV op. tsc + 114 API tests green, codex-fixed the one dangling test ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)