### PR TITLE
fix(notifications): dedup dismissals per-org (re-audit MED)

### DIFF
--- a/convex/notificationDismissals.ts
+++ b/convex/notificationDismissals.ts
@@ -88,13 +88,18 @@ export const createManyIfMissing = mutation({
     let created = 0;
     let skipped = 0;
     for (const item of items) {
+      // Dedup PER-ORG, not globally. Most keys embed an entity cuid (org-unique),
+      // but the two crew keys (crew-pending-offers/-timesheets) are constant across
+      // orgs — a multi-org user must be able to dismiss them in each org separately
+      // (reads are org-scoped via list({orgId})). by_userId_notificationKey is
+      // GLOBAL, so filter its (few — one per membership) rows by organizationId.
       const existing = await ctx.db
         .query("notificationDismissals")
         .withIndex("by_userId_notificationKey", (q) =>
           q.eq("userId", userId).eq("notificationKey", item.notificationKey),
         )
-        .first();
-      if (existing) {
+        .collect();
+      if (existing.some((d) => d.organizationId === organizationId)) {
         skipped++;
         continue;
       }

--- a/convex/notificationDismissalsCreateMany.test.ts
+++ b/convex/notificationDismissalsCreateMany.test.ts
@@ -12,6 +12,7 @@ import { api } from "./_generated/api";
 
 const modules = import.meta.glob("./**/*.ts");
 const ORG = "org_1";
+const OTHER = "org_2";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
 const SERVICE = { subject: "gearflow-service", svc: true };
@@ -79,6 +80,35 @@ describe("notificationDismissals.createManyIfMissing", () => {
     expect(res).toEqual({ created: 1, skipped: 0 });
     expect(await keysFor(t, USER)).toEqual(["k1"]);
     expect(await keysFor(t, "user_2")).toEqual(["k1"]);
+  });
+
+  test("dedup is PER-ORG — a multi-org user can dismiss the same constant key in each org", async () => {
+    const t = makeT();
+    // Same user, same constant key (e.g. "crew-pending-offers"), two orgs.
+    await t.withIdentity(SERVICE).mutation(api.notificationDismissals.createManyIfMissing, {
+      organizationId: ORG,
+      userId: USER,
+      items: [{ id: "d1", notificationKey: "crew-pending-offers", dismissedAt: NOW }],
+    });
+    // In OTHER org the key must NOT be deduped against the org_1 row → it inserts.
+    const res = await t.withIdentity(SERVICE).mutation(api.notificationDismissals.createManyIfMissing, {
+      organizationId: OTHER,
+      userId: USER,
+      items: [{ id: "d2", notificationKey: "crew-pending-offers", dismissedAt: NOW }],
+    });
+    expect(res).toEqual({ created: 1, skipped: 0 });
+    // Re-dismissing in ORG is still a no-op (same org).
+    const again = await t.withIdentity(SERVICE).mutation(api.notificationDismissals.createManyIfMissing, {
+      organizationId: ORG,
+      userId: USER,
+      items: [{ id: "d3", notificationKey: "crew-pending-offers", dismissedAt: NOW }],
+    });
+    expect(again).toEqual({ created: 0, skipped: 1 });
+    // One row per org.
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("notificationDismissals").withIndex("by_userId", (q) => q.eq("userId", USER)).collect(),
+    );
+    expect(rows.map((r) => r.organizationId).sort()).toEqual([ORG, OTHER].sort());
   });
 
   test("rejects a non-service (browser) caller", async () => {


### PR DESCRIPTION
Fixes the one MED regression the independent re-audit found in #490.

## Bug
`notificationDismissals.createManyIfMissing` deduped via the **global** `by_userId_notificationKey` index (no org column), but dismissal reads are org-scoped (`list({orgId})`). For a **multi-org user**, dismissing a constant cross-org key (`crew-pending-offers` / `crew-pending-timesheets` — the only two notification ids that don't embed an entity cuid) in org A created an org-A row; dismissing the same key in org B then matched that org-A row and **skipped**, so org B never got a row and the notification **reappeared** in org B after the optimistic local set cleared.

The pre-#490 single-dismiss deduped org-scoped; this restores that.

## Fix
Collect the (few — one per membership) `by_userId_notificationKey` rows and skip only if **this org** already has one. Dormant in prod (single-org, dark) but a real correctness bug.

Adds a per-org dedup test (multi-org user dismisses the same constant key in each org → one row per org). This test fails on the old code. codex + focused test green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)