### PR TITLE
harden(money): reject non-finite + strip injection in public line-item/project mutations

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -91,6 +91,7 @@ import type * as lib_dto from "../lib/dto.js";
 import type * as lib_fulfillment from "../lib/fulfillment.js";
 import type * as lib_inventory from "../lib/inventory.js";
 import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
+import type * as lib_moneyGuards from "../lib/moneyGuards.js";
 import type * as lib_notificationPreferences from "../lib/notificationPreferences.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_rateLimiter from "../lib/rateLimiter.js";
@@ -276,6 +277,7 @@ declare const fullApi: ApiFromModules<{
   "lib/fulfillment": typeof lib_fulfillment;
   "lib/inventory": typeof lib_inventory;
   "lib/lineItemUnits": typeof lib_lineItemUnits;
+  "lib/moneyGuards": typeof lib_moneyGuards;
   "lib/notificationPreferences": typeof lib_notificationPreferences;
   "lib/permissionsCore": typeof lib_permissionsCore;
   "lib/rateLimiter": typeof lib_rateLimiter;

--- a/convex/lib/moneyGuards.ts
+++ b/convex/lib/moneyGuards.ts
@@ -1,0 +1,68 @@
+import { ConvexError } from "convex/values";
+
+/**
+ * Money-domain input guards for the PUBLIC browser-callable line-item / project write
+ * mutations. Convex `v.number()` is an IEEE-754 float64 and accepts `NaN`, `Infinity`,
+ * and negatives — none of which the server-side Zod schemas (src/lib/validations/*) ever
+ * let through. A browser-direct caller bypasses that Zod, so without these guards a
+ * `quantity: NaN` / `lineTotal: Infinity` is written verbatim and then summed by
+ * `convex/lib/recalc.ts` (`num(v) = Number(v)`) straight into `project.total`/`margin`,
+ * silently poisoning the project's money to `NaN`/`Infinity`. Bounds mirror
+ * `src/lib/validations/line-item.ts` exactly, so the legit service-token path (already
+ * Zod-validated) is unaffected — these only reject inputs Zod would have rejected too.
+ */
+
+/** Reject a non-finite number (NaN/Infinity) — the recalc poisoners. `null`/`undefined` skip. */
+export function assertFinite(value: number | null | undefined, field: string): void {
+  if (value == null) return;
+  if (!Number.isFinite(value)) {
+    throw new ConvexError({ code: "INVALID_NUMBER", message: `${field} must be a finite number.` });
+  }
+}
+
+/**
+ * Validate the numeric line-item fields to the same bounds `lineItemSchema` /
+ * `customLineItemSchema` enforce, EXCEPT the two derived values that can legitimately
+ * exceed their input caps and so are only checked finite + non-negative:
+ *  - `lineTotal` (unitPrice × qty × duration − discount) — magnitude bounded by its
+ *    components; can legitimately be large.
+ *  - `quantity` UPPER bound is NOT enforced here: the addLineItem MERGE path patches
+ *    `existing.quantity + parsed.quantity`, a sum of two Zod-capped values that can
+ *    exceed 99999. Enforcing the cap would regress that legit service-token merge. We
+ *    still require a finite positive integer (the anti-poisoning invariant); the 99999
+ *    input cap stays enforced by Zod on the create path.
+ */
+export function assertLineMoneyFields(f: {
+  quantity?: number | null;
+  unitPrice?: number | null;
+  discount?: number | null;
+  duration?: number | null;
+  lineTotal?: number | null;
+}): void {
+  if (f.quantity != null) {
+    // No upper cap — the merge path sums two Zod-capped quantities (see doc above).
+    if (!Number.isFinite(f.quantity) || !Number.isInteger(f.quantity) || f.quantity < 1) {
+      throw new ConvexError({ code: "INVALID_QUANTITY", message: "Quantity must be a positive whole number." });
+    }
+  }
+  if (f.unitPrice != null) {
+    if (!Number.isFinite(f.unitPrice) || f.unitPrice < 0 || f.unitPrice > 999999.99) {
+      throw new ConvexError({ code: "INVALID_PRICE", message: "Unit price must be between 0 and 999999.99." });
+    }
+  }
+  if (f.discount != null) {
+    if (!Number.isFinite(f.discount) || f.discount < 0 || f.discount > 999999.99) {
+      throw new ConvexError({ code: "INVALID_DISCOUNT", message: "Discount must be between 0 and 999999.99." });
+    }
+  }
+  if (f.duration != null) {
+    if (!Number.isFinite(f.duration) || !Number.isInteger(f.duration) || f.duration < 1 || f.duration > 3650) {
+      throw new ConvexError({ code: "INVALID_DURATION", message: "Duration must be a whole number between 1 and 3650." });
+    }
+  }
+  if (f.lineTotal != null) {
+    if (!Number.isFinite(f.lineTotal) || f.lineTotal < 0) {
+      throw new ConvexError({ code: "INVALID_LINE_TOTAL", message: "Line total must be a non-negative finite number." });
+    }
+  }
+}

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -126,6 +126,37 @@ describe("lineItemWrites.patchNative", () => {
     await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
   });
+  test("strips structural/lifecycle fields from a client set (injection guard)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Light", quantity: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    // A malicious set tries to cancel the line (drop it from revenue), forge the tree,
+    // and spoof a fulfillment counter — alongside a legit quantity edit.
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, {
+      ...pargs,
+      set: { quantity: 4, status: "CANCELLED", isKitChild: true, parentLineItemId: "evil", checkedOutQuantity: 999, allocatedRevenue: 1e9, updatedAt: NOW },
+      clear: [],
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(4); // legit field applied
+      expect(li?.status).toBe("CONFIRMED"); // structural field stripped
+      expect(li?.isKitChild).toBe(false);
+      expect(li?.parentLineItemId).toBeUndefined();
+      expect(li?.checkedOutQuantity).toBeUndefined();
+      expect(li?.allocatedRevenue).toBeUndefined();
+    });
+  });
+  test("rejects a non-finite money field in a patch set", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => { await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", quantity: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false }); });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { lineTotal: Number.NaN, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow();
+  });
 });
 
 describe("lineItemWrites.addCustomNative", () => {
@@ -150,6 +181,26 @@ describe("lineItemWrites.addCustomNative", () => {
     const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, cargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("rejects non-finite / out-of-range money (would poison recalc)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    const bad = async (fields: Record<string, unknown>) =>
+      expect(
+        t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, { ...cargs, fields: { description: "x", quantity: 1, ...fields } }),
+      ).rejects.toThrow();
+    await bad({ unitPrice: Number.NaN });
+    await bad({ lineTotal: Number.POSITIVE_INFINITY });
+    await bad({ unitPrice: -5 });
+    await bad({ quantity: 0 });
+    await bad({ quantity: 1.5 });
+    await bad({ duration: 99999 });
+    // Nothing was inserted.
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "cust1")).first();
+      expect(li).toBeNull();
+    });
   });
 });
 

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -6,6 +6,7 @@ import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { sanitizeClientSet } from "./lib/sanitizeSet";
+import { assertLineMoneyFields } from "./lib/moneyGuards";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
@@ -103,7 +104,31 @@ export const removeNative = mutation({
   },
 });
 
-const LINE_NEVER_CLEAR = new Set(["id", "organizationId", "projectId"]);
+/**
+ * Fields a client must NEVER set or clear on a line via `patchNative` (a public mutation
+ * with a `set: v.any()` surface). None are sent by the two legit callers
+ * (src/server/line-items.ts updateLineItem — quantity/pricingType/duration/isOptional/
+ * showSubhireOnDocs/description/unitPrice/discount/lineTotal/groupName/notes/
+ * subhireOrderNumber/modelId/assetId/bulkAssetId/supplierId), so stripping them is
+ * non-breaking. Covers: the tenant/immutable anchors, the parent/child structural tree
+ * (a forged `isKitChild`/`parentLineItemId` corrupts the ~40 kit-child filters + recalc),
+ * lifecycle/status (`status:"CANCELLED"` silently drops a line from revenue), the
+ * warehouse fulfillment counters, the recalc-owned allocation fields, and the internal
+ * sub-hire linkage. Money integrity of the ALLOWED fields is enforced separately by
+ * assertLineMoneyFields. */
+const LINE_IMMUTABLE_ON_PATCH = [
+  "projectId",
+  // NOTE: `type` is intentionally NOT here — updateLineItem legitimately patches it.
+  "kitId", "isKitChild", "childKind", "parentLineItemId", "pricingMode", "isCustomItem", "isContainerLineItem",
+  "status", "returnStatus", "prepStatus", "prepContainer", "returnCondition", "returnNotes",
+  "checkedOutQuantity", "returnedQuantity", "assignedQuantity", "packedQuantity", "damagedQuantity", "lostQuantity",
+  "checkedOutAt", "checkedOutById", "returnedAt", "returnedById",
+  "allocatedRevenue", "allocationBasis",
+  "subHireId", "subHireItemId", "subHireGroupId", "supplierOrderId",
+  "createdAt",
+] as const;
+
+const LINE_NEVER_CLEAR = new Set<string>(["id", "organizationId", ...LINE_IMMUTABLE_ON_PATCH]);
 
 /**
  * patchNative — apply a set/clear patch to a line item + UPDATE audit, atomic.
@@ -134,7 +159,13 @@ export const patchNative = mutation({
     if (!doc) throw new ConvexError({ code: "NOT_FOUND", message: "This item was deleted by someone else. Refresh the page." });
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
-    const setObj = sanitizeClientSet(set, ["projectId"]); // strip organizationId/id/projectId
+    // Strip organizationId/id + the structural/fulfillment/allocation/lifecycle fields a
+    // client must never patch (see LINE_IMMUTABLE_ON_PATCH), then bound-check the money
+    // fields it CAN set — a browser-direct caller bypasses the server-side Zod.
+    const setObj = sanitizeClientSet(set, LINE_IMMUTABLE_ON_PATCH);
+    assertLineMoneyFields(setObj as {
+      quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
+    });
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, setObj);
     } else {
@@ -215,6 +246,8 @@ export const addCustomNative = mutation({
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
     await assertProjectInOrg(ctx, projectId, organizationId); // client projectId — must be the caller's org (see helper)
+
+    assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
 
     // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
     // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
@@ -307,6 +340,7 @@ export const addNative = mutation({
     // (stamped with their org) into ANOTHER org's project, which recalcProjectTotals
     // (collects lines by projectId, no org filter) would sweep into that org's totals.
     await assertProjectInOrg(ctx, projectId, organizationId);
+    assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
 
     // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
     // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -122,6 +122,26 @@ describe("projectWrites.updateNative", () => {
     await seedProject(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { updatedAt: NOW }, clear: [] })).rejects.toThrow(/insufficient permissions/i);
   });
+  test("strips forged money totals + isTemplate from a client set (injection guard)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, total: 500, margin: 100, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, {
+      ...uargs,
+      set: { name: "Edited", total: 0, margin: 999999999, equipmentRevenue: 1e9, isTemplate: true, updatedAt: NOW },
+      clear: [],
+    });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.name).toBe("Edited"); // legit field applied
+      expect(p?.total).toBe(500); // recalc-owned totals untouched
+      expect(p?.margin).toBe(100);
+      expect(p?.equipmentRevenue).toBeUndefined();
+      expect(p?.isTemplate).toBe(false); // no in-place template flip
+    });
+  });
 });
 
 describe("projectWrites.createNative", () => {
@@ -156,6 +176,17 @@ describe("projectWrites.createNative", () => {
     const t = makeT();
     await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "viewer" }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+  test("strips forged money totals from a create (recalc owns them)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, total: 999999, margin: 888888, equipmentRevenue: 777777 } as typeof cargs);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first();
+      expect(p?.total).toBeUndefined();
+      expect(p?.margin).toBeUndefined();
+      expect(p?.equipmentRevenue).toBeUndefined();
+    });
   });
 });
 

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -156,7 +156,27 @@ export const archiveNative = mutation({
   },
 });
 
-const PROJECT_NEVER_CLEAR = new Set(["id", "organizationId", "projectNumber"]);
+/**
+ * The recalc-OWNED money totals. They are derived from the full line-item/service/
+ * sub-hire/assignment set by `recalcProjectTotals` (convex/lib/recalc.ts) and must NEVER
+ * come from a client — a browser-direct caller could otherwise `set:{ total:0, margin:1e9 }`
+ * and forge the project's financials. The legit server path never sends these (createProject
+ * omits them; updateProject builds a Zod-validated set with no totals), so stripping is
+ * non-breaking. `taxRate`/`discountPercent` are recalc INPUTS and stay settable.
+ */
+const PROJECT_MONEY_ANCHORS = [
+  "equipmentRevenue", "serviceCostTotal", "labourCostTotal", "subHireCostTotal",
+  "subtotal", "discountAmount", "taxAmount", "total", "margin",
+] as const;
+
+/** Immutable on a general `updateNative` patch: the money anchors + `isTemplate` (a project
+ * is never flipped to a template in place — that's a saveAsTemplate copy). `projectNumber`
+ * stays editable (a legit code edit). */
+const PROJECT_UPDATE_IMMUTABLE = [...PROJECT_MONEY_ANCHORS, "isTemplate"] as const;
+
+const PROJECT_NEVER_CLEAR = new Set<string>([
+  "id", "organizationId", "projectNumber", ...PROJECT_UPDATE_IMMUTABLE,
+]);
 
 /**
  * updateNative — general project field patch (set/clear) + UPDATE audit, atomic.
@@ -185,7 +205,9 @@ export const updateNative = mutation({
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
-    const setObj = sanitizeClientSet(set); // strip organizationId/id — no cross-tenant reassign
+    // strip organizationId/id (no cross-tenant reassign) + the recalc-owned money anchors
+    // and isTemplate (no client-forged totals / in-place template flip).
+    const setObj = sanitizeClientSet(set, PROJECT_UPDATE_IMMUTABLE);
     if (clear.length === 0) {
       await ctx.db.patch(project._id, setObj);
       await bumpProjectCounters(ctx, orgId, project, { ...project, ...setObj });
@@ -259,7 +281,15 @@ export const createNative = mutation({
     const dupId = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
     if (dupId) throw new ConvexError("Project already exists");
 
-    await ctx.db.insert("projects", fields);
+    // Strip the recalc-owned money totals: a new project starts with none, and
+    // recalcProjectTotals is the only writer. A browser-direct caller could otherwise
+    // mint a project with forged financials (projectWriteFields exposes them as args).
+    // Non-breaking: createProject never sends these. (bumpProjectCounters keys off
+    // status/isTemplate, not money, so it's unaffected by the strip.)
+    const insertFields = { ...fields };
+    for (const k of PROJECT_MONEY_ANCHORS) delete (insertFields as Record<string, unknown>)[k];
+
+    await ctx.db.insert("projects", insertFields);
     await bumpProjectCounters(ctx, fields.organizationId, null, fields);
 
     await writeActivityLog(ctx, {

--- a/docs/audits/2026-07-16-money-keystone-parity-gap-map.md
+++ b/docs/audits/2026-07-16-money-keystone-parity-gap-map.md
@@ -1,0 +1,119 @@
+# Money-Keystone Native-vs-Legacy Gap Map (2026-07-16)
+
+Step-1 scoping/parity audit for the Phase-3 money-keystone migration (browser-direct
+Convex + delete `src/server/` data layer). Built from 3 parallel adversarial audits +
+live prod verification. **Nothing was flipped/changed to produce this — audit only.**
+
+## Ground truth (verified live, corrects stale memory)
+- **Prod money flags are ALREADY ON** (verified `docker exec <app> env` on the prod box,
+  container `ghcr.io/twotoned/gearflow:latest`): `NATIVE_LINEITEM_WRITES`,
+  `NATIVE_PROJECT_WRITES`, `NATIVE_RECALC`, `NATIVE_ASSET/KIT/CREW_WRITES`,
+  `NATIVE_ACTIVITY_READS/WRITES` all `=true`. The "one-flip recalc win" is **live** — the
+  native money math (`convex/lib/recalc.ts` + `lineItemWrites.*Native` + `projectWrites.*`)
+  is battle-tested by real prod writes → **math parity de-risked.**
+- **`recalcProjectTotals` (`convex/lib/recalc.ts`) is byte-parity** with legacy
+  `recalculateProjectTotals` (`src/server/line-items.ts:1610`), parity-tested
+  (`convex/recalc.test.ts`). Prod = 307 healthy.
+- **`search.ts` raw-SQL Stage-4 blocker is GONE** — `src/server/search.ts` deleted; native
+  `convex/globalSearch.ts` + `convex/search.ts`. Only remaining `$queryRaw` is test fixtures.
+- **How the flags route today:** the flag makes the SERVER ACTION call the native mutation
+  with a **SERVICE token** (`getConvexClient()` → `src/lib/convex-client.ts:36`). Under a
+  service token the 4 browser guards short-circuit; the server action still runs
+  zod + `requirePermission` + availability + pricing + cascade first. **So the flag-on state
+  is safe — the gaps below are what blocks BROWSER-DIRECT conversion (user token), not the
+  current service-mediated path.**
+
+## ⚠️ Latent exposure (the one thing worth noting now)
+Every `*Native` mutation in `lineItemWrites.ts`/`projectWrites.ts` is a **public** `mutation`
+(user-token-reachable by design — `convex/lib/auth.ts:196`). They were built EARLY and
+**presuppose the server action enforced availability/pricing/validation**, so they do NOT
+meet the in-mutation enforcement bar the later-shipped `*Writes.ts` (crew/asset/kit/PM) all
+hold. A member with `manage_line_items` could craft a direct Convex call to
+`addNative`/`patchNative`/`updateNative` and bypass availability + money integrity. Prod is
+DARK (1 org, 3 trusted users) so practical risk ≈ 0, but this is the strongest reason to
+harden these two files BEFORE onboarding real users or going browser-direct.
+
+Live browser-direct today: only `projectWrites.updateNotesNative` (SAFE — field-union
+constrained). `use-native-line-item-writes.ts` is an optimistic READ overlay only; the real
+line-item write still lands via the server action.
+
+---
+
+## Files WITH native browser-callable mutations (need HARDENING)
+
+### `convex/lineItemWrites.ts` (7 mutations)
+| Mutation | Bar met? | Gaps |
+|---|---|---|
+| removeNative | ✅ full parity | — |
+| reorderNative | ✅ (3 guards correct — no audit) | — |
+| recalcNative | ✅ byte-parity | — |
+| addCustomNative | ⚠️ | MF-3 (no finite guard), MF-4 (trusts client `lineTotal`) |
+| patchNative | ❌ | MF-2 (`set: v.any()`, strips only org/id/projectId → can set `status`/`isKitChild`/`parentLineItemId`/`lineTotal`/fulfillment counters), MF-3, MF-4, missing stale-guard + qty↑ availability re-check |
+| addNative | ❌ | MF-1 (NO availability/double-booking/asset-in-kit/RETIRED-LOST), MF-3, MF-4, NTH merge-dedup + auto-pricing absent |
+| addKitNative | ❌ | MF-1 (NO kit availability + IN_MAINTENANCE/INCOMPLETE guard) |
+
+### `convex/projectWrites.ts` (6 mutations)
+| Mutation | Bar met? | Gaps |
+|---|---|---|
+| updateNotesNative | ✅ (live browser-direct, safe) | — |
+| updateStatusNative | ⚠️ | missing blocking-comments gate parity |
+| archiveNative | ✅ | — |
+| updateNative | ❌ | **money-anchor injection** (`sanitizeClientSet` doesn't strip `total`/`margin`/`equipmentRevenue`/… nor `projectNumber`/`isTemplate`), missing projectNumber dup-guard, blocking-comments gate |
+| createNative | ❌ | **money-anchor injection** (`projectWriteFields` exposes totals as typed args, inserted raw), project-number allocation is `requireService`-gated → can't go browser-direct |
+| deleteNative | ❌ | **NO cascade** (assets/kits stuck CHECKED_OUT, orphaned lines/groups/PMs/crew), no CANCELLED precondition, no isTemplate guard |
+
+### Shared MUST-FIX severity (lineItemWrites)
+- **MF-1** (highest) — port availability/double-booking + kit-status enforcement INTO
+  `addNative`/`patchNative`/`addKitNative`. Template: `projectLineItems.swapLineItemAsset`
+  (range-scan + OCC double-booking gate inside a mutation). = the "line-items keystone".
+- **MF-2** — replace `patchNative` `v.any()` with a typed non-structural whitelist (exclude
+  `status`/`isKitChild`/`parentLineItemId`/`childKind`/`kitId`/`subHireId`/`isCustomItem`/
+  fulfillment counters).
+- **MF-3** — `Number.isFinite` + range guard on `quantity`/`unitPrice`/`discount`/`lineTotal`
+  in every create/patch (Convex `v.number()` accepts NaN/Infinity/negatives → poisons
+  `recalc` totals to NaN).
+- **MF-4** — recompute `lineTotal` inside the mutation from validated inputs; ignore client.
+
+### projectWrites MUST-FIX
+- Strip money anchors in `updateNative` sanitize + omit from `createNative` insert.
+- `deleteNative` cascade + CANCELLED/isTemplate guards (or keep service-only).
+- Fold project-number allocation (`reserveNextNumber`, `projectNumberSequences.ts:120`,
+  currently `requireService`) into `createNative` before it can be browser-direct.
+- Blocking-comments gate parity on update/status.
+
+### projectWrites GAPS (no native twin — block deleting `src/server/projects.ts`)
+`duplicateProject`, `saveAsTemplate`, `deleteTemplate`, `deleteProject` cascade body.
+
+---
+
+## Files with ONLY service-gated CRUD mirrors (need `*Writes.ts` AUTHORED)
+Every mutation in these is `requireService` — zero browser-callable, and none carry the
+orchestration (recalc/cascade/pricing/rate-memory). Each needs a `*Writes.ts` authored to
+the `projectManagersWrites.ts` bar, then browser-direct conversion + server delete.
+Recalc-coupled domains just `import { recalcProjectTotals } from "./lib/recalc"` and call it.
+
+| Domain | legacy writes | recalc-coupled | carve-outs (stay server) |
+|---|---|---|---|
+| project-categories | 4 | no | — |
+| warehouse-close | 2 | no | — |
+| group-templates | 5 | yes (applyGroupTemplate) | — |
+| project-groups | 9 | yes | — |
+| category-slots | 4 | yes | — |
+| project-services | 13 | yes | crew messaging + CSV/template mapping |
+| warehouse | 24 | no | crypto webhook emit + blocking-comment gate + native scan query |
+| sub-hires | 19 | yes (+ native `recalculateSubHireTotals`/`generateSubHireLineItems`/supplier-rate) | media `refCountFile` union |
+
+---
+
+## Recommended execution order (revised from the brief, given flags already live)
+1. **Harden `lineItemWrites` + `projectWrites` to the browser-direct bar** (closes the latent
+   public-mutation exposure; non-behavior-changing for the service path):
+   1a. Safe defensive slice: MF-3 finite guards + MF-4 lineTotal recompute + MF-2 typed patch
+       whitelist + projectWrites money-anchor stripping. *(no availability port yet)*
+   1b. Line-items keystone: MF-1 in-mutation availability/double-booking/kit-status + pricing.
+   1c. projectWrites deleteNative cascade + numbering fold + blocking-comments.
+2. **Browser-direct convert + delete server layer, domain-by-domain** (each its own PR):
+   line-items → projects → project-services → project-groups → project-categories →
+   group-templates → category-slots → sub-hires → warehouse/close. Author the missing
+   `*Writes.ts` per domain (table above) as part of each domain's PR.
+3. After server callers deleted: demote dead `requireService` CRUD mirrors to `internal*`.


### PR DESCRIPTION
## Summary
First slice of the **money-keystone** Phase-3 migration. Step-1 scoping/parity audit is complete (see `docs/audits/2026-07-16-money-keystone-parity-gap-map.md`); this PR is the **safe defensive hardening** it recommended (1a).

The `*Native` mutations in `convex/lineItemWrites.ts` / `convex/projectWrites.ts` are **public** (user-token-reachable by design) but were built early **presupposing the server action enforced Zod validation**. They don't yet meet the in-mutation bar the later-shipped `*Writes.ts` (crew/asset/kit/PM) hold. This closes the *latent* exposure without changing behaviour for the current service-token path.

## What this fixes
- **NaN/Infinity money poisoning** — `v.number()` accepts NaN/Infinity/negatives; recalc (`convex/lib/recalc.ts`) sums them straight into `project.total`/`margin`. New `convex/lib/moneyGuards.ts` rejects them (bounds mirror `src/lib/validations/line-item.ts`).
- **`patchNative` `set: v.any()` injection** — a client could forge the parent/child tree (`isKitChild`/`parentLineItemId`/…), flip `status:"CANCELLED"` to drop a line from revenue, spoof fulfillment counters, or set `allocatedRevenue`. `LINE_IMMUTABLE_ON_PATCH` strips those (and blocks clearing them). `type` intentionally stays settable — `updateLineItem` patches it.
- **project money-anchor injection** — `updateNative`/`createNative` no longer accept client-supplied `equipmentRevenue`/…/`total`/`margin` (recalc owns them); `isTemplate` is immutable on update.

## Non-breaking guarantee
The service-token server-action path already sends Zod-validated values, so these guards reject only inputs Zod would have too. `quantity` keeps only finite+positive-integer (the `addLineItem` merge path sums two Zod-capped quantities → can exceed 99999); codex flagged both this and a `type`-strip regression, both fixed.

## Scope
Does **not** convert anything browser-direct. Availability/double-booking enforcement (MF-1) and lineTotal recompute (MF-4) land in the line-items keystone PR.

## Testing
- `tsc --noEmit` clean
- +5 cases across `lineItemWrites.test.ts` / `projectWrites.test.ts` (finite rejection, structural strip, money-anchor strip); 36 focused tests green
- Convex functions deployed to prod (additive/inert)
- Independent codex review (2 real findings fixed, rest clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)