### PR TITLE
refactor(warehouse): browser-direct return/undeploy/container writes (PR-A of 3)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -189,6 +189,7 @@ import type * as warehouseDashboardTokens from "../warehouseDashboardTokens.js";
 import type * as warehouseDetail from "../warehouseDetail.js";
 import type * as warehouseList from "../warehouseList.js";
 import type * as warehouseOps from "../warehouseOps.js";
+import type * as warehouseWrites from "../warehouseWrites.js";
 import type * as webhooks from "../webhooks.js";
 import type * as wooCommerceActions from "../wooCommerceActions.js";
 import type * as wooCommerceIntegrations from "../wooCommerceIntegrations.js";
@@ -383,6 +384,7 @@ declare const fullApi: ApiFromModules<{
   warehouseDetail: typeof warehouseDetail;
   warehouseList: typeof warehouseList;
   warehouseOps: typeof warehouseOps;
+  warehouseWrites: typeof warehouseWrites;
   webhooks: typeof webhooks;
   wooCommerceActions: typeof wooCommerceActions;
   wooCommerceIntegrations: typeof wooCommerceIntegrations;

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -684,6 +684,16 @@ async function checkinKitCore(ctx: Ctx, a: KitCheckinArgs, kitLine: KitParentLin
     return [a.kitId, ...nestedKitIds];
 }
 
+/** Full check-in for one kit (parent-line lookup + default loc + core). Shared. */
+export async function checkinKitFull(ctx: Ctx, a: KitCheckinArgs): Promise<{ kitId: string; affectedKitIds: string[] }> {
+  const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
+  if (!kitLine) throw new ConvexError("Kit not found on this project");
+  const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
+  const defaultLoc = locs.find((l) => l.isDefault)?.id ?? null;
+  const affectedKitIds = await checkinKitCore(ctx, a, kitLine, defaultLoc);
+  return { kitId: a.kitId, affectedKitIds };
+}
+
 export const checkinKit = mutation({
   args: {
     organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(),
@@ -691,12 +701,7 @@ export const checkinKit = mutation({
   },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
-    if (!kitLine) throw new ConvexError("Kit not found on this project");
-    const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
-    const defaultLocationId = locs.find((l) => l.isDefault)?.id ?? null;
-    const affectedKitIds = await checkinKitCore(ctx, a, kitLine, defaultLocationId);
-    return { kitId: a.kitId, affectedKitIds };
+    return checkinKitFull(ctx, a);
   },
 });
 
@@ -710,6 +715,29 @@ export const checkinKit = mutation({
  * ONE transaction, so a genuine mid-execution failure (e.g. a missing bulk asset)
  * rolls the whole batch back (atomic) and the operator retries.
  */
+export type CheckinKitsBatchArgs = {
+  organizationId: string; projectId: string; userId: string;
+  items: Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }>;
+  now: number;
+};
+
+/** Core batch check-in (per-kit org/project re-check, default loc once). Shared. */
+export async function checkinKitsBatchCore(ctx: Ctx, a: CheckinKitsBatchArgs): Promise<KitBatchResult> {
+  const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
+  const defaultLoc = locs.find((l) => l.isDefault)?.id ?? null;
+  const succeeded: string[] = [];
+  const errors: { kitId: string; message: string }[] = [];
+  const affected = new Set<string>();
+  for (const item of a.items) {
+    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, item.kitId);
+    if (!kitLine) { errors.push({ kitId: item.kitId, message: "Kit not found on this project" }); continue; }
+    const aff = await checkinKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId: item.kitId, returnCondition: item.returnCondition, now: a.now }, kitLine, defaultLoc);
+    succeeded.push(item.kitId);
+    for (const k of aff) affected.add(k);
+  }
+  return { succeeded, errors, affectedKitIds: [...affected] };
+}
+
 export const checkinKitsBatch = mutation({
   args: {
     organizationId: v.string(), projectId: v.string(), userId: v.string(),
@@ -718,21 +746,53 @@ export const checkinKitsBatch = mutation({
   },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
-    const defaultLocationId = locs.find((l) => l.isDefault)?.id ?? null;
-    const succeeded: string[] = [];
-    const errors: { kitId: string; message: string }[] = [];
-    const affected = new Set<string>();
-    for (const item of a.items) {
-      const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, item.kitId);
-      if (!kitLine) { errors.push({ kitId: item.kitId, message: "Kit not found on this project" }); continue; }
-      const aff = await checkinKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId: item.kitId, returnCondition: item.returnCondition, now: a.now }, kitLine, defaultLocationId);
-      succeeded.push(item.kitId);
-      for (const k of aff) affected.add(k);
-    }
-    return { succeeded, errors, affectedKitIds: [...affected] };
+    return checkinKitsBatchCore(ctx, a);
   },
 });
+
+export type CheckinItemsArgs = {
+  organizationId: string;
+  projectId: string;
+  userId: string;
+  items: Array<{
+    lineItemId: string;
+    assetId?: string;
+    returnCondition: "GOOD" | "DAMAGED" | "MISSING";
+    quantity?: number;
+    notes?: string;
+  }>;
+  now: number;
+};
+
+/** Core check-in (unit returns, asset/bulk restores, scan logs, accessory cascade,
+ *  line rollups). Shared by the requireService mutation + the browser-direct write. */
+export async function checkinItemsCore(ctx: Ctx, a: CheckinItemsArgs): Promise<{ updatedLineIds: string[] }> {
+  // org default location to restore assets to
+  const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
+  const defaultLocationId = locs.find((l) => l.isDefault)?.id ?? null;
+
+  const updated = new Set<string>();
+  for (const item of a.items) {
+    const { unitsFlipped, assetsTouched } = await returnLineUnits(ctx, {
+      organizationId: a.organizationId, projectId: a.projectId, lineItemId: item.lineItemId, assetId: item.assetId,
+      returnCondition: item.returnCondition, quantity: item.quantity, notes: item.notes, userId: a.userId, defaultLocationId,
+    });
+    if (assetsTouched.length === 1) {
+      await scanLog(ctx, { organizationId: a.organizationId, assetId: assetsTouched[0], projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: item.notes ?? undefined });
+    } else if (unitsFlipped > 0 || assetsTouched.length > 0) {
+      await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: item.notes || `Returned ${unitsFlipped} unit(s)` });
+    }
+    await syncLineItemRollup(ctx, item.lineItemId);
+    if (unitsFlipped > 0) {
+      await checkinAccessoryChildren(ctx, {
+        organizationId: a.organizationId, projectId: a.projectId, parentLineItemId: item.lineItemId,
+        returnCondition: item.returnCondition ?? "GOOD", userId: a.userId, defaultLocationId, returnedAssetId: item.assetId ?? null,
+      });
+    }
+    updated.add(item.lineItemId);
+  }
+  return { updatedLineIds: [...updated] };
+}
 
 export const checkinItems = mutation({
   args: {
@@ -750,31 +810,7 @@ export const checkinItems = mutation({
   },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    // org default location to restore assets to
-    const locs = await ctx.db.query("locations").withIndex("by_organizationId", (q) => q.eq("organizationId", a.organizationId)).collect();
-    const defaultLocationId = locs.find((l) => l.isDefault)?.id ?? null;
-
-    const updated = new Set<string>();
-    for (const item of a.items) {
-      const { unitsFlipped, assetsTouched } = await returnLineUnits(ctx, {
-        organizationId: a.organizationId, projectId: a.projectId, lineItemId: item.lineItemId, assetId: item.assetId,
-        returnCondition: item.returnCondition, quantity: item.quantity, notes: item.notes, userId: a.userId, defaultLocationId,
-      });
-      if (assetsTouched.length === 1) {
-        await scanLog(ctx, { organizationId: a.organizationId, assetId: assetsTouched[0], projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: item.notes ?? undefined });
-      } else if (unitsFlipped > 0 || assetsTouched.length > 0) {
-        await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: item.notes || `Returned ${unitsFlipped} unit(s)` });
-      }
-      await syncLineItemRollup(ctx, item.lineItemId);
-      if (unitsFlipped > 0) {
-        await checkinAccessoryChildren(ctx, {
-          organizationId: a.organizationId, projectId: a.projectId, parentLineItemId: item.lineItemId,
-          returnCondition: item.returnCondition ?? "GOOD", userId: a.userId, defaultLocationId, returnedAssetId: item.assetId ?? null,
-        });
-      }
-      updated.add(item.lineItemId);
-    }
-    return { updatedLineIds: [...updated] };
+    return checkinItemsCore(ctx, a);
   },
 });
 
@@ -835,79 +871,104 @@ const reverseItemArg = v.object({ lineItemId: v.string(), assetId: v.optional(v.
 
 /** Deployed → Prepped: reverse checkoutItems. Units CHECKED_OUT → prepped,
  *  assets back to AVAILABLE at the default location. */
+export type ReverseItemsArgs = {
+  organizationId: string;
+  projectId: string;
+  userId: string;
+  items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>;
+  now: number;
+};
+
+/** Core Deployed → Prepped (reverse checkoutItems). Shared by requireService + browser. */
+export async function undeployItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<{ updatedLineIds: string[] }> {
+  const defLoc = await defaultLocationId(ctx, a.organizationId);
+  const updated = new Set<string>();
+  for (const item of a.items) {
+    const line = await lineByCuid(ctx, item.lineItemId);
+    if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
+    const { flipped } = await flipLineUnits(ctx, {
+      organizationId: a.organizationId, lineItemId: line.id, fromStatus: "CHECKED_OUT",
+      toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE",
+      locationId: defLoc, clearLoc: true, want: item.quantity, now: a.now,
+    });
+    const wholeLine = flipped === 0 && line.status === "CHECKED_OUT";
+    if (wholeLine) {
+      // Legacy unit-less line — set counters directly; a rollup would zero them.
+      await ctx.db.patch(line._id, { status: "CONFIRMED", prepStatus: "PACKED", checkedOutQuantity: 0, updatedAt: a.now });
+    }
+    await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "CHECKED_OUT", toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE", locationId: defLoc, clearLoc: true, now: a.now });
+    if (!wholeLine) await syncLineItemRollup(ctx, line.id);
+    await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Prepped (un-deploy)" });
+    updated.add(line.id);
+  }
+  return { updatedLineIds: [...updated] };
+}
+
 export const undeployItems = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), items: v.array(reverseItemArg), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const defLoc = await defaultLocationId(ctx, a.organizationId);
-    const updated = new Set<string>();
-    for (const item of a.items) {
-      const line = await lineByCuid(ctx, item.lineItemId);
-      if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
-      const { flipped } = await flipLineUnits(ctx, {
-        organizationId: a.organizationId, lineItemId: line.id, fromStatus: "CHECKED_OUT",
-        toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE",
-        locationId: defLoc, clearLoc: true, want: item.quantity, now: a.now,
-      });
-      const wholeLine = flipped === 0 && line.status === "CHECKED_OUT";
-      if (wholeLine) {
-        // Legacy unit-less line — set counters directly; a rollup would zero them.
-        await ctx.db.patch(line._id, { status: "CONFIRMED", prepStatus: "PACKED", checkedOutQuantity: 0, updatedAt: a.now });
-      }
-      await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "CHECKED_OUT", toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE", locationId: defLoc, clearLoc: true, now: a.now });
-      if (!wholeLine) await syncLineItemRollup(ctx, line.id);
-      await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Prepped (un-deploy)" });
-      updated.add(line.id);
-    }
-    return { updatedLineIds: [...updated] };
+    return undeployItemsCore(ctx, a);
   },
 });
 
 /** Returned → Deployed: reverse checkinItems. Units RETURNED → CHECKED_OUT,
  *  assets back out at the project location. */
+/** Core Returned → Deployed (reverse checkinItems). Shared by requireService + browser. */
+export async function unreturnItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<{ updatedLineIds: string[] }> {
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
+  const projLoc = project?.locationId ?? null;
+  const updated = new Set<string>();
+  for (const item of a.items) {
+    const line = await lineByCuid(ctx, item.lineItemId);
+    if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
+    const { flipped } = await flipLineUnits(ctx, {
+      organizationId: a.organizationId, lineItemId: line.id, fromStatus: "RETURNED",
+      toStatus: "CHECKED_OUT", resetReturnedQty: true, assetStatus: "CHECKED_OUT",
+      locationId: projLoc, clearLoc: false, want: item.quantity, now: a.now,
+    });
+    const wholeLine = flipped === 0 && line.status === "RETURNED";
+    if (wholeLine) {
+      // Legacy unit-less line — restore checked-out counters directly; a rollup
+      // would zero checkedOutQuantity (no units to recompute from).
+      await ctx.db.patch(line._id, { status: "CHECKED_OUT", returnedQuantity: 0, checkedOutQuantity: line.quantity ?? 0, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
+    }
+    await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "RETURNED", toStatus: "CHECKED_OUT", assetStatus: "CHECKED_OUT", locationId: projLoc, clearLoc: false, now: a.now });
+    if (!wholeLine) await syncLineItemRollup(ctx, line.id);
+    await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Deployed (un-return)" });
+    updated.add(line.id);
+  }
+  return { updatedLineIds: [...updated] };
+}
+
 export const unreturnItems = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), items: v.array(reverseItemArg), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
-    const projLoc = project?.locationId ?? null;
-    const updated = new Set<string>();
-    for (const item of a.items) {
-      const line = await lineByCuid(ctx, item.lineItemId);
-      if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
-      const { flipped } = await flipLineUnits(ctx, {
-        organizationId: a.organizationId, lineItemId: line.id, fromStatus: "RETURNED",
-        toStatus: "CHECKED_OUT", resetReturnedQty: true, assetStatus: "CHECKED_OUT",
-        locationId: projLoc, clearLoc: false, want: item.quantity, now: a.now,
-      });
-      const wholeLine = flipped === 0 && line.status === "RETURNED";
-      if (wholeLine) {
-        // Legacy unit-less line — restore checked-out counters directly; a rollup
-        // would zero checkedOutQuantity (no units to recompute from).
-        await ctx.db.patch(line._id, { status: "CHECKED_OUT", returnedQuantity: 0, checkedOutQuantity: line.quantity ?? 0, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
-      }
-      await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "RETURNED", toStatus: "CHECKED_OUT", assetStatus: "CHECKED_OUT", locationId: projLoc, clearLoc: false, now: a.now });
-      if (!wholeLine) await syncLineItemRollup(ctx, line.id);
-      await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Deployed (un-return)" });
-      updated.add(line.id);
-    }
-    return { updatedLineIds: [...updated] };
+    return unreturnItemsCore(ctx, a);
   },
 });
 
 /** De-prepped → Returned: re-pack a returned line (prepStatus back to PACKED).
  *  Status stays RETURNED; this only reverses the de-prep prepStatus reset. */
+export type UndeprepLineArgs = { organizationId: string; projectId: string; lineItemId: string; now: number };
+
+/** Core De-prepped → Returned (re-pack a returned line). Shared by requireService + browser. */
+export async function undeprepLineCore(ctx: Ctx, a: UndeprepLineArgs): Promise<{ id: string }> {
+  const line = await lineByCuid(ctx, a.lineItemId);
+  if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError("Line item not found in project");
+  await ctx.db.patch(line._id, { prepStatus: "PACKED", updatedAt: a.now });
+  for (const child of (await childLines(ctx, a.lineItemId, a.organizationId)).filter((c) => c.childKind === "ACCESSORY")) {
+    await ctx.db.patch(child._id, { prepStatus: "PACKED", updatedAt: a.now });
+  }
+  return { id: a.lineItemId };
+}
+
 export const undeprepLine = mutation({
   args: { organizationId: v.string(), projectId: v.string(), lineItemId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const line = await lineByCuid(ctx, a.lineItemId);
-    if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError("Line item not found in project");
-    await ctx.db.patch(line._id, { prepStatus: "PACKED", updatedAt: a.now });
-    for (const child of (await childLines(ctx, a.lineItemId, a.organizationId)).filter((c) => c.childKind === "ACCESSORY")) {
-      await ctx.db.patch(child._id, { prepStatus: "PACKED", updatedAt: a.now });
-    }
-    return { id: a.lineItemId };
+    return undeprepLineCore(ctx, a);
   },
 });
 
@@ -954,15 +1015,20 @@ async function undeployKitCore(ctx: Ctx, a: KitOpArgs, kitLine: KitParentLine, d
     return [a.kitId, ...nestedKitIds];
 }
 
+/** Full Deployed → Prepped for one kit (parent-line lookup + defLoc + core). Shared. */
+export async function undeployKitFull(ctx: Ctx, a: KitOpArgs): Promise<{ kitId: string; affectedKitIds: string[] }> {
+  const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
+  if (!kitLine) throw new ConvexError("Kit not found on this project");
+  const defLoc = await defaultLocationId(ctx, a.organizationId);
+  const affectedKitIds = await undeployKitCore(ctx, a, kitLine, defLoc);
+  return { kitId: a.kitId, affectedKitIds };
+}
+
 export const undeployKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
-    if (!kitLine) throw new ConvexError("Kit not found on this project");
-    const defLoc = await defaultLocationId(ctx, a.organizationId);
-    const affectedKitIds = await undeployKitCore(ctx, a, kitLine, defLoc);
-    return { kitId: a.kitId, affectedKitIds };
+    return undeployKitFull(ctx, a);
   },
 });
 
@@ -976,22 +1042,30 @@ export const undeployKit = mutation({
  * ONE transaction, so a genuine mid-execution failure would roll the whole batch back;
  * the client surfaces the error and the operator retries.) `defLoc` resolved once.
  */
+export type KitsBatchArgs = { organizationId: string; projectId: string; userId: string; kitIds: string[]; now: number };
+export type KitBatchResult = { succeeded: string[]; errors: { kitId: string; message: string }[]; affectedKitIds: string[] };
+
+/** Core batch Deployed → Prepped (per-kit org/project re-check, defLoc once). Shared. */
+export async function undeployKitsBatchCore(ctx: Ctx, a: KitsBatchArgs): Promise<KitBatchResult> {
+  const defLoc = await defaultLocationId(ctx, a.organizationId);
+  const succeeded: string[] = [];
+  const errors: { kitId: string; message: string }[] = [];
+  const affected = new Set<string>();
+  for (const kitId of a.kitIds) {
+    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
+    if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
+    const aff = await undeployKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, defLoc);
+    succeeded.push(kitId);
+    for (const k of aff) affected.add(k);
+  }
+  return { succeeded, errors, affectedKitIds: [...affected] };
+}
+
 export const undeployKitsBatch = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitIds: v.array(v.string()), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const defLoc = await defaultLocationId(ctx, a.organizationId);
-    const succeeded: string[] = [];
-    const errors: { kitId: string; message: string }[] = [];
-    const affected = new Set<string>();
-    for (const kitId of a.kitIds) {
-      const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
-      if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
-      const aff = await undeployKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, defLoc);
-      succeeded.push(kitId);
-      for (const k of aff) affected.add(k);
-    }
-    return { succeeded, errors, affectedKitIds: [...affected] };
+    return undeployKitsBatchCore(ctx, a);
   },
 });
 
@@ -1033,16 +1107,21 @@ async function unreturnKitCore(ctx: Ctx, a: KitOpArgs, kitLine: KitParentLine, p
     return [a.kitId, ...nestedKitIds];
 }
 
+/** Full Returned → Deployed for one kit (parent-line lookup + projLoc + core). Shared. */
+export async function unreturnKitFull(ctx: Ctx, a: KitOpArgs): Promise<{ kitId: string; affectedKitIds: string[] }> {
+  const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
+  if (!kitLine) throw new ConvexError("Kit not found on this project");
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
+  const projLoc = project?.locationId ?? null;
+  const affectedKitIds = await unreturnKitCore(ctx, a, kitLine, projLoc);
+  return { kitId: a.kitId, affectedKitIds };
+}
+
 export const unreturnKit = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, a.kitId);
-    if (!kitLine) throw new ConvexError("Kit not found on this project");
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
-    const projLoc = project?.locationId ?? null;
-    const affectedKitIds = await unreturnKitCore(ctx, a, kitLine, projLoc);
-    return { kitId: a.kitId, affectedKitIds };
+    return unreturnKitFull(ctx, a);
   },
 });
 
@@ -1056,23 +1135,28 @@ export const unreturnKit = mutation({
  * back (atomic) rather than leaving it half-applied. The client surfaces the error and
  * the operator retries. `projLoc` resolved once (all kits share the projectId).
  */
+/** Core batch Returned → Deployed (per-kit org/project re-check, projLoc once). Shared. */
+export async function unreturnKitsBatchCore(ctx: Ctx, a: KitsBatchArgs): Promise<KitBatchResult> {
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
+  const projLoc = project?.locationId ?? null;
+  const succeeded: string[] = [];
+  const errors: { kitId: string; message: string }[] = [];
+  const affected = new Set<string>();
+  for (const kitId of a.kitIds) {
+    const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
+    if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
+    const aff = await unreturnKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, projLoc);
+    succeeded.push(kitId);
+    for (const k of aff) affected.add(k);
+  }
+  return { succeeded, errors, affectedKitIds: [...affected] };
+}
+
 export const unreturnKitsBatch = mutation({
   args: { organizationId: v.string(), projectId: v.string(), userId: v.string(), kitIds: v.array(v.string()), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).unique();
-    const projLoc = project?.locationId ?? null;
-    const succeeded: string[] = [];
-    const errors: { kitId: string; message: string }[] = [];
-    const affected = new Set<string>();
-    for (const kitId of a.kitIds) {
-      const kitLine = await kitParentLine(ctx, a.projectId, a.organizationId, kitId);
-      if (!kitLine) { errors.push({ kitId, message: "Kit not found on this project" }); continue; }
-      const aff = await unreturnKitCore(ctx, { organizationId: a.organizationId, projectId: a.projectId, userId: a.userId, kitId, now: a.now }, kitLine, projLoc);
-      succeeded.push(kitId);
-      for (const k of aff) affected.add(k);
-    }
-    return { succeeded, errors, affectedKitIds: [...affected] };
+    return unreturnKitsBatchCore(ctx, a);
   },
 });
 
@@ -1262,64 +1346,52 @@ export const quickAdd = mutation({
   },
 });
 
+export type EnsureContainerArgs = { organizationId: string; projectId: string; assetId: string; modelId: string; containerName: string; now: number };
+
+/** Core check-then-create of a container line item (idempotent via the existing
+ *  (asset, project, isContainerLineItem) uniqueness check). Shared. */
+export async function ensureContainerOnProjectCore(ctx: Ctx, a: EnsureContainerArgs): Promise<{ id: string; created: boolean }> {
+  const existing = (await ctx.db.query("projectLineItems").withIndex("by_assetId", (q) => q.eq("assetId", a.assetId)).collect())
+    .find((l) => l.projectId === a.projectId && l.organizationId === a.organizationId && l.isContainerLineItem);
+  if (existing) return { id: existing.id, created: false };
+  const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
+    .filter((l) => l.organizationId === a.organizationId);
+  const sortOrder = lines.reduce((m, l) => Math.max(m, l.sortOrder ?? -1), -1) + 1;
+  const id = createId();
+  await ctx.db.insert("projectLineItems", {
+    id, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT", modelId: a.modelId, assetId: a.assetId,
+    quantity: 1, sortOrder, status: "CONFIRMED", checkedOutQuantity: 0, prepStatus: "PACKED", prepContainer: a.containerName,
+    isContainerLineItem: true, createdAt: a.now, updatedAt: a.now,
+  });
+  return { id, created: true };
+}
+
 export const ensureContainerOnProject = mutation({
   args: { organizationId: v.string(), projectId: v.string(), assetId: v.string(), modelId: v.string(), containerName: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const existing = (await ctx.db.query("projectLineItems").withIndex("by_assetId", (q) => q.eq("assetId", a.assetId)).collect())
-      .find((l) => l.projectId === a.projectId && l.organizationId === a.organizationId && l.isContainerLineItem);
-    if (existing) return { id: existing.id, created: false };
-    const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
-      .filter((l) => l.organizationId === a.organizationId);
-    const sortOrder = lines.reduce((m, l) => Math.max(m, l.sortOrder ?? -1), -1) + 1;
-    const id = createId();
-    await ctx.db.insert("projectLineItems", {
-      id, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT", modelId: a.modelId, assetId: a.assetId,
-      quantity: 1, sortOrder, status: "CONFIRMED", checkedOutQuantity: 0, prepStatus: "PACKED", prepContainer: a.containerName,
-      isContainerLineItem: true, createdAt: a.now, updatedAt: a.now,
-    });
-    return { id, created: true };
+    return ensureContainerOnProjectCore(ctx, a);
   },
 });
+
+export type ClearPrepContainerArgs = { organizationId: string; projectId: string; containerName: string; now: number };
+
+/** Core clear-prep-container (strip prepContainer off every line in the container). Shared. */
+export async function clearPrepContainerCore(ctx: Ctx, a: ClearPrepContainerArgs): Promise<{ success: true }> {
+  const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
+    .filter((l) => l.organizationId === a.organizationId && l.prepContainer === a.containerName);
+  for (const l of lines) {
+    const { _id, _creationTime, prepContainer: _p, ...rest } = l;
+    await ctx.db.replace(_id, { ...rest, updatedAt: a.now });
+  }
+  return { success: true };
+}
 
 export const clearPrepContainer = mutation({
   args: { organizationId: v.string(), projectId: v.string(), containerName: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
-      .filter((l) => l.organizationId === a.organizationId && l.prepContainer === a.containerName);
-    for (const l of lines) {
-      const { _id, _creationTime, prepContainer: _p, ...rest } = l;
-      await ctx.db.replace(_id, { ...rest, updatedAt: a.now });
-    }
-    return { success: true };
-  },
-});
-
-export const syncContainerStatus = mutation({
-  args: { organizationId: v.string(), projectId: v.string(), containerName: v.string(), userId: v.string(), now: v.number() },
-  handler: async (ctx, a) => {
-    await requireService(ctx);
-    const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
-      .filter((l) => l.organizationId === a.organizationId && l.prepContainer === a.containerName);
-    const containerLI = lines.find((l) => l.isContainerLineItem);
-    if (!containerLI) return { updated: false };
-    const contents = lines.filter((l) => !l.isContainerLineItem);
-    if (contents.length === 0) return { updated: false };
-    const allDeployed = contents.every((i) => i.status === "CHECKED_OUT");
-    const allReturned = contents.every((i) => i.status === "RETURNED");
-    const allDeployedFlag = allDeployed && containerLI.status !== "CHECKED_OUT";
-    const allReturnedFlag = allReturned && containerLI.status !== "RETURNED";
-    if (!allDeployedFlag && !allReturnedFlag) return { updated: false };
-    if (allDeployedFlag) {
-      await ctx.db.patch(containerLI._id, { status: "CHECKED_OUT", checkedOutQuantity: containerLI.quantity ?? 1, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
-    } else {
-      await ctx.db.patch(containerLI._id, { status: "RETURNED", returnedQuantity: 1, returnedAt: a.now, returnedById: a.userId, returnCondition: "GOOD", updatedAt: a.now });
-    }
-    if (containerLI.assetId) {
-      await setAssetsStatus(ctx, [containerLI.assetId], allDeployedFlag ? "CHECKED_OUT" : "AVAILABLE", null, false, a.now);
-    }
-    return { updated: true, status: allDeployedFlag ? "CHECKED_OUT" : "RETURNED" };
+    return clearPrepContainerCore(ctx, a);
   },
 });
 
@@ -1334,14 +1406,15 @@ export const syncContainerStatus = mutation({
  * its asset when all contents are uniformly deployed/returned). Org scoping is
  * inherent (by_projectId scan filtered to organizationId).
  */
-export const syncContainersBatch = mutation({
-  args: { organizationId: v.string(), projectId: v.string(), containerNames: v.array(v.string()), userId: v.string(), now: v.number() },
-  handler: async (ctx, a) => {
-    await requireService(ctx);
-    const allLines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
-      .filter((l) => l.organizationId === a.organizationId);
-    const results: Array<{ containerName: string; updated: boolean; status?: string }> = [];
-    for (const containerName of a.containerNames) {
+export type SyncContainersBatchArgs = { organizationId: string; projectId: string; containerNames: string[]; userId: string; now: number };
+
+/** Core batch container roll-up (read lines once, bucket by prepContainer, flip each
+ *  container line + asset when contents are uniformly deployed/returned). Shared. */
+export async function syncContainersBatchCore(ctx: Ctx, a: SyncContainersBatchArgs): Promise<{ results: Array<{ containerName: string; updated: boolean; status?: string }> }> {
+  const allLines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", a.projectId)).collect())
+    .filter((l) => l.organizationId === a.organizationId);
+  const results: Array<{ containerName: string; updated: boolean; status?: string }> = [];
+  for (const containerName of a.containerNames) {
       const lines = allLines.filter((l) => l.prepContainer === containerName);
       const containerLI = lines.find((l) => l.isContainerLineItem);
       if (!containerLI) { results.push({ containerName, updated: false }); continue; }
@@ -1363,6 +1436,13 @@ export const syncContainersBatch = mutation({
       results.push({ containerName, updated: true, status: allDeployedFlag ? "CHECKED_OUT" : "RETURNED" });
     }
     return { results };
+}
+
+export const syncContainersBatch = mutation({
+  args: { organizationId: v.string(), projectId: v.string(), containerNames: v.array(v.string()), userId: v.string(), now: v.number() },
+  handler: async (ctx, a) => {
+    await requireService(ctx);
+    return syncContainersBatchCore(ctx, a);
   },
 });
 

--- a/convex/warehouseWrites.test.ts
+++ b/convex/warehouseWrites.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment node
+//
+// Browser-direct WAREHOUSE writes (Phase 3 PR-A) — the return / undeploy / container
+// write family. Verifies for a representative subset (checkInItems, undeployKitsBatch,
+// checkInKit, ensureContainerOnProject, syncContainersBatch): success + state
+// transition + in-mutation audit; RBAC deny (viewer); cross-org FK rejection; batch
+// empty-guard + dedupe; and that a spoofed actor.userId is overridden by the verified
+// token subject. The requireService mirrors are covered by kitPerUnit / warehousePageBatch.
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_other";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+// A deliberately-wrong actor — resolveActor must pin attribution to the token subject.
+const SPOOF = { userId: "attacker_id", userName: "Mallory" };
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+type T = ReturnType<typeof makeT>;
+
+async function member(t: T, role: string, orgId = ORG) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: `m-${role}`, organizationId: orgId, userId: USER, role });
+  });
+}
+
+async function seedProject(t: T, id = "p1", orgId = ORG) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", {
+      id, organizationId: orgId, projectNumber: `P-${id}`, name: "Gig", status: "CONFIRMED",
+      defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1, total: 0,
+    });
+  });
+}
+
+const baseLine = (id: string, extra: Record<string, unknown>, orgId = ORG) => ({
+  id, organizationId: orgId, projectId: "p1", type: "EQUIPMENT" as const, quantity: 1, sortOrder: 0,
+  status: "CONFIRMED" as const, checkedOutQuantity: 0, prepStatus: "PENDING" as const,
+  isKitChild: false, createdAt: NOW, updatedAt: NOW, ...extra,
+});
+
+const lineById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique());
+const unitById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("projectLineItemUnits").withIndex("by_cuid", (q) => q.eq("id", id)).unique());
+const assetById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique());
+const kitById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique());
+const logById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", id)).first());
+
+async function seedModelAsset(t: T, orgId = ORG, status: "CHECKED_OUT" | "AVAILABLE" | "IN_MAINTENANCE" | "RETIRED" | "LOST" | "RESERVED" = "CHECKED_OUT") {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("models", { id: "m1", organizationId: orgId, name: "PAR", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("assets", { id: "a1", organizationId: orgId, modelId: "m1", assetTag: "A-1", status, condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+  });
+}
+
+// ─── checkInItems ─────────────────────────────────────────────────────────────
+describe("checkInItems", () => {
+  async function seed(t: T) {
+    await member(t, "member");
+    await seedProject(t);
+    await seedModelAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", baseLine("li1", { modelId: "m1", assetId: "a1", status: "CHECKED_OUT", checkedOutQuantity: 1 }));
+      await ctx.db.insert("projectLineItemUnits", { id: "u1", organizationId: ORG, lineItemId: "li1", ordinal: 0, assetId: "a1", quantity: 1, status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW });
+    });
+  }
+
+  test("returns a serialised unit (CHECKED_OUT → RETURNED) + asset AVAILABLE + audit", async () => {
+    const t = makeT();
+    await seed(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInItems, {
+      orgId: ORG, projectId: "p1",
+      items: [{ lineItemId: "li1", assetId: "a1", returnCondition: "GOOD" }],
+      auditIds: ["log1"], now: NOW, actor: SPOOF,
+    });
+    expect(res.updatedLineIds).toEqual(["li1"]);
+    expect((await unitById(t, "u1"))?.status).toBe("RETURNED");
+    expect((await assetById(t, "a1"))?.status).toBe("AVAILABLE");
+    const log = await logById(t, "log1");
+    expect(log?.action).toBe("CHECK_IN");
+    expect(log?.entityId).toBe("li1");
+    expect(log?.summary).toBe("Checked in item on project (condition: GOOD)");
+    // Spoofed actor.userId is overridden by the verified token subject everywhere.
+    expect(log?.userId).toBe(USER);
+    expect((await unitById(t, "u1"))?.returnedById).toBe(USER);
+  });
+
+  test("cross-org line item rejected", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t); // p1 in ORG
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { ...baseLine("liX", { modelId: "m1", status: "CHECKED_OUT" }, OTHER), projectId: "pX" });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInItems, {
+        orgId: ORG, projectId: "p1", items: [{ lineItemId: "liX", returnCondition: "GOOD" }], auditIds: ["log1"], now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/not found in project/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInItems, {
+        orgId: ORG, projectId: "p1", items: [{ lineItemId: "li1", returnCondition: "GOOD" }], auditIds: ["log1"], now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+// ─── undeployKitsBatch ──────────────────────────────────────────────────────────
+describe("undeployKitsBatch", () => {
+  async function seedKit(t: T) {
+    await member(t, "member");
+    await seedProject(t);
+    await seedModelAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Lighting", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", baseLine("kl1", { kitId: "k1", isKitChild: false, status: "CHECKED_OUT", checkedOutQuantity: 1 }));
+      await ctx.db.insert("projectLineItems", baseLine("c1", { parentLineItemId: "kl1", isKitChild: true, modelId: "m1", assetId: "a1", status: "CHECKED_OUT", checkedOutQuantity: 1 }));
+    });
+  }
+
+  test("moves eligible kit Deployed → Prepped; ghost kit → per-item error; audit + spoof override", async () => {
+    const t = makeT();
+    await seedKit(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.undeployKitsBatch, {
+      orgId: ORG, projectId: "p1", kitIds: ["k1", "ghost"], auditId: "log1", now: NOW, actor: SPOOF,
+    });
+    expect(res.succeeded).toEqual(["k1"]);
+    expect(res.errors.map((e) => e.kitId)).toEqual(["ghost"]);
+    expect((await lineById(t, "kl1"))?.status).toBe("CONFIRMED");
+    expect((await lineById(t, "kl1"))?.prepStatus).toBe("PACKED");
+    expect((await assetById(t, "a1"))?.status).toBe("AVAILABLE");
+    const log = await logById(t, "log1");
+    expect(log?.summary).toBe("Moved 1 kit(s) back to Prepped (un-deploy)");
+    expect(log?.userId).toBe(USER);
+  });
+
+  test("empty-guard throws", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.undeployKitsBatch, {
+        orgId: ORG, projectId: "p1", kitIds: [], auditId: "log1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/No kits selected/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.undeployKitsBatch, {
+        orgId: ORG, projectId: "p1", kitIds: ["k1"], auditId: "log1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+// ─── checkInKit ───────────────────────────────────────────────────────────────
+describe("checkInKit", () => {
+  async function seedKit(t: T, kitOrg = ORG) {
+    await member(t, "member");
+    await seedProject(t);
+    await seedModelAsset(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: kitOrg, assetTag: "KIT-1", name: "Lighting", status: "CHECKED_OUT", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", baseLine("kl1", { kitId: "k1", isKitChild: false, status: "CHECKED_OUT", checkedOutQuantity: 1 }));
+      await ctx.db.insert("projectLineItems", baseLine("c1", { parentLineItemId: "kl1", isKitChild: true, modelId: "m1", assetId: "a1", status: "CHECKED_OUT", checkedOutQuantity: 1 }));
+    });
+  }
+
+  test("returns a whole kit (lines RETURNED, asset AVAILABLE, kit AVAILABLE) + audit", async () => {
+    const t = makeT();
+    await seedKit(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInKit, {
+      orgId: ORG, projectId: "p1", kitId: "k1", returnCondition: "GOOD", auditId: "log1", now: NOW, actor: SPOOF,
+    });
+    expect(res.kitId).toBe("k1");
+    expect((await lineById(t, "kl1"))?.status).toBe("RETURNED");
+    expect((await assetById(t, "a1"))?.status).toBe("AVAILABLE");
+    expect((await kitById(t, "k1"))?.status).toBe("AVAILABLE");
+    const log = await logById(t, "log1");
+    expect(log?.action).toBe("CHECK_IN");
+    expect(log?.summary).toBe("Checked in kit (condition: GOOD)");
+    expect(log?.userId).toBe(USER);
+  });
+
+  test("cross-org kit rejected", async () => {
+    const t = makeT();
+    await seedKit(t, OTHER); // kit lives in another org
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInKit, {
+        orgId: ORG, projectId: "p1", kitId: "k1", returnCondition: "GOOD", auditId: "log1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/Kit not found/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkInKit, {
+        orgId: ORG, projectId: "p1", kitId: "k1", returnCondition: "GOOD", auditId: "log1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+// ─── ensureContainerOnProject ───────────────────────────────────────────────────
+describe("ensureContainerOnProject", () => {
+  async function seed(t: T) {
+    await member(t, "member");
+    await seedProject(t);
+    await seedModelAsset(t, ORG, "AVAILABLE");
+  }
+
+  test("creates a container line (idempotent on the (asset, project) uniqueness check)", async () => {
+    const t = makeT();
+    await seed(t);
+    const r1 = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.ensureContainerOnProject, {
+      orgId: ORG, projectId: "p1", assetId: "a1", modelId: "m1", containerName: "C1", now: NOW, actor: SPOOF,
+    });
+    expect(r1.created).toBe(true);
+    const line = await lineById(t, r1.id);
+    expect(line?.isContainerLineItem).toBe(true);
+    expect(line?.prepContainer).toBe("C1");
+    // Retry → same line, no duplicate.
+    const r2 = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.ensureContainerOnProject, {
+      orgId: ORG, projectId: "p1", assetId: "a1", modelId: "m1", containerName: "C1", now: NOW, actor: SPOOF,
+    });
+    expect(r2).toEqual({ id: r1.id, created: false });
+  });
+
+  test("cross-org asset rejected", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "a1", organizationId: OTHER, modelId: "m1", assetTag: "A-1", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.ensureContainerOnProject, {
+        orgId: ORG, projectId: "p1", assetId: "a1", modelId: "m1", containerName: "C1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/Asset not found/i);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t);
+    await seedModelAsset(t, ORG, "AVAILABLE");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.ensureContainerOnProject, {
+        orgId: ORG, projectId: "p1", assetId: "a1", modelId: "m1", containerName: "C1", now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+// ─── syncContainersBatch ────────────────────────────────────────────────────────
+describe("syncContainersBatch", () => {
+  async function seedContainers(t: T) {
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      // C1: container line CONFIRMED + all-deployed contents → flips CHECKED_OUT.
+      await ctx.db.insert("projectLineItems", baseLine("c1li", { prepContainer: "C1", isContainerLineItem: true }));
+      await ctx.db.insert("projectLineItems", baseLine("c1a", { prepContainer: "C1", status: "CHECKED_OUT" }));
+      await ctx.db.insert("projectLineItems", baseLine("c1b", { prepContainer: "C1", status: "CHECKED_OUT" }));
+    });
+  }
+
+  test("rolls up + dedupes container names; ghost → no-op; spoof userId overridden", async () => {
+    const t = makeT();
+    await seedContainers(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.syncContainersBatch, {
+      orgId: ORG, projectId: "p1", containerNames: ["C1", "C1", "Cghost"], now: NOW, actor: SPOOF,
+    });
+    // Deduped: exactly one C1 result + one Cghost.
+    expect(res.results).toHaveLength(2);
+    const byName = new Map(res.results.map((r) => [r.containerName, r]));
+    expect(byName.get("C1")).toEqual({ containerName: "C1", updated: true, status: "CHECKED_OUT" });
+    expect(byName.get("Cghost")).toEqual({ containerName: "Cghost", updated: false });
+    const containerLine = await lineById(t, "c1li");
+    expect(containerLine?.status).toBe("CHECKED_OUT");
+    expect(containerLine?.checkedOutById).toBe(USER); // spoofed actor overridden
+  });
+
+  test("empty-guard returns no results", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.syncContainersBatch, {
+      orgId: ORG, projectId: "p1", containerNames: [], now: NOW, actor: SPOOF,
+    });
+    expect(res).toEqual({ results: [] });
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.syncContainersBatch, {
+        orgId: ORG, projectId: "p1", containerNames: ["C1"], now: NOW, actor: SPOOF,
+      }),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/warehouseWrites.ts
+++ b/convex/warehouseWrites.ts
@@ -1,0 +1,597 @@
+import { v, ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { writeActivityLog } from "./lib/audit";
+import {
+  checkinItemsCore,
+  undeployItemsCore,
+  unreturnItemsCore,
+  undeprepLineCore,
+  undeployKitFull,
+  unreturnKitFull,
+  undeployKitsBatchCore,
+  unreturnKitsBatchCore,
+  checkinKitFull,
+  checkinKitsBatchCore,
+  clearPrepContainerCore,
+  ensureContainerOnProjectCore,
+  syncContainersBatchCore,
+} from "./warehouseOps";
+
+/**
+ * Browser-direct WAREHOUSE writes (Phase 3 PR-A — the return/undeploy/container write
+ * family). Each guarded `api.warehouseWrites.*` mutation folds the kill-switch +
+ * per-user rate limit + RBAC (warehouse:check_in|check_out) + FK/org validation +
+ * the SAME extracted `warehouseOps` core + in-mutation audit into ONE transaction.
+ *
+ * The state machine ALREADY lives in Convex (`warehouseOps.ts`); these mutations reuse
+ * its exported `*Core` functions verbatim, so behaviour is byte-identical to the
+ * `requireService` mirror the server action called. NO recalc — warehouse is
+ * fulfillment/status, not money.
+ *
+ * Security baseline (docs/designs/convex-phase5-auth-bridge.md + the Phase 3 browser
+ * bar): `actor` is CLIENT-SUPPLIED but pinned to the verified token identity by
+ * `resolveActor` — the cores' trusted `userId` writes (checkedOutById / returnedById /
+ * scan-log + audit attribution) use `actor.userId`, NEVER a client arg. Every client
+ * FK (project / line item / kit / asset / model) is org-validated at the boundary
+ * BEFORE the core runs (by_cuid is a GLOBAL index → a cross-tenant id must be
+ * rejected). Batch mutations preserve the server actions' empty-guard / dedupe exactly.
+ *
+ * Return shape is IDS ONLY — the warehouse page reads a live `warehouseDetail` /
+ * `warehousePageBatch` subscription, so the server's `attachModelToResults` re-read
+ * waterfall is dropped (no consumer read those model-attached rows).
+ *
+ * The `requireService` mirrors in `warehouseOps.ts` stay (partial-keep): check-records
+ * + the warehouseOps test suite still call them with a SERVICE token.
+ */
+
+const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+const returnCond = v.union(v.literal("GOOD"), v.literal("DAMAGED"), v.literal("MISSING"));
+
+// ─── FK / org-scope validation helpers (by_cuid is GLOBAL — must org-re-check) ────
+
+async function requireProjectInOrg(ctx: MutationCtx, projectId: string, orgId: string): Promise<void> {
+  const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
+  if (!p || p.organizationId !== orgId) throw new ConvexError("Project not found");
+}
+
+async function requireLineInProject(ctx: MutationCtx, lineItemId: string, orgId: string, projectId: string): Promise<void> {
+  const l = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", lineItemId)).first();
+  if (!l || l.organizationId !== orgId || l.projectId !== projectId) {
+    throw new ConvexError(`Line item ${lineItemId} not found in project`);
+  }
+}
+
+async function requireKitInOrg(ctx: MutationCtx, kitId: string, orgId: string): Promise<void> {
+  const k = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+  if (!k || k.organizationId !== orgId) throw new ConvexError("Kit not found");
+}
+
+async function assertAssetInOrg(ctx: MutationCtx, assetId: string, orgId: string): Promise<void> {
+  const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", assetId)).first();
+  if (!asset || asset.organizationId !== orgId) throw new ConvexError("Asset not found");
+}
+
+async function assertModelInOrg(ctx: MutationCtx, modelId: string, orgId: string): Promise<void> {
+  const m = await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", modelId)).first();
+  if (!m || m.organizationId !== orgId) throw new ConvexError("Model not found");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkInItems — unit returns + asset/bulk restores + accessory cascade + rollups.
+// Parity: checkInItems server action. warehouse:check_in. One audit row per item.
+// ─────────────────────────────────────────────────────────────────────────────
+export const checkInItems = mutation({
+  args: {
+    orgId: v.string(),
+    projectId: v.string(),
+    items: v.array(v.object({
+      lineItemId: v.string(),
+      assetId: v.optional(v.string()),
+      returnCondition: returnCond,
+      quantity: v.optional(v.number()),
+      notes: v.optional(v.string()),
+    })),
+    auditIds: v.array(v.string()),
+    now: v.number(),
+    actor: actorValidator,
+  },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    for (const it of a.items) {
+      await requireLineInProject(ctx, it.lineItemId, a.orgId, a.projectId);
+      // Validate the optional client assetId too — returnLineUnits' legacy fallback calls
+      // setAssetStatus on it without an org check, so a foreign assetId is a cross-tenant write.
+      if (it.assetId) await assertAssetInOrg(ctx, it.assetId, a.orgId);
+    }
+
+    const res = await checkinItemsCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, items: a.items, now: a.now,
+    });
+
+    for (let i = 0; i < a.items.length; i++) {
+      const item = a.items[i];
+      const auditId = a.auditIds[i];
+      if (!auditId) continue;
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: a.orgId,
+        action: "CHECK_IN",
+        entityType: "asset",
+        entityId: item.lineItemId,
+        entityName: `Line item ${item.lineItemId}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Checked in item on project (condition: ${item.returnCondition})`,
+        projectId: a.projectId,
+        createdAt: a.now,
+      });
+    }
+
+    return res; // { updatedLineIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// undeployItems — Deployed → Prepped. Parity: undeployItems. warehouse:check_in.
+// ─────────────────────────────────────────────────────────────────────────────
+export const undeployItems = mutation({
+  args: {
+    orgId: v.string(),
+    projectId: v.string(),
+    items: v.array(v.object({ lineItemId: v.string(), assetId: v.optional(v.string()), quantity: v.optional(v.number()) })),
+    auditIds: v.array(v.string()),
+    now: v.number(),
+    actor: actorValidator,
+  },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    for (const it of a.items) {
+      await requireLineInProject(ctx, it.lineItemId, a.orgId, a.projectId);
+      if (it.assetId) await assertAssetInOrg(ctx, it.assetId, a.orgId);
+    }
+
+    const res = await undeployItemsCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, items: a.items, now: a.now,
+    });
+
+    for (let i = 0; i < a.items.length; i++) {
+      const item = a.items[i];
+      const auditId = a.auditIds[i];
+      if (!auditId) continue;
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: a.orgId,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: item.assetId || item.lineItemId,
+        entityName: `Line item ${item.lineItemId}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: "Moved item back to Prepped (un-deploy)",
+        projectId: a.projectId,
+        ...(item.assetId ? { assetId: item.assetId } : {}),
+        createdAt: a.now,
+      });
+    }
+
+    return res; // { updatedLineIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// unreturnItems — Returned → Deployed. Parity: unreturnItems. warehouse:check_out.
+// ─────────────────────────────────────────────────────────────────────────────
+export const unreturnItems = mutation({
+  args: {
+    orgId: v.string(),
+    projectId: v.string(),
+    items: v.array(v.object({ lineItemId: v.string(), assetId: v.optional(v.string()), quantity: v.optional(v.number()) })),
+    auditIds: v.array(v.string()),
+    now: v.number(),
+    actor: actorValidator,
+  },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    for (const it of a.items) {
+      await requireLineInProject(ctx, it.lineItemId, a.orgId, a.projectId);
+      if (it.assetId) await assertAssetInOrg(ctx, it.assetId, a.orgId);
+    }
+
+    const res = await unreturnItemsCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, items: a.items, now: a.now,
+    });
+
+    for (let i = 0; i < a.items.length; i++) {
+      const item = a.items[i];
+      const auditId = a.auditIds[i];
+      if (!auditId) continue;
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: a.orgId,
+        action: "UPDATE",
+        entityType: "asset",
+        entityId: item.assetId || item.lineItemId,
+        entityName: `Line item ${item.lineItemId}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: "Moved item back to Deployed (un-return)",
+        projectId: a.projectId,
+        ...(item.assetId ? { assetId: item.assetId } : {}),
+        createdAt: a.now,
+      });
+    }
+
+    return res; // { updatedLineIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// undeprepLine — De-prepped → Returned (re-pack). Parity: undeprepLine. check_out.
+// ─────────────────────────────────────────────────────────────────────────────
+export const undeprepLine = mutation({
+  args: { orgId: v.string(), projectId: v.string(), lineItemId: v.string(), auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    await requireLineInProject(ctx, a.lineItemId, a.orgId, a.projectId);
+
+    const res = await undeprepLineCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, lineItemId: a.lineItemId, now: a.now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: a.auditId,
+      organizationId: a.orgId,
+      action: "UPDATE",
+      entityType: "asset",
+      entityId: a.lineItemId,
+      entityName: `Line item ${a.lineItemId}`,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Re-packed returned item (un-deprep)",
+      projectId: a.projectId,
+      createdAt: a.now,
+    });
+
+    return res; // { id }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// undeployKit / unreturnKit — whole-kit reverse (singular). Parity: undeployKit /
+// unreturnKit. undeploy=check_in, unreturn=check_out.
+// ─────────────────────────────────────────────────────────────────────────────
+export const undeployKit = mutation({
+  args: { orgId: v.string(), projectId: v.string(), kitId: v.string(), auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    await requireKitInOrg(ctx, a.kitId, a.orgId);
+
+    const res = await undeployKitFull(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, kitId: a.kitId, now: a.now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: a.auditId,
+      organizationId: a.orgId,
+      action: "UPDATE",
+      entityType: "kit",
+      entityId: a.kitId,
+      entityName: `Kit ${a.kitId}`,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Moved kit back to Prepped (un-deploy)",
+      projectId: a.projectId,
+      kitId: a.kitId,
+      createdAt: a.now,
+    });
+
+    return res; // { kitId, affectedKitIds }
+  },
+});
+
+export const unreturnKit = mutation({
+  args: { orgId: v.string(), projectId: v.string(), kitId: v.string(), auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    await requireKitInOrg(ctx, a.kitId, a.orgId);
+
+    const res = await unreturnKitFull(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, kitId: a.kitId, now: a.now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: a.auditId,
+      organizationId: a.orgId,
+      action: "UPDATE",
+      entityType: "kit",
+      entityId: a.kitId,
+      entityName: `Kit ${a.kitId}`,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Moved kit back to Deployed (un-return)",
+      projectId: a.projectId,
+      kitId: a.kitId,
+      createdAt: a.now,
+    });
+
+    return res; // { kitId, affectedKitIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// undeployKitsBatch / unreturnKitsBatch — bulk whole-kit reverse. Parity: the batch
+// server actions (empty-guard throw). One summary audit row when any kit succeeds.
+// ─────────────────────────────────────────────────────────────────────────────
+export const undeployKitsBatch = mutation({
+  args: { orgId: v.string(), projectId: v.string(), kitIds: v.array(v.string()), auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+    if (a.kitIds.length === 0) throw new ConvexError("No kits selected");
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    // Dedupe: the core adjusts kit inventory per occurrence, so a duplicate id would
+    // double-apply. Cross-tenant safety comes from the core itself — it operates via each
+    // kit's PARENT LINE in this org's project (kitParentLine), so a foreign/ghost kit has
+    // no parent line here and lands in `errors` (partial-success), never a cross-org write.
+    const unique = [...new Set(a.kitIds)];
+
+    const res = await undeployKitsBatchCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, kitIds: unique, now: a.now,
+    });
+
+    if (res.succeeded.length > 0) {
+      await writeActivityLog(ctx, {
+        id: a.auditId,
+        organizationId: a.orgId,
+        action: "UPDATE",
+        entityType: "kit",
+        entityId: res.succeeded[0],
+        entityName: `${res.succeeded.length} kits`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Moved ${res.succeeded.length} kit(s) back to Prepped (un-deploy)`,
+        projectId: a.projectId,
+        createdAt: a.now,
+      });
+    }
+
+    return res; // { succeeded, errors, affectedKitIds }
+  },
+});
+
+export const unreturnKitsBatch = mutation({
+  args: { orgId: v.string(), projectId: v.string(), kitIds: v.array(v.string()), auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    const actor = await resolveActor(ctx, a.actor);
+    if (a.kitIds.length === 0) throw new ConvexError("No kits selected");
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    // Dedupe (per-occurrence inventory adjust would double-apply). Cross-tenant safety is
+    // the core's kitParentLine (foreign/ghost kit → per-item error, not a cross-org write).
+    const unique = [...new Set(a.kitIds)];
+
+    const res = await unreturnKitsBatchCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, kitIds: unique, now: a.now,
+    });
+
+    if (res.succeeded.length > 0) {
+      await writeActivityLog(ctx, {
+        id: a.auditId,
+        organizationId: a.orgId,
+        action: "UPDATE",
+        entityType: "kit",
+        entityId: res.succeeded[0],
+        entityName: `${res.succeeded.length} kits`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Moved ${res.succeeded.length} kit(s) back to Deployed (un-return)`,
+        projectId: a.projectId,
+        createdAt: a.now,
+      });
+    }
+
+    return res; // { succeeded, errors, affectedKitIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkInKit — whole-kit return (singular). Parity: checkInKit. warehouse:check_in.
+// ─────────────────────────────────────────────────────────────────────────────
+export const checkInKit = mutation({
+  args: { orgId: v.string(), projectId: v.string(), kitId: v.string(), returnCondition: returnCond, auditId: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    await requireKitInOrg(ctx, a.kitId, a.orgId);
+
+    const res = await checkinKitFull(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, userId: actor.userId, kitId: a.kitId, returnCondition: a.returnCondition, now: a.now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: a.auditId,
+      organizationId: a.orgId,
+      action: "CHECK_IN",
+      entityType: "kit",
+      entityId: a.kitId,
+      entityName: `Kit ${a.kitId}`,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Checked in kit (condition: ${a.returnCondition})`,
+      projectId: a.projectId,
+      kitId: a.kitId,
+      createdAt: a.now,
+    });
+
+    return res; // { kitId, affectedKitIds }
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkInKitsBatch — bulk whole-kit return. Parity: checkInKitsBatch (dedupe by
+// kitId keep-first, empty → {succeeded:[],errors:[]}). One audit per succeeded kit.
+// ─────────────────────────────────────────────────────────────────────────────
+export const checkInKitsBatch = mutation({
+  args: {
+    orgId: v.string(),
+    projectId: v.string(),
+    items: v.array(v.object({ kitId: v.string(), returnCondition: returnCond, auditId: v.string() })),
+    now: v.number(),
+    actor: actorValidator,
+  },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_in");
+    const actor = await resolveActor(ctx, a.actor);
+
+    // Dedupe by kitId (keep first occurrence) — checkinKit restores the kit's bulk
+    // contents each call, so returning the same kit twice would overstate availability.
+    const seen = new Set<string>();
+    const uniqueItems = a.items.filter((it) => (seen.has(it.kitId) ? false : (seen.add(it.kitId), true)));
+    if (uniqueItems.length === 0) return { succeeded: [] as string[], errors: [] as { kitId: string; message: string }[] };
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    for (const it of uniqueItems) await requireKitInOrg(ctx, it.kitId, a.orgId);
+
+    const res = await checkinKitsBatchCore(ctx, {
+      organizationId: a.orgId,
+      projectId: a.projectId,
+      userId: actor.userId,
+      items: uniqueItems.map(({ kitId, returnCondition }) => ({ kitId, returnCondition })),
+      now: a.now,
+    });
+
+    for (const kitId of res.succeeded) {
+      const it = uniqueItems.find((x) => x.kitId === kitId);
+      if (!it) continue;
+      await writeActivityLog(ctx, {
+        id: it.auditId,
+        organizationId: a.orgId,
+        action: "CHECK_IN",
+        entityType: "kit",
+        entityId: kitId,
+        entityName: `Kit ${kitId}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Checked in kit (condition: ${it.returnCondition})`,
+        projectId: a.projectId,
+        kitId,
+        createdAt: a.now,
+      });
+    }
+
+    return { succeeded: res.succeeded, errors: res.errors };
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// clearPrepContainer — strip prepContainer off a container's lines. Parity:
+// clearPrepContainer (no audit). warehouse:check_out.
+// ─────────────────────────────────────────────────────────────────────────────
+export const clearPrepContainer = mutation({
+  args: { orgId: v.string(), projectId: v.string(), containerName: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+
+    return clearPrepContainerCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, containerName: a.containerName, now: a.now,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ensureContainerOnProject — idempotent check-then-create of a container line item
+// (idempotency via the existing (asset, project, isContainerLineItem) check — the
+// line id is minted server-side inside the core). Parity: ensureContainerOnProject
+// (no audit). warehouse:check_out. Returns { id, created } (drops the model re-read).
+// ─────────────────────────────────────────────────────────────────────────────
+export const ensureContainerOnProject = mutation({
+  args: { orgId: v.string(), projectId: v.string(), assetId: v.string(), modelId: v.string(), containerName: v.string(), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    await resolveActor(ctx, a.actor);
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    await assertAssetInOrg(ctx, a.assetId, a.orgId);
+    await assertModelInOrg(ctx, a.modelId, a.orgId);
+
+    return ensureContainerOnProjectCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, assetId: a.assetId, modelId: a.modelId, containerName: a.containerName, now: a.now,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// syncContainersBatch — roll up N containers in one call. Parity: syncContainersBatch
+// (dedupe [...new Set()], empty → {results:[]}, no audit). warehouse:check_out.
+// ─────────────────────────────────────────────────────────────────────────────
+export const syncContainersBatch = mutation({
+  args: { orgId: v.string(), projectId: v.string(), containerNames: v.array(v.string()), now: v.number(), actor: actorValidator },
+  handler: async (ctx, a) => {
+    await assertWritesEnabled(ctx, "warehouse");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, a.orgId, "warehouse", "check_out");
+    const actor = await resolveActor(ctx, a.actor);
+
+    const unique = [...new Set(a.containerNames)];
+    if (unique.length === 0) return { results: [] as Array<{ containerName: string; updated: boolean; status?: string }> };
+
+    await requireProjectInOrg(ctx, a.projectId, a.orgId);
+
+    return syncContainersBatchCore(ctx, {
+      organizationId: a.orgId, projectId: a.projectId, containerNames: unique, userId: actor.userId, now: a.now,
+    });
+  },
+});

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -31,22 +31,12 @@ import { transitionNeedsCheck, lineHasModelChecks, kitHasChecks } from "@/lib/wa
 import {
   lookupAssetForScan,
   checkOutItems,
-  checkInItems,
   checkOutKit,
-  checkInKit,
   checkOutKitsBatch,
-  checkInKitsBatch,
-  undeployItems,
-  unreturnItems,
-  undeprepLine,
-  undeployKitsBatch,
-  unreturnKitsBatch,
   getAvailableAssetsForModels,
   quickAddAndCheckOut,
-  clearPrepContainer,
-  ensureContainerOnProject,
-  syncContainersBatch,
 } from "@/server/warehouse";
+import { useWarehouseWrites } from "@/hooks/use-warehouse-writes";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { StatusIndicator } from "@/components/ui/status-indicator";
@@ -666,6 +656,9 @@ function WarehouseProjectPage({
   const project = native.data as any;
   const isLoading = native.isLoading;
 
+  // Browser-direct warehouse writes (PR-A: return / undeploy / container family).
+  const warehouseWrites = useWarehouseWrites();
+
   // Post-write refresh is now a no-op: the native subscription pushes every
   // warehouseOps change live over the WebSocket, so an explicit refetch is
   // redundant (kept to avoid touching every call site).
@@ -681,9 +674,9 @@ function WarehouseProjectPage({
     const asset = selectedContainerAssetRef.current;
     const container = selectedContainerRef.current;
     if (asset?.assetId && asset.modelId) {
-      await ensureContainerOnProject(projectId, asset.assetId, asset.modelId, container);
+      await warehouseWrites.ensureContainerOnProject(projectId, asset.assetId, asset.modelId, container);
     }
-  }, [projectId]);
+  }, [projectId, warehouseWrites]);
 
   const checkOutMutation = useServerMutation({
     mutationFn: async (params: { items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>; includeAccessories?: boolean }) => {
@@ -693,7 +686,7 @@ function WarehouseProjectPage({
       const containers = new Set(
         params.items.map((i) => lineItems.find((l) => l.id === i.lineItemId)?.prepContainer).filter(Boolean) as string[]
       );
-      if (containers.size > 0) await syncContainersBatch(projectId, [...containers]);
+      if (containers.size > 0) await warehouseWrites.syncContainersBatch(projectId, [...containers]);
       return result;
     },
     onSuccess: invalidate,
@@ -704,13 +697,13 @@ function WarehouseProjectPage({
     mutationFn: async (data: {
       items: Array<{ lineItemId: string; assetId?: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING"; quantity?: number; notes?: string }>;
     }) => {
-      const result = await checkInItems(projectId, data.items);
+      const result = await warehouseWrites.checkInItems(projectId, data.items);
       // Sync container status for affected containers — ONE batch call (was one
       // round-trip per container).
       const containers = new Set(
         data.items.map((i) => lineItems.find((l) => l.id === i.lineItemId)?.prepContainer).filter(Boolean) as string[]
       );
-      if (containers.size > 0) await syncContainersBatch(projectId, [...containers]);
+      if (containers.size > 0) await warehouseWrites.syncContainersBatch(projectId, [...containers]);
       return result;
     },
     onSuccess: () => {
@@ -771,7 +764,7 @@ function WarehouseProjectPage({
 
   const kitCheckInMutation = useServerMutation({
     mutationFn: (data: { kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }) =>
-      checkInKit(projectId, data.kitId, data.returnCondition),
+      warehouseWrites.checkInKit(projectId, data.kitId, data.returnCondition),
     onSuccess: () => invalidate(),
     onError: (e) => showError(e),
   });
@@ -789,7 +782,7 @@ function WarehouseProjectPage({
     onError: (e) => showError(e),
   });
   const kitBatchInMutation = useServerMutation<KitBatchResult, Array<{ kitId: string; returnCondition: "GOOD" | "DAMAGED" | "MISSING" }>>({
-    mutationFn: (kits) => checkInKitsBatch(projectId, kits),
+    mutationFn: (kits) => warehouseWrites.checkInKitsBatch(projectId, kits),
     onSuccess: (res) => {
       if (res.succeeded.length > 0) toast.success(`Returned ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"}`);
       if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} failed: ${res.errors[0].message}`);
@@ -813,12 +806,12 @@ function WarehouseProjectPage({
   // ── Move-back (reverse a stage) mutations ──────────────────────────────────
   const undeployMutation = useServerMutation({
     mutationFn: (items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>) =>
-      undeployItems(projectId, items),
+      warehouseWrites.undeployItems(projectId, items),
     onSuccess: () => { toast.success("Moved back to Prepped"); invalidate(); },
     onError: (e) => showError(e),
   });
   const undeployKitsMutation = useServerMutation<KitBatchResult, string[]>({
-    mutationFn: (kitIds: string[]) => undeployKitsBatch(projectId, kitIds),
+    mutationFn: (kitIds: string[]) => warehouseWrites.undeployKitsBatch(projectId, kitIds),
     onSuccess: (res) => {
       if (res.succeeded.length > 0) toast.success(`Moved ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"} back to Prepped`);
       if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} skipped: ${res.errors[0].message}`);
@@ -828,12 +821,12 @@ function WarehouseProjectPage({
   });
   const unreturnMutation = useServerMutation({
     mutationFn: (items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>) =>
-      unreturnItems(projectId, items),
+      warehouseWrites.unreturnItems(projectId, items),
     onSuccess: () => { toast.success("Moved back to Deployed"); invalidate(); },
     onError: (e) => showError(e),
   });
   const unreturnKitsMutation = useServerMutation<KitBatchResult, string[]>({
-    mutationFn: (kitIds: string[]) => unreturnKitsBatch(projectId, kitIds),
+    mutationFn: (kitIds: string[]) => warehouseWrites.unreturnKitsBatch(projectId, kitIds),
     onSuccess: (res) => {
       if (res.succeeded.length > 0) toast.success(`Moved ${res.succeeded.length} kit${res.succeeded.length === 1 ? "" : "s"} back to Deployed`);
       if (res.errors.length > 0) toast.error(`${res.errors.length} kit${res.errors.length === 1 ? "" : "s"} skipped: ${res.errors[0].message}`);
@@ -842,7 +835,7 @@ function WarehouseProjectPage({
     onError: (e) => showError(e),
   });
   const undeprepMutation = useServerMutation({
-    mutationFn: (lineItemId: string) => undeprepLine(projectId, lineItemId),
+    mutationFn: (lineItemId: string) => warehouseWrites.undeprepLine(projectId, lineItemId),
     onSuccess: () => { toast.success("Re-packed — back to Returned"); invalidate(); },
     onError: (e) => showError(e),
   });
@@ -888,7 +881,7 @@ function WarehouseProjectPage({
   };
 
   const clearContainerMutation = useServerMutation({
-    mutationFn: (containerName: string) => clearPrepContainer(projectId, containerName),
+    mutationFn: (containerName: string) => warehouseWrites.clearPrepContainer(projectId, containerName),
     onSuccess: () => {
       toast.success("Container removed");
       invalidate();
@@ -3081,7 +3074,7 @@ function WarehouseProjectPage({
                     // RETURN store with no checks — return to inventory via the
                     // no-check check-in path (same as finishCheckQueue's direct
                     // items) rather than completeCheckAndStore (min(1)).
-                    await checkInItems(projectId, [
+                    await warehouseWrites.checkInItems(projectId, [
                       {
                         lineItemId: item.lineItemId,
                         assetId: item.assetId || undefined,

--- a/src/hooks/use-warehouse-writes.ts
+++ b/src/hooks/use-warehouse-writes.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { createId } from "@paralleldrive/cuid2";
+import { useSession, useActiveOrganization } from "@/lib/auth-client";
+import { api } from "../../convex/_generated/api";
+
+type ReturnCondition = "GOOD" | "DAMAGED" | "MISSING";
+
+/**
+ * Browser-direct WAREHOUSE writes (Phase 3 PR-A — the return/undeploy/container write
+ * family). Each guarded `api.warehouseWrites.*` mutation folds kill-switch + rate limit
+ * + RBAC (warehouse:check_in|check_out) + FK/org validation + the SAME warehouseOps
+ * core + in-mutation audit into ONE transaction. The state machine already lives in
+ * Convex, so these are drop-in replacements for the thin `src/server/warehouse.ts`
+ * wrappers — the client just mints the audit cuids and supplies actor/orgId/now.
+ *
+ * The signatures mirror the old server actions so the warehouse page rewire is minimal.
+ * Return shape is ids only — the page reads a live warehouseDetail subscription, so the
+ * server's model-attach re-read is dropped.
+ */
+export function useWarehouseWrites() {
+  const { data: session } = useSession();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const checkInItemsM = useMutation(api.warehouseWrites.checkInItems);
+  const undeployItemsM = useMutation(api.warehouseWrites.undeployItems);
+  const unreturnItemsM = useMutation(api.warehouseWrites.unreturnItems);
+  const undeprepLineM = useMutation(api.warehouseWrites.undeprepLine);
+  const undeployKitsBatchM = useMutation(api.warehouseWrites.undeployKitsBatch);
+  const unreturnKitsBatchM = useMutation(api.warehouseWrites.unreturnKitsBatch);
+  const checkInKitM = useMutation(api.warehouseWrites.checkInKit);
+  const checkInKitsBatchM = useMutation(api.warehouseWrites.checkInKitsBatch);
+  const clearPrepContainerM = useMutation(api.warehouseWrites.clearPrepContainer);
+  const ensureContainerOnProjectM = useMutation(api.warehouseWrites.ensureContainerOnProject);
+  const syncContainersBatchM = useMutation(api.warehouseWrites.syncContainersBatch);
+
+  const actor = () => ({
+    userId: session?.user.id ?? "",
+    userName: session?.user.name ?? "",
+  });
+  const requireOrg = (): string => {
+    if (!orgId) throw new Error("No active organization");
+    return orgId;
+  };
+
+  return {
+    checkInItems: async (
+      projectId: string,
+      items: Array<{ lineItemId: string; assetId?: string; returnCondition: ReturnCondition; quantity?: number; notes?: string }>,
+    ): Promise<{ updatedLineIds: string[] }> => {
+      return checkInItemsM({
+        orgId: requireOrg(),
+        projectId,
+        items,
+        auditIds: items.map(() => createId()),
+        now: Date.now(),
+        actor: actor(),
+      });
+    },
+
+    undeployItems: async (
+      projectId: string,
+      items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>,
+    ): Promise<{ updatedLineIds: string[] }> => {
+      return undeployItemsM({
+        orgId: requireOrg(),
+        projectId,
+        items,
+        auditIds: items.map(() => createId()),
+        now: Date.now(),
+        actor: actor(),
+      });
+    },
+
+    unreturnItems: async (
+      projectId: string,
+      items: Array<{ lineItemId: string; assetId?: string; quantity?: number }>,
+    ): Promise<{ updatedLineIds: string[] }> => {
+      return unreturnItemsM({
+        orgId: requireOrg(),
+        projectId,
+        items,
+        auditIds: items.map(() => createId()),
+        now: Date.now(),
+        actor: actor(),
+      });
+    },
+
+    undeprepLine: async (projectId: string, lineItemId: string): Promise<{ id: string }> => {
+      return undeprepLineM({ orgId: requireOrg(), projectId, lineItemId, auditId: createId(), now: Date.now(), actor: actor() });
+    },
+
+    undeployKitsBatch: async (
+      projectId: string,
+      kitIds: string[],
+    ): Promise<{ succeeded: string[]; errors: { kitId: string; message: string }[] }> => {
+      if (kitIds.length === 0) throw new Error("No kits selected");
+      return undeployKitsBatchM({ orgId: requireOrg(), projectId, kitIds, auditId: createId(), now: Date.now(), actor: actor() });
+    },
+
+    unreturnKitsBatch: async (
+      projectId: string,
+      kitIds: string[],
+    ): Promise<{ succeeded: string[]; errors: { kitId: string; message: string }[] }> => {
+      if (kitIds.length === 0) throw new Error("No kits selected");
+      return unreturnKitsBatchM({ orgId: requireOrg(), projectId, kitIds, auditId: createId(), now: Date.now(), actor: actor() });
+    },
+
+    checkInKit: async (
+      projectId: string,
+      kitId: string,
+      returnCondition: ReturnCondition = "GOOD",
+    ): Promise<{ kitId: string; affectedKitIds: string[] }> => {
+      return checkInKitM({ orgId: requireOrg(), projectId, kitId, returnCondition, auditId: createId(), now: Date.now(), actor: actor() });
+    },
+
+    checkInKitsBatch: async (
+      projectId: string,
+      kits: Array<{ kitId: string; returnCondition: ReturnCondition }>,
+    ): Promise<{ succeeded: string[]; errors: { kitId: string; message: string }[] }> => {
+      return checkInKitsBatchM({
+        orgId: requireOrg(),
+        projectId,
+        items: kits.map((k) => ({ ...k, auditId: createId() })),
+        now: Date.now(),
+        actor: actor(),
+      });
+    },
+
+    clearPrepContainer: async (projectId: string, containerName: string): Promise<{ success: true }> => {
+      return clearPrepContainerM({ orgId: requireOrg(), projectId, containerName, now: Date.now(), actor: actor() });
+    },
+
+    ensureContainerOnProject: async (
+      projectId: string,
+      assetId: string,
+      modelId: string,
+      containerName: string,
+    ): Promise<{ id: string; created: boolean }> => {
+      return ensureContainerOnProjectM({ orgId: requireOrg(), projectId, assetId, modelId, containerName, now: Date.now(), actor: actor() });
+    },
+
+    syncContainersBatch: async (
+      projectId: string,
+      containerNames: string[],
+    ): Promise<{ results: Array<{ containerName: string; updated: boolean; status?: string }> }> => {
+      return syncContainersBatchM({ orgId: requireOrg(), projectId, containerNames, now: Date.now(), actor: actor() });
+    },
+  };
+}

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -553,90 +553,8 @@ export async function unreturnItems(
   return serialize(await attachModelToResults(organizationId, rows));
 }
 
-/** De-prepped → Returned. Re-pack a returned line (prepStatus back to PACKED). */
-export async function undeprepLine(projectId: string, lineItemId: string) {
-  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
-  const convex = await getConvexClient();
-  await convex.mutation(api.warehouseOps.undeprepLine, {
-    organizationId,
-    projectId,
-    lineItemId,
-    now: Date.now(),
-  });
-  await logActivity({
-    organizationId, userId, userName, action: "UPDATE", entityType: "asset",
-    entityId: lineItemId, entityName: `Line item ${lineItemId}`,
-    summary: "Re-packed returned item (un-deprep)", projectId,
-  });
-  const row = await convex.query(api.projectLineItems.getById, { id: lineItemId });
-  return serialize(await attachModelToResults(organizationId, [row]));
-}
-
-/** Deployed → Prepped for a whole kit. Reverse of checkOutKit. */
-export async function undeployKit(projectId: string, kitId: string) {
-  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.undeployKit, {
-    organizationId, projectId, userId, kitId, now: Date.now(),
-  });
-  await logActivity({
-    organizationId, userId, userName, action: "UPDATE", entityType: "kit",
-    entityId: kitId, entityName: `Kit ${kitId}`, summary: "Moved kit back to Prepped (un-deploy)", projectId, kitId,
-  });
-  return serialize({ success: true, ...res });
-}
-
-/** Returned → Deployed for a whole kit. Reverse of checkInKit. */
-export async function unreturnKit(projectId: string, kitId: string) {
-  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.unreturnKit, {
-    organizationId, projectId, userId, kitId, now: Date.now(),
-  });
-  await logActivity({
-    organizationId, userId, userName, action: "UPDATE", entityType: "kit",
-    entityId: kitId, entityName: `Kit ${kitId}`, summary: "Moved kit back to Deployed (un-return)", projectId, kitId,
-  });
-  return serialize({ success: true, ...res });
-}
-
-/** Bulk single-call un-deploy: move N kits Deployed→Prepped in ONE array mutation +
- *  one server round-trip (was one `undeployKit` per selected kit). Partial-success. */
-export async function undeployKitsBatch(projectId: string, kitIds: string[]) {
-  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_in");
-  if (kitIds.length === 0) throw new Error("No kits selected");
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.undeployKitsBatch, {
-    organizationId, projectId, userId, kitIds, now: Date.now(),
-  });
-  if (res.succeeded.length > 0) {
-    await logActivity({
-      organizationId, userId, userName, action: "UPDATE", entityType: "kit",
-      entityId: res.succeeded[0], entityName: `${res.succeeded.length} kits`,
-      summary: `Moved ${res.succeeded.length} kit(s) back to Prepped (un-deploy)`, projectId,
-    });
-  }
-  return serialize({ success: true, ...res });
-}
-
-/** Bulk single-call un-return: move N kits Returned→Deployed in ONE array mutation +
- *  one server round-trip (was one `unreturnKit` per selected kit). Partial-success. */
-export async function unreturnKitsBatch(projectId: string, kitIds: string[]) {
-  const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
-  if (kitIds.length === 0) throw new Error("No kits selected");
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.unreturnKitsBatch, {
-    organizationId, projectId, userId, kitIds, now: Date.now(),
-  });
-  if (res.succeeded.length > 0) {
-    await logActivity({
-      organizationId, userId, userName, action: "UPDATE", entityType: "kit",
-      entityId: res.succeeded[0], entityName: `${res.succeeded.length} kits`,
-      summary: `Moved ${res.succeeded.length} kit(s) back to Deployed (un-return)`, projectId,
-    });
-  }
-  return serialize({ success: true, ...res });
-}
+// undeprepLine / undeployKit / unreturnKit / undeployKitsBatch / unreturnKitsBatch
+// moved browser-direct (PR-A) — see convex/warehouseWrites.ts + src/hooks/use-warehouse-writes.ts.
 
 export async function checkOutKit(projectId: string, kitId: string) {
   const { organizationId, userId, userName } = await requirePermission("warehouse", "check_out");
@@ -905,87 +823,9 @@ export async function quickAddAndCheckOut(
   return serialize({ ...lineItem, model: modelWithCount });
 }
 
-export async function clearPrepContainer(projectId: string, containerName: string) {
-  const { organizationId } = await requirePermission("warehouse", "check_out");
-
-  const convex = await getConvexClient();
-  await convex.mutation(api.warehouseOps.clearPrepContainer, {
-    organizationId,
-    projectId,
-    containerName,
-    now: Date.now(),
-  });
-
-  return serialize({ success: true });
-}
-
-export async function ensureContainerOnProject(
-  projectId: string,
-  assetId: string,
-  modelId: string,
-  containerName: string
-) {
-  const { organizationId } = await requirePermission("warehouse", "check_out");
-
-  // Atomic check-then-create inside one Convex mutation to prevent duplicates.
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.ensureContainerOnProject, {
-    organizationId,
-    projectId,
-    assetId,
-    modelId,
-    containerName,
-    now: Date.now(),
-  });
-
-  const lineItem = await convex.query(api.projectLineItems.getById, { id: res.id });
-
-  // Graft the Convex model doc onto the line item (replaces the `model: true` join).
-  const modelMap = await getModelMap(organizationId);
-  const model = lineItem?.modelId ? modelMap.get(lineItem.modelId) ?? null : null;
-  return serialize({ ...lineItem, model });
-}
-
-export async function syncContainerStatus(projectId: string, containerName: string) {
-  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
-
-  // The container roll-up (read contents, flip the container line + its asset)
-  // runs in one Convex mutation.
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.syncContainerStatus, {
-    organizationId,
-    projectId,
-    containerName,
-    userId,
-    now: Date.now(),
-  });
-
-  return serialize(res);
-}
-
-/**
- * Bulk single-call container sync (Phase 3 bulk invariant): roll up N containers in
- * ONE Convex array mutation + ONE server round-trip — replaces the client's
- * `for (const c of containers) await syncContainerStatus(...)` loop that fired one
- * round-trip per affected container after a bulk checkout/check-in. Container names
- * are deduped; the mutation reports each container's rollup result.
- */
-export async function syncContainersBatch(projectId: string, containerNames: string[]) {
-  const { organizationId, userId } = await requirePermission("warehouse", "check_out");
-  const unique = [...new Set(containerNames)];
-  if (unique.length === 0) return serialize({ results: [] as Array<{ containerName: string; updated: boolean; status?: string }> });
-
-  const convex = await getConvexClient();
-  const res = await convex.mutation(api.warehouseOps.syncContainersBatch, {
-    organizationId,
-    projectId,
-    containerNames: unique,
-    userId,
-    now: Date.now(),
-  });
-
-  return serialize(res);
-}
+// clearPrepContainer / ensureContainerOnProject / syncContainersBatch moved
+// browser-direct (PR-A) — see convex/warehouseWrites.ts + src/hooks/use-warehouse-writes.ts.
+// The dead singular syncContainerStatus was dropped (no live caller).
 
 type AvailableAssetRow = {
   id: string;


### PR DESCRIPTION
## Summary
First of 3 warehouse PRs. The check-out/in **state machine already lives natively** in `convex/warehouseOps.ts` (`requireService` mutations); the server writes are thin wrappers with **no recalc**. This PR extracts shared `*Core` functions and adds browser-direct mutations reusing them.

- **`convex/warehouseOps.ts`** — extracted + exported 13 `*Core` fns; each `requireService` mutation is now thin. Dropped dead singular `syncContainerStatus`.
- **`convex/warehouseWrites.ts`** (NEW) — 13 browser mutations to the security bar, calling the same cores: checkInItems, undeploy/unreturnItems, undeprepLine, undeploy/unreturnKit(sBatch), checkInKit(sBatch), clearPrepContainer, ensureContainerOnProject, syncContainersBatch. In-mutation audit; returns ids only (dropped the `attachModelToResults` re-read — the page has live subscriptions).
- **★ Partial-keep:** the `requireService` mutations stay (`check-records.ts` + ~15 tests use them).
- `use-warehouse-writes.ts` hook; 11 page call-sites rewired; 9 now-unused server exports deleted (rest of `warehouse.ts` stays for PR-B/C).

## Review
Codex-reviewed — **3 boundary bugs fixed**: items now org-validate the optional client `assetId` (a `setAssetStatus` legacy fallback was a cross-tenant write); kit batches **dedupe** `kitIds` (per-occurrence inventory adjust would double-apply), with cross-tenant safety via the core's `kitParentLine` (foreign/ghost kit → per-item error, partial-success preserved). `actor.userId` for `returnedById` + audit. tsc clean; 51 warehouse/kit tests green; full convex suite unregressed by the core extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)