### PR TITLE
fix(perf): dashboardStats date-metrics range-scan (Appendix B open item)

### DIFF
--- a/convex/dashboardCounters.test.ts
+++ b/convex/dashboardCounters.test.ts
@@ -112,6 +112,27 @@ describe("dashboardCounters", () => {
     });
   });
 
+  // The date-derived metrics now range-scan by composite index (Appendix B).
+  // A `.lte`/`.lt(now)` range sweeps in rows whose date field is undefined (they
+  // sort before all numbers), so the handler must drop them with a != null guard.
+  test("dashboardStats excludes open maintenance / overdue-status rows that have no date", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+      // Open maintenance with NO scheduledDate — swept by the lte range, must be excluded.
+      await ctx.db.insert("maintenanceRecords", { id: "mr_nd", organizationId: ORG, title: "nd", type: "REPAIR", status: "SCHEDULED" });
+      // One genuinely due record for a positive control.
+      await ctx.db.insert("maintenanceRecords", { id: "mr_due", organizationId: ORG, title: "due", type: "REPAIR", status: "IN_PROGRESS", scheduledDate: NOW - DAY });
+      // Non-terminal project with NO rentalEndDate — swept by the lt range, must be excluded.
+      await ctx.db.insert("projects", { id: "p_nd", organizationId: ORG, projectNumber: "PND", name: "PND", status: "CHECKED_OUT", isTemplate: false });
+      await ctx.db.insert("projectLineItems", { id: "li_nd", organizationId: ORG, projectId: "p_nd", status: "CHECKED_OUT", quantity: 1 });
+    });
+    // No reconcile → countersReady false, but the date-derived metrics still compute.
+    const stats = await t.withIdentity(asUser(ORG)).query(api.dashboardStats.bundle, { orgId: ORG, now: NOW });
+    expect(stats.maintenanceDue).toBe(1); // only mr_due (mr_nd has no date)
+    expect(stats.overdueReturns).toBe(0); // p_nd has no rentalEndDate → not overdue
+  });
+
   test("bump adjusts a single field and clamps at 0", async () => {
     const t = makeT();
     await seed(t);

--- a/convex/dashboardStats.ts
+++ b/convex/dashboardStats.ts
@@ -18,7 +18,12 @@ import { readCounterValues, ZERO_COUNTERS } from "./dashboardCounters";
  */
 
 const RETURN_TERMINAL = new Set(["RETURNED", "COMPLETED", "INVOICED", "CANCELLED"]);
-const OPEN_MAINTENANCE = new Set(["SCHEDULED", "IN_PROGRESS"]);
+const OPEN_MAINTENANCE_STATUSES = ["SCHEDULED", "IN_PROGRESS"] as const;
+// A range `.lte`/`.lt(now)` sweeps in rows whose date field is undefined (undefined
+// sorts before all numbers in a Convex index). Pin the lower bound at the minimum
+// representable timestamp so undated rows stay OUT of the read-set entirely (matters
+// for date-less draft/quote projects), keeping the reactive read-set minimal.
+const MIN_TS = -8_640_000_000_000_000;
 
 export const bundle = query({
   args: { orgId: v.string(), now: v.number() },
@@ -38,28 +43,37 @@ export const bundle = query({
     const counter = ready ? await readCounterValues(ctx, orgId) : ZERO_COUNTERS;
 
     // ── Date-derived: maintenanceDue (open + scheduledDate arrived) ──
-    const maintenance = await ctx.db
-      .query("maintenanceRecords")
-      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
-      .collect();
-    const maintenanceDue = maintenance.filter(
-      (m) => OPEN_MAINTENANCE.has(m.status ?? "") && m.scheduledDate != null && (m.scheduledDate as number) <= now,
-    ).length;
+    // Range-scan by (org, status, MIN_TS < scheduledDate <= now) per open status so
+    // the reactive read-set is only the dated-and-due records, not the whole
+    // maintenance table (Appendix B). The lower bound keeps undated rows out.
+    let maintenanceDue = 0;
+    for (const status of OPEN_MAINTENANCE_STATUSES) {
+      const due = await ctx.db
+        .query("maintenanceRecords")
+        .withIndex("by_organizationId_status_scheduledDate", (q) =>
+          q.eq("organizationId", orgId).eq("status", status).gt("scheduledDate", MIN_TS).lte("scheduledDate", now),
+        )
+        .collect();
+      maintenanceDue += due.length;
+    }
 
     // ── Date-derived: overdueReturns (CHECKED_OUT line items in overdue projects) ──
     // Overdue = non-template project past its rentalEndDate, not in a terminal
-    // status. The overdue set is small; read CHECKED_OUT line items per overdue
-    // project via by_projectId_status (bounded), NOT the whole org's line items.
-    const projects = await ctx.db
+    // status. Range-scan by (org, MIN_TS < rentalEndDate < now) so the reactive
+    // read-set is only past-end-date projects, not the whole org's projects table
+    // (Appendix B); the lower bound keeps date-less draft/quote projects out. Then
+    // read CHECKED_OUT line items per overdue project via by_projectId_status
+    // (bounded), NOT the whole org's line items.
+    const overdueProjects = await ctx.db
       .query("projects")
-      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .withIndex("by_organizationId_rentalEndDate", (q) =>
+        q.eq("organizationId", orgId).gt("rentalEndDate", MIN_TS).lt("rentalEndDate", now),
+      )
       .collect();
-    const overdueProjectIds = projects
+    const overdueProjectIds = overdueProjects
       .filter(
         (p) =>
           p.isTemplate !== true &&
-          p.rentalEndDate != null &&
-          (p.rentalEndDate as number) < now &&
           !RETURN_TERMINAL.has(p.status ?? ""),
       )
       .map((p) => p.id);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -759,7 +759,11 @@ export default defineSchema({
     .index("by_reportedById", ["reportedById"])
     .index("by_assignedToId", ["assignedToId"])
     .index("by_status", ["status"])
-    .index("by_scheduledDate", ["scheduledDate"]),
+    .index("by_scheduledDate", ["scheduledDate"])
+    // Range-scan an org's OPEN maintenance whose scheduledDate has arrived
+    // (dashboardStats.maintenanceDue) — bounds the reactive read-set to the due
+    // records instead of collecting the whole org's maintenance table.
+    .index("by_organizationId_status_scheduledDate", ["organizationId", "status", "scheduledDate"]),
 
 
   // MaintenanceRecordAsset
@@ -862,6 +866,10 @@ export default defineSchema({
     // Range-scan an org's projects by rental date (fleet ROI window). A prefix
     // take + filter reads the wrong projects once an org outgrows the cap.
     .index("by_organizationId_rentalStartDate", ["organizationId", "rentalStartDate"])
+    // Range-scan an org's overdue projects by rentalEndDate (dashboardStats.
+    // overdueReturns) — bounds the reactive read-set to past-end-date projects
+    // instead of collecting the whole org's projects table.
+    .index("by_organizationId_rentalEndDate", ["organizationId", "rentalEndDate"])
     .index("by_isTemplate", ["isTemplate"])
     .index("by_organizationId_status", ["organizationId", "status"]),
   // (No project search index: the app never picks a project in a combobox — projects


### PR DESCRIPTION
Closes the audit's remaining OPEN efficiency item (Appendix B): `dashboardStats.bundle` still `.collect()`-ed the whole `maintenanceRecords` and `projects` tables on a **reactive** subscribed path, so any write to either table re-read+re-billed the entire org table.

## Change
- **maintenanceDue** → new composite index `by_organizationId_status_scheduledDate`; range-scan per open status `MIN_TS < scheduledDate <= now`.
- **overdueReturns** → new composite index `by_organizationId_rentalEndDate`; range-scan `MIN_TS < rentalEndDate < now` (per-project line-item read was already bounded).
- `MIN_TS` lower bound excludes undated rows (undefined sorts before all numbers in a Convex index) — matters for date-less draft/quote projects.

The six numeric counters were already O(1) sharded; only the two date-derived metrics needed this.

## Safety
- Results **identical** to the prior `collect()+filter` (codex-verified: status set, terminal filter, isTemplate, undefined-date handling all preserved).
- Indexes are additive; already deployed to prod Convex (built cleanly).
- Adds an edge-case test: an open maintenance / non-terminal project with no date is excluded. Full `dashboardCounters` suite green (8/8), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)