### PR TITLE
Projects: browser-direct detail writes (slice A) + un-gate status

### DIFF
--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -41,12 +41,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useActiveOrganization } from "@/lib/auth-client";
 
-import {
-  updateProjectStatus,
-  updateProjectNotes,
-  archiveProject,
-  deleteProject,
-} from "@/server/projects";
+import { deleteProject } from "@/server/projects";
 import { DuplicateProjectDialog } from "@/components/projects/duplicate-project-dialog";
 import { DetailPageSkeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -74,7 +69,7 @@ import { useMediaWrites } from "@/hooks/use-media-writes";
 import { getPublishedTemplatesForDropdown } from "@/server/document-templates";
 import { MediaUploader, type MediaItem } from "@/components/media/media-uploader";
 import { NotesEditor } from "@/components/ui/notes-editor";
-import { useOptimisticProjectNotes, useNativeProjectStatus } from "@/hooks/use-native-project-writes";
+import { useOptimisticProjectNotes, useNativeProjectStatus, useProjectWrites } from "@/hooks/use-native-project-writes";
 import { CanDo } from "@/components/auth/permission-gate";
 import { RequirePermission } from "@/components/auth/require-permission";
 import { FadeIn } from "@/components/ui/motion";
@@ -154,37 +149,26 @@ export default function ProjectDetailPage({
   const { data: project, isLoading } = useProjectDetail(id);
   const media = useMediaWrites("project");
 
-  // Phase 3 browser-direct: optimistic project-notes save (flag-gated, default OFF →
-  // falls back to the updateProjectNotes server action). Consequence: notes are safe
-  // to optimistic (a wrong save just re-renders; nothing irreversible happens).
+  // Phase 3 browser-direct: optimistic project-notes save (always native — the notes
+  // are safe to optimistic; a wrong save just re-renders, nothing irreversible happens).
   const optimisticNotes = useOptimisticProjectNotes(id, orgId);
   const saveProjectNotes = (
     field: "crewNotes" | "internalNotes" | "clientNotes",
     notes: string,
-  ) =>
-    optimisticNotes.enabled
-      ? optimisticNotes.save(field, notes)
-      : updateProjectNotes(id, field, notes);
+  ) => optimisticNotes.save(field, notes);
 
   const { data: customTemplates } = useServerQuery({
     queryKey: ["document-templates-dropdown", orgId],
     queryFn: () => getPublishedTemplatesForDropdown(),
   });
 
-  // Phase 3 browser-direct: status write (flag-gated, default OFF → falls back to the
-  // updateProjectStatus server action). The detail view is reactive, so it re-renders
-  // on its own once the native mutation commits.
+  // Phase 3 browser-direct: status write (always native). The detail view is reactive,
+  // so it re-renders on its own once the native mutation commits.
   const statusBrowser = useNativeProjectStatus(orgId);
+  const projectWrites = useProjectWrites(orgId);
   const statusMutation = useServerMutation({
     mutationFn: async (nextStatus: string) => {
-      if (statusBrowser.enabled) {
-        await statusBrowser.updateStatus(id, nextStatus);
-      } else {
-        await updateProjectStatus(
-          id,
-          nextStatus as Parameters<typeof updateProjectStatus>[1]
-        );
-      }
+      await statusBrowser.updateStatus(id, nextStatus);
     },
     onSuccess: () => {
       toast.success("Status updated");
@@ -196,7 +180,7 @@ export default function ProjectDetailPage({
   });
 
   const archiveMutation = useServerMutation({
-    mutationFn: () => archiveProject(id),
+    mutationFn: () => projectWrites.archive(id),
     onSuccess: () => {
       toast.success("Project cancelled");
       refreshProjectDetail(id);

--- a/src/app/(app)/projects/templates/page.tsx
+++ b/src/app/(app)/projects/templates/page.tsx
@@ -8,7 +8,8 @@ import { useServerMutation } from "@/hooks/use-server-mutation";
 import { toast } from "sonner";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { BookTemplate, Plus, Trash2, Copy } from "lucide-react";
-import { getTemplates, deleteTemplate, duplicateProject } from "@/server/projects";
+import { getTemplates, duplicateProject } from "@/server/projects";
+import { useProjectWrites } from "@/hooks/use-native-project-writes";
 import { RequirePermission } from "@/components/auth/require-permission";
 import { CanDo } from "@/components/auth/permission-gate";
 import { Button } from "@/components/ui/button";
@@ -61,6 +62,7 @@ export default function TemplatesPage() {
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const projectWrites = useProjectWrites(orgId);
 
   const { data: templates, isLoading, error, refetch: refetchTemplates } = useServerQuery({
     queryKey: ["templates", orgId],
@@ -68,7 +70,7 @@ export default function TemplatesPage() {
   });
 
   const deleteMut = useServerMutation({
-    mutationFn: deleteTemplate,
+    mutationFn: (id: string) => projectWrites.deleteTemplate(id),
     onSuccess: () => {
       refetchTemplates();
       toast.success("Template deleted");

--- a/src/app/(app)/warehouse/page.tsx
+++ b/src/app/(app)/warehouse/page.tsx
@@ -20,7 +20,6 @@ import {
 import { toast } from "sonner";
 import { format } from "date-fns";
 
-import { updateProjectStatus } from "@/server/projects";
 import { useNativeProjectStatus } from "@/hooks/use-native-project-writes";
 import { useWarehouseCloseWrites } from "@/hooks/use-warehouse-close-writes";
 import { AssetTagInput } from "@/components/ui/asset-tag-input";
@@ -260,17 +259,12 @@ export default function WarehousePage() {
   // Post-write refresh is a no-op: the subscription pushes every change live.
   const refetch = useCallback(() => {}, []);
 
-  // Phase 3 browser-direct: status write (flag-gated, default OFF → falls back to the
-  // updateProjectStatus server action). The board list is a reactive useQuery, so the
-  // pipeline column updates on its own once the native mutation commits.
+  // Phase 3 browser-direct: status write (always native). The board list is a reactive
+  // useQuery, so the pipeline column updates on its own once the native mutation commits.
   const statusBrowser = useNativeProjectStatus(orgId);
   const statusMutation = useServerMutation({
     mutationFn: async ({ id, status }: { id: string; status: "CHECKED_OUT" | "RETURNED" | "COMPLETED" }) => {
-      if (statusBrowser.enabled) {
-        await statusBrowser.updateStatus(id, status);
-      } else {
-        await updateProjectStatus(id, status);
-      }
+      await statusBrowser.updateStatus(id, status);
     },
     onSuccess: (_, { status }) => {
       const label = status === "CHECKED_OUT" ? "Deployed" : status === "RETURNED" ? "Returned" : "Completed";

--- a/src/hooks/use-native-project-writes.ts
+++ b/src/hooks/use-native-project-writes.ts
@@ -65,7 +65,7 @@ export function useOptimisticProjectNotes(projectId: string, orgId: string | und
 }
 
 /**
- * Native browser-direct project STATUS write — Phase 3, flag-gated + default OFF.
+ * Native browser-direct project STATUS write — Phase 3.
  * Swaps the `updateProjectStatus` server action for a direct
  * `useMutation(api.projectWrites.updateStatusNative)`, passing `emitSideEffects: true`
  * so the mutation folds the `project.status_changed` webhook in-transaction.
@@ -76,23 +76,19 @@ export function useOptimisticProjectNotes(projectId: string, orgId: string | und
  *
  * Security at the Convex boundary (USER token): assertWritesEnabled(project) +
  * enforceBrowserWriteLimit + requireOrgPermission(project, update) + resolveActor
- * (audit identity pinned to the verified token). Flag off → callers keep the server
- * action.
+ * (audit identity pinned to the verified token).
  */
-export const NATIVE_PROJECT_STATUS_BROWSER =
-  process.env.NEXT_PUBLIC_NATIVE_PROJECT_STATUS_BROWSER === "true";
-
 type StatusArg = FunctionArgs<typeof api.projectWrites.updateStatusNative>["status"];
 
 export function useNativeProjectStatus(orgId: string | undefined) {
   const { data: session } = useSession();
   const mutate = useMutation(api.projectWrites.updateStatusNative);
 
-  const enabled = NATIVE_PROJECT_STATUS_BROWSER && !!orgId && !!session?.user;
+  const enabled = !!orgId && !!session?.user;
 
   /** Change a project's status browser-direct. Resolves once the server confirms. */
   const updateStatus = async (projectId: string, status: string): Promise<void> => {
-    if (!orgId || !session?.user) return;
+    if (!orgId || !session?.user) throw new Error("Not ready");
     try {
       await mutate({
         id: projectId,
@@ -109,4 +105,57 @@ export function useNativeProjectStatus(orgId: string | undefined) {
   };
 
   return { enabled, updateStatus };
+}
+
+/**
+ * Native browser-direct project WRITE hook — the simple id-based project-detail
+ * writes (Phase 3): archive (status → CANCELLED) + template delete. Status has its
+ * own dedicated `useNativeProjectStatus` (both consumers already use it); notes has
+ * `useOptimisticProjectNotes`. Each method mints a client cuid for the audit row,
+ * pins the actor to the verified session, and passes `now: Date.now()`.
+ *
+ * Security at the Convex boundary (USER token): assertWritesEnabled(project) +
+ * enforceBrowserWriteLimit + requireOrgPermission(project, update|delete) +
+ * resolveActor (audit identity pinned to the verified token). ConvexError codes
+ * map back to the same UserFacingError toasts via `mapNativeWriteError`.
+ */
+export function useProjectWrites(orgId: string | undefined) {
+  const { data: session } = useSession();
+  const archiveM = useMutation(api.projectWrites.archiveNative);
+  const deleteTemplateM = useMutation(api.projectWrites.deleteTemplateNative);
+
+  const enabled = !!orgId && !!session?.user;
+
+  /** Cancel (archive) a project browser-direct. Resolves once the server confirms. */
+  const archive = async (projectId: string): Promise<void> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    try {
+      await archiveM({
+        id: projectId,
+        orgId,
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+  };
+
+  /** Delete a project TEMPLATE browser-direct (full cascade runs in-mutation). */
+  const deleteTemplate = async (templateId: string): Promise<void> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    try {
+      await deleteTemplateM({
+        id: templateId,
+        orgId,
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapNativeWriteError(e);
+    }
+  };
+
+  return { enabled, archive, deleteTemplate };
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -794,94 +794,6 @@ export async function updateProject(id: string, data: ProjectFormValues) {
   return serialize(updated);
 }
 
-export async function updateProjectStatus(
-  id: string,
-  status: ProjectFormValues["status"]
-) {
-  const { organizationId, userId, userName } = await requirePermission("project", "update");
-  const project = await getProjectByIdMapped(id, organizationId);
-  if (!project) {
-    throw new UserFacingError({
-      code: "NOT_FOUND",
-      title: "Project not found",
-      message: "This project was deleted or moved. Refresh the page to see the latest state.",
-    });
-  }
-  if (project.isTemplate) {
-    throw new UserFacingError({
-      code: "TEMPLATE_STATUS",
-      title: "Cannot change template status",
-      message: "Templates don't have a status — they're a starting point for creating projects.",
-    });
-  }
-
-  if (project.status !== status && isBlockedForwardProjectStatus(status)) {
-    await assertNoBlockingComments(organizationId, id, {
-      actionLabel: `move this project to ${String(status).toLowerCase().replaceAll("_", " ")}`,
-    });
-  }
-
-  // project is Convex-only — patch the status directly.
-  const convex = await getConvexClient();
-  // Template guard + patch + STATUS_CHANGE audit atomic in the mutation.
-  await convex.mutation(api.projectWrites.updateStatusNative, {
-    id,
-    orgId: organizationId,
-    // A status change always carries a concrete status (the field is optional only
-    // in the shared form type).
-    status: status as NonNullable<typeof status>,
-    // The mutation emits the `project.status_changed` webhook itself (in-transaction).
-    emitSideEffects: true,
-    actor: { userId, userName },
-    auditId: createId(),
-    now: Date.now(),
-  });
-
-  const updated = await getProjectByIdMapped(id, organizationId);
-  if (!updated) throw new Error("Project status update failed");
-
-  return serialize(updated);
-}
-
-export async function updateProjectNotes(
-  id: string,
-  field: "crewNotes" | "internalNotes" | "clientNotes",
-  notes: string,
-) {
-  const { organizationId, userId, userName } = await requirePermission("project", "update");
-  // project is Convex-only — patch the single whitelisted notes field (clear when
-  // emptied, mirroring the old `notes || null`).
-  const convex = await getConvexClient();
-  await convex.mutation(api.projectWrites.updateNotesNative, {
-    id,
-    orgId: organizationId,
-    field,
-    notes: notes || null,
-    actor: { userId, userName },
-    auditId: createId(),
-    now: Date.now(),
-  });
-  const updated = await getProjectByIdMapped(id, organizationId);
-  if (!updated) throw new Error("Project notes update failed");
-  return serialize(updated);
-}
-
-export async function archiveProject(id: string) {
-  const { organizationId, userId, userName } = await requirePermission("project", "update");
-  // project is Convex-only — set status to CANCELLED.
-  const convex = await getConvexClient();
-  await convex.mutation(api.projectWrites.archiveNative, {
-    id,
-    orgId: organizationId,
-    actor: { userId, userName },
-    auditId: createId(),
-    now: Date.now(),
-  });
-  const updated = await getProjectByIdMapped(id, organizationId);
-  if (!updated) throw new Error("Project archive failed");
-  return serialize(updated);
-}
-
 /**
  * Map a ConvexError thrown by duplicateNative / saveAsTemplateNative back to the
  * rich UserFacingError the legacy server path threw, so the toast UX is identical.
@@ -1011,39 +923,6 @@ export async function getTemplates() {
 
   // Clients live in Convex — attach instead of a Prisma join.
   return serialize(await attachClient(organizationId, withCounts));
-}
-
-export async function deleteTemplate(id: string) {
-  const { organizationId, userId, userName } = await requirePermission("project", "delete");
-
-  // project is Convex-only — read the template scalars from Convex.
-  const template = await getProjectByIdMapped(id, organizationId);
-  if (!template) {
-    throw new UserFacingError({
-      code: "NOT_FOUND",
-      title: "Template not found",
-      message: "This template was deleted or moved. Refresh the page to see the latest state.",
-    });
-  }
-  if (!template.isTemplate) {
-    throw new UserFacingError({
-      code: "NOT_A_TEMPLATE",
-      title: "Not a template",
-      message: "That ID points at a project, not a template.",
-    });
-  }
-
-  // The full delete cascade (PM/tasks/services → grouping → line items →
-  // projectModelRevenues → the project row) runs atomically INSIDE Convex — one
-  // round-trip, no orphan window. RBAC + the isTemplate guard are re-checked there.
-  const convexForDelete = await getConvexClient();
-  await convexForDelete.mutation(api.projectWrites.deleteTemplateNative, {
-    id,
-    orgId: organizationId,
-    actor: { userId, userName },
-    now: Date.now(),
-  });
-  return { success: true };
 }
 
 export async function deleteProject(id: string) {


### PR DESCRIPTION
Wires the 4 simple id-based project writes (status/notes/archive/deleteTemplate) to their existing hardened native mutations (user token) + removes the dormant `NATIVE_PROJECT_STATUS_BROWSER` flag — **status is now browser-direct**.

Deletes those 4 server actions from projects.ts. KEEPS the numbering/cascade writes (create/update/duplicate/saveAsTemplate/delete) for slice B + all reads.

Codex clean (mutation args match, no stragglers, notes authoritative write persists). tsc + 3678 tests + build green; mutations already deployed. ⚠️ First time project status runs browser-direct in prod — will live-smoke the status change.