### PR TITLE
refactor(categories): model+kit counts browser-native (drop getCategoryCounts)

### DIFF
--- a/convex/categories.ts
+++ b/convex/categories.ts
@@ -32,6 +32,37 @@ export const getById = query({
   },
 });
 
+/**
+ * Per-category model + kit counts (categoryId → { models, kits }) for the category
+ * manager — browser-native replacement for the getCategoryCounts server action.
+ * Tallies every org model and kit that has a categoryId (parity with
+ * buildModelKitCounts, no filter). Fetched ONE-SHOT by the manager (counts have no
+ * liveness need), so this is not a reactive org-wide subscription (Appendix B).
+ */
+export const counts = query({
+  args: { orgId: v.string() },
+  returns: v.record(v.string(), v.object({ models: v.number(), kits: v.number() })),
+  handler: async (ctx, { orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const out: Record<string, { models: number; kits: number }> = {};
+    const ensure = (id: string) => (out[id] ??= { models: 0, kits: 0 });
+
+    const models = await ctx.db
+      .query("models")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const m of models) if (m.categoryId) ensure(m.categoryId).models++;
+
+    const kits = await ctx.db
+      .query("kits")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const k of kits) if (k.categoryId) ensure(k.categoryId).kits++;
+
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/categoriesCounts.test.ts
+++ b/convex/categoriesCounts.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+//
+// categories.counts — browser-native replacement for getCategoryCounts. Verifies:
+// tallies models + kits per categoryId (parity with buildModelKitCounts — every
+// model/kit with a categoryId, no filter), org isolation, and RBAC.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+const seed = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    const model = (id: string, org: string, categoryId?: string) =>
+      ctx.db.insert("models", { id, organizationId: org, name: id, categoryId });
+    const kit = (id: string, org: string, categoryId?: string) =>
+      ctx.db.insert("kits", { id, organizationId: org, assetTag: id, name: id, categoryId });
+    // cat1: 2 models + 1 kit; cat2: 1 model; no-category model ignored; other-org excluded.
+    await model("m1", ORG, "cat1");
+    await model("m2", ORG, "cat1");
+    await model("m3", ORG, "cat2");
+    await model("m4", ORG, undefined);
+    await model("mx", OTHER, "cat1"); // other org
+    await kit("k1", ORG, "cat1");
+    await kit("k2", ORG, undefined); // no category
+    await kit("kx", OTHER, "cat1"); // other org
+  });
+
+describe("categories.counts", () => {
+  test("tallies models + kits per categoryId, no cross-org leak", async () => {
+    const t = makeT();
+    await seed(t);
+    const counts = await t.withIdentity(asUser).query(api.categories.counts, { orgId: ORG });
+    expect(counts).toEqual({
+      cat1: { models: 2, kits: 1 }, // m1,m2 + k1 (mx/kx other-org excluded)
+      cat2: { models: 1, kits: 0 },
+    });
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.categories.counts, { orgId: ORG }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/app/(app)/assets/categories/page.tsx
+++ b/src/app/(app)/assets/categories/page.tsx
@@ -8,10 +8,10 @@ import { Plus, Pencil, Trash2, Boxes, Container, FolderOpen, Folder, FolderTree,
 import { toast } from "sonner";
 
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
-import { getCategoryCounts, createCategory, updateCategory, deleteCategory } from "@/server/categories";
+import { createCategory, updateCategory, deleteCategory } from "@/server/categories";
+import { useCategoryCounts } from "@/hooks/use-category-counts";
 import { useCategories } from "@/hooks/use-categories";
 import { useServerMutation } from "@/hooks/use-server-mutation";
-import { useServerQuery } from "@/hooks/use-server-query";
 import { Button } from "@/components/ui/button";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
 import { Input } from "@/components/ui/input";
@@ -67,11 +67,7 @@ function CategoriesContent() {
   // mirrors CategoryManager.
   const allCategories = useCategories(orgId);
   const isLoading = allCategories === undefined;
-  const { data: categoryCounts } = useServerQuery({
-    queryKey: ["category-counts", orgId],
-    queryFn: () => getCategoryCounts(),
-    enabled: !!orgId,
-  });
+  const categoryCounts = useCategoryCounts(orgId);
   const categories = useMemo(() => {
     const source = allCategories ?? [];
     const childCount = new Map<string, number>();

--- a/src/components/assets/category-manager.tsx
+++ b/src/components/assets/category-manager.tsx
@@ -8,10 +8,10 @@ import { toast } from "sonner";
 
 import { categorySchema, type CategoryFormValues } from "@/lib/validations/category";
 import { useActiveOrganization } from "@/lib/auth-client";
-import { getCategoryCounts, createCategory, updateCategory, deleteCategory } from "@/server/categories";
+import { createCategory, updateCategory, deleteCategory } from "@/server/categories";
+import { useCategoryCounts } from "@/hooks/use-category-counts";
 import { useCategories } from "@/hooks/use-categories";
 import { useServerMutation } from "@/hooks/use-server-mutation";
-import { useServerQuery } from "@/hooks/use-server-query";
 import { useOrgTags } from "@/hooks/use-org-tags";
 import { TagInput } from "@/components/ui/tag-input";
 import { Button } from "@/components/ui/button";
@@ -45,11 +45,7 @@ export function CategoryManager() {
   // they come from a separate, non-reactive server query; children counts are
   // derived from the flat reactive list itself.
   const allCategories = useCategories(orgId);
-  const { data: categoryCounts } = useServerQuery({
-    queryKey: ["category-counts", orgId],
-    queryFn: () => getCategoryCounts(),
-    enabled: !!orgId,
-  });
+  const categoryCounts = useCategoryCounts(orgId);
   const isLoading = allCategories === undefined;
 
   const categories = useMemo(() => {

--- a/src/hooks/use-category-counts.ts
+++ b/src/hooks/use-category-counts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export type CategoryCounts = Record<string, { models: number; kits: number }>;
+
+/**
+ * Per-category model + kit counts (categoryId → { models, kits }) for the category
+ * manager — the browser-native replacement for the getCategoryCounts server action
+ * (Phase 3 read re-homing).
+ *
+ * The old datum was a non-reactive `useServerQuery`, and the counts have no
+ * liveness requirement, so this is a ONE-SHOT `useConvex().query` on mount /
+ * org-switch rather than a reactive org-wide `.collect()` subscription (Appendix
+ * B). Gated on Convex auth so a pre-token orgId doesn't reject and stick counts at
+ * empty. Returns an empty map until org context loads / while fetching.
+ */
+export function useCategoryCounts(orgId: string | undefined): CategoryCounts {
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
+  const [counts, setCounts] = useState<CategoryCounts>({});
+
+  useEffect(() => {
+    setCounts({});
+    if (!orgId || !isAuthenticated) return;
+    let cancelled = false;
+    convex
+      .query(api.categories.counts, { orgId })
+      .then((next) => {
+        if (!cancelled) setCounts(next);
+      })
+      .catch(() => {
+        // Best-effort — a failed count renders 0s in the models/kits columns.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, isAuthenticated, convex]);
+
+  return counts;
+}

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -89,7 +89,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "categories.getCaseCategoryIds": { name: "categories.getCaseCategoryIds", module: "categories", fn: "getCaseCategoryIds", kind: "read", resource: "model", action: "read", scope: "model:read", params: [], dangerous: false, summary: "Get category + all descendant IDs for container cases." },
   "categories.getCategories": { name: "categories.getCategories", module: "categories", fn: "getCategories", kind: "read", resource: "model", action: "read", scope: "model:read", params: [], dangerous: false, summary: "Equipment Categories are CONVEX-ONLY (Phase B write inversion): every" },
   "categories.getCategory": { name: "categories.getCategory", module: "categories", fn: "getCategory", kind: "read", resource: "model", action: "read", scope: "model:read", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "" },
-  "categories.getCategoryCounts": { name: "categories.getCategoryCounts", module: "categories", fn: "getCategoryCounts", kind: "read", resource: "model", action: "read", scope: "model:read", params: [], dangerous: false, summary: "Per-category model + kit counts (categoryId -> counts). Cross-domain: models" },
   "categories.getCategoryTree": { name: "categories.getCategoryTree", module: "categories", fn: "getCategoryTree", kind: "read", resource: "model", action: "read", scope: "model:read", params: [], dangerous: false, summary: "Category tree — READ FROM CONVEX (Phase A). Tree rebuilt client-side from the" },
   "categories.searchContainerAssets": { name: "categories.searchContainerAssets", module: "categories", fn: "searchContainerAssets", kind: "read", resource: "model", action: "read", scope: "model:read", params: [{ name: "query", type: "string", optional: true }], dangerous: false, summary: "---------------------------------------------------------------------------" },
   "categories.updateCategory": { name: "categories.updateCategory", module: "categories", fn: "updateCategory", kind: "write", resource: "model", action: "update", scope: "model:update", params: [{ name: "id", type: "string", optional: false }, { name: "data", type: "CategoryFormValues", optional: false, schemaRef: "CategoryFormValues" }], dangerous: false, summary: "" },
@@ -4273,4 +4272,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 520;
+export const OPERATION_COUNT = 519;

--- a/src/server/categories.ts
+++ b/src/server/categories.ts
@@ -9,7 +9,6 @@ import { getModelMap, mapConvexModelToRow, getModelsByOrg } from "@/lib/models-r
 import { getPrimaryPhotoMap } from "@/lib/media-read";
 import {
   listCategoriesWithCounts,
-  getCategoryModelKitCounts,
   listCategoryTree,
   collectDescendantCategoryIds,
   getMappedCategoriesByOrg,
@@ -130,19 +129,6 @@ export async function getCategory(id: string) {
     _count: { models: ownCounts.models, kits: ownCounts.kits, children: childCounts.get(id) ?? 0 },
     models,
   });
-}
-
-/**
- * Per-category model + kit counts (categoryId -> counts). Cross-domain: models
- * and kits still live in Prisma, so this can't come from Convex. Used by the
- * reactive category manager, which subscribes to the category list via Convex and
- * merges these (non-reactive) counts in. (Children counts are derived client-side
- * from the reactive list itself.)
- */
-export async function getCategoryCounts(): Promise<Record<string, { models: number; kits: number }>> {
-  const { organizationId } = await getOrgContext();
-  // Models AND kits live in Convex — count by categoryId in JS from both lists.
-  return serialize(await getCategoryModelKitCounts(organizationId));
 }
 
 // Category tree — READ FROM CONVEX (Phase A). Tree rebuilt client-side from the


### PR DESCRIPTION
Phase 3 read re-homing — same count-map pattern as suppliers.counts (#497) / clients.projectCounts (#494).

- **`categories.counts({orgId})`** — `requireOrgRead`; scans org models + kits by `by_organizationId`, tallies `categoryId → {models, kits}`. Parity with `buildModelKitCounts` (every row with a categoryId, no filter).
- **`useCategoryCounts`** — one-shot `useConvex().query`, auth-gated (Appendix B).
- category-manager + categories page rewired; **`getCategoryCounts` deleted** (not curated → op 520→519).
- `categoriesCounts.test.ts` (parity + org isolation + RBAC). tsc+eslint clean; api suite green; codex clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)