### PR TITLE
harden(projectWrites): blocking-comment gate on forward status transitions

### DIFF
--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -45,6 +45,41 @@ describe("projectWrites.updateStatusNative", () => {
     });
   });
 
+  test("an open BLOCKING comment blocks a forward move to PREPPING", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("commentThreads", { orgId: ORG, entityType: "project", entityId: "p1", projectId: "p1", status: "open", isBlocking: true, createdBy: USER, createdByName: "Alice", createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args),
+    ).rejects.toThrow();
+    // Status unchanged.
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("CONFIRMED");
+  });
+
+  test("a RESOLVED blocking comment does NOT block; a non-forward status is ungated", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("commentThreads", { orgId: ORG, entityType: "project", entityId: "p1", projectId: "p1", status: "resolved", isBlocking: true, createdBy: USER, createdByName: "Alice", createdAt: NOW, updatedAt: NOW });
+    });
+    // resolved comment → forward move allowed
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, args);
+    expect((await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first()))?.status).toBe("PREPPING");
+  });
+
+  test("an open blocking comment does NOT block a BACKWARD/neutral move (e.g. CANCELLED)", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("commentThreads", { orgId: ORG, entityType: "project", entityId: "p1", projectId: "p1", status: "open", isBlocking: true, createdBy: USER, createdByName: "Alice", createdAt: NOW, updatedAt: NOW });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, { ...args, status: "CANCELLED" as const });
+    expect((await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first()))?.status).toBe("CANCELLED");
+  });
+
   test("rejects a template (TEMPLATE_STATUS)", async () => {
     const t = makeT();
     await seedProject(t, undefined, true);

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -3,6 +3,13 @@ import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
+
+/** Forward status transitions that a project's open BLOCKING comments must gate
+ *  (parity with src/server/projects.ts BLOCKED_FORWARD_PROJECT_STATUSES). */
+const BLOCKED_FORWARD_STATUSES = new Set(["PREPPING", "CHECKED_OUT", "ON_SITE"]);
+const blockedForwardLabel = (status: string): string =>
+  `move this project to ${status.toLowerCase().replaceAll("_", " ")}`;
 import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { writeActivityLog } from "./lib/audit";
 import { bumpProjectCounters } from "./lib/counters";
@@ -51,6 +58,11 @@ export const updateStatusNative = mutation({
     }
 
     const from = project.status ?? "";
+    // Open blocking comments gate a FORWARD move into PREPPING/CHECKED_OUT/ON_SITE (parity
+    // with the deleted server action). Only on an actual status change (template excluded above).
+    if (from !== status && BLOCKED_FORWARD_STATUSES.has(status)) {
+      await assertNoBlockingCommentsInMutation(ctx, orgId, id, { actionLabel: blockedForwardLabel(status) });
+    }
     await ctx.db.patch(project._id, { status, updatedAt: now });
     await bumpProjectCounters(ctx, orgId, project, { ...project, status });
 
@@ -208,6 +220,13 @@ export const updateNative = mutation({
     // strip organizationId/id (no cross-tenant reassign) + the recalc-owned money anchors
     // and isTemplate (no client-forged totals / in-place template flip).
     const setObj = sanitizeClientSet(set, PROJECT_UPDATE_IMMUTABLE);
+
+    // A general update that also moves the status FORWARD into PREPPING/CHECKED_OUT/ON_SITE
+    // must clear the blocking-comment gate too (parity with the server updateProject path).
+    const nextStatus = typeof setObj.status === "string" ? setObj.status : undefined;
+    if (nextStatus && nextStatus !== project.status && BLOCKED_FORWARD_STATUSES.has(nextStatus) && !project.isTemplate) {
+      await assertNoBlockingCommentsInMutation(ctx, orgId, id, { actionLabel: blockedForwardLabel(nextStatus) });
+    }
     if (clear.length === 0) {
       await ctx.db.patch(project._id, setObj);
       await bumpProjectCounters(ctx, orgId, project, { ...project, ...setObj });


### PR DESCRIPTION
## Summary
Closes a projectWrites browser-direct parity gap: a project's open **blocking** comments must gate a **forward** status move into `PREPPING`/`CHECKED_OUT`/`ON_SITE` (parity with the server `updateProjectStatus`/`updateProject`). Reuses `convex/lib/blockingCommentsGate.ts` (built for warehouse PR-C).

- `updateStatusNative` + `updateNative` call `assertNoBlockingCommentsInMutation` only when the target status is a forward move into the blocked set, the status actually changes, and the project isn't a template. Throws `ConvexError`. Backward/neutral moves (e.g. `CANCELLED`) + resolved comments are ungated.

## Testing
+3 tests (open blocking comment blocks PREPPING; resolved doesn't; CANCELLED ungated); tsc clean; `projectWrites.test.ts` 18 green; deployed additive/inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)