### PR TITLE
fix(convex): close within-org money/integrity gaps from the Phase-3 audit

### DIFF
--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -263,6 +263,30 @@ describe("assetWrites.createNative", () => {
       t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs),
     ).rejects.toThrow(/insufficient permissions/i);
   });
+
+  test("rejects a duplicate cuid (DUPLICATE_ASSET) — replay can't insert a 2nd by_cuid row", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs);
+    // Same id, different tag (so it's the id guard firing, not the tag guard).
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, { ...createArgs, assetTag: "NEW-2", auditId: "log2" }),
+    ).rejects.toThrow(/already exists/i);
+    const rows = await t.run(async (ctx) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", "new1")).collect());
+    expect(rows).toHaveLength(1); // still exactly one row
+  });
+
+  test("rejects a non-finite purchasePrice", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, { ...createArgs, purchasePrice: Number.POSITIVE_INFINITY }),
+    ).rejects.toThrow(/finite/i);
+  });
 });
 
 describe("assetWrites.updateNative", () => {

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -6,6 +6,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { bumpAssetCounters, bumpCountersForTable } from "./lib/counters";
+import { assertFinite } from "./lib/moneyGuards";
 import { reserveAssetTagCounter } from "./lib/assetTagCounter";
 import { registerAssetTestTag, backfillTestTagAssetsCore } from "./lib/testtagBackfill";
 import * as enums from "./lib/validators";
@@ -320,6 +321,13 @@ export const createNative = mutation({
     await requireOrgPermission(ctx, fields.organizationId, "asset", "create");
     const actor = await resolveActor(ctx, suppliedActor);
 
+    // dup-id guard (by_cuid is GLOBAL + non-unique) — a replayed/duplicate client cuid
+    // inserts a 2nd `assets` row that later crashes every `by_cuid(...).unique()` reader
+    // (kit add, checkout, detail). Mirrors bulkAssetsWrites/kitWrites createNative.
+    const dupId = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    if (dupId) throw new ConvexError({ code: "DUPLICATE_ASSET", message: "Asset already exists." });
+    assertFinite(fields.purchasePrice, "purchasePrice");
+
     const dup = await ctx.db
       .query("assets")
       .withIndex("by_organizationId_assetTag", (q) =>
@@ -388,6 +396,7 @@ export const updateNative = mutation({
     const doc = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc) throw new ConvexError("Asset not found: " + id);
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
+    assertFinite((set as { purchasePrice?: number }).purchasePrice, "purchasePrice");
 
     // DUP GUARD only when the tag changed (mirrors updateAsset).
     if (set.assetTag && set.assetTag !== doc.assetTag) {
@@ -503,6 +512,9 @@ export const createManyNative = mutation({
 
     const ids: string[] = [];
     for (const a of assets) {
+      const dupId = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
+      if (dupId) throw new ConvexError({ code: "DUPLICATE_ASSET", message: `Asset already exists: ${a.id}` });
+      assertFinite(a.purchasePrice, "purchasePrice");
       const dup = await ctx.db.query("assets")
         .withIndex("by_organizationId_assetTag", (q) => q.eq("organizationId", orgId).eq("assetTag", a.assetTag)).first();
       if (dup) throw new ConvexError({ code: "DUPLICATE_ASSET_TAG", tag: a.assetTag, message: `Asset tag "${a.assetTag}" already exists.` });

--- a/convex/projectGroupsWrites.test.ts
+++ b/convex/projectGroupsWrites.test.ts
@@ -238,6 +238,21 @@ describe("projectGroupsWrites.updateGroupPriceNative", () => {
       t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, { id: "g1", orgId: ORG, price: 10, now: NOW, actor: ACTOR, auditId: "log1" }),
     ).rejects.toThrow(/insufficient permissions/i);
   });
+
+  test("rejects a non-finite price (NaN/Infinity would poison recalc → project.total NaN)", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+        id: "g1", orgId: ORG, price: Number.NaN, now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/finite/i);
+    // The group price + project.total are untouched by the rejected write.
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.price ?? null).toBeNull();
+    });
+  });
 });
 
 // ─── deleteGroupNative ────────────────────────────────────────────────────────

--- a/convex/projectGroupsWrites.ts
+++ b/convex/projectGroupsWrites.ts
@@ -58,7 +58,9 @@ function assertValidRentalQuantity(rentalQuantity: number) {
   }
 }
 function assertValidPrice(price: number) {
-  if (price < 0) throw new ConvexError("Price must be at least 0");
+  // Number.isFinite first — NaN/Infinity both pass `< 0` and then poison recalcProjectTotals
+  // (groupRevenue += num(price) * qty → project.total = NaN). Browser-direct bypasses Zod.
+  if (!Number.isFinite(price) || price < 0) throw new ConvexError("Price must be a finite number ≥ 0");
 }
 
 // ─── Collaboration colour (deterministic from userId) ────────────────────────

--- a/convex/projectServicesWrites.test.ts
+++ b/convex/projectServicesWrites.test.ts
@@ -78,6 +78,20 @@ describe("createServiceNative", () => {
     expect((await projById(t, "p1"))?.total).toBe(110);
   });
 
+  test("rejects non-finite money (NaN unitPrice would poison recalc → project.total NaN)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceNative, {
+        id: "s1", orgId: ORG, projectId: "p1", ...baseInput, unitPrice: Number.NaN, now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/finite/i);
+    // No row, no audit, project.total unchanged (rejected before any write).
+    expect(await svcById(t, "s1")).toBeNull();
+    expect((await projById(t, "p1"))?.total).toBe(999);
+  });
+
   test("crew assignment inserted (PENDING, phase, role) + counter bump", async () => {
     const t = makeT();
     await member(t, "member");

--- a/convex/projectServicesWrites.ts
+++ b/convex/projectServicesWrites.ts
@@ -6,6 +6,7 @@ import type { Doc } from "./_generated/dataModel";
 import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { assertFinite } from "./lib/moneyGuards";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import { bumpCountersForTable } from "./lib/counters";
@@ -154,6 +155,12 @@ type ServiceInput = {
 /** Port of buildServiceData — clamps endDate by type, computes lineTotal, and returns
  *  the normalized `fields` (null = cleared) plus the clamped serviceDate/serviceEndDate. */
 function buildServiceFields(a: ServiceInput) {
+  // Reject non-finite money before it reaches calculateServiceLineTotal / recalcProjectTotals
+  // (serviceRevenue += num(lineTotal), serviceCostTotal += num(costTotal) → project.total/
+  // margin = NaN). Browser-direct bypasses the server Zod that used to catch this.
+  assertFinite(a.unitPrice, "unitPrice");
+  assertFinite(a.discount, "discount");
+  assertFinite(a.costTotal, "costTotal");
   const serviceDate = a.date ?? null;
   let serviceEndDate = a.endDate ?? serviceDate;
   if (!MULTI_DAY_TYPES.has(a.type)) serviceEndDate = serviceDate;
@@ -1190,6 +1197,7 @@ export const createServiceTemplateNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, a.orgId, "orgSettings", "update");
     const actor = await resolveActor(ctx, a.actor);
+    assertFinite(a.defaultUnitPrice, "defaultUnitPrice"); // generateServicesNative copies it into unitPrice → recalc
 
     if (!a.title) throw new ConvexError("Title is required");
 
@@ -1240,6 +1248,7 @@ export const updateServiceTemplateNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, a.orgId, "orgSettings", "update");
     const actor = await resolveActor(ctx, a.actor);
+    assertFinite(a.defaultUnitPrice, "defaultUnitPrice"); // generateServicesNative copies it into unitPrice → recalc
 
     if (!a.title) throw new ConvexError("Title is required");
     const doc = await ctx.db.query("serviceTemplates").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();


### PR DESCRIPTION
Independent full-audit follow-up (compliance fixes, batch 1 of the quick fixes). All findings are **within-org integrity** — the audit confirmed **no cross-tenant leak** in the mutation layer.

- **asset dup-id guard** (`assetWrites.createNative`/`createManyNative`): a replayed client cuid otherwise inserts a 2nd `assets` row that crashes every `by_cuid(...).unique()` reader. Mirrors `bulkAssetsWrites`/`kitWrites`.
- **`assertFinite` on browser-controlled money** → stops NaN/Infinity poisoning `recalcProjectTotals` (`project.total`/`margin` = NaN): asset `purchasePrice`, projectServices `unitPrice`/`discount`/`costTotal` + template `defaultUnitPrice` (copied into unitPrice by `generateServicesNative` — codex catch), projectGroups `price` (`assertValidPrice` was only `price < 0`; NaN/Infinity passed).

Tests: dup-cuid + non-finite rejection on assets/groups/services. Full convex suite green (913); tsc clean; **codex CLEAN**. Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)