### PR TITLE
harden(projectWrites): full deleteNative cascade + deleteTemplateNative (fixes prod orphan bug)

### DIFF
--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -1,5 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
@@ -417,6 +419,23 @@ export const patchAssignment = mutation({
   },
 });
 
+/**
+ * Delete an assignment + its shifts + its (linked) time entries — atomic. Extracted
+ * as a plain function so mutations that can't call another mutation (Convex forbids
+ * mutation→mutation) — e.g. projectWrites.deleteNative — reuse the EXACT shift +
+ * time-entry purge AND the pendingCrewOffers counter bump. Caller org-scopes `doc`
+ * before invoking. Standalone time entries (no assignmentId) are kept.
+ */
+export async function deleteCrewAssignmentCascadeCore(ctx: MutationCtx, doc: Doc<"crewAssignments">): Promise<void> {
+  const id = doc.id;
+  const shifts = await ctx.db.query("crewShifts").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect();
+  for (const s of shifts) await ctx.db.delete(s._id);
+  const entries = await ctx.db.query("crewTimeEntries").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect();
+  for (const e of entries) await ctx.db.delete(e._id);
+  await ctx.db.delete(doc._id);
+  await bumpCountersForTable(ctx, "crewAssignments", doc, null);
+}
+
 /** Delete an assignment + its shifts + its (linked) time entries — atomic. Replaces
  *  the dropped Prisma FK cascade. Standalone time entries (no assignmentId) are kept. */
 export const deleteCascade = mutation({
@@ -425,12 +444,7 @@ export const deleteCascade = mutation({
     await requireService(ctx);
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
     if (!doc) throw new ConvexError("crewAssignments not found: " + id);
-    const shifts = await ctx.db.query("crewShifts").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect();
-    for (const s of shifts) await ctx.db.delete(s._id);
-    const entries = await ctx.db.query("crewTimeEntries").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect();
-    for (const e of entries) await ctx.db.delete(e._id);
-    await ctx.db.delete(doc._id);
-    await bumpCountersForTable(ctx, "crewAssignments", doc, null);
+    await deleteCrewAssignmentCascadeCore(ctx, doc);
   },
 });
 

--- a/convex/projectCategories.ts
+++ b/convex/projectCategories.ts
@@ -1,5 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
 
 /**
@@ -213,34 +214,47 @@ export const deleteCascade = mutation({
  * Used on project delete now that the Prisma FK cascade is gone (Phase C #254).
  * Read-your-writes within the mutation makes the overlapping slot deletes safe.
  */
+/**
+ * Body of deleteAllForProject as a plain function so mutations that can't call
+ * another mutation (Convex forbids mutation→mutation) — e.g.
+ * projectWrites.deleteNative — reuse the EXACT category/group/slot purge. Pure
+ * ctx.db (no auth); callers org-scope the project first.
+ */
+export async function deleteAllForProjectCore(
+  ctx: MutationCtx,
+  projectId: string,
+): Promise<{ categories: number; groups: number }> {
+  const cats = await ctx.db
+    .query("projectCategories")
+    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+    .collect();
+  for (const c of cats) {
+    const catSlots = await ctx.db
+      .query("categorySlots")
+      .withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", c.id))
+      .collect();
+    for (const s of catSlots) await ctx.db.delete(s._id);
+  }
+  const groups = await ctx.db
+    .query("projectGroups")
+    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+    .collect();
+  for (const g of groups) {
+    const gslots = await ctx.db
+      .query("categorySlots")
+      .withIndex("by_projectGroupId", (q) => q.eq("projectGroupId", g.id))
+      .collect();
+    for (const s of gslots) await ctx.db.delete(s._id);
+    await ctx.db.delete(g._id);
+  }
+  for (const c of cats) await ctx.db.delete(c._id);
+  return { categories: cats.length, groups: groups.length };
+}
+
 export const deleteAllForProject = mutation({
   args: { projectId: v.string() },
   handler: async (ctx, { projectId }) => {
     await requireService(ctx);
-    const cats = await ctx.db
-      .query("projectCategories")
-      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
-    for (const c of cats) {
-      const catSlots = await ctx.db
-        .query("categorySlots")
-        .withIndex("by_projectCategoryId", (q) => q.eq("projectCategoryId", c.id))
-        .collect();
-      for (const s of catSlots) await ctx.db.delete(s._id);
-    }
-    const groups = await ctx.db
-      .query("projectGroups")
-      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
-    for (const g of groups) {
-      const gslots = await ctx.db
-        .query("categorySlots")
-        .withIndex("by_projectGroupId", (q) => q.eq("projectGroupId", g.id))
-        .collect();
-      for (const s of gslots) await ctx.db.delete(s._id);
-      await ctx.db.delete(g._id);
-    }
-    for (const c of cats) await ctx.db.delete(c._id);
-    return { categories: cats.length, groups: groups.length };
+    return await deleteAllForProjectCore(ctx, projectId);
   },
 });

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -700,19 +700,29 @@ export const patchLineItem = mutation({
   },
 });
 
+/**
+ * Cascade-delete a line: its children (+ all units), then the line (+ its units).
+ * Extracted as a plain function so mutations that can't call another mutation
+ * (Convex forbids mutation→mutation) — e.g. projectWrites.deleteNative — reuse the
+ * EXACT child-scan + unit-purge. Callers org-scope the line before invoking.
+ */
+export async function removeLineItemCascadeCore(ctx: MutationCtx, id: string): Promise<void> {
+  const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+  if (!line) throw new ConvexError("projectLineItems not found: " + id);
+  const children = await ctx.db
+    .query("projectLineItems")
+    .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
+    .collect();
+  for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id);
+  await deleteLineWithUnits(ctx, line._id, line.id);
+}
+
 /** Cascade delete a line: its children (+ all units), then the line (+ its units). */
 export const removeLineItemCascade = mutation({
   args: { id: v.string() },
   handler: async (ctx, { id }) => {
     await requireService(ctx);
-    const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-    if (!line) throw new ConvexError("projectLineItems not found: " + id);
-    const children = await ctx.db
-      .query("projectLineItems")
-      .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
-      .collect();
-    for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id);
-    await deleteLineWithUnits(ctx, line._id, line.id);
+    await removeLineItemCascadeCore(ctx, id);
   },
 });
 

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -226,21 +226,193 @@ describe("projectWrites.createNative", () => {
 });
 
 describe("projectWrites.deleteNative", () => {
-  const dargs = { id: "p1", orgId: ORG, freedAssets: 2, freedKits: 1, actor: ACTOR, auditId: "log1", now: NOW };
-  test("owner deletes project + DELETE audit (freed counts)", async () => {
-    const t = makeT();
-    await seedProject(t, "owner");
-    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs);
+  const dargs = { id: "p1", orgId: ORG, defaultLocationId: "loc1" as string | null, actor: ACTOR, auditId: "log1", now: NOW };
+
+  // Seed a CANCELLED project loaded with every dependent row-type the cascade must
+  // clear, plus a checked-out LOOSE asset + a checked-out KIT (with a serialized
+  // member asset) that must be freed to AVAILABLE.
+  async function seedFullCancelledProject(t: ReturnType<typeof convexTest>, role = "owner") {
     await t.run(async (ctx) => {
-      expect(await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first()).toBeNull();
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CANCELLED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+      // The org's default location (the delete mutation org-validates defaultLocationId).
+      await ctx.db.insert("locations", { id: "loc1", organizationId: ORG, name: "Warehouse", createdAt: NOW, updatedAt: NOW });
+
+      // A loose serialized asset, checked out on a line.
+      await ctx.db.insert("assets", { id: "asset_loose", organizationId: ORG, modelId: "model1", assetTag: "A-1", status: "CHECKED_OUT", isActive: true, locationId: "old_loc", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "li_loose", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", assetId: "asset_loose", quantity: 1, status: "CHECKED_OUT", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItemUnits", { id: "unit_loose", organizationId: ORG, lineItemId: "li_loose", assetId: "asset_loose", status: "CHECKED_OUT", ordinal: 0, createdAt: NOW, updatedAt: NOW });
+
+      // A checked-out kit + its serialized member asset + the kit parent line.
+      await ctx.db.insert("kits", { id: "kit1", organizationId: ORG, assetTag: "K-1", name: "Kit One", status: "CHECKED_OUT", locationId: "old_loc", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id: "asset_kit", organizationId: ORG, modelId: "model1", assetTag: "A-2", status: "CHECKED_OUT", isActive: true, locationId: "old_loc", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("kitSerializedItems", { id: "ksi1", organizationId: ORG, kitId: "kit1", assetId: "asset_kit", addedById: USER, addedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "li_kit", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", kitId: "kit1", quantity: 1, status: "CHECKED_OUT", sortOrder: 1, createdAt: NOW, updatedAt: NOW });
+      // A kit-child line + unit (must be cascaded via the parent).
+      await ctx.db.insert("projectLineItems", { id: "li_kit_child", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", assetId: "asset_kit", quantity: 1, status: "CHECKED_OUT", sortOrder: 2, isKitChild: true, parentLineItemId: "li_kit", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItemUnits", { id: "unit_kit_child", organizationId: ORG, lineItemId: "li_kit_child", assetId: "asset_kit", status: "CHECKED_OUT", ordinal: 0, createdAt: NOW, updatedAt: NOW });
+
+      // Crew assignment → shift → time entry.
+      await ctx.db.insert("crewAssignments", { id: "ca1", organizationId: ORG, projectId: "p1", crewMemberId: "cm1", status: "CONFIRMED", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("crewShifts", { id: "cs1", assignmentId: "ca1", date: NOW });
+      await ctx.db.insert("crewTimeEntries", { id: "cte1", organizationId: ORG, assignmentId: "ca1", crewMemberId: "cm1", date: NOW, startTime: "09:00", endTime: "17:00" });
+
+      // PM / task / service.
+      await ctx.db.insert("projectManagers", { id: "pm1", organizationId: ORG, projectId: "p1", userId: USER, addedAt: NOW });
+      await ctx.db.insert("projectTasks", { id: "task1", organizationId: ORG, projectId: "p1", title: "Load in", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectServices", { id: "svc1", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Labour", createdAt: NOW, updatedAt: NOW });
+
+      // Grouping: category + group + slots.
+      await ctx.db.insert("projectCategories", { id: "cat1", organizationId: ORG, projectId: "p1", name: "Audio", sortOrder: 0 });
+      await ctx.db.insert("projectGroups", { id: "grp1", organizationId: ORG, projectId: "p1", title: "Stage", sortOrder: 0 });
+      await ctx.db.insert("categorySlots", { id: "slot_cat", projectCategoryId: "cat1", sortOrder: 0 });
+      await ctx.db.insert("categorySlots", { id: "slot_grp", projectCategoryId: "cat1", projectGroupId: "grp1", sortOrder: 0 });
+
+      // The revenue rollup (the orphan the stub missed).
+      await ctx.db.insert("projectModelRevenues", { id: "pmr1", organizationId: ORG, projectId: "p1", modelId: "model1", allocatedRevenue: 100, updatedAt: NOW });
+    });
+  }
+
+  test("full cascade: project + every dependent row gone; assets/kit freed to AVAILABLE", async () => {
+    const t = makeT();
+    await seedFullCancelledProject(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs);
+    // freedAssets = 2: the loose line's asset + the kit-CHILD line's asset (the raw
+    // line loop counts kit-child lines too — exact parity with the old server loop).
+    expect(res).toEqual({ id: "p1", freedAssets: 2, freedKits: 1 });
+
+    await t.run(async (ctx) => {
+      const gone = async (table: string, id: string) =>
+        (await ctx.db.query(table as "projects").withIndex("by_cuid", (q) => q.eq("id", id)).first()) ?? null;
+      // Project + all dependents cleared.
+      expect(await gone("projects", "p1")).toBeNull();
+      for (const [tbl, id] of [
+        ["projectLineItems", "li_loose"], ["projectLineItems", "li_kit"], ["projectLineItems", "li_kit_child"],
+        ["projectLineItemUnits", "unit_loose"], ["projectLineItemUnits", "unit_kit_child"],
+        ["crewAssignments", "ca1"], ["crewShifts", "cs1"], ["crewTimeEntries", "cte1"],
+        ["projectManagers", "pm1"], ["projectTasks", "task1"], ["projectServices", "svc1"],
+        ["projectCategories", "cat1"], ["projectGroups", "grp1"],
+        ["categorySlots", "slot_cat"], ["categorySlots", "slot_grp"],
+        ["projectModelRevenues", "pmr1"],
+      ] as const) {
+        expect(await gone(tbl, id)).toBeNull();
+      }
+      // Loose asset + kit-serialized asset freed to AVAILABLE at the default location.
+      const loose = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "asset_loose")).first();
+      expect(loose?.status).toBe("AVAILABLE");
+      expect(loose?.locationId).toBe("loc1");
+      const kitAsset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "asset_kit")).first();
+      expect(kitAsset?.status).toBe("AVAILABLE");
+      expect(kitAsset?.locationId).toBe("loc1");
+      // Kit itself freed to AVAILABLE (not archived).
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "kit1")).first();
+      expect(kit?.status).toBe("AVAILABLE");
+      expect(kit?.locationId).toBe("loc1");
+      // DELETE audit with computed freed counts.
       const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
       expect(log?.action).toBe("DELETE");
-      expect((log?.details as { freedAssets: number }).freedAssets).toBe(2);
+      expect((log?.details as { freedAssets: number; freedKits: number }).freedAssets).toBe(2);
+      expect((log?.details as { freedAssets: number; freedKits: number }).freedKits).toBe(1);
     });
   });
+
+  test("rejects a non-CANCELLED project (DELETE_GUARD)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "owner" });
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs),
+    ).rejects.toThrow(/cancelled/i);
+  });
+
+  test("rejects a template (must use deleteTemplateNative)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "owner" });
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "T", status: "CANCELLED", isTemplate: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs),
+    ).rejects.toThrow(/template/i);
+  });
+
   test("a member (no project:delete) is denied", async () => {
     const t = makeT();
-    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CANCELLED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, dargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("frees assets with NO default location (clears locationId)", async () => {
+    const t = makeT();
+    await seedFullCancelledProject(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteNative, { ...dargs, defaultLocationId: null });
+    await t.run(async (ctx) => {
+      const loose = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "asset_loose")).first();
+      expect(loose?.status).toBe("AVAILABLE");
+      expect(loose?.locationId).toBeUndefined();
+      // Kit keeps its old location (server never clears a kit's location).
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", "kit1")).first();
+      expect(kit?.status).toBe("AVAILABLE");
+      expect(kit?.locationId).toBe("old_loc");
+    });
+  });
+});
+
+describe("projectWrites.deleteTemplateNative", () => {
+  const targs = { id: "t1", orgId: ORG, actor: ACTOR, now: NOW };
+
+  async function seedTemplate(t: ReturnType<typeof convexTest>, role = "owner", isTemplate = true) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+      await ctx.db.insert("projects", { id: "t1", organizationId: ORG, projectNumber: "T1", name: "Template", isTemplate, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "tli1", organizationId: ORG, projectId: "t1", type: "EQUIPMENT", quantity: 1, status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectManagers", { id: "tpm1", organizationId: ORG, projectId: "t1", userId: USER, addedAt: NOW });
+      await ctx.db.insert("projectCategories", { id: "tcat1", organizationId: ORG, projectId: "t1", name: "Audio", sortOrder: 0 });
+      await ctx.db.insert("categorySlots", { id: "tslot1", projectCategoryId: "tcat1", sortOrder: 0 });
+      await ctx.db.insert("projectModelRevenues", { id: "tpmr1", organizationId: ORG, projectId: "t1", modelId: "model1", allocatedRevenue: 0, updatedAt: NOW });
+    });
+  }
+
+  test("deletes a template + its lines/grouping/rollup (no audit)", async () => {
+    const t = makeT();
+    await seedTemplate(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteTemplateNative, targs);
+    expect(res).toEqual({ success: true });
+    await t.run(async (ctx) => {
+      const gone = async (table: string, id: string) =>
+        (await ctx.db.query(table as "projects").withIndex("by_cuid", (q) => q.eq("id", id)).first()) ?? null;
+      expect(await gone("projects", "t1")).toBeNull();
+      for (const [tbl, id] of [
+        ["projectLineItems", "tli1"], ["projectManagers", "tpm1"],
+        ["projectCategories", "tcat1"], ["categorySlots", "tslot1"],
+        ["projectModelRevenues", "tpmr1"],
+      ] as const) {
+        expect(await gone(tbl, id)).toBeNull();
+      }
+      // No audit is written for a template delete.
+      const logs = await ctx.db.query("activityLogs").withIndex("by_organizationId", (q) => q.eq("organizationId", ORG)).collect();
+      expect(logs.length).toBe(0);
+    });
+  });
+
+  test("rejects a non-template (NOT_A_TEMPLATE)", async () => {
+    const t = makeT();
+    await seedTemplate(t, "owner", false);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteTemplateNative, targs),
+    ).rejects.toThrow(/not a template|project, not a template/i);
+  });
+
+  test("a member (no project:delete) is denied", async () => {
+    const t = makeT();
+    await seedTemplate(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.deleteTemplateNative, targs),
+    ).rejects.toThrow(/insufficient permissions/i);
   });
 });

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -15,6 +15,10 @@ import { writeActivityLog } from "./lib/audit";
 import { bumpProjectCounters } from "./lib/counters";
 import * as enums from "./lib/validators";
 import { projectWriteFields } from "./projects";
+import { setAssetsStatus } from "./warehouseOps";
+import { removeLineItemCascadeCore } from "./projectLineItems";
+import { deleteCrewAssignmentCascadeCore } from "./crewAssignments";
+import { deleteAllForProjectCore } from "./projectCategories";
 
 /**
  * Native PROJECT write mutations (Phase 5) — the MONEY-FREE project writes only:
@@ -330,35 +334,165 @@ export const createNative = mutation({
 });
 
 /**
- * deleteNative — remove the project row + DELETE audit, atomic. RBAC(project, delete).
- * Option A: the server action runs the multi-table cascade (line items, crew
- * assignments, managers/tasks/services, freeing checked-out assets/kits) via the
- * existing mutations first; this does the final project-row delete + audit. `freed*`
- * counts are computed server-side and passed for the audit detail.
+ * deleteNative — the FULL, atomic project-delete cascade + DELETE audit.
+ * RBAC(project, delete). Parity with the (former) server `deleteProject`: only a
+ * CANCELLED, non-template project may be deleted; every dependent Convex row is
+ * purged in ONE transaction (no more N server→Convex round-trips, no orphan window):
+ *
+ *   1. Free loose checked-out/confirmed assets → setAssetsStatus (dashboard counters!)
+ *   2. Free checked-out/confirmed kits inline (kits carry no counter)
+ *   3. Free those kits' serialized member assets → setAssetsStatus
+ *   4. Cascade every top-level line item (children + units) → removeLineItemCascadeCore
+ *   5. Crew assignments (→ shifts + linked time entries) → deleteCrewAssignmentCascadeCore
+ *   6. Project managers / tasks / services (inline)
+ *   7. Grouping (categories / groups / slots) → deleteAllForProjectCore
+ *   8. projectModelRevenues rollup (Convex-only cache — MUST purge or it orphans)
+ *   then bumpProjectCounters + delete the project row + DELETE audit.
+ *
+ * `freedAssets`/`freedKits` are computed IN-mutation (never trusted from the client)
+ * and returned + audited. `defaultLocationId` is the org's default location (resolved
+ * by the caller, mirrors getDefaultLocation) applied to every freed asset/kit.
+ * Convex forbids mutation→mutation, so the cascade reuses extracted `*Core` fns.
  */
+/** Free a set of assets to AVAILABLE, but ONLY the ones that belong to `orgId` — a
+ *  forged line/kit-member could otherwise point at a foreign asset, and setAssetsStatus
+ *  resolves by the GLOBAL by_cuid index. Routes through setAssetsStatus so the sharded
+ *  asset counters stay in sync. Returns the count actually freed. */
+async function freeOrgAssets(
+  ctx: Parameters<typeof setAssetsStatus>[0],
+  assetIds: string[],
+  orgId: string,
+  locationId: string | null,
+  now: number,
+): Promise<number> {
+  const owned: string[] = [];
+  for (const aid of [...new Set(assetIds)]) {
+    const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", aid)).first();
+    if (asset && asset.organizationId === orgId) owned.push(aid);
+  }
+  if (owned.length > 0) await setAssetsStatus(ctx, owned, "AVAILABLE", locationId, true, now);
+  return owned.length;
+}
+
 export const deleteNative = mutation({
-  returns: v.object({ id: v.string() }),
+  returns: v.object({ id: v.string(), freedAssets: v.number(), freedKits: v.number() }),
   args: {
     id: v.string(),
     orgId: v.string(),
-    freedAssets: v.number(),
-    freedKits: v.number(),
+    defaultLocationId: v.union(v.string(), v.null()),
+    // Legacy args — retained for wire-compat but IGNORED: the freed counts are now
+    // computed in-mutation (a client must not be able to forge the audit detail).
+    freedAssets: v.optional(v.number()),
+    freedKits: v.optional(v.number()),
     actor: actorValidator,
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, orgId, freedAssets, freedKits, actor: suppliedActor, auditId, now }) => {
+  handler: async (ctx, { id, orgId, defaultLocationId, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "project");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
+
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+    if (project.status !== "CANCELLED") {
+      throw new ConvexError({ code: "DELETE_GUARD", message: "Only cancelled projects can be deleted." });
+    }
+    if (project.isTemplate) {
+      throw new ConvexError({ code: "DELETE_GUARD", message: "Templates must be deleted via deleteTemplateNative." });
+    }
 
-    await ctx.db.delete(project._id);
+    // Validate the client-supplied default location belongs to this org (by_cuid is global)
+    // before it's written onto freed assets/kits — else use null (clear the location).
+    let safeLocationId: string | null = null;
+    if (defaultLocationId != null) {
+      const loc = await ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", defaultLocationId)).first();
+      if (loc && loc.organizationId === orgId) safeLocationId = defaultLocationId;
+    }
+
+    // ── Step 0: scan the project's line items (org-filtered) → collect the assets
+    // and kits to free. by_projectId is a project-scoped index; the org re-check is
+    // defensive (a project's lines always share its org).
+    const lineItems = (
+      await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((li) => li.organizationId === orgId);
+
+    const checkedOutAssetIds: string[] = [];
+    const checkedOutKitIds: string[] = [];
+    for (const li of lineItems) {
+      if (li.assetId && (li.status === "CHECKED_OUT" || li.status === "CONFIRMED")) checkedOutAssetIds.push(li.assetId);
+      if (li.kitId && (li.status === "CHECKED_OUT" || li.status === "CONFIRMED")) checkedOutKitIds.push(li.kitId);
+    }
+
+    // Step 1 — free loose checked-out assets (org-scoped; routes through setAssetsStatus so
+    // the sharded dashboard counters stay in sync; clear location when there's no default).
+    await freeOrgAssets(ctx, checkedOutAssetIds, orgId, safeLocationId, now);
+
+    // Step 2 — free checked-out kits inline (status AVAILABLE + location; kits have
+    // no counter). Leave the kit's location untouched when there's no default.
+    for (const kitId of checkedOutKitIds) {
+      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+      if (!kit || kit.organizationId !== orgId) continue;
+      await ctx.db.patch(kit._id, {
+        status: "AVAILABLE",
+        ...(safeLocationId != null ? { locationId: safeLocationId } : {}),
+        updatedAt: now,
+      });
+    }
+
+    // Step 3 — free those kits' serialized member assets (org-scoped, counter-safe path).
+    const kitAssetIds: string[] = [];
+    for (const kitId of checkedOutKitIds) {
+      const members = await ctx.db.query("kitSerializedItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect();
+      for (const m of members) if (m.organizationId === orgId) kitAssetIds.push(m.assetId);
+    }
+    await freeOrgAssets(ctx, kitAssetIds, orgId, safeLocationId, now);
+
+    // Step 4 — cascade every top-level line (its children + all units go with it).
+    for (const li of lineItems) {
+      if (li.parentLineItemId == null) await removeLineItemCascadeCore(ctx, li.id);
+    }
+
+    // Step 5 — crew assignments (→ shifts + linked time entries + offer counter).
+    const assignments = (
+      await ctx.db.query("crewAssignments").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((a) => a.organizationId === orgId);
+    for (const a of assignments) await deleteCrewAssignmentCascadeCore(ctx, a);
+
+    // Step 6 — project managers / tasks / services (org-filtered inline deletes).
+    // NOT projectServices.removeManyCascade — that would re-cascade lines/crew we
+    // already handled above.
+    const pms = (
+      await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of pms) await ctx.db.delete(r._id);
+    const tasks = (
+      await ctx.db.query("projectTasks").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of tasks) await ctx.db.delete(r._id);
+    const services = (
+      await ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of services) await ctx.db.delete(r._id);
+
+    // Step 7 — grouping (categories / groups / slots).
+    await deleteAllForProjectCore(ctx, id);
+
+    // Step 8 — projectModelRevenues rollup (Convex-only cache; no FK to cascade —
+    // the (former) native stub missed this, orphaning one row per model per delete).
+    const rollups = (
+      await ctx.db.query("projectModelRevenues").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of rollups) await ctx.db.delete(r._id);
+
+    // Finally — project row + active-project counter + DELETE audit.
     await bumpProjectCounters(ctx, orgId, project, null);
+    await ctx.db.delete(project._id);
 
+    const freedAssets = checkedOutAssetIds.length;
+    const freedKits = checkedOutKitIds.length;
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
@@ -374,6 +508,74 @@ export const deleteNative = mutation({
       createdAt: now,
     });
 
-    return { id };
+    return { id, freedAssets, freedKits };
+  },
+});
+
+/**
+ * deleteTemplateNative — the atomic template-delete cascade. RBAC(project, delete).
+ * Parity with the (former) server `deleteTemplate`: a template has NO CANCELLED
+ * precondition, frees NO assets/kits (a template holds none checked out), has NO
+ * crew cascade and writes NO audit. Cascade: PM/tasks/services → grouping → line
+ * items → projectModelRevenues → the project row (+ counter).
+ */
+export const deleteTemplateNative = mutation({
+  returns: v.object({ success: v.boolean() }),
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    actor: actorValidator,
+    now: v.number(),
+  },
+  handler: async (ctx, { id, orgId, actor: suppliedActor, now }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "delete");
+    await resolveActor(ctx, suppliedActor);
+
+    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Template not found." });
+    if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+    if (!project.isTemplate) {
+      throw new ConvexError({ code: "NOT_A_TEMPLATE", message: "That ID points at a project, not a template." });
+    }
+
+    // Project managers / tasks / services (org-filtered inline deletes).
+    const pms = (
+      await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of pms) await ctx.db.delete(r._id);
+    const tasks = (
+      await ctx.db.query("projectTasks").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of tasks) await ctx.db.delete(r._id);
+    const services = (
+      await ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of services) await ctx.db.delete(r._id);
+
+    // Grouping (categories / groups / slots).
+    await deleteAllForProjectCore(ctx, id);
+
+    // Template line items (top-level cascade → children + units).
+    const lineItems = (
+      await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((li) => li.organizationId === orgId);
+    for (const li of lineItems) {
+      if (li.parentLineItemId == null) await removeLineItemCascadeCore(ctx, li.id);
+    }
+
+    // projectModelRevenues rollup (Convex-only cache).
+    const rollups = (
+      await ctx.db.query("projectModelRevenues").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const r of rollups) await ctx.db.delete(r._id);
+
+    // Delete the template row (+ active-project counter — templates never count as
+    // active, so the delta is 0, but keep the call uniform with deleteNative).
+    await bumpProjectCounters(ctx, orgId, project, null);
+    await ctx.db.delete(project._id);
+
+    return { success: true };
   },
 });

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -402,7 +402,7 @@ async function collectKitBulkAdjustments(ctx: Ctx, kitId: string, organizationId
   const bulks = await ctx.db.query("kitBulkItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect();
   return bulks.filter((b) => b.organizationId === organizationId).map((b) => ({ bulkAssetId: b.bulkAssetId, delta: sign * b.quantity }));
 }
-async function setAssetsStatus(ctx: Ctx, assetIds: string[], status: string, locationId: string | null, clearLocIfNull: boolean, now: number) {
+export async function setAssetsStatus(ctx: Ctx, assetIds: string[], status: string, locationId: string | null, clearLocIfNull: boolean, now: number) {
   for (const id of assetIds) {
     const a = await assetByCuid(ctx, id);
     if (!a) continue;

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -27,11 +27,9 @@ import { serialize } from "@/lib/serialize";
 import { computeOverbookedStatus } from "@/lib/availability";
 import { recalculateProjectTotals } from "@/server/line-items";
 import { logActivity } from "@/lib/activity-log";
-import { getKitSerializedItemsByOrg } from "@/lib/kits-read";
 import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { getProjectMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { api } from "../../convex/_generated/api";
-import { getAssignmentsByProject } from "@/lib/crew-scheduling-read";
 import { type FilterValue } from "@/lib/table-utils";
 import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { getDefaultLocation, getLocationMap, getMappedLocationsByOrg, mapLocation } from "@/lib/locations-read";
@@ -1397,7 +1395,7 @@ export async function getTemplates() {
 }
 
 export async function deleteTemplate(id: string) {
-  const { organizationId } = await requirePermission("project", "delete");
+  const { organizationId, userId, userName } = await requirePermission("project", "delete");
 
   // project is Convex-only — read the template scalars from Convex.
   const template = await getProjectByIdMapped(id, organizationId);
@@ -1416,31 +1414,16 @@ export async function deleteTemplate(id: string) {
     });
   }
 
-  // Delete the Convex-only sub-table rows (PM/tasks/services), then the project doc.
-  // (No Prisma FK cascade remains — they're all explicit Convex cascades now.)
+  // The full delete cascade (PM/tasks/services → grouping → line items →
+  // projectModelRevenues → the project row) runs atomically INSIDE Convex — one
+  // round-trip, no orphan window. RBAC + the isTemplate guard are re-checked there.
   const convexForDelete = await getConvexClient();
-  const [pmRows, taskRows, serviceRows] = await Promise.all([
-    convexForDelete.query(api.projectManagers.listByProject, { projectId: id, orgId: organizationId }),
-    convexForDelete.query(api.projectTasks.listByProject, { projectId: id, orgId: organizationId }),
-    convexForDelete.query(api.projectServices.listByProject, { projectId: id, orgId: organizationId }),
-  ]);
-  await Promise.all([
-    ...pmRows.map((pm) => convexForDelete.mutation(api.projectManagers.remove, { id: pm.id })),
-    ...taskRows.map((t) => convexForDelete.mutation(api.projectTasks.remove, { id: t.id })),
-    ...serviceRows.map((s) => convexForDelete.mutation(api.projectServices.remove, { id: s.id })),
-  ]);
-  // Grouping (category/group/slot) + any template line items live in Convex only.
-  await convexForDelete.mutation(api.projectCategories.deleteAllForProject, { projectId: id });
-  const templateLineItems = await convexForDelete.query(api.projectLineItems.listByProject, {
-    projectId: id,
+  await convexForDelete.mutation(api.projectWrites.deleteTemplateNative, {
+    id,
     orgId: organizationId,
+    actor: { userId, userName },
+    now: Date.now(),
   });
-  await Promise.all(
-    templateLineItems
-      .filter((li) => li.parentLineItemId == null)
-      .map((li) => convexForDelete.mutation(api.projectLineItems.removeLineItemCascade, { id: li.id })),
-  );
-  await convexForDelete.mutation(api.projects.remove, { id });
   return { success: true };
 }
 
@@ -1469,136 +1452,22 @@ export async function deleteProject(id: string) {
 
   const convex = await getConvexClient();
 
-  // Line items are Convex-only — read them to collect assets/kits to free and
-  // to drive the explicit cascade removal (the dropped FK no longer cascades).
-  const lineItems = await convex.query(api.projectLineItems.listByProject, {
-    projectId: id,
-    orgId: organizationId,
-  });
-
-  // Collect IDs to reset
-  const checkedOutAssetIds: string[] = [];
-  const checkedOutKitIds: string[] = [];
-
-  for (const li of lineItems) {
-    if (li.assetId && (li.status === "CHECKED_OUT" || li.status === "CONFIRMED")) {
-      checkedOutAssetIds.push(li.assetId);
-    }
-    if (li.kitId && (li.status === "CHECKED_OUT" || li.status === "CONFIRMED")) {
-      checkedOutKitIds.push(li.kitId);
-    }
-  }
-
-  // Get org default location from Convex.
+  // The full delete cascade runs atomically INSIDE Convex (deleteNative): it frees
+  // checked-out assets/kits (+ kit-serialized members) through the counter-safe
+  // path, cascades every line item + its units, deletes crew assignments (→ shifts
+  // + time entries), managers/tasks/services, grouping, the projectModelRevenues
+  // rollup, then the project row + DELETE audit — in ONE round-trip, no orphan
+  // window. The CANCELLED + non-template guards are re-checked there. We only
+  // resolve the org default location to pass through (mirrors getDefaultLocation).
   const defaultLocation = await getDefaultLocation(organizationId);
-  const now = Date.now();
-
-  // The project's crew assignments (Convex-only) — captured so their cascade
-  // (assignment → shifts + linked time-entries) can be deleted from Convex after
-  // the project row goes (no Prisma FK cascade remains — dropped in #254).
-  const crewAssignmentIds = (await getAssignmentsByProject(id, organizationId)).map((a) => a.id);
-
-  // Reset checked-out assets to AVAILABLE (Convex). Clear locationId when there
-  // is no default location.
-  if (checkedOutAssetIds.length > 0) {
-    await convex.mutation(api.assets.bulkUpdate, {
-      organizationId,
-      ids: checkedOutAssetIds,
-      set: { status: "AVAILABLE", ...(defaultLocation?.id ? { locationId: defaultLocation.id } : {}), updatedAt: now },
-      ...(defaultLocation?.id ? {} : { clear: ["locationId"] }),
-    });
-  }
-
-  // Reset checked-out kits and their contents to AVAILABLE (Convex). Kits are
-  // patched per-id (status AVAILABLE + location — NOT archived). Kit serialized
-  // assets are reset via assets.bulkUpdate.
-  const kitAssetIds: string[] = [];
-  if (checkedOutKitIds.length > 0) {
-    const allKitSerialized = await getKitSerializedItemsByOrg(organizationId);
-    const checkedOutKitIdSet = new Set(checkedOutKitIds);
-    await Promise.all(
-      checkedOutKitIds.map((kitId) =>
-        convex.mutation(api.kits.update, {
-          id: kitId,
-          patch: { status: "AVAILABLE", ...(defaultLocation?.id ? { locationId: defaultLocation.id } : {}), updatedAt: now },
-        }),
-      ),
-    );
-    for (const ks of allKitSerialized) {
-      if (checkedOutKitIdSet.has(ks.kitId)) kitAssetIds.push(ks.assetId);
-    }
-  }
-  if (kitAssetIds.length > 0) {
-    await convex.mutation(api.assets.bulkUpdate, {
-      organizationId,
-      ids: kitAssetIds,
-      set: { status: "AVAILABLE", ...(defaultLocation?.id ? { locationId: defaultLocation.id } : {}), updatedAt: now },
-      ...(defaultLocation?.id ? {} : { clear: ["locationId"] }),
-    });
-  }
-
-  // Remove the project's line items from Convex. The project↔line-item FK is
-  // dropped, so prisma.project.delete no longer cascades — explicitly cascade
-  // each top-level line (removeLineItemCascade handles its children + units).
-  // Fire concurrently (each top-level line is independent) — was one sequential
-  // Convex round-trip per line, so a 200-line project took 200 sequential calls.
-  await Promise.all(
-    lineItems
-      .filter((li) => li.parentLineItemId == null)
-      .map((li) => convex.mutation(api.projectLineItems.removeLineItemCascade, { id: li.id })),
-  );
-
-  // Tidy the remaining Convex sub-tables / crew cascade, then delete the project
-  // doc. The project + all its sub-tables are Convex-only now (no Prisma FK
-  // cascade remains — dropped in Phase C #254), so each is removed explicitly.
-  await Promise.all(
-    crewAssignmentIds.map((aid) => convex.mutation(api.crewAssignments.deleteCascade, { id: aid })),
-  );
-  // Delete Convex-only sub-table rows (PM/tasks/services).
-  const [pmRows, taskRows, serviceRows] = await Promise.all([
-    convex.query(api.projectManagers.listByProject, { projectId: id, orgId: organizationId }),
-    convex.query(api.projectTasks.listByProject, { projectId: id, orgId: organizationId }),
-    convex.query(api.projectServices.listByProject, { projectId: id, orgId: organizationId }),
-  ]);
-  await Promise.all([
-    ...pmRows.map((pm) => convex.mutation(api.projectManagers.remove, { id: pm.id })),
-    ...taskRows.map((t) => convex.mutation(api.projectTasks.remove, { id: t.id })),
-    ...serviceRows.map((s) => convex.mutation(api.projectServices.remove, { id: s.id })),
-  ]);
-  // Grouping (category/group/slot) lives in Convex only; the Prisma FK cascade
-  // that used to clean these up was dropped in Phase C #254, so purge them here.
-  await convex.mutation(api.projectCategories.deleteAllForProject, { projectId: id });
-  // Finally delete the project doc itself (Convex-only).
-  if (nativeProjectWrites()) {
-    // Native: final project-row delete + DELETE audit atomic (the cascade above ran
-    // server-side; recalc N/A for a delete).
-    await convex.mutation(api.projectWrites.deleteNative, {
-      id,
-      orgId: organizationId,
-      freedAssets: checkedOutAssetIds.length,
-      freedKits: checkedOutKitIds.length,
-      actor: { userId, userName },
-      auditId: createId(),
-      now: Date.now(),
-    });
-  } else {
-    await convex.mutation(api.projects.remove, { id });
-    await logActivity({
-      organizationId,
-      userId,
-      userName,
-      action: "DELETE",
-      entityType: "project",
-      entityId: id,
-      entityName: project.projectNumber,
-      summary: `Deleted project ${project.projectNumber} - ${project.name}`,
-      details: {
-        deleted: { projectNumber: project.projectNumber, name: project.name },
-        freedAssets: checkedOutAssetIds.length,
-        freedKits: checkedOutKitIds.length,
-      },
-    });
-  }
+  await convex.mutation(api.projectWrites.deleteNative, {
+    id,
+    orgId: organizationId,
+    defaultLocationId: defaultLocation?.id ?? null,
+    actor: { userId, userName },
+    auditId: createId(),
+    now: Date.now(),
+  });
 }
 
 /** Get project milestone dates for call sheet dialog */


### PR DESCRIPTION
## Summary
The old `deleteNative` was a **stub** (deleted only the row + audit). With `NATIVE_PROJECT_WRITES` on in prod, project deletion was **orphaning rows + leaving assets/kits stuck CHECKED_OUT**. This ports the entire `deleteProject` cascade into one atomic mutation, assembled from cores extracted across the domain conversions.

- **Extracted cores** (requireService mutations kept thin — partial-keep): `setAssetsStatus` (exported, counter-safe asset-free), `removeLineItemCascadeCore`, `deleteCrewAssignmentCascadeCore` (`bumpCountersForTable`), `deleteAllForProjectCore`.
- **`deleteNative`** — 8-step cascade: free CHECKED_OUT/CONFIRMED loose assets + kits + kit-serialized member assets (org-scoped, via `setAssetsStatus` → sharded counters stay in sync); `removeLineItemCascadeCore` per top-level line; `deleteCrewAssignmentCascadeCore` per assignment; inline PM/tasks/services; `deleteAllForProjectCore`; **delete `projectModelRevenues`** (the rollup the stub orphaned); then `bumpProjectCounters` + row + audit. Guards: CANCELLED + non-template.
- **`deleteTemplateNative`** — the template-scoped subset. Server `deleteProject`/`deleteTemplate` thinned to call the native mutations.

## Review
Codex-reviewed — **2 High cross-tenant fixes**: asset frees now org-scoped (`freeOrgAssets` — a forged line/kit-member can't free/relocate another tenant's asset through the global `by_cuid` resolve); `defaultLocationId` org-validated before it's written onto freed assets/kits. Integration test seeds every dependent row-type + asserts all gone + assets/kit AVAILABLE. tsc clean; 24 projectWrites tests + full convex suite (865) green; deployed additive/inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)