### PR TITLE
refactor(suppliers): asset+order counts browser-native (drop getSupplierCounts)

### DIFF
--- a/convex/suppliers.ts
+++ b/convex/suppliers.ts
@@ -32,6 +32,38 @@ export const getById = query({
   },
 });
 
+/**
+ * Asset + order counts per supplier (supplierId → { assets, orders }) for the
+ * suppliers table — browser-native replacement for the getSupplierCounts server
+ * action. Tallies every org asset and supplier order that has a supplierId,
+ * matching countSupplierAssetsAndOrders (no isActive filter). Fetched ONE-SHOT by
+ * the table (counts have no liveness need), so this is not a reactive org-wide
+ * subscription (Appendix B).
+ */
+export const counts = query({
+  args: { orgId: v.string() },
+  returns: v.record(v.string(), v.object({ assets: v.number(), orders: v.number() })),
+  handler: async (ctx, { orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const out: Record<string, { assets: number; orders: number }> = {};
+    const ensure = (id: string) => (out[id] ??= { assets: 0, orders: 0 });
+
+    const assets = await ctx.db
+      .query("assets")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const a of assets) if (a.supplierId) ensure(a.supplierId).assets++;
+
+    const orders = await ctx.db
+      .query("supplierOrders")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const o of orders) if (o.supplierId) ensure(o.supplierId).orders++;
+
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/suppliersCounts.test.ts
+++ b/convex/suppliersCounts.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+//
+// suppliers.counts — browser-native replacement for getSupplierCounts. Verifies:
+// tallies assets + supplier orders per supplierId (parity with
+// countSupplierAssetsAndOrders — every row with a supplierId, no isActive filter),
+// org isolation (another org's assets/orders don't leak), and RBAC.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+const seed = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    const asset = (id: string, org: string, supplierId?: string, isActive = true) =>
+      ctx.db.insert("assets", { id, organizationId: org, modelId: "m1", assetTag: id, status: "AVAILABLE", isActive, supplierId });
+    // s1: 2 assets (one inactive — still counted, no isActive filter); s2: 1 asset; no supplier: ignored.
+    await asset("a1", ORG, "s1");
+    await asset("a2", ORG, "s1", false);
+    await asset("a3", ORG, "s2");
+    await asset("a4", ORG, undefined);
+    await asset("ax", OTHER, "s1"); // other org → must not leak
+    const order = (id: string, org: string, supplierId: string) =>
+      ctx.db.insert("supplierOrders", { id, organizationId: org, supplierId, orderNumber: id, type: "PURCHASE" });
+    await order("o1", ORG, "s1"); // s1: 1 order
+    await order("o2", ORG, "s2");
+    await order("o3", ORG, "s2"); // s2: 2 orders
+    await order("ox", OTHER, "s1"); // other org → must not leak
+  });
+
+describe("suppliers.counts", () => {
+  test("tallies assets + orders per supplier, no isActive filter, no cross-org leak", async () => {
+    const t = makeT();
+    await seed(t);
+    const counts = await t.withIdentity(asUser).query(api.suppliers.counts, { orgId: ORG });
+    expect(counts).toEqual({
+      s1: { assets: 2, orders: 1 }, // a1+a2 (inactive counted), o1; ax/ox other-org excluded
+      s2: { assets: 1, orders: 2 },
+    });
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.suppliers.counts, { orgId: ORG }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/app/(app)/suppliers/page.tsx
+++ b/src/app/(app)/suppliers/page.tsx
@@ -9,8 +9,7 @@ import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import { FadeIn } from "@/components/ui/motion";
 import { useSuppliers } from "@/hooks/use-suppliers";
 import { useActiveOrganization } from "@/lib/auth-client";
-import { useServerQuery } from "@/hooks/use-server-query";
-import { getSupplierCounts } from "@/server/suppliers";
+import { useSupplierCounts } from "@/hooks/use-supplier-counts";
 import { cn } from "@/lib/utils";
 
 /**
@@ -52,11 +51,7 @@ export default function SuppliersPage() {
   // Same reactive list + counts the SupplierTable consumes — we aggregate it
   // client-side for the dashboard tiles so there's no extra server work.
   const allSuppliers = useSuppliers(orgId);
-  const { data: supplierCounts } = useServerQuery({
-    queryKey: ["supplier-counts", orgId],
-    queryFn: () => getSupplierCounts(),
-    enabled: !!orgId,
-  });
+  const supplierCounts = useSupplierCounts(orgId);
 
   const stats = useMemo(() => {
     const list = allSuppliers ?? [];

--- a/src/components/suppliers/supplier-table.tsx
+++ b/src/components/suppliers/supplier-table.tsx
@@ -4,8 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Plus } from "lucide-react";
 
-import { getSupplierCounts } from "@/server/suppliers";
-import { useServerQuery } from "@/hooks/use-server-query";
+import { useSupplierCounts } from "@/hooks/use-supplier-counts";
 import { useSuppliers } from "@/hooks/use-suppliers";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useTablePreferences } from "@/lib/use-table-preferences";
@@ -147,13 +146,9 @@ export function SupplierTable() {
   // Reactive supplier list straight from Convex (auto-updates on any supplier
   // create/update/delete). Asset + order counts are a cross-domain aggregate
   // that nothing invalidates (no liveness need) so they come from a one-shot,
-  // non-reactive server query (useServerQuery, not React Query).
+  // non-reactive browser-native Convex query (useSupplierCounts → suppliers.counts).
   const allSuppliers = useSuppliers(orgId);
-  const { data: supplierCounts } = useServerQuery({
-    queryKey: ["supplier-counts", orgId],
-    queryFn: () => getSupplierCounts(),
-    enabled: !!orgId,
-  });
+  const supplierCounts = useSupplierCounts(orgId);
 
   // Filter / sort / paginate in the browser over the reactive list (mirrors the
   // old getSuppliersPaginated where: isActive enum filter + name/contact/email/

--- a/src/hooks/use-supplier-counts.ts
+++ b/src/hooks/use-supplier-counts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export type SupplierCounts = Record<string, { assets: number; orders: number }>;
+
+/**
+ * Asset + order counts per supplier (supplierId → { assets, orders }) for the
+ * suppliers table — the browser-native replacement for the getSupplierCounts
+ * server action (Phase 3 read re-homing).
+ *
+ * The old datum was a non-reactive `useServerQuery`, and the counts have no
+ * liveness requirement, so this is a ONE-SHOT `useConvex().query` on mount /
+ * org-switch rather than a reactive org-wide `.collect()` subscription (Appendix
+ * B). Gated on Convex auth so a pre-token orgId doesn't reject and stick counts at
+ * empty. Returns an empty map until org context loads / while fetching.
+ */
+export function useSupplierCounts(orgId: string | undefined): SupplierCounts {
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
+  const [counts, setCounts] = useState<SupplierCounts>({});
+
+  useEffect(() => {
+    setCounts({});
+    if (!orgId || !isAuthenticated) return;
+    let cancelled = false;
+    convex
+      .query(api.suppliers.counts, { orgId })
+      .then((next) => {
+        if (!cancelled) setCounts(next);
+      })
+      .catch(() => {
+        // Best-effort — a failed count renders 0s in the assets/orders columns.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, isAuthenticated, convex]);
+
+  return counts;
+}

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -450,7 +450,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "suppliers.deleteSupplier": { name: "suppliers.deleteSupplier", module: "suppliers", fn: "deleteSupplier", kind: "write", resource: "supplier", action: "delete", scope: "supplier:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "" },
   "suppliers.getSupplierAssets": { name: "suppliers.getSupplierAssets", module: "suppliers", fn: "getSupplierAssets", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "supplierId", type: "string", optional: false }, { name: "params", type: "{ page?: number; pageSize?: number; }", optional: false }], dangerous: false, summary: "" },
   "suppliers.getSupplierById": { name: "suppliers.getSupplierById", module: "suppliers", fn: "getSupplierById", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "" },
-  "suppliers.getSupplierCounts": { name: "suppliers.getSupplierCounts", module: "suppliers", fn: "getSupplierCounts", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [], dangerous: false, summary: "Asset + order counts per supplier (supplierId -> { assets, orders })." },
   "suppliers.getSuppliers": { name: "suppliers.getSuppliers", module: "suppliers", fn: "getSuppliers", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [], dangerous: false, summary: "" },
   "suppliers.getSuppliersPaginated": { name: "suppliers.getSuppliersPaginated", module: "suppliers", fn: "getSuppliersPaginated", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "params", type: "{ search?: string; filters?: Record<string, FilterValue>; page?: number; pageSize?: number; sortBy?: string; sortOrder?: \"asc\" | \"desc\"; }", optional: false }], dangerous: false, summary: "" },
   "suppliers.getSupplierSubhires": { name: "suppliers.getSupplierSubhires", module: "suppliers", fn: "getSupplierSubhires", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "supplierId", type: "string", optional: false }, { name: "params", type: "{ page?: number; pageSize?: number; }", optional: false }], dangerous: false, summary: "" },
@@ -4274,4 +4273,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 521;
+export const OPERATION_COUNT = 520;

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -18,8 +18,6 @@ import {
   type SubhireProjectSelect,
 } from "@/lib/line-item-count-read";
 import {
-  getSupplierOrdersByOrg,
-  countSupplierAssetsAndOrders,
   getSupplierById as getConvexSupplierById,
   getMappedSuppliersByOrg,
   mapSupplier,
@@ -142,22 +140,6 @@ export async function getSuppliersPaginated(params: {
   return serialize({ suppliers, total });
 }
 
-/**
- * Asset + order counts per supplier (supplierId -> { assets, orders }).
- * Both inputs now come off Convex — assets via getAssetsByOrg and supplier orders
- * via getSupplierOrdersByOrg (both dual-written) — counted in JS by
- * countSupplierAssetsAndOrders, replacing the Prisma `supplierOrder.groupBy`
- * (Phase A). Used by the reactive supplier table, which subscribes to the supplier
- * list via Convex and merges these (non-reactive) counts.
- */
-export async function getSupplierCounts(): Promise<Record<string, { assets: number; orders: number }>> {
-  const { organizationId } = await getOrgContext();
-  const [allAssets, orders] = await Promise.all([
-    getAssetsByOrg(organizationId),
-    getSupplierOrdersByOrg(organizationId),
-  ]);
-  return serialize(countSupplierAssetsAndOrders(allAssets, orders));
-}
 
 export async function getSupplierById(id: string) {
   const { organizationId } = await getOrgContext();


### PR DESCRIPTION
Phase 3 read re-homing — mirrors `clients.projectCounts` (#494).

## Change
- **`suppliers.counts({orgId})`** — `requireOrgRead`; scans org `assets` + `supplierOrders` by `by_organizationId`, tallies `supplierId → {assets, orders}`. Exact parity with `countSupplierAssetsAndOrders` (every row with a `supplierId`, no `isActive` filter).
- **`useSupplierCounts`** — ONE-SHOT `useConvex().query` (no liveness need → not a reactive org-wide `.collect()`, Appendix B), auth-gated.
- suppliers table + page rewired; **`getSupplierCounts` deleted** (not curated → op 521→520). Pure helper + its unit test stay.

## Tests
- `convex/suppliersCounts.test.ts` — parity (inactive assets counted) + org isolation + non-member RBAC. tsc + eslint clean; api suite (114) green; **codex clean** (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)