### PR TITLE
refactor(warehouse-close): browser-direct Convex close-out writes, delete server action

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3832,6 +3832,46 @@ yet re-homed onto Convex queries. That residual orchestration must move into the
 before deletion is safe; `src/lib/*-read.ts` stays exempt. This is the remaining bulk of
 WS2 and is largely Phase-4-adjacent mechanical work.
 
+## Phase 3 (WS2) — browser-direct, `warehouseClose` domain (2026-07-16)
+
+Migrated the warehouse close-out WRITES off the server actions onto the
+browser-direct native surface (following the just-merged `projectCategoriesWrites` /
+`projectManagersWrites` pattern). This deletes `src/server/warehouse-close.ts`.
+
+- **`convex/warehouseCloseWrites.ts` — 2 public mutations, `warehouse:close`-gated.**
+  Both run the standard 4-guard prologue (`assertWritesEnabled("warehouseClose")` →
+  `enforceBrowserWriteLimit` → `requireOrgPermission(orgId,"warehouse","close")` →
+  `resolveActor`). A shared `closeOutCore` helper is the byte-parity port of the old
+  `closeOutProject` body (project-in-org + non-template check → top-level EQUIPMENT
+  line tally → pending-items guard → **folded-in** `closeOutIfNotClosed` uniqueness
+  check on `by_projectId_organizationId` → insert → per-project `UPDATE` audit). The
+  three old Convex/Postgres round-trips (listByProject → closeOutIfNotClosed → Postgres
+  logActivity) collapse into ONE atomic mutation.
+  - `closeOutNative` — single close; client mints the `warehouseClose` cuid + `auditId`
+    and passes `closedById` (session user). Returns `{id, storedCount, damagedCount, lostCount}`.
+  - `batchCloseOutNative` — partial-success loop over `closeOutCore` (per-project
+    ConvexError captured as a `{projectId, projectName, success, error}` row, never
+    aborts the batch). Client mints a `{id, auditId}` per item + one `batchAuditId`;
+    the single batch-summary audit is written only when ≥1 project closes. `empty`/`>25`
+    guards preserved. `convex/warehouseCloseWrites.test.ts` (11 tests: tally + audit,
+    pending guard, already-closed, template/other-org reject, viewer denied, batch
+    partial-success + batch-audit-once + empty/>25).
+- **`src/hooks/use-warehouse-close-writes.ts`** — `useWarehouseCloseWrites()` exposes
+  `closeOut(projectId)` + `batchCloseOut(projectIds)`; actor from `useSession`, orgId
+  from `useActiveOrganization`, all cuids/`now` minted client-side. Wired into
+  `close-out-tab.tsx` (`closeMutation`) and `warehouse/page.tsx` (`batchCloseMutation`).
+- **The `getCloseOutSummary` READ stays a server action**, relocated verbatim to
+  `src/server/warehouse-close-read.ts` (so the old writes file could be deleted). It
+  composes Convex line-item/model/asset reads PLUS a Prisma `user` lookup for the
+  closer's display name (auth stays on Postgres), so it cannot be a pure native query
+  today. A future full-native re-home is possible (the `users` mirror carries name/email)
+  but the model-name + asset-tag composition makes it non-trivial — out of scope here.
+- **Untouched (parity infra):** the `requireService` CRUD + `closeOutIfNotClosed` in
+  `convex/warehouseCloses.ts` (no longer called from `src/` but left for backfill /
+  project-delete cascade / regeneration parity). `warehouseCloseSchema` /
+  `WarehouseCloseFormValues` in `validations/check-item.ts` are now unused by app code
+  (only their own unit test references them); left in place.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -178,6 +178,7 @@ import type * as testTagAuditorTokens from "../testTagAuditorTokens.js";
 import type * as testTagRecords from "../testTagRecords.js";
 import type * as userNotificationPreferences from "../userNotificationPreferences.js";
 import type * as users from "../users.js";
+import type * as warehouseCloseWrites from "../warehouseCloseWrites.js";
 import type * as warehouseCloses from "../warehouseCloses.js";
 import type * as warehouseDashboardTokens from "../warehouseDashboardTokens.js";
 import type * as warehouseDetail from "../warehouseDetail.js";
@@ -366,6 +367,7 @@ declare const fullApi: ApiFromModules<{
   testTagRecords: typeof testTagRecords;
   userNotificationPreferences: typeof userNotificationPreferences;
   users: typeof users;
+  warehouseCloseWrites: typeof warehouseCloseWrites;
   warehouseCloses: typeof warehouseCloses;
   warehouseDashboardTokens: typeof warehouseDashboardTokens;
   warehouseDetail: typeof warehouseDetail;

--- a/convex/warehouseCloseWrites.test.ts
+++ b/convex/warehouseCloseWrites.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment node
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+
+const modules = import.meta.glob("./**/*.ts");
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const ACTOR = { userId: USER, userName: "Alice" };
+
+async function member(t: ReturnType<typeof convexTest>, role: string) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role });
+  });
+}
+
+/** Seed a project + its top-level EQUIPMENT lines (returnCondition per line). */
+async function seedProject(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    projectId: string;
+    orgId?: string;
+    name?: string;
+    isTemplate?: boolean;
+    lines?: Array<{ status: string; returnCondition?: string; isKitChild?: boolean; type?: string }>;
+  },
+) {
+  const orgId = opts.orgId ?? ORG;
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", {
+      id: opts.projectId,
+      organizationId: orgId,
+      projectNumber: `PN-${opts.projectId}`,
+      name: opts.name ?? "Show",
+      isTemplate: opts.isTemplate ?? false,
+    });
+    let i = 0;
+    for (const li of opts.lines ?? []) {
+      await ctx.db.insert("projectLineItems", {
+        id: `${opts.projectId}_li_${i++}`,
+        organizationId: orgId,
+        projectId: opts.projectId,
+        type: li.type ?? "EQUIPMENT",
+        isKitChild: li.isKitChild ?? false,
+        status: li.status,
+        returnCondition: li.returnCondition,
+      });
+    }
+  });
+}
+
+describe("warehouseCloseWrites.closeOutNative", () => {
+  const args = {
+    id: "wc1",
+    orgId: ORG,
+    projectId: "p1",
+    now: NOW,
+    actor: ACTOR,
+    auditId: "log1",
+  };
+
+  test("member closes out — counts tally, warehouseClose row + UPDATE audit", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, {
+      projectId: "p1",
+      name: "Gala",
+      lines: [
+        { status: "RETURNED", returnCondition: "GOOD" },
+        { status: "RETURNED" }, // no condition → stored
+        { status: "RETURNED", returnCondition: "DAMAGED" },
+        { status: "RETURNED", returnCondition: "MISSING" },
+        { status: "CANCELLED" }, // terminal, not returned → not counted
+        { status: "RETURNED", isKitChild: true, returnCondition: "DAMAGED" }, // kit child excluded
+      ],
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args);
+    expect(res).toEqual({ id: "wc1", storedCount: 2, damagedCount: 1, lostCount: 1 });
+    await t.run(async (ctx) => {
+      const wc = await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", "wc1")).first();
+      expect(wc?.projectId).toBe("p1");
+      expect(wc?.closedById).toBe(USER);
+      expect(wc?.closedAt).toBe(NOW);
+      expect(wc?.storedCount).toBe(2);
+      expect(wc?.damagedCount).toBe(1);
+      expect(wc?.lostCount).toBe(1);
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.action).toBe("UPDATE");
+      expect(log?.entityType).toBe("project");
+      expect(log?.entityId).toBe("p1");
+      expect(log?.summary).toBe('Closed out warehouse for "Gala" — 2 stored, 1 damaged, 1 lost');
+    });
+  });
+
+  test("pending (unreturned) items block the close", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, {
+      projectId: "p1",
+      lines: [{ status: "RETURNED", returnCondition: "GOOD" }, { status: "CHECKED_OUT" }],
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args),
+    ).rejects.toThrow(/Cannot close: 1 item still not returned/i);
+    await t.run(async (ctx) => {
+      const wc = await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", "wc1")).first();
+      expect(wc).toBeNull();
+    });
+  });
+
+  test("an already-closed project throws", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, { projectId: "p1", lines: [{ status: "RETURNED", returnCondition: "GOOD" }] });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("warehouseCloses", { id: "prior", organizationId: ORG, projectId: "p1", closedById: USER });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args),
+    ).rejects.toThrow(/already been closed out/i);
+  });
+
+  test("a template project is rejected", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, { projectId: "p1", isTemplate: true, lines: [] });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args),
+    ).rejects.toThrow(/Project not found/i);
+  });
+
+  test("a project in another org is rejected", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, { projectId: "p1", orgId: "org_other", lines: [] });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args),
+    ).rejects.toThrow(/Project not found/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t, { projectId: "p1", lines: [] });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, args),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("warehouseCloseWrites.batchCloseOutNative", () => {
+  const batchArgs = (items: Array<{ projectId: string; id: string; auditId: string }>) => ({
+    orgId: ORG,
+    items,
+    now: NOW,
+    actor: ACTOR,
+    batchAuditId: "batchlog",
+  });
+
+  test("partial success — one closes, one fails on pending; batch audit written once", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, { projectId: "pOk", name: "Alpha", lines: [{ status: "RETURNED", returnCondition: "GOOD" }] });
+    await seedProject(t, { projectId: "pBad", name: "Beta", lines: [{ status: "CHECKED_OUT" }] });
+
+    const res = await t.withIdentity(asUser(ORG)).mutation(
+      api.warehouseCloseWrites.batchCloseOutNative,
+      batchArgs([
+        { projectId: "pOk", id: "wcOk", auditId: "logOk" },
+        { projectId: "pBad", id: "wcBad", auditId: "logBad" },
+      ]),
+    );
+    expect(res).toHaveLength(2);
+    const ok = res.find((r) => r.projectId === "pOk");
+    const bad = res.find((r) => r.projectId === "pBad");
+    expect(ok).toMatchObject({ projectName: "Alpha", success: true });
+    expect(bad?.success).toBe(false);
+    expect(bad?.projectName).toBe("Beta");
+    expect(bad?.error).toMatch(/still not returned/i);
+
+    await t.run(async (ctx) => {
+      // The good project got a close row + its per-project audit; the bad one did not.
+      expect(await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", "wcOk")).first()).not.toBeNull();
+      expect(await ctx.db.query("warehouseCloses").withIndex("by_cuid", (q) => q.eq("id", "wcBad")).first()).toBeNull();
+      expect(await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "logOk")).first()).not.toBeNull();
+      expect(await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "logBad")).first()).toBeNull();
+      // One batch-summary audit (successCount=1 of 2).
+      const batchLog = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "batchlog")).first();
+      expect(batchLog?.summary).toBe("Batch closed 1 of 2 projects");
+      expect(batchLog?.entityName).toBe("Batch close-out");
+    });
+  });
+
+  test("no batch audit when nothing closes", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t, { projectId: "pBad", name: "Beta", lines: [{ status: "CHECKED_OUT" }] });
+    const res = await t.withIdentity(asUser(ORG)).mutation(
+      api.warehouseCloseWrites.batchCloseOutNative,
+      batchArgs([{ projectId: "pBad", id: "wcBad", auditId: "logBad" }]),
+    );
+    expect(res[0].success).toBe(false);
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "batchlog")).first()).toBeNull();
+    });
+  });
+
+  test("empty selection throws", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.batchCloseOutNative, batchArgs([])),
+    ).rejects.toThrow(/No projects selected/i);
+  });
+
+  test("more than 25 projects throws", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    const items = Array.from({ length: 26 }, (_, i) => ({
+      projectId: `p${i}`,
+      id: `wc${i}`,
+      auditId: `log${i}`,
+    }));
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.batchCloseOutNative, batchArgs(items)),
+    ).rejects.toThrow(/Maximum 25 projects/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(
+        api.warehouseCloseWrites.batchCloseOutNative,
+        batchArgs([{ projectId: "p1", id: "wc1", auditId: "log1" }]),
+      ),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/warehouseCloseWrites.ts
+++ b/convex/warehouseCloseWrites.ts
@@ -1,0 +1,265 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { writeActivityLog } from "./lib/audit";
+
+/**
+ * Native WAREHOUSE-CLOSE write mutations (Phase 3 browser-direct — replaces the
+ * closeOutProject/batchCloseOut server actions in src/server/warehouse-close.ts).
+ * Both gate on `warehouse:close` (exact parity with the deleted actions'
+ * requirePermission("warehouse", "close")).
+ *
+ * The old actions did three Convex round-trips (listByProject read → the
+ * closeOutIfNotClosed uniqueness-safe insert → a separate Postgres logActivity).
+ * The whole close-out — pending-items guard, return-condition tally, race-safe
+ * single insert, and audit — now runs as ONE atomic mutation (serializable OCC
+ * forces a concurrent close of the same project to observe the existing row,
+ * exactly the invariant the folded-in closeOutIfNotClosed enforced). Standard
+ * shape: 4 guards + resolveActor + per-row org re-check on every by_cuid /
+ * global-index fetch + atomic writeActivityLog.
+ *
+ * The `requireService` mirrors + closeOutIfNotClosed in warehouseCloses.ts are
+ * intentionally UNTOUCHED (backfill / project-delete cascade / parity infra).
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+/**
+ * The shared close-out core — the byte-parity port of closeOutProject's body,
+ * MINUS the 4 guards + resolveActor (which the public mutations run once each).
+ * closeOutNative wraps this once; batchCloseOutNative loops it (catching per-project
+ * ConvexErrors). It writes the per-project audit using the supplied `auditId`.
+ *
+ * Throws ConvexError on: project-not-found (missing / other-org / template),
+ * pending (unreturned) items, or an already-closed project. Returns the tally +
+ * the project name (for the batch result rows).
+ */
+async function closeOutCore(
+  ctx: MutationCtx,
+  args: {
+    id: string;
+    orgId: string;
+    projectId: string;
+    now: number;
+    actor: Actor;
+    auditId: string;
+  },
+): Promise<{ storedCount: number; damagedCount: number; lostCount: number; projectName: string }> {
+  // closedById is the VERIFIED actor (resolveActor overwrites a user token's userId with
+  // the unspoofable subject) — never a client arg. Parity with the deleted action's userId.
+  const { id, orgId, projectId, now, actor, auditId } = args;
+  const closedById = actor.userId;
+
+  // 1. Load the project (by_cuid is global — re-check org + reject templates).
+  const project = await ctx.db
+    .query("projects")
+    .withIndex("by_cuid", (q) => q.eq("id", projectId))
+    .first();
+  if (!project || project.organizationId !== orgId || project.isTemplate) {
+    throw new ConvexError("Project not found");
+  }
+
+  // 2. Top-level EQUIPMENT lines only (by_projectId is global — org-filter).
+  const lines = (
+    await ctx.db
+      .query("projectLineItems")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .collect()
+  ).filter(
+    (li) => li.organizationId === orgId && li.type === "EQUIPMENT" && li.isKitChild !== true,
+  );
+
+  // 3. Every line must be in a terminal state (returned / cancelled).
+  const pending = lines.filter(
+    (li) => li.status !== "RETURNED" && li.status !== "CANCELLED",
+  ).length;
+  if (pending > 0) {
+    throw new ConvexError(
+      `Cannot close: ${pending} item${pending === 1 ? "" : "s"} still not returned`,
+    );
+  }
+
+  // 4. Tally the return conditions of the RETURNED lines.
+  const returned = lines.filter((li) => li.status === "RETURNED");
+  const storedCount = returned.filter(
+    (li) => !li.returnCondition || li.returnCondition === "GOOD",
+  ).length;
+  const damagedCount = returned.filter((li) => li.returnCondition === "DAMAGED").length;
+  const lostCount = returned.filter((li) => li.returnCondition === "MISSING").length;
+
+  // 5. Race-safe single close-out (folds in closeOutIfNotClosed's uniqueness check).
+  const existing = await ctx.db
+    .query("warehouseCloses")
+    .withIndex("by_projectId_organizationId", (q) =>
+      q.eq("projectId", projectId).eq("organizationId", orgId),
+    )
+    .first();
+  if (existing) throw new ConvexError("Project has already been closed out");
+
+  await ctx.db.insert("warehouseCloses", {
+    id,
+    organizationId: orgId,
+    projectId,
+    closedById,
+    closedAt: now,
+    storedCount,
+    damagedCount,
+    lostCount,
+  });
+
+  // 6. Audit (parity: uppercase "UPDATE" action, same summary as the server action).
+  await writeActivityLog(ctx, {
+    id: auditId,
+    organizationId: orgId,
+    action: "UPDATE",
+    entityType: "project",
+    entityId: projectId,
+    projectId,
+    entityName: project.name,
+    userId: actor.userId,
+    userName: actor.userName,
+    summary: `Closed out warehouse for "${project.name}" — ${storedCount} stored, ${damagedCount} damaged, ${lostCount} lost`,
+    createdAt: now,
+  });
+
+  return { storedCount, damagedCount, lostCount, projectName: project.name };
+}
+
+/** Extract a ConvexError's user-facing message for the batch result rows. */
+function errorMessage(e: unknown): string {
+  if (e instanceof ConvexError) {
+    return typeof e.data === "string" ? e.data : "Unknown error";
+  }
+  return e instanceof Error ? e.message : "Unknown error";
+}
+
+/**
+ * Close out a single project. The client mints the warehouseClose cuid (`id`) +
+ * `auditId` and passes `closedById` (the session user). Returns the tally so the
+ * caller can surface the stored/damaged/lost counts.
+ */
+export const closeOutNative = mutation({
+  returns: v.object({
+    id: v.string(),
+    storedCount: v.number(),
+    damagedCount: v.number(),
+    lostCount: v.number(),
+  }),
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    projectId: v.string(),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, { id, orgId, projectId, now, actor: suppliedActor, auditId }) => {
+    await assertWritesEnabled(ctx, "warehouseClose");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "warehouse", "close");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    const { storedCount, damagedCount, lostCount } = await closeOutCore(ctx, {
+      id,
+      orgId,
+      projectId,
+      now,
+      actor,
+      auditId,
+    });
+    return { id, storedCount, damagedCount, lostCount };
+  },
+});
+
+/**
+ * Batch close-out (the warehouse landing "close out N returned projects" bar).
+ * Partial-success: each project runs the SAME closeOutCore; a per-project failure
+ * (pending items / already closed / not found) is captured as a result row rather
+ * than aborting the batch. The client mints a {id, auditId} per item + one
+ * batchAuditId. A single batch-summary audit is written only when ≥1 project closes
+ * (parity with the server action, which also emitted the per-project audits via
+ * each closeOutCore call).
+ */
+export const batchCloseOutNative = mutation({
+  returns: v.array(
+    v.object({
+      projectId: v.string(),
+      projectName: v.string(),
+      success: v.boolean(),
+      error: v.optional(v.string()),
+    }),
+  ),
+  args: {
+    orgId: v.string(),
+    items: v.array(v.object({ projectId: v.string(), id: v.string(), auditId: v.string() })),
+    now: v.number(),
+    actor: actorValidator,
+    batchAuditId: v.string(),
+  },
+  handler: async (ctx, { orgId, items, now, actor: suppliedActor, batchAuditId }) => {
+    await assertWritesEnabled(ctx, "warehouseClose");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "warehouse", "close");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    if (items.length === 0) throw new ConvexError("No projects selected");
+    if (items.length > 25) throw new ConvexError("Maximum 25 projects per batch close-out");
+
+    const results: Array<{
+      projectId: string;
+      projectName: string;
+      success: boolean;
+      error?: string;
+    }> = [];
+
+    for (const item of items) {
+      // Resolve a display name up front (parity with the server's getProjectById
+      // fallback) — closeOutCore may throw before we'd otherwise learn it.
+      const project = await ctx.db
+        .query("projects")
+        .withIndex("by_cuid", (q) => q.eq("id", item.projectId))
+        .first();
+      const projectName =
+        project && project.organizationId === orgId ? project.name : item.projectId;
+      try {
+        const core = await closeOutCore(ctx, {
+          id: item.id,
+          orgId,
+          projectId: item.projectId,
+          now,
+          actor,
+          auditId: item.auditId,
+        });
+        results.push({ projectId: item.projectId, projectName: core.projectName, success: true });
+      } catch (e) {
+        results.push({
+          projectId: item.projectId,
+          projectName,
+          success: false,
+          error: errorMessage(e),
+        });
+      }
+    }
+
+    const successCount = results.filter((r) => r.success).length;
+    if (successCount > 0) {
+      await writeActivityLog(ctx, {
+        id: batchAuditId,
+        organizationId: orgId,
+        action: "UPDATE",
+        entityType: "project",
+        entityId: items[0].projectId,
+        entityName: "Batch close-out",
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Batch closed ${successCount} of ${items.length} projects`,
+        createdAt: now,
+      });
+    }
+
+    return results;
+  },
+});

--- a/src/app/(app)/warehouse/page.tsx
+++ b/src/app/(app)/warehouse/page.tsx
@@ -21,7 +21,7 @@ import { toast } from "sonner";
 import { format } from "date-fns";
 
 import { updateProjectStatus } from "@/server/projects";
-import { batchCloseOut } from "@/server/warehouse-close";
+import { useWarehouseCloseWrites } from "@/hooks/use-warehouse-close-writes";
 import { AssetTagInput } from "@/components/ui/asset-tag-input";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { Button } from "@/components/ui/button";
@@ -242,6 +242,7 @@ export default function WarehousePage() {
   const [selectedForClose, setSelectedForClose] = useState<Set<string>>(new Set());
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const { batchCloseOut } = useWarehouseCloseWrites();
 
   // Native warehouse landing list (Phase 4 — the version-vector + getProjects
   // server-action path is retired). ONE warehouseList.bundle subscription returns

--- a/src/components/warehouse/close-out-tab.tsx
+++ b/src/components/warehouse/close-out-tab.tsx
@@ -12,7 +12,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { getCloseOutSummary, closeOutProject } from "@/server/warehouse-close";
+import { getCloseOutSummary } from "@/server/warehouse-close-read";
+import { useWarehouseCloseWrites } from "@/hooks/use-warehouse-close-writes";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useCanDo } from "@/lib/use-permissions";
 
@@ -57,6 +58,7 @@ export function CloseOutTab({
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
   const canClose = useCanDo("warehouse", "close");
+  const { closeOut } = useWarehouseCloseWrites();
 
   const [confirmStep, setConfirmStep] = useState(0); // 0 = none, 1 = first click, 2 = confirmed
 
@@ -79,7 +81,7 @@ export function CloseOutTab({
   }, [closeFp, refetch]);
 
   const closeMutation = useServerMutation({
-    mutationFn: () => closeOutProject({ projectId }),
+    mutationFn: () => closeOut(projectId),
     onSuccess: () => {
       toast.success("Project closed out successfully");
       refetch();

--- a/src/hooks/use-warehouse-close-writes.ts
+++ b/src/hooks/use-warehouse-close-writes.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { createId } from "@paralleldrive/cuid2";
+import { useSession, useActiveOrganization } from "@/lib/auth-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Browser-direct WAREHOUSE-CLOSE writes (Phase 3 — replaces the closeOutProject/
+ * batchCloseOut server actions in src/server/warehouse-close.ts). The pending-items
+ * guard, return-condition tally, race-safe insert, and audit now run inside the
+ * guarded `api.warehouseCloseWrites.*` mutations. The warehouseCloses table is a
+ * reactive native subscription (close-out-tab already subscribes), so a close is
+ * reflected live with no server-action refetch.
+ *
+ * The client mints every cuid: the warehouseClose `id` + the audit `id`(s) (Convex
+ * mutations can't mint a cuid deterministically). For a batch, each item carries its
+ * own {id, auditId}, plus one batchAuditId for the batch-summary audit row.
+ */
+export type BatchCloseResult = {
+  projectId: string;
+  projectName: string;
+  success: boolean;
+  error?: string;
+};
+
+export function useWarehouseCloseWrites() {
+  const { data: session } = useSession();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const closeM = useMutation(api.warehouseCloseWrites.closeOutNative);
+  const batchM = useMutation(api.warehouseCloseWrites.batchCloseOutNative);
+
+  const actor = () => ({
+    userId: session?.user.id ?? "",
+    userName: session?.user.name ?? "",
+  });
+  const requireOrg = (): string => {
+    if (!orgId) throw new Error("No active organization");
+    return orgId;
+  };
+
+  return {
+    closeOut: async (
+      projectId: string,
+    ): Promise<{ storedCount: number; damagedCount: number; lostCount: number }> => {
+      const res = await closeM({
+        id: createId(),
+        orgId: requireOrg(),
+        projectId,
+        now: Date.now(),
+        actor: actor(),
+        auditId: createId(),
+      });
+      return {
+        storedCount: res.storedCount,
+        damagedCount: res.damagedCount,
+        lostCount: res.lostCount,
+      };
+    },
+    batchCloseOut: async (projectIds: string[]): Promise<BatchCloseResult[]> => {
+      return await batchM({
+        orgId: requireOrg(),
+        items: projectIds.map((projectId) => ({
+          projectId,
+          id: createId(),
+          auditId: createId(),
+        })),
+        now: Date.now(),
+        actor: actor(),
+        batchAuditId: createId(),
+      });
+    },
+  };
+}

--- a/src/server/warehouse-close-read.ts
+++ b/src/server/warehouse-close-read.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
@@ -10,14 +9,19 @@ import { getProjectById } from "@/lib/projects-read";
 import { getWarehouseCloseByProject } from "@/lib/warehouse-close-read";
 import { getAssetsByOrg, getBulkAssetsByOrg } from "@/lib/assets-read";
 import { serialize } from "@/lib/serialize";
-import { logActivity } from "@/lib/activity-log";
-import {
-  warehouseCloseSchema,
-  type WarehouseCloseFormValues,
-} from "@/lib/validations/check-item";
 
-// ─── Close-Out Summary ──────────────────────────────────────────────────────
-
+/**
+ * Close-out summary READ (relocated out of the deleted src/server/warehouse-close.ts,
+ * whose closeOutProject/batchCloseOut writes are now browser-direct — see
+ * convex/warehouseCloseWrites.ts + src/hooks/use-warehouse-close-writes.ts).
+ *
+ * This stays a server action because it composes a Prisma read (the closer's display
+ * name from the kept Postgres `user` table — auth stays on Prisma) on top of the
+ * Convex line-item / model / asset / warehouse-close reads. A future full-native
+ * re-home is possible (the `users` mirror carries name/email, so the closer name
+ * could come from Convex), but the model-name + asset-tag composition makes a native
+ * composite non-trivial and is out of scope for the write migration.
+ */
 export async function getCloseOutSummary(projectId: string) {
   const { organizationId } = await requirePermission("warehouse", "close");
 
@@ -180,158 +184,4 @@ export async function getCloseOutSummary(projectId: string) {
       existingClose?.closedAt != null ? new Date(existingClose.closedAt) : null,
     closedBy: closedByName,
   });
-}
-
-// ─── Close Out Project ──────────────────────────────────────────────────────
-
-export async function closeOutProject(data: WarehouseCloseFormValues) {
-  const { organizationId, userId, userName } = await requirePermission(
-    "warehouse",
-    "close"
-  );
-  const parsed = warehouseCloseSchema.parse(data);
-
-  const project = await getProjectById(parsed.projectId);
-  if (!project || project.organizationId !== organizationId || project.isTemplate) {
-    throw new Error("Project not found");
-  }
-
-  // projectLineItem is Convex-only — read this project's lines once and apply
-  // the type/isKitChild/status where-filters in JS.
-  const convex = await getConvexClient();
-  const projectLines = (
-    await convex.query(api.projectLineItems.listByProject, {
-      projectId: parsed.projectId,
-      orgId: organizationId,
-    })
-  ).filter((li) => li.type === "EQUIPMENT" && li.isKitChild !== true);
-
-  // Verify all items are in a terminal state (returned)
-  const pendingItems = projectLines.filter(
-    (li) => li.status !== "RETURNED" && li.status !== "CANCELLED",
-  ).length;
-
-  if (pendingItems > 0) {
-    throw new Error(
-      `Cannot close: ${pendingItems} item${pendingItems === 1 ? "" : "s"} still not returned`
-    );
-  }
-
-  // Get counts for the close record
-  const lineItems = projectLines.filter((li) => li.status === "RETURNED");
-
-  const storedCount = lineItems.filter(
-    (i) => !i.returnCondition || i.returnCondition === "GOOD"
-  ).length;
-  const damagedCount = lineItems.filter(
-    (i) => i.returnCondition === "DAMAGED"
-  ).length;
-  const lostCount = lineItems.filter(
-    (i) => i.returnCondition === "MISSING"
-  ).length;
-
-  // warehouseCloses is Convex-only (Phase C). The [projectId, organizationId]
-  // uniqueness invariant the old Prisma unique constraint enforced now lives in
-  // the closeOutIfNotClosed mutation (race-safe via Convex serializable OCC).
-  const id = createId();
-  const closedAt = Date.now();
-  const { alreadyClosed } = await (await getConvexClient()).mutation(
-    api.warehouseCloses.closeOutIfNotClosed,
-    {
-      id,
-      organizationId,
-      projectId: parsed.projectId,
-      closedById: userId,
-      closedAt,
-      storedCount,
-      damagedCount,
-      lostCount,
-    },
-  );
-  if (alreadyClosed) {
-    throw new Error("Project has already been closed out");
-  }
-
-  const result = {
-    id,
-    organizationId,
-    projectId: parsed.projectId,
-    closedById: userId,
-    closedAt: new Date(closedAt),
-    storedCount,
-    damagedCount,
-    lostCount,
-    project: { name: project.name, projectNumber: project.projectNumber },
-    closedBy: { name: userName },
-  };
-
-  await logActivity({
-    organizationId,
-    userId,
-    userName,
-    action: "UPDATE",
-    entityType: "project",
-    entityId: parsed.projectId,
-    entityName: project.name,
-    summary: `Closed out warehouse for "${project.name}" — ${storedCount} stored, ${damagedCount} damaged, ${lostCount} lost`,
-    projectId: parsed.projectId,
-  });
-
-  return serialize(result);
-}
-
-// ─── Batch Close Out ────────────────────────────────────────────────────────
-
-export async function batchCloseOut(projectIds: string[]) {
-  const { organizationId, userId, userName } = await requirePermission(
-    "warehouse",
-    "close"
-  );
-
-  if (projectIds.length === 0) {
-    throw new Error("No projects selected");
-  }
-
-  if (projectIds.length > 25) {
-    throw new Error("Maximum 25 projects per batch close-out");
-  }
-
-  const results: Array<{
-    projectId: string;
-    projectName: string;
-    success: boolean;
-    error?: string;
-  }> = [];
-
-  for (const projectId of projectIds) {
-    const projectForName = await getProjectById(projectId);
-    const projectName = projectForName?.name || projectId;
-    try {
-      await closeOutProject({ projectId });
-      results.push({ projectId, projectName, success: true });
-    } catch (error) {
-      results.push({
-        projectId,
-        projectName,
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-    }
-  }
-
-  const successCount = results.filter((r) => r.success).length;
-  if (successCount > 0) {
-    await logActivity({
-      organizationId,
-      userId,
-      userName,
-      action: "UPDATE",
-      entityType: "project",
-      entityId: projectIds[0],
-      entityName: `Batch close-out`,
-      summary: `Batch closed ${successCount} of ${projectIds.length} projects`,
-    });
-  }
-
-  return serialize(results);
 }


### PR DESCRIPTION
## Summary
Second **Wave-5** domain converted browser-direct + server file deleted.

- **`convex/warehouseCloseWrites.ts`** — `closeOutNative` + `batchCloseOutNative` to the security bar. Shared `closeOutCore` = byte-parity port of `closeOutProject` (not-found/template guard, EQUIPMENT+!isKitChild filter, pending-items guard, stored/damaged/lost tally, folded-in `closeOutIfNotClosed` uniqueness via `by_projectId_organizationId`, atomic `UPDATE` audit). Batch is single-call **partial-success** (per-project try/catch; core throws before any write so a failure leaves no partial state and doesn't roll back siblings), with empty/>25 guards and one batch-summary audit when ≥1 closes.
- **`closedById` comes from the verified `actor.userId`**, never a client arg (codex caught the spoof; matches the deleted action).
- **Consumers** — `use-warehouse-close-writes.ts` hook; `close-out-tab.tsx` + `warehouse/page.tsx` rewired (batch mints per-item `{id, auditId}` + `batchAuditId`).
- **Read** — `getCloseOutSummary` is LIVE and composes a Prisma user-name lookup (auth stays Postgres) → relocated to a thin `src/server/warehouse-close-read.ts`; full native re-home noted out of scope.
- **Deleted** `src/server/warehouse-close.ts` (grep clean). `requireService` mirrors + `closeOutIfNotClosed` left untouched (backfill / project-delete cascade).

## Review
Codex-reviewed — core parity, batch Convex partial-success semantics, index existence, consumer wiring confirmed; 1 finding fixed (spoofable `closedById`). tsc clean; `warehouseCloseWrites.test.ts` (11) green; deployed additive/inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)