### PR TITLE
refactor(locations): asset/bulk/kit counts browser-native (drop getLocationCounts)

### DIFF
--- a/convex/locations.ts
+++ b/convex/locations.ts
@@ -33,6 +33,46 @@ export const getById = query({
   },
 });
 
+/**
+ * Asset + bulk-asset + kit counts per location (locationId → { assets, bulkAssets,
+ * kits }) for the locations table — browser-native replacement for the
+ * getLocationCounts server action. Tallies every org asset/bulkAsset/kit that has a
+ * locationId (parity with the action, no filter). Fetched ONE-SHOT by the table
+ * (counts have no liveness need) → not a reactive org-wide subscription (Appendix B).
+ */
+export const counts = query({
+  args: { orgId: v.string() },
+  returns: v.record(
+    v.string(),
+    v.object({ assets: v.number(), bulkAssets: v.number(), kits: v.number() }),
+  ),
+  handler: async (ctx, { orgId }) => {
+    await requireOrgRead(ctx, orgId);
+    const out: Record<string, { assets: number; bulkAssets: number; kits: number }> = {};
+    const ensure = (id: string) => (out[id] ??= { assets: 0, bulkAssets: 0, kits: 0 });
+
+    const assets = await ctx.db
+      .query("assets")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const a of assets) if (a.locationId) ensure(a.locationId).assets++;
+
+    const bulkAssets = await ctx.db
+      .query("bulkAssets")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const b of bulkAssets) if (b.locationId) ensure(b.locationId).bulkAssets++;
+
+    const kits = await ctx.db
+      .query("kits")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .collect();
+    for (const k of kits) if (k.locationId) ensure(k.locationId).kits++;
+
+    return out;
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/locationsCounts.test.ts
+++ b/convex/locationsCounts.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+//
+// locations.counts — browser-native replacement for getLocationCounts. Verifies:
+// tallies assets + bulkAssets + kits per locationId (parity with the action — every
+// row with a locationId, no filter), org isolation, and RBAC.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+const seed = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "viewer" });
+    const asset = (id: string, org: string, locationId?: string) =>
+      ctx.db.insert("assets", { id, organizationId: org, modelId: "m1", assetTag: id, status: "AVAILABLE", isActive: true, locationId });
+    const bulk = (id: string, org: string, locationId?: string) =>
+      ctx.db.insert("bulkAssets", { id, organizationId: org, modelId: "m1", assetTag: id, totalQuantity: 1, isActive: true, locationId });
+    const kit = (id: string, org: string, locationId?: string) =>
+      ctx.db.insert("kits", { id, organizationId: org, assetTag: id, name: id, locationId });
+    // loc1: 2 assets + 1 bulk + 1 kit; loc2: 1 asset; no-location + other-org excluded.
+    await asset("a1", ORG, "loc1");
+    await asset("a2", ORG, "loc1");
+    await asset("a3", ORG, "loc2");
+    await asset("a4", ORG, undefined);
+    await asset("ax", OTHER, "loc1");
+    await bulk("b1", ORG, "loc1");
+    await bulk("bx", OTHER, "loc1");
+    await kit("k1", ORG, "loc1");
+    await kit("kx", OTHER, "loc1");
+  });
+
+describe("locations.counts", () => {
+  test("tallies assets+bulkAssets+kits per location, no cross-org leak", async () => {
+    const t = makeT();
+    await seed(t);
+    const counts = await t.withIdentity(asUser).query(api.locations.counts, { orgId: ORG });
+    expect(counts).toEqual({
+      loc1: { assets: 2, bulkAssets: 1, kits: 1 }, // a1,a2 / b1 / k1 (other-org excluded)
+      loc2: { assets: 1, bulkAssets: 0, kits: 0 },
+    });
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.locations.counts, { orgId: ORG }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/app/(app)/locations/page.tsx
+++ b/src/app/(app)/locations/page.tsx
@@ -9,8 +9,7 @@ import { ListPageLayout } from "@/components/layout/page-layouts";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import { FadeIn } from "@/components/ui/motion";
 import { useLocations } from "@/hooks/use-locations";
-import { useServerQuery } from "@/hooks/use-server-query";
-import { getLocationCounts } from "@/server/locations";
+import { useLocationCounts } from "@/hooks/use-location-counts";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
@@ -25,11 +24,7 @@ function LocationsDashboardHeader() {
   const orgId = activeOrg?.id;
 
   const locations = useLocations(orgId);
-  const { data: counts } = useServerQuery({
-    queryKey: ["location-counts", orgId],
-    queryFn: () => getLocationCounts(),
-    enabled: !!orgId,
-  });
+  const counts = useLocationCounts(orgId);
 
   const stats = useMemo(() => {
     const list = locations ?? [];

--- a/src/components/locations/location-table.tsx
+++ b/src/components/locations/location-table.tsx
@@ -4,8 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Plus, Star } from "lucide-react";
 
-import { getLocationCounts } from "@/server/locations";
-import { useServerQuery } from "@/hooks/use-server-query";
+import { useLocationCounts } from "@/hooks/use-location-counts";
 import { useLocations } from "@/hooks/use-locations";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useTablePreferences } from "@/lib/use-table-preferences";
@@ -157,11 +156,7 @@ export function LocationTable() {
   // create/update/delete). Asset/bulk/kit counts are cross-domain (still in
   // Prisma) so they come from a separate, non-reactive server query.
   const allLocations = useLocations(orgId);
-  const { data: locationCounts } = useServerQuery({
-    queryKey: ["location-counts", orgId],
-    queryFn: () => getLocationCounts(),
-    enabled: !!orgId,
-  });
+  const locationCounts = useLocationCounts(orgId);
 
   // Filter (search name/address + type) → sort siblings (isDefault first, then
   // the chosen column) → build the hierarchy tree → paginate the tree rows. All

--- a/src/hooks/use-location-counts.ts
+++ b/src/hooks/use-location-counts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export type LocationCounts = Record<string, { assets: number; bulkAssets: number; kits: number }>;
+
+/**
+ * Asset + bulk-asset + kit counts per location (locationId → { assets, bulkAssets,
+ * kits }) for the locations table — the browser-native replacement for the
+ * getLocationCounts server action (Phase 3 read re-homing).
+ *
+ * The old datum was a non-reactive `useServerQuery`, and the counts have no
+ * liveness requirement, so this is a ONE-SHOT `useConvex().query` on mount /
+ * org-switch rather than a reactive org-wide `.collect()` subscription (Appendix
+ * B). Gated on Convex auth so a pre-token orgId doesn't reject and stick counts at
+ * empty. Returns an empty map until org context loads / while fetching.
+ */
+export function useLocationCounts(orgId: string | undefined): LocationCounts {
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
+  const [counts, setCounts] = useState<LocationCounts>({});
+
+  useEffect(() => {
+    setCounts({});
+    if (!orgId || !isAuthenticated) return;
+    let cancelled = false;
+    convex
+      .query(api.locations.counts, { orgId })
+      .then((next) => {
+        if (!cancelled) setCounts(next);
+      })
+      .catch(() => {
+        // Best-effort — a failed count renders 0s in the columns.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, isAuthenticated, convex]);
+
+  return counts;
+}

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -269,7 +269,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "locations.createLocation": { name: "locations.createLocation", module: "locations", fn: "createLocation", kind: "write", resource: "location", action: "create", scope: "location:create", params: [{ name: "data", type: "LocationFormValues", optional: false, schemaRef: "LocationFormValues" }], dangerous: false, summary: "" },
   "locations.deleteLocation": { name: "locations.deleteLocation", module: "locations", fn: "deleteLocation", kind: "write", resource: "location", action: "delete", scope: "location:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "" },
   "locations.getLocation": { name: "locations.getLocation", module: "locations", fn: "getLocation", kind: "read", resource: "location", action: "read", scope: "location:read", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "Detail-page composite — READ FROM CONVEX (Phase B). The deep Prisma include" },
-  "locations.getLocationCounts": { name: "locations.getLocationCounts", module: "locations", fn: "getLocationCounts", kind: "read", resource: "location", action: "read", scope: "location:read", params: [], dangerous: false, summary: "Asset + bulk-asset + kit counts per location (locationId -> counts)." },
   "locations.getLocations": { name: "locations.getLocations", module: "locations", fn: "getLocations", kind: "read", resource: "location", action: "read", scope: "location:read", params: [{ name: "params", type: "{ search?: string; type?: string; filters?: Record<string, FilterValue>; page?: number; pageSize?: number; sortBy?: string; sortOrder?: \"asc\" | \"desc\"; }", optional: true }], dangerous: false, summary: "Locations list — READ FROM CONVEX. Filter/sort/paginate + the parent name" },
   "locations.updateLocation": { name: "locations.updateLocation", module: "locations", fn: "updateLocation", kind: "write", resource: "location", action: "update", scope: "location:update", params: [{ name: "id", type: "string", optional: false }, { name: "data", type: "LocationFormValues", optional: false, schemaRef: "LocationFormValues" }], dangerous: false, summary: "" },
   "locations.updateLocationNotes": { name: "locations.updateLocationNotes", module: "locations", fn: "updateLocationNotes", kind: "write", resource: "location", action: "update", scope: "location:update", params: [{ name: "id", type: "string", optional: false }, { name: "notes", type: "string", optional: false }], dangerous: false, summary: "" },
@@ -4272,4 +4271,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 519;
+export const OPERATION_COUNT = 518;

--- a/src/server/locations.ts
+++ b/src/server/locations.ts
@@ -5,7 +5,6 @@ import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
-import { getKitsByOrg } from "@/lib/kits-read";
 import { locationSchema, type LocationFormValues } from "@/lib/validations/asset";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
@@ -101,25 +100,6 @@ export async function getLocations(params?: {
       sortOrder,
     }),
   );
-}
-
-/**
- * Asset + bulk-asset + kit counts per location (locationId -> counts).
- * All three domains live in Convex — aggregate in JS from the org-level lists.
- */
-export async function getLocationCounts(): Promise<Record<string, { assets: number; bulkAssets: number; kits: number }>> {
-  const { organizationId } = await getOrgContext();
-  const [allAssets, allBulkAssets, allKits] = await Promise.all([
-    getAssetsByOrg(organizationId),
-    getBulkAssetsByOrg(organizationId),
-    getKitsByOrg(organizationId),
-  ]);
-  const counts: Record<string, { assets: number; bulkAssets: number; kits: number }> = {};
-  const ensure = (id: string) => (counts[id] ??= { assets: 0, bulkAssets: 0, kits: 0 });
-  for (const a of allAssets) if (a.locationId) ensure(a.locationId).assets++;
-  for (const b of allBulkAssets) if (b.locationId) ensure(b.locationId).bulkAssets++;
-  for (const k of allKits) if (k.locationId) ensure(k.locationId).kits++;
-  return serialize(counts);
 }
 
 // Detail-page composite — READ FROM CONVEX (Phase B). The deep Prisma include


### PR DESCRIPTION
Phase 3 read re-homing — completes the categories/locations/suppliers count-map trio (#497 suppliers, #498 categories).

- **`locations.counts({orgId})`** — `requireOrgRead`; scans org assets + bulkAssets + kits by `by_organizationId`, tallies `locationId → {assets, bulkAssets, kits}`. Parity with the action (every row with a locationId, no filter).
- **`useLocationCounts`** — one-shot `useConvex().query`, auth-gated (Appendix B).
- locations table + page rewired; **`getLocationCounts` deleted** (not curated → op 519→518).
- `locationsCounts.test.ts` (parity + org isolation + RBAC). tsc+eslint clean; api suite green; codex clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)