### PR TITLE
phase3(collaboration): browser-direct comment/review-marker writes (RBAC + gate preserved)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -88,6 +88,7 @@ import type * as lib_availabilityBookings from "../lib/availabilityBookings.js";
 import type * as lib_availabilityCore from "../lib/availabilityCore.js";
 import type * as lib_blockingCommentsGate from "../lib/blockingCommentsGate.js";
 import type * as lib_bulkCheckin from "../lib/bulkCheckin.js";
+import type * as lib_collaborationColors from "../lib/collaborationColors.js";
 import type * as lib_counters from "../lib/counters.js";
 import type * as lib_crewRate from "../lib/crewRate.js";
 import type * as lib_crewTimeHours from "../lib/crewTimeHours.js";
@@ -292,6 +293,7 @@ declare const fullApi: ApiFromModules<{
   "lib/availabilityCore": typeof lib_availabilityCore;
   "lib/blockingCommentsGate": typeof lib_blockingCommentsGate;
   "lib/bulkCheckin": typeof lib_bulkCheckin;
+  "lib/collaborationColors": typeof lib_collaborationColors;
   "lib/counters": typeof lib_counters;
   "lib/crewRate": typeof lib_crewRate;
   "lib/crewTimeHours": typeof lib_crewTimeHours;

--- a/convex/collaboration.ts
+++ b/convex/collaboration.ts
@@ -2,14 +2,24 @@ import { v, ConvexError } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { query, mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
-import { requireOrgRead, requireService } from "./lib/auth";
+import { requireOrgRead, requireOrgPermission, requireService, resolveActor } from "./lib/auth";
+import { assertWritesEnabled } from "./lib/writeGuard";
+import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { getUserColor } from "./lib/collaborationColors";
 
 /**
  * Convex collaboration substrate — presence, edit locks, comment threads,
  * review markers, and activity events.
  *
- * AUTH: all mutations require the trusted backend SERVICE token (writes flow
- * browser → Next.js server action → Convex, same as the rest of the app).
+ * AUTH: the comment/review-marker WRITES are browser-direct (Phase 3): they run
+ * the 4-guard bar — assertWritesEnabled + enforceBrowserWriteLimit +
+ * requireOrgRead / requireOrgPermission(project, manage_line_items) + resolveActor
+ * (audit identity pinned to the verified token; a client can't spoof the author or
+ * the avatar colour, which is recomputed from the pinned userId). All four guards
+ * no-op / bypass for the SERVICE token, so the in-flight deployed image (which
+ * still calls these via the server action until Coolify ships) is unaffected —
+ * backward-compatible expand-contract (colour args relaxed to optional, nothing
+ * removed). Presence/lock mutations remain SERVICE-gated for now (server action).
  * Queries use org-scoped user reads: requireOrgRead(ctx, orgId).
  *
  * Presence TTL: 45 s from lastSeenAt. Heartbeat every 15 s.
@@ -352,18 +362,39 @@ export const createThread = mutation({
     firstComment: v.string(),
     createdBy: v.string(),
     createdByName: v.string(),
-    authorColor: v.string(),
+    // Relaxed required → optional (expand-contract): the deployed image still sends
+    // it; browser-direct callers omit it — the colour is recomputed from the pinned
+    // actor below, never trusted from the client.
+    authorColor: v.optional(v.string()),
     isBlocking: v.optional(v.boolean()),
     projectId: v.optional(v.string()),
     mentionUserIds: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
-    await requireService(ctx);
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    // A blocking comment feeds the project blocking gate → gate it on
+    // manage_line_items (owner/admin/manager/member); a plain discussion is open to
+    // any org member. Service token bypasses both.
+    if (args.isBlocking) {
+      if (args.entityType !== "project") {
+        throw new ConvexError("Blocking comments are only supported on projects.");
+      }
+      await requireOrgPermission(ctx, args.orgId, "project", "manage_line_items");
+    } else {
+      // A plain discussion is open to any org member — project:read is held by every
+      // built-in role, so this is the membership-aware "any member" bar (unlike
+      // requireOrgRead, it re-checks the members row, not just the token's orgId claim).
+      await requireOrgPermission(ctx, args.orgId, "project", "read");
+    }
+    const actor = await resolveActor(ctx, { userId: args.createdBy, userName: args.createdByName });
+    const color = getUserColor(actor.userId);
     const now = Date.now();
-    // For "project" entities the entityId already IS the project id; fall back to
-    // it so blocking summaries always have a project to group by.
+    // For a "project" entity the entityId IS the project id — derive projectId from
+    // it and IGNORE any client-supplied projectId, so a blocking thread can't be
+    // indexed against (and thus gate) a DIFFERENT project than the one it's on.
     const projectId =
-      args.projectId ?? (args.entityType === "project" ? args.entityId : undefined);
+      args.entityType === "project" ? args.entityId : args.projectId;
     const mentions = args.mentionUserIds?.length ? args.mentionUserIds : undefined;
     const threadId = await ctx.db.insert("commentThreads", {
       orgId: args.orgId,
@@ -375,8 +406,8 @@ export const createThread = mutation({
       isBlocking: args.isBlocking ?? false,
       projectId,
       mentionUserIds: mentions,
-      createdBy: args.createdBy,
-      createdByName: args.createdByName,
+      createdBy: actor.userId,
+      createdByName: actor.userName,
       createdAt: now,
       updatedAt: now,
     });
@@ -385,9 +416,9 @@ export const createThread = mutation({
       orgId: args.orgId,
       threadId: threadId as unknown as string,
       body: args.firstComment,
-      authorId: args.createdBy,
-      authorName: args.createdByName,
-      authorColor: args.authorColor,
+      authorId: actor.userId,
+      authorName: actor.userName,
+      authorColor: color,
       mentionUserIds: mentions,
       createdAt: now,
     });
@@ -395,9 +426,9 @@ export const createThread = mutation({
     const where = targetLabel(args.targetType);
     await recordActivity(ctx, {
       orgId: args.orgId,
-      actorUserId: args.createdBy,
-      actorName: args.createdByName,
-      actorColor: args.authorColor,
+      actorUserId: actor.userId,
+      actorName: actor.userName,
+      actorColor: color,
       entityType: args.entityType,
       entityId: args.entityId,
       targetType: args.targetType,
@@ -419,11 +450,17 @@ export const addComment = mutation({
     body: v.string(),
     authorId: v.string(),
     authorName: v.string(),
-    authorColor: v.string(),
+    // Relaxed required → optional (expand-contract); colour recomputed from the pinned actor.
+    authorColor: v.optional(v.string()),
     mentionUserIds: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
-    await requireService(ctx);
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    // Any org member may reply (membership-aware; project:read is universal).
+    await requireOrgPermission(ctx, args.orgId, "project", "read");
+    const actor = await resolveActor(ctx, { userId: args.authorId, userName: args.authorName });
+    const color = getUserColor(actor.userId);
     const now = Date.now();
 
     const thread = await ctx.db.get(args.threadId as unknown as Id<"commentThreads">);
@@ -454,18 +491,18 @@ export const addComment = mutation({
       orgId: args.orgId,
       threadId: args.threadId,
       body: args.body,
-      authorId: args.authorId,
-      authorName: args.authorName,
-      authorColor: args.authorColor,
+      authorId: actor.userId,
+      authorName: actor.userName,
+      authorColor: color,
       mentionUserIds: newMentions.length ? newMentions : undefined,
       createdAt: now,
     });
 
     await recordActivity(ctx, {
       orgId: args.orgId,
-      actorUserId: args.authorId,
-      actorName: args.authorName,
-      actorColor: args.authorColor,
+      actorUserId: actor.userId,
+      actorName: actor.userName,
+      actorColor: color,
       entityType: thread.entityType,
       entityId: thread.entityId,
       targetType: thread.targetType,
@@ -488,28 +525,30 @@ export const setThreadBlocking = mutation({
     actorName: v.optional(v.string()),
     actorColor: v.optional(v.string()),
   },
-  handler: async (ctx, { orgId, threadId, isBlocking, actorUserId, actorName, actorColor }) => {
-    await requireService(ctx);
+  handler: async (ctx, { orgId, threadId, isBlocking, actorUserId, actorName }) => {
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    // Toggling the blocking flag moves the project gate → manage_line_items.
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, { userId: actorUserId ?? "", userName: actorName ?? "" });
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
     if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     await ctx.db.patch(thread._id, { isBlocking, updatedAt: Date.now() });
-    if (actorUserId && actorName && actorColor) {
-      await recordActivity(ctx, {
-        orgId,
-        actorUserId,
-        actorName,
-        actorColor,
-        entityType: thread.entityType,
-        entityId: thread.entityId,
-        targetType: thread.targetType,
-        targetId: thread.targetId,
-        action: isBlocking ? "thread_blocked" : "thread_unblocked",
-        summary: isBlocking
-          ? `marked a comment as blocking${targetLabel(thread.targetType)}`
-          : `cleared the blocking flag${targetLabel(thread.targetType)}`,
-        metadata: { threadId },
-      });
-    }
+    await recordActivity(ctx, {
+      orgId,
+      actorUserId: actor.userId,
+      actorName: actor.userName,
+      actorColor: getUserColor(actor.userId),
+      entityType: thread.entityType,
+      entityId: thread.entityId,
+      targetType: thread.targetType,
+      targetId: thread.targetId,
+      action: isBlocking ? "thread_blocked" : "thread_unblocked",
+      summary: isBlocking
+        ? `marked a comment as blocking${targetLabel(thread.targetType)}`
+        : `cleared the blocking flag${targetLabel(thread.targetType)}`,
+      metadata: { threadId },
+    });
   },
 });
 
@@ -521,32 +560,33 @@ export const resolveThread = mutation({
     actorName: v.optional(v.string()),
     actorColor: v.optional(v.string()),
   },
-  handler: async (ctx, { orgId, threadId, resolvedBy, actorName, actorColor }) => {
-    await requireService(ctx);
+  handler: async (ctx, { orgId, threadId, resolvedBy, actorName }) => {
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, { userId: resolvedBy, userName: actorName ?? "" });
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
     if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     const now = Date.now();
     await ctx.db.patch(thread._id, {
       status: "resolved",
-      resolvedBy,
+      resolvedBy: actor.userId,
       resolvedAt: now,
       updatedAt: now,
     });
-    if (actorName && actorColor) {
-      await recordActivity(ctx, {
-        orgId,
-        actorUserId: resolvedBy,
-        actorName,
-        actorColor,
-        entityType: thread.entityType,
-        entityId: thread.entityId,
-        targetType: thread.targetType,
-        targetId: thread.targetId,
-        action: "thread_resolved",
-        summary: `resolved a discussion${targetLabel(thread.targetType)}`,
-        metadata: { threadId },
-      });
-    }
+    await recordActivity(ctx, {
+      orgId,
+      actorUserId: actor.userId,
+      actorName: actor.userName,
+      actorColor: getUserColor(actor.userId),
+      entityType: thread.entityType,
+      entityId: thread.entityId,
+      targetType: thread.targetType,
+      targetId: thread.targetId,
+      action: "thread_resolved",
+      summary: `resolved a discussion${targetLabel(thread.targetType)}`,
+      metadata: { threadId },
+    });
   },
 });
 
@@ -558,8 +598,11 @@ export const reopenThread = mutation({
     actorName: v.optional(v.string()),
     actorColor: v.optional(v.string()),
   },
-  handler: async (ctx, { orgId, threadId, actorUserId, actorName, actorColor }) => {
-    await requireService(ctx);
+  handler: async (ctx, { orgId, threadId, actorUserId, actorName }) => {
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, { userId: actorUserId ?? "", userName: actorName ?? "" });
     const thread = await ctx.db.get(threadId as unknown as Id<"commentThreads">);
     if (!thread || thread.orgId !== orgId) throw new ConvexError("Thread not found");
     await ctx.db.patch(thread._id, {
@@ -568,21 +611,19 @@ export const reopenThread = mutation({
       resolvedAt: undefined,
       updatedAt: Date.now(),
     });
-    if (actorUserId && actorName && actorColor) {
-      await recordActivity(ctx, {
-        orgId,
-        actorUserId,
-        actorName,
-        actorColor,
-        entityType: thread.entityType,
-        entityId: thread.entityId,
-        targetType: thread.targetType,
-        targetId: thread.targetId,
-        action: "thread_reopened",
-        summary: `reopened a discussion${targetLabel(thread.targetType)}`,
-        metadata: { threadId },
-      });
-    }
+    await recordActivity(ctx, {
+      orgId,
+      actorUserId: actor.userId,
+      actorName: actor.userName,
+      actorColor: getUserColor(actor.userId),
+      entityType: thread.entityType,
+      entityId: thread.entityId,
+      targetType: thread.targetType,
+      targetId: thread.targetId,
+      action: "thread_reopened",
+      summary: `reopened a discussion${targetLabel(thread.targetType)}`,
+      metadata: { threadId },
+    });
   },
 });
 
@@ -641,7 +682,13 @@ export const setReviewMarker = mutation({
     actorColor: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await requireService(ctx);
+    await assertWritesEnabled(ctx, "collaboration");
+    await enforceBrowserWriteLimit(ctx);
+    // A review marker is a lightweight annotation — any org member (no RBAC in the
+    // old action; project:read is universal, membership-aware). Service token bypasses.
+    await requireOrgPermission(ctx, args.orgId, "project", "read");
+    const actor = await resolveActor(ctx, { userId: args.createdBy, userName: args.createdByName });
+    const color = getUserColor(actor.userId);
     const now = Date.now();
 
     const existing = await ctx.db
@@ -653,12 +700,11 @@ export const setReviewMarker = mutation({
       .first();
 
     const logMarker = async () => {
-      if (!args.actorColor) return;
       await recordActivity(ctx, {
         orgId: args.orgId,
-        actorUserId: args.createdBy,
-        actorName: args.createdByName,
-        actorColor: args.actorColor,
+        actorUserId: actor.userId,
+        actorName: actor.userName,
+        actorColor: color,
         entityType: args.entityType,
         entityId: args.entityId,
         targetType: args.targetType,
@@ -675,7 +721,7 @@ export const setReviewMarker = mutation({
         reason: args.reason,
         note: args.note,
         updatedAt: now,
-        resolvedBy: args.status === "resolved" ? args.createdBy : undefined,
+        resolvedBy: args.status === "resolved" ? actor.userId : undefined,
         resolvedAt: args.status === "resolved" ? now : undefined,
       });
       await logMarker();
@@ -691,8 +737,8 @@ export const setReviewMarker = mutation({
       status: args.status,
       reason: args.reason,
       note: args.note,
-      createdBy: args.createdBy,
-      createdByName: args.createdByName,
+      createdBy: actor.userId,
+      createdByName: actor.userName,
       createdAt: now,
       updatedAt: now,
     })) as string;

--- a/convex/collaborationColors.test.ts
+++ b/convex/collaborationColors.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+//
+// Pins the Convex-side getUserColor / COLLAB_COLORS port (convex/lib/collaborationColors.ts)
+// byte-for-byte to the src canonical (@/lib/collaboration-colors), so the avatar colour a
+// browser-direct collaboration mutation recomputes from the pinned actor matches what the
+// UI derives client-side.
+import { describe, test, expect } from "vitest";
+import { getUserColor as convexColor, COLLAB_COLORS as convexPalette } from "./lib/collaborationColors";
+import { getUserColor as srcColor, COLLAB_COLORS as srcPalette } from "../src/lib/collaboration-colors";
+
+describe("collaborationColors port parity", () => {
+  test("palettes are identical", () => {
+    expect([...convexPalette]).toEqual([...srcPalette]);
+  });
+
+  test("getUserColor agrees across a range of ids", () => {
+    const ids = ["", "u", "user_1", "user_2", "abc123", "a".repeat(50), "cuid_zx8y7", "🙂emoji"];
+    for (const id of ids) {
+      expect(convexColor(id)).toBe(srcColor(id));
+    }
+  });
+});

--- a/convex/collaborationWrites.test.ts
+++ b/convex/collaborationWrites.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+//
+// convex/collaboration.ts — the browser-direct comment/review-marker writes.
+// Verifies: actor pinned to the verified token (spoofed createdBy ignored), avatar
+// colour recomputed from the pinned actor, RBAC on the blocking/resolve/reopen paths
+// (viewer denied, member allowed), per-row org re-check, the blocking gate is fed by
+// createThread(isBlocking)/setThreadBlocking/resolveThread, and the SERVICE token path
+// (deployed image) still works with the pre-migration arg shape (backward-compat).
+import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { buildBlockingSummary } from "./lib/blockingCommentsGate";
+import { getUserColor } from "./lib/collaborationColors";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER_ORG = "org_2";
+const MEMBER = "user_member";
+const VIEWER = "user_viewer";
+const PROJECT = "proj_1";
+
+function makeT() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  return t;
+}
+
+async function seed(t: ReturnType<typeof makeT>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("users", { id: MEMBER, name: "Mia Member", email: "mia@x.co" });
+    await ctx.db.insert("users", { id: VIEWER, name: "Vic Viewer", email: "vic@x.co" });
+    await ctx.db.insert("members", { id: "m_member", organizationId: ORG, userId: MEMBER, role: "member" });
+    await ctx.db.insert("members", { id: "m_viewer", organizationId: ORG, userId: VIEWER, role: "viewer" });
+  });
+}
+
+const asMember = { subject: MEMBER, orgId: ORG, role: "member" };
+const asViewer = { subject: VIEWER, orgId: ORG, role: "viewer" };
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+describe("collaboration browser-direct writes", () => {
+  test("createThread (non-blocking) pins the actor + recomputes colour; a spoofed createdBy is ignored", async () => {
+    const t = makeT();
+    await seed(t);
+    const threadId = await t.withIdentity(asMember).mutation(api.collaboration.createThread, {
+      orgId: ORG,
+      entityType: "project",
+      entityId: PROJECT,
+      firstComment: "hello",
+      createdBy: "SPOOFED_someone_else", // must be ignored — pinned to the token subject
+      createdByName: "Spoofed Name",
+    });
+    const thread = await t.run(async (ctx) => ctx.db.get(threadId as unknown as Id<"commentThreads">));
+    expect(thread!.createdBy).toBe(MEMBER);
+    expect(thread!.createdByName).toBe("Mia Member"); // from the users mirror, not the client label
+    const comment = await t.run(async (ctx) =>
+      ctx.db.query("comments").withIndex("by_orgId_threadId", (q) => q.eq("orgId", ORG).eq("threadId", threadId as string)).first(),
+    );
+    expect(comment!.authorId).toBe(MEMBER);
+    expect(comment!.authorColor).toBe(getUserColor(MEMBER)); // recomputed from the pinned id
+  });
+
+  test("blocking createThread requires manage_line_items and feeds the gate; viewer denied; non-project rejected", async () => {
+    const t = makeT();
+    await seed(t);
+    // Viewer lacks manage_line_items → denied.
+    await expect(
+      t.withIdentity(asViewer).mutation(api.collaboration.createThread, {
+        orgId: ORG, entityType: "project", entityId: PROJECT, firstComment: "block", createdBy: VIEWER, createdByName: "V", isBlocking: true,
+      }),
+    ).rejects.toThrow();
+    // Blocking on a non-project entity is rejected.
+    await expect(
+      t.withIdentity(asMember).mutation(api.collaboration.createThread, {
+        orgId: ORG, entityType: "asset", entityId: "a1", firstComment: "block", createdBy: MEMBER, createdByName: "M", isBlocking: true,
+      }),
+    ).rejects.toThrow();
+    // Member CAN create a blocking project thread → gate reflects it.
+    await t.withIdentity(asMember).mutation(api.collaboration.createThread, {
+      orgId: ORG, entityType: "project", entityId: PROJECT, firstComment: "block", createdBy: MEMBER, createdByName: "M", isBlocking: true,
+    });
+    const summary = await t.run(async (ctx) => buildBlockingSummary(ctx, ORG, PROJECT));
+    expect(summary.hasProjectLevel).toBe(true);
+  });
+
+  test("resolveThread clears the gate and is manage_line_items-gated", async () => {
+    const t = makeT();
+    await seed(t);
+    const threadId = await t.withIdentity(asMember).mutation(api.collaboration.createThread, {
+      orgId: ORG, entityType: "project", entityId: PROJECT, firstComment: "block", createdBy: MEMBER, createdByName: "M", isBlocking: true,
+    });
+    expect((await t.run(async (ctx) => buildBlockingSummary(ctx, ORG, PROJECT))).hasProjectLevel).toBe(true);
+    // Viewer cannot resolve.
+    await expect(
+      t.withIdentity(asViewer).mutation(api.collaboration.resolveThread, { orgId: ORG, threadId: threadId as string, resolvedBy: VIEWER }),
+    ).rejects.toThrow();
+    // Member resolves → gate clears (status !== open).
+    await t.withIdentity(asMember).mutation(api.collaboration.resolveThread, { orgId: ORG, threadId: threadId as string, resolvedBy: MEMBER });
+    expect((await t.run(async (ctx) => buildBlockingSummary(ctx, ORG, PROJECT))).hasProjectLevel).toBe(false);
+  });
+
+  test("addComment rejects replies on resolved threads and re-checks the thread org", async () => {
+    const t = makeT();
+    await seed(t);
+    const threadId = await t.withIdentity(asMember).mutation(api.collaboration.createThread, {
+      orgId: ORG, entityType: "project", entityId: PROJECT, firstComment: "hi", createdBy: MEMBER, createdByName: "M",
+    });
+    // Per-row org re-check: a thread owned by ANOTHER org, addressed with the caller's
+    // OWN (matching) org, must not be writable → thread.orgId !== args.orgId → not found.
+    const foreignThread = await t.run(async (ctx) =>
+      ctx.db.insert("commentThreads", {
+        orgId: OTHER_ORG, entityType: "project", entityId: "pX", status: "open", isBlocking: false,
+        createdBy: "x", createdByName: "x", createdAt: 1, updatedAt: 1,
+      }),
+    );
+    await expect(
+      t.withIdentity(asMember).mutation(api.collaboration.addComment, { orgId: ORG, threadId: foreignThread as string, body: "x", authorId: MEMBER, authorName: "M" }),
+    ).rejects.toThrow();
+    // Normal reply works.
+    await t.withIdentity(asMember).mutation(api.collaboration.addComment, { orgId: ORG, threadId: threadId as string, body: "reply", authorId: MEMBER, authorName: "M" });
+    // Resolve then reply → rejected.
+    await t.withIdentity(asMember).mutation(api.collaboration.resolveThread, { orgId: ORG, threadId: threadId as string, resolvedBy: MEMBER });
+    await expect(
+      t.withIdentity(asMember).mutation(api.collaboration.addComment, { orgId: ORG, threadId: threadId as string, body: "late", authorId: MEMBER, authorName: "M" }),
+    ).rejects.toThrow();
+  });
+
+  test("setReviewMarker is any-member (viewer allowed) + pins the actor", async () => {
+    const t = makeT();
+    await seed(t);
+    const id = await t.withIdentity(asViewer).mutation(api.collaboration.setReviewMarker, {
+      orgId: ORG, entityType: "project", entityId: PROJECT, targetType: "lineItem", targetId: "li1", status: "needs_review", createdBy: "SPOOF", createdByName: "S",
+    });
+    const marker = await t.run(async (ctx) => ctx.db.get(id as unknown as Id<"reviewMarkers">));
+    expect(marker!.createdBy).toBe(VIEWER); // pinned, spoof ignored
+  });
+
+  test("SERVICE token still works with the pre-migration arg shape (backward-compat)", async () => {
+    const t = makeT();
+    await seed(t);
+    // Deployed image sends actor fields + a colour string; service trusts the supplied actor.
+    const threadId = await t.withIdentity(SERVICE).mutation(api.collaboration.createThread, {
+      orgId: ORG, entityType: "project", entityId: PROJECT, firstComment: "svc", createdBy: MEMBER, createdByName: "Mia Member", authorColor: "#123456", isBlocking: false,
+    });
+    const thread = await t.run(async (ctx) => ctx.db.get(threadId as unknown as Id<"commentThreads">));
+    expect(thread!.createdBy).toBe(MEMBER);
+    // service resolveActor trusts supplied; colour is still recomputed from that id (deterministic parity).
+    const comment = await t.run(async (ctx) =>
+      ctx.db.query("comments").withIndex("by_orgId_threadId", (q) => q.eq("orgId", ORG).eq("threadId", threadId as string)).first(),
+    );
+    expect(comment!.authorColor).toBe(getUserColor(MEMBER));
+  });
+});

--- a/convex/lib/collaborationColors.ts
+++ b/convex/lib/collaborationColors.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic collaboration user colours — Convex-side port of
+ * src/lib/collaboration-colors.ts (getUserColor + COLLAB_COLORS). Convex can't
+ * import from `@/lib`, so the pure hash is copied here and pinned byte-for-byte to
+ * the src canonical by a cross-import equality test (convex/collaborationColors.test.ts).
+ *
+ * Browser-direct collaboration mutations recompute the actor colour from the
+ * VERIFIED (resolveActor-pinned) userId rather than trusting a client-supplied
+ * colour, so a caller can't attribute a comment under a spoofed avatar colour.
+ */
+
+// 12 distinct colours covering the hue wheel, skipping red and orange.
+export const COLLAB_COLORS = [
+  "#2563eb", // blue
+  "#7c3aed", // violet
+  "#db2777", // pink
+  "#0891b2", // cyan
+  "#059669", // emerald
+  "#65a30d", // lime
+  "#d97706", // amber — warm but not error-red
+  "#0d9488", // teal
+  "#4f46e5", // indigo
+  "#9333ea", // purple
+  "#0284c7", // sky
+  "#16a34a", // green
+] as const;
+
+/** Derive a stable colour hex from a user id string. Pure function, no random. */
+export function getUserColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return COLLAB_COLORS[hash % COLLAB_COLORS.length];
+}

--- a/src/components/collaboration/comment-thread-panel.tsx
+++ b/src/components/collaboration/comment-thread-panel.tsx
@@ -23,13 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
-import {
-  createThread,
-  addComment,
-  resolveThread,
-  reopenThread,
-  setThreadBlocking,
-} from "@/server/collaboration";
+import { useCollaborationWrites } from "@/hooks/use-collaboration-writes";
 import { getMentionableMembers } from "@/server/org-members";
 import { getForegroundColor, getUserInitials, timeAgo } from "@/lib/collaboration-colors";
 import { cn } from "@/lib/utils";
@@ -170,6 +164,7 @@ interface ThreadViewProps {
 function ThreadView({ orgId, thread, members, allowBlocking }: ThreadViewProps) {
   const [reply, setReply] = useState("");
   const [mentions, setMentions] = useState<string[]>([]);
+  const { addComment, resolveThread, reopenThread, setThreadBlocking } = useCollaborationWrites();
   const comments = useAuthedQuery(api.collaboration.listComments, {
     orgId,
     threadId: thread._id,
@@ -336,6 +331,7 @@ export function CommentThreadPanel({
   const [newComment, setNewComment] = useState("");
   const [blocking, setBlocking] = useState(false);
   const [mentions, setMentions] = useState<string[]>([]);
+  const { createThread } = useCollaborationWrites();
 
   // Blocking comments gate project prep / send-out. They are meaningless on
   // other entities (assets, clients, …), so the toggle is project-only.

--- a/src/components/projects/__tests__/equipment-mobile-cards.smoke.test.tsx
+++ b/src/components/projects/__tests__/equipment-mobile-cards.smoke.test.tsx
@@ -18,8 +18,11 @@ vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => true }));
 // comment-counts). Stub the hook so the card renders without a Convex client.
 vi.mock("@/hooks/use-authed-query", () => ({ useAuthedQuery: () => undefined }));
 
-// setReviewMarker is a server action pulled in at module load — stub it.
-vi.mock("@/server/collaboration", () => ({ setReviewMarker: vi.fn(async () => {}) }));
+// setReviewMarker is now a browser-direct Convex write behind useCollaborationWrites
+// (uses useMutation) — stub the hook so the card renders without a Convex client.
+vi.mock("@/hooks/use-collaboration-writes", () => ({
+  useCollaborationWrites: () => ({ setReviewMarker: vi.fn(async () => {}) }),
+}));
 
 // LineAssetsIndicator's history popover imports a warehouse server action.
 vi.mock("@/server/warehouse", () => ({ getScanLog: vi.fn(async () => ({ logs: [] })) }));

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -48,7 +48,7 @@ import { useRowShortcuts } from "./use-row-shortcuts";
 import { ReviewMarkerBadge } from "@/components/collaboration/review-marker-badge";
 import type { MarkerStatus } from "@/components/collaboration/review-marker-badge";
 import { CommentThreadPanel } from "@/components/collaboration/comment-thread-panel";
-import { setReviewMarker } from "@/server/collaboration";
+import { useCollaborationWrites } from "@/hooks/use-collaboration-writes";
 import { toast } from "sonner";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -1135,6 +1135,7 @@ export function LineItemRow({
   // Captures the shift key on checkbox click so the row-level handler can extend
   // a range — Radix's onCheckedChange doesn't forward the originating event.
   const shiftKeyRef = useRef(false);
+  const { setReviewMarker } = useCollaborationWrites();
 
   // Collaboration: reactive lock and review marker for this row
   const liveLock = useAuthedQuery(

--- a/src/hooks/use-collaboration-writes.ts
+++ b/src/hooks/use-collaboration-writes.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback } from "react";
+import { useMutation } from "convex/react";
+import { useSession, useActiveOrganization } from "@/lib/auth-client";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Browser-direct collaboration comment/review-marker writes (Phase 3 — replaces
+ * the createThread / addComment / setThreadBlocking / resolveThread / reopenThread
+ * / setReviewMarker server actions in src/server/collaboration.ts). The Convex
+ * mutations now run the 4-guard bar (assertWritesEnabled + enforceBrowserWriteLimit
+ * + requireOrgRead|requireOrgPermission + resolveActor); the author + avatar colour
+ * are pinned to the verified token INSIDE the mutation, so this hook does NOT pass a
+ * colour and the createdBy/name it sends are advisory (resolveActor overwrites them).
+ *
+ * Signatures mirror the deleted server actions so consumers only swap the import.
+ * The RBAC on the blocking/resolve/reopen paths (project manage_line_items) is now
+ * enforced Convex-side; a non-permitted caller's mutation throws (surfaced by the
+ * consumer's useServerMutation error handling).
+ */
+export function useCollaborationWrites() {
+  const { data: session } = useSession();
+  const { data: activeOrg } = useActiveOrganization();
+
+  const createThreadM = useMutation(api.collaboration.createThread);
+  const addCommentM = useMutation(api.collaboration.addComment);
+  const setThreadBlockingM = useMutation(api.collaboration.setThreadBlocking);
+  const resolveThreadM = useMutation(api.collaboration.resolveThread);
+  const reopenThreadM = useMutation(api.collaboration.reopenThread);
+  const setReviewMarkerM = useMutation(api.collaboration.setReviewMarker);
+
+  const requireOrg = useCallback((): string => {
+    const id = activeOrg?.id;
+    if (!id) throw new Error("No active organization");
+    return id;
+  }, [activeOrg?.id]);
+  const uid = session?.user.id ?? "";
+  const uname = session?.user.name ?? "";
+
+  const createThread = useCallback(
+    async (
+      entityType: string,
+      entityId: string,
+      firstComment: string,
+      targetType?: string,
+      targetId?: string,
+      options?: { isBlocking?: boolean; mentionUserIds?: string[]; projectId?: string },
+    ): Promise<{ threadId: string }> => {
+      const threadId = await createThreadM({
+        orgId: requireOrg(),
+        entityType,
+        entityId,
+        targetType,
+        targetId,
+        firstComment,
+        createdBy: uid,
+        createdByName: uname,
+        isBlocking: options?.isBlocking ?? false,
+        projectId: options?.projectId,
+        mentionUserIds: options?.mentionUserIds,
+      });
+      return { threadId: threadId as unknown as string };
+    },
+    [createThreadM, requireOrg, uid, uname],
+  );
+
+  const addComment = useCallback(
+    async (threadId: string, body: string, options?: { mentionUserIds?: string[] }): Promise<{ ok: true }> => {
+      await addCommentM({
+        orgId: requireOrg(),
+        threadId,
+        body,
+        authorId: uid,
+        authorName: uname,
+        mentionUserIds: options?.mentionUserIds,
+      });
+      return { ok: true };
+    },
+    [addCommentM, requireOrg, uid, uname],
+  );
+
+  const setThreadBlocking = useCallback(
+    async (threadId: string, isBlocking: boolean): Promise<{ ok: true }> => {
+      await setThreadBlockingM({ orgId: requireOrg(), threadId, isBlocking, actorUserId: uid, actorName: uname });
+      return { ok: true };
+    },
+    [setThreadBlockingM, requireOrg, uid, uname],
+  );
+
+  const resolveThread = useCallback(
+    async (threadId: string): Promise<{ ok: true }> => {
+      await resolveThreadM({ orgId: requireOrg(), threadId, resolvedBy: uid, actorName: uname });
+      return { ok: true };
+    },
+    [resolveThreadM, requireOrg, uid, uname],
+  );
+
+  const reopenThread = useCallback(
+    async (threadId: string): Promise<{ ok: true }> => {
+      await reopenThreadM({ orgId: requireOrg(), threadId, actorUserId: uid, actorName: uname });
+      return { ok: true };
+    },
+    [reopenThreadM, requireOrg, uid, uname],
+  );
+
+  const setReviewMarker = useCallback(
+    async (
+      entityType: string,
+      entityId: string,
+      targetType: string,
+      targetId: string,
+      status: "needs_review" | "follow_up" | "resolved",
+      reason?: string,
+      note?: string,
+    ): Promise<{ ok: true }> => {
+      await setReviewMarkerM({
+        orgId: requireOrg(),
+        entityType,
+        entityId,
+        targetType,
+        targetId,
+        status,
+        reason,
+        note,
+        createdBy: uid,
+        createdByName: uname,
+      });
+      return { ok: true };
+    },
+    [setReviewMarkerM, requireOrg, uid, uname],
+  );
+
+  return { createThread, addComment, setThreadBlocking, resolveThread, reopenThread, setReviewMarker };
+}

--- a/src/server/collaboration.ts
+++ b/src/server/collaboration.ts
@@ -2,7 +2,7 @@
 
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
-import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { getOrgContext } from "@/lib/org-context";
 import { getUserColor } from "@/lib/collaboration-colors";
 import { serialize } from "@/lib/serialize";
 
@@ -133,135 +133,14 @@ export async function takeoverLock(
   return serialize(result);
 }
 
-// ─── Comments ─────────────────────────────────────────────────────────────────
-
-export async function createThread(
-  entityType: string,
-  entityId: string,
-  firstComment: string,
-  targetType?: string,
-  targetId?: string,
-  options?: { isBlocking?: boolean; mentionUserIds?: string[]; projectId?: string }
-) {
-  const ctx = await getOrgContext();
-  if (options?.isBlocking) {
-    // Blocking comments only gate project prep / send-out — they're meaningless
-    // on other records, so reject them server-side (the UI hides the toggle too).
-    if (entityType !== "project") {
-      throw new Error("Blocking comments are only supported on projects.");
-    }
-    await requirePermission("project", "manage_line_items");
-  }
-  const userColor = getUserColor(ctx.userId);
-  const convex = await getConvexClient();
-  const threadId = await convex.mutation(api.collaboration.createThread, {
-    orgId: ctx.organizationId,
-    entityType,
-    entityId,
-    targetType,
-    targetId,
-    firstComment,
-    createdBy: ctx.userId,
-    createdByName: ctx.userName,
-    authorColor: userColor,
-    isBlocking: options?.isBlocking ?? false,
-    projectId: options?.projectId,
-    mentionUserIds: options?.mentionUserIds,
-  });
-  return serialize({ threadId: threadId as unknown as string });
-}
-
-export async function addComment(
-  threadId: string,
-  body: string,
-  options?: { mentionUserIds?: string[] }
-) {
-  const ctx = await getOrgContext();
-  const userColor = getUserColor(ctx.userId);
-  const convex = await getConvexClient();
-  await convex.mutation(api.collaboration.addComment, {
-    orgId: ctx.organizationId,
-    threadId,
-    body,
-    authorId: ctx.userId,
-    authorName: ctx.userName,
-    authorColor: userColor,
-    mentionUserIds: options?.mentionUserIds,
-  });
-  return serialize({ ok: true });
-}
-
-export async function setThreadBlocking(threadId: string, isBlocking: boolean) {
-  const ctx = await getOrgContext();
-  await requirePermission("project", "manage_line_items");
-  const convex = await getConvexClient();
-  await convex.mutation(api.collaboration.setThreadBlocking, {
-    orgId: ctx.organizationId,
-    threadId,
-    isBlocking,
-    actorUserId: ctx.userId,
-    actorName: ctx.userName,
-    actorColor: getUserColor(ctx.userId),
-  });
-  return serialize({ ok: true });
-}
-
-export async function resolveThread(threadId: string) {
-  const ctx = await getOrgContext();
-  await requirePermission("project", "manage_line_items");
-  const convex = await getConvexClient();
-  await convex.mutation(api.collaboration.resolveThread, {
-    orgId: ctx.organizationId,
-    threadId,
-    resolvedBy: ctx.userId,
-    actorName: ctx.userName,
-    actorColor: getUserColor(ctx.userId),
-  });
-  return serialize({ ok: true });
-}
-
-export async function reopenThread(threadId: string) {
-  const ctx = await getOrgContext();
-  await requirePermission("project", "manage_line_items");
-  const convex = await getConvexClient();
-  await convex.mutation(api.collaboration.reopenThread, {
-    orgId: ctx.organizationId,
-    threadId,
-    actorUserId: ctx.userId,
-    actorName: ctx.userName,
-    actorColor: getUserColor(ctx.userId),
-  });
-  return serialize({ ok: true });
-}
-
-// ─── Review Markers ──────────────────────────────────────────────────────────
-
-export async function setReviewMarker(
-  entityType: string,
-  entityId: string,
-  targetType: string,
-  targetId: string,
-  status: "needs_review" | "follow_up" | "resolved",
-  reason?: string,
-  note?: string
-) {
-  const ctx = await getOrgContext();
-  const convex = await getConvexClient();
-  await convex.mutation(api.collaboration.setReviewMarker, {
-    orgId: ctx.organizationId,
-    entityType,
-    entityId,
-    targetType,
-    targetId,
-    status,
-    reason,
-    note,
-    createdBy: ctx.userId,
-    createdByName: ctx.userName,
-    actorColor: getUserColor(ctx.userId),
-  });
-  return serialize({ ok: true });
-}
+// ─── Comments + Review Markers ────────────────────────────────────────────────
+//
+// createThread / addComment / setThreadBlocking / resolveThread / reopenThread /
+// setReviewMarker moved BROWSER-DIRECT in Phase 3 — the Convex mutations now run
+// the 4-guard bar (RBAC on the blocking/resolve/reopen paths, actor pinned to the
+// verified token). See convex/collaboration.ts + src/hooks/use-collaboration-writes.ts.
+// The presence/lock actions above remain server-mediated (service token) until the
+// presence/lock browser-direct slice lands.
 
 // ─── Activity ─────────────────────────────────────────────────────────────────
 //


### PR DESCRIPTION
Converts the 6 collaboration **comment/review-marker** Convex mutations from `requireService` to browser-direct in place, and rewires consumers to `useMutation` instead of the deleted server actions (Phase 3, collaboration PR-A of 2 — presence/lock + server-file deletion follow in PR-B).

## Security bar
Each mutation now runs `assertWritesEnabled` + `enforceBrowserWriteLimit` + RBAC + `resolveActor`:
- **RBAC parity** with the old server actions: blocking `createThread` / `setThreadBlocking` / `resolveThread` / `reopenThread` → `project:manage_line_items`; non-blocking `createThread` / `addComment` / `setReviewMarker` → `project:read` (membership-aware "any member" bar — every built-in role holds `project:read`, and unlike `requireOrgRead` it re-checks the members row).
- **Actor + avatar colour pinned** to the verified token via `resolveActor`; colour recomputed from the pinned userId (`convex/lib/collaborationColors.ts`, byte-parity port pinned by a cross-import equality test) — a client can't spoof author or colour.
- **Per-row org re-check** on every thread fetch (already present; verified).

## Blocking gate preserved
The mutations still write `commentThreads.isBlocking/status/projectId`, so `projectWrites`/`warehouseWrites` gate enforcement is unaffected. **Fix (codex High):** for a `"project"` entity, `projectId` is now derived from `entityId` (client `projectId` ignored) so a blocking thread can't be indexed against — and gate — a *different* project.

## Backward-compatible (expand-contract)
Colour args relaxed `v.string()` → `v.optional`; all four guards no-op/bypass for the service token, so the in-flight deployed image (still calling these via the server action until Coolify ships) is unaffected. No arg removed or added-required.

## Verification
- `tsc` clean, ESLint clean, `convex/collaborationWrites.test.ts` (6) + `collaborationColors.test.ts` (2) + warehouse gate-pin tests (50) green.
- Codex adversarial review: confirmed backward-compat, RBAC parity, actor pinning, org re-checks. Its 3 findings all fixed (projectId gate injection, membership-aware guard, test `Id` casts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)