### PR TITLE
harden(crew): audit fixes — crew:read gate, drop responseToken, org-scoped dup-guard

### DIFF
--- a/convex/crew.ts
+++ b/convex/crew.ts
@@ -53,7 +53,11 @@ function mapRole(d: Record<string, unknown>) {
 export const memberDetail = query({
   args: { id: v.string(), orgId: v.string() },
   handler: async (ctx, { id, orgId }) => {
-    await requireOrgRead(ctx, orgId);
+    // crew:read (membership + permission) — parity with the old getCrewMemberById's
+    // requirePermission; requireOrgRead alone would serve crew PII (icalToken/rates/DOB)
+    // to a stale-token ex-member or a no-crew-read role (audit). Sibling orgUsersForCrewLink
+    // already gates on crew:update.
+    await requireOrgPermission(ctx, orgId, "crew", "read");
     const doc = await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc || doc.organizationId !== orgId) return null;
     const member = mapMember(doc);
@@ -87,9 +91,14 @@ export const memberDetail = query({
     const assignments = assignmentRows.map((a) => {
       const proj = a.projectId ? projById.get(a.projectId) ?? null : null;
       const arole = a.crewRoleId ? roleById.get(a.crewRoleId) : null;
+      // Strip the Convex system fields and the single-use offer-respond bearer token
+      // (never consumed here) from the wire; ISO every date incl. offer/response stamps (audit).
+      const { _id, _creationTime, responseToken, ...rest } = a;
+      void _id; void _creationTime; void responseToken;
       return {
-        ...a,
+        ...rest,
         startDate: iso(a.startDate), endDate: iso(a.endDate), createdAt: iso(a.createdAt), updatedAt: iso(a.updatedAt),
+        offeredAt: iso(a.offeredAt), respondedAt: iso(a.respondedAt), confirmedAt: iso(a.confirmedAt),
         project: proj,
         crewRole: arole ? { id: arole.id, name: arole.name, color: arole.color } : null,
       };
@@ -103,7 +112,7 @@ export const memberDetail = query({
 export const memberExtras = query({
   args: { orgId: v.string() },
   handler: async (ctx, { orgId }) => {
-    await requireOrgRead(ctx, orgId);
+    await requireOrgPermission(ctx, orgId, "crew", "read"); // parity with getCrewMemberExtras (audit)
     const [members, skillMap] = await Promise.all([
       ctx.db.query("crewMembers").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).collect(),
       orgSkillMap(ctx, orgId),

--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -77,8 +77,12 @@ export const projectCrew = query({
           confirmedBy = u ? { id: u.id, name: u.name ?? null } : null;
         }
       }
+      // Strip Convex system fields + the single-use offer-respond bearer token (no
+      // consumer reads it off projectCrew) before it reaches any crew:read caller (audit).
+      const { _id, _creationTime, responseToken, ...arest } = a;
+      void _id; void _creationTime; void responseToken;
       out.push({
-        ...a,
+        ...arest,
         startDate: isoMs(a.startDate), endDate: isoMs(a.endDate), confirmedAt: isoMs(a.confirmedAt), offeredAt: isoMs(a.offeredAt), respondedAt: isoMs(a.respondedAt), createdAt: isoMs(a.createdAt), updatedAt: isoMs(a.updatedAt),
         crewMember: { id: m.id, firstName: m.firstName, lastName: m.lastName, email: m.email ?? null, phone: m.phone ?? null, image: m.image ?? null, defaultDayRate: m.defaultDayRate ?? null, defaultHourlyRate: m.defaultHourlyRate ?? null },
         crewRole: role ? { id: role.id, name: role.name, color: role.color ?? null, defaultRate: role.defaultRate ?? null, rateType: role.rateType ?? null } : null,

--- a/convex/crewTimeEntriesWrites.test.ts
+++ b/convex/crewTimeEntriesWrites.test.ts
@@ -52,6 +52,25 @@ describe("crewTimeEntriesWrites", () => {
     expect(res.errors[0].crewMemberId).toBe("ghost");
   });
 
+  test("createMany: same-org id is an idempotent skip; foreign-org id fails closed (no insert suppression)", async () => {
+    const t = makeT(); await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("crewTimeEntries", { id: "dup1", organizationId: ORG, crewMemberId: "c1", date: NOW, startTime: "09:00", endTime: "17:00", status: "DRAFT" });
+      await ctx.db.insert("crewTimeEntries", { id: "dupX", organizationId: OTHER, crewMemberId: "cX", date: NOW, startTime: "09:00", endTime: "17:00", status: "DRAFT" });
+    });
+    const res = await t.withIdentity(asUser).mutation(api.crewTimeEntriesWrites.createManyNative, {
+      orgId: ORG, now: NOW, actor,
+      shared: { date: NOW, startTime: "09:00", endTime: "17:00", breakMinutes: 0 },
+      entries: [{ id: "dup1", crewMemberId: "c1", auditId: "l1" }, { id: "dupX", crewMemberId: "c1", auditId: "l2" }],
+    });
+    expect(res.created).toEqual(["c1"]);        // same-org dup1 → idempotent skip, reported created
+    expect(res.errors[0].crewMemberId).toBe("c1"); // foreign-org dupX → error, not silent suppression
+    // the foreign row is untouched (still OTHER's), and no new row minted under its id
+    const rows = await t.run(async (ctx) => ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", "dupX")).collect());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organizationId).toBe(OTHER);
+  });
+
   test("status machine: submit (DRAFT→SUBMITTED) then approve (→APPROVED w/ approver stamp); from-gate skips ineligible", async () => {
     const t = makeT(); await seed(t);
     await t.withIdentity(asUser).mutation(api.crewTimeEntriesWrites.createNative, base);

--- a/convex/crewTimeEntriesWrites.ts
+++ b/convex/crewTimeEntriesWrites.ts
@@ -121,6 +121,15 @@ export const createManyNative = mutation({
       const member = await memberName(ctx, a.orgId, e.crewMemberId);
       if (!member.ok) { errors.push({ crewMemberId: e.crewMemberId, message: "Crew member not found" }); continue; }
       if (a.shared.assignmentId && assignmentMember != null && assignmentMember !== e.crewMemberId) { errors.push({ crewMemberId: e.crewMemberId, message: "Crew member does not match assignment" }); continue; }
+      // Idempotent on the client-minted cuid (parity with the old createIfMissing) — a
+      // retried batch can't double-insert. by_cuid is GLOBAL, so only a same-org hit is a
+      // genuine retry → skip as success; a foreign-org id fails closed (never suppress the
+      // insert on a cross-tenant collision, which would silently drop the real entry).
+      const dup = await ctx.db.query("crewTimeEntries").withIndex("by_cuid", (q) => q.eq("id", e.id)).first();
+      if (dup) {
+        if (dup.organizationId === a.orgId) { created.push(e.crewMemberId); continue; }
+        errors.push({ crewMemberId: e.crewMemberId, message: "Duplicate id" }); continue;
+      }
       await ctx.db.insert("crewTimeEntries", buildDoc({ ...a.shared, crewMemberId: e.crewMemberId }, a.orgId, e.id, a.now));
       await logTime(ctx, { orgId: a.orgId, actor, auditId: e.auditId, now: a.now, action: "CREATE", id: e.id, name: member.name, summary: `Logged time for ${member.name} on ${projectName}` });
       created.push(e.crewMemberId);

--- a/convex/crewWrites.test.ts
+++ b/convex/crewWrites.test.ts
@@ -193,4 +193,16 @@ describe("crew reads", () => {
     const linkable = await t.withIdentity(asUser(ORG)).query(api.crew.orgUsersForCrewLink, { orgId: ORG });
     expect(linkable.find((u) => u.id === USER)?.alreadyLinked).toBe(true);
   });
+
+  test("memberDetail/memberExtras enforce crew:read (not just org membership)", async () => {
+    // A member of the org whose role lacks crew:read (unknown role → fail-closed).
+    // requireOrgRead would have served crew PII on org-match alone; the tightened
+    // requireOrgPermission gate must reject — parity with the old requirePermission.
+    const t = makeT(); await member(t, "norole");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("crewMembers", { id: "c1", organizationId: ORG, firstName: "Bob", lastName: "Ryan", isActive: true });
+    });
+    await expect(t.withIdentity(asUser(ORG)).query(api.crew.memberDetail, { id: "c1", orgId: ORG })).rejects.toThrow(/Forbidden|permission/i);
+    await expect(t.withIdentity(asUser(ORG)).query(api.crew.memberExtras, { orgId: ORG })).rejects.toThrow(/Forbidden|permission/i);
+  });
 });


### PR DESCRIPTION
Hardening PR from the full adversarial audit of the browser-direct crew cluster (#547 crew, #548 crew-assignments, #549 crew-time). Three independent trust-nothing auditors reported the **security bar clean** across all mutations (guard order, per-row org re-checks on global-index fetches, membership-gated joins, org-keyed shared-store holder cleared on logout). Findings addressed here:

### CONFIRMED
- **crew RBAC downgrade** — `convex/crew.ts` `memberDetail`/`memberExtras` used `requireOrgRead` (org-membership only) where the deleted server actions used `requirePermission("crew","read")`. Restored via `requireOrgPermission(ctx,orgId,"crew","read")`, matching sibling `orgUsersForCrewLink`. Prevents a role without `crew:read` (or a stale-token ex-member) reading crew PII (icalToken secret / rates / DOB / emergency contacts). Locked with a denial test (unknown role → fail-closed).

### Defense-in-depth
- **Drop `responseToken` (single-use offer-respond bearer credential) + Convex `_id`/`_creationTime`** from `memberDetail.assignments` and `projectCrew` — no consumer reads them off these composites. Also ISO `offeredAt`/`respondedAt`/`confirmedAt` (were leaking raw ms).
- **`createManyNative` dup-guard** — added a `by_cuid` idempotency guard (parity with the old `createIfMissing`). `by_cuid` is global, so only a **same-org** hit is a genuine retry (skip as success); a **foreign-org** id fails closed with an error and never suppresses the real insert on a cross-tenant collision. codex-reviewed + test.

All crew-cluster tests green (`crewWrites`, `crewTimeEntriesWrites`, `crewAssignmentsWrites`). Convex functions pushed. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)