### PR TITLE
feat(projectWrites): numbering fold + duplicate/saveAsTemplate native twins

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -98,6 +98,8 @@ import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
 import type * as lib_moneyGuards from "../lib/moneyGuards.js";
 import type * as lib_notificationPreferences from "../lib/notificationPreferences.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
+import type * as lib_projectNumber from "../lib/projectNumber.js";
+import type * as lib_projectNumberCounter from "../lib/projectNumberCounter.js";
 import type * as lib_rateLimiter from "../lib/rateLimiter.js";
 import type * as lib_recalc from "../lib/recalc.js";
 import type * as lib_reservationConflicts from "../lib/reservationConflicts.js";
@@ -299,6 +301,8 @@ declare const fullApi: ApiFromModules<{
   "lib/moneyGuards": typeof lib_moneyGuards;
   "lib/notificationPreferences": typeof lib_notificationPreferences;
   "lib/permissionsCore": typeof lib_permissionsCore;
+  "lib/projectNumber": typeof lib_projectNumber;
+  "lib/projectNumberCounter": typeof lib_projectNumberCounter;
   "lib/rateLimiter": typeof lib_rateLimiter;
   "lib/recalc": typeof lib_recalc;
   "lib/reservationConflicts": typeof lib_reservationConflicts;

--- a/convex/lib/projectNumber.ts
+++ b/convex/lib/projectNumber.ts
@@ -1,0 +1,102 @@
+/**
+ * Configurable auto-incrementing project numbers — PURE renderers, copied
+ * byte-for-byte from src/lib/project-number.ts.
+ *
+ * The Convex bundler can't resolve the `@/` alias, so the pure functions the
+ * native createNative auto-number loop needs (`renderProjectNumber`,
+ * `scopeKeyFor`, `datePartsInTimezone`, `hasIncrementToken`) are duplicated here.
+ * PINNED to the src/lib originals by a cross-import equality test in
+ * `convex/projectNumber.test.ts` (same pattern as `convex/lib/availabilityCore`
+ * and `convex/lib/blockingCommentsGate`). Do NOT diverge from the src/lib copy.
+ */
+
+export type IncrementReset = "NONE" | "YEARLY" | "MONTHLY" | "DAILY";
+
+export interface ProjectNumberDateParts {
+  /** Full year, e.g. 2026. */
+  year: number;
+  /** 1-12. */
+  month: number;
+  /** 1-31. */
+  day: number;
+}
+
+export const DEFAULT_INCREMENT_PADDING = 2;
+
+/** The tokens that render the sequence counter (any one of these makes numbers unique). */
+const INCREMENT_TOKENS = ["%INCREMENT", "%INC", "%SEQ"] as const;
+
+/** True if the template contains at least one increment token. */
+export function hasIncrementToken(format: string): boolean {
+  return INCREMENT_TOKENS.some((t) => format.includes(t));
+}
+
+/** The counter-bucket key for a given reset period + date. */
+export function scopeKeyFor(reset: IncrementReset, parts: ProjectNumberDateParts): string {
+  const yyyy = String(parts.year).padStart(4, "0");
+  const mm = String(parts.month).padStart(2, "0");
+  const dd = String(parts.day).padStart(2, "0");
+  switch (reset) {
+    case "YEARLY":
+      return yyyy;
+    case "MONTHLY":
+      return `${yyyy}-${mm}`;
+    case "DAILY":
+      return `${yyyy}-${mm}-${dd}`;
+    case "NONE":
+    default:
+      return "GLOBAL";
+  }
+}
+
+/**
+ * Render the template. Longer tokens are substituted before their prefixes
+ * (%YYYY before %YY, %MM before %M, %INCREMENT before %INC) so they don't clash.
+ */
+export function renderProjectNumber(
+  format: string,
+  opts: { parts: ProjectNumberDateParts; sequence: number; padding?: number },
+): string {
+  const { parts, sequence } = opts;
+  const padding = opts.padding ?? DEFAULT_INCREMENT_PADDING;
+  const yyyy = String(parts.year).padStart(4, "0");
+  const yy = yyyy.slice(-2);
+  const mm = String(parts.month).padStart(2, "0");
+  const dd = String(parts.day).padStart(2, "0");
+  const seq = String(sequence).padStart(Math.max(1, padding), "0");
+
+  return format
+    .replace(/%YYYY/g, yyyy)
+    .replace(/%YY/g, yy)
+    .replace(/%MM/g, mm)
+    .replace(/%M/g, String(parts.month))
+    .replace(/%DD/g, dd)
+    .replace(/%D/g, String(parts.day))
+    .replace(/%INCREMENT/g, seq)
+    .replace(/%INC/g, seq)
+    .replace(/%SEQ/g, seq);
+}
+
+/**
+ * Compute date parts for a Date in a given IANA timezone (no external deps).
+ * Defaults to the system zone if tz is omitted/invalid.
+ */
+export function datePartsInTimezone(date: Date, timezone?: string): ProjectNumberDateParts {
+  try {
+    const fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone || undefined,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const parts = fmt.formatToParts(date);
+    const get = (t: string) => Number(parts.find((p) => p.type === t)?.value);
+    const year = get("year");
+    const month = get("month");
+    const day = get("day");
+    if (!year || !month || !day) throw new Error("bad parts");
+    return { year, month, day };
+  } catch {
+    return { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate() };
+  }
+}

--- a/convex/lib/projectNumberCounter.ts
+++ b/convex/lib/projectNumberCounter.ts
@@ -1,0 +1,37 @@
+import type { MutationCtx } from "../_generated/server";
+
+/**
+ * Project-number sequence counter RMW, extracted from the inline body of
+ * projectNumberSequences.reserveNextNumber so browser-direct project create
+ * mutations (createNative auto-number) can reserve the next sequence value INSIDE
+ * their own transaction instead of a SERVICE-gated round-trip. Atomic within the
+ * calling mutation — Convex mutations are serializable on the documents they
+ * touch, so concurrent project creates conflict on the by_organizationId_scopeKey
+ * read range and retry, never double-allocating.
+ *
+ * BYTE-IDENTICAL to the former inline logic in reserveNextNumber: the Convex
+ * equivalent of the Postgres `INSERT … ON CONFLICT … value = value + 1 RETURNING
+ * value`. `newRowId` is the cuid used only when the counter row is first created
+ * (ignored if it already exists). Returns the new value.
+ * projectNumberSequences.reserveNextNumber now delegates here, so the still-server
+ * backfill path is unchanged.
+ */
+export async function reserveProjectNumberCounter(
+  ctx: MutationCtx,
+  organizationId: string,
+  scopeKey: string,
+  newRowId: string,
+  now: number,
+): Promise<number> {
+  const existing = await ctx.db
+    .query("projectNumberSequences")
+    .withIndex("by_organizationId_scopeKey", (q) => q.eq("organizationId", organizationId).eq("scopeKey", scopeKey))
+    .unique();
+  if (existing) {
+    const value = (existing.value ?? 0) + 1;
+    await ctx.db.patch(existing._id, { value, updatedAt: now });
+    return value;
+  }
+  await ctx.db.insert("projectNumberSequences", { id: newRowId, organizationId, scopeKey, value: 1, updatedAt: now });
+  return 1;
+}

--- a/convex/projectNumber.test.ts
+++ b/convex/projectNumber.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+//
+// convex/lib/projectNumber.ts — the PURE project-number renderers the native
+// createNative auto-number loop needs. The Convex bundler can't resolve `@/`, so
+// they're duplicated byte-for-byte from src/lib/project-number.ts. This test PINS
+// the duplication: it imports BOTH copies and asserts identical output over a
+// matrix (same pattern as convex/availabilityCore.test.ts).
+import { describe, test, expect } from "vitest";
+import {
+  renderProjectNumber as convexRender,
+  scopeKeyFor as convexScope,
+  datePartsInTimezone as convexParts,
+  hasIncrementToken as convexHasInc,
+  type IncrementReset,
+} from "./lib/projectNumber";
+import {
+  renderProjectNumber as srcRender,
+  scopeKeyFor as srcScope,
+  datePartsInTimezone as srcParts,
+  hasIncrementToken as srcHasInc,
+} from "@/lib/project-number";
+
+const RESETS: IncrementReset[] = ["NONE", "YEARLY", "MONTHLY", "DAILY"];
+const FORMATS = [
+  "%YY%MM%INC",
+  "%YYYY-%INCREMENT",
+  "P-%YYYY%MM%DD-%SEQ",
+  "%M/%D/%YY #%INC",
+  "JOB%SEQ",
+  "no-token-here",
+  "%INCREMENT",
+];
+const PARTS = [
+  { year: 2026, month: 6, day: 5 },
+  { year: 2026, month: 12, day: 31 },
+  { year: 2000, month: 1, day: 1 },
+  { year: 2026, month: 7, day: 8 },
+];
+
+describe("projectNumber renderers — convex/lib == src/lib (byte-for-byte pin)", () => {
+  test("hasIncrementToken matches over every format", () => {
+    for (const f of FORMATS) {
+      expect(convexHasInc(f)).toBe(srcHasInc(f));
+    }
+  });
+
+  test("scopeKeyFor matches over every reset × parts", () => {
+    for (const reset of RESETS) {
+      for (const parts of PARTS) {
+        expect(convexScope(reset, parts)).toBe(srcScope(reset, parts));
+      }
+    }
+  });
+
+  test("renderProjectNumber matches over every format × parts × padding × sequence", () => {
+    for (const format of FORMATS) {
+      for (const parts of PARTS) {
+        for (const padding of [1, 2, 4]) {
+          for (const sequence of [1, 7, 42, 1000]) {
+            expect(convexRender(format, { parts, sequence, padding })).toBe(
+              srcRender(format, { parts, sequence, padding }),
+            );
+          }
+        }
+      }
+    }
+  });
+
+  test("renderProjectNumber default padding matches (padding omitted)", () => {
+    for (const format of FORMATS) {
+      expect(convexRender(format, { parts: PARTS[0], sequence: 3 })).toBe(
+        srcRender(format, { parts: PARTS[0], sequence: 3 }),
+      );
+    }
+  });
+
+  test("datePartsInTimezone matches over a set of dates + zones", () => {
+    const dates = [new Date("2026-06-05T12:00:00Z"), new Date("2026-12-31T23:30:00Z"), new Date("2026-01-01T00:15:00Z")];
+    const zones: (string | undefined)[] = [undefined, "UTC", "Australia/Sydney", "America/Los_Angeles", "not-a-zone"];
+    for (const d of dates) {
+      for (const z of zones) {
+        expect(convexParts(d, z)).toEqual(srcParts(d, z));
+      }
+    }
+  });
+});

--- a/convex/projectNumberSequences.ts
+++ b/convex/projectNumberSequences.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireService } from "./lib/auth";
+import { reserveProjectNumberCounter } from "./lib/projectNumberCounter";
 
 /**
  * Thin CRUD for ProjectNumberSequence (Convex table "projectNumberSequences"). GENERATED — Phase 2/5.
@@ -120,16 +121,8 @@ export const reserveNextNumber = mutation({
   args: { organizationId: v.string(), scopeKey: v.string(), newId: v.string(), now: v.number() },
   handler: async (ctx, { organizationId, scopeKey, newId, now }) => {
     await requireService(ctx);
-    const existing = await ctx.db
-      .query("projectNumberSequences")
-      .withIndex("by_organizationId_scopeKey", (q) => q.eq("organizationId", organizationId).eq("scopeKey", scopeKey))
-      .unique();
-    if (existing) {
-      const value = (existing.value ?? 0) + 1;
-      await ctx.db.patch(existing._id, { value, updatedAt: now });
-      return value;
-    }
-    await ctx.db.insert("projectNumberSequences", { id: newId, organizationId, scopeKey, value: 1, updatedAt: now });
-    return 1;
+    // Delegate to the extracted RMW helper (byte-identical). createNative's
+    // auto-number loop reserves via the same helper inside its own transaction.
+    return await reserveProjectNumberCounter(ctx, organizationId, scopeKey, newId, now);
   },
 });

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -416,3 +416,243 @@ describe("projectWrites.deleteTemplateNative", () => {
     ).rejects.toThrow(/insufficient permissions/i);
   });
 });
+
+describe("projectWrites.createNative auto-number", () => {
+  // "%YY%MM%INC" + parts {2026-07-15} + padding 2 → "260701", "260702", … ;
+  // MONTHLY reset → scopeKey "2026-07".
+  const autoArgs = (id: string, auditId: string) => ({
+    id,
+    organizationId: ORG,
+    name: "Auto Gig",
+    isTemplate: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    autoNumber: { format: "%YY%MM%INC", reset: "MONTHLY" as const, padding: 2, parts: { year: 2026, month: 7, day: 15 } },
+    actor: ACTOR,
+    auditId,
+  });
+
+  test("renders the format + increments the sequence across creates", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+    expect(await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, autoArgs("a1", "log1"))).toEqual({ created: true, id: "a1" });
+    expect(await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, autoArgs("a2", "log2"))).toEqual({ created: true, id: "a2" });
+    await t.run(async (ctx) => {
+      const p1 = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      const p2 = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "a2")).first();
+      expect(p1?.projectNumber).toBe("260701");
+      expect(p2?.projectNumber).toBe("260702");
+      const seq = await ctx.db
+        .query("projectNumberSequences")
+        .withIndex("by_organizationId_scopeKey", (q) => q.eq("organizationId", ORG).eq("scopeKey", "2026-07"))
+        .unique();
+      expect(seq?.value).toBe(2);
+    });
+  });
+
+  test("skips a rendered code that's already taken (clash retry advances the counter)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" });
+      // 260701 already exists (e.g. entered manually) — the auto loop must skip past it.
+      await ctx.db.insert("projects", { id: "taken", organizationId: ORG, projectNumber: "260701", name: "Taken", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
+    expect(await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, autoArgs("a1", "log1"))).toEqual({ created: true, id: "a1" });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "a1")).first();
+      expect(p?.projectNumber).toBe("260702"); // skipped the taken 260701
+    });
+  });
+
+  test("throws when neither projectNumber nor autoNumber is supplied", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, {
+        id: "a1", organizationId: ORG, name: "X", isTemplate: false, createdAt: NOW, updatedAt: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/projectNumber or autoNumber/i);
+  });
+});
+
+describe("projectWrites.duplicateNative", () => {
+  const dupArgs = { sourceId: "src", newId: "dup1", newProjectNumber: "P-DUP", newName: "Copy", orgId: ORG, orgDefaultTaxRate: 10 as number | null, now: NOW, actor: ACTOR, auditId: "dlog1" };
+
+  // Source project loaded with grouping + line items + PMs (must copy) PLUS
+  // services/tasks/crew/slots (must NOT copy).
+  async function seedSource(t: ReturnType<typeof convexTest>, role = "owner") {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+      await ctx.db.insert("projects", { id: "src", organizationId: ORG, projectNumber: "SRC-1", name: "Original", status: "CONFIRMED", type: "DRY_HIRE", isTemplate: false, taxRate: 5, discountPercent: 0, tags: ["a"], createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectCategories", { id: "cat1", organizationId: ORG, projectId: "src", name: "Audio", sortOrder: 0 });
+      await ctx.db.insert("projectGroups", { id: "grp1", organizationId: ORG, projectId: "src", categoryId: "cat1", title: "Stage", quantity: 1, price: 100, sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      // Grouped parent + kit child.
+      await ctx.db.insert("projectLineItems", { id: "lp1", organizationId: ORG, projectId: "src", categoryId: "cat1", groupId: "grp1", type: "EQUIPMENT", quantity: 1, unitPrice: 50, lineTotal: 50, isKitChild: false, status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "lc1", organizationId: ORG, projectId: "src", type: "EQUIPMENT", quantity: 1, isKitChild: true, parentLineItemId: "lp1", childKind: "KIT", status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      // Ungrouped standalone line (bills its own lineTotal).
+      await ctx.db.insert("projectLineItems", { id: "lp2", organizationId: ORG, projectId: "src", type: "EQUIPMENT", quantity: 1, unitPrice: 30, lineTotal: 30, isKitChild: false, status: "CONFIRMED", sortOrder: 1, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectManagers", { id: "pm1", organizationId: ORG, projectId: "src", userId: USER, addedAt: NOW });
+      // NOT copied:
+      await ctx.db.insert("projectServices", { id: "svc1", organizationId: ORG, projectId: "src", type: "LABOUR", title: "Labour", costTotal: 20, lineTotal: 40, showOnDocuments: true, status: "CONFIRMED", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectTasks", { id: "task1", organizationId: ORG, projectId: "src", title: "Load in", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("crewAssignments", { id: "ca1", organizationId: ORG, projectId: "src", crewMemberId: "cm1", status: "CONFIRMED", estimatedCost: 200, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("categorySlots", { id: "slot1", projectCategoryId: "cat1", sortOrder: 0 });
+    });
+  }
+
+  test("deep-copies categories/groups/lines (remapped ids, children under new parents) + PMs + recalc; NOT services/tasks/crew/slots", async () => {
+    const t = makeT();
+    await seedSource(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, dupArgs);
+    expect(res).toEqual({ id: "dup1" });
+
+    await t.run(async (ctx) => {
+      const proj = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "dup1")).first();
+      expect(proj?.status).toBe("ENQUIRY");
+      expect(proj?.isTemplate).toBe(false);
+      expect(proj?.projectNumber).toBe("P-DUP");
+      expect(proj?.name).toBe("Copy");
+      expect(proj?.taxRate).toBe(5); // scalar copied
+
+      // Categories — new id, same name.
+      const cats = (await ctx.db.query("projectCategories").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect());
+      expect(cats.length).toBe(1);
+      expect(cats[0].id).not.toBe("cat1");
+      expect(cats[0].name).toBe("Audio");
+      const newCatId = cats[0].id;
+
+      // Groups — new id, categoryId remapped to the NEW category.
+      const groups = (await ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect());
+      expect(groups.length).toBe(1);
+      expect(groups[0].id).not.toBe("grp1");
+      expect(groups[0].categoryId).toBe(newCatId);
+      const newGroupId = groups[0].id;
+
+      // Line items — parents + children, remapped, status QUOTED.
+      const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect());
+      expect(lines.length).toBe(3);
+      const parents = lines.filter((l) => !l.isKitChild);
+      const children = lines.filter((l) => l.isKitChild);
+      expect(parents.length).toBe(2);
+      expect(children.length).toBe(1);
+      for (const l of lines) expect(l.status).toBe("QUOTED");
+      // Grouped parent: remapped category/group.
+      const gp = parents.find((l) => l.groupId != null)!;
+      expect(gp.categoryId).toBe(newCatId);
+      expect(gp.groupId).toBe(newGroupId);
+      expect(gp.id).not.toBe("lp1");
+      // Child hangs off the NEW parent + inherits its category/group.
+      expect(children[0].parentLineItemId).toBe(gp.id);
+      expect(children[0].categoryId).toBe(newCatId);
+      expect(children[0].groupId).toBe(newGroupId);
+      expect(children[0].childKind).toBe("KIT");
+
+      // PMs copied (new id).
+      const pms = (await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect());
+      expect(pms.length).toBe(1);
+      expect(pms[0].id).not.toBe("pm1");
+      expect(pms[0].userId).toBe(USER);
+
+      // NOT copied.
+      expect((await ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect()).length).toBe(0);
+      expect((await ctx.db.query("projectTasks").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect()).length).toBe(0);
+      expect((await ctx.db.query("crewAssignments").withIndex("by_projectId", (q) => q.eq("projectId", "dup1")).collect()).length).toBe(0);
+
+      // Recalc ran: equipmentRevenue = grouped bundle (100) + standalone (30) = 130.
+      expect(proj?.equipmentRevenue).toBe(130);
+      // Services NOT copied → no service revenue in the copy's totals.
+      expect(proj?.serviceCostTotal).toBe(0);
+    });
+  });
+
+  test("rejects a cross-org source (NOT_FOUND)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "owner" });
+      await ctx.db.insert("projects", { id: "src", organizationId: "other_org", projectNumber: "SRC-1", name: "Foreign", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, dupArgs)).rejects.toThrow(/not found/i);
+  });
+
+  test("rejects a project-number clash (DUPLICATE_PROJECT_CODE)", async () => {
+    const t = makeT();
+    await seedSource(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "taken", organizationId: ORG, projectNumber: "P-DUP", name: "Taken", status: "CONFIRMED", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, dupArgs)).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (project:create)", async () => {
+    const t = makeT();
+    await seedSource(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, dupArgs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
+describe("projectWrites.saveAsTemplateNative", () => {
+  const tplArgs = { sourceId: "src", newId: "tpl1", templateNumber: "TPL-0001", templateName: "My Template", orgId: ORG, orgDefaultTaxRate: 10 as number | null, now: NOW, actor: ACTOR };
+
+  async function seedSource(t: ReturnType<typeof convexTest>, role = "owner") {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role });
+      await ctx.db.insert("projects", { id: "src", organizationId: ORG, projectNumber: "SRC-1", name: "Original", status: "CONFIRMED", type: "DRY_HIRE", isTemplate: false, tags: [], createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectCategories", { id: "cat1", organizationId: ORG, projectId: "src", name: "Audio", sortOrder: 0 });
+      await ctx.db.insert("projectGroups", { id: "grp1", organizationId: ORG, projectId: "src", categoryId: "cat1", title: "Stage", quantity: 1, price: 0, sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      // A grouped parent + child — the template must copy the LINES but drop category/group.
+      await ctx.db.insert("projectLineItems", { id: "lp1", organizationId: ORG, projectId: "src", categoryId: "cat1", groupId: "grp1", type: "EQUIPMENT", quantity: 1, unitPrice: 40, lineTotal: 40, isKitChild: false, status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "lc1", organizationId: ORG, projectId: "src", type: "EQUIPMENT", quantity: 1, isKitChild: true, parentLineItemId: "lp1", status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectManagers", { id: "pm1", organizationId: ORG, projectId: "src", userId: USER, addedAt: NOW });
+    });
+  }
+
+  test("creates a template + copies lines WITHOUT category/group; no categories/groups/PMs; recalc", async () => {
+    const t = makeT();
+    await seedSource(t);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.saveAsTemplateNative, tplArgs);
+    expect(res).toEqual({ id: "tpl1" });
+
+    await t.run(async (ctx) => {
+      const tpl = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "tpl1")).first();
+      expect(tpl?.isTemplate).toBe(true);
+      expect(tpl?.status).toBe("ENQUIRY");
+      expect(tpl?.projectNumber).toBe("TPL-0001");
+
+      // Lines copied — parent + child — but category/group OMITTED.
+      const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", "tpl1")).collect());
+      expect(lines.length).toBe(2);
+      for (const l of lines) {
+        expect(l.status).toBe("QUOTED");
+        expect(l.categoryId).toBeUndefined();
+        expect(l.groupId).toBeUndefined();
+      }
+      const child = lines.find((l) => l.isKitChild)!;
+      const parent = lines.find((l) => !l.isKitChild)!;
+      expect(child.parentLineItemId).toBe(parent.id);
+
+      // No categories / groups / PMs copied.
+      expect((await ctx.db.query("projectCategories").withIndex("by_projectId", (q) => q.eq("projectId", "tpl1")).collect()).length).toBe(0);
+      expect((await ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", "tpl1")).collect()).length).toBe(0);
+      expect((await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", "tpl1")).collect()).length).toBe(0);
+
+      // Recalc ran: no groups on the copy → equipmentRevenue = the ungrouped parent's
+      // lineTotal (40).
+      expect(tpl?.equipmentRevenue).toBe(40);
+    });
+  });
+
+  test("rejects a template-number clash", async () => {
+    const t = makeT();
+    await seedSource(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "taken", organizationId: ORG, projectNumber: "TPL-0001", name: "Taken", isTemplate: true, createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.saveAsTemplateNative, tplArgs)).rejects.toThrow(/already exists/i);
+  });
+
+  test("a viewer is denied (project:create)", async () => {
+    const t = makeT();
+    await seedSource(t, "viewer");
+    await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.saveAsTemplateNative, tplArgs)).rejects.toThrow(/insufficient permissions/i);
+  });
+});

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -1,6 +1,10 @@
 import { v, ConvexError } from "convex/values";
+import { createId } from "@paralleldrive/cuid2";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { reserveProjectNumberCounter } from "./lib/projectNumberCounter";
+import { renderProjectNumber, scopeKeyFor } from "./lib/projectNumber";
+import { recalcProjectTotals } from "./lib/recalc";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
@@ -32,6 +36,18 @@ import { deleteAllForProjectCore } from "./projectCategories";
  */
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
+
+/** Resolved auto project-number config, passed by the caller (the format/reset/
+ *  padding originate in Postgres `organization.metadata`, which has no Convex
+ *  mirror, and `parts` are computed in the org timezone server-side). When
+ *  present + `projectNumber` is omitted, createNative allocates the number
+ *  in-mutation (scopeKey → reserve sequence → render → clash-guard → retry). */
+const autoNumberValidator = v.object({
+  format: v.string(),
+  reset: v.union(v.literal("NONE"), v.literal("YEARLY"), v.literal("MONTHLY"), v.literal("DAILY")),
+  padding: v.number(),
+  parts: v.object({ year: v.number(), month: v.number(), day: v.number() }),
+});
 const NOTES_FIELD = v.union(
   v.literal("crewNotes"),
   v.literal("internalNotes"),
@@ -266,54 +282,102 @@ export const updateNative = mutation({
 
 /**
  * createNative — insert a project with the unique-project-number check + CREATE
- * audit, atomic. RBAC(project, create). Mirrors createWithUniqueNumber: returns
- * {created:false} without inserting/auditing when the number clashes (the server
- * action's allocation retry loop handles that), {created:true} + audit on success.
- * generateProjectNumber (the auto-number allocator) stays server-side.
+ * audit, atomic. RBAC(project, create).
+ *
+ * Two number paths (mutually exclusive per call):
+ *  - MANUAL/TEMPLATE: caller passes `projectNumber` — mirrors createWithUniqueNumber,
+ *    returns {created:false} without inserting/auditing when the number clashes
+ *    (the caller surfaces DUPLICATE_PROJECT_CODE), {created:true} + audit on success.
+ *  - AUTO: caller omits `projectNumber` and passes `autoNumber` config — the number
+ *    is allocated IN-mutation (fold of the former server generateProjectNumber loop):
+ *    scopeKey → reserveProjectNumberCounter → renderProjectNumber → the org-scoped
+ *    clash-guard; on a rendered-code clash the counter advances and we retry
+ *    (bounded), so a lagging counter skips past manually-entered codes. Atomic — the
+ *    sequence bump and the create commit (or roll back) together.
  */
 export const createNative = mutation({
   returns: v.object({ created: v.boolean(), id: v.string() }),
   args: {
     id: v.string(),
     organizationId: v.string(),
-    projectNumber: v.string(),
+    projectNumber: v.optional(v.string()),
+    autoNumber: v.optional(autoNumberValidator),
     name: v.string(),
     ...projectWriteFields,
     actor: actorValidator,
     auditId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { actor: suppliedActor, auditId, ...fields } = args;
+    const { actor: suppliedActor, auditId, autoNumber, projectNumber: suppliedNumber, ...fields } = args;
     await assertWritesEnabled(ctx, "project");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "project", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
-    const clash = await ctx.db
-      .query("projects")
-      .withIndex("by_organizationId_projectNumber", (q) =>
-        q.eq("organizationId", fields.organizationId).eq("projectNumber", fields.projectNumber),
-      )
-      .unique();
-    if (clash) return { created: false as const, id: clash.id };
-
-    // The projectNumber clash-guard is org-scoped and doesn't catch a cross-org cuid
-    // collision — dup-guard the client-minted id too. THROW (not the `{created:false}`
-    // number-clash signal, which callers retry with the SAME id): a cuid collision is a
-    // hard error, else another org's by_cuid reads get muddied.
+    // Dup-guard the client-minted cuid first (applies to both number paths). The
+    // projectNumber clash-guard below is org-scoped and doesn't catch a cross-org
+    // cuid collision. THROW (not the `{created:false}` number-clash signal, which
+    // manual callers retry with a NEW number): a cuid collision is a hard error,
+    // else another org's by_cuid reads get muddied.
     const dupId = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
     if (dupId) throw new ConvexError("Project already exists");
+
+    // The counter row's updatedAt / render `now` — the server used one `now` for
+    // both the create timestamps and the counter (byte-identical here).
+    const now = typeof fields.createdAt === "number" ? fields.createdAt : Date.now();
+
+    let projectNumber: string;
+    if (suppliedNumber != null) {
+      // Manual / template code — single org-scoped clash check; retry is the caller's.
+      const clash = await ctx.db
+        .query("projects")
+        .withIndex("by_organizationId_projectNumber", (q) =>
+          q.eq("organizationId", fields.organizationId).eq("projectNumber", suppliedNumber),
+        )
+        .unique();
+      if (clash) return { created: false as const, id: clash.id };
+      projectNumber = suppliedNumber;
+    } else if (autoNumber) {
+      // Auto-number — allocate in-mutation (fold of generateProjectNumber). Reserve a
+      // sequence each attempt (matches the server: a rendered-code clash consumes the
+      // value and bumps again), render, and re-check the org-scoped clash-guard.
+      const scopeKey = scopeKeyFor(autoNumber.reset, autoNumber.parts);
+      let resolved: string | null = null;
+      for (let attempt = 0; attempt < 50; attempt++) {
+        const sequence = await reserveProjectNumberCounter(ctx, fields.organizationId, scopeKey, createId(), now);
+        if (!Number.isFinite(sequence)) throw new ConvexError("Invalid project-number sequence");
+        const candidate = renderProjectNumber(autoNumber.format, {
+          parts: autoNumber.parts,
+          sequence,
+          padding: autoNumber.padding,
+        });
+        const clash = await ctx.db
+          .query("projects")
+          .withIndex("by_organizationId_projectNumber", (q) =>
+            q.eq("organizationId", fields.organizationId).eq("projectNumber", candidate),
+          )
+          .unique();
+        if (!clash) {
+          resolved = candidate;
+          break;
+        }
+      }
+      if (resolved == null) throw new ConvexError("Could not generate a unique project number");
+      projectNumber = resolved;
+    } else {
+      throw new ConvexError("createNative requires either projectNumber or autoNumber config");
+    }
 
     // Strip the recalc-owned money totals: a new project starts with none, and
     // recalcProjectTotals is the only writer. A browser-direct caller could otherwise
     // mint a project with forged financials (projectWriteFields exposes them as args).
     // Non-breaking: createProject never sends these. (bumpProjectCounters keys off
     // status/isTemplate, not money, so it's unaffected by the strip.)
-    const insertFields = { ...fields };
+    const insertFields = { ...fields, projectNumber };
     for (const k of PROJECT_MONEY_ANCHORS) delete (insertFields as Record<string, unknown>)[k];
 
     await ctx.db.insert("projects", insertFields);
-    await bumpProjectCounters(ctx, fields.organizationId, null, fields);
+    await bumpProjectCounters(ctx, fields.organizationId, null, insertFields);
 
     await writeActivityLog(ctx, {
       id: auditId,
@@ -321,10 +385,10 @@ export const createNative = mutation({
       action: "CREATE",
       entityType: "project",
       entityId: fields.id,
-      entityName: fields.projectNumber,
+      entityName: projectNumber,
       userId: actor.userId,
       userName: actor.userName,
-      summary: `Created ${fields.isTemplate ? "template" : "project"} ${fields.projectNumber} - ${fields.name}`,
+      summary: `Created ${fields.isTemplate ? "template" : "project"} ${projectNumber} - ${fields.name}`,
       projectId: fields.id,
       createdAt: typeof fields.createdAt === "number" ? fields.createdAt : 0,
     });
@@ -577,5 +641,435 @@ export const deleteTemplateNative = mutation({
     await ctx.db.delete(project._id);
 
     return { success: true };
+  },
+});
+
+/** Sanitize a numeric that will feed recalc — a non-finite client value falls
+ *  back to null (the org-default path). */
+const finiteOrNull = (n: number | null): number | null => (n != null && Number.isFinite(n) ? n : null);
+
+/** Copy the project SCALARS a duplicate carries forward (parity with the server
+ *  createWithUniqueNumber call in duplicateProject). Dates / depositPaid /
+ *  invoicedTotal / notes-money are deliberately NOT copied. */
+function duplicateProjectScalars(source: {
+  type?: string; clientId?: string; description?: string; locationId?: string;
+  siteContactName?: string; siteContactPhone?: string; siteContactEmail?: string;
+  crewNotes?: string; internalNotes?: string; clientNotes?: string;
+  discountPercent?: number; depositPercent?: number;
+  defaultRentalPeriod?: string; defaultRentalQuantity?: number; taxRate?: number;
+  tags?: string[];
+}): Record<string, unknown> {
+  return {
+    ...(source.type ? { type: source.type } : {}),
+    ...(source.clientId ? { clientId: source.clientId } : {}),
+    ...(source.description ? { description: source.description } : {}),
+    ...(source.locationId ? { locationId: source.locationId } : {}),
+    ...(source.siteContactName ? { siteContactName: source.siteContactName } : {}),
+    ...(source.siteContactPhone ? { siteContactPhone: source.siteContactPhone } : {}),
+    ...(source.siteContactEmail ? { siteContactEmail: source.siteContactEmail } : {}),
+    ...(source.crewNotes ? { crewNotes: source.crewNotes } : {}),
+    ...(source.internalNotes ? { internalNotes: source.internalNotes } : {}),
+    ...(source.clientNotes ? { clientNotes: source.clientNotes } : {}),
+    ...(source.discountPercent != null ? { discountPercent: source.discountPercent } : {}),
+    ...(source.depositPercent != null ? { depositPercent: source.depositPercent } : {}),
+    ...(source.defaultRentalPeriod ? { defaultRentalPeriod: source.defaultRentalPeriod } : {}),
+    ...(source.defaultRentalQuantity != null ? { defaultRentalQuantity: source.defaultRentalQuantity } : {}),
+    ...(source.taxRate != null ? { taxRate: source.taxRate } : {}),
+    tags: source.tags ?? [],
+  };
+}
+
+type SrcLine = {
+  id: string; organizationId: string; type?: string; modelId?: string; bulkAssetId?: string;
+  kitId?: string; supplierId?: string; description?: string; quantity?: number; unitPrice?: number;
+  pricingType?: string; duration?: number; discount?: number; lineTotal?: number; sortOrder?: number;
+  groupName?: string; notes?: string; isOptional?: boolean; showSubhireOnDocs?: boolean;
+  pricingMode?: string; childKind?: string; isKitChild?: boolean; parentLineItemId?: string;
+  categoryId?: string; groupId?: string;
+};
+
+/**
+ * duplicateNative — deep-copy a source project into a fresh project (status
+ * ENQUIRY, isTemplate false), atomic. RBAC(project, create). Parity with the
+ * (former) server duplicateProject: copies categories → groups (remapped
+ * categoryId) → line items parent-then-children (remapped categoryId/groupId,
+ * status QUOTED) → project managers, then recalcProjectTotals. Deliberately does
+ * NOT copy categorySlots / services / tasks / crew. Secondary-row cuids are minted
+ * inline (Convex tolerates createId()); the project's `newId` is client-passed +
+ * dup-guarded. A number clash on `newProjectNumber` throws (the caller supplies a
+ * user-chosen code, not a retry loop).
+ */
+export const duplicateNative = mutation({
+  returns: v.object({ id: v.string() }),
+  args: {
+    sourceId: v.string(),
+    newId: v.string(),
+    newProjectNumber: v.string(),
+    newName: v.string(),
+    orgId: v.string(),
+    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+  },
+  handler: async (ctx, { sourceId, newId, newProjectNumber, newName, orgId, orgDefaultTaxRate, now, actor: suppliedActor, auditId }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "create");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    // Source project — org-checked (by_cuid is global).
+    const source = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", sourceId)).first();
+    if (!source || source.organizationId !== orgId) {
+      throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    }
+
+    // Dup-guard the client-minted project cuid (COLLECT all — a foreign-org
+    // collision must throw, not silently reuse another org's row).
+    const cuidMatches = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", newId)).collect();
+    if (cuidMatches.length > 0) throw new ConvexError("Project already exists");
+
+    // Number clash (org-scoped @@unique guard) — a user-chosen code, so a hard error.
+    const clash = await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId_projectNumber", (q) => q.eq("organizationId", orgId).eq("projectNumber", newProjectNumber))
+      .unique();
+    if (clash) throw new ConvexError({ code: "DUPLICATE_PROJECT_CODE", message: `A project with code "${newProjectNumber}" already exists.` });
+
+    // 1. New project row (children below reference its id).
+    await ctx.db.insert("projects", {
+      id: newId,
+      organizationId: orgId,
+      projectNumber: newProjectNumber,
+      name: newName,
+      status: "ENQUIRY",
+      isTemplate: false,
+      ...duplicateProjectScalars(source),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // 2. Categories (sorted) → catIdMap.
+    const sourceCategories = (
+      await ctx.db.query("projectCategories").withIndex("by_projectId", (q) => q.eq("projectId", sourceId)).collect()
+    )
+      .filter((c) => c.organizationId === orgId)
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+    const catIdMap = new Map<string, string>();
+    for (const cat of sourceCategories) {
+      const nid = createId();
+      catIdMap.set(cat.id, nid);
+      await ctx.db.insert("projectCategories", {
+        id: nid,
+        organizationId: orgId,
+        projectId: newId,
+        name: cat.name,
+        sortOrder: cat.sortOrder ?? 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    // 3. Groups → groupIdMap (categoryId remapped).
+    const sourceGroups = (
+      await ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", sourceId)).collect()
+    ).filter((g) => g.organizationId === orgId);
+    const groupIdMap = new Map<string, string>();
+    const groupById = new Map<string, (typeof sourceGroups)[number]>();
+    for (const g of sourceGroups) groupById.set(g.id, g);
+    for (const group of sourceGroups) {
+      const nid = createId();
+      groupIdMap.set(group.id, nid);
+      await ctx.db.insert("projectGroups", {
+        id: nid,
+        organizationId: orgId,
+        projectId: newId,
+        ...(group.categoryId ? { categoryId: catIdMap.get(group.categoryId) } : {}),
+        title: group.title,
+        ...(group.description != null ? { description: group.description } : {}),
+        ...(group.quantity != null ? { quantity: group.quantity } : {}),
+        ...(group.price != null ? { price: group.price } : {}),
+        ...(group.suggestedPrice != null ? { suggestedPrice: group.suggestedPrice } : {}),
+        ...(group.rentalPeriod != null ? { rentalPeriod: group.rentalPeriod } : {}),
+        ...(group.rentalQuantity != null ? { rentalQuantity: group.rentalQuantity } : {}),
+        sortOrder: group.sortOrder ?? 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    // 4. Line items — parents then their children. A parent's remapped
+    //    category/group is inherited by its children (parity with the server's
+    //    copyLineItem, which passes newCategoryId/newGroupId down to children).
+    const allLines = (
+      await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", sourceId)).collect()
+    ).filter((li) => li.organizationId === orgId) as unknown as SrcLine[];
+    const childrenByParent = new Map<string, SrcLine[]>();
+    for (const li of allLines) {
+      if (li.isKitChild && li.parentLineItemId) {
+        const arr = childrenByParent.get(li.parentLineItemId) ?? [];
+        arr.push(li);
+        childrenByParent.set(li.parentLineItemId, arr);
+      }
+    }
+    const parents = allLines
+      .filter((li) => !li.isKitChild)
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+
+    for (const li of parents) {
+      // Resolve the new category/group this parent (and its children) land under.
+      let newGroupId: string | null = null;
+      let newCatId: string | null = null;
+      if (li.groupId) {
+        newGroupId = groupIdMap.get(li.groupId) ?? null;
+        const srcGroup = groupById.get(li.groupId);
+        newCatId = srcGroup?.categoryId ? catIdMap.get(srcGroup.categoryId) ?? null : null;
+      } else if (li.categoryId) {
+        newCatId = catIdMap.get(li.categoryId) ?? null;
+      }
+
+      const newParentId = createId();
+      await ctx.db.insert("projectLineItems", {
+        id: newParentId,
+        organizationId: orgId,
+        projectId: newId,
+        ...(newCatId ? { categoryId: newCatId } : {}),
+        ...(newGroupId ? { groupId: newGroupId } : {}),
+        ...(li.type ? { type: li.type } : {}),
+        ...(li.modelId ? { modelId: li.modelId } : {}),
+        ...(li.bulkAssetId ? { bulkAssetId: li.bulkAssetId } : {}),
+        ...(li.kitId ? { kitId: li.kitId } : {}),
+        ...(li.supplierId ? { supplierId: li.supplierId } : {}),
+        ...(li.description != null ? { description: li.description } : {}),
+        ...(li.quantity != null ? { quantity: li.quantity } : {}),
+        ...(li.unitPrice != null ? { unitPrice: Number(li.unitPrice) } : {}),
+        ...(li.pricingType ? { pricingType: li.pricingType } : {}),
+        ...(li.duration != null ? { duration: Number(li.duration) } : {}),
+        ...(li.discount != null ? { discount: Number(li.discount) } : {}),
+        ...(li.lineTotal != null ? { lineTotal: Number(li.lineTotal) } : {}),
+        ...(li.sortOrder != null ? { sortOrder: li.sortOrder } : {}),
+        ...(li.groupName != null ? { groupName: li.groupName } : {}),
+        ...(li.notes != null ? { notes: li.notes } : {}),
+        ...(li.isOptional != null ? { isOptional: li.isOptional } : {}),
+        ...(li.showSubhireOnDocs != null ? { showSubhireOnDocs: li.showSubhireOnDocs } : {}),
+        ...(li.pricingMode ? { pricingMode: li.pricingMode } : {}),
+        isKitChild: false,
+        status: "QUOTED",
+        createdAt: now,
+        updatedAt: now,
+      } as Record<string, unknown> as never);
+
+      for (const child of childrenByParent.get(li.id) ?? []) {
+        await ctx.db.insert("projectLineItems", {
+          id: createId(),
+          organizationId: orgId,
+          projectId: newId,
+          ...(newCatId ? { categoryId: newCatId } : {}),
+          ...(newGroupId ? { groupId: newGroupId } : {}),
+          ...(child.type ? { type: child.type } : {}),
+          ...(child.modelId ? { modelId: child.modelId } : {}),
+          ...(child.bulkAssetId ? { bulkAssetId: child.bulkAssetId } : {}),
+          ...(child.description != null ? { description: child.description } : {}),
+          ...(child.quantity != null ? { quantity: child.quantity } : {}),
+          ...(child.unitPrice != null ? { unitPrice: Number(child.unitPrice) } : {}),
+          ...(child.pricingType ? { pricingType: child.pricingType } : {}),
+          ...(child.duration != null ? { duration: Number(child.duration) } : {}),
+          ...(child.discount != null ? { discount: Number(child.discount) } : {}),
+          ...(child.lineTotal != null ? { lineTotal: Number(child.lineTotal) } : {}),
+          ...(child.sortOrder != null ? { sortOrder: child.sortOrder } : {}),
+          ...(child.groupName != null ? { groupName: child.groupName } : {}),
+          ...(child.notes != null ? { notes: child.notes } : {}),
+          ...(child.childKind ? { childKind: child.childKind } : {}),
+          isKitChild: true,
+          parentLineItemId: newParentId,
+          status: "QUOTED",
+          createdAt: now,
+          updatedAt: now,
+        } as Record<string, unknown> as never);
+      }
+    }
+
+    // 5. Project managers.
+    const sourcePMs = (
+      await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", sourceId)).collect()
+    ).filter((r) => r.organizationId === orgId);
+    for (const pm of sourcePMs) {
+      await ctx.db.insert("projectManagers", {
+        id: createId(),
+        organizationId: orgId,
+        projectId: newId,
+        userId: pm.userId,
+        addedAt: now,
+      });
+    }
+
+    // 6. Recalc totals from the copied lines (never trust client money).
+    await recalcProjectTotals(ctx, newId, orgId, finiteOrNull(orgDefaultTaxRate), now);
+
+    // CREATE audit for the new project (native path logs it atomically).
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId: orgId,
+      action: "CREATE",
+      entityType: "project",
+      entityId: newId,
+      entityName: newProjectNumber,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Duplicated project ${source.projectNumber} to ${newProjectNumber} - ${newName}`,
+      projectId: newId,
+      createdAt: now,
+    });
+
+    return { id: newId };
+  },
+});
+
+/**
+ * saveAsTemplateNative — snapshot a source project as a TEMPLATE (isTemplate true,
+ * status ENQUIRY), atomic. RBAC(project, create). Parity with the (former) server
+ * saveAsTemplate: copies ONLY the line items (parents + children, status QUOTED)
+ * and — critically — OMITS categoryId/groupId on every copied line (a template
+ * carries no grouping structure). Copies NO categories / groups / project managers,
+ * writes NO audit. `templateNumber` is resolved by the caller (generateTemplateCode,
+ * a Convex-mirror template count). recalcProjectTotals recomputes totals.
+ */
+export const saveAsTemplateNative = mutation({
+  returns: v.object({ id: v.string() }),
+  args: {
+    sourceId: v.string(),
+    newId: v.string(),
+    templateNumber: v.string(),
+    templateName: v.string(),
+    orgId: v.string(),
+    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    now: v.number(),
+    actor: actorValidator,
+  },
+  handler: async (ctx, { sourceId, newId, templateNumber, templateName, orgId, orgDefaultTaxRate, now, actor: suppliedActor }) => {
+    await assertWritesEnabled(ctx, "project");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "create");
+    await resolveActor(ctx, suppliedActor);
+
+    const source = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", sourceId)).first();
+    if (!source || source.organizationId !== orgId) {
+      throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+    }
+
+    // Dup-guard the client-minted template cuid (COLLECT all).
+    const cuidMatches = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", newId)).collect();
+    if (cuidMatches.length > 0) throw new ConvexError("Template already exists");
+
+    // Number clash (org-scoped @@unique guard).
+    const clash = await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId_projectNumber", (q) => q.eq("organizationId", orgId).eq("projectNumber", templateNumber))
+      .unique();
+    if (clash) throw new ConvexError({ code: "DUPLICATE_PROJECT_CODE", message: `A template with code "${templateNumber}" already exists.` });
+
+    // 1. Template project row. Parity: saveAsTemplate copies FEWER scalars than
+    //    duplicate — no taxRate, no defaultRentalPeriod/Quantity.
+    await ctx.db.insert("projects", {
+      id: newId,
+      organizationId: orgId,
+      projectNumber: templateNumber,
+      name: templateName,
+      status: "ENQUIRY",
+      isTemplate: true,
+      ...(source.type ? { type: source.type } : {}),
+      ...(source.clientId ? { clientId: source.clientId } : {}),
+      ...(source.description ? { description: source.description } : {}),
+      ...(source.locationId ? { locationId: source.locationId } : {}),
+      ...(source.siteContactName ? { siteContactName: source.siteContactName } : {}),
+      ...(source.siteContactPhone ? { siteContactPhone: source.siteContactPhone } : {}),
+      ...(source.siteContactEmail ? { siteContactEmail: source.siteContactEmail } : {}),
+      ...(source.crewNotes ? { crewNotes: source.crewNotes } : {}),
+      ...(source.internalNotes ? { internalNotes: source.internalNotes } : {}),
+      ...(source.clientNotes ? { clientNotes: source.clientNotes } : {}),
+      ...(source.discountPercent != null ? { discountPercent: source.discountPercent } : {}),
+      ...(source.depositPercent != null ? { depositPercent: source.depositPercent } : {}),
+      tags: source.tags ?? [],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // 2. Line items — parents then children. ★ categoryId/groupId OMITTED (parity).
+    const allLines = (
+      await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", sourceId)).collect()
+    ).filter((li) => li.organizationId === orgId) as unknown as SrcLine[];
+    const childrenByParent = new Map<string, SrcLine[]>();
+    for (const li of allLines) {
+      if (li.isKitChild && li.parentLineItemId) {
+        const arr = childrenByParent.get(li.parentLineItemId) ?? [];
+        arr.push(li);
+        childrenByParent.set(li.parentLineItemId, arr);
+      }
+    }
+    const parents = allLines
+      .filter((li) => !li.isKitChild)
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+
+    for (const li of parents) {
+      const newParentId = createId();
+      await ctx.db.insert("projectLineItems", {
+        id: newParentId,
+        organizationId: orgId,
+        projectId: newId,
+        ...(li.type ? { type: li.type } : {}),
+        ...(li.modelId ? { modelId: li.modelId } : {}),
+        ...(li.bulkAssetId ? { bulkAssetId: li.bulkAssetId } : {}),
+        ...(li.kitId ? { kitId: li.kitId } : {}),
+        ...(li.supplierId ? { supplierId: li.supplierId } : {}),
+        ...(li.description != null ? { description: li.description } : {}),
+        ...(li.quantity != null ? { quantity: li.quantity } : {}),
+        ...(li.unitPrice != null ? { unitPrice: Number(li.unitPrice) } : {}),
+        ...(li.pricingType ? { pricingType: li.pricingType } : {}),
+        ...(li.duration != null ? { duration: Number(li.duration) } : {}),
+        ...(li.discount != null ? { discount: Number(li.discount) } : {}),
+        ...(li.lineTotal != null ? { lineTotal: Number(li.lineTotal) } : {}),
+        ...(li.sortOrder != null ? { sortOrder: li.sortOrder } : {}),
+        ...(li.groupName != null ? { groupName: li.groupName } : {}),
+        ...(li.notes != null ? { notes: li.notes } : {}),
+        ...(li.isOptional != null ? { isOptional: li.isOptional } : {}),
+        ...(li.showSubhireOnDocs != null ? { showSubhireOnDocs: li.showSubhireOnDocs } : {}),
+        ...(li.pricingMode ? { pricingMode: li.pricingMode } : {}),
+        isKitChild: false,
+        status: "QUOTED",
+        createdAt: now,
+        updatedAt: now,
+      } as Record<string, unknown> as never);
+
+      for (const child of childrenByParent.get(li.id) ?? []) {
+        await ctx.db.insert("projectLineItems", {
+          id: createId(),
+          organizationId: orgId,
+          projectId: newId,
+          ...(child.type ? { type: child.type } : {}),
+          ...(child.modelId ? { modelId: child.modelId } : {}),
+          ...(child.bulkAssetId ? { bulkAssetId: child.bulkAssetId } : {}),
+          ...(child.description != null ? { description: child.description } : {}),
+          ...(child.quantity != null ? { quantity: child.quantity } : {}),
+          ...(child.unitPrice != null ? { unitPrice: Number(child.unitPrice) } : {}),
+          ...(child.pricingType ? { pricingType: child.pricingType } : {}),
+          ...(child.duration != null ? { duration: Number(child.duration) } : {}),
+          ...(child.discount != null ? { discount: Number(child.discount) } : {}),
+          ...(child.lineTotal != null ? { lineTotal: Number(child.lineTotal) } : {}),
+          ...(child.sortOrder != null ? { sortOrder: child.sortOrder } : {}),
+          ...(child.groupName != null ? { groupName: child.groupName } : {}),
+          ...(child.notes != null ? { notes: child.notes } : {}),
+          isKitChild: true,
+          parentLineItemId: newParentId,
+          status: "QUOTED",
+          createdAt: now,
+          updatedAt: now,
+        } as Record<string, unknown> as never);
+      }
+    }
+
+    // 3. Recalc totals from the copied lines.
+    await recalcProjectTotals(ctx, newId, orgId, finiteOrNull(orgDefaultTaxRate), now);
+
+    return { id: newId };
   },
 });

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -35,6 +35,8 @@ import { translatePrismaError, UserFacingError } from "@/lib/errors";
 import { getDefaultLocation, getLocationMap, getMappedLocationsByOrg, mapLocation } from "@/lib/locations-read";
 import { createId } from "@paralleldrive/cuid2";
 import { nativeProjectWrites } from "@/lib/native-writes";
+import { readOrgDefaultTaxRate } from "@/lib/org-settings-read";
+import { ConvexError } from "convex/values";
 import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
 import {
   renderProjectNumber,
@@ -614,31 +616,56 @@ export async function createProject(data: ProjectFormValues & { isTemplate?: boo
   // One audit id for the whole allocation loop — only the winning insert writes it.
   const projectAuditId = createId();
   let created: { created: boolean; id: string } | null = null;
-  for (let attempt = 0; attempt < 50; attempt++) {
-    const projectNumber = useAutoNumber
-      ? await generateProjectNumber(organizationId, autoConfig!, now)
-      : (templateNumber ?? parsed.projectNumber!);
-    created = nativeProjectWrites()
-      ? await convex.mutation(api.projectWrites.createNative, {
-          ...baseArgs,
-          projectNumber,
-          actor: { userId, userName },
-          auditId: projectAuditId,
-        })
-      : await convex.mutation(api.projects.createWithUniqueNumber, { ...baseArgs, projectNumber });
-    if (created.created) break;
-    // Number taken. A manual / template number is a hard duplicate; an auto number
-    // lost a race — loop to allocate the next one.
-    if (!useAutoNumber) {
+
+  if (nativeProjectWrites()) {
+    // Native: the auto-number allocation loop is folded INTO createNative (scopeKey →
+    // reserve sequence → render → clash-guard → retry, all in one transaction), so a
+    // single call suffices. Auto numbering passes the resolved config + date parts
+    // (computed here in the org timezone); manual/template pass the code directly.
+    created = await convex.mutation(api.projectWrites.createNative, {
+      ...baseArgs,
+      ...(useAutoNumber
+        ? {
+            autoNumber: {
+              format: autoConfig!.format,
+              reset: autoConfig!.reset,
+              padding: autoConfig!.padding,
+              parts: datePartsInTimezone(now, autoConfig!.timezone),
+            },
+          }
+        : { projectNumber: templateNumber ?? parsed.projectNumber! }),
+      actor: { userId, userName },
+      auditId: projectAuditId,
+    });
+    // A manual/template number clash is a hard duplicate (auto retries in-mutation).
+    if (!created.created) {
       throw new UserFacingError({
         code: "DUPLICATE_PROJECT_CODE",
         title: "Project code already in use",
-        message: `A ${isTemplate ? "template" : "project"} with code "${projectNumber}" already exists.`,
+        message: `A ${isTemplate ? "template" : "project"} with code "${templateNumber ?? parsed.projectNumber}" already exists.`,
         field: "projectNumber",
       });
     }
+  } else {
+    // Legacy (server-side allocation): generate the number then createWithUniqueNumber,
+    // retrying on an auto-number race.
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const projectNumber = useAutoNumber
+        ? await generateProjectNumber(organizationId, autoConfig!, now)
+        : (templateNumber ?? parsed.projectNumber!);
+      created = await convex.mutation(api.projects.createWithUniqueNumber, { ...baseArgs, projectNumber });
+      if (created.created) break;
+      if (!useAutoNumber) {
+        throw new UserFacingError({
+          code: "DUPLICATE_PROJECT_CODE",
+          title: "Project code already in use",
+          message: `A ${isTemplate ? "template" : "project"} with code "${projectNumber}" already exists.`,
+          field: "projectNumber",
+        });
+      }
+    }
+    if (!created?.created) throw new Error("Could not allocate a unique project number");
   }
-  if (!created?.created) throw new Error("Could not allocate a unique project number");
 
   const result = await getProjectByIdMapped(id, organizationId);
   if (!result) throw new Error("Project create failed");
@@ -959,10 +986,73 @@ export async function archiveProject(id: string) {
   return serialize(updated);
 }
 
+/**
+ * Map a ConvexError thrown by duplicateNative / saveAsTemplateNative back to the
+ * rich UserFacingError the legacy server path threw, so the toast UX is identical.
+ * Handles the NOT_FOUND (source gone) + DUPLICATE_PROJECT_CODE (number clash) codes.
+ */
+function mapProjectCopyError(e: unknown, isTemplate: boolean): unknown {
+  if (
+    e instanceof ConvexError &&
+    e.data &&
+    typeof e.data === "object" &&
+    "code" in e.data &&
+    typeof (e.data as { code: unknown }).code === "string"
+  ) {
+    const code = (e.data as { code: string }).code;
+    const message =
+      typeof (e.data as { message?: unknown }).message === "string"
+        ? (e.data as { message: string }).message
+        : undefined;
+    if (code === "NOT_FOUND") {
+      return new UserFacingError({
+        code: "NOT_FOUND",
+        title: "Project not found",
+        message: "This project was deleted or moved. Refresh the page to see the latest state.",
+      });
+    }
+    if (code === "DUPLICATE_PROJECT_CODE") {
+      return new UserFacingError({
+        code,
+        title: isTemplate ? "Template code already in use" : "Project code already in use",
+        message: message ?? `A ${isTemplate ? "template" : "project"} with that code already exists.`,
+        field: "projectNumber",
+      });
+    }
+  }
+  return e;
+}
+
 export async function duplicateProject(sourceId: string, newProjectNumber: string, newName: string) {
-  const { organizationId } = await requirePermission("project", "create");
+  const { organizationId, userId, userName } = await requirePermission("project", "create");
 
   const client = await getConvexClient();
+
+  // Native: the entire deep-copy (categories → groups → line items → PMs → recalc)
+  // runs in ONE atomic mutation instead of N sequential server→Convex round-trips.
+  if (nativeProjectWrites()) {
+    const newProjectId = createId();
+    const orgDefaultTaxRate = await readOrgDefaultTaxRate(organizationId);
+    try {
+      await client.mutation(api.projectWrites.duplicateNative, {
+        sourceId,
+        newId: newProjectId,
+        newProjectNumber,
+        newName,
+        orgId: organizationId,
+        orgDefaultTaxRate,
+        now: Date.now(),
+        actor: { userId, userName },
+        auditId: createId(),
+      });
+    } catch (e) {
+      throw mapProjectCopyError(e, false);
+    }
+    const nativeResult = await getProjectByIdMapped(newProjectId, organizationId);
+    if (!nativeResult) throw new Error("Project duplicate failed");
+    return serialize(nativeResult);
+  }
+
   // project is Convex-only — read the source scalars + its project managers from Convex.
   const source = await getProjectByIdMapped(sourceId, organizationId);
   if (!source) {
@@ -1245,7 +1335,33 @@ export async function duplicateProject(sourceId: string, newProjectNumber: strin
 }
 
 export async function saveAsTemplate(projectId: string, templateName: string) {
-  const { organizationId } = await requirePermission("project", "create");
+  const { organizationId, userId, userName } = await requirePermission("project", "create");
+
+  // Native: create the template + copy its line items (grouping OMITTED) + recalc in
+  // ONE atomic mutation. generateTemplateCode stays server-side (Convex-mirror count).
+  if (nativeProjectWrites()) {
+    const templateId = createId();
+    const templateNumber = await generateTemplateCode(organizationId);
+    const orgDefaultTaxRate = await readOrgDefaultTaxRate(organizationId);
+    const client = await getConvexClient();
+    try {
+      await client.mutation(api.projectWrites.saveAsTemplateNative, {
+        sourceId: projectId,
+        newId: templateId,
+        templateNumber,
+        templateName,
+        orgId: organizationId,
+        orgDefaultTaxRate,
+        now: Date.now(),
+        actor: { userId, userName },
+      });
+    } catch (e) {
+      throw mapProjectCopyError(e, true);
+    }
+    const nativeResult = await getProjectByIdMapped(templateId, organizationId);
+    if (!nativeResult) throw new Error("Template create failed");
+    return serialize(nativeResult);
+  }
 
   // project is Convex-only — read the source scalars from Convex.
   const source = await getProjectByIdMapped(projectId, organizationId);


### PR DESCRIPTION
## Summary
Finishes the projectWrites browser-direct surface. With #566 (blocking gate) + #567 (deleteNative cascade) + this, projectWrites is fully browser-direct-ready.

- **`convex/lib/projectNumberCounter.ts`** — `reserveProjectNumberCounter` extracted; `reserveNextNumber` delegates (byte-identical).
- **`convex/lib/projectNumber.ts`** — pure renderers byte-copied from `src/lib/project-number.ts`, **cross-import-pinned**.
- **`createNative`** — optional `projectNumber` + `autoNumber` config; runs the allocate loop in-mutation (parity with `generateProjectNumber`, counter advances per clash). Config originates in Postgres so the caller passes it resolved.
- **`duplicateNative`** — deep copy with remapped category/group/line ids (children under new parents), status `QUOTED`, PMs, recalc; **not** categorySlots/services/tasks/crew.
- **`saveAsTemplateNative`** — lines copied **omitting** categoryId/groupId (parity), recalc; no cats/groups/PMs.
- Server `createProject`/`duplicateProject`/`saveAsTemplate` thinned to resolve Postgres config/tax + call the natives.

## Review
Codex-reviewed **clean** (no findings — auto-number retry, tenant checks, id-remap, template omission, money recompute all parity). tsc clean; 39 target tests + full convex suite (880) green; deployed additive/inert (gated behind `NATIVE_PROJECT_WRITES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)