### PR TITLE
refactor(suppliers): supplier detail read browser-direct native (drop getSupplierById)

### DIFF
--- a/convex/suppliers.ts
+++ b/convex/suppliers.ts
@@ -64,6 +64,80 @@ export const counts = query({
   },
 });
 
+/**
+ * Supplier DETAIL composite for the supplier detail + new-order pages — browser-native
+ * replacement for the getSupplierById server action. Returns the mapped supplier (Prisma
+ * row shape: null/default coercion + ISO dates, matching mapSupplier + serialize) plus
+ * `_count` of its assets / orders / referencing line items. Every count is index-scoped
+ * to the supplier and org re-checked (the by_supplierId indexes are global). Throws
+ * "Supplier not found" for a missing / cross-org id, matching the server action.
+ */
+export const detail = query({
+  args: { orgId: v.string(), id: v.string() },
+  returns: v.object({
+    id: v.string(),
+    organizationId: v.string(),
+    name: v.string(),
+    contactName: v.union(v.string(), v.null()),
+    email: v.union(v.string(), v.null()),
+    phone: v.union(v.string(), v.null()),
+    website: v.union(v.string(), v.null()),
+    address: v.union(v.string(), v.null()),
+    latitude: v.union(v.number(), v.null()),
+    longitude: v.union(v.number(), v.null()),
+    notes: v.union(v.string(), v.null()),
+    accountNumber: v.union(v.string(), v.null()),
+    paymentTerms: v.union(v.string(), v.null()),
+    defaultLeadTime: v.union(v.string(), v.null()),
+    tags: v.array(v.string()),
+    isActive: v.boolean(),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    _count: v.object({ assets: v.number(), orders: v.number(), lineItems: v.number() }),
+  }),
+  handler: async (ctx, { orgId, id }) => {
+    await requireOrgRead(ctx, orgId);
+    const doc = await ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId) throw new ConvexError("Supplier not found");
+
+    // Counts — index-scoped to the supplier, org re-checked (by_supplierId is global).
+    const assets = (
+      await ctx.db.query("assets").withIndex("by_supplierId", (q) => q.eq("supplierId", id)).collect()
+    ).filter((a) => a.organizationId === orgId).length;
+    const orders = (
+      await ctx.db
+        .query("supplierOrders")
+        .withIndex("by_organizationId_supplierId", (q) => q.eq("organizationId", orgId).eq("supplierId", id))
+        .collect()
+    ).length;
+    const lineItems = (
+      await ctx.db.query("projectLineItems").withIndex("by_supplierId", (q) => q.eq("supplierId", id)).collect()
+    ).filter((li) => li.organizationId === orgId).length;
+
+    return {
+      id: doc.id,
+      organizationId: doc.organizationId,
+      name: doc.name,
+      contactName: doc.contactName ?? null,
+      email: doc.email ?? null,
+      phone: doc.phone ?? null,
+      website: doc.website ?? null,
+      address: doc.address ?? null,
+      latitude: doc.latitude ?? null,
+      longitude: doc.longitude ?? null,
+      notes: doc.notes ?? null,
+      accountNumber: doc.accountNumber ?? null,
+      paymentTerms: doc.paymentTerms ?? null,
+      defaultLeadTime: doc.defaultLeadTime ?? null,
+      tags: doc.tags ?? [],
+      isActive: doc.isActive ?? true,
+      createdAt: new Date(doc.createdAt ?? 0).toISOString(),
+      updatedAt: new Date(doc.updatedAt ?? 0).toISOString(),
+      _count: { assets, orders, lineItems },
+    };
+  },
+});
+
 export const create = mutation({
   args: {
     id: v.string(),

--- a/convex/suppliersDetail.test.ts
+++ b/convex/suppliersDetail.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+//
+// suppliers.detail — browser-native replacement for getSupplierById. Verifies the
+// mapped supplier shape + _count{assets, orders, lineItems} (each index-scoped to
+// the supplier, org-filtered — parity with getOrgSupplierCounts), null/default
+// coercion, cross-tenant isolation, and RBAC.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const USER = "user_1";
+const asUser = { subject: USER, orgId: ORG };
+const makeT = () => convexTest(schema, modules);
+
+const seed = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "admin" });
+    await ctx.db.insert("suppliers", {
+      id: "sup1",
+      organizationId: ORG,
+      name: "Acme Rentals",
+      email: "hi@acme.test",
+      tags: ["preferred"],
+    });
+    await ctx.db.insert("suppliers", { id: "supX", organizationId: OTHER, name: "Other Org Supplier" });
+
+    // assets for sup1 (2 in-org) + 1 other-org (must NOT count)
+    const asset = (id: string, org: string, supplierId: string | undefined) =>
+      ctx.db.insert("assets", { id, organizationId: org, modelId: "mod", assetTag: "T" + id, ...(supplierId ? { supplierId } : {}) });
+    await asset("a1", ORG, "sup1");
+    await asset("a2", ORG, "sup1");
+    await asset("a3", ORG, "sup2"); // different supplier
+    await asset("ax", OTHER, "sup1"); // other-org, same supplierId
+
+    // orders for sup1: 3 in-org + 1 other-org
+    const order = (id: string, org: string, supplierId: string) =>
+      ctx.db.insert("supplierOrders", { id, organizationId: org, supplierId, orderNumber: "PO-" + id, type: "PURCHASE" });
+    await order("o1", ORG, "sup1");
+    await order("o2", ORG, "sup1");
+    await order("o3", ORG, "sup1");
+    await order("ox", OTHER, "sup1");
+
+    // line items referencing sup1: 1 in-org + 1 other-org
+    const line = (id: string, org: string, supplierId: string) =>
+      ctx.db.insert("projectLineItems", { id, organizationId: org, projectId: "p1", supplierId });
+    await line("l1", ORG, "sup1");
+    await line("lx", OTHER, "sup1");
+  });
+
+describe("suppliers.detail", () => {
+  test("returns mapped supplier + org-scoped counts", async () => {
+    const t = makeT();
+    await seed(t);
+    const s = await t.withIdentity(asUser).query(api.suppliers.detail, { orgId: ORG, id: "sup1" });
+    expect(s.id).toBe("sup1");
+    expect(s.name).toBe("Acme Rentals");
+    expect(s.email).toBe("hi@acme.test");
+    expect(s.contactName).toBeNull(); // default coercion
+    expect(s.tags).toEqual(["preferred"]);
+    expect(s.isActive).toBe(true); // default
+    expect(typeof s.createdAt).toBe("string"); // ISO
+    expect(s._count).toEqual({ assets: 2, orders: 3, lineItems: 1 }); // other-org excluded
+  });
+
+  test("throws for a supplier in another org (cross-tenant)", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity(asUser).query(api.suppliers.detail, { orgId: ORG, id: "supX" }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("throws for a missing supplier", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity(asUser).query(api.suppliers.detail, { orgId: ORG, id: "ghost" }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("rejects a non-member", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity({ subject: USER, orgId: "nope" }).query(api.suppliers.detail, { orgId: ORG, id: "sup1" }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/app/(app)/suppliers/[id]/orders/new/page.tsx
+++ b/src/app/(app)/suppliers/[id]/orders/new/page.tsx
@@ -13,7 +13,8 @@ import { Truck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supplierOrderSchema, type SupplierOrderFormValues } from "@/lib/validations/supplier-order";
 import { createSupplierOrder } from "@/server/supplier-orders";
-import { getSupplierById } from "@/server/suppliers";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../../../../../../convex/_generated/api";
 import { supplierOrderStatusLabels } from "@/lib/status-labels";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { RequirePermission } from "@/components/auth/require-permission";
@@ -59,12 +60,15 @@ export default function NewSupplierOrderPage({ params }: { params: Promise<{ id:
 function NewSupplierOrderContent({ params }: { params: Promise<{ id: string }> }) {
   const { id: supplierId } = use(params);
   const router = useRouter();
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
   const { data: supplier, isLoading, error } = useServerQuery({
     queryKey: ["supplier", orgId, supplierId],
-    queryFn: () => getSupplierById(supplierId),
+    enabled: !!orgId && isAuthenticated,
+    queryFn: () => convex.query(api.suppliers.detail, { orgId: orgId!, id: supplierId }),
   });
 
   const form = useForm<SupplierOrderFormValues>({

--- a/src/app/(app)/suppliers/[id]/page.tsx
+++ b/src/app/(app)/suppliers/[id]/page.tsx
@@ -12,7 +12,9 @@ import { AddressDisplay } from "@/components/ui/address-display";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { getSupplierById, getSupplierAssets, getSupplierSubhires, deleteSupplier } from "@/server/suppliers";
+import { getSupplierAssets, getSupplierSubhires, deleteSupplier } from "@/server/suppliers";
+import { useConvex, useConvexAuth } from "convex/react";
+import { api } from "../../../../../convex/_generated/api";
 import { assetStatusLabels, supplierOrderStatusLabels, projectStatusLabels, formatLabel } from "@/lib/status-labels";
 import { formatCurrency } from "@/lib/formatters";
 import { getSupplierOrders } from "@/server/supplier-orders";
@@ -73,12 +75,15 @@ export default function SupplierDetailPage({ params }: { params: Promise<{ id: s
 function SupplierDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const router = useRouter();
+  const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
   const { data: supplier, isLoading } = useServerQuery({
     queryKey: ["supplier", orgId, id],
-    queryFn: () => getSupplierById(id),
+    enabled: !!orgId && isAuthenticated,
+    queryFn: () => convex.query(api.suppliers.detail, { orgId: orgId!, id }),
   });
 
   const { data: ordersData, refetch: refetchOrders } = useServerQuery({

--- a/src/lib/api/generated/operations.ts
+++ b/src/lib/api/generated/operations.ts
@@ -440,7 +440,6 @@ export const OPERATIONS: Record<string, OperationMeta> = {
   "suppliers.createSupplier": { name: "suppliers.createSupplier", module: "suppliers", fn: "createSupplier", kind: "write", resource: "supplier", action: "create", scope: "supplier:create", params: [{ name: "data", type: "SupplierFormValues", optional: false, schemaRef: "SupplierFormValues" }], dangerous: false, summary: "" },
   "suppliers.deleteSupplier": { name: "suppliers.deleteSupplier", module: "suppliers", fn: "deleteSupplier", kind: "write", resource: "supplier", action: "delete", scope: "supplier:delete", params: [{ name: "id", type: "string", optional: false }], dangerous: true, summary: "" },
   "suppliers.getSupplierAssets": { name: "suppliers.getSupplierAssets", module: "suppliers", fn: "getSupplierAssets", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "supplierId", type: "string", optional: false }, { name: "params", type: "{ page?: number; pageSize?: number; }", optional: false }], dangerous: false, summary: "" },
-  "suppliers.getSupplierById": { name: "suppliers.getSupplierById", module: "suppliers", fn: "getSupplierById", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "id", type: "string", optional: false }], dangerous: false, summary: "" },
   "suppliers.getSuppliers": { name: "suppliers.getSuppliers", module: "suppliers", fn: "getSuppliers", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [], dangerous: false, summary: "" },
   "suppliers.getSuppliersPaginated": { name: "suppliers.getSuppliersPaginated", module: "suppliers", fn: "getSuppliersPaginated", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "params", type: "{ search?: string; filters?: Record<string, FilterValue>; page?: number; pageSize?: number; sortBy?: string; sortOrder?: \"asc\" | \"desc\"; }", optional: false }], dangerous: false, summary: "" },
   "suppliers.getSupplierSubhires": { name: "suppliers.getSupplierSubhires", module: "suppliers", fn: "getSupplierSubhires", kind: "read", resource: "supplier", action: "read", scope: "supplier:read", params: [{ name: "supplierId", type: "string", optional: false }, { name: "params", type: "{ page?: number; pageSize?: number; }", optional: false }], dangerous: false, summary: "" },
@@ -4263,4 +4262,4 @@ export const PARAM_SCHEMAS: Record<string, JsonSchema> = {
   }
 };
 
-export const OPERATION_COUNT = 511;
+export const OPERATION_COUNT = 510;

--- a/src/server/suppliers.ts
+++ b/src/server/suppliers.ts
@@ -140,27 +140,6 @@ export async function getSuppliersPaginated(params: {
   return serialize({ suppliers, total });
 }
 
-
-export async function getSupplierById(id: string) {
-  const { organizationId } = await getOrgContext();
-  const doc = await getConvexSupplierById(id);
-  if (!doc || doc.organizationId !== organizationId) throw new Error("Supplier not found");
-
-  // assets/orders/lineItems counts all from Convex now.
-  // The embedded `orders` array the old shape carried is dropped — the detail page
-  // fetches its order list via getSupplierOrders, never reads `supplier.orders`.
-  const counts = await getOrgSupplierCounts(organizationId);
-
-  return serialize({
-    ...mapSupplier(doc),
-    _count: {
-      assets: counts.get(id)?.assets ?? 0,
-      orders: counts.get(id)?.orders ?? 0,
-      lineItems: counts.get(id)?.lineItems ?? 0,
-    },
-  });
-}
-
 export async function getSupplierAssets(supplierId: string, params: {
   page?: number;
   pageSize?: number;


### PR DESCRIPTION
## What
Re-homes `getSupplierById` (supplier detail + new-order pages) to a browser-direct native Convex query — Phase 3 read re-homing.

- **`convex/suppliers.ts`** — new `detail` composite (`requireOrgRead`). Supplier `by_cuid` (org re-checked); `_count{assets,orders,lineItems}` index-scoped to the supplier + org-filtered (parity with `getOrgSupplierCounts`). Mapped shape reproduces `mapSupplier` (null/default coercion + ISO dates). `returns` validator.
- **Consumers** — `useServerQuery` queryFn → `convex.query(api.suppliers.detail)`, gated on `orgId` + Convex auth.
- **Deleted** `getSupplierById` from `src/server/suppliers.ts`; regen registry (non-curated op drops). Paginated `getSupplierAssets`/`getSupplierSubhires` remain (follow-up).
- **`convex/suppliersDetail.test.ts`** — count parity + cross-tenant + RBAC.

## Verification
tsc + vitest (registry + suppliers-read + new test) green; codex (cross-tenant / count parity / mapped shape / client gating) → no bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)