### PR TITLE
fix(security): close 9 cross-tenant read leaks + create-idempotency gaps (Phase-3 audit)

### DIFF
--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -53,10 +53,11 @@ export const listByModel = query({
   args: { modelId: v.string(), orgId: v.string() },
   handler: async (ctx, { modelId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_modelId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("assets")
       .withIndex("by_modelId", (q) => q.eq("modelId", modelId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/bulkAssets.ts
+++ b/convex/bulkAssets.ts
@@ -50,10 +50,11 @@ export const listByModel = query({
   args: { modelId: v.string(), orgId: v.string() },
   handler: async (ctx, { modelId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_modelId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("bulkAssets")
       .withIndex("by_modelId", (q) => q.eq("modelId", modelId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/clientWrites.ts
+++ b/convex/clientWrites.ts
@@ -57,6 +57,11 @@ export const createNative = mutation({
     await requireOrgPermission(ctx, fields.organizationId, "client", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
+    // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
+    // makes another org's getById .unique() crash (and makes a retried create non-idempotent).
+    const dup = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    if (dup) throw new ConvexError("Client already exists");
+
     await ctx.db.insert("clients", fields);
 
     await writeActivityLog(ctx, {

--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -38,10 +38,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("crewAssignments")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 
@@ -74,7 +75,8 @@ export const listByServiceIds = query({
         .query("crewAssignments")
         .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
         .collect();
-      results.push(...rows);
+      // by_serviceId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+      results.push(...rows.filter((r) => r.organizationId === orgId));
     }
     return results;
   },

--- a/convex/customFieldDefinitionsWrites.ts
+++ b/convex/customFieldDefinitionsWrites.ts
@@ -115,6 +115,10 @@ export const createNative = mutation({
         `A custom field with key "${fields.fieldKey}" already exists for ${fields.entityType.toLowerCase()}s.`,
       );
     }
+    // The fieldKey guard is org-scoped and doesn't catch a cross-org cuid collision —
+    // dup-guard the client-minted id too (else another org's getById .unique() crashes).
+    const dupId = await ctx.db.query("customFieldDefinitions").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    if (dupId) throw new ConvexError("Custom field already exists");
 
     // Normalize at the mutation boundary (parity with the deleted server action):
     // non-SELECT fields carry no options; blank help text stores as absent.

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -100,6 +100,10 @@ export const createNative = mutation({
         message: `Asset tag "${fields.assetTag}" already exists`,
       });
     }
+    // The assetTag guard is org-scoped and does NOT catch a cross-org cuid collision —
+    // dup-guard the client-minted id too (else another org's kit getById .unique() crashes).
+    const dupId = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    if (dupId) throw new ConvexError("Kit already exists");
 
     await ctx.db.insert("kits", fields);
 

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -31,12 +31,14 @@ import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-/** Delete a line + its fulfillment units (replica of deleteLineWithUnits). */
-async function deleteLineWithUnits(ctx: MutationCtx, lineDocId: Id<"projectLineItems">, lineCuid: string) {
-  const units = await ctx.db
+/** Delete a line + its fulfillment units (replica of deleteLineWithUnits). The unit
+ *  cascade org-filters: by_lineItemId is a GLOBAL index, so without the org guard a
+ *  cuid-colliding line in another org could have its units swept. */
+async function deleteLineWithUnits(ctx: MutationCtx, lineDocId: Id<"projectLineItems">, lineCuid: string, orgId: string) {
+  const units = (await ctx.db
     .query("projectLineItemUnits")
     .withIndex("by_lineItemId", (q) => q.eq("lineItemId", lineCuid))
-    .collect();
+    .collect()).filter((u) => u.organizationId === orgId);
   for (const u of units) await ctx.db.delete(u._id);
   await ctx.db.delete(lineDocId);
 }
@@ -73,12 +75,12 @@ export const removeNative = mutation({
 
     // Cascade-delete the children (+ their units) and the line (+ its units) — the
     // exact removeLineItemCascade sequence, now atomic with the guard + audit.
-    const children = await ctx.db
+    const children = (await ctx.db
       .query("projectLineItems")
       .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
-      .collect();
-    for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id);
-    await deleteLineWithUnits(ctx, line._id, line.id);
+      .collect()).filter((c) => c.organizationId === orgId);
+    for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id, orgId);
+    await deleteLineWithUnits(ctx, line._id, line.id, orgId);
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -214,6 +216,11 @@ export const addCustomNative = mutation({
     const actor = await resolveActor(ctx, suppliedActor);
     await assertProjectInOrg(ctx, projectId, organizationId); // client projectId — must be the caller's org (see helper)
 
+    // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
+    // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
+    const dup = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dup) throw new ConvexError("Line item already exists");
+
     const sortOrder = await nextLineSort(ctx, projectId, organizationId);
     await ctx.db.insert("projectLineItems", {
       id,
@@ -301,6 +308,11 @@ export const addNative = mutation({
     // (collects lines by projectId, no org filter) would sweep into that org's totals.
     await assertProjectInOrg(ctx, projectId, organizationId);
 
+    // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
+    // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
+    const dupLine = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dupLine) throw new ConvexError("Line item already exists");
+
     // Mirrors createLineItem exactly (sortOrder in-mutation, no TOCTOU; permanent
     // accessories expanded as child lines atomically via the shared helper).
     const sortOrder = await nextLineSort(ctx, projectId, organizationId);
@@ -377,6 +389,10 @@ export const addKitNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    // Dup-guard the client-minted kit-line id (by_cuid is global + non-unique).
+    const dupKit = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dupKit) throw new ConvexError("Line item already exists");
 
     await createKitLineItemCore(ctx, {
       id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, now,

--- a/convex/projectCategories.ts
+++ b/convex/projectCategories.ts
@@ -36,10 +36,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("projectCategories")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/projectManagers.ts
+++ b/convex/projectManagers.ts
@@ -36,10 +36,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("projectManagers")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/projectServices.ts
+++ b/convex/projectServices.ts
@@ -38,10 +38,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("projectServices")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -37,10 +37,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("projectTasks")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -252,6 +252,13 @@ export const createNative = mutation({
       .unique();
     if (clash) return { created: false as const, id: clash.id };
 
+    // The projectNumber clash-guard is org-scoped and doesn't catch a cross-org cuid
+    // collision — dup-guard the client-minted id too. THROW (not the `{created:false}`
+    // number-clash signal, which callers retry with the SAME id): a cuid collision is a
+    // hard error, else another org's by_cuid reads get muddied.
+    const dupId = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    if (dupId) throw new ConvexError("Project already exists");
+
     await ctx.db.insert("projects", fields);
     await bumpProjectCounters(ctx, fields.organizationId, null, fields);
 

--- a/convex/savedTableViewsWrites.ts
+++ b/convex/savedTableViewsWrites.ts
@@ -67,6 +67,11 @@ export const createNative = mutation({
     const { userId, orgId, actor } = await requireUserOrg(ctx, suppliedActor);
     const cleanName = assertName(name);
 
+    // Dup-guard the client-minted id (by_cuid is global) so a retried create is
+    // idempotent and a colliding id can't make requireOwnView's .first() nondeterministic.
+    const dup = await ctx.db.query("savedTableViews").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dup) throw new ConvexError("Saved view already exists");
+
     // Atomically clear any existing default for (user, table, org) before inserting a
     // new default — mirrors savedTableViews.createForUser (prevents two defaults).
     if (isDefault) {

--- a/convex/subHires.ts
+++ b/convex/subHires.ts
@@ -37,10 +37,11 @@ export const listByProject = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
+    // by_projectId is a GLOBAL index — filter to the caller's org (cross-tenant guard).
+    return (await ctx.db
       .query("subHires")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+      .collect()).filter((r) => r.organizationId === orgId);
   },
 });
 

--- a/convex/xtenantHardening.test.ts
+++ b/convex/xtenantHardening.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+//
+// Regression tests for the Phase-3 cross-tenant hardening pass:
+//  (1) the `listBy<FK>` read queries now org-filter global-index results (a member of
+//      org A supplying a foreign FK must NOT receive org B's rows);
+//  (2) the client-minted-id createNative mutations now dup-guard by_cuid.
+// Representative coverage of each class (the fix is identical across all sites).
+import { convexTest, type TestConvex } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+type T = TestConvex<typeof schema>;
+const A = "org_A";
+const B = "org_B";
+const USER = "user_1";
+const asA = { subject: USER, orgId: A, role: "admin" };
+
+function makeT(): T {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
+async function member(t: T, org: string, role = "admin") {
+  await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m-" + org, organizationId: org, userId: USER, role }); });
+}
+
+describe("read-leak org filter", () => {
+  test("projectManagers.listByProject excludes a foreign-org row sharing the projectId", async () => {
+    const t = makeT(); await member(t, A);
+    await t.run(async (ctx) => {
+      // Same projectId cuid appears in BOTH orgs (the collision the global by_projectId index exposes).
+      await ctx.db.insert("projectManagers", { id: "pmA", organizationId: A, projectId: "p1", userId: USER });
+      await ctx.db.insert("projectManagers", { id: "pmB", organizationId: B, projectId: "p1", userId: "victim" });
+    });
+    const rows = await t.withIdentity(asA).query(api.projectManagers.listByProject, { orgId: A, projectId: "p1" });
+    expect(rows.map((r) => r.id)).toEqual(["pmA"]); // org B's row NOT leaked
+  });
+
+  test("assets.listByModel excludes a foreign-org asset sharing the modelId", async () => {
+    const t = makeT(); await member(t, A);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("assets", { id: "aA", organizationId: A, assetTag: "A1", modelId: "m1" });
+      await ctx.db.insert("assets", { id: "aB", organizationId: B, assetTag: "B1", modelId: "m1" });
+    });
+    const rows = await t.withIdentity(asA).query(api.assets.listByModel, { orgId: A, modelId: "m1" });
+    expect(rows.map((r) => r.id)).toEqual(["aA"]);
+  });
+
+  test("subHires.listByProject excludes a foreign-org sub-hire sharing the projectId", async () => {
+    const t = makeT(); await member(t, A);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subHires", { id: "shA", organizationId: A, projectId: "p1", supplierId: "s", createdById: USER, orderNumber: "SH-A" });
+      await ctx.db.insert("subHires", { id: "shB", organizationId: B, projectId: "p1", supplierId: "s", createdById: "victim", orderNumber: "SH-B" });
+    });
+    const rows = await t.withIdentity(asA).query(api.subHires.listByProject, { orgId: A, projectId: "p1" });
+    expect(rows.map((r) => r.id)).toEqual(["shA"]);
+  });
+});
+
+describe("create dup-guard", () => {
+  test("clientWrites.createNative rejects a colliding cuid (idempotency + cross-org DoS guard)", async () => {
+    const t = makeT(); await member(t, A);
+    const actor = { userId: USER, userName: "A" };
+    await t.withIdentity(asA).mutation(api.clientWrites.createNative, { id: "c1", organizationId: A, name: "Acme", actor, auditId: "x1" });
+    await expect(
+      t.withIdentity(asA).mutation(api.clientWrites.createNative, { id: "c1", organizationId: A, name: "Dup", actor, auditId: "x2" }),
+    ).rejects.toThrow(/already exists/i);
+  });
+});


### PR DESCRIPTION
A full Phase-3 compliance audit (5 parallel auditors + a comprehensive central grep) surfaced two real defect classes in already-shipped browser-direct code. This PR closes them.

## 🔴 Cross-tenant READ leaks (9)
Public `listBy<FK>` queries called `requireOrgRead(caller_org)` then fetched a **global** relation index (`by_projectId`/`by_modelId`/`by_serviceId`) and returned rows with **no `organizationId` filter**. An authed user passing their own `orgId` + a foreign FK could read another org's data (pricing, costs, PII). Fixed by org-filtering the result — a **no-op for legitimate own-org callers**:
`assets.listByModel`, `bulkAssets.listByModel`, `crewAssignments.listByProject` + `listByServiceIds`, `projectManagers/projectCategories/projectServices/projectTasks/subHires.listByProject`.

## 🟠 Client-minted-id create idempotency
`createNative` mutations inserted a client-supplied `id` with no `by_cuid` dup guard (their org-scoped composite guards don't catch a cross-org **cuid** collision), which breaks `.unique()` reads and retried optimistic creates. Added `by_cuid` guards: `clientWrites`, `kitWrites`, `customFieldDefinitionsWrites`, `savedTableViewsWrites`, `projectWrites`, and `lineItemWrites` (add/addCustom/addKit).

## 🟠 Line-item unit cascade
`lineItemWrites.deleteLineWithUnits` deleted `projectLineItemUnits` by the **global** `by_lineItemId` index with no org filter → a conditional cross-tenant *unit-delete*. Now org-filters the unit cascade **and** the children fetch.

## Test
`convex/xtenantHardening.test.ts` — read-filter (projectManagers/assets/subHires exclude a foreign-org row sharing the FK) + create dup-guard (clientWrites). **Full convex suite: 544 tests green.** `tsc` + `eslint` clean. Codex review: `projectWrites` cuid guard now throws (not the retryable `{created:false}` number-clash signal).

Note: the write **guards** (4-guard shape) + per-row org re-checks were already fully compliant — these are the read-side + idempotency gaps the audit found. Low live exploitability (cross-tenant paths need a known random cuid) but real confidentiality/reliability defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)