### PR TITLE
fix(phase3): Wave-3 audit parity fixes (assets updatedAt + T&T detail profile)

### DIFF
--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -342,6 +342,24 @@ describe("assetWrites — Phase 3 folds (counter + T&T)", () => {
   });
 });
 
+describe("assetWrites.updateNative updatedAt", () => {
+  test("stamps updatedAt from the mutation now (both patch + clear branches)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "manager" });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "m", assetTag: "A1", status: "AVAILABLE", condition: "GOOD", notes: "keep", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    // patch branch (no clear)
+    await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNative, { id: "a1", orgId: ORG, set: { assetTag: "A1", status: "IN_MAINTENANCE", tags: [], images: [] }, clear: [], actor: ACTOR, auditId: "l1", now: NOW + 1000 });
+    expect((await t.run(async (ctx) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first()))?.updatedAt).toBe(NOW + 1000);
+    // clear branch (clears notes)
+    await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.updateNative, { id: "a1", orgId: ORG, set: { assetTag: "A1", tags: [], images: [] }, clear: ["notes"], actor: ACTOR, auditId: "l2", now: NOW + 2000 });
+    const d = await t.run(async (ctx) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "a1")).first());
+    expect(d?.updatedAt).toBe(NOW + 2000);
+    expect(d?.notes).toBeUndefined();
+  });
+});
+
 describe("assetWrites.createManyNative", () => {
   async function seedManager(t: ReturnType<typeof convexTest>) {
     await t.run(async (ctx) => {

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -405,13 +405,15 @@ export const updateNative = mutation({
       }
     }
 
-    // Apply set (+ clear-to-null) — the patchAsset pattern.
+    // Apply set (+ clear-to-null) — the patchAsset pattern. Stamp updatedAt from the
+    // mutation `now` (the client `set` omits it; parity with the old updateAsset).
+    const setWithTs = { ...set, updatedAt: now };
     if (clear.length === 0) {
-      await ctx.db.patch(doc._id, set);
-      await bumpAssetCounters(ctx, orgId, doc, { ...doc, ...set });
+      await ctx.db.patch(doc._id, setWithTs);
+      await bumpAssetCounters(ctx, orgId, doc, { ...doc, ...setWithTs });
     } else {
       const { _id, _creationTime, ...rest } = doc;
-      const merged: Record<string, unknown> = { ...rest, ...set };
+      const merged: Record<string, unknown> = { ...rest, ...setWithTs };
       for (const k of clear) {
         if (ASSET_NEVER_CLEAR.has(k)) continue;
         delete merged[k];

--- a/convex/testTagAssets.ts
+++ b/convex/testTagAssets.ts
@@ -261,10 +261,14 @@ export const detail = query({
     if (!item || item.organizationId !== orgId) return null;
 
     const { total, records } = await ttRecordsFor(ctx, orgId, id, 10);
-    const profile = item.testProfileId ? await ctx.db.query("testProfiles").withIndex("by_cuid", (q) => q.eq("id", item.testProfileId!)).unique() : null;
-    const resolvedProfile = profile && profile.organizationId === orgId ? profile : null;
+    // Org-wide profile map so EACH record resolves its OWN testProfile (parity with the
+    // old getTestTagAsset profileMap — a record tested under a since-changed profile must
+    // still show that profile's name, not null).
+    const profiles = await ctx.db.query("testProfiles").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect();
+    const profileById = new Map(profiles.map((p) => [p.id, p]));
+    const resolvedProfile = item.testProfileId ? profileById.get(item.testProfileId) ?? null : null;
     const withProfileRecords = records.map((r) => {
-      const p = r.testProfileId ? (r.testProfileId === resolvedProfile?.id ? resolvedProfile : null) : null;
+      const p = r.testProfileId ? profileById.get(r.testProfileId) ?? null : null;
       return { ...r, testProfile: p ? { id: p.id, name: p.name } : null };
     });
     const la = item.assetId ? await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", item.assetId!)).unique() : null;

--- a/convex/testTagAssetsWrites.test.ts
+++ b/convex/testTagAssetsWrites.test.ts
@@ -109,11 +109,13 @@ describe("testTagAssets reads", () => {
     await t.run(async (ctx) => {
       await ctx.db.insert("assets", { id: "as1", organizationId: ORG, assetTag: "PA-1", modelId: "m1", isActive: true });
       await ctx.db.insert("testProfiles", { id: "prof1", organizationId: ORG, name: "Standard", visualChecks: {}, electricalTests: {}, thresholds: {} });
+      await ctx.db.insert("testProfiles", { id: "prof2", organizationId: ORG, name: "Historical", visualChecks: {}, electricalTests: {}, thresholds: {} });
       await ctx.db.insert("users", { id: USER, name: "Alice", email: "a@x.com" });
       await ctx.db.insert("testTagAssets", { id: "tt1", organizationId: ORG, testTagId: "TT0002", description: "B", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", status: "OVERDUE", nextDueDate: NOW - 1000, assetId: "as1", testProfileId: "prof1", isActive: true });
       await ctx.db.insert("testTagAssets", { id: "tt2", organizationId: ORG, testTagId: "TT0001", description: "A", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", status: "CURRENT", isActive: true });
       await ctx.db.insert("testTagAssets", { id: "ttX", organizationId: OTHER, testTagId: "ZZ", description: "F", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", status: "CURRENT", isActive: true });
-      await ctx.db.insert("testTagRecords", { id: "rec1", organizationId: ORG, testTagAssetId: "tt1", testDate: NOW, testedById: USER, testerName: "Al", result: "PASS", nextDueDate: NOW });
+      // rec1 tested under prof2 (NOT the asset's current prof1) — detail must still name it.
+      await ctx.db.insert("testTagRecords", { id: "rec1", organizationId: ORG, testTagAssetId: "tt1", testDate: NOW, testedById: USER, testerName: "Al", result: "PASS", nextDueDate: NOW, testProfileId: "prof2" });
     });
   }
 
@@ -133,6 +135,8 @@ describe("testTagAssets reads", () => {
     const res = await t.withIdentity(asUser).query(api.testTagAssets.detail, { id: "tt1", orgId: ORG });
     expect(res?.testTagId).toBe("TT0002");
     expect(res?.testRecords[0].testedBy.name).toBe("Alice");
+    expect(res?.testRecords[0].testProfile?.name).toBe("Historical"); // record's OWN profile, not the asset's current
+    expect(res?.testProfile?.name).toBe("Standard"); // the asset's current profile
     expect(res?.asset?.assetTag).toBe("PA-1");
     expect(await t.withIdentity(asUser).query(api.testTagAssets.detail, { id: "ttX", orgId: ORG })).toBeNull();
   });


### PR DESCRIPTION
Follow-up to the 5-domain independent adversarial re-audit of #540-#544.

**Audit verdict: security bar CLEAN across all 5 domains** — no cross-tenant leaks, all 4 guards present + correctly ordered (no-audit mutations correctly omit only resolveActor), keystones byte-identical to the delegating orgSettings reservers, ConvexError throughout, per-row org re-check on every global-index fetch.

Two confirmed **non-security parity regressions** fixed here:
1. `assetWrites.updateNative` didn't bump `assets.updatedAt` (client `set` omits it, mutation patched verbatim) → stale last-modified. Now stamps `updatedAt: now` in both patch + clear branches.
2. `testTagAssets.detail` resolved each historical record's `testProfile` only against the asset's *current* profile → records under a since-changed profile showed null. Now resolves each record's own `testProfileId` from an org-wide profile map (parity with the deleted `getTestTagAsset`).

Tests added for both. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)