### PR TITLE
feat(assets): bulk "Add tags" action (append, single call — audit open item)

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -406,6 +406,39 @@ export const bulkUpdate = mutation({
   },
 });
 
+/**
+ * Bulk APPEND tags to N assets in a SINGLE call (Appendix A invariant — powers
+ * the assets bulk-bar "Add tags"). Unlike bulkUpdate (which replaces a field),
+ * this unions the supplied tags into each asset's existing `tags` array. Per-row
+ * org re-check (by_cuid is GLOBAL). Idempotent: a tag already present is a no-op.
+ * Tags don't feed any counter, so no counter bump. Returns the count of
+ * org-matched assets processed.
+ */
+export const bulkAddTags = mutation({
+  args: {
+    organizationId: v.string(),
+    ids: v.array(v.string()),
+    tags: v.array(v.string()),
+  },
+  returns: v.number(),
+  handler: async (ctx, { organizationId, ids, tags }) => {
+    await requireService(ctx);
+    const add = [...new Set(tags.map((t) => t.trim()).filter(Boolean))];
+    if (add.length === 0) return 0;
+    let n = 0;
+    for (const id of ids) {
+      const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+      if (!doc || doc.organizationId !== organizationId) continue;
+      n++;
+      const existing = doc.tags ?? [];
+      const merged = [...new Set([...existing, ...add])];
+      if (merged.length === existing.length) continue; // all already present
+      await ctx.db.patch(doc._id, { tags: merged, updatedAt: Date.now() });
+    }
+    return n;
+  },
+});
+
 // ── CUSTOM (Phase C H) — child-asset lookup ──
 export const listByParentAssetId = query({
   args: { parentAssetId: v.string(), orgId: v.string() },

--- a/convex/assetsBulkAddTags.test.ts
+++ b/convex/assetsBulkAddTags.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+//
+// assets.bulkAddTags — bulk APPEND tags to N assets in one call (powers the
+// assets bulk-bar "Add tags"). Verifies: union/append (not replace) semantics,
+// idempotent dedup, per-row org re-check (skips other-org ids), input
+// normalization (trim/dedup/drop-empty), and non-service rejection.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+
+const modules = import.meta.glob("./**/*.ts");
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+const ORG = "org_1";
+const OTHER = "org_other";
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+const seed = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m1", assetTag: "a1", status: "AVAILABLE", isActive: true, tags: ["existing"] });
+    await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "a2", status: "AVAILABLE", isActive: true }); // no tags
+    await ctx.db.insert("assets", { id: "ax", organizationId: OTHER, modelId: "m1", assetTag: "ax", status: "AVAILABLE", isActive: true, tags: ["secret"] });
+  });
+
+const tagsOf = (t: ReturnType<typeof makeT>, id: string) =>
+  t.run(async (ctx) => {
+    const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    return (doc?.tags ?? []).slice().sort();
+  });
+
+describe("assets.bulkAddTags", () => {
+  test("appends (unions) tags without dropping existing, deduped per asset", async () => {
+    const t = makeT();
+    await seed(t);
+    // Add "blue" + "existing" to both. a1 already has "existing" (deduped, not
+    // duplicated); a2 has no tags so it gets both.
+    const n = await t.withIdentity(SERVICE).mutation(api.assets.bulkAddTags, {
+      organizationId: ORG,
+      ids: ["a1", "a2"],
+      tags: ["blue", "existing"],
+    });
+    expect(n).toBe(2);
+    expect(await tagsOf(t, "a1")).toEqual(["blue", "existing"]); // "existing" kept, "blue" appended
+    expect(await tagsOf(t, "a2")).toEqual(["blue", "existing"]); // both appended
+  });
+
+  test("per-row org re-check — an other-org id is skipped and untouched", async () => {
+    const t = makeT();
+    await seed(t);
+    const n = await t.withIdentity(SERVICE).mutation(api.assets.bulkAddTags, {
+      organizationId: ORG,
+      ids: ["a1", "ax"], // ax belongs to OTHER
+      tags: ["blue"],
+    });
+    expect(n).toBe(1); // only a1 counted
+    expect(await tagsOf(t, "a1")).toEqual(["blue", "existing"]);
+    expect(await tagsOf(t, "ax")).toEqual(["secret"]); // untouched
+  });
+
+  test("normalizes input (trim, dedup, drop empty); all-empty is a no-op", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.withIdentity(SERVICE).mutation(api.assets.bulkAddTags, {
+      organizationId: ORG,
+      ids: ["a2"],
+      tags: ["  blue  ", "blue", ""],
+    });
+    expect(await tagsOf(t, "a2")).toEqual(["blue"]);
+
+    const n = await t.withIdentity(SERVICE).mutation(api.assets.bulkAddTags, {
+      organizationId: ORG,
+      ids: ["a2"],
+      tags: ["   ", ""],
+    });
+    expect(n).toBe(0); // nothing to add
+  });
+
+  test("rejects a non-service (browser) caller", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: "u1", orgId: ORG }).mutation(api.assets.bulkAddTags, {
+        organizationId: ORG,
+        ids: ["a1"],
+        tags: ["blue"],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/components/assets/__tests__/bulk-add-tags-dialog.smoke.test.tsx
+++ b/src/components/assets/__tests__/bulk-add-tags-dialog.smoke.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+// Org-tag suggestions come from a Convex query hook — stub it out.
+vi.mock("@/hooks/use-org-tags", () => ({ useOrgTags: vi.fn(() => ["blue", "green"]) }));
+// The server action isn't invoked on render, but keep it inert.
+vi.mock("@/server/assets", () => ({ bulkTagAssets: vi.fn() }));
+
+import { BulkAddTagsDialog } from "@/components/assets/asset-table";
+
+/**
+ * The bulk "Add tags" dialog nests a TagInput (Radix Popover) inside a Radix
+ * modal Dialog — the SAFE composition (a Base UI popup here would inherit the
+ * modal's pointer-events lock and swallow clicks; see CLAUDE.md). This smoke
+ * test just proves the overlay renders open without throwing — the only thing
+ * that catches an overlay-composition regression, per the smoke-test rule.
+ */
+describe("BulkAddTagsDialog smoke", () => {
+  it("renders open without throwing", () => {
+    render(
+      <BulkAddTagsDialog
+        open
+        onOpenChange={() => {}}
+        selectedIds={new Set(["a1", "a2"])}
+        orgId="org_1"
+        onSuccess={() => {}}
+      />,
+    );
+    // Radix Dialog portals to <body>; assert the title + append copy are present.
+    expect(screen.getByText("Add tags to 2 assets")).toBeTruthy();
+    expect(screen.getByText(/Tags are appended/)).toBeTruthy();
+    expect(screen.getByText("Add to 2 assets")).toBeTruthy();
+  });
+});

--- a/src/components/assets/asset-table.tsx
+++ b/src/components/assets/asset-table.tsx
@@ -5,11 +5,11 @@ import Link from "next/link";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
 
-import { Plus, Pencil, Download, Upload, RotateCcw } from "lucide-react";
+import { Plus, Pencil, Download, Upload, RotateCcw, Tag } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn, focusRing, disabledState } from "@/lib/utils";
-import { bulkUpdateAssets, getAssetRegistryPhotos } from "@/server/assets";
+import { bulkUpdateAssets, bulkTagAssets, getAssetRegistryPhotos } from "@/server/assets";
 import { useAssets, useBulkAssets } from "@/hooks/use-assets";
 import { useModels } from "@/hooks/use-models";
 import { bulkForceReturnAssets } from "@/server/warehouse";
@@ -26,6 +26,8 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { TagInput } from "@/components/ui/tag-input";
+import { useOrgTags } from "@/hooks/use-org-tags";
 import {
   Dialog,
   DialogContent,
@@ -363,6 +365,7 @@ export function AssetTable() {
   const [search, setSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [bulkTagsOpen, setBulkTagsOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [bulkForceReturnOpen, setBulkForceReturnOpen] = useState(false);
 
@@ -534,6 +537,7 @@ export function AssetTable() {
   const clearSelection = () => {
     setSelectedIds(new Set());
     setBulkEditOpen(false);
+    setBulkTagsOpen(false);
   };
 
   const forceReturnMutation = useServerMutation({
@@ -615,6 +619,12 @@ export function AssetTable() {
             <Button size="sm" variant="line" onClick={() => setBulkEditOpen(true)}>
               <Pencil className="mr-2 h-3 w-3" />
               Bulk edit
+            </Button>
+          </CanDo>
+          <CanDo resource="asset" action="update">
+            <Button size="sm" variant="line" onClick={() => setBulkTagsOpen(true)}>
+              <Tag className="mr-2 h-3 w-3" />
+              Add tags
             </Button>
           </CanDo>
           <CanDo resource="warehouse" action="check_in">
@@ -724,6 +734,16 @@ export function AssetTable() {
         onOpenChange={setBulkEditOpen}
         selectedIds={selectedIds}
         locations={locations}
+        onSuccess={() => {
+          clearSelection();
+        }}
+      />
+
+      <BulkAddTagsDialog
+        open={bulkTagsOpen}
+        onOpenChange={setBulkTagsOpen}
+        selectedIds={selectedIds}
+        orgId={orgId}
         onSuccess={() => {
           clearSelection();
         }}
@@ -846,6 +866,64 @@ function BulkEditDialog({
           </Button>
           <Button onClick={() => mutation.mutate()} loading={mutation.isPending} disabled={!hasChanges}>
             Update {selectedIds.size} assets
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function BulkAddTagsDialog({
+  open,
+  onOpenChange,
+  selectedIds,
+  orgId,
+  onSuccess,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedIds: Set<string>;
+  orgId: string | undefined;
+  onSuccess: () => void;
+}) {
+  const [tags, setTags] = useState<string[]>([]);
+  const orgTags = useOrgTags(orgId);
+
+  const mutation = useServerMutation({
+    mutationFn: () => bulkTagAssets(Array.from(selectedIds), tags),
+    onSuccess: (result) => {
+      toast.success(`Added tags to ${result.count} asset${result.count === 1 ? "" : "s"}`);
+      setTags([]);
+      onSuccess();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setTags([]);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add tags to {selectedIds.size} asset{selectedIds.size === 1 ? "" : "s"}</DialogTitle>
+        </DialogHeader>
+        <p className="text-ui-text text-muted">
+          Tags are appended — existing tags on each asset are kept. Duplicates are ignored.
+        </p>
+        <div className="space-y-2 py-2">
+          <Label>Tags</Label>
+          <TagInput value={tags} onChange={setTags} suggestions={orgTags} placeholder="Add tags…" />
+        </div>
+        <DialogFooter>
+          <Button variant="line" onClick={() => { setTags([]); onOpenChange(false); }}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate()} loading={mutation.isPending} disabled={tags.length === 0}>
+            Add to {selectedIds.size} asset{selectedIds.size === 1 ? "" : "s"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -54,6 +54,7 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "asset-media.removeAssetMedia": { name: "asset-media.removeAssetMedia", module: "asset-media", fn: "removeAssetMedia", kind: "write", resource: "asset", action: "update", scope: "asset:update", params: [{ name: "mediaId", type: "string", optional: false }], dangerous: true, summary: "" },
   "asset-media.setAssetPrimaryPhoto": { name: "asset-media.setAssetPrimaryPhoto", module: "asset-media", fn: "setAssetPrimaryPhoto", kind: "write", resource: "asset", action: "update", scope: "asset:update", params: [{ name: "assetId", type: "string", optional: false }, { name: "mediaId", type: "string", optional: false }], dangerous: false, summary: "" },
   "assets.archiveAsset": { name: "assets.archiveAsset", module: "assets", fn: "archiveAsset", kind: "write", resource: "asset", action: "update", scope: "asset:update", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "" },
+  "assets.bulkTagAssets": { name: "assets.bulkTagAssets", module: "assets", fn: "bulkTagAssets", kind: "write", resource: "asset", action: "update", scope: "asset:update", params: [{ name: "ids", type: "string[]", optional: false }, { name: "tags", type: "string[]", optional: false }], dangerous: false, summary: "" },
   "assets.bulkUpdateAssets": { name: "assets.bulkUpdateAssets", module: "assets", fn: "bulkUpdateAssets", kind: "write", resource: "asset", action: "update", scope: "asset:update", params: [{ name: "ids", type: "string[]", optional: false }, { name: "data", type: "{ status?: string; condition?: string; locationId?: string | null; }", optional: false }], dangerous: false, summary: "" },
   "assets.createAsset": { name: "assets.createAsset", module: "assets", fn: "createAsset", kind: "write", resource: "asset", action: "create", scope: "asset:create", params: [{ name: "data", type: "AssetFormValues", optional: false, schemaRef: "AssetFormValues" }], dangerous: false, summary: "" },
   "assets.createAssets": { name: "assets.createAssets", module: "assets", fn: "createAssets", kind: "write", resource: "asset", action: "create", scope: "asset:create", params: [{ name: "data", type: "AssetFormValues", optional: false, schemaRef: "AssetFormValues" }, { name: "assets", type: "{ tag: string; serialNumber?: string }[]", optional: false }], dangerous: false, summary: "" },
@@ -4275,4 +4276,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 522;
+export const OPERATION_COUNT = 523;

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -820,6 +820,36 @@ export async function bulkUpdateAssets(
   return { count };
 }
 
+export async function bulkTagAssets(ids: string[], tags: string[]) {
+  const { organizationId } = await requirePermission("asset", "update");
+  if (ids.length === 0) {
+    throw new UserFacingError({
+      code: "NO_SELECTION",
+      title: "Nothing selected",
+      message: "Select at least one asset before adding tags.",
+    });
+  }
+  const clean = [...new Set(tags.map((t) => t.trim()).filter(Boolean))];
+  if (clean.length === 0) {
+    throw new UserFacingError({
+      code: "NO_TAGS",
+      title: "No tags entered",
+      message: "Enter at least one tag to add to the selected assets.",
+    });
+  }
+
+  // APPEND semantics — unions into each asset's existing tags in one array
+  // mutation (Appendix A single-call invariant), with a per-row org re-check.
+  const convex = await getConvexClient();
+  const count = await convex.mutation(api.assets.bulkAddTags, {
+    organizationId,
+    ids,
+    tags: clean,
+  });
+
+  return { count };
+}
+
 export async function deleteAsset(id: string) {
   const { organizationId, userId, userName } = await requirePermission("asset", "delete");
 


### PR DESCRIPTION
Closes audit OPEN item 2 (one of the 3 false "DONE 12 Jul" plan claims): the assets bulk bar could bulk-edit status/condition/location but had no bulk **tag** action.

## Change
- **`assets.bulkAddTags`** — bulk single-call array mutation (Appendix A). **Appends** (unions) the supplied tags into each asset's existing `tags` (not replace), deduped, with a **per-row org re-check** (`by_cuid` is global). Tags feed no counter → no bump. Idempotent.
- **`bulkTagAssets(ids, tags)`** server action — `requirePermission("asset","update")`, empty-selection / empty-tags guards, input normalization, one Convex call.
- **UI** — "Add tags" bulk-bar button + `BulkAddTagsDialog` (`TagInput` with org-tag suggestions; Radix Popover nested in a Radix modal Dialog = the safe composition per CLAUDE.md). Dialog closes on success via `clearSelection`; Cancel/close clears entered tags.

## Tests
- `convex/assetsBulkAddTags.test.ts` — append/dedup per asset, per-row org re-check skip, input normalization + all-empty no-op, non-service rejection.
- jsdom smoke test renders the dialog **open** (overlay-composition regression guard).
- codex-reviewed (mutation/server-action correctness + no cross-tenant issue confirmed; 2 UX P2s fixed inline). tsc clean; api suite (114) + new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)