### PR TITLE
feat(clients): bulk-archive + row-selection (audit open item)

### DIFF
--- a/convex/clientWrites.test.ts
+++ b/convex/clientWrites.test.ts
@@ -90,4 +90,53 @@ describe("clientWrites", () => {
       }),
     ).rejects.toThrow();
   });
+
+  test("archiveMany: bulk-archives own clients, skips foreign, idempotent, one audit each", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "c1", organizationId: ORG, name: "Acme", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("clients", { id: "c2", organizationId: ORG, name: "Beta", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("clients", { id: "c3", organizationId: ORG, name: "Gone", isActive: false, createdAt: NOW, updatedAt: NOW }); // already archived
+      await ctx.db.insert("clients", { id: "cX", organizationId: OTHER, name: "Other", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+
+    const res = await t.withIdentity(asUser).mutation(api.clientWrites.archiveManyNative, {
+      orgId: ORG,
+      items: [
+        { id: "c1", auditId: "b1" },
+        { id: "c2", auditId: "b2" },
+        { id: "c3", auditId: "b3" }, // already archived → counted, not re-audited
+        { id: "cX", auditId: "bx" }, // foreign org → skipped
+        { id: "missing", auditId: "bm" }, // missing → skipped
+      ],
+      actor,
+      now: NOW + 1,
+    });
+    // c1, c2, c3 are org-matched → counted (3); cX + missing skipped.
+    expect(res).toEqual({ archived: 3 });
+
+    expect((await getClient(t, "c1"))?.isActive).toBe(false);
+    expect((await getClient(t, "c2"))?.isActive).toBe(false);
+    expect((await getClient(t, "cX"))?.isActive).toBe(true); // untouched
+
+    // One audit row per NEWLY-archived client (c1, c2 only — c3 was already archived).
+    const audits = await t.run(async (ctx) =>
+      ctx.db.query("activityLogs").withIndex("by_organizationId", (q) => q.eq("organizationId", ORG)).collect(),
+    );
+    const archiveAudits = audits.filter((a) => a.entityType === "client" && a.action === "DELETE");
+    expect(archiveAudits.map((a) => a.entityId).sort()).toEqual(["c1", "c2"]);
+  });
+
+  test("archiveMany rejects a non-member (RBAC)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "c1", organizationId: ORG, name: "Acme", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser).mutation(api.clientWrites.archiveManyNative, {
+        orgId: ORG, items: [{ id: "c1", auditId: "b1" }], actor, now: NOW,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/convex/clientWrites.ts
+++ b/convex/clientWrites.ts
@@ -193,3 +193,52 @@ export const archiveNative = mutation({
     return { id };
   },
 });
+
+/**
+ * Bulk-archive N clients in a SINGLE call (Appendix A invariant — powers the
+ * clients table bulk-bar "Archive"). Same 4 guards as archiveNative, a per-row
+ * org re-check (by_cuid is GLOBAL — foreign/missing ids are skipped, not thrown),
+ * and one atomic audit row per newly-archived client (caller mints an auditId per
+ * id). Idempotent: an already-archived client is counted but not re-audited.
+ * Returns the count of org-matched clients now archived.
+ */
+export const archiveManyNative = mutation({
+  returns: v.object({ archived: v.number() }),
+  args: {
+    orgId: v.string(),
+    items: v.array(v.object({ id: v.string(), auditId: v.string() })),
+    actor: actorValidator,
+    now: v.number(),
+  },
+  handler: async (ctx, { orgId, items, actor: suppliedActor, now }) => {
+    await assertWritesEnabled(ctx, "client");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "client", "update");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    let archived = 0;
+    const seen = new Set<string>();
+    for (const { id, auditId } of items) {
+      if (seen.has(id)) continue; // dedup — a repeated id must not double-count
+      seen.add(id);
+      const doc = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+      if (!doc || doc.organizationId !== orgId) continue; // per-row org re-check
+      archived++;
+      if (doc.isActive === false) continue; // already archived — idempotent, no re-audit
+      await ctx.db.patch(doc._id, { isActive: false, updatedAt: now });
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: orgId,
+        action: "DELETE",
+        entityType: "client",
+        entityId: id,
+        entityName: doc.name,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Archived client ${doc.name}`,
+        createdAt: now,
+      });
+    }
+    return { archived };
+  },
+});

--- a/src/components/clients/client-table.tsx
+++ b/src/components/clients/client-table.tsx
@@ -2,15 +2,19 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { Plus, Archive } from "lucide-react";
+import { toast } from "sonner";
 
 import { getClientProjectCounts } from "@/server/clients";
 import { useServerQuery } from "@/hooks/use-server-query";
+import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useClients } from "@/hooks/use-clients";
+import { useClientWrites } from "@/hooks/use-native-client-writes";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useTablePreferences } from "@/lib/use-table-preferences";
 import { Button } from "@/components/ui/button";
 import { CanDo } from "@/components/auth/permission-gate";
+import { DeleteDialog } from "@/components/ui/delete-dialog";
 import { Badge } from "@/components/ui/badge";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
@@ -137,8 +141,21 @@ export function ClientTable() {
   } = useTablePreferences("clients", { sortBy: "name", sortOrder: "asc" });
 
   const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkArchiveOpen, setBulkArchiveOpen] = useState(false);
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+
+  const { bulkArchive } = useClientWrites();
+  const clearSelection = () => setSelectedIds(new Set());
+  const bulkArchiveMutation = useServerMutation({
+    mutationFn: () => bulkArchive(Array.from(selectedIds)),
+    onSuccess: (result) => {
+      toast.success(`Archived ${result.archived} client${result.archived === 1 ? "" : "s"}`);
+      clearSelection();
+    },
+    onError: (e) => toast.error(e.message),
+  });
 
   // Reactive client list straight from Convex (auto-updates on any client
   // create/update/archive). Project counts are cross-domain (projects still in
@@ -203,31 +220,71 @@ export function ClientTable() {
   );
 
   return (
-    <DataTable
-      data={clients}
-      columns={columns}
-      totalRows={total}
-      page={page}
-      pageSize={pageSize}
-      onPageChange={setPage}
-      onPageSizeChange={setPageSize}
-      sortField={sortBy}
-      sortDirection={sortOrder}
-      onSortChange={handleSort}
-      filters={filters}
-      onFilterChange={setFilter}
-      searchValue={search}
-      onSearchChange={(v) => { setSearch(v); setPage(1); }}
-      searchPlaceholder="Search by name, contact, or email..."
-      columnVisibility={columnVisibility}
-      onToggleColumnVisibility={toggleColumnVisibility}
-      onResetPreferences={resetPreferences}
-      savedViews={{ tableId: "clients", currentConfig, applyConfig }}
-      isLoading={isLoading}
-      emptyPreset="clients"
-      emptyTitle="No clients yet"
-      emptyDescription="Add a client to start quoting and tracking their projects."
-      toolbarActions={toolbarActions}
-    />
+    <div className="space-y-4">
+      {/* Bulk action bar */}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center gap-3 rounded-[var(--r)] border-2 border-line-2 bg-paper-2/50 px-4 py-2">
+          <span className="text-ui-text font-medium text-ink tabular-nums">{selectedIds.size} selected</span>
+          <CanDo resource="client" action="update">
+            <Button
+              size="sm"
+              variant="line"
+              className="text-warn"
+              loading={bulkArchiveMutation.isPending}
+              onClick={() => setBulkArchiveOpen(true)}
+            >
+              <Archive className="mr-2 h-3 w-3" />
+              Archive
+            </Button>
+          </CanDo>
+          <Button size="sm" variant="ghost" onClick={clearSelection}>
+            Clear
+          </Button>
+        </div>
+      )}
+
+      <DataTable
+        data={clients}
+        columns={columns}
+        totalRows={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
+        sortField={sortBy}
+        sortDirection={sortOrder}
+        onSortChange={handleSort}
+        filters={filters}
+        onFilterChange={setFilter}
+        searchValue={search}
+        onSearchChange={(v) => { setSearch(v); setPage(1); }}
+        searchPlaceholder="Search by name, contact, or email..."
+        columnVisibility={columnVisibility}
+        onToggleColumnVisibility={toggleColumnVisibility}
+        onResetPreferences={resetPreferences}
+        savedViews={{ tableId: "clients", currentConfig, applyConfig }}
+        isLoading={isLoading}
+        emptyPreset="clients"
+        emptyTitle="No clients yet"
+        emptyDescription="Add a client to start quoting and tracking their projects."
+        enableRowSelection
+        selectedRows={selectedIds}
+        onSelectionChange={setSelectedIds}
+        toolbarActions={toolbarActions}
+      />
+
+      <DeleteDialog
+        open={bulkArchiveOpen}
+        onOpenChange={setBulkArchiveOpen}
+        title={`Archive ${selectedIds.size} client${selectedIds.size === 1 ? "" : "s"}?`}
+        description="Archived clients are hidden from the active list but keep their history and projects. You can reactivate a client from its detail page."
+        confirmLabel={`Archive ${selectedIds.size}`}
+        onConfirm={() => {
+          bulkArchiveMutation.mutate();
+          setBulkArchiveOpen(false);
+        }}
+        pending={bulkArchiveMutation.isPending}
+      />
+    </div>
   );
 }

--- a/src/hooks/use-native-client-writes.ts
+++ b/src/hooks/use-native-client-writes.ts
@@ -23,6 +23,7 @@ export function useClientWrites() {
   const updateM = useMutation(api.clientWrites.updateNative);
   const notesM = useMutation(api.clientWrites.updateNotesNative);
   const archiveM = useMutation(api.clientWrites.archiveNative);
+  const archiveManyM = useMutation(api.clientWrites.archiveManyNative);
 
   const actor = () => ({
     userId: session?.user.id ?? "",
@@ -80,6 +81,17 @@ export function useClientWrites() {
     archive: async (id: string): Promise<void> => {
       const org = requireOrg();
       await archiveM({ id, orgId: org, actor: actor(), auditId: createId(), now: Date.now() });
+    },
+    bulkArchive: async (ids: string[]): Promise<{ archived: number }> => {
+      const org = requireOrg();
+      // One array mutation (Appendix A single-call invariant); the caller mints a
+      // unique auditId per id so each archived client gets its own audit row.
+      return await archiveManyM({
+        orgId: org,
+        items: ids.map((id) => ({ id, auditId: createId() })),
+        actor: actor(),
+        now: Date.now(),
+      });
     },
   };
 }


### PR DESCRIPTION
Closes audit OPEN item 2 (the last of the 3 false "DONE 12 Jul" plan claims): the clients table had no row-selection and no bulk-archive.

## Change
- **`clientWrites.archiveManyNative`** — browser-direct bulk single-call (Appendix A). Same 4 guards as `archiveNative`, **per-row org re-check** (`by_cuid` is global — foreign/missing ids skipped, not thrown), one **atomic audit** per newly-archived client, idempotent on already-archived, dup-id guard (codex). One rate-limit token for the batch.
- **`useClientWrites().bulkArchive(ids)`** — one call; mints a unique `auditId` per id.
- **clients table** — row selection + a "N selected" bulk bar with an "Archive" action (gated `client:update`) behind a confirm `DeleteDialog`.

## Safety / tests
- Extends `convex/clientWrites.test.ts`: bulk-archives own clients / skips foreign+missing / idempotent already-archived / exactly one audit per newly-archived; non-member RBAC rejection.
- codex-reviewed — "no cross-tenant, audit-ID, rate-limit, permission-gate, selection, or confirmation-flow issue found"; the one dup-count nit fixed inline. tsc clean; api suite (114) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)