### PR TITLE
harden(money): port kit availability/double-booking into addKitNative (MF-1 PR2)

### DIFF
--- a/convex/lib/availabilityCore.ts
+++ b/convex/lib/availabilityCore.ts
@@ -255,3 +255,59 @@ export async function findAssetConflict(
   const conflictProjId = lineConflict?.projectId ?? unitConflictProjId;
   return conflictProjId ? (projectMap.get(conflictProjId) ?? null) : null;
 }
+
+// ─── Dated kit double-booking (mirror of line-items.ts:823-860) ───────────────
+
+/**
+ * Dated-only kit double-booking. Returns the FIRST other-project doc the kit is booked
+ * on (a non-cancelled, non-child parent kit line) during `[rentalStart, rentalEnd]`, or
+ * null. Bounded to the kit's referenced projects (parity-equivalent to the server's
+ * whole-org conflictSet, which is only probed via `conflictSet.has(kitLine.projectId)`).
+ */
+export async function findKitConflict(
+  ctx: MutationCtx,
+  opts: {
+    kitId: string;
+    orgId: string;
+    excludeProjectId: string;
+    rentalStart: number;
+    rentalEnd: number;
+  },
+): Promise<Doc<"projects"> | null> {
+  const { kitId, orgId, excludeProjectId, rentalStart, rentalEnd } = opts;
+
+  const kitLinesRaw = await ctx.db
+    .query("projectLineItems")
+    .withIndex("by_kitId", (q) => q.eq("kitId", kitId))
+    .collect();
+  const kitLines = kitLinesRaw.filter(
+    (li) =>
+      li.organizationId === orgId &&
+      li.kitId === kitId &&
+      !li.isKitChild &&
+      li.status !== "CANCELLED",
+  );
+
+  const projectIds = [...new Set(kitLines.map((li) => li.projectId))];
+  const projectDocs = await Promise.all(
+    projectIds.map((pid) =>
+      ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique(),
+    ),
+  );
+  const projectMap = new Map<string, Doc<"projects">>();
+  const conflictSet = new Set<string>();
+  for (const p of projectDocs) {
+    if (!p || p.organizationId !== orgId) continue;
+    projectMap.set(p.id, p);
+    if (p.id === excludeProjectId) continue;
+    if (p.isTemplate) continue;
+    if (DEAD_PROJECT_STATUSES.includes(p.status ?? "")) continue;
+    if (p.rentalStartDate == null || p.rentalEndDate == null) continue;
+    if ((p.rentalStartDate as number) <= rentalEnd && (p.rentalEndDate as number) >= rentalStart) {
+      conflictSet.add(p.id);
+    }
+  }
+
+  const conflict = kitLines.find((li) => conflictSet.has(li.projectId));
+  return conflict ? (projectMap.get(conflict.projectId) ?? null) : null;
+}

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -458,6 +458,33 @@ describe("lineItemWrites.addKitNative", () => {
     await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs)).rejects.toThrow(/insufficient permissions/i);
   });
+
+  test("throws KIT_UNAVAILABLE when the kit is IN_MAINTENANCE (unconditional)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "IN_MAINTENANCE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs),
+    ).rejects.toThrow(/KIT-1 is in maintenance/i);
+  });
+
+  test("throws KIT_DOUBLE_BOOKED on a dated overlap with another project", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      // Target project (dated).
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, rentalStartDate: NOW, rentalEndDate: NOW + 86_400_000 });
+      // Another overlapping project already has the kit booked (parent line).
+      await ctx.db.insert("projects", { id: "p2", organizationId: ORG, projectNumber: "P2", name: "Other", status: "CONFIRMED", isTemplate: false, rentalStartDate: NOW, rentalEndDate: NOW + 86_400_000 });
+      await ctx.db.insert("projectLineItems", { id: "kl0", organizationId: ORG, projectId: "p2", kitId: "k1", type: "EQUIPMENT", status: "CONFIRMED", isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs),
+    ).rejects.toThrow(/KIT-1 is on P2/i);
+  });
 });
 
 describe("lineItemWrites.reorderNative", () => {

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -16,6 +16,7 @@ import {
   loadModelAvailabilityBundle,
   computeModelAvailability,
   findAssetConflict,
+  findKitConflict,
 } from "./lib/availabilityCore";
 
 /**
@@ -555,9 +556,50 @@ export const addKitNative = mutation({
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
+    // The client supplies projectId; verify it's the caller's org before reading it or
+    // sweeping its lines (by_cuid is global) — same guard addNative applies.
+    await assertProjectInOrg(ctx, projectId, organizationId);
+
     // Dup-guard the client-minted kit-line id (by_cuid is global + non-unique).
     const dupKit = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (dupKit) throw new ConvexError("Line item already exists");
+
+    // Kit availability enforcement (parity with addKitLineItem, src/server/line-items.ts:
+    // 811-860). UNCONDITIONAL — no allowOverbook for kits. (createKitLineItemCore re-reads
+    // + org-validates the kit; this pre-read is only for the guards.)
+    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).unique();
+    if (kit && kit.organizationId === organizationId) {
+      // (a) Block truly unavailable kits (allow checked-out — the date check handles those).
+      if (kit.status === "IN_MAINTENANCE" || kit.status === "INCOMPLETE") {
+        throw new ConvexError({
+          code: "KIT_UNAVAILABLE",
+          title: "Kit cannot be added",
+          message: `Kit ${kit.assetTag} is ${kit.status.replace("_", " ").toLowerCase()}.`,
+          hint: kit.status === "IN_MAINTENANCE"
+            ? "Wait for maintenance to finish, or pick a different kit."
+            : "Complete the kit's missing items before booking it.",
+        });
+      }
+      // (b) Dated double-booking on an overlapping project (parent kit line only).
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).unique();
+      if (project?.rentalStartDate != null && project?.rentalEndDate != null) {
+        const conflict = await findKitConflict(ctx, {
+          kitId,
+          orgId: organizationId,
+          excludeProjectId: projectId,
+          rentalStart: project.rentalStartDate,
+          rentalEnd: project.rentalEndDate,
+        });
+        if (conflict) {
+          throw new ConvexError({
+            code: "KIT_DOUBLE_BOOKED",
+            title: "Kit already booked",
+            message: `Kit ${kit.assetTag} is on ${conflict.projectNumber ?? conflict.id} — ${conflict.name ?? ""} during those dates.`,
+            hint: "Pick a different kit, adjust the rental dates, or remove it from the other project.",
+          });
+        }
+      }
+    }
 
     await createKitLineItemCore(ctx, {
       id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, now,

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -116,6 +116,16 @@ const ASSET_WRITE_ERROR_MAP: Record<
     message: "This asset is unavailable.",
     hint: "Pick a different asset.",
   },
+  KIT_UNAVAILABLE: {
+    title: "Kit cannot be added",
+    message: "This kit is unavailable.",
+    hint: "Pick a different kit.",
+  },
+  KIT_DOUBLE_BOOKED: {
+    title: "Kit already booked",
+    message: "This kit is already booked during those dates.",
+    hint: "Pick a different kit, adjust the rental dates, or remove it from the other project.",
+  },
 };
 
 export function mapAssetWriteError(e: unknown): unknown {

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -878,14 +878,19 @@ export async function addKitLineItem(
   };
   if (nativeLineItemWrites()) {
     // Native: parent + expanded member children (shared core) + CREATE audit atomic.
-    // The kit availability/double-booking check above stays server-side.
-    await kitConvex.mutation(api.lineItemWrites.addKitNative, {
-      ...kitLineArgs,
-      kitLabel: `${kit.assetTag} - ${kit.name}`,
-      orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
-      actor: { userId, userName },
-      auditId: createId(),
-    });
+    // The server pre-check above already gated kit availability identically; the mutation
+    // re-checks belt-and-braces, so map any ConvexError back to the rich toast.
+    try {
+      await kitConvex.mutation(api.lineItemWrites.addKitNative, {
+        ...kitLineArgs,
+        kitLabel: `${kit.assetTag} - ${kit.name}`,
+        orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
+        actor: { userId, userName },
+        auditId: createId(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
   } else {
     await kitConvex.mutation(api.projectLineItems.createKitLineItem, kitLineArgs);
   }


### PR DESCRIPTION
## Summary
Completes the line-items availability keystone (MF-1) for the **kit** path (follows #552 which did the model/asset paths). `addKitNative` presupposed the server action enforced kit availability; this ports it into the mutation, byte-parity with `addKitLineItem` (`src/server/line-items.ts:811-860`).

- **`convex/lib/availabilityCore.ts`** — new `findKitConflict`: dated kit double-booking, the server predicate (parent kit lines `kitId===kitId && !isKitChild && status!=="CANCELLED"` on overlapping non-template/non-dead projects excluding the target), bounded to the kit's referenced projects, org-filtered.
- **`convex/lineItemWrites.ts` addKitNative** — `assertProjectInOrg` up front (was missing — the project org-guard `addNative` already had); `KIT_UNAVAILABLE` on `IN_MAINTENANCE`/`INCOMPLETE` (**unconditional** — kits have no `allowOverbook`); dated `KIT_DOUBLE_BOOKED`.
- **`src/lib/native-writes.ts`** — `+KIT_UNAVAILABLE`/`KIT_DOUBLE_BOOKED` map entries (dynamic title/message/hint from the mutation win).
- **`src/server/line-items.ts`** — wrap the `addKitNative` call in `mapNativeWriteError`.

## Non-breaking / scope
Runs **in addition** to the unchanged server pre-check (not browser-direct). Codex-reviewed, 1 finding fixed (missing project org-check → `assertProjectInOrg`).

## Testing
+2 `addKitNative` cases (`KIT_UNAVAILABLE`, `KIT_DOUBLE_BOOKED`). tsc clean; `lineItemWrites` + `availabilityCore` green; deployed to prod (additive/inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)