### PR TITLE
fix(security): close 3 cross-tenant line-item holes (Phase-3 audit)

### DIFF
--- a/convex/lineItemOrgIsolation.test.ts
+++ b/convex/lineItemOrgIsolation.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// Cross-tenant isolation on the browser-direct line-item surface (Phase 3 security
+// audit fixes). by_cuid/by_projectId are GLOBAL indexes and requireOrgRead/
+// requireOrgPermission only authorize the CALLER's org — so every row fetched by a
+// caller-supplied id/projectId must be re-checked against the caller's org, and the
+// create paths must verify the target project belongs to the caller's org (else a
+// phantom cross-org line corrupts the victim's recalculated totals).
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_A";
+const OTHER = "org_B";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const actor = { userId: USER, userName: "Alice" };
+const asUser = { subject: USER, orgId: ORG };
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
+
+async function seed(t: ReturnType<typeof makeT>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "owner" });
+    // A project + line item belonging to ANOTHER org.
+    await ctx.db.insert("projects", { id: "projB", organizationId: OTHER, projectNumber: "B-1", name: "Foreign", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("projectLineItems", { id: "liB", organizationId: OTHER, projectId: "projB", description: "secret", lineTotal: 999, sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+    // A project belonging to the CALLER's org.
+    await ctx.db.insert("projects", { id: "projA", organizationId: ORG, projectNumber: "A-1", name: "Mine", createdAt: NOW, updatedAt: NOW });
+  });
+}
+
+describe("line-item cross-tenant isolation", () => {
+  test("listByIds skips a foreign-org line item", async () => {
+    const t = makeT();
+    await seed(t);
+    const rows = await t.withIdentity(asUser).query(api.projectLineItems.listByIds, { orgId: ORG, ids: ["liB"] });
+    expect(rows).toHaveLength(0); // liB belongs to org_B → not leaked
+  });
+
+  test("listByProjectIds skips a foreign-org project's line items", async () => {
+    const t = makeT();
+    await seed(t);
+    const rows = await t.withIdentity(asUser).query(api.projectLineItems.listByProjectIds, { orgId: ORG, projectIds: ["projB"] });
+    expect(rows).toHaveLength(0); // projB is org_B's → its lines not leaked
+  });
+
+  test("addCustomNative rejects inserting into a foreign-org project", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity(asUser).mutation(api.lineItemWrites.addCustomNative, {
+        id: "new1", organizationId: ORG, projectId: "projB",
+        fields: { quantity: 1, lineTotal: 9_999_999 },
+        orgDefaultTaxRate: 0, actor, auditId: "a1", now: NOW,
+      }),
+    ).rejects.toThrow(/forbidden|another organization/i);
+    // No phantom row was written into the foreign project.
+    const count = await t.run(async (ctx) =>
+      (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", "projB")).collect()).length,
+    );
+    expect(count).toBe(1); // only the original liB
+  });
+
+  test("addCustomNative succeeds for the caller's own project", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.withIdentity(asUser).mutation(api.lineItemWrites.addCustomNative, {
+      id: "new2", organizationId: ORG, projectId: "projA",
+      fields: { quantity: 1, lineTotal: 100 },
+      orgDefaultTaxRate: 0, actor, auditId: "a2", now: NOW,
+    });
+    const row = await t.run(async (ctx) => ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "new2")).unique());
+    expect(row?.organizationId).toBe(ORG);
+  });
+});

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -10,7 +10,7 @@ import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
 import { expandAccessoryChildLines } from "./lib/fulfillment";
-import { createKitLineItemCore } from "./projectLineItems";
+import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
 
 /**
  * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
@@ -212,6 +212,7 @@ export const addCustomNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
+    await assertProjectInOrg(ctx, projectId, organizationId); // client projectId — must be the caller's org (see helper)
 
     const sortOrder = await nextLineSort(ctx, projectId, organizationId);
     await ctx.db.insert("projectLineItems", {
@@ -293,6 +294,12 @@ export const addNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    // The client supplies `projectId`; requireOrgPermission only proves the caller's
+    // org. Verify the target project IS that org's — else a member could insert a line
+    // (stamped with their org) into ANOTHER org's project, which recalcProjectTotals
+    // (collects lines by projectId, no org filter) would sweep into that org's totals.
+    await assertProjectInOrg(ctx, projectId, organizationId);
 
     // Mirrors createLineItem exactly (sortOrder in-mutation, no TOCTOU; permanent
     // accessories expanded as child lines atomically via the shared helper).

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -69,7 +69,9 @@ export const listByIds = query({
         .query("projectLineItems")
         .withIndex("by_cuid", (q) => q.eq("id", id))
         .unique();
-      if (doc) out.push(doc);
+      // by_cuid is a GLOBAL index; requireOrgRead only authorizes the CALLER's org, so
+      // a caller-supplied foreign cuid would otherwise leak another org's line item.
+      if (doc && doc.organizationId === orgId) out.push(doc);
     }
     return out;
   },
@@ -80,8 +82,10 @@ export const listByIds = query({
  * warehouse-display dashboard to count items per dispatch/return/prep project
  * without scanning the whole org's line-item table on a public endpoint — only
  * the handful of projects the dashboard renders are queried, each via the
- * `by_projectId` index. Org-scoped: caller passes the org id so the service /
- * user token is authorized, and every returned row is its own project's.
+ * `by_projectId` index. Org-scoped: `requireOrgRead` authorizes the CALLER's org, and
+ * every returned row is re-checked to belong to it — `by_projectId` is a GLOBAL index,
+ * so a caller-supplied foreign projectId would otherwise leak another org's line items
+ * (same footgun as `listByProject`).
  */
 export const listByProjectIds = query({
   args: { orgId: v.string(), projectIds: v.array(v.string()) },
@@ -93,7 +97,7 @@ export const listByProjectIds = query({
         .query("projectLineItems")
         .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
         .collect();
-      for (const r of rows) out.push(r);
+      for (const r of rows) if (r.organizationId === orgId) out.push(r);
     }
     return out;
   },
@@ -558,6 +562,27 @@ export const createKitLineItem = mutation({
  * ITEMIZED pricing rather than duplicating it). Inserts the kit parent line + one
  * child line per serialized / bulk member, computing sortOrder in-mutation.
  */
+/**
+ * Guard the line-item create paths against inserting into ANOTHER org's project. The
+ * create mutations take `projectId` from the browser; `requireOrgPermission` only
+ * authorizes the CALLER's org, and `recalcProjectTotals` sweeps lines `by_projectId`
+ * with NO org filter — so a line inserted into a FOREIGN project (stamped with the
+ * caller's org) would be swept into that project's org's totals and corrupt them.
+ * Rejects only when the project EXISTS in a different org: a non-existent projectId has
+ * no recalc target (recalc returns early on a missing project) and thus no victim, so
+ * it's left permissive to avoid over-constraining callers/fixtures.
+ */
+export async function assertProjectInOrg(
+  ctx: MutationCtx,
+  projectId: string,
+  orgId: string,
+): Promise<void> {
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
+  if (project && project.organizationId !== orgId) {
+    throw new ConvexError({ code: "FORBIDDEN", message: "Forbidden: project belongs to another organization." });
+  }
+}
+
 export async function createKitLineItemCore(
   ctx: MutationCtx,
   a: {
@@ -573,6 +598,7 @@ export async function createKitLineItemCore(
     now: number;
   },
 ): Promise<{ id: string }> {
+    await assertProjectInOrg(ctx, a.projectId, a.organizationId);
     const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", a.kitId)).unique();
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     let sort = await nextLineSort(ctx, a.projectId, a.organizationId);


### PR DESCRIPTION
Independent Phase-3 compliance audit found 3 confirmed cross-tenant defects on the browser-direct line-item surface (dark prod → nil real-world blast radius, but genuine multi-tenant holes):

1. **`listByIds`** (read) — `requireOrgRead` + `by_cuid` (global) with **no** per-row org filter → foreign line-item leak. Fixed.
2. **`listByProjectIds`** (read) — same via `by_projectId` + a foreign `projectId` (reachable from any project URL). Fixed.
3. **line-item CREATE** (`addNative`/`addCustomNative`/`addKitNative`) trusted a client `projectId`; combined with `recalcProjectTotals` sweeping lines `by_projectId` with no org filter, a member could insert a phantom line into another org's project and corrupt its totals. New `assertProjectInOrg` guard.

`convex/lineItemOrgIsolation.test.ts` proves all three. Deployed to prod (holes closed). tsc + 56 tests green, codex CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)