### PR TITLE
refactor(kits): delete-dialog preview browser-direct native (drop canDeleteKit)

### DIFF
--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -83,6 +83,53 @@ export const counts = query({
 });
 
 /**
+ * Kit deletability preview for the delete-kit dialog — browser-native replacement
+ * for the `canDeleteKit` server action. Returns whether the kit can be archived /
+ * hard-deleted plus the count of referencing project line items. The decision logic
+ * is a byte-for-byte port of `computeKitDeletability` (src/lib/kits-read.ts, pinned
+ * by kits-read.test.ts); the kit is org-re-checked (by_cuid is global) and the
+ * line-item count is org-filtered (by_kitId is global).
+ */
+export const deletability = query({
+  args: { orgId: v.string(), id: v.string() },
+  returns: v.object({
+    canArchive: v.boolean(),
+    canHardDelete: v.boolean(),
+    referencingLineItems: v.number(),
+    reason: v.optional(v.string()),
+  }),
+  handler: async (ctx, { orgId, id }) => {
+    await requireOrgRead(ctx, orgId);
+    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!kit || kit.organizationId !== orgId) throw new ConvexError("Kit not found");
+
+    const referencingLineItems = (
+      await ctx.db.query("projectLineItems").withIndex("by_kitId", (q) => q.eq("kitId", id)).collect()
+    ).filter((r) => r.organizationId === orgId).length;
+
+    const status = kit.status ?? "AVAILABLE";
+    const isActive = kit.isActive ?? true;
+
+    // Archive is allowed whenever the kit is AVAILABLE (matches archiveKit guard).
+    const canArchive = status === "AVAILABLE" && isActive;
+    // Hard delete adds: no ProjectLineItem references, AVAILABLE status.
+    const canHardDelete = status === "AVAILABLE" && isActive && referencingLineItems === 0;
+
+    let reason: string | undefined;
+    if (!canArchive) {
+      reason =
+        status !== "AVAILABLE"
+          ? `Kit status is ${status} — only AVAILABLE kits can be archived or deleted.`
+          : "Kit is already archived.";
+    } else if (!canHardDelete) {
+      reason = `Kit is referenced by ${referencingLineItems} project line item${referencingLineItems === 1 ? "" : "s"}. Archive it instead, or remove it from those projects first.`;
+    }
+
+    return { canArchive, canHardDelete, referencingLineItems, reason };
+  },
+});
+
+/**
  * Batch point-read kits by cuid, scoped to one org — lets a composite read only
  * the kits its line items reference (e.g. buildProjectEquipmentTree) instead of
  * getKitsByOrg (every kit in the org). Cross-org ids are dropped.

--- a/convex/kitsDeletability.test.ts
+++ b/convex/kitsDeletability.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+//
+// kits.deletability — browser-native replacement for canDeleteKit. Verifies the
+// archive/hard-delete decision (computeKitDeletability parity), the referencing
+// line-item count (by_kitId, org-filtered), org isolation, and RBAC.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+const seedMember = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "admin" });
+  });
+
+const insertKit = (
+  t: ReturnType<typeof makeT>,
+  id: string,
+  org: string,
+  status: string | undefined,
+  isActive: boolean | undefined,
+) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("kits", {
+      id,
+      organizationId: org,
+      assetTag: "KIT-" + id,
+      name: "Kit " + id,
+      ...(status !== undefined ? { status: status as never } : {}),
+      ...(isActive !== undefined ? { isActive } : {}),
+    });
+  });
+
+const insertLine = (t: ReturnType<typeof makeT>, id: string, org: string, kitId: string) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("projectLineItems", { id, organizationId: org, projectId: "p1", kitId });
+  });
+
+describe("kits.deletability", () => {
+  test("AVAILABLE + no references → archive + hard-delete both allowed", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", ORG, "AVAILABLE", true);
+    const r = await t.withIdentity(asUser).query(api.kits.deletability, { orgId: ORG, id: "k1" });
+    expect(r).toEqual({ canArchive: true, canHardDelete: true, referencingLineItems: 0, reason: undefined });
+  });
+
+  test("AVAILABLE + references → archive only, hard-delete blocked", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", ORG, "AVAILABLE", true);
+    await insertLine(t, "l1", ORG, "k1");
+    await insertLine(t, "l2", ORG, "k1");
+    await insertLine(t, "lx", OTHER, "k1"); // other-org line must NOT count
+    const r = await t.withIdentity(asUser).query(api.kits.deletability, { orgId: ORG, id: "k1" });
+    expect(r.canArchive).toBe(true);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.referencingLineItems).toBe(2);
+    expect(r.reason).toContain("2 project line items");
+  });
+
+  test("non-AVAILABLE status → neither allowed", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", ORG, "CHECKED_OUT", true);
+    const r = await t.withIdentity(asUser).query(api.kits.deletability, { orgId: ORG, id: "k1" });
+    expect(r.canArchive).toBe(false);
+    expect(r.canHardDelete).toBe(false);
+    expect(r.reason).toContain("CHECKED_OUT");
+  });
+
+  test("inactive (archived) kit → 'already archived'", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", ORG, "AVAILABLE", false);
+    const r = await t.withIdentity(asUser).query(api.kits.deletability, { orgId: ORG, id: "k1" });
+    expect(r.canArchive).toBe(false);
+    expect(r.reason).toContain("already archived");
+  });
+
+  test("a kit in another org is not readable (cross-tenant)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", OTHER, "AVAILABLE", true);
+    await expect(
+      t.withIdentity(asUser).query(api.kits.deletability, { orgId: ORG, id: "k1" }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await insertKit(t, "k1", ORG, "AVAILABLE", true);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.kits.deletability, { orgId: ORG, id: "k1" }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/components/kits/delete-kit-dialog.tsx
+++ b/src/components/kits/delete-kit-dialog.tsx
@@ -15,7 +15,10 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { archiveKit, deleteKit, canDeleteKit } from "@/server/kits";
+import { archiveKit, deleteKit } from "@/server/kits";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { useActiveOrganization } from "@/lib/auth-client";
 
 interface DeleteKitDialogProps {
   kitId: string;
@@ -35,11 +38,15 @@ export function DeleteKitDialog({
   onDeleted,
 }: DeleteKitDialogProps) {
   const [mode, setMode] = useState<DeleteMode>("archive");
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
 
   const { data: info, isLoading: infoLoading } = useServerQuery({
-    queryKey: ["kit-delete-info", kitId],
-    queryFn: () => canDeleteKit(kitId),
-    enabled: open,
+    queryKey: ["kit-delete-info", orgId, kitId],
+    queryFn: () => convex.query(api.kits.deletability, { orgId: orgId!, id: kitId }),
+    enabled: open && !!orgId && isAuthenticated,
   });
 
   const archiveMutation = useServerMutation({

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -236,7 +236,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "kits.addSerializedItemsToKit": { name: "kits.addSerializedItemsToKit", module: "kits", fn: "addSerializedItemsToKit", kind: "write", resource: "kit", action: "update", scope: "kit:update", params: [{ name: "kitId", type: "string", optional: false }, { name: "items", type: "Array<{ assetId: string; position?: string }>", optional: false }], dangerous: false, summary: "Batch add multiple serialized assets." },
   "kits.addSerializedItemToKit": { name: "kits.addSerializedItemToKit", module: "kits", fn: "addSerializedItemToKit", kind: "write", resource: "kit", action: "update", scope: "kit:update", params: [{ name: "kitId", type: "string", optional: false }, { name: "data", type: "KitSerializedItemFormValues", optional: false, schemaRef: "KitSerializedItemFormValues" }], dangerous: false, summary: "" },
   "kits.archiveKit": { name: "kits.archiveKit", module: "kits", fn: "archiveKit", kind: "write", resource: "kit", action: "delete", scope: "kit:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "---------------------------------------------------------------------------" },
-  "kits.canDeleteKit": { name: "kits.canDeleteKit", module: "kits", fn: "canDeleteKit", kind: "write", resource: "kit", action: "delete", scope: "kit:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "---------------------------------------------------------------------------" },
   "kits.createKit": { name: "kits.createKit", module: "kits", fn: "createKit", kind: "write", resource: "kit", action: "create", scope: "kit:create", params: [{ name: "data", type: "KitFormValues", optional: false, schemaRef: "KitFormValues" }], dangerous: false, summary: "" },
   "kits.deleteKit": { name: "kits.deleteKit", module: "kits", fn: "deleteKit", kind: "write", resource: "kit", action: "delete", scope: "kit:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "---------------------------------------------------------------------------" },
   "kits.getAvailableAssetsForKit": { name: "kits.getAvailableAssetsForKit", module: "kits", fn: "getAvailableAssetsForKit", kind: "read", resource: "kit", action: "read", scope: "kit:read", params: [{ name: "modelId", type: "string", optional: true }], dangerous: false, summary: "Serialized assets not in any kit. Reads off the dual-written Convex `assets`" },
@@ -4264,4 +4263,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 512;
+export const OPERATION_COUNT = 511;

--- a/src/server/kits.ts
+++ b/src/server/kits.ts
@@ -24,7 +24,7 @@ import { getLocationMap } from "@/lib/locations-read";
 import { getCategoryMap } from "@/lib/categories-read";
 import { mapLineItemDoc } from "@/lib/project-line-item-read";
 import { getAssetById, getBulkAssetById, getAssetsByOrg, getBulkAssetsByOrg, filterAvailableAssetsForKit, filterAvailableBulkAssetsForKit, sortByAssetTagAsc, mapConvexAssetToPrisma, mapConvexBulkAssetToPrisma } from "@/lib/assets-read";
-import { getKitById, getKitByAssetTag, coerceKitDeletabilityRow, computeKitDeletability } from "@/lib/kits-read";
+import { getKitById, getKitByAssetTag } from "@/lib/kits-read";
 import { getMaintenanceRecordsByOrg } from "@/lib/maintenance-read";
 
 
@@ -432,28 +432,6 @@ export async function archiveKit(id: string) {
   }
 
   return serialize(archived);
-}
-
-// ---------------------------------------------------------------------------
-// canDeleteKit – predicate for UI to decide which delete options are available
-// ---------------------------------------------------------------------------
-export async function canDeleteKit(id: string) {
-  const { organizationId } = await requirePermission("kit", "delete");
-
-  // The kit row comes off Convex (the dual-written reactive mirror); a miss
-  // reads null with no Prisma fallback (a fallback would mask mirror drift).
-  const convexKit = await getKitById(id);
-  if (!convexKit || convexKit.organizationId !== organizationId) {
-    throw new Error("Kit not found");
-  }
-
-  // ProjectLineItem references stay on Prisma until the keystone
-  // project-line-item tree migrates (see FEATUREDOCS/54).
-  const referencingLineItems = (await (await getConvexClient()).query(api.projectLineItems.listByKitId, { kitId: id, orgId: organizationId })).length;
-
-  return serialize(
-    computeKitDeletability(coerceKitDeletabilityRow(convexKit), referencingLineItems),
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Re-homes the `canDeleteKit` server action (the delete-kit dialog's archive/hard-delete preview) to a browser-direct native Convex query — Phase 3 read re-homing (`docs/phase-3-continuation-session-prompt-2.md` §2).

- **`convex/kits.ts`** — new `deletability` query (`requireOrgRead`). Kit fetched `by_cuid` (org re-checked → `ConvexError` if missing/cross-org); referencing line items counted via `by_kitId` (org-filtered). Decision logic is a byte-for-byte port of `computeKitDeletability`. `returns` validator.
- **`delete-kit-dialog.tsx`** — `useServerQuery` queryFn now calls `convex.query(api.kits.deletability)`, gated on `orgId` + Convex auth.
- **Deleted** `canDeleteKit` from `src/server/kits.ts` (+ now-unused imports); regen registry (non-curated op drops). Pure helpers stay in `src/lib/kits-read.ts` (still tested).
- **`convex/kitsDeletability.test.ts`** — parity states + line-item count + cross-tenant + RBAC (6 tests).

## Verification
- `tsc` clean; `vitest` (registry + kits-read + new test) green; codex (cross-tenant / parity / client gating) → no bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)