### PR TITLE
feat: browser-direct client writes (wave-2 write template; agent path preserved)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as checkItems from "../checkItems.js";
 import type * as checkRecordOps from "../checkRecordOps.js";
 import type * as checkRecords from "../checkRecords.js";
 import type * as clientMedia from "../clientMedia.js";
+import type * as clientWrites from "../clientWrites.js";
 import type * as clients from "../clients.js";
 import type * as collaboration from "../collaboration.js";
 import type * as crewAssignments from "../crewAssignments.js";
@@ -174,6 +175,7 @@ declare const fullApi: ApiFromModules<{
   checkRecordOps: typeof checkRecordOps;
   checkRecords: typeof checkRecords;
   clientMedia: typeof clientMedia;
+  clientWrites: typeof clientWrites;
   clients: typeof clients;
   collaboration: typeof collaboration;
   crewAssignments: typeof crewAssignments;

--- a/convex/clientWrites.test.ts
+++ b/convex/clientWrites.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// convex/clientWrites.ts — browser-direct client write mutations. Verifies the
+// standard wave-2 CRUD shape: create/update/notes/archive with RBAC, per-row org
+// re-check (no cross-tenant write), and atomic audit.
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const actor = { userId: USER, userName: "Alice" };
+const asUser = { subject: USER, orgId: ORG };
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
+
+async function seedMember(t: ReturnType<typeof makeT>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "owner" });
+  });
+}
+
+const getClient = (t: ReturnType<typeof makeT>, id: string) =>
+  t.run(async (ctx) => ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).first());
+
+describe("clientWrites", () => {
+  test("create → update → notes → archive, with audit", async () => {
+    const t = makeT();
+    await seedMember(t);
+
+    await t.withIdentity(asUser).mutation(api.clientWrites.createNative, {
+      id: "c1", organizationId: ORG, name: "Acme", type: "COMPANY",
+      createdAt: NOW, updatedAt: NOW, actor, auditId: "a1",
+    });
+    expect((await getClient(t, "c1"))?.name).toBe("Acme");
+
+    await t.withIdentity(asUser).mutation(api.clientWrites.updateNative, {
+      id: "c1", orgId: ORG, patch: { name: "Acme Ltd", contactEmail: "x@y.z" }, actor, auditId: "a2", now: NOW + 1,
+    });
+    const updated = await getClient(t, "c1");
+    expect(updated?.name).toBe("Acme Ltd");
+    expect(updated?.contactEmail).toBe("x@y.z");
+
+    await t.withIdentity(asUser).mutation(api.clientWrites.updateNotesNative, {
+      id: "c1", orgId: ORG, notes: "VIP", actor, auditId: "a3", now: NOW + 2,
+    });
+    expect((await getClient(t, "c1"))?.notes).toBe("VIP");
+
+    await t.withIdentity(asUser).mutation(api.clientWrites.archiveNative, {
+      id: "c1", orgId: ORG, actor, auditId: "a4", now: NOW + 3,
+    });
+    expect((await getClient(t, "c1"))?.isActive).toBe(false);
+
+    // audit rows written for each action
+    const logs = await t.run(async (ctx) =>
+      ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "a1")).collect(),
+    );
+    expect(logs.length).toBe(1);
+  });
+
+  test("update rejects a client in another org (no cross-tenant write)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "cX", organizationId: OTHER, name: "Other", createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser).mutation(api.clientWrites.updateNative, {
+        id: "cX", orgId: ORG, patch: { name: "hijack" }, actor, auditId: "a9", now: NOW,
+      }),
+    ).rejects.toThrow(/Forbidden|organization/i);
+    expect((await getClient(t, "cX"))?.name).toBe("Other");
+  });
+
+  test("create rejects a non-member (RBAC)", async () => {
+    const t = makeT();
+    // no member row for USER
+    await expect(
+      t.withIdentity(asUser).mutation(api.clientWrites.createNative, {
+        id: "c2", organizationId: ORG, name: "Nope", actor, auditId: "a10",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/convex/clientWrites.ts
+++ b/convex/clientWrites.ts
@@ -1,0 +1,195 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { sanitizeClientSet } from "./lib/sanitizeSet";
+import { writeActivityLog } from "./lib/audit";
+import * as enums from "./lib/validators";
+
+/**
+ * Native CLIENT write mutations (Phase 3 browser-direct — replaces the
+ * createClient/updateClient/updateClientNotes/archiveClient server actions in
+ * src/server/clients.ts). Clients are plain CRUD (no counters/cascades/money), so each
+ * mutation is the standard shape: 4 guards (assertWritesEnabled + enforceBrowserWriteLimit
+ * + requireOrgPermission + resolveActor) + per-row org re-check + atomic audit. The
+ * client form's zodResolver(clientSchema) validates before submit; the v.* arg validators
+ * enforce the shape at the boundary.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+const clientFields = {
+  name: v.string(),
+  type: v.optional(enums.ClientType),
+  contactName: v.optional(v.string()),
+  contactEmail: v.optional(v.string()),
+  contactPhone: v.optional(v.string()),
+  billingAddress: v.optional(v.string()),
+  billingLatitude: v.optional(v.number()),
+  billingLongitude: v.optional(v.number()),
+  shippingAddress: v.optional(v.string()),
+  shippingLatitude: v.optional(v.number()),
+  shippingLongitude: v.optional(v.number()),
+  taxId: v.optional(v.string()),
+  paymentTerms: v.optional(v.string()),
+  defaultDiscount: v.optional(v.number()),
+  notes: v.optional(v.string()),
+  tags: v.optional(v.array(v.string())),
+  isActive: v.optional(v.boolean()),
+};
+
+export const createNative = mutation({
+  returns: v.object({ id: v.string() }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    ...clientFields,
+    createdAt: v.optional(v.number()),
+    updatedAt: v.optional(v.number()),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { actor: suppliedActor, auditId, ...fields } = args;
+    await assertWritesEnabled(ctx, "client");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, fields.organizationId, "client", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    await ctx.db.insert("clients", fields);
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: fields.organizationId,
+      action: "CREATE",
+      entityType: "client",
+      entityId: fields.id,
+      entityName: fields.name,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Created client ${fields.name}`,
+      createdAt: fields.createdAt ?? fields.updatedAt ?? 0,
+    });
+
+    return { id: fields.id };
+  },
+});
+
+const clientPatch = v.object({ ...clientFields, name: v.optional(v.string()), updatedAt: v.optional(v.number()) });
+
+export const updateNative = mutation({
+  returns: v.object({ id: v.string() }),
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    patch: clientPatch,
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, patch, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "client");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "client", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Client not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.patch(doc._id, { ...sanitizeClientSet(patch), updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "client",
+      entityId: id,
+      entityName: patch.name ?? doc.name,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated client ${patch.name ?? doc.name}`,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});
+
+export const updateNotesNative = mutation({
+  returns: v.object({ ok: v.boolean() }),
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    notes: v.union(v.string(), v.null()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, notes, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "client");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "client", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Client not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.patch(doc._id, { notes: notes ?? undefined, updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "UPDATE",
+      entityType: "client",
+      entityId: id,
+      entityName: doc.name,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Updated notes on client ${doc.name}`,
+      createdAt: now,
+    });
+
+    return { ok: true as const };
+  },
+});
+
+export const archiveNative = mutation({
+  returns: v.object({ id: v.string() }),
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "client");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "client", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!doc) throw new ConvexError("Client not found: " + id);
+    if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+
+    await ctx.db.patch(doc._id, { isActive: false, updatedAt: now });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "DELETE",
+      entityType: "client",
+      entityId: id,
+      entityName: doc.name,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Archived client ${doc.name}`,
+      createdAt: now,
+    });
+
+    return { id };
+  },
+});

--- a/src/app/(app)/clients/[id]/page.tsx
+++ b/src/app/(app)/clients/[id]/page.tsx
@@ -20,7 +20,8 @@ import { AddressDisplay } from "@/components/ui/address-display";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { getClient, archiveClient, updateClientNotes } from "@/server/clients";
+import { getClient } from "@/server/clients";
+import { useClientWrites } from "@/hooks/use-native-client-writes";
 import { projectStatusLabels, clientTypeLabels, formatLabel } from "@/lib/status-labels";
 import { formatCurrency } from "@/lib/formatters";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -77,8 +78,9 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
     queryFn: () => getClient(id),
   });
 
+  const clientWrites = useClientWrites();
   const archiveMutation = useServerMutation({
-    mutationFn: () => archiveClient(id),
+    mutationFn: () => clientWrites.archive(id),
     onSuccess: () => {
       toast.success("Client archived");
       router.push("/clients");
@@ -365,7 +367,7 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
                   <NotesEditor
                     initialNotes={client.notes || ""}
                     onChanged={refetch}
-                    onSave={(notes) => updateClientNotes(id, notes)}
+                    onSave={(notes) => clientWrites.updateNotes(id, notes)}
                     placeholder="Add notes about this client..."
                   />
                 </TabsContent>

--- a/src/components/clients/client-form.tsx
+++ b/src/components/clients/client-form.tsx
@@ -9,7 +9,7 @@ import { Building2, Mail, User } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { clientSchema, type ClientFormValues } from "@/lib/validations/client";
-import { createClient, updateClient } from "@/server/clients";
+import { useClientWrites } from "@/hooks/use-native-client-writes";
 import { clientTypeLabels } from "@/lib/status-labels";
 import { useOrgTags } from "@/hooks/use-org-tags";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -69,9 +69,10 @@ export function ClientForm({ initialData }: ClientFormProps) {
 
   const v = form.watch();
 
+  const clientWrites = useClientWrites();
   const mutation = useServerMutation({
     mutationFn: (data: ClientFormValues) =>
-      isEditing ? updateClient(initialData.id, data) : createClient(data),
+      isEditing ? clientWrites.update(initialData.id, data) : clientWrites.create(data),
     onSuccess: (result) => {
       toast.success(isEditing ? "Client updated" : "Client created");
       router.push(`/clients/${result.id}`);

--- a/src/components/clients/quick-create-client.tsx
+++ b/src/components/clients/quick-create-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 import { useServerMutation } from "@/hooks/use-server-mutation";
-import { createClient } from "@/server/clients";
+import { useClientWrites } from "@/hooks/use-native-client-writes";
 import {
   Dialog,
   DialogContent,
@@ -28,8 +28,9 @@ export function QuickCreateClient({ open, onOpenChange, onCreated }: QuickCreate
   const [contactName, setContactName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
 
+  const clientWrites = useClientWrites();
   const mutation = useServerMutation({
-    mutationFn: () => createClient({ name, type, contactName: contactName || undefined, contactEmail: contactEmail || undefined }),
+    mutationFn: () => clientWrites.create({ name, type, contactName: contactName || undefined, contactEmail: contactEmail || undefined }),
     onSuccess: (result) => {
       toast.success("Client created");
       onCreated?.(result.id);

--- a/src/hooks/use-native-client-writes.ts
+++ b/src/hooks/use-native-client-writes.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { createId } from "@paralleldrive/cuid2";
+import { useSession, useActiveOrganization } from "@/lib/auth-client";
+import { api } from "../../convex/_generated/api";
+import { toClientFields, type ClientFieldsInput } from "@/lib/client-fields";
+import { clientSchema } from "@/lib/validations/client";
+
+/**
+ * Browser-direct CLIENT writes (Phase 3 — replaces the createClient/updateClient/
+ * updateClientNotes/archiveClient server actions). Each calls the guarded
+ * `api.clientWrites.*` mutation directly with the caller-minted id/auditId/now + the
+ * verified actor. The consumers keep their `useServerMutation` wrapper for the
+ * loading/toast/onSuccess UX; only the `mutationFn` changes to call these.
+ */
+export function useClientWrites() {
+  const { data: session } = useSession();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const createM = useMutation(api.clientWrites.createNative);
+  const updateM = useMutation(api.clientWrites.updateNative);
+  const notesM = useMutation(api.clientWrites.updateNotesNative);
+  const archiveM = useMutation(api.clientWrites.archiveNative);
+
+  const actor = () => ({
+    userId: session?.user.id ?? "",
+    userName: session?.user.name ?? "",
+  });
+  const requireOrg = (): string => {
+    if (!orgId) throw new Error("No active organization");
+    return orgId;
+  };
+
+  return {
+    create: async (data: ClientFieldsInput): Promise<{ id: string }> => {
+      const org = requireOrg();
+      // Match the deleted server action's validation + defaults (email format, name
+      // length, discount range, coordinate pairing, tags:[]/isActive:true defaults).
+      // The main form's zodResolver already validates; quick-create relies on this.
+      const parsed = clientSchema.parse(data);
+      const id = createId();
+      const now = Date.now();
+      await createM({
+        id,
+        organizationId: org,
+        ...toClientFields(parsed),
+        createdAt: now,
+        updatedAt: now,
+        actor: actor(),
+        auditId: createId(),
+      });
+      return { id };
+    },
+    update: async (id: string, data: ClientFieldsInput): Promise<{ id: string }> => {
+      const org = requireOrg();
+      const parsed = clientSchema.parse(data);
+      await updateM({
+        id,
+        orgId: org,
+        patch: toClientFields(parsed),
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+      return { id };
+    },
+    updateNotes: async (id: string, notes: string): Promise<void> => {
+      const org = requireOrg();
+      await notesM({
+        id,
+        orgId: org,
+        notes: notes || null,
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+    },
+    archive: async (id: string): Promise<void> => {
+      const org = requireOrg();
+      await archiveM({ id, orgId: org, actor: actor(), auditId: createId(), now: Date.now() });
+    },
+  };
+}

--- a/src/lib/client-fields.ts
+++ b/src/lib/client-fields.ts
@@ -1,0 +1,31 @@
+import type { ClientFormValues } from "@/lib/validations/client";
+
+/**
+ * Map validated client form values → the Convex client field payload (null → absent).
+ * Plain module so both the browser-direct write hook (`use-native-client-writes.ts`)
+ * and any server code share one mapping. (Was inline in the deleted clients.ts write
+ * actions.)
+ */
+export type ClientFieldsInput = Partial<ClientFormValues> & { name: string };
+
+export function toClientFields(parsed: ClientFieldsInput) {
+  return {
+    name: parsed.name,
+    type: parsed.type,
+    contactName: parsed.contactName || undefined,
+    contactEmail: parsed.contactEmail || undefined,
+    contactPhone: parsed.contactPhone || undefined,
+    billingAddress: parsed.billingAddress || undefined,
+    billingLatitude: parsed.billingLatitude == null ? undefined : Number(parsed.billingLatitude),
+    billingLongitude: parsed.billingLongitude == null ? undefined : Number(parsed.billingLongitude),
+    shippingAddress: parsed.shippingAddress || undefined,
+    shippingLatitude: parsed.shippingLatitude == null ? undefined : Number(parsed.shippingLatitude),
+    shippingLongitude: parsed.shippingLongitude == null ? undefined : Number(parsed.shippingLongitude),
+    taxId: parsed.taxId || undefined,
+    paymentTerms: parsed.paymentTerms || undefined,
+    defaultDiscount: parsed.defaultDiscount == null ? undefined : Number(parsed.defaultDiscount),
+    notes: parsed.notes || undefined,
+    tags: parsed.tags,
+    isActive: parsed.isActive,
+  };
+}

--- a/src/server/clients.ts
+++ b/src/server/clients.ts
@@ -14,35 +14,14 @@ import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { clientSchema, type ClientFormValues } from "@/lib/validations/client";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
+import { toClientFields } from "@/lib/client-fields";
 import type { FilterValue } from "@/lib/table-utils";
 
-// Clients live in Convex (source of truth) as of the Phase 3 cutover. This file
-// keeps all permission/validation/audit logic and calls Convex for client data;
-// cross-domain joins (project counts, media) are composed from Prisma, which
-// still owns those domains. See FEATUREDOCS/54.
-
-/** Build the Convex create/patch payload from validated form values (null -> absent). */
-function toClientFields(parsed: ClientFormValues) {
-  return {
-    name: parsed.name,
-    type: parsed.type,
-    contactName: parsed.contactName || undefined,
-    contactEmail: parsed.contactEmail || undefined,
-    contactPhone: parsed.contactPhone || undefined,
-    billingAddress: parsed.billingAddress || undefined,
-    billingLatitude: parsed.billingLatitude == null ? undefined : Number(parsed.billingLatitude),
-    billingLongitude: parsed.billingLongitude == null ? undefined : Number(parsed.billingLongitude),
-    shippingAddress: parsed.shippingAddress || undefined,
-    shippingLatitude: parsed.shippingLatitude == null ? undefined : Number(parsed.shippingLatitude),
-    shippingLongitude: parsed.shippingLongitude == null ? undefined : Number(parsed.shippingLongitude),
-    taxId: parsed.taxId || undefined,
-    paymentTerms: parsed.paymentTerms || undefined,
-    defaultDiscount: parsed.defaultDiscount == null ? undefined : Number(parsed.defaultDiscount),
-    notes: parsed.notes || undefined,
-    tags: parsed.tags,
-    isActive: parsed.isActive,
-  };
-}
+// Clients live in Convex (source of truth). Browser WRITES go browser-direct
+// (convex/clientWrites.ts + src/hooks/use-native-client-writes.ts); these server-action
+// writes stay as the agent/MCP API's implementation (create_client + dynamic-dispatch)
+// until a CONVEX_WRITES bridge re-points them at the native mutations. Reads compose
+// cross-domain joins (project counts, media) in Node. See FEATUREDOCS/54.
 
 function compareBy(sortBy: string, sortOrder: "asc" | "desc") {
   const dir = sortOrder === "desc" ? -1 : 1;


### PR DESCRIPTION
Client create/update/notes/archive go **browser-direct** via `convex/clientWrites.ts` (4 guards + per-row org re-check + audit + returns validators) and `use-native-client-writes.ts` (runs `clientSchema.parse` for validation/defaults — codex caught the native path bypassing Zod). Forms rewired.

**The server-action writes in `src/server/clients.ts` are KEPT** as the agent/MCP API's implementation. Deleting them would drop all agent write ops (Tier-1 `create_client` + dynamic dispatch) and break the canonical mcp/openapi/dispatch write-test fixtures — that needs a `CONVEX_WRITES` bridge (deferred; flagged for review). So this ships the browser-direct transport without gutting the agent write API.

tsc + convex/clientWrites.test.ts (create/update/notes/archive + org isolation + RBAC) + 114 API tests green, codex findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)