### PR TITLE
fix(perf): ROI reads one-shot not reactive (Appendix B efficiency)

### DIFF
--- a/src/hooks/use-roi.ts
+++ b/src/hooks/use-roi.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useConvex } from "convex/react";
 import { useActiveOrganization } from "@/lib/auth-client";
-import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { api } from "../../convex/_generated/api";
 import { computeRoi, statusesForScope, type RoiScope } from "@/lib/roi";
 
@@ -10,11 +10,15 @@ import { computeRoi, statusesForScope, type RoiScope } from "@/lib/roi";
  * Browser-direct ROI reads (Phase 3 — replaces the `getFleetRoi`/`getModelRoi`
  * server actions in `src/server/roi.ts`, now deleted).
  *
- * `api.roi.fleetRevenue` / `fleetInventory` / `getModelRoi` are already
- * browser-callable (`requireOrgRead`). The Map-join + `computeRoi` + sort/totals that
- * the server action did in Node moves here verbatim — it's a pure client composition
- * over the two live subscriptions. The report reads what the allocation pass wrote;
- * it never recomputes revenue.
+ * `api.roi.fleetRevenue` / `fleetInventory` / `getModelRoi` are browser-callable
+ * (`requireOrgRead`). The Map-join + `computeRoi` + sort/totals that the server action
+ * did in Node moves here verbatim.
+ *
+ * These fetch ONE-SHOT (`useConvex().query` on mount + when the scope/window changes),
+ * NOT a reactive `useAuthedQuery` subscription: a ROI *report* has no liveness
+ * requirement, and `fleetInventory` reads up to ~13k org-wide docs — holding that as a
+ * live subscription would re-scan on every asset/model write for zero benefit
+ * (Appendix B #4). Matches the old server-action's non-reactive behaviour.
  */
 
 export type FleetRoiRow = {
@@ -39,21 +43,44 @@ export function useFleetRoi(opts: {
   from?: number;
   to?: number;
 }): { data: FleetRoiData | undefined; isLoading: boolean } {
+  const convex = useConvex();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
-  const statuses = statusesForScope(opts.scope);
+  const { scope, from, to } = opts;
+  const key = `${orgId ?? ""}|${scope}|${from ?? ""}|${to ?? ""}`;
 
-  const revenue = useAuthedQuery(
-    api.roi.fleetRevenue,
-    orgId ? { orgId, statuses, from: opts.from, to: opts.to } : "skip",
-  );
-  const inventory = useAuthedQuery(
-    api.roi.fleetInventory,
-    orgId ? { orgId } : "skip",
-  );
+  const [raw, setRaw] = useState<
+    | { key: string; revenue: (typeof api.roi.fleetRevenue)["_returnType"]; inventory: (typeof api.roi.fleetInventory)["_returnType"] }
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (!orgId) {
+      setRaw(undefined);
+      return;
+    }
+    let cancelled = false;
+    const statuses = statusesForScope(scope);
+    Promise.all([
+      convex.query(api.roi.fleetRevenue, { orgId, statuses, from, to }),
+      convex.query(api.roi.fleetInventory, { orgId }),
+    ])
+      .then(([revenue, inventory]) => {
+        if (!cancelled) setRaw({ key, revenue, inventory });
+      })
+      .catch(() => {
+        /* report read is best-effort; leave loading state */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [convex, orgId, scope, from, to, key]);
 
   const data = useMemo<FleetRoiData | undefined>(() => {
-    if (!revenue || !inventory) return undefined;
+    // Gate on the request key so a scope/window change shows loading immediately,
+    // never the previous scope's data for a render before the refetch lands.
+    if (!raw || raw.key !== key) return undefined;
+    const { revenue, inventory } = raw;
 
     const revenueByModel = new Map(revenue.rows.map((r) => [r.modelId, r]));
 
@@ -87,13 +114,13 @@ export function useFleetRoi(opts: {
 
     return {
       rows,
-      scope: opts.scope,
+      scope,
       projectsCounted: revenue.projectsCounted,
       truncated: revenue.truncated || inventory.truncated,
       totalRevenue: rows.reduce((s, r) => s + r.revenue, 0),
       totalFleetCost: rows.reduce((s, r) => s + (r.fleetCost ?? 0), 0),
     };
-  }, [revenue, inventory, opts.scope]);
+  }, [raw, key, scope]);
 
   return { data, isLoading: data === undefined };
 }
@@ -108,23 +135,42 @@ export function useModelRoi(
   modelId: string,
   opts: { scope: RoiScope; from?: number; to?: number },
 ): { data: ModelRoiData | undefined; isLoading: boolean } {
+  const convex = useConvex();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
-  const statuses = statusesForScope(opts.scope);
+  const { scope, from, to } = opts;
+  const key = `${orgId ?? ""}|${modelId}|${scope}|${from ?? ""}|${to ?? ""}`;
 
-  const raw = useAuthedQuery(
-    api.roi.getModelRoi,
-    orgId ? { orgId, modelId, statuses, from: opts.from, to: opts.to } : "skip",
-  );
+  const [raw, setRaw] = useState<{ key: string; value: ModelRoiQuery } | undefined>(undefined);
+
+  useEffect(() => {
+    if (!orgId) {
+      setRaw(undefined);
+      return;
+    }
+    let cancelled = false;
+    const statuses = statusesForScope(scope);
+    convex
+      .query(api.roi.getModelRoi, { orgId, modelId, statuses, from, to })
+      .then((value) => {
+        if (!cancelled) setRaw({ key, value });
+      })
+      .catch(() => {
+        /* report read is best-effort; leave loading state */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [convex, orgId, modelId, scope, from, to, key]);
 
   const data = useMemo<ModelRoiData | undefined>(() => {
-    if (!raw) return undefined;
+    if (!raw || raw.key !== key) return undefined; // gate on request key (no stale-scope render)
     return {
-      ...raw,
-      scope: opts.scope,
-      ...computeRoi(raw.revenue, raw.unitsOwned, raw.replacementCost),
+      ...raw.value,
+      scope,
+      ...computeRoi(raw.value.revenue, raw.value.unitsOwned, raw.value.replacementCost),
     };
-  }, [raw, opts.scope]);
+  }, [raw, key, scope]);
 
   return { data, isLoading: data === undefined };
 }


### PR DESCRIPTION
Phase-3 audit finding F2: the ROI re-home used reactive `useAuthedQuery`, but a ROI report has no liveness need and `fleetInventory` reads ~13k org-wide docs — a live subscription re-scans on every asset/model write (Appendix B #4). Converted to one-shot `useConvex().query` (keyed effect + cancellation + request-key guard against stale-scope renders). Composition unchanged. tsc + smoke test green, codex-reviewed (transient-stale note fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)