### PR TITLE
feat(line-items): addLineItemSmartNative — re-home merge/auto-pricing native

### DIFF
--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -514,6 +514,234 @@ describe("lineItemWrites.reorderNative", () => {
   });
 });
 
+describe("lineItemWrites.addLineItemSmartNative", () => {
+  const smartArgs = (
+    fields: Record<string, unknown>,
+    opts?: { over?: boolean; sep?: boolean; acc?: boolean; id?: string },
+  ) => ({
+    id: opts?.id ?? "sm1",
+    organizationId: ORG,
+    projectId: "p1",
+    fields: { type: "EQUIPMENT" as const, quantity: 1, pricingType: "PER_DAY" as const, ...fields },
+    allowOverbook: opts?.over ?? false,
+    forceSeparate: opts?.sep ?? false,
+    includeAccessories: opts?.acc ?? false,
+    orgDefaultTaxRate: null,
+    actor: ACTOR,
+    auditId: "log1",
+    now: NOW,
+  });
+
+  const seedProjectModel = async (
+    t: ReturnType<typeof makeT>,
+    modelExtra: Record<string, unknown> = {},
+    projExtra: Record<string, unknown> = {},
+  ) => {
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false, taxRate: 10, discountPercent: 0, ...projExtra });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED", ...modelExtra });
+    });
+  };
+
+  test("auto-pricing: PER_DAY, no manual price → dailyRate × rentalQuantity → lineTotal", async () => {
+    const t = makeT();
+    // dailyRate 20, project default rental quantity 3.
+    await seedProjectModel(t, { dailyRate: 20 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 3 });
+    const res = await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 2 }, { over: true }),
+    );
+    expect(res.merged).toBe(false);
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "sm1")).first();
+      expect(li?.unitPrice).toBe(20);
+      expect(li?.duration).toBe(3); // rentalQuantity
+      expect(li?.lineTotal).toBe(120); // 20 × 2 × 3
+    });
+  });
+
+  test("auto-pricing: WEEKLY period uses weeklyRate", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 20, weeklyRate: 50 }, { defaultRentalPeriod: "WEEKLY", defaultRentalQuantity: 1 });
+    await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 2 }, { over: true }),
+    );
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "sm1")).first();
+      expect(li?.unitPrice).toBe(50);
+      expect(li?.lineTotal).toBe(100); // 50 × 2 × 1
+    });
+  });
+
+  test("manual price is kept (no auto-pricing)", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 20 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 3 });
+    await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 2, unitPrice: 15, duration: 1 }, { over: true }),
+    );
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "sm1")).first();
+      expect(li?.unitPrice).toBe(15); // manual kept, not auto 20
+      expect(li?.duration).toBe(1);
+      expect(li?.lineTotal).toBe(30); // 15 × 2 × 1
+    });
+  });
+
+  test("merge-dedup: same model/group/category merges quantity + recomputes lineTotal + joins notes", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 20 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: ORG, projectId: "p1", title: "Stage", suggestedPrice: 0, sortOrder: 0 });
+      await ctx.db.insert("projectLineItems", { id: "ex", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: 2, unitPrice: 10, duration: 1, groupId: "g1", status: "CONFIRMED", isKitChild: false, notes: "first" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 3, groupId: "g1", notes: "second" }, { over: true }),
+    );
+    expect(res.merged).toBe(true);
+    expect(res.id).toBe("ex");
+    await t.run(async (ctx) => {
+      const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", "p1")).collect()).filter((l) => l.modelId === "m1");
+      expect(lines).toHaveLength(1); // merged, no new row
+      const ex = lines[0];
+      expect(ex.quantity).toBe(5); // 2 + 3
+      expect(ex.lineTotal).toBe(50); // 10 × 5 × 1
+      expect(ex.notes).toBe("first; second");
+      // No sm1 row was inserted.
+      const sm = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "sm1")).first();
+      expect(sm).toBeNull();
+    });
+  });
+
+  test("forceSeparate: inserts a new row instead of merging", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 20 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "ex", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: 2, unitPrice: 10, duration: 1, status: "CONFIRMED", isKitChild: false });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 3 }, { over: true, sep: true }),
+    );
+    expect(res.merged).toBe(false);
+    await t.run(async (ctx) => {
+      const lines = (await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", "p1")).collect()).filter((l) => l.modelId === "m1");
+      expect(lines).toHaveLength(2); // separate row created
+    });
+  });
+
+  test("group-suggested-price is recomputed + persisted onto the group", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 10 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: ORG, projectId: "p1", title: "Stage", suggestedPrice: 0, sortOrder: 0 });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 2, groupId: "g1" }, { over: true }),
+    );
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.suggestedPrice).toBe(20); // dailyRate 10 × qty 2 × rentalQuantity 1
+    });
+  });
+
+  test("availability: throws INSUFFICIENT_STOCK when qty exceeds free stock", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED", dailyRate: 10 });
+      for (let i = 0; i < 3; i++) await ctx.db.insert("assets", { id: `a${i}`, organizationId: ORG, modelId: "m1", assetTag: `A-${i}`, status: "AVAILABLE", isActive: true });
+      await ctx.db.insert("projectLineItems", { id: "booked", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: 3, status: "CONFIRMED", isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1 })),
+    ).rejects.toThrow(/Only 0 of 1 requested are free/);
+  });
+
+  test("availability: allowOverbook bypasses enforcement", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "PAR", assetType: "SERIALIZED", dailyRate: 10 });
+      for (let i = 0; i < 3; i++) await ctx.db.insert("assets", { id: `a${i}`, organizationId: ORG, modelId: "m1", assetTag: `A-${i}`, status: "AVAILABLE", isActive: true });
+      await ctx.db.insert("projectLineItems", { id: "booked", organizationId: ORG, projectId: "p1", modelId: "m1", type: "EQUIPMENT", quantity: 3, status: "CONFIRMED", isKitChild: false });
+    });
+    // forceSeparate so we exercise the insert path (not a merge into the booked line).
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1 }, { over: true, sep: true }));
+    expect(res.merged).toBe(false);
+  });
+
+  test("accessory expansion: model bulk accessory becomes a child line (qty × parent)", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 10 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("bulkAssets", { id: "ba1", organizationId: ORG, modelId: "m2", assetTag: "BA-1", isActive: true });
+      await ctx.db.insert("modelBulkAccessories", { id: "mba1", organizationId: ORG, modelId: "m1", bulkAssetId: "ba1", quantity: 2, addedById: USER });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(
+      api.lineItemWrites.addLineItemSmartNative,
+      smartArgs({ modelId: "m1", quantity: 3 }, { over: true, acc: true }),
+    );
+    await t.run(async (ctx) => {
+      const children = await ctx.db.query("projectLineItems").withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", "sm1")).collect();
+      expect(children).toHaveLength(1);
+      expect(children[0].childKind).toBe("ACCESSORY");
+      expect(children[0].bulkAssetId).toBe("ba1");
+      expect(children[0].quantity).toBe(6); // 2 × parent qty 3
+    });
+  });
+
+  test("cross-org modelId is rejected (by_cuid is global)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "CONFIRMED", isTemplate: false });
+      // Model belongs to ANOTHER org.
+      await ctx.db.insert("models", { id: "m1", organizationId: "org_other", name: "PAR", assetType: "SERIALIZED", dailyRate: 10 });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1 }, { over: true })),
+    ).rejects.toThrow(/not found in your organization/);
+  });
+
+  test("cross-org groupId is rejected", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 10 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: "org_other", projectId: "px", title: "X", suggestedPrice: 0, sortOrder: 0 });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1, groupId: "g1" }, { over: true })),
+    ).rejects.toThrow(/not found in your organization/);
+  });
+
+  test("dup-guard: a reused client id is rejected", async () => {
+    const t = makeT();
+    await seedProjectModel(t, { dailyRate: 10 }, { defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "sm1", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", quantity: 1, status: "CONFIRMED", isKitChild: false, description: "existing" });
+    });
+    // forceSeparate so we skip the merge path and reach the insert dup-guard.
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1 }, { over: true, sep: true })),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  test("viewer denied", async () => {
+    const t = makeT();
+    await member(t, "viewer");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addLineItemSmartNative, smartArgs({ modelId: "m1", quantity: 1 }, { over: true })),
+    ).rejects.toThrow(/insufficient permissions/i);
+  });
+});
+
 describe("lineItemWrites.recalcNative", () => {
   test("member recomputes + persists project totals (one round-trip)", async () => {
     const t = makeT();

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -18,6 +18,7 @@ import {
   findAssetConflict,
   findKitConflict,
 } from "./lib/availabilityCore";
+import { computeGroupSuggestedPrice } from "./lib/suggestedPrice";
 
 /**
  * Native LINE-ITEM write mutations (Phase 5, the money domain — done safely).
@@ -265,6 +266,77 @@ async function nextLineSort(ctx: MutationCtx, projectId: string, organizationId:
     .order("desc")
     .first();
   return ((top && top.organizationId === organizationId ? top.sortOrder : undefined) ?? -1) + 1;
+}
+
+// ─── addLineItemSmartNative helpers (money-math ports) ────────────────────────
+
+/** roundCurrency port (src/lib/formatters.ts:27) — bankers-free half-up on cents. */
+const roundCurrencyNative = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Byte-parity port of src/server/line-items.ts:1595 `calculateLineTotal`:
+ * unitPrice==null → null; gross=round(unitPrice·qty·duration); result=max(0, round(gross−disc)).
+ */
+function calcLineTotalNative(
+  unitPrice: number | undefined,
+  quantity: number,
+  duration: number,
+  discount: number | undefined,
+): number | null {
+  if (unitPrice == null) return null;
+  const gross = roundCurrencyNative(unitPrice * quantity * duration);
+  const disc = discount ?? 0;
+  return Math.max(0, roundCurrencyNative(gross - disc));
+}
+
+/**
+ * Org-validate a client-supplied FK id against `by_cuid` (a GLOBAL index — the row could
+ * belong to another org). Throws if the referenced row is missing or cross-org. All five
+ * tables carry `id` (by_cuid) + `organizationId`.
+ */
+async function assertRefInOrg(
+  ctx: MutationCtx,
+  table: "models" | "assets" | "bulkAssets" | "projectGroups" | "projectCategories",
+  id: string,
+  orgId: string,
+): Promise<void> {
+  const doc = await ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).first();
+  if (!doc || doc.organizationId !== orgId) {
+    throw new ConvexError({ code: "FORBIDDEN", message: `Referenced ${table} not found in your organization.` });
+  }
+}
+
+/**
+ * Recompute + persist a project group's suggested price (mirrors the server
+ * calculateSuggestedPrice + projectGroupsWrites.recomputeGroupSuggestedById). No-op if
+ * the group is gone / cross-org. Uses the shared computeGroupSuggestedPrice port.
+ */
+async function recomputeGroupSuggestedNative(
+  ctx: MutationCtx,
+  groupId: string,
+  orgId: string,
+  now: number,
+): Promise<void> {
+  const group = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", groupId)).first();
+  if (!group || group.organizationId !== orgId) return;
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", group.projectId)).first();
+  const suggested = await computeGroupSuggestedPrice(ctx, {
+    projectId: group.projectId,
+    groupId,
+    orgId,
+    defaultRentalPeriod: project?.defaultRentalPeriod ?? undefined,
+    defaultRentalQuantity: project?.defaultRentalQuantity ?? undefined,
+    groupRentalPeriod: group.rentalPeriod ?? undefined,
+    groupRentalQuantity: group.rentalQuantity ?? undefined,
+  });
+  await ctx.db.patch(group._id, { suggestedPrice: suggested, updatedAt: now });
+}
+
+/** Drop keys whose value is undefined (parity with the Convex client stripping undefined
+ *  args over the wire — the server merge/insert relied on that to mean "leave unset"). */
+function dropUndefined<T extends Record<string, unknown>>(obj: T): T {
+  for (const k of Object.keys(obj)) if (obj[k] === undefined) delete obj[k];
+  return obj;
 }
 
 /**
@@ -679,5 +751,309 @@ export const recalcNative = mutation({
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     await recalcProjectTotals(ctx, projectId, orgId, orgDefaultTaxRate, now);
     return { ok: true as const };
+  },
+});
+
+/**
+ * addLineItemSmartNative — the FULL browser-direct port of src/server/line-items.ts
+ * `addLineItem` (the money-adjacent add orchestration), all in one atomic mutation:
+ *
+ *   guards → FK org-validation → availability/double-booking → merge-dedup
+ *   → auto-pricing → build fields → insert → accessory expansion → group-suggested-price
+ *   → recalc.
+ *
+ * The availability block is copied verbatim from `addNative`; the three still-server-only
+ * pieces are ported here for byte-parity:
+ *   • auto-pricing  (src/server/line-items.ts:361-401) — PER_DAY, no manual price → fill
+ *     from the model's daily/weekly rate × the project's default rental quantity.
+ *   • merge-dedup   (src/server/line-items.ts:266-358) — a model-backed, asset-less,
+ *     same-group/category add merges into the existing line (quantity summed, lineTotal
+ *     recomputed, notes joined) instead of inserting a duplicate row.
+ *   • group-suggested-price (computeGroupSuggestedPrice) — persisted onto the group.
+ *
+ * lineTotal is ALWAYS recomputed in-mutation (calcLineTotalNative) — never trusted from
+ * the client. `fields.lineTotal` is intentionally absent from the args.
+ */
+export const addLineItemSmartNative = mutation({
+  returns: v.object({ id: v.string(), merged: v.boolean() }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    fields: v.object({
+      categoryId: v.optional(v.string()),
+      groupId: v.optional(v.string()),
+      type: v.optional(enums.LineItemType),
+      modelId: v.optional(v.string()),
+      assetId: v.optional(v.string()),
+      bulkAssetId: v.optional(v.string()),
+      description: v.optional(v.string()),
+      quantity: v.number(),
+      unitPrice: v.optional(v.number()),
+      pricingType: v.optional(enums.PricingType),
+      duration: v.optional(v.number()),
+      discount: v.optional(v.number()),
+      groupName: v.optional(v.string()),
+      notes: v.optional(v.string()),
+      isOptional: v.optional(v.boolean()),
+      showSubhireOnDocs: v.optional(v.boolean()),
+      supplierId: v.optional(v.string()),
+      subhireOrderNumber: v.optional(v.string()),
+    }),
+    allowOverbook: v.boolean(),
+    forceSeparate: v.boolean(),
+    includeAccessories: v.boolean(),
+    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, {
+    id, organizationId, projectId, fields, allowOverbook, forceSeparate, includeAccessories,
+    orgDefaultTaxRate, actor: suppliedActor, auditId, now,
+  }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    // Client-supplied projectId: prove it's the caller's org before reading/sweeping its
+    // lines (by_cuid + by_projectId are GLOBAL). Then bound-check the money inputs.
+    await assertProjectInOrg(ctx, projectId, organizationId);
+    assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
+
+    // Org-validate every referenced FK (by_cuid is global — the row could be another org's).
+    if (fields.modelId) await assertRefInOrg(ctx, "models", fields.modelId, organizationId);
+    if (fields.assetId) await assertRefInOrg(ctx, "assets", fields.assetId, organizationId);
+    if (fields.bulkAssetId) await assertRefInOrg(ctx, "bulkAssets", fields.bulkAssetId, organizationId);
+    if (fields.groupId) await assertRefInOrg(ctx, "projectGroups", fields.groupId, organizationId);
+    if (fields.categoryId) await assertRefInOrg(ctx, "projectCategories", fields.categoryId, organizationId);
+
+    // ── Availability / double-booking (copied verbatim from addNative) ─────────
+    if (fields.type === "EQUIPMENT" && fields.modelId && !allowOverbook) {
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).unique();
+      const rentalStart = project?.rentalStartDate ?? null;
+      const rentalEnd = project?.rentalEndDate ?? null;
+      const hasDates = rentalStart != null && rentalEnd != null;
+
+      if (fields.assetId) {
+        const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", fields.assetId!)).unique();
+        if (asset && asset.organizationId === organizationId && asset.kitId) {
+          const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", asset.kitId!)).unique();
+          const kitTag = kit && kit.organizationId === organizationId ? kit.assetTag : asset.kitId;
+          throw new ConvexError({
+            code: "ASSET_IN_KIT",
+            title: "Asset is in a kit",
+            message: `This asset belongs to Kit ${kitTag}.`,
+            hint: "Add the Kit to the project instead, or remove the asset from the Kit first.",
+          });
+        }
+        if (hasDates) {
+          const conflict = await findAssetConflict(ctx, {
+            assetId: fields.assetId,
+            orgId: organizationId,
+            excludeProjectId: projectId,
+            rentalStart,
+            rentalEnd,
+          });
+          if (conflict) {
+            throw new ConvexError({
+              code: "ASSET_DOUBLE_BOOKED",
+              message: `This asset is booked on ${conflict.projectNumber} — ${conflict.name} during those dates.`,
+            });
+          }
+        }
+        if (asset && asset.organizationId === organizationId && (asset.status === "RETIRED" || asset.status === "LOST")) {
+          throw new ConvexError({
+            code: "ASSET_UNAVAILABLE",
+            message: `This asset is marked ${asset.status.replace("_", " ").toLowerCase()}.`,
+            hint: asset.status === "LOST"
+              ? "Find the asset and mark it Available, or pick a different one."
+              : "Retired assets cannot be booked. Pick a different asset.",
+          });
+        }
+      } else {
+        const bundle = await loadModelAvailabilityBundle(ctx, fields.modelId, organizationId);
+        if (bundle.model) {
+          const { available, booked, unavailable, totalStock } = computeModelAvailability(bundle, {
+            rentalStart,
+            rentalEnd,
+            excludeProjectId: projectId,
+          });
+          if (fields.quantity > available) {
+            const detail = unavailable > 0
+              ? `${booked} booked, ${unavailable} unavailable, ${totalStock} total`
+              : `${booked} already booked out of ${totalStock} total`;
+            throw new ConvexError({
+              code: "INSUFFICIENT_STOCK",
+              message: `Only ${available} of ${fields.quantity} requested are free during those dates.`,
+              hint: `Stock: ${detail}. Reduce the quantity, change the dates, or add a sub-hire to cover the gap.`,
+            });
+          }
+        }
+      }
+    }
+
+    // ── Merge-dedup (src/server/line-items.ts:266-358) ─────────────────────────
+    // A model-backed, asset-less, same-group/category, non-sub-hire, non-child add merges
+    // into the existing matching line (quantity summed, lineTotal recomputed) instead of
+    // inserting a duplicate row. Never when forceSeparate.
+    if (fields.type === "EQUIPMENT" && fields.modelId && !fields.assetId && !forceSeparate) {
+      const projectLines = (
+        await ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect()
+      ).filter((li) => li.organizationId === organizationId);
+      const existing = projectLines.find(
+        (li) =>
+          li.modelId === fields.modelId &&
+          li.assetId == null &&
+          (li.groupId ?? null) === (fields.groupId ?? null) &&
+          (li.categoryId ?? null) === (fields.categoryId ?? null) &&
+          !li.isKitChild &&
+          li.subHireId == null &&
+          li.status !== "CANCELLED",
+      );
+
+      if (existing) {
+        const newQuantity = (existing.quantity ?? 0) + fields.quantity;
+        // lineTotal recomputed server-side (never trusts the client). Mirrors the server
+        // merge exactly: parsed value first, else the existing row's value.
+        const mergedUnitPrice = fields.unitPrice ?? (existing.unitPrice != null ? Number(existing.unitPrice) : undefined);
+        const mergedDuration = fields.duration || existing.duration || 1;
+        const mergedDiscount = fields.discount ?? (existing.discount != null ? Number(existing.discount) : undefined);
+        const newLineTotal = calcLineTotalNative(mergedUnitPrice, newQuantity, mergedDuration, mergedDiscount);
+        const mergedNotes = fields.notes
+          ? existing.notes ? `${existing.notes}; ${fields.notes}` : fields.notes
+          : existing.notes;
+
+        // Only defined keys are patched (the server passed these through the Convex client,
+        // which strips undefined — so `?? undefined` meant "leave the field untouched").
+        const mergeSet = dropUndefined({
+          quantity: newQuantity,
+          unitPrice: fields.unitPrice ?? existing.unitPrice ?? undefined,
+          pricingType: fields.pricingType || existing.pricingType,
+          duration: fields.duration || existing.duration || undefined,
+          discount: fields.discount ?? existing.discount ?? undefined,
+          lineTotal: newLineTotal ?? undefined,
+          groupName: fields.groupName || existing.groupName || undefined,
+          notes: mergedNotes || undefined,
+          updatedAt: now,
+        } as Record<string, unknown>);
+        await ctx.db.patch(existing._id, mergeSet);
+
+        await writeActivityLog(ctx, {
+          id: auditId,
+          organizationId,
+          action: "UPDATE",
+          entityType: "lineItem",
+          entityId: existing.id,
+          entityName: existing.description || "Line item",
+          userId: actor.userId,
+          userName: actor.userName,
+          summary: `Merged line item into existing on project (qty ${existing.quantity ?? 0} -> ${newQuantity})`,
+          projectId,
+          createdAt: now,
+        });
+
+        if (existing.groupId) await recomputeGroupSuggestedNative(ctx, existing.groupId, organizationId, now);
+        await recalcProjectTotals(ctx, projectId, organizationId, orgDefaultTaxRate, now);
+        return { id: existing.id, merged: true };
+      }
+    }
+
+    // ── Auto-pricing (src/server/line-items.ts:361-401) ────────────────────────
+    // PER_DAY model-backed line, no manual price → fill from the model's rate using the
+    // project's default rental period/quantity. Manual prices are kept.
+    let autoUnitPrice = fields.unitPrice;
+    let autoDuration = fields.duration;
+    // `== null` (not `!unitPrice`) — an EXPLICIT $0 manual price (a free item) is a real
+    // choice and must be kept, not overwritten by the model rate. (The server addLineItem
+    // has the `!parsed.unitPrice` truthiness bug; this fixes it in the native port.)
+    if (fields.modelId && fields.pricingType === "PER_DAY" && fields.unitPrice == null) {
+      const [model, proj] = await Promise.all([
+        ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", fields.modelId!)).first(),
+        ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first(),
+      ]);
+      if (model && model.organizationId === organizationId) {
+        const rentalPeriod = proj?.defaultRentalPeriod ?? "DAILY";
+        const rentalQuantity = proj?.defaultRentalQuantity ?? 1;
+        const rate =
+          rentalPeriod === "WEEKLY"
+            ? (model.weeklyRate ?? model.dailyRate ?? null)
+            : (model.dailyRate ?? null);
+        if (rate != null) {
+          autoUnitPrice = Number(rate);
+          autoDuration = rentalQuantity;
+        }
+      }
+    }
+
+    const lineTotal = calcLineTotalNative(autoUnitPrice, fields.quantity, autoDuration ?? 1, fields.discount);
+
+    // ── Insert (mirrors createLineItem / addNative) ────────────────────────────
+    const dupLine = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dupLine) throw new ConvexError("Line item already exists");
+
+    const sortOrder = await nextLineSort(ctx, projectId, organizationId);
+    await ctx.db.insert("projectLineItems", {
+      id,
+      organizationId,
+      projectId,
+      type: fields.type,
+      modelId: fields.modelId || undefined,
+      assetId: fields.assetId || undefined,
+      bulkAssetId: fields.bulkAssetId || undefined,
+      description: fields.description || undefined,
+      quantity: fields.quantity,
+      unitPrice: autoUnitPrice ?? undefined,
+      pricingType: fields.pricingType,
+      duration: autoDuration ?? undefined,
+      discount: fields.discount ?? undefined,
+      lineTotal: lineTotal ?? undefined,
+      groupName: fields.groupName || undefined,
+      notes: fields.notes || undefined,
+      isOptional: fields.isOptional,
+      showSubhireOnDocs: fields.showSubhireOnDocs,
+      supplierId: fields.supplierId || undefined,
+      subhireOrderNumber: fields.subhireOrderNumber || undefined,
+      categoryId: fields.categoryId || undefined,
+      groupId: fields.groupId || undefined,
+      status: "CONFIRMED",
+      sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    if (includeAccessories && fields.type === "EQUIPMENT" && (fields.assetId || fields.modelId)) {
+      await expandAccessoryChildLines(ctx, {
+        id,
+        assetId: fields.assetId,
+        modelId: fields.modelId,
+        quantity: fields.quantity,
+        categoryId: fields.categoryId,
+        groupId: fields.groupId,
+        duration: autoDuration,
+        pricingType: fields.pricingType,
+        organizationId,
+        projectId,
+      });
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "CREATE",
+      entityType: "lineItem",
+      entityId: id,
+      entityName: fields.description || "Line item",
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: "Added line item to project",
+      projectId,
+      createdAt: now,
+    });
+
+    if (fields.groupId) await recomputeGroupSuggestedNative(ctx, fields.groupId, organizationId, now);
+    await recalcProjectTotals(ctx, projectId, organizationId, orgDefaultTaxRate, now);
+    return { id, merged: false };
   },
 });

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -65,6 +65,85 @@ export async function addLineItem(projectId: string, data: LineItemFormValues, a
   const { organizationId, userId, userName } = await requirePermission("project", "manage_line_items", actor);
   const parsed = lineItemSchema.parse(data);
 
+  // NATIVE PATH: the FULL add orchestration — availability, merge-dedup, auto-pricing,
+  // insert, accessory expansion, group-suggested-price, and recalc — runs atomically in
+  // one Convex mutation (addLineItemSmartNative). The server keeps only the parse + actor
+  // + org-tax resolution above, and the non-money tail (collab feed + supplier enrich +
+  // webhook) below. lineTotal is recomputed in-mutation; the client is never trusted.
+  if (nativeLineItemWrites()) {
+    const convex = await getConvexClient();
+    let res: { id: string; merged: boolean };
+    try {
+      res = await convex.mutation(api.lineItemWrites.addLineItemSmartNative, {
+        id: createId(),
+        organizationId,
+        projectId,
+        fields: {
+          type: parsed.type,
+          modelId: parsed.modelId || undefined,
+          assetId: parsed.assetId || undefined,
+          bulkAssetId: parsed.bulkAssetId || undefined,
+          description: parsed.description || undefined,
+          quantity: parsed.quantity,
+          unitPrice: parsed.unitPrice ?? undefined,
+          pricingType: parsed.pricingType,
+          duration: parsed.duration ?? undefined,
+          discount: parsed.discount ?? undefined,
+          groupName: parsed.groupName || undefined,
+          notes: parsed.notes || undefined,
+          isOptional: parsed.isOptional,
+          showSubhireOnDocs: parsed.showSubhireOnDocs,
+          supplierId: parsed.supplierId || undefined,
+          subhireOrderNumber: parsed.subhireOrderNumber || undefined,
+          categoryId: parsed.categoryId || undefined,
+          groupId: parsed.groupId || undefined,
+        },
+        allowOverbook,
+        forceSeparate,
+        includeAccessories,
+        orgDefaultTaxRate: await orgDefaultTaxRateFor(organizationId),
+        actor: { userId, userName },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+
+    const result = (await readBackLine(res.id))!;
+
+    // Non-money tail (best-effort collab feed + supplier enrich). The money orchestration
+    // + CREATE/UPDATE audit + recalc already committed atomically in the mutation.
+    const [, supplier] = await Promise.all([
+      writeCollabActivityEvent(
+        { organizationId, userId, userName },
+        {
+          entityType: "project",
+          entityId: projectId,
+          action: "line_item_added",
+          summary: `added ${result.description || "a line item"}`,
+          targetType: "lineItem",
+          targetId: result.id,
+        },
+      ),
+      result.supplierId ? getSupplierById(result.supplierId).catch(() => null) : Promise.resolve(null),
+    ]);
+
+    void emitWebhookEvent(organizationId, "line_item.added", {
+      projectId,
+      lineItemId: result.id,
+      modelId: result.modelId ?? null,
+      quantity: result.quantity ?? null,
+      type: result.type ?? null,
+      description: result.description ?? null,
+    });
+
+    if (res.merged) {
+      return serialize({ ...result, supplier, _merged: true, _newQuantity: result.quantity });
+    }
+    return serialize({ ...result, supplier });
+  }
+
   // Server-side availability enforcement for equipment.
   // Sub-hire items represent third-party stock and never consume our inventory.
   // Detection moved from `isSubhire` boolean to `subHireId != null` (Wave 2).


### PR DESCRIPTION
## Summary
Ports the full `addLineItem` orchestration into one native mutation, re-homing the last server-only money logic (**merge-dedup + auto-pricing + group-suggested-price**) — the prerequisite for a browser-direct line-items add surface. Availability + accessory expansion + recalc reuse the already-native pieces.

- **`addLineItemSmartNative`** — 4 guards + FK org-validation (model/asset/bulk/group/category — new hardening) + availability (verbatim from `addNative`) + merge-dedup (exact match predicate → patch existing, sum qty, recompute `lineTotal`, join notes) + auto-pricing (byte-parity) + insert + accessory expansion + group-suggested-price (persisted) + recalc. `lineTotal` always recomputed server-side (never trusted). Returns `{id, merged}`.
- `src/server/line-items.ts addLineItem` native branch routes through the mutation; keeps parse + actor + tax + the non-money tail (collab/supplier/webhook). Legacy flag-off path unchanged.

## Review
Codex-reviewed — auto-pricing/merge/suggested-price byte-parity + availability reuse + FK/dup-guard/actor confirmed; **1 money bug fixed**: an explicit **$0 manual price is now kept** (`== null` not `!unitPrice`; the server has the same latent bug). tsc clean; +14 tests = 49; full convex suite (893) green; deployed additive/inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)