### PR TITLE
harden(money): port line-item availability/double-booking into native mutations (MF-1)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -83,6 +83,7 @@ import type * as lib_audit from "../lib/audit.js";
 import type * as lib_auditChanges from "../lib/auditChanges.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_availabilityBookings from "../lib/availabilityBookings.js";
+import type * as lib_availabilityCore from "../lib/availabilityCore.js";
 import type * as lib_bulkCheckin from "../lib/bulkCheckin.js";
 import type * as lib_counters from "../lib/counters.js";
 import type * as lib_crewRate from "../lib/crewRate.js";
@@ -269,6 +270,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auditChanges": typeof lib_auditChanges;
   "lib/auth": typeof lib_auth;
   "lib/availabilityBookings": typeof lib_availabilityBookings;
+  "lib/availabilityCore": typeof lib_availabilityCore;
   "lib/bulkCheckin": typeof lib_bulkCheckin;
   "lib/counters": typeof lib_counters;
   "lib/crewRate": typeof lib_crewRate;

--- a/convex/availabilityCore.test.ts
+++ b/convex/availabilityCore.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+//
+// convex/lib/availabilityCore.ts — the availability CORE for the native line-item
+// mutations. Two guarantees:
+//  (a) The pure stock math (computeStockBreakdown / resolveModelAssetType) is a
+//      byte-for-byte duplicate of src/lib/overbooking-core.ts — PINNED here by a
+//      cross-import equality matrix (same pattern as reservationConflicts.test.ts).
+//  (b) computeModelAvailability mirrors the server-side model-path math
+//      (src/server/line-items.ts == checkAvailability) over the key fixtures.
+import { describe, test, expect } from "vitest";
+import {
+  computeStockBreakdown as coreStock,
+  resolveModelAssetType as coreType,
+  computeModelAvailability,
+  type ModelAvailabilityBundle,
+} from "./lib/availabilityCore";
+import {
+  computeStockBreakdown as origStock,
+  resolveModelAssetType as origType,
+} from "@/lib/overbooking-core";
+
+// ─── (a) cross-import equality — pins the duplication ─────────────────────────
+
+describe("availabilityCore stock math == overbooking-core (byte-for-byte pin)", () => {
+  test("resolveModelAssetType matches the original over every combo", () => {
+    for (const assetType of [undefined, null, "SERIALIZED", "BULK", "OTHER", ""]) {
+      for (const hasBulk of [true, false]) {
+        expect(coreType(assetType, hasBulk)).toBe(origType(assetType, hasBulk));
+      }
+    }
+  });
+
+  test("computeStockBreakdown matches the original over SERIALIZED/BULK/mixed/empty/all-unavailable", () => {
+    const matrices: Array<Parameters<typeof coreStock>[0]> = [
+      // SERIALIZED — empty
+      { assetType: "SERIALIZED", assets: [], bulkAssets: [] },
+      // SERIALIZED — all available
+      { assetType: "SERIALIZED", assets: [{ status: "AVAILABLE" }, { status: "CHECKED_OUT" }, { status: "RESERVED" }], bulkAssets: [] },
+      // SERIALIZED — all unavailable (maintenance / lost / retired)
+      { assetType: "SERIALIZED", assets: [{ status: "IN_MAINTENANCE" }, { status: "LOST" }, { status: "RETIRED" }], bulkAssets: [] },
+      // SERIALIZED — mixed
+      { assetType: "SERIALIZED", assets: [{ status: "AVAILABLE" }, { status: "IN_MAINTENANCE" }, { status: "AVAILABLE" }, { status: "RETIRED" }], bulkAssets: [] },
+      // BULK — several quantities
+      { assetType: "BULK", assets: [], bulkAssets: [{ totalQuantity: 10 }, { totalQuantity: 5 }] },
+      // BULK — empty
+      { assetType: "BULK", assets: [], bulkAssets: [] },
+      // BULK — with (ignored) serialized assets present
+      { assetType: "BULK", assets: [{ status: "AVAILABLE" }], bulkAssets: [{ totalQuantity: 7 }] },
+    ];
+    for (const m of matrices) {
+      expect(coreStock(m)).toEqual(origStock(m));
+    }
+  });
+});
+
+// ─── (b) computeModelAvailability fixtures ────────────────────────────────────
+
+type L = { projectId: string; quantity?: number; status?: string; subHireId?: string | null };
+type P = { id: string; rentalStartDate?: number | null; rentalEndDate?: number | null; status?: string; isTemplate?: boolean };
+
+function mkBundle(opts: {
+  assetType?: "SERIALIZED" | "BULK";
+  assets?: { status?: string }[];
+  bulks?: { totalQuantity?: number }[];
+  lines?: L[];
+  projects?: P[];
+  model?: null;
+}): ModelAvailabilityBundle {
+  return {
+    model: opts.model === null ? null : ({ assetType: opts.assetType ?? "SERIALIZED" } as never),
+    activeAssets: (opts.assets ?? []) as never,
+    activeBulkAssets: (opts.bulks ?? []) as never,
+    lines: (opts.lines ?? []) as never,
+    projects: (opts.projects ?? []) as never,
+  };
+}
+
+const START = 1_000;
+const END = 2_000;
+
+describe("computeModelAvailability", () => {
+  test("dateless: only THIS project's bookings count", () => {
+    const b = mkBundle({
+      assets: [{ status: "AVAILABLE" }, { status: "AVAILABLE" }, { status: "AVAILABLE" }],
+      lines: [
+        { projectId: "thisP", quantity: 2 },
+        { projectId: "otherP", quantity: 5 }, // ignored — no dates, not this project
+      ],
+    });
+    const r = computeModelAvailability(b, { rentalStart: null, rentalEnd: null, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ totalStock: 3, effectiveStock: 3, booked: 2, available: 1, assetType: "SERIALIZED" });
+  });
+
+  test("dated: overlapping bookings across projects (incl. this project) count", () => {
+    const b = mkBundle({
+      assets: [{ status: "AVAILABLE" }, { status: "AVAILABLE" }, { status: "AVAILABLE" }],
+      lines: [
+        { projectId: "thisP", quantity: 2 },
+        { projectId: "otherP", quantity: 5 },
+      ],
+      projects: [
+        { id: "thisP", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED" },
+        { id: "otherP", rentalStartDate: START + 100, rentalEndDate: END + 100, status: "CONFIRMED" },
+      ],
+    });
+    const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ totalStock: 3, booked: 7, available: 0 });
+  });
+
+  test("SERIALIZED effectiveStock reduced by IN_MAINTENANCE / LOST / RETIRED", () => {
+    const b = mkBundle({
+      assets: [
+        { status: "AVAILABLE" }, { status: "AVAILABLE" },
+        { status: "IN_MAINTENANCE" }, { status: "LOST" }, { status: "RETIRED" },
+      ],
+    });
+    const r = computeModelAvailability(b, { rentalStart: null, rentalEnd: null, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ totalStock: 5, effectiveStock: 2, unavailable: 3, booked: 0, available: 2 });
+  });
+
+  test("BULK: availability from summed totalQuantity", () => {
+    const b = mkBundle({
+      assetType: "BULK",
+      bulks: [{ totalQuantity: 10 }, { totalQuantity: 4 }],
+      lines: [{ projectId: "thisP", quantity: 3 }],
+      projects: [{ id: "thisP", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED" }],
+    });
+    const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ totalStock: 14, effectiveStock: 14, unavailable: 0, booked: 3, available: 11, assetType: "BULK" });
+  });
+
+  test("dated: CANCELLED lines + sub-hire lines are excluded from booked", () => {
+    const b = mkBundle({
+      assets: [{ status: "AVAILABLE" }, { status: "AVAILABLE" }, { status: "AVAILABLE" }],
+      lines: [
+        { projectId: "thisP", quantity: 5, status: "CANCELLED" },
+        { projectId: "thisP", quantity: 3, subHireId: "sh1" },
+        { projectId: "thisP", quantity: 2, status: "CONFIRMED" },
+      ],
+      projects: [{ id: "thisP", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED" }],
+    });
+    const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ booked: 2, available: 1 });
+  });
+
+  test("dated: template + dead-status projects are excluded from booked", () => {
+    const b = mkBundle({
+      assets: [{ status: "AVAILABLE" }, { status: "AVAILABLE" }, { status: "AVAILABLE" }],
+      lines: [
+        { projectId: "tmpl", quantity: 4 },
+        { projectId: "dead", quantity: 4 },
+        { projectId: "live", quantity: 2 },
+      ],
+      projects: [
+        { id: "tmpl", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED", isTemplate: true },
+        { id: "dead", rentalStartDate: START, rentalEndDate: END, status: "CANCELLED" },
+        { id: "live", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED" },
+      ],
+    });
+    const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "live" });
+    expect(r).toMatchObject({ booked: 2, available: 1 });
+  });
+});

--- a/convex/lib/availabilityCore.ts
+++ b/convex/lib/availabilityCore.ts
@@ -1,0 +1,257 @@
+/**
+ * Availability / double-booking CORE for the native line-item mutations
+ * (`convex/lineItemWrites.ts` addNative / patchNative).
+ *
+ * The two pure stock-math helpers (`resolveModelAssetType`, `computeStockBreakdown`)
+ * are copied BYTE-FOR-BYTE from `src/lib/overbooking-core.ts:46-74` — the Convex
+ * bundler can't resolve the `@/` alias, so they're duplicated here (same pattern as
+ * `convex/lib/reservationConflicts.ts`) and PINNED against the originals by a
+ * cross-import equality test in `convex/availabilityCore.test.ts`.
+ *
+ * `loadModelAvailabilityBundle` mirrors `convex/availabilityCheck.ts:21-53` (minus the
+ * bulk-accessory count) — all reads are backend-local + bounded (referenced-only
+ * projects). `computeModelAvailability` is PURE and mirrors the model-path math in
+ * `src/server/line-items.ts:192-252` (== `checkAvailability`), so the enforcement the
+ * native mutation adds is parity-equivalent to the server-side pre-check.
+ *
+ * `findAssetConflict` mirrors the dated asset double-booking check in
+ * `src/server/line-items.ts:107-158`, bounded to the asset's referenced projects.
+ */
+import type { MutationCtx } from "../_generated/server";
+import type { Doc } from "../_generated/dataModel";
+
+// ─── Pure stock breakdown (copied byte-for-byte from overbooking-core.ts) ─────
+
+export function resolveModelAssetType(
+  assetType: string | null | undefined,
+  hasBulkAssets: boolean,
+): "SERIALIZED" | "BULK" {
+  if (assetType === "BULK" || assetType === "SERIALIZED") return assetType;
+  return hasBulkAssets ? "BULK" : "SERIALIZED";
+}
+
+export function computeStockBreakdown(model: {
+  assetType: "SERIALIZED" | "BULK";
+  assets: { status: string }[];
+  bulkAssets: { totalQuantity: number }[];
+}): { totalStock: number; effectiveStock: number; unavailable: number } {
+  if (model.assetType === "SERIALIZED") {
+    const totalStock = model.assets.length;
+    const unavailable = model.assets.filter(
+      (a) =>
+        a.status === "IN_MAINTENANCE" ||
+        a.status === "LOST" ||
+        a.status === "RETIRED",
+    ).length;
+    return { totalStock, effectiveStock: totalStock - unavailable, unavailable };
+  }
+  const totalStock = model.bulkAssets.reduce(
+    (sum, ba) => sum + ba.totalQuantity,
+    0,
+  );
+  return { totalStock, effectiveStock: totalStock, unavailable: 0 };
+}
+
+/** Project statuses whose bookings are released (mirrors server literal list). */
+const DEAD_PROJECT_STATUSES = ["CANCELLED", "RETURNED", "COMPLETED", "INVOICED"];
+
+// ─── Model availability bundle (mirror of availabilityCheck.checkBundle) ──────
+
+export interface ModelAvailabilityBundle {
+  model: Doc<"models"> | null;
+  activeAssets: Doc<"assets">[];
+  activeBulkAssets: Doc<"bulkAssets">[];
+  lines: Doc<"projectLineItems">[];
+  projects: Doc<"projects">[];
+}
+
+/**
+ * ONE bundle of everything the model-level availability math needs, all reads
+ * backend-local + bounded. Mirrors `convex/availabilityCheck.ts:21-53` exactly
+ * (minus the bulk-accessory count, which enforcement doesn't use):
+ * model (org-rechecked → null if another org), active assets/bulkAssets
+ * (`isActive !== false`), this model's org line items, and the REFERENCED-ONLY
+ * projects those lines point at (unique projectIds, each `by_cuid`, org-rechecked).
+ */
+export async function loadModelAvailabilityBundle(
+  ctx: MutationCtx,
+  modelId: string,
+  orgId: string,
+): Promise<ModelAvailabilityBundle> {
+  const [modelDoc, assetsRaw, bulksRaw, lineRaw] = await Promise.all([
+    ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", modelId)).unique(),
+    ctx.db.query("assets").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
+    ctx.db.query("bulkAssets").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
+    ctx.db.query("projectLineItems").withIndex("by_modelId", (q) => q.eq("modelId", modelId)).collect(),
+  ]);
+
+  const lines = lineRaw.filter((r) => r.organizationId === orgId);
+  const projectIds = [...new Set(lines.map((li) => li.projectId))];
+  const projectDocs = await Promise.all(
+    projectIds.map((pid) =>
+      ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique(),
+    ),
+  );
+
+  return {
+    model: modelDoc && modelDoc.organizationId === orgId ? modelDoc : null,
+    // Org-filter as well as isActive: by_modelId is a GLOBAL index (CLAUDE.md rule),
+    // and the server enforcement path reads org-scoped (getActiveAssetsByModel). Without
+    // this, a cross-org asset sharing the modelId would inflate effectiveStock and let an
+    // overbook through.
+    activeAssets: assetsRaw.filter((a) => a.organizationId === orgId && a.isActive !== false),
+    activeBulkAssets: bulksRaw.filter((b) => b.organizationId === orgId && b.isActive !== false),
+    lines,
+    projects: projectDocs.filter(
+      (p): p is NonNullable<typeof p> => !!p && p.organizationId === orgId,
+    ),
+  };
+}
+
+export interface ModelAvailability {
+  totalStock: number;
+  effectiveStock: number;
+  unavailable: number;
+  booked: number;
+  available: number;
+  assetType: "SERIALIZED" | "BULK";
+}
+
+/**
+ * PURE model availability — mirrors `src/server/line-items.ts:192-252`
+ * (== `checkAvailability:1332-1431`). `booked` sums non-cancelled, non-sub-hire
+ * lines on overlapping live projects (dated) or on `excludeProjectId` (dateless).
+ * `available = max(0, effectiveStock - booked)`.
+ *
+ * NOTE: dated `booked` INCLUDES `excludeProjectId`'s own lines (parity:
+ * checkAvailability's booked includes this project; excludeProjectId only shapes
+ * the conflicts list, which enforcement doesn't consult).
+ */
+export function computeModelAvailability(
+  bundle: ModelAvailabilityBundle,
+  opts: {
+    rentalStart: number | null;
+    rentalEnd: number | null;
+    excludeProjectId: string;
+  },
+): ModelAvailability {
+  const { model, activeAssets, activeBulkAssets, lines, projects } = bundle;
+  const { rentalStart, rentalEnd, excludeProjectId } = opts;
+  const hasDates = rentalStart != null && rentalEnd != null;
+
+  const assetType = resolveModelAssetType(model?.assetType, activeBulkAssets.length > 0);
+  const modelForBreakdown = {
+    assetType,
+    assets: activeAssets.map((a) => ({ status: a.status ?? "AVAILABLE" })),
+    bulkAssets: activeBulkAssets.map((ba) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
+  };
+
+  let overlapping: Doc<"projectLineItems">[];
+  if (hasDates) {
+    const conflictProjectIds = new Set(
+      projects
+        .filter(
+          (p) =>
+            !p.isTemplate &&
+            !DEAD_PROJECT_STATUSES.includes(p.status ?? "") &&
+            p.rentalStartDate != null &&
+            p.rentalEndDate != null &&
+            (p.rentalStartDate as number) <= rentalEnd &&
+            (p.rentalEndDate as number) >= rentalStart,
+        )
+        .map((p) => p.id),
+    );
+    overlapping = lines.filter(
+      (li) =>
+        li.status !== "CANCELLED" &&
+        li.subHireId == null &&
+        conflictProjectIds.has(li.projectId),
+    );
+  } else {
+    overlapping = lines.filter(
+      (li) =>
+        li.status !== "CANCELLED" &&
+        li.subHireId == null &&
+        li.projectId === excludeProjectId,
+    );
+  }
+
+  const booked = overlapping.reduce((sum, li) => sum + (li.quantity ?? 0), 0);
+  const { totalStock, effectiveStock, unavailable } = computeStockBreakdown(modelForBreakdown);
+  const available = Math.max(0, effectiveStock - booked);
+
+  return { totalStock, effectiveStock, unavailable, booked, available, assetType };
+}
+
+// ─── Dated asset double-booking (mirror of line-items.ts:107-158) ─────────────
+
+/**
+ * Dated-only asset double-booking. Returns the FIRST other-project doc the asset is
+ * booked on during `[rentalStart, rentalEnd]` (via a legacy `line.assetId` row OR a
+ * live unit), or null. Bounded to the asset's referenced projects (parity-equivalent
+ * to the server's whole-org `getProjectsByOrg` conflictSet, which is only ever probed
+ * by `conflictSet.has(assetLine.projectId)`).
+ */
+export async function findAssetConflict(
+  ctx: MutationCtx,
+  opts: {
+    assetId: string;
+    orgId: string;
+    excludeProjectId: string;
+    rentalStart: number;
+    rentalEnd: number;
+  },
+): Promise<Doc<"projects"> | null> {
+  const { assetId, orgId, excludeProjectId, rentalStart, rentalEnd } = opts;
+
+  const [assetLines, assetUnits] = await Promise.all([
+    ctx.db.query("projectLineItems").withIndex("by_assetId", (q) => q.eq("assetId", assetId)).collect(),
+    ctx.db.query("projectLineItemUnits").withIndex("by_assetId", (q) => q.eq("assetId", assetId)).collect(),
+  ]);
+  const lines = assetLines.filter((l) => l.organizationId === orgId);
+  const units = assetUnits.filter((u) => u.organizationId === orgId && u.status !== "RETURNED");
+
+  // Batch-fetch the line items backing the asset's live units (one read each).
+  const unitLineIds = [...new Set(units.map((u) => u.lineItemId))];
+  const unitLineDocs = await Promise.all(
+    unitLineIds.map((lid) =>
+      ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", lid)).unique(),
+    ),
+  );
+  const unitLines = unitLineDocs.filter(
+    (l): l is NonNullable<typeof l> => !!l && l.organizationId === orgId,
+  );
+
+  // Referenced-only projects: the ones the asset's (non-cancelled) lines/units point
+  // at. conflictSet only probes these projectIds, so fetching just them is parity.
+  const projectIds = [
+    ...new Set([...lines, ...unitLines].filter((l) => l.status !== "CANCELLED").map((l) => l.projectId)),
+  ];
+  const projectDocs = await Promise.all(
+    projectIds.map((pid) =>
+      ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique(),
+    ),
+  );
+  const projectMap = new Map<string, Doc<"projects">>();
+  const conflictSet = new Set<string>();
+  for (const p of projectDocs) {
+    if (!p || p.organizationId !== orgId) continue;
+    projectMap.set(p.id, p);
+    if (p.id === excludeProjectId) continue;
+    if (p.isTemplate) continue;
+    if (DEAD_PROJECT_STATUSES.includes(p.status ?? "")) continue;
+    if (p.rentalStartDate == null || p.rentalEndDate == null) continue;
+    if ((p.rentalStartDate as number) <= rentalEnd && (p.rentalEndDate as number) >= rentalStart) {
+      conflictSet.add(p.id);
+    }
+  }
+
+  const lineConflict = lines.find(
+    (li) => li.status !== "CANCELLED" && conflictSet.has(li.projectId),
+  );
+  const unitConflictProjId = unitLines.find(
+    (ul) => ul.status !== "CANCELLED" && conflictSet.has(ul.projectId),
+  )?.projectId;
+  const conflictProjId = lineConflict?.projectId ?? unitConflictProjId;
+  return conflictProjId ? (projectMap.get(conflictProjId) ?? null) : null;
+}

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -92,7 +92,7 @@ describe("lineItemWrites.removeNative", () => {
 });
 
 describe("lineItemWrites.patchNative", () => {
-  const pargs = { id: "li1", orgId: ORG, orgDefaultTaxRate: null, entityName: "Light", actor: ACTOR, auditId: "log1", now: NOW };
+  const pargs = { id: "li1", orgId: ORG, orgDefaultTaxRate: null, entityName: "Light", allowOverbook: false, actor: ACTOR, auditId: "log1", now: NOW };
   test("member patches fields + UPDATE audit", async () => {
     const t = makeT();
     await member(t, "member");
@@ -205,7 +205,7 @@ describe("lineItemWrites.addCustomNative", () => {
 });
 
 describe("lineItemWrites.addNative", () => {
-  const aargs = { id: "new1", organizationId: ORG, projectId: "p1", fields: { type: "EQUIPMENT" as const, description: "PAR Can", quantity: 2, unitPrice: 15 }, includeAccessories: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
+  const aargs = { id: "new1", organizationId: ORG, projectId: "p1", fields: { type: "EQUIPMENT" as const, description: "PAR Can", quantity: 2, unitPrice: 15 }, includeAccessories: false, allowOverbook: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
   test("member adds an inventory line (sortOrder in-mutation) + CREATE audit", async () => {
     const t = makeT();
     await member(t, "member");
@@ -227,6 +227,204 @@ describe("lineItemWrites.addNative", () => {
     const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("lineItemWrites.addNative availability enforcement", () => {
+  const DAY = 86_400_000;
+  const enfArgs = (fields: { modelId?: string; assetId?: string; quantity: number }, over = false) => ({
+    id: "nx", organizationId: ORG, projectId: "p1",
+    fields: { type: "EQUIPMENT" as const, ...fields },
+    includeAccessories: false, allowOverbook: over, orgDefaultTaxRate: null,
+    actor: ACTOR, auditId: "log1", now: NOW,
+  });
+
+  // A SERIALIZED model with `n` active AVAILABLE assets, a project, and an existing
+  // booking on THIS project (dateless → only this-project bookings count).
+  async function seedModelStock(t: ReturnType<typeof makeT>, n: number, bookedQty: number, dates?: { s: number; e: number }) {
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, ...(dates ? { rentalStartDate: dates.s, rentalEndDate: dates.e } : {}) });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      for (let i = 0; i < n; i++) {
+        await ctx.db.insert("assets", { id: `a${i}`, organizationId: ORG, modelId: "m1", assetTag: `A-${i}`, status: "AVAILABLE", isActive: true });
+      }
+      if (bookedQty > 0) {
+        await ctx.db.insert("projectLineItems", { id: "lx", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: bookedQty, status: "CONFIRMED", isKitChild: false });
+      }
+    });
+  }
+
+  test("model path throws INSUFFICIENT_STOCK when qty exceeds available", async () => {
+    const t = makeT();
+    await seedModelStock(t, 3, 3); // 3 stock, 3 already booked on this project → 0 free
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", quantity: 1 })),
+    ).rejects.toThrow(/Only 0 of 1 requested are free/);
+  });
+
+  test("model path SUCCEEDS with allowOverbook:true (enforcement bypassed)", async () => {
+    const t = makeT();
+    await seedModelStock(t, 3, 3);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", quantity: 1 }, true));
+    expect(res.id).toBe("nx");
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "nx")).first();
+      expect(li?.quantity).toBe(1);
+    });
+  });
+
+  test("model path allows a qty that exactly fills free stock (boundary)", async () => {
+    const t = makeT();
+    await seedModelStock(t, 3, 1); // 3 stock, 1 booked → 2 free
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", quantity: 2 }));
+    expect(res.id).toBe("nx");
+  });
+
+  test("asset path throws ASSET_IN_KIT (precedence: beats a RETIRED status)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      // Asset is BOTH kit-owned AND retired — the kit guard must win (runs first).
+      await ctx.db.insert("assets", { id: "ak", organizationId: ORG, modelId: "m1", assetTag: "A-K", status: "RETIRED", isActive: true, kitId: "k1" });
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-9", name: "L", status: "AVAILABLE", condition: "GOOD", isActive: true });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", assetId: "ak", quantity: 1 })),
+    ).rejects.toThrow(/Kit KIT-9/);
+  });
+
+  test("asset path throws ASSET_DOUBLE_BOOKED on a dated overlap (via a line booking)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, rentalStartDate: NOW, rentalEndDate: NOW + 5 * DAY });
+      await ctx.db.insert("projects", { id: "p2", organizationId: ORG, projectNumber: "P2", name: "Festival", status: "CONFIRMED", isTemplate: false, rentalStartDate: NOW + DAY, rentalEndDate: NOW + 3 * DAY });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "m1", assetTag: "A-2", status: "AVAILABLE", isActive: true });
+      // A2 already booked on the overlapping project P2 via a legacy line.assetId row.
+      await ctx.db.insert("projectLineItems", { id: "lp2", organizationId: ORG, projectId: "p2", modelId: "m1", assetId: "a2", type: "EQUIPMENT", quantity: 1, status: "CONFIRMED", isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", assetId: "a2", quantity: 1 })),
+    ).rejects.toThrow(/booked on P2 — Festival during those dates/);
+  });
+
+  test("asset path throws ASSET_UNAVAILABLE for a RETIRED asset (not kit, not double-booked)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      await ctx.db.insert("assets", { id: "a3", organizationId: ORG, modelId: "m1", assetTag: "A-3", status: "RETIRED", isActive: true });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, enfArgs({ modelId: "m1", assetId: "a3", quantity: 1 })),
+    ).rejects.toThrow(/marked retired/);
+  });
+});
+
+describe("lineItemWrites.patchNative availability enforcement", () => {
+  const pargs = { id: "li1", orgId: ORG, orgDefaultTaxRate: null, entityName: "Light", allowOverbook: false, actor: ACTOR, auditId: "log1", now: NOW };
+  // Dateless project, SERIALIZED model with 3 active assets, one existing line (li1)
+  // on the project booking `oldQty` of the model.
+  async function seed(t: ReturnType<typeof makeT>, oldQty: number) {
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      for (let i = 0; i < 3; i++) {
+        await ctx.db.insert("assets", { id: `a${i}`, organizationId: ORG, modelId: "m1", assetTag: `A-${i}`, status: "AVAILABLE", isActive: true });
+      }
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: oldQty, status: "CONFIRMED", isKitChild: false });
+    });
+  }
+
+  test("throws on a qty increase that exceeds available (delta > free)", async () => {
+    const t = makeT();
+    await seed(t, 1); // 3 stock, this line booked 1 → 2 free; delta 5-1=4 > 2
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 5, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/Only 2 of 4 requested are free/);
+  });
+
+  test("allows a resize that exactly fills stock (boundary: delta == free)", async () => {
+    const t = makeT();
+    await seed(t, 1); // 3 stock, 1 booked → 2 free; delta 3-1=2 == 2 → allowed
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 3, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(3);
+    });
+  });
+
+  test("allows a qty DECREASE without an availability check", async () => {
+    const t = makeT();
+    await seed(t, 3); // decrease 3 → 1: gate is newQty > currentQty, so it's skipped
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 1, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(1);
+    });
+  });
+
+  test("qty increase SUCCEEDS with allowOverbook:true", async () => {
+    const t = makeT();
+    await seed(t, 1);
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, allowOverbook: true, set: { quantity: 9, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(9);
+    });
+  });
+
+  test("model CHANGE compares FULL newQty (not delta) against the new model", async () => {
+    const t = makeT();
+    await seed(t, 1); // line is on m1 (3 stock)
+    await t.run(async (ctx) => {
+      // A second model with only 2 stock; the line is NOT booked against it.
+      await ctx.db.insert("models", { id: "m2", organizationId: ORG, name: "Fresnel", assetType: "SERIALIZED" });
+      for (let i = 0; i < 2; i++) await ctx.db.insert("assets", { id: `b${i}`, organizationId: ORG, modelId: "m2", assetTag: `B-${i}`, status: "AVAILABLE", isActive: true });
+    });
+    // Switch to m2 and request 3 — m2 has 2 free, line not in m2's booked → full 3 > 2 → throw.
+    // (A delta check 3-1=2 would have WRONGLY allowed it.)
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 3, modelId: "m2", updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/Only 2 of 3 requested are free/);
+  });
+
+  test("CLEARING modelId skips enforcement (converting to a custom line)", async () => {
+    const t = makeT();
+    await seed(t, 3); // fully booked on m1
+    // Clear modelId + bump qty: the server skips enforcement when there's no model, so must we.
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 8, updatedAt: NOW }, clear: ["modelId"] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.quantity).toBe(8);
+      expect(li?.modelId).toBeUndefined();
+    });
+  });
+});
+
+describe("lineItemWrites availability org-isolation", () => {
+  test("a cross-org asset sharing the modelId does NOT inflate available stock", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED" });
+      // Our org: exactly 1 active asset for the model.
+      await ctx.db.insert("assets", { id: "mine", organizationId: ORG, modelId: "m1", assetTag: "A-0", status: "AVAILABLE", isActive: true });
+      // ANOTHER org: an asset with the SAME modelId (by_modelId is global). Must not count.
+      await ctx.db.insert("assets", { id: "theirs", organizationId: "org_other", modelId: "m1", assetTag: "X-0", status: "AVAILABLE", isActive: true });
+    });
+    // Adding qty 2 must fail — only 1 unit is ours, despite 2 assets sharing the modelId.
+    const aargs = { id: "new1", organizationId: ORG, projectId: "p1", fields: { type: "EQUIPMENT" as const, modelId: "m1", description: "PAR", quantity: 2 }, includeAccessories: false, allowOverbook: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW };
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs),
+    ).rejects.toThrow(/Only 1 of 2 requested are free/);
   });
 });
 

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -12,6 +12,11 @@ import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
 import { expandAccessoryChildLines } from "./lib/fulfillment";
 import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
+import {
+  loadModelAvailabilityBundle,
+  computeModelAvailability,
+  findAssetConflict,
+} from "./lib/availabilityCore";
 
 /**
  * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
@@ -145,11 +150,12 @@ export const patchNative = mutation({
     set: v.any(),
     clear: v.array(v.string()),
     entityName: v.string(),
+    allowOverbook: v.boolean(),
     actor: actorValidator,
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, orgDefaultTaxRate, set, clear, entityName, actor: suppliedActor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, orgDefaultTaxRate, set, clear, entityName, allowOverbook, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
@@ -166,6 +172,57 @@ export const patchNative = mutation({
     assertLineMoneyFields(setObj as {
       quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
     });
+
+    // Availability re-check on a quantity INCREASE (parity with updateLineItem's
+    // server-side re-check). Only EQUIPMENT, model-backed, non-sub-hire lines that grow
+    // are re-validated. The EFFECTIVE post-patch view must respect `clear` (a caller can
+    // clear modelId to convert to a custom line — the server then skips enforcement).
+    const currentQty = doc.quantity ?? 0;
+    const clearSet = new Set(clear.filter((k) => !LINE_NEVER_CLEAR.has(k)));
+    const effField = (key: string): unknown =>
+      clearSet.has(key) ? undefined : ((setObj as Record<string, unknown>)[key] ?? (doc as Record<string, unknown>)[key]);
+    const effType = effField("type");
+    const effModelId = effField("modelId") as string | undefined;
+    const newQty = clearSet.has("quantity") ? currentQty : ((setObj.quantity as number | undefined) ?? currentQty);
+    // Gate is `newQty > currentQty` (NOT `!sameModel || ...`) to stay BYTE-parity with
+    // updateLineItem (src/server/line-items.ts:565-573), which ALSO skips enforcement when
+    // the new qty isn't an increase — even on a model change. Over-enforcing here would
+    // throw where the service-token server path does not, breaking the legit path. (A model
+    // change with a lower qty escaping the check is a pre-existing server gap, out of scope
+    // for a parity port.)
+    if (
+      effType === "EQUIPMENT" &&
+      effModelId &&
+      doc.subHireId == null && // subHireId is immutable-on-patch, so read from the doc
+      !allowOverbook &&
+      newQty > currentQty
+    ) {
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", doc.projectId)).unique();
+      const bundle = await loadModelAvailabilityBundle(ctx, effModelId, orgId);
+      if (bundle.model) {
+        const { available, booked, unavailable, totalStock } = computeModelAvailability(bundle, {
+          rentalStart: project?.rentalStartDate ?? null,
+          rentalEnd: project?.rentalEndDate ?? null,
+          excludeProjectId: doc.projectId,
+        });
+        // If the model is UNCHANGED, this line's currentQty is already in `booked`, so
+        // compare the DELTA (== updateLineItem's exclude-this-line semantics). If the model
+        // CHANGED, the line is NOT in the new model's `booked`, so compare the full newQty.
+        const sameModel = doc.modelId != null && effModelId === doc.modelId;
+        const requested = sameModel ? newQty - currentQty : newQty;
+        if (requested > available) {
+          const detail = unavailable > 0
+            ? `${booked} booked, ${unavailable} unavailable, ${totalStock} total`
+            : `${booked} already booked out of ${totalStock} total`;
+          throw new ConvexError({
+            code: "INSUFFICIENT_STOCK",
+            message: `Only ${available} of ${requested} requested are free during those dates.`,
+            hint: `Stock: ${detail}. Reduce the quantity, change the dates, or add a sub-hire to cover the gap.`,
+          });
+        }
+      }
+    }
+
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, setObj);
     } else {
@@ -324,12 +381,13 @@ export const addNative = mutation({
       subhireOrderNumber: v.optional(v.string()),
     }),
     includeAccessories: v.boolean(),
+    allowOverbook: v.boolean(),
     orgDefaultTaxRate: v.union(v.number(), v.null()),
     actor: actorValidator,
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, fields, includeAccessories, allowOverbook, orgDefaultTaxRate, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
@@ -346,6 +404,79 @@ export const addNative = mutation({
     // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
     const dupLine = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (dupLine) throw new ConvexError("Line item already exists");
+
+    // Availability / double-booking enforcement, IN the mutation (parity with the
+    // server-action pre-check at src/server/line-items.ts). Runs in ADDITION to the
+    // service-authed server pre-check; it only throws in the same cases the server
+    // does, so it's non-breaking for the legit path and self-sufficient for a future
+    // browser-direct caller. Sub-hire items never consume our stock (excluded).
+    if (fields.type === "EQUIPMENT" && fields.modelId && !allowOverbook) {
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).unique();
+      const rentalStart = project?.rentalStartDate ?? null;
+      const rentalEnd = project?.rentalEndDate ?? null;
+      const hasDates = rentalStart != null && rentalEnd != null;
+
+      if (fields.assetId) {
+        // (a) Kit membership — a kit asset must be booked via the kit workflow.
+        const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", fields.assetId!)).unique();
+        if (asset && asset.organizationId === organizationId && asset.kitId) {
+          const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", asset.kitId!)).unique();
+          const kitTag = kit && kit.organizationId === organizationId ? kit.assetTag : asset.kitId;
+          throw new ConvexError({
+            code: "ASSET_IN_KIT",
+            title: "Asset is in a kit",
+            message: `This asset belongs to Kit ${kitTag}.`,
+            hint: "Add the Kit to the project instead, or remove the asset from the Kit first.",
+          });
+        }
+        // (b) Dated double-booking across overlapping projects (legacy line OR unit).
+        if (hasDates) {
+          const conflict = await findAssetConflict(ctx, {
+            assetId: fields.assetId,
+            orgId: organizationId,
+            excludeProjectId: projectId,
+            rentalStart,
+            rentalEnd,
+          });
+          if (conflict) {
+            throw new ConvexError({
+              code: "ASSET_DOUBLE_BOOKED",
+              message: `This asset is booked on ${conflict.projectNumber} — ${conflict.name} during those dates.`,
+            });
+          }
+        }
+        // (c) Permanently unavailable (retired / lost).
+        if (asset && asset.organizationId === organizationId && (asset.status === "RETIRED" || asset.status === "LOST")) {
+          throw new ConvexError({
+            code: "ASSET_UNAVAILABLE",
+            message: `This asset is marked ${asset.status.replace("_", " ").toLowerCase()}.`,
+            hint: asset.status === "LOST"
+              ? "Find the asset and mark it Available, or pick a different one."
+              : "Retired assets cannot be booked. Pick a different asset.",
+          });
+        }
+      } else {
+        // Model-level — enforce quantity against effective stock.
+        const bundle = await loadModelAvailabilityBundle(ctx, fields.modelId, organizationId);
+        if (bundle.model) {
+          const { available, booked, unavailable, totalStock } = computeModelAvailability(bundle, {
+            rentalStart,
+            rentalEnd,
+            excludeProjectId: projectId,
+          });
+          if (fields.quantity > available) {
+            const detail = unavailable > 0
+              ? `${booked} booked, ${unavailable} unavailable, ${totalStock} total`
+              : `${booked} already booked out of ${totalStock} total`;
+            throw new ConvexError({
+              code: "INSUFFICIENT_STOCK",
+              message: `Only ${available} of ${fields.quantity} requested are free during those dates.`,
+              hint: `Stock: ${detail}. Reduce the quantity, change the dates, or add a sub-hire to cover the gap.`,
+            });
+          }
+        }
+      }
+    }
 
     // Mirrors createLineItem exactly (sortOrder in-mutation, no TOCTOU; permanent
     // accessories expanded as child lines atomically via the shared helper).

--- a/convex/writeParity.test.ts
+++ b/convex/writeParity.test.ts
@@ -95,7 +95,7 @@ describe("write-parity: line-items", () => {
   test("addNative == createLineItem (same resulting parent line)", async () => {
     const t = makeT();
     await t.withIdentity(SERVICE).mutation(api.projectLineItems.createLineItem, { id: "svc", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, now: NOW });
-    await t.withIdentity(SERVICE).mutation(api.lineItemWrites.addNative, { id: "nat", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW });
+    await t.withIdentity(SERVICE).mutation(api.lineItemWrites.addNative, { id: "nat", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, allowOverbook: true, orgDefaultTaxRate: null, actor: ACTOR, auditId: "log1", now: NOW });
     const svc = normalize(await readByCuid(t, "projectLineItems", "svc"));
     const nat = normalize(await readByCuid(t, "projectLineItems", "nat"));
     // sortOrder differs (svc got 0, nat got 1) — normalize it.

--- a/docs/phase3-data-layer-deletion-map.md
+++ b/docs/phase3-data-layer-deletion-map.md
@@ -72,7 +72,16 @@ mints cuids inline — Convex mutations tolerate `createId()`) is shared by mode
 - `crew-assignments.ts` (author rate cascade + CONFIRMED stamp + shift-generation mutations), ~~`crew-availability.ts`~~ **DONE (#529)** — memberAvailability/conflicts/plannerData reads + add/remove writes, `crew-time.ts` (calculateTotalHours + EXPORTED-lock + status machines; bulk submit/approve near-done; keep exportTimesheetCSV), ~~`crew-dashboard.ts`~~ **DONE (#531)** — 6 composite reads → convex/crewDashboard.ts
 
 ### Wave 5 — project keystone + money (LAST, hardest)
-- Foundation: native `recalculateProjectTotals` (keystone #1) FIRST
+> **★ 2026-07-16 — SCOPING/PARITY AUDIT DONE.** Full gap map:
+> `docs/audits/2026-07-16-money-keystone-parity-gap-map.md`. Key facts: native recalc
+> (`convex/lib/recalc.ts`) + prod money flags are ALREADY live (math de-risked; keystone #1
+> below is DONE). `lineItemWrites`/`projectWrites` `*Native` mutations exist but were built
+> early presupposing the server action — need MF-1 (in-mutation availability/double-booking)
+> + MF-2/3/4 hardening before browser-direct. The other 8 domains have ONLY `requireService`
+> CRUD mirrors → each needs a `*Writes.ts` authored to the `projectManagersWrites.ts` bar.
+> **PR #551 (MERGED)** = slice 1a defensive hardening (finite guards + patch structural-strip
+> + project money-anchor strip; `convex/lib/moneyGuards.ts`). NEXT: line-items keystone MF-1.
+- Foundation: native `recalculateProjectTotals` (keystone #1) FIRST — **DONE** (`convex/lib/recalc.ts` + `lineItemWrites.recalcNative`, prod flag `NATIVE_RECALC=true`)
 - ~~`project-managers.ts`~~ **DONE (#520)** — deleted; getProjectManagers was DEAD (panel reads managers from the project-detail composite); 3 writes → `convex/projectManagersWrites.ts` add/remove/setNative. ★ The Better Auth seam is ELIMINATED — member validation (`members` by_org_user) + user-label audit (`users` mirror name||email||id) run inside the mutation via the existing Convex mirrors, no Prisma. RBAC project:manage = owner-only via the shared permissionsCore wildcard (exact parity). / ~~`project-tasks.ts`~~ **DONE (#522)** — deleted; getMyOpenTasks/reorder dead; 2 composite reads (assignees + listByProjectWithRelations, users/crew mirrors, assigneeUser membership-gated) + 5 writes (create/update/delete/bulkUpdate/bulkDelete, project:update), `project-media.ts` (ownership guard), `project-costs` done W1
 - `project-groups.ts`, `project-categories.ts` (cascade null-out + suggested-price math → mutations), `group-templates.ts` (applyGroupTemplate orchestration)
 - `line-items.ts` (THE keystone — availability/double-booking + merge-dedup + auto-pricing + stale-guard into mutations; batch writes need flags/native)

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -65,6 +65,10 @@ const ASSET_WRITE_ERROR_MAP: Record<
     hint: "Archive it instead so the history stays intact.",
   },
   ASSET_IN_KIT: {
+    // Shared code across the asset-DELETE path (convex/assetWrites.ts) and the line-item
+    // ADD path (convex/lineItemWrites.ts addNative). These are the DELETE-context static
+    // fallbacks; the add path passes its own dynamic title/message/hint (all three are
+    // preferred over these statics — see mapAssetWriteError), so neither context regresses.
     title: "Cannot delete",
     message: "This asset is part of a kit.",
     hint: "Remove it from the kit first, then delete.",
@@ -94,6 +98,24 @@ const ASSET_WRITE_ERROR_MAP: Record<
     message: "This item is an accessory of another asset.",
     hint: "Remove the parent asset's line to remove it, or detach the accessory from the asset in the catalog.",
   },
+  // Line-item availability guards (mirror src/server/line-items.ts). All carry a
+  // dynamic message (and ASSET_UNAVAILABLE / INSUFFICIENT_STOCK a dynamic hint) from
+  // the mutation; these are the static fallbacks / titles.
+  INSUFFICIENT_STOCK: {
+    title: "Not enough available",
+    message: "Not enough stock is free during those dates.",
+    hint: "Reduce the quantity, change the dates, or add a sub-hire to cover the gap.",
+  },
+  ASSET_DOUBLE_BOOKED: {
+    title: "Asset already booked",
+    message: "This asset is already booked during those dates.",
+    hint: "Pick a different asset, adjust the rental dates, or remove it from the other project.",
+  },
+  ASSET_UNAVAILABLE: {
+    title: "Asset cannot be added",
+    message: "This asset is unavailable.",
+    hint: "Pick a different asset.",
+  },
 };
 
 export function mapAssetWriteError(e: unknown): unknown {
@@ -111,7 +133,14 @@ export function mapAssetWriteError(e: unknown): unknown {
       // offending asset tag) over the static fallback.
       const dyn = (e.data as { message?: unknown }).message;
       const message = typeof dyn === "string" && dyn ? dyn : mapped.message;
-      return new UserFacingError({ code, title: mapped.title, message, hint: mapped.hint });
+      // Prefer the mutation's own hint + title too (e.g. LOST vs RETIRED guidance, the
+      // stock-breakdown detail, or the add-vs-delete context of a shared code like
+      // ASSET_IN_KIT) over the static fallback — mirrors the message rule.
+      const dynHint = (e.data as { hint?: unknown }).hint;
+      const hint = typeof dynHint === "string" && dynHint ? dynHint : mapped.hint;
+      const dynTitle = (e.data as { title?: unknown }).title;
+      const title = typeof dynTitle === "string" && dynTitle ? dynTitle : mapped.title;
+      return new UserFacingError({ code, title, message, hint });
     }
   }
   return e;

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -315,6 +315,7 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
             set: mergeSet,
             clear: [],
             entityName: existing.description || "Line item",
+            allowOverbook,
             orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
             actor: { userId, userName },
             auditId: createId(),
@@ -429,19 +430,25 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
   };
   if (nativeLineItemWrites()) {
     // Native: atomic insert + accessory expansion (the shared expandAccessoryChildLines
-    // helper, same as createLineItem) + CREATE audit. The cross-project availability
-    // check above + the price computation stay server-side.
-    await convex.mutation(api.lineItemWrites.addNative, {
-      id: newLineId,
-      organizationId,
-      projectId,
-      fields: lineFields,
-      includeAccessories,
-      orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
-      actor: { userId, userName },
-      auditId: createId(),
-      now: Date.now(),
-    });
+    // helper, same as createLineItem) + CREATE audit. The server pre-check above already
+    // gated availability identically; the mutation re-checks belt-and-braces, so map any
+    // ConvexError back to the rich UserFacingError toast if it ever fires.
+    try {
+      await convex.mutation(api.lineItemWrites.addNative, {
+        id: newLineId,
+        organizationId,
+        projectId,
+        fields: lineFields,
+        includeAccessories,
+        allowOverbook,
+        orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
+        actor: { userId, userName },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
   } else {
     await convex.mutation(api.projectLineItems.createLineItem, {
       id: newLineId,
@@ -717,6 +724,7 @@ export async function updateLineItem(
         set,
         clear,
         entityName: parsed.description || "Line item",
+        allowOverbook,
         orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
         actor: { userId, userName },
         auditId: createId(),


### PR DESCRIPTION
## Summary
The **line-items availability keystone** (MF-1 from the money-keystone gap map). The native `addNative`/`patchNative` mutations presupposed the server action enforced availability; this ports that enforcement **into** the mutations, byte-parity with the server pre-check, so line-items can eventually go browser-direct and the latent public-mutation exposure is closed.

## New `convex/lib/availabilityCore.ts` (single source of truth)
- `resolveModelAssetType` + `computeStockBreakdown` copied **byte-for-byte** from `src/lib/overbooking-core.ts`, **pinned** against the originals by a cross-import equality test (Convex can't resolve `@/`; same pattern as `reservationConflicts.ts`).
- `loadModelAvailabilityBundle` — the `checkBundle` reads, backend-local + bounded (referenced-only projects), **org-filtered** assets/bulks (`by_modelId` is global).
- `computeModelAvailability` — pure; mirrors `line-items.ts:192-252` (== `checkAvailability`): dated `booked` spans overlapping live projects incl. this one, dateless = this project only; effectiveStock reduced by IN_MAINTENANCE/LOST/RETIRED; CANCELLED + sub-hire line exclusion; template + dead-status project exclusion.
- `findAssetConflict` — dated asset double-booking (legacy line OR live unit), bounded to the asset's referenced projects.

## Wiring (gated on `!allowOverbook`)
- **addNative** — asset path `ASSET_IN_KIT → ASSET_DOUBLE_BOOKED → ASSET_UNAVAILABLE` (exact server order, org-rechecked); model path `INSUFFICIENT_STOCK`.
- **patchNative** — qty-increase re-check; respects `clear[]` (clearing `modelId` skips, as the server does); **delta** when model unchanged (= `updateLineItem`'s exclude-this-line semantics), **full `newQty`** when the model changes. Gate stays `newQty > currentQty` for byte-parity with the server.
- `allowOverbook` threaded from the 3 server call sites; `addNative` call wrapped in `mapNativeWriteError`.

## Non-breaking / scope
The check runs **in addition** to the unchanged service-token server pre-check (does NOT wire browser-direct). So even a residual divergence can only surface as a spurious toast, never silent money corruption — and the tricky cases are tested. Merge-dedup + auto-pricing re-homing is the later browser-direct PR; `addKitNative` enforcement is PR 2.

## Testing
- `convex/availabilityCore.test.ts` — cross-import equality matrix (pins the stock-math duplication) + `computeModelAvailability` fixtures (dated/dateless, SERIALIZED/BULK, unavailable-asset reduction, exclusions).
- `convex/lineItemWrites.test.ts` — 12 enforcement cases: model/asset paths, `allowOverbook` bypass, boundary, model-change (full-qty), clear-`modelId` (skip), cross-org stock isolation.
- **Codex-reviewed**, 3 findings fixed (cross-tenant asset stock, patchNative model-change/clear delta, shared error-code title). tsc clean; full convex glob + `src/lib` green; deployed to prod (additive/inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)