### PR TITLE
Line-items: bulk edit/remove browser-direct (write layer done)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -98,6 +98,7 @@ import type * as lib_dto from "../lib/dto.js";
 import type * as lib_fulfillment from "../lib/fulfillment.js";
 import type * as lib_inventory from "../lib/inventory.js";
 import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
+import type * as lib_lineTotal from "../lib/lineTotal.js";
 import type * as lib_moneyGuards from "../lib/moneyGuards.js";
 import type * as lib_notificationPreferences from "../lib/notificationPreferences.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
@@ -307,6 +308,7 @@ declare const fullApi: ApiFromModules<{
   "lib/fulfillment": typeof lib_fulfillment;
   "lib/inventory": typeof lib_inventory;
   "lib/lineItemUnits": typeof lib_lineItemUnits;
+  "lib/lineTotal": typeof lib_lineTotal;
   "lib/moneyGuards": typeof lib_moneyGuards;
   "lib/notificationPreferences": typeof lib_notificationPreferences;
   "lib/permissionsCore": typeof lib_permissionsCore;

--- a/convex/lib/lineTotal.test.ts
+++ b/convex/lib/lineTotal.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { roundCurrency, computeLineTotal } from "./lineTotal";
+
+describe("roundCurrency", () => {
+  it("rounds to two decimal places, half-up", () => {
+    expect(roundCurrency(1.005)).toBe(1.0); // float64 1.005 rounds down — pinned to match src/lib/formatters
+    expect(roundCurrency(2.675)).toBe(2.68); // float64: 2.675*100 → 267.5 → 268
+    expect(roundCurrency(10)).toBe(10);
+    expect(roundCurrency(1.234)).toBe(1.23);
+  });
+});
+
+describe("computeLineTotal", () => {
+  it("returns null when there is no unit price", () => {
+    expect(computeLineTotal(undefined, 5, 3, 10)).toBeNull();
+  });
+
+  it("computes gross minus discount, floored at zero", () => {
+    // 100 × 2 × 3 = 600; − 50 discount = 550
+    expect(computeLineTotal(100, 2, 3, 50)).toBe(550);
+    // no discount defaults to 0
+    expect(computeLineTotal(100, 2, 3, undefined)).toBe(600);
+    // an explicit $0 unit price is a real (free) line, not null
+    expect(computeLineTotal(0, 4, 2, undefined)).toBe(0);
+    // discount larger than gross floors at 0 (never negative)
+    expect(computeLineTotal(10, 1, 1, 999)).toBe(0);
+    // rounding applied to the gross
+    expect(computeLineTotal(9.99, 3, 1, undefined)).toBe(29.97);
+  });
+});

--- a/convex/lib/lineTotal.ts
+++ b/convex/lib/lineTotal.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure money helpers shared by the native line-item write mutations.
+ *
+ * Byte-parity ports of:
+ *  - `roundCurrency`  (src/lib/formatters.ts:27)
+ *  - `computeLineTotal` (src/hooks/use-native-line-item-writes.ts:25)
+ *
+ * The server action, the client optimistic overlay, and now the in-mutation bulk
+ * recompute all derive `lineTotal` the same way, so a browser-direct bulk edit lands
+ * exactly the value every other consumer would have produced.
+ */
+
+/** roundCurrency port (src/lib/formatters.ts:27) — half-up on cents. */
+export function roundCurrency(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * lineTotal = max(0, round(unitPrice·qty·duration) − discount); `null` when there is no
+ * unit price. Byte-parity port of use-native-line-item-writes.ts `computeLineTotal`.
+ */
+export function computeLineTotal(
+  unitPrice: number | undefined,
+  quantity: number,
+  duration: number,
+  discount: number | undefined,
+): number | null {
+  if (unitPrice == null) return null;
+  const gross = roundCurrency(unitPrice * quantity * duration);
+  return Math.max(0, roundCurrency(gross - (discount ?? 0)));
+}

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -7,6 +7,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { assertLineMoneyFields } from "./lib/moneyGuards";
+import { roundCurrency, computeLineTotal } from "./lib/lineTotal";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import * as enums from "./lib/validators";
@@ -164,6 +165,80 @@ export const removeNative = mutation({
     }
 
     return { projectId: line.projectId };
+  },
+});
+
+/**
+ * removeManyNative — browser-direct bulk line-item remove. RBAC(project, manage_line_items).
+ *
+ * Byte-parity port of the deleted `removeLineItemsBatch` server action (+ its Convex
+ * `removeManyCascade`): one backend-local pass loops the ids, org-scopes + child-guards
+ * each row (a kit/accessory/sub-hire child is removed via its parent, never individually
+ * — so it's SKIPPED here, matching the server), cascade-deletes each removable line's
+ * children + units via the same `deleteLineWithUnits` removeNative uses, then writes ONE
+ * aggregate DELETE audit and recalcs each affected project ONCE. All atomic. The org
+ * default tax rate is resolved in-mutation from orgSettings (a browser caller can't spoof it).
+ */
+export const removeManyNative = mutation({
+  returns: v.object({ removed: v.number(), skipped: v.number() }),
+  args: {
+    ids: v.array(v.string()),
+    orgId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { ids, orgId, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    let removed = 0;
+    let skipped = 0;
+    // Affected projectIds in first-seen order (recalc each once; audit uses [0]).
+    const affected: string[] = [];
+    const affectedSet = new Set<string>();
+
+    for (const id of ids) {
+      const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+      // Missing / cross-org (by_cuid is GLOBAL) / a child item → skipped, never removed.
+      if (!line || line.organizationId !== orgId || line.isKitChild) {
+        skipped++;
+        continue;
+      }
+      const children = (await ctx.db
+        .query("projectLineItems")
+        .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
+        .collect()).filter((c) => c.organizationId === orgId);
+      for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id, orgId);
+      await deleteLineWithUnits(ctx, line._id, line.id, orgId);
+      if (!affectedSet.has(line.projectId)) {
+        affectedSet.add(line.projectId);
+        affected.push(line.projectId);
+      }
+      removed++;
+    }
+
+    if (removed > 0) {
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: orgId,
+        action: "DELETE",
+        entityType: "lineItem",
+        entityId: ids[0],
+        entityName: `${removed} line item${removed === 1 ? "" : "s"}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Removed ${removed} line item${removed === 1 ? "" : "s"} from project`,
+        projectId: affected[0],
+        createdAt: now,
+      });
+      const rate = await resolveOrgDefaultTaxRate(ctx, orgId);
+      for (const pid of affected) await recalcProjectTotals(ctx, pid, orgId, rate, now);
+    }
+
+    return { removed, skipped };
   },
 });
 
@@ -346,6 +421,137 @@ export const patchNative = mutation({
     }
 
     return { projectId: doc.projectId };
+  },
+});
+
+/**
+ * patchManyNative — browser-direct bulk line-item EDIT (shared fields). RBAC(project,
+ * manage_line_items). Byte-parity port of the deleted `updateLineItemsBatch` server
+ * action (+ its Convex `patchMany`): loops the ids, org-scopes + child-guards each row
+ * (kit/accessory/sub-hire children are SKIPPED), builds the set/clear IN-mutation from the
+ * shared `patch`, then writes ONE aggregate UPDATE audit + recalcs each affected project once.
+ *
+ * MONEY — the discount %/lineTotal recompute reads the DOC's OWN unitPrice/quantity/duration
+ * (never a client-supplied base), so a browser caller can't inflate a line total by lying
+ * about the base. Only `patch.discount.{mode,value}` (the intended input) is client-supplied,
+ * and `assertLineMoneyFields` bound-checks the resulting discount/lineTotal before it lands.
+ */
+export const patchManyNative = mutation({
+  returns: v.object({ updated: v.number(), skipped: v.number() }),
+  args: {
+    ids: v.array(v.string()),
+    orgId: v.string(),
+    patch: v.object({
+      pricingType: v.optional(v.string()),
+      discount: v.optional(v.union(v.object({ mode: v.string(), value: v.number() }), v.null())),
+      notes: v.optional(v.union(v.string(), v.null())),
+      isOptional: v.optional(v.boolean()),
+    }),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { ids, orgId, patch, actor: suppliedActor, auditId, now }) => {
+    await assertWritesEnabled(ctx, "lineItem");
+    await enforceBrowserWriteLimit(ctx);
+    await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    const actor = await resolveActor(ctx, suppliedActor);
+
+    let updated = 0;
+    let skipped = 0;
+    // Affected projectIds in first-seen order (recalc each once; audit uses [0]).
+    const affected: string[] = [];
+    const affectedSet = new Set<string>();
+
+    for (const id of ids) {
+      const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+      // Missing / cross-org (by_cuid is GLOBAL) / a child item → skipped, never edited.
+      if (!doc || doc.organizationId !== orgId || doc.isKitChild) {
+        skipped++;
+        continue;
+      }
+
+      // Build set/clear IN-mutation — byte-parity with updateLineItemsBatch, reading the
+      // doc's OWN money fields (never the client's) for the % discount + lineTotal recompute.
+      const set: Record<string, unknown> = { updatedAt: now };
+      const clear: string[] = [];
+
+      if (patch.pricingType !== undefined) set.pricingType = patch.pricingType;
+      if (patch.isOptional !== undefined) set.isOptional = patch.isOptional;
+      if (patch.notes !== undefined) {
+        if (patch.notes == null || patch.notes === "") clear.push("notes");
+        else set.notes = patch.notes;
+      }
+
+      if (patch.discount !== undefined) {
+        let discountApplied: number | undefined;
+        if (patch.discount == null || patch.discount.value <= 0) {
+          clear.push("discount");
+          discountApplied = undefined;
+        } else if (patch.discount.mode === "%") {
+          const base = (doc.unitPrice ?? 0) * (doc.quantity ?? 0) * (doc.duration ?? 1);
+          discountApplied = roundCurrency((base * patch.discount.value) / 100);
+          set.discount = discountApplied;
+        } else {
+          discountApplied = patch.discount.value;
+          set.discount = discountApplied;
+        }
+        // Discount feeds the stored line total — recompute from the item's own
+        // price/quantity/duration (unchanged) + the new discount.
+        const lineTotal = computeLineTotal(
+          doc.unitPrice ?? undefined,
+          doc.quantity ?? 0,
+          doc.duration ?? 1,
+          discountApplied,
+        );
+        if (lineTotal == null) clear.push("lineTotal");
+        else set.lineTotal = lineTotal;
+      }
+
+      // Belt-and-braces bound-check on the money fields this bulk edit can touch (a
+      // browser-direct caller bypasses the server-side Zod).
+      assertLineMoneyFields(set as {
+        quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
+      });
+
+      if (clear.length === 0) {
+        await ctx.db.patch(doc._id, set);
+      } else {
+        const { _id, _creationTime, ...rest } = doc;
+        const merged: Record<string, unknown> = { ...rest, ...set };
+        for (const k of clear) {
+          if (LINE_NEVER_CLEAR.has(k)) continue;
+          delete merged[k];
+        }
+        await ctx.db.replace(doc._id, merged as typeof rest);
+      }
+
+      if (!affectedSet.has(doc.projectId)) {
+        affectedSet.add(doc.projectId);
+        affected.push(doc.projectId);
+      }
+      updated++;
+    }
+
+    if (updated > 0) {
+      await writeActivityLog(ctx, {
+        id: auditId,
+        organizationId: orgId,
+        action: "UPDATE",
+        entityType: "lineItem",
+        entityId: ids[0],
+        entityName: `${updated} line item${updated === 1 ? "" : "s"}`,
+        userId: actor.userId,
+        userName: actor.userName,
+        summary: `Bulk edited ${updated} line item${updated === 1 ? "" : "s"}`,
+        projectId: affected[0],
+        createdAt: now,
+      });
+      const rate = await resolveOrgDefaultTaxRate(ctx, orgId);
+      for (const pid of affected) await recalcProjectTotals(ctx, pid, orgId, rate, now);
+    }
+
+    return { updated, skipped };
   },
 });
 

--- a/src/components/projects/bulk-edit-line-items-dialog.tsx
+++ b/src/components/projects/bulk-edit-line-items-dialog.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "lucide-react";
-import type { BulkLineItemPatch } from "@/server/line-items";
+import type { BulkLineItemPatch } from "@/hooks/use-line-item-writes";
 
 const PRICING_LABELS: Record<string, string> = {
   PER_DAY: "Per day",

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -27,13 +27,9 @@ import { useProjectServices } from "@/hooks/use-project-services";
 import { useGroupTemplates } from "@/hooks/use-group-templates";
 import { useGroupTemplateWrites } from "@/hooks/use-group-templates-writes";
 import {
-  removeLineItemsBatch,
-  updateLineItemsBatch,
-  type BulkLineItemPatch,
-} from "@/server/line-items";
-import {
   useLineItemWrites,
   buildLineItemSetClear,
+  type BulkLineItemPatch,
 } from "@/hooks/use-line-item-writes";
 import { lineItemSchema } from "@/lib/validations/line-item";
 import { Button } from "@/components/ui/button";
@@ -561,7 +557,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   // ─── Bulk mutations (operate on the current multi-selection) ───────────────
 
   const bulkDeleteMut = useServerMutation({
-    mutationFn: (ids: string[]) => removeLineItemsBatch(ids),
+    mutationFn: (ids: string[]) => {
+      if (!lineItemWrites.enabled) throw new Error("Not ready — try again in a moment.");
+      return lineItemWrites.removeMany(ids);
+    },
     onSuccess: (r: { removed: number; skipped: number }) => {
       invalidate();
       selection.clearSelection();
@@ -575,8 +574,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   });
 
   const bulkEditMut = useServerMutation({
-    mutationFn: ({ ids, patch }: { ids: string[]; patch: BulkLineItemPatch }) =>
-      updateLineItemsBatch(ids, patch),
+    mutationFn: ({ ids, patch }: { ids: string[]; patch: BulkLineItemPatch }) => {
+      if (!lineItemWrites.enabled) throw new Error("Not ready — try again in a moment.");
+      return lineItemWrites.updateMany(ids, patch);
+    },
     onSuccess: (r: { updated: number; skipped: number }) => {
       invalidate();
       selection.clearSelection();

--- a/src/hooks/use-line-item-writes.ts
+++ b/src/hooks/use-line-item-writes.ts
@@ -19,6 +19,20 @@ type ParsedLineItem = z.output<typeof lineItemSchema>;
 type ParsedCustomLineItem = z.output<typeof customLineItemSchema>;
 
 /**
+ * A shared value to apply to every selected line item in a bulk edit. Mirrors the shape
+ * of the deleted `updateLineItemsBatch` server-action interface (src/server/line-items.ts)
+ * — moved here so the browser-direct bulk edit and its consumers share one source of truth.
+ */
+export interface BulkLineItemPatch {
+  pricingType?: "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR" | "OPTIMIZED";
+  /** `null` or a non-positive value clears the discount. `%` is resolved per-item. */
+  discount?: { mode: "$" | "%"; value: number } | null;
+  /** `null`/empty clears the note. */
+  notes?: string | null;
+  isOptional?: boolean;
+}
+
+/**
  * Browser-direct LINE-ITEM writes (Phase 3 — the flag-gated, default-OFF twin of the
  * add/update/remove/reorder line-item server actions in src/server/line-items.ts).
  *
@@ -128,6 +142,8 @@ export function useLineItemWrites() {
   const addKitM = useMutation(api.lineItemWrites.addKitNative);
   const patchM = useMutation(api.lineItemWrites.patchNative);
   const removeM = useMutation(api.lineItemWrites.removeNative);
+  const removeManyM = useMutation(api.lineItemWrites.removeManyNative);
+  const patchManyM = useMutation(api.lineItemWrites.patchManyNative);
   const reorderM = useMutation(api.lineItemWrites.reorderNative);
 
   const actor = () => ({
@@ -291,6 +307,46 @@ export function useLineItemWrites() {
           actor: actor(),
           auditId: createId(),
           emitSideEffects: true,
+          now: Date.now(),
+        });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
+    },
+
+    /** Bulk remove — one atomic backend-local pass: child-guard + cascade (children +
+     *  units) per row + ONE aggregate DELETE audit + recalc-per-project. Returns
+     *  `{ removed, skipped }` (children/cross-org rows counted as skipped). */
+    removeMany: async (ids: string[]): Promise<{ removed: number; skipped: number }> => {
+      if (!enabled) throw new Error("Not ready — try again in a moment.");
+      try {
+        return await removeManyM({
+          ids,
+          orgId: requireOrg(),
+          actor: actor(),
+          auditId: createId(),
+          now: Date.now(),
+        });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
+    },
+
+    /** Bulk edit shared fields (pricing type / discount / notes / optional) across the
+     *  selection, one atomic pass. The %/lineTotal recompute runs in-mutation off each
+     *  row's OWN money fields. Returns `{ updated, skipped }`. */
+    updateMany: async (
+      ids: string[],
+      patch: BulkLineItemPatch,
+    ): Promise<{ updated: number; skipped: number }> => {
+      if (!enabled) throw new Error("Not ready — try again in a moment.");
+      try {
+        return await patchManyM({
+          ids,
+          orgId: requireOrg(),
+          patch,
+          actor: actor(),
+          auditId: createId(),
           now: Date.now(),
         });
       } catch (e) {

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -1,13 +1,11 @@
 "use server";
 
-import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { getOrgContext } from "@/lib/org-context";
 import { readOrgDefaultTaxRate } from "@/lib/org-settings-read";
 import { serialize } from "@/lib/serialize";
-import { logActivity } from "@/lib/activity-log";
 import type { ActorContext } from "@/lib/actor-context";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
-import { roundCurrency } from "@/lib/formatters";
 import { UserFacingError } from "@/lib/errors";
 import { computeStockBreakdown, resolveModelAssetType } from "@/lib/availability";
 import { getModelWithCategoryMap } from "@/lib/models-read";
@@ -27,156 +25,6 @@ import { getAssignmentsByProject } from "@/lib/crew-scheduling-read";
 async function orgDefaultTaxRateFor(orgId: string): Promise<number | null> {
   // Org default tax lives in the Convex org-settings row (Phase 1 inversion).
   return readOrgDefaultTaxRate(orgId);
-}
-
-/**
- * Bulk-remove line items in a single server round-trip.
- *
- * Collapses the old N-client-round-trips loop (one `removeLineItem` call per
- * selected row) into one action: loops the legacy cascade-delete Convex mutation
- * server-side, then recalcs each affected project ONCE and writes ONE bulk audit.
- * Child items (kit members, accessory children, sub-hire group children) are
- * skipped — they are removed via their parent, never individually (same guard as
- * `removeLineItem`) — and reported back in `skipped`.
- */
-export async function removeLineItemsBatch(ids: string[]) {
-  const { organizationId, userId, userName } = await requirePermission("project", "manage_line_items");
-  if (ids.length === 0) return serialize({ removed: 0, skipped: 0 });
-
-  const convex = await getConvexClient();
-  // ONE backend-local pass: the org-scope + child-guard + cascade loop runs inside
-  // a single Convex mutation, not one server→Convex round-trip per item.
-  const { removed, skipped, projectIds } = await convex.mutation(
-    api.projectLineItems.removeManyCascade,
-    { ids, orgId: organizationId },
-  );
-
-  await Promise.all([
-    ...projectIds.map((pid: string) => recalculateProjectTotals(pid)),
-    removed > 0
-      ? logActivity({
-          organizationId,
-          userId,
-          userName,
-          action: "DELETE",
-          entityType: "lineItem",
-          entityId: ids[0],
-          entityName: `${removed} line item${removed === 1 ? "" : "s"}`,
-          summary: `Removed ${removed} line item${removed === 1 ? "" : "s"} from project`,
-          projectId: projectIds[0],
-        })
-      : Promise.resolve(),
-  ]);
-
-  return serialize({ removed, skipped });
-}
-
-/** A shared value to apply to every selected line item in a bulk edit. */
-export interface BulkLineItemPatch {
-  pricingType?: "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR" | "OPTIMIZED";
-  /** `null` or a non-positive value clears the discount. `%` is resolved per-item. */
-  discount?: { mode: "$" | "%"; value: number } | null;
-  /** `null`/empty clears the note. */
-  notes?: string | null;
-  isOptional?: boolean;
-}
-
-/**
- * Bulk-edit shared fields across selected line items in one server round-trip.
- *
- * Only the fields that legitimately apply to many rows are settable (pricing
- * type, discount, notes, optional flag) — quantity/unit-price/description are
- * per-item and stay out. A `%` discount is resolved against each item's own base
- * (unitPrice × quantity × duration). `lineTotal` is recomputed per item whenever
- * the discount changes. Child items are skipped. Recalc + audit run once at the end.
- */
-export async function updateLineItemsBatch(ids: string[], patch: BulkLineItemPatch) {
-  const { organizationId, userId, userName } = await requirePermission("project", "manage_line_items");
-  if (ids.length === 0) return serialize({ updated: 0, skipped: 0 });
-
-  const convex = await getConvexClient();
-  // ONE read for all selected rows — the per-item discount/lineTotal maths needs
-  // each row's own price/qty/duration, but that's a single round-trip, not N.
-  const docs = await convex.query(api.projectLineItems.listByIdsForOrg, {
-    ids,
-    orgId: organizationId,
-  });
-
-  const now = Date.now();
-  const items: { id: string; set: Record<string, unknown>; clear: string[] }[] = [];
-  // Rows dropped by the org-scoped read (missing / wrong org) count as skipped.
-  let skipped = ids.length - docs.length;
-
-  for (const doc of docs) {
-    if (doc.isKitChild) {
-      skipped++;
-      continue;
-    }
-
-    const set: Record<string, unknown> = { updatedAt: now };
-    const clear: string[] = [];
-
-    if (patch.pricingType !== undefined) set.pricingType = patch.pricingType;
-    if (patch.isOptional !== undefined) set.isOptional = patch.isOptional;
-    if (patch.notes !== undefined) {
-      if (patch.notes == null || patch.notes === "") clear.push("notes");
-      else set.notes = patch.notes;
-    }
-
-    if (patch.discount !== undefined) {
-      let discountApplied: number | undefined;
-      if (patch.discount == null || patch.discount.value <= 0) {
-        clear.push("discount");
-        discountApplied = undefined;
-      } else if (patch.discount.mode === "%") {
-        const base = (doc.unitPrice ?? 0) * (doc.quantity ?? 0) * (doc.duration ?? 1);
-        discountApplied = roundCurrency((base * patch.discount.value) / 100);
-        set.discount = discountApplied;
-      } else {
-        discountApplied = patch.discount.value;
-        set.discount = discountApplied;
-      }
-      // Discount feeds the stored line total — recompute it from the item's own
-      // price/quantity/duration (unchanged) and the new discount.
-      const lineTotal = calculateLineTotal(
-        doc.unitPrice ?? undefined,
-        doc.quantity ?? 0,
-        doc.duration ?? 1,
-        discountApplied,
-      );
-      if (lineTotal == null) clear.push("lineTotal");
-      else set.lineTotal = lineTotal;
-    }
-
-    items.push({ id: doc.id, set, clear });
-  }
-
-  if (items.length === 0) return serialize({ updated: 0, skipped });
-
-  // ONE backend-local write pass for every row.
-  const { updated, projectIds } = await convex.mutation(api.projectLineItems.patchMany, {
-    orgId: organizationId,
-    items,
-  });
-
-  await Promise.all([
-    ...projectIds.map((pid: string) => recalculateProjectTotals(pid)),
-    updated > 0
-      ? logActivity({
-          organizationId,
-          userId,
-          userName,
-          action: "UPDATE",
-          entityType: "lineItem",
-          entityId: ids[0],
-          entityName: `${updated} line item${updated === 1 ? "" : "s"}`,
-          summary: `Bulk edited ${updated} line item${updated === 1 ? "" : "s"}`,
-          projectId: projectIds[0],
-        })
-      : Promise.resolve(),
-  ]);
-
-  return serialize({ updated, skipped });
 }
 
 export async function checkAvailability(
@@ -459,18 +307,6 @@ export async function checkKitAvailability(
 }
 
 // --- Internal helpers ---
-
-function calculateLineTotal(
-  unitPrice: number | undefined,
-  quantity: number,
-  duration: number,
-  discount: number | undefined
-): number | null {
-  if (unitPrice == null) return null;
-  const gross = roundCurrency(unitPrice * quantity * duration);
-  const disc = discount ?? 0;
-  return Math.max(0, roundCurrency(gross - disc));
-}
 
 /**
  * Recalculate all project financial totals from source data.


### PR DESCRIPTION
Slice 2 — completes the line-items browser-direct conversion.

Authors the hardened batch mutations (removeManyNative + patchManyNative) the bulk ops needed, wires equipment-tab, and deletes the last 2 line-item write server actions (removeLineItemsBatch/updateLineItemsBatch). `line-items.ts` is now reads + recalc only.

★ **Money:** patchManyNative recomputes the %-discount base + lineTotal from the fetched **doc** (server truth); the client passes only the patch intent (mode/value/notes/flags). 4 guards + per-item org re-check + kit-child skip + cascade + recalc-per-project + pinned actor. Codex CLEAN (byte-parity with the deleted actions, no client money trusted). tsc + 3678 tests + build green; mutations already deployed additively to prod.

⚠️ Will live-smoke bulk-edit + bulk-remove after deploy.