### PR TITLE
refactor(clients): client detail page browser-native (drop getClient)

### DIFF
--- a/convex/clients.ts
+++ b/convex/clients.ts
@@ -58,6 +58,80 @@ export const projectCounts = query({
   },
 });
 
+/**
+ * Client DETAIL composite for the client detail page — browser-native replacement
+ * for the getClient server action. Returns the client doc plus its recent projects
+ * (each with a total line-item count) and its media gallery (files resolved). All
+ * reads are CLIENT-scoped (by_clientId / by_projectId) with a per-row org re-check
+ * on the global-index fetches — bounded, not org-wide, so this is safe as a reactive
+ * subscription (Appendix B). Returns null if the client is missing / in another org.
+ */
+export const detail = query({
+  args: { orgId: v.string(), id: v.string() },
+  handler: async (ctx, { orgId, id }) => {
+    await requireOrgRead(ctx, orgId);
+
+    const client = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!client || client.organizationId !== orgId) return null;
+
+    // Recent projects for this client — newest first, capped at 20 (parity with the
+    // action). by_clientId is a GLOBAL index → re-check organizationId per row.
+    const clientProjects = (
+      await ctx.db.query("projects").withIndex("by_clientId", (q) => q.eq("clientId", id)).collect()
+    )
+      .filter((p) => p.organizationId === orgId)
+      .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+      .slice(0, 20);
+
+    // Per-project TOTAL line-item count (all rows, matching countAllLineItemsByProject).
+    // by_projectId is a GLOBAL index → re-check organizationId per row (parity with
+    // the deleted listByProjectIds, which org-filters; defense-in-depth even though
+    // projectId is a unique cuid).
+    const projects = await Promise.all(
+      clientProjects.map(async (p) => {
+        const lineItems = await ctx.db
+          .query("projectLineItems")
+          .withIndex("by_projectId", (q) => q.eq("projectId", p.id))
+          .collect();
+        const lineItemCount = lineItems.filter((li) => li.organizationId === orgId).length;
+        return { ...p, _count: { lineItems: lineItemCount } };
+      }),
+    );
+
+    // Media gallery — clientMedia by_clientId (org re-check), sorted by sortOrder,
+    // with the nested `file` point-read and resolved (drop rows whose file is
+    // missing / cross-org — matches withResolvedFile on the required FK).
+    const mediaRows = (
+      await ctx.db.query("clientMedia").withIndex("by_clientId", (q) => q.eq("clientId", id)).collect()
+    )
+      .filter((m) => m.organizationId === orgId)
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+
+    const media = [];
+    for (const m of mediaRows) {
+      const file = await ctx.db.query("fileUploads").withIndex("by_cuid", (q) => q.eq("id", m.fileId)).unique();
+      if (!file || file.organizationId !== orgId) continue;
+      media.push({
+        id: m.id,
+        fileId: m.fileId,
+        type: m.type ?? "OTHER",
+        displayName: m.displayName ?? null,
+        sortOrder: m.sortOrder ?? 0,
+        file: {
+          id: file.id,
+          fileName: file.fileName,
+          fileSize: file.fileSize,
+          mimeType: file.mimeType,
+          url: file.url,
+          thumbnailUrl: file.thumbnailUrl ?? null,
+        },
+      });
+    }
+
+    return { ...client, projects, media };
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/clientsDetail.test.ts
+++ b/convex/clientsDetail.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// clients.detail — browser-native composite replacing the getClient server action.
+// Verifies: composes client + recent projects (newest-first, capped 20, with a
+// TOTAL line-item count) + media gallery (files resolved, sorted by sortOrder),
+// per-row org isolation on the global-index fetches (projects/media/file), and
+// null for a missing / cross-org client.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+async function seed(t: ReturnType<typeof makeT>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    await ctx.db.insert("clients", { id: "c1", organizationId: ORG, name: "Acme", type: "COMPANY", isActive: true, notes: "hi" });
+    await ctx.db.insert("clients", { id: "cX", organizationId: OTHER, name: "Other" });
+
+    // Projects for c1: two owned (different createdAt), one for another client, one cross-org (same clientId!).
+    await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Old", clientId: "c1", createdAt: 100 });
+    await ctx.db.insert("projects", { id: "p2", organizationId: ORG, projectNumber: "P2", name: "New", clientId: "c1", createdAt: 200 });
+    await ctx.db.insert("projects", { id: "p3", organizationId: ORG, projectNumber: "P3", name: "Nope", clientId: "c2", createdAt: 300 });
+    await ctx.db.insert("projects", { id: "pX", organizationId: OTHER, projectNumber: "PX", name: "Foreign", clientId: "c1", createdAt: 400 }); // cross-org, must NOT leak
+
+    // Line items: p1 has 2 (any status/type — count is ALL), p2 has 1.
+    await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CANCELLED", quantity: 1 });
+    await ctx.db.insert("projectLineItems", { id: "li2", organizationId: ORG, projectId: "p1", status: "CONFIRMED", quantity: 1 });
+    await ctx.db.insert("projectLineItems", { id: "li3", organizationId: ORG, projectId: "p2", status: "CONFIRMED", quantity: 1 });
+    // Malformed cross-org line item reusing p1's id → must NOT inflate p1's count.
+    await ctx.db.insert("projectLineItems", { id: "liX", organizationId: OTHER, projectId: "p1", status: "CONFIRMED", quantity: 1 });
+
+    // A file + two media rows (out-of-order sortOrder) + a media row whose file is missing.
+    await ctx.db.insert("fileUploads", { id: "f1", organizationId: ORG, fileName: "a.pdf", fileSize: 10, mimeType: "application/pdf", storageKey: "k1", url: "http://x/a.pdf", uploadedById: USER });
+    await ctx.db.insert("fileUploads", { id: "f2", organizationId: ORG, fileName: "b.png", fileSize: 20, mimeType: "image/png", storageKey: "k2", url: "http://x/b.png", uploadedById: USER });
+    await ctx.db.insert("clientMedia", { id: "cm1", organizationId: ORG, clientId: "c1", fileId: "f2", sortOrder: 2, type: "OTHER" });
+    await ctx.db.insert("clientMedia", { id: "cm2", organizationId: ORG, clientId: "c1", fileId: "f1", sortOrder: 1, type: "OTHER" });
+    await ctx.db.insert("clientMedia", { id: "cm3", organizationId: ORG, clientId: "c1", fileId: "missing", sortOrder: 3, type: "OTHER" }); // dropped (unresolved file)
+  });
+}
+
+describe("clients.detail", () => {
+  test("composes client + recent projects (counts) + resolved media; no cross-org leak", async () => {
+    const t = makeT();
+    await seed(t);
+    const detail = await t.withIdentity(asUser).query(api.clients.detail, { orgId: ORG, id: "c1" });
+    expect(detail).not.toBeNull();
+    expect(detail!.name).toBe("Acme");
+    expect(detail!.notes).toBe("hi");
+
+    // Projects: only c1's OWN-org projects, newest first (p2 before p1); pX (cross-org) excluded.
+    expect(detail!.projects.map((p) => p.id)).toEqual(["p2", "p1"]);
+    // Line-item counts are TOTAL rows (incl. CANCELLED): p1=2, p2=1.
+    const byId = Object.fromEntries(detail!.projects.map((p) => [p.id, p._count.lineItems]));
+    expect(byId).toEqual({ p1: 2, p2: 1 });
+
+    // Media: sorted by sortOrder (f1 then f2), the missing-file row dropped, file resolved.
+    expect(detail!.media.map((m) => m.file.id)).toEqual(["f1", "f2"]);
+    expect(detail!.media[0].file).toMatchObject({ fileName: "a.pdf", url: "http://x/a.pdf" });
+  });
+
+  test("returns null for a missing or cross-org client", async () => {
+    const t = makeT();
+    await seed(t);
+    expect(await t.withIdentity(asUser).query(api.clients.detail, { orgId: ORG, id: "missing" })).toBeNull();
+    // cX belongs to OTHER → viewer in ORG gets null (not a cross-tenant read).
+    expect(await t.withIdentity(asUser).query(api.clients.detail, { orgId: ORG, id: "cX" })).toBeNull();
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.clients.detail, { orgId: ORG, id: "c1" }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/app/(app)/clients/[id]/page.tsx
+++ b/src/app/(app)/clients/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState } from "react";
 import Link from "next/link";
 import { PageMeta } from "@/components/layout/page-meta";
-import { useServerQuery } from "@/hooks/use-server-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import {
   Pencil,
@@ -20,7 +20,7 @@ import { AddressDisplay } from "@/components/ui/address-display";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { getClient } from "@/server/clients";
+import { api } from "../../../../../convex/_generated/api";
 import { useClientWrites } from "@/hooks/use-native-client-writes";
 import { projectStatusLabels, clientTypeLabels, formatLabel } from "@/lib/status-labels";
 import { formatCurrency } from "@/lib/formatters";
@@ -73,10 +73,11 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
-  const { data: client, isLoading, refetch } = useServerQuery({
-    queryKey: ["client", orgId, id],
-    queryFn: () => getClient(id),
-  });
+  // Browser-native reactive detail bundle (replaces the getClient server action).
+  // Client writes (notes/archive) + media add/remove write to Convex, so this
+  // subscription auto-updates — no manual refetch needed.
+  const client = useAuthedQuery(api.clients.detail, orgId ? { orgId, id } : "skip");
+  const isLoading = client === undefined;
 
   const clientWrites = useClientWrites();
   const archiveMutation = useServerMutation({
@@ -366,7 +367,6 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
                 <TabsContent value="notes" className="mt-4">
                   <NotesEditor
                     initialNotes={client.notes || ""}
-                    onChanged={refetch}
                     onSave={(notes) => clientWrites.updateNotes(id, notes)}
                     placeholder="Add notes about this client..."
                   />
@@ -380,7 +380,6 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
                       entityId={id}
                       accept=".pdf,.doc,.docx,.xls,.xlsx,.txt,.csv,image/*"
                       existingMedia={(client.media || []).map((m: MediaItem) => m)}
-                      onChanged={refetch}
                       onUploadComplete={async (fileUpload) => {
                         await addClientMedia({
                           clientId: id,

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -140,7 +140,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "client-media.removeClientMedia": { name: "client-media.removeClientMedia", module: "client-media", fn: "removeClientMedia", kind: "write", resource: "client", action: "update", scope: "client:update", params: [{ name: "mediaId", type: "string", optional: false }], dangerous: true, summary: "" },
   "clients.archiveClient": { name: "clients.archiveClient", module: "clients", fn: "archiveClient", kind: "write", resource: "client", action: "update", scope: "client:update", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "" },
   "clients.createClient": { name: "clients.createClient", module: "clients", fn: "createClient", kind: "write", resource: "client", action: "create", scope: "client:create", params: [{ name: "data", type: "ClientFormValues", optional: false, schemaRef: "ClientFormValues" }], dangerous: false, summary: "" },
-  "clients.getClient": { name: "clients.getClient", module: "clients", fn: "getClient", kind: "read", resource: "client", action: "read", scope: "client:read", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "" },
   "clients.getClients": { name: "clients.getClients", module: "clients", fn: "getClients", kind: "read", resource: "client", action: "read", scope: "client:read", params: [{ name: "params", type: "{ search?: string; type?: string; isActive?: boolean; filters?: Record<string, FilterValue>; page?: number; pageSize?: number; sortBy?: string; sortOrder?: \"asc\" | \"desc\"; }", optional: true }], dangerous: false, summary: "" },
   "clients.updateClient": { name: "clients.updateClient", module: "clients", fn: "updateClient", kind: "write", resource: "client", action: "update", scope: "client:update", params: [{ name: "id", type: "string", optional: false }, { name: "data", type: "ClientFormValues", optional: false, schemaRef: "ClientFormValues" }], dangerous: false, summary: "" },
   "clients.updateClientNotes": { name: "clients.updateClientNotes", module: "clients", fn: "updateClientNotes", kind: "write", resource: "client", action: "update", scope: "client:update", params: [{ name: "id", type: "string", optional: false }, { name: "notes", type: "string", optional: false }], dangerous: false, summary: "" },
@@ -4275,4 +4274,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 522;
+export const OPERATION_COUNT = 521;

--- a/src/server/clients.ts
+++ b/src/server/clients.ts
@@ -2,13 +2,8 @@
 
 import { createId } from "@paralleldrive/cuid2";
 import { getConvexClient } from "@/lib/convex-client";
-import { getClientMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { getClientById, getClientsByOrg, type ConvexClient } from "@/lib/clients-read";
 import { getProjectsByOrg } from "@/lib/projects-read";
-import {
-  getLineItemsByProjectIds,
-  countAllLineItemsByProject,
-} from "@/lib/line-item-count-read";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { clientSchema, type ClientFormValues } from "@/lib/validations/client";
@@ -89,39 +84,6 @@ export async function getClients(params?: {
   }));
 
   return serialize({ clients: withCounts, total, page, pageSize, totalPages: Math.ceil(total / pageSize) });
-}
-
-export async function getClient(id: string) {
-  const { organizationId } = await getOrgContext();
-  const client = await getClientById(id);
-  if (!client || client.organizationId !== organizationId) return serialize(null);
-
-  const [allOrgProjects, media] = await Promise.all([
-    getProjectsByOrg(organizationId),
-    // clientMedia gallery now read from the Convex mirror (was a Prisma
-    // clientMedia + file join). Dual-written, so identical data. See media-read.ts.
-    getClientMediaFromConvex(id),
-  ]);
-
-  const clientProjects = allOrgProjects
-    .filter((p) => p.clientId === id)
-    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
-    .slice(0, 20);
-
-  // Per-project line-item counts (all line items, like the old groupBy scoped by
-  // the project's clientId) now come from the dual-written Convex line items, for
-  // exactly the projects rendered on the detail page.
-  const projectIds = clientProjects.map((p) => p.id);
-  const lineItemCountMap = countAllLineItemsByProject(
-    await getLineItemsByProjectIds(organizationId, projectIds),
-    projectIds,
-  );
-  const projects = clientProjects.map((p) => ({
-    ...p,
-    _count: { lineItems: lineItemCountMap.get(p.id) ?? 0 },
-  }));
-
-  return serialize({ ...client, projects, media: withResolvedFile(media) });
 }
 
 export async function createClient(data: ClientFormValues) {


### PR DESCRIPTION
Phase 3 read re-homing — closes the **clients-reads** domain (`getClientProjectCounts` done #494; `getClients` is agent-only, deferred).

## Change
- **`clients.detail({orgId, id})`** — composite reactive query: client doc + recent projects (`by_clientId`, newest-first, cap 20, each with a **total** line-item count) + media gallery (`clientMedia` by_clientId, sorted by `sortOrder`, `fileUploads` point-read + resolved, unresolved-file rows dropped). Every global-index fetch (projects / line-items / media / file) is **org-re-checked**; the read-set is **client-scoped, not org-wide** → safe as a reactive subscription (Appendix B). Returns `null` for missing/foreign.
- Detail page → `useAuthedQuery(api.clients.detail, …)`; drops the manual `refetch` (writes go to Convex, subscription auto-updates). `MediaItem` shape reproduced exactly.
- **`getClient` server action deleted** (not a curated agent tool → op drops 522→521).

## Tests
- `convex/clientsDetail.test.ts` — compose parity (project sort/cap + line-item count incl. CANCELLED; media sort/resolve/drop), **cross-org isolation incl. a malformed cross-org line-item collision**, null for missing/foreign, non-member RBAC.
- codex-reviewed: parity/cross-tenant/Appendix-B/refetch-removal confirmed; its one **High** (missing line-item org re-check) fixed inline. tsc clean; api suite (114) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)