### PR TITLE
fix(custom-fields): enforce full definition schema at the mutation boundary

### DIFF
--- a/convex/customFieldDefinitionsWrites.test.ts
+++ b/convex/customFieldDefinitionsWrites.test.ts
@@ -150,6 +150,43 @@ describe("customFieldDefinitionsWrites", () => {
     expect(await getDef(t, "dX")).not.toBeNull();
   });
 
+  test("createNative re-enforces the schema at the boundary (bypassing the client hook)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    const bad = (over: Record<string, unknown>) =>
+      t.withIdentity(asUser).mutation(api.customFieldDefinitionsWrites.createNative, {
+        id: "d1", organizationId: ORG, ...baseCreate, createdAt: NOW, actor, auditId: "a1", ...over,
+      });
+    await expect(bad({ label: "" })).rejects.toThrow(/label is required/i);
+    await expect(bad({ fieldKey: "bad key!" })).rejects.toThrow(/letters, numbers/i);
+    await expect(bad({ fieldType: "SELECT", options: [] })).rejects.toThrow(/at least one option/i);
+    await expect(bad({ fieldType: "SELECT", options: [""] })).rejects.toThrow(/1.80 characters/i);
+    await expect(bad({ sortOrder: -1 })).rejects.toThrow(/non-negative/i);
+    // A valid definition still succeeds.
+    await bad({});
+    expect(await getDef(t, "d1")).not.toBeNull();
+  });
+
+  test("updateNative re-enforces the schema at the boundary (no fieldKey check)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await t.withIdentity(asUser).mutation(api.customFieldDefinitionsWrites.createNative, {
+      id: "d1", organizationId: ORG, ...baseCreate, createdAt: NOW, actor, auditId: "a1",
+    });
+    await expect(
+      t.withIdentity(asUser).mutation(api.customFieldDefinitionsWrites.updateNative, {
+        id: "d1", orgId: ORG, label: "", fieldType: "TEXT", options: [], required: false,
+        sortOrder: 0, isActive: true, actor, auditId: "a2", now: NOW + 1,
+      }),
+    ).rejects.toThrow(/label is required/i);
+    await expect(
+      t.withIdentity(asUser).mutation(api.customFieldDefinitionsWrites.updateNative, {
+        id: "d1", orgId: ORG, label: "OK", fieldType: "SELECT", options: [], required: false,
+        sortOrder: 0, isActive: true, actor, auditId: "a2", now: NOW + 1,
+      }),
+    ).rejects.toThrow(/at least one option/i);
+  });
+
   test("rejects a member without orgSettings:update permission", async () => {
     const t = makeT();
     await seedMember(t, "viewer");

--- a/convex/customFieldDefinitionsWrites.ts
+++ b/convex/customFieldDefinitionsWrites.ts
@@ -23,6 +23,55 @@ import * as enums from "./lib/validators";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
+// A fieldKey must be a stable, JSON-safe identifier (mirrors fieldKeyRegex in
+// src/lib/validations/custom-field.ts — the Convex bundler can't import the zod module).
+const FIELD_KEY_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+
+/**
+ * Re-enforce the customFieldDefinitionSchema invariants at the mutation boundary.
+ * Client hooks run zod before calling, but this is now the PUBLIC write surface — a
+ * direct caller could otherwise persist an empty label / malformed fieldKey / optionless
+ * SELECT / over-long values. `checkKey` is false on update (fieldKey is immutable there).
+ */
+function assertValidDefinition(
+  input: {
+    label: string;
+    fieldType: string;
+    options: string[];
+    helpText?: string;
+    sortOrder: number;
+    fieldKey?: string;
+  },
+  checkKey: boolean,
+): void {
+  // Raw-length checks (exact parity with the client zod, which does not trim).
+  if (input.label.length < 1) throw new ConvexError("Label is required");
+  if (input.label.length > 60) throw new ConvexError("Label must be 60 characters or fewer");
+  if (checkKey) {
+    const key = input.fieldKey ?? "";
+    if (!key) throw new ConvexError("Key is required");
+    if (key.length > 40) throw new ConvexError("Key must be 40 characters or fewer");
+    if (!FIELD_KEY_REGEX.test(key)) {
+      throw new ConvexError("Key must start with a letter; letters, numbers, underscores only");
+    }
+  }
+  if (input.helpText !== undefined && input.helpText.length > 200) {
+    throw new ConvexError("Help text must be 200 characters or fewer");
+  }
+  if (!Number.isInteger(input.sortOrder) || input.sortOrder < 0) {
+    throw new ConvexError("Sort order must be a non-negative integer");
+  }
+  if (input.fieldType === "SELECT") {
+    if (input.options.length === 0) throw new ConvexError("SELECT fields need at least one option");
+    if (input.options.length > 50) throw new ConvexError("A field can have at most 50 options");
+    for (const opt of input.options) {
+      if (opt.length < 1 || opt.length > 80) {
+        throw new ConvexError("Each option must be 1–80 characters");
+      }
+    }
+  }
+}
+
 export const createNative = mutation({
   returns: v.object({ id: v.string() }),
   args: {
@@ -47,6 +96,8 @@ export const createNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "orgSettings", "update");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    assertValidDefinition(fields, true);
 
     // Re-implement the @@unique([organizationId, entityType, fieldKey]) DB guard:
     // reject a duplicate fieldKey for this org + entity type (composite index).
@@ -113,6 +164,8 @@ export const updateNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "orgSettings", "update");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    assertValidDefinition(patch, false);
 
     const doc = await ctx.db
       .query("customFieldDefinitions")


### PR DESCRIPTION
## What

Closes the one LOW-severity finding from the independent adversarial re-audit of the Phase-3 write-domain cluster (#512/#513/#514).

`convex/customFieldDefinitionsWrites.ts` is now the public write boundary, but only the unique-fieldKey guard + non-SELECT options-clearing were enforced server-side. The rest of `customFieldDefinitionSchema` (label/fieldKey/helpText/options length, fieldKey regex, SELECT-needs-options, non-negative integer sortOrder) lived **only** in the client hook's `.parse()`.

**Failing scenario:** an owner/admin (has `orgSettings:update`) mints a user token and calls `createNative` directly with `{ label: "", fieldKey: "bad key!", fieldType: "SELECT", options: [] }` — all four guards + the dup check pass, so a corrupt definition (empty label, space in the JSON key, optionless dropdown) is stored in their own org. Same-org, admin-gated, no cross-tenant reach, but real data-integrity corruption.

## Fix

`assertValidDefinition` (raw-length checks for exact parity with the client zod, which does not trim; fieldKey regex mirrors `fieldKeyRegex`) called in both `createNative` (checkKey=true) and `updateNative` (checkKey=false — fieldKey is immutable on update). Two boundary-validation tests added (9 total). tsc clean.

The other two domains (notification-prefs, saved-views) audited **CLEAN** on cross-tenant, cross-user, actor-spoofing, write-guard, and invariant dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)