### PR TITLE
feat(projects): browser-direct writes slice B (create/update/duplicate/saveAsTemplate/delete)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -3872,6 +3872,96 @@ browser-direct native surface (following the just-merged `projectCategoriesWrite
   `WarehouseCloseFormValues` in `validations/check-item.ts` are now unused by app code
   (only their own unit test references them); left in place.
 
+## Phase 3 — browser-direct, `projects` domain Slice B (create/update/duplicate/saveAsTemplate/delete)
+
+Following Slice A (PR #586: status/notes/archive/deleteTemplate), converted the
+remaining project WRITE server actions — `createProject`, `updateProject`,
+`duplicateProject`, `saveAsTemplate`, `deleteProject` — to browser-direct calls
+into the already-prod-hardened `createNative`/`updateNative`/`duplicateNative`/
+`saveAsTemplateNative`/`deleteNative` mutations in `convex/projectWrites.ts` (no
+mutation logic changed — this slice only moves the *caller* off the service-token
+server action onto a user-token `useMutation` hook). All 5 methods live on the
+existing `useProjectWrites(orgId)` hook in `src/hooks/use-native-project-writes.ts`
+alongside Slice A's `archive`/`deleteTemplate`.
+
+- **`create`** — Zod-validates client-side (mirrors the deleted server's
+  `projectSchema.parse`), resolves the org's auto-number config via a new kept
+  READ-ONLY action `getProjectNumberConfig()` (byte-identical `organization.metadata`
+  source to the old inline read), and either passes an `autoNumber` config (number
+  ALLOCATED atomically inside `createNative` — reserve → render → clash-retry, no
+  client loop needed) or a manual/template number directly. A manual/template clash
+  returns `{created:false}` (no retry, matches prior behavior) → thrown as
+  `DUPLICATE_PROJECT_CODE`.
+- **`update`** — Zod-validates, then re-checks the (possibly edited) project code
+  via the pre-existing kept read `checkProjectNumberAvailable` — this backstop had
+  to move client-side because `updateNative` does NOT itself re-check projectNumber
+  uniqueness (only `createNative` does). The blocked-forward-status × open-blocking-
+  comments gate needs no client replication — `updateNative` already runs it
+  in-mutation. Tax-rate-changed recalc now calls `api.lineItemWrites.recalcNative`
+  directly (browser-direct, RBAC'd) instead of the server-only
+  `recalculateProjectTotals`, same best-effort try/catch as before.
+- **`duplicate` / `saveAsTemplate`** — the hook sends no `orgDefaultTaxRate` at all.
+  **Hardened as part of this slice** (not deferred): the implementing subagent's
+  first pass had these two mutations still trusting a client-supplied
+  `orgDefaultTaxRate` directly for the recalc (a pre-existing gap in
+  `duplicateNative`/`saveAsTemplateNative` that was harmless while only the
+  service-token server action could call them, but became a real spoofable
+  money-input the moment they went browser-direct). Fixed by extracting the
+  existing `resolveOrgDefaultTaxRate` helper (previously private to
+  `lineItemWrites.ts`) into a shared `convex/lib/orgSettings.ts`, and having both
+  `duplicateNative` and `saveAsTemplateNative` resolve it IN-MUTATION from the
+  `orgSettings` mirror — same pattern as `recalcNative` and every other
+  `lineItemWrites.ts` mutation. `orgDefaultTaxRate` stays in the arg validator as
+  `v.optional(...)`, accepted-but-ignored, purely for expand-contract back-compat
+  with the pre-slice app image; the client no longer reads/sends it, so
+  `useProjectWrites` no longer depends on `useOrganization(orgId)` at all.
+  `saveAsTemplate`'s template number comes from a new kept read
+  `peekNextTemplateCode()` (wraps the existing private `generateTemplateCode`).
+- **`remove`** — the full 8-step delete cascade (free checked-out assets/kits,
+  cascade lines/crew/managers/tasks/services/grouping, purge the
+  `projectModelRevenues` rollup, then the row) is unchanged, still entirely inside
+  `deleteNative`. `defaultLocationId` now comes from the already-client-subscribed
+  `useLocations(orgId)` reactive list (`.find(l => l.isDefault)`) instead of the
+  server-only `getDefaultLocation`. The mutation's `{freedAssets, freedKits}` return
+  (computed in-mutation, never trusted from the client) is now surfaced in the
+  delete toast on `projects/[id]/page.tsx` (previously silently discarded).
+- **Error mapping** — a new `mapProjectWriteError` in `use-native-project-writes.ts`
+  replicates the deleted server-side `mapProjectCopyError` (NOT_FOUND /
+  DUPLICATE_PROJECT_CODE) plus a DELETE_GUARD case, falling back to the shared
+  `mapNativeWriteError` for anything else — so the toast/inline-field UX is
+  unchanged whether the write ran server-side or browser-direct.
+- **Callers rewired:** `project-wizard.tsx` (create/update),
+  `duplicate-project-dialog.tsx` (duplicate/saveAsTemplate),
+  `projects/templates/page.tsx` (duplicate, "create from template"),
+  `projects/[id]/page.tsx` (remove). `getProjects`/`getProject`/`getTemplates`/
+  `getProjectIssueFlags`/`peekNextProjectNumber`/`checkProjectNumberAvailable`/
+  `getCallSheetDates` all stay as kept reads in `src/server/projects.ts`
+  (990 → ~600 lines; also dropped dead code: the unused `generateProjectNumber`
+  loop and `isBlockedForwardProjectStatus`/`BLOCKED_FORWARD_PROJECT_STATUSES`,
+  both orphaned once the fold-into-`createNative`/`updateNative` refactor that
+  predates this slice made them unreachable).
+- **Codex review round (also this slice, before shipping)** caught one more
+  pre-existing gap the same browser-direct exposure creates: `updateNative`'s
+  `set` arg is `v.any()` and `createNative` spreads `projectWriteFields`
+  (`v.optional(v.number())`, no bounds) for `taxRate`/`discountPercent`/
+  `depositPercent`/`depositPaid`/`invoicedTotal` — recalc INPUTS the client Zod
+  schema (`src/lib/validations/project.ts`) bounds to 0-100 / >=0, but Convex's
+  `v.number()` accepts `NaN`/`Infinity`/negatives, and a browser caller bypasses
+  Zod entirely. Fixed with a new `assertProjectMoneyFields` guard in
+  `convex/lib/moneyGuards.ts` (mirrors the existing `assertLineMoneyFields`
+  pattern for line items), called from both `updateNative` and `createNative`
+  with the same bounds Zod enforces. Covered by new `projectWrites.test.ts`
+  cases (out-of-bounds `taxRate`/`discountPercent`/`depositPaid` on update,
+  negative `invoicedTotal` on create) plus two org-default-tax-rate hardening
+  tests proving a forged client `orgDefaultTaxRate` is ignored on
+  duplicate/saveAsTemplate. Codex's second finding (a client can pick the
+  manual-number path on `createNative` by simply supplying `projectNumber`,
+  even when the org is configured for auto-numbering) was investigated and is
+  **not a regression** — the deleted server `createProject` had the identical
+  `!parsed.projectNumber` gate, so a client-supplied form value already
+  overrode auto-numbering pre-slice; left as-is (byte-for-byte parity), noted
+  here for anyone re-auditing this later.
+
 ## Conventions
 
 See [`convex/README.md`](../convex/README.md) for the authoritative coding

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -101,6 +101,7 @@ import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
 import type * as lib_lineTotal from "../lib/lineTotal.js";
 import type * as lib_moneyGuards from "../lib/moneyGuards.js";
 import type * as lib_notificationPreferences from "../lib/notificationPreferences.js";
+import type * as lib_orgSettings from "../lib/orgSettings.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_projectNumber from "../lib/projectNumber.js";
 import type * as lib_projectNumberCounter from "../lib/projectNumberCounter.js";
@@ -311,6 +312,7 @@ declare const fullApi: ApiFromModules<{
   "lib/lineTotal": typeof lib_lineTotal;
   "lib/moneyGuards": typeof lib_moneyGuards;
   "lib/notificationPreferences": typeof lib_notificationPreferences;
+  "lib/orgSettings": typeof lib_orgSettings;
   "lib/permissionsCore": typeof lib_permissionsCore;
   "lib/projectNumber": typeof lib_projectNumber;
   "lib/projectNumberCounter": typeof lib_projectNumberCounter;

--- a/convex/lib/moneyGuards.ts
+++ b/convex/lib/moneyGuards.ts
@@ -66,3 +66,47 @@ export function assertLineMoneyFields(f: {
     }
   }
 }
+
+/**
+ * Validate the project-level money-adjacent fields to the same bounds
+ * `src/lib/validations/project.ts` `projectSchema` enforces (taxRate/discountPercent/
+ * depositPercent: 0-100; depositPaid/invoicedTotal: >=0). These are recalc INPUTS
+ * (unlike PROJECT_MONEY_ANCHORS in convex/projectWrites.ts, which are recalc OUTPUTS
+ * and stripped entirely), so they stay settable but must be bounded — a browser-direct
+ * caller bypasses the Zod schema, and an unbounded `taxRate: -1e9` or
+ * `discountPercent: NaN` would poison `recalcProjectTotals`'s output the same way an
+ * unbounded line-item field would.
+ */
+export function assertProjectMoneyFields(f: {
+  taxRate?: number | null;
+  discountPercent?: number | null;
+  depositPercent?: number | null;
+  depositPaid?: number | null;
+  invoicedTotal?: number | null;
+}): void {
+  if (f.taxRate != null) {
+    if (!Number.isFinite(f.taxRate) || f.taxRate < 0 || f.taxRate > 100) {
+      throw new ConvexError({ code: "INVALID_TAX_RATE", message: "Tax rate must be between 0 and 100." });
+    }
+  }
+  if (f.discountPercent != null) {
+    if (!Number.isFinite(f.discountPercent) || f.discountPercent < 0 || f.discountPercent > 100) {
+      throw new ConvexError({ code: "INVALID_DISCOUNT_PERCENT", message: "Discount percent must be between 0 and 100." });
+    }
+  }
+  if (f.depositPercent != null) {
+    if (!Number.isFinite(f.depositPercent) || f.depositPercent < 0 || f.depositPercent > 100) {
+      throw new ConvexError({ code: "INVALID_DEPOSIT_PERCENT", message: "Deposit percent must be between 0 and 100." });
+    }
+  }
+  if (f.depositPaid != null) {
+    if (!Number.isFinite(f.depositPaid) || f.depositPaid < 0) {
+      throw new ConvexError({ code: "INVALID_DEPOSIT_PAID", message: "Deposit paid must be a non-negative finite number." });
+    }
+  }
+  if (f.invoicedTotal != null) {
+    if (!Number.isFinite(f.invoicedTotal) || f.invoicedTotal < 0) {
+      throw new ConvexError({ code: "INVALID_INVOICED_TOTAL", message: "Invoiced total must be a non-negative finite number." });
+    }
+  }
+}

--- a/convex/lib/orgSettings.ts
+++ b/convex/lib/orgSettings.ts
@@ -1,0 +1,12 @@
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+/** Org default tax rate from the Convex orgSettings mirror (source of truth; the
+ *  Postgres column is deprecated). null when unset. Resolved IN-mutation so browser
+ *  callers can't spoof a money-affecting tax rate. */
+export async function resolveOrgDefaultTaxRate(ctx: MutationCtx | QueryCtx, orgId: string): Promise<number | null> {
+  const row = await ctx.db
+    .query("orgSettings")
+    .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+    .first();
+  return row?.defaultTaxRate ?? null;
+}

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -10,6 +10,7 @@ import { assertLineMoneyFields } from "./lib/moneyGuards";
 import { roundCurrency, computeLineTotal } from "./lib/lineTotal";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
+import { resolveOrgDefaultTaxRate } from "./lib/orgSettings";
 import * as enums from "./lib/validators";
 import { expandAccessoryChildLines } from "./lib/fulfillment";
 import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
@@ -53,17 +54,6 @@ function getUserColor(userId: string): string {
   let hash = 0;
   for (let i = 0; i < userId.length; i++) hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
   return COLLAB_COLORS[hash % COLLAB_COLORS.length];
-}
-
-/** Org default tax rate from the Convex orgSettings mirror (source of truth; the
- *  Postgres column is deprecated). null when unset. Resolved IN-mutation so browser
- *  callers can't spoof a money-affecting tax rate. */
-async function resolveOrgDefaultTaxRate(ctx: MutationCtx, orgId: string): Promise<number | null> {
-  const row = await ctx.db
-    .query("orgSettings")
-    .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
-    .first();
-  return row?.defaultTaxRate ?? null;
 }
 
 /** Delete a line + its fulfillment units (replica of deleteLineWithUnits). The unit

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -220,6 +220,19 @@ describe("projectWrites.updateNative", () => {
       expect(p?.isTemplate).toBe(false); // no in-place template flip
     });
   });
+  test("rejects an out-of-bounds money field a browser caller bypassing Zod could forge", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { taxRate: 150, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/tax rate/i);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { discountPercent: Number.NaN, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/discount percent/i);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { depositPaid: -50, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/deposit paid/i);
+  });
 });
 
 describe("projectWrites.createNative", () => {
@@ -265,6 +278,13 @@ describe("projectWrites.createNative", () => {
       expect(p?.margin).toBeUndefined();
       expect(p?.equipmentRevenue).toBeUndefined();
     });
+  });
+  test("rejects an out-of-bounds money field on create", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, invoicedTotal: -1 } as typeof cargs),
+    ).rejects.toThrow(/invoiced total/i);
   });
 });
 
@@ -631,6 +651,23 @@ describe("projectWrites.duplicateNative", () => {
     await seedSource(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, dupArgs)).rejects.toThrow(/insufficient permissions/i);
   });
+  test("ignores a client-forged orgDefaultTaxRate — resolves from orgSettings in-mutation", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "owner" });
+      // Source project has NO taxRate of its own, so the copy falls back to the org default.
+      await ctx.db.insert("projects", { id: "src", organizationId: ORG, projectNumber: "SRC-1", name: "Original", status: "CONFIRMED", isTemplate: false, tags: [], createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "lp1", organizationId: ORG, projectId: "src", type: "EQUIPMENT", quantity: 1, unitPrice: 100, lineTotal: 100, isKitChild: false, status: "CONFIRMED", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("orgSettings", { organizationId: ORG, defaultTaxRate: 7 });
+    });
+    // A malicious/stale client sends 99 — must be ignored in favor of the orgSettings row (7).
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.duplicateNative, { ...dupArgs, orgDefaultTaxRate: 99 });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "dup1")).first();
+      expect(p?.taxRate).toBeUndefined(); // no scalar copied (source had none)
+      expect(p?.taxAmount).toBe(7); // 100 * 7% — NOT 100 * 99%
+    });
+  });
 });
 
 describe("projectWrites.saveAsTemplateNative", () => {
@@ -691,6 +728,20 @@ describe("projectWrites.saveAsTemplateNative", () => {
       await ctx.db.insert("projects", { id: "taken", organizationId: ORG, projectNumber: "TPL-0001", name: "Taken", isTemplate: true, createdAt: NOW, updatedAt: NOW });
     });
     await expect(t.withIdentity(asUser(ORG)).mutation(api.projectWrites.saveAsTemplateNative, tplArgs)).rejects.toThrow(/already exists/i);
+  });
+
+  test("ignores a client-forged orgDefaultTaxRate — resolves from orgSettings in-mutation", async () => {
+    const t = makeT();
+    await seedSource(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("orgSettings", { organizationId: ORG, defaultTaxRate: 7 });
+    });
+    // A malicious/stale client sends 99 — must be ignored in favor of the orgSettings row (7).
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.saveAsTemplateNative, { ...tplArgs, orgDefaultTaxRate: 99 });
+    await t.run(async (ctx) => {
+      const tpl = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "tpl1")).first();
+      expect(tpl?.taxAmount).toBe(2.8); // 40 (equipmentRevenue) * 7% — NOT * 99%
+    });
   });
 
   test("a viewer is denied (project:create)", async () => {

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -5,6 +5,8 @@ import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { reserveProjectNumberCounter } from "./lib/projectNumberCounter";
 import { renderProjectNumber, scopeKeyFor } from "./lib/projectNumber";
 import { recalcProjectTotals } from "./lib/recalc";
+import { resolveOrgDefaultTaxRate } from "./lib/orgSettings";
+import { assertProjectMoneyFields } from "./lib/moneyGuards";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
@@ -265,6 +267,18 @@ export const updateNative = mutation({
     // and isTemplate (no client-forged totals / in-place template flip).
     const setObj = sanitizeClientSet(set, PROJECT_UPDATE_IMMUTABLE);
 
+    // Bound-check the recalc-INPUT money fields — `set` is v.any() (Convex only
+    // enforces "is a number", not range/finiteness), and a browser-direct caller
+    // bypasses the client Zod schema entirely. Without this, a forged
+    // `taxRate: -1e9` or `discountPercent: NaN` would poison recalcProjectTotals.
+    assertProjectMoneyFields({
+      taxRate: typeof setObj.taxRate === "number" ? setObj.taxRate : undefined,
+      discountPercent: typeof setObj.discountPercent === "number" ? setObj.discountPercent : undefined,
+      depositPercent: typeof setObj.depositPercent === "number" ? setObj.depositPercent : undefined,
+      depositPaid: typeof setObj.depositPaid === "number" ? setObj.depositPaid : undefined,
+      invoicedTotal: typeof setObj.invoicedTotal === "number" ? setObj.invoicedTotal : undefined,
+    });
+
     // A general update that also moves the status FORWARD into PREPPING/CHECKED_OUT/ON_SITE
     // must clear the blocking-comment gate too (parity with the server updateProject path).
     const nextStatus = typeof setObj.status === "string" ? setObj.status : undefined;
@@ -337,6 +351,15 @@ export const createNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "project", "create");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    // Bound-check the recalc-INPUT money fields — same rationale as updateNative:
+    // projectWriteFields only declares `v.number()` (no range/finiteness), and a
+    // browser-direct caller bypasses the client Zod schema.
+    assertProjectMoneyFields({
+      taxRate: fields.taxRate, discountPercent: fields.discountPercent,
+      depositPercent: fields.depositPercent, depositPaid: fields.depositPaid,
+      invoicedTotal: fields.invoicedTotal,
+    });
 
     // Dup-guard the client-minted cuid first (applies to both number paths). The
     // projectNumber clash-guard below is org-scoped and doesn't catch a cross-org
@@ -731,12 +754,16 @@ export const duplicateNative = mutation({
     newProjectNumber: v.string(),
     newName: v.string(),
     orgId: v.string(),
-    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    // Accepted-but-IGNORED for backward-compat with the pre-internalization app image.
+    // The rate is ALWAYS resolved in-mutation from orgSettings — a client value is
+    // never trusted (a browser caller could otherwise spoof a money-affecting tax
+    // rate on the duplicated project's recalculated totals).
+    orgDefaultTaxRate: v.optional(v.union(v.number(), v.null())),
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
   },
-  handler: async (ctx, { sourceId, newId, newProjectNumber, newName, orgId, orgDefaultTaxRate, now, actor: suppliedActor, auditId }) => {
+  handler: async (ctx, { sourceId, newId, newProjectNumber, newName, orgId, now, actor: suppliedActor, auditId }) => {
     await assertWritesEnabled(ctx, "project");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "create");
@@ -927,8 +954,10 @@ export const duplicateNative = mutation({
       });
     }
 
-    // 6. Recalc totals from the copied lines (never trust client money).
-    await recalcProjectTotals(ctx, newId, orgId, finiteOrNull(orgDefaultTaxRate), now);
+    // 6. Recalc totals from the copied lines (never trust client money — org default
+    // tax rate resolved in-mutation from orgSettings, not the client arg above).
+    const orgDefaultTaxRate = await resolveOrgDefaultTaxRate(ctx, orgId);
+    await recalcProjectTotals(ctx, newId, orgId, orgDefaultTaxRate, now);
 
     // CREATE audit for the new project (native path logs it atomically).
     await writeActivityLog(ctx, {
@@ -966,11 +995,13 @@ export const saveAsTemplateNative = mutation({
     templateNumber: v.string(),
     templateName: v.string(),
     orgId: v.string(),
-    orgDefaultTaxRate: v.union(v.number(), v.null()),
+    // Accepted-but-IGNORED for backward-compat — see duplicateNative's comment.
+    // Always resolved in-mutation from orgSettings, never trusted from the client.
+    orgDefaultTaxRate: v.optional(v.union(v.number(), v.null())),
     now: v.number(),
     actor: actorValidator,
   },
-  handler: async (ctx, { sourceId, newId, templateNumber, templateName, orgId, orgDefaultTaxRate, now, actor: suppliedActor }) => {
+  handler: async (ctx, { sourceId, newId, templateNumber, templateName, orgId, now, actor: suppliedActor }) => {
     await assertWritesEnabled(ctx, "project");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "project", "create");
@@ -1091,7 +1122,9 @@ export const saveAsTemplateNative = mutation({
       }
     }
 
-    // 3. Recalc totals from the copied lines.
+    // 3. Recalc totals from the copied lines (org default tax rate resolved
+    // in-mutation from orgSettings, never trusted from the client).
+    const orgDefaultTaxRate = await resolveOrgDefaultTaxRate(ctx, orgId);
     await recalcProjectTotals(ctx, newId, orgId, finiteOrNull(orgDefaultTaxRate), now);
 
     return { id: newId };

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -41,7 +41,6 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useActiveOrganization } from "@/lib/auth-client";
 
-import { deleteProject } from "@/server/projects";
 import { DuplicateProjectDialog } from "@/components/projects/duplicate-project-dialog";
 import { DetailPageSkeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -189,9 +188,18 @@ export default function ProjectDetailPage({
   });
 
   const deleteMutation = useServerMutation({
-    mutationFn: () => deleteProject(id),
-    onSuccess: () => {
-      toast.success("Project deleted");
+    mutationFn: () => projectWrites.remove(id),
+    onSuccess: (result) => {
+      const freedBits: string[] = [];
+      if (result.freedAssets > 0) {
+        freedBits.push(`${result.freedAssets} asset${result.freedAssets === 1 ? "" : "s"}`);
+      }
+      if (result.freedKits > 0) {
+        freedBits.push(`${result.freedKits} kit${result.freedKits === 1 ? "" : "s"}`);
+      }
+      toast.success(
+        freedBits.length > 0 ? `Project deleted — freed ${freedBits.join(" and ")}` : "Project deleted",
+      );
       router.push("/projects");
     },
     onError: (e) => toast.error(e.message),

--- a/src/app/(app)/projects/templates/page.tsx
+++ b/src/app/(app)/projects/templates/page.tsx
@@ -8,7 +8,7 @@ import { useServerMutation } from "@/hooks/use-server-mutation";
 import { toast } from "sonner";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { BookTemplate, Plus, Trash2, Copy } from "lucide-react";
-import { getTemplates, duplicateProject } from "@/server/projects";
+import { getTemplates } from "@/server/projects";
 import { useProjectWrites } from "@/hooks/use-native-project-writes";
 import { RequirePermission } from "@/components/auth/require-permission";
 import { CanDo } from "@/components/auth/permission-gate";
@@ -80,7 +80,7 @@ export default function TemplatesPage() {
 
   const createMut = useServerMutation({
     mutationFn: () =>
-      duplicateProject(createFrom.id, projectNumber, projectName),
+      projectWrites.duplicate(createFrom.id, projectNumber, projectName),
     onSuccess: (result) => {
       toast.success("Project created from template");
       setCreateFrom(null);

--- a/src/components/projects/duplicate-project-dialog.tsx
+++ b/src/components/projects/duplicate-project-dialog.tsx
@@ -16,7 +16,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { duplicateProject, saveAsTemplate } from "@/server/projects";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useProjectWrites } from "@/hooks/use-native-project-writes";
 
 interface DuplicateProjectDialogProps {
   open: boolean;
@@ -37,6 +38,8 @@ export function DuplicateProjectDialog({
 }: DuplicateProjectDialogProps) {
   const router = useRouter();
   const isTemplate = mode === "template";
+  const { data: activeOrg } = useActiveOrganization();
+  const projectWrites = useProjectWrites(activeOrg?.id);
 
   const [projectNumber, setProjectNumber] = useState(
     `${sourceProject.projectNumber}-COPY`
@@ -48,8 +51,8 @@ export function DuplicateProjectDialog({
   const mutation = useServerMutation({
     mutationFn: () =>
       isTemplate
-        ? saveAsTemplate(sourceProject.id, name)
-        : duplicateProject(sourceProject.id, projectNumber, name),
+        ? projectWrites.saveAsTemplate(sourceProject.id, name)
+        : projectWrites.duplicate(sourceProject.id, projectNumber, name),
     onSuccess: (result) => {
       toast.success(isTemplate ? "Template created" : "Project duplicated");
       onOpenChange(false);

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -17,7 +17,8 @@ import {
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { projectSchema, type ProjectFormValues } from "@/lib/validations/project";
-import { createProject, updateProject, peekNextProjectNumber, checkProjectNumberAvailable } from "@/server/projects";
+import { peekNextProjectNumber, checkProjectNumberAvailable } from "@/server/projects";
+import { useProjectWrites } from "@/hooks/use-native-project-writes";
 import { useProjectManagerWrites } from "@/hooks/use-project-managers-writes";
 import { useClientSearch, useClient } from "@/hooks/use-clients";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -114,6 +115,7 @@ export function ProjectWizard({
   const { data: activeOrg } = useActiveOrganization();
   const managerWrites = useProjectManagerWrites();
   const orgId = activeOrg?.id;
+  const projectWrites = useProjectWrites(orgId);
 
   const isEditing = !!project;
   const isTemplate = isTemplateProp ?? project?.isTemplate ?? false;
@@ -221,8 +223,8 @@ export function ProjectWizard({
       }
 
       const result = project
-        ? await updateProject(project.id, data)
-        : await createProject({ ...data, isTemplate });
+        ? await projectWrites.update(project.id, data, isTemplate)
+        : await projectWrites.create({ ...data, isTemplate });
 
       // Reconcile managers to the full selected set in one call — the server
       // diffs against the current rows (create mode = add all; edit mode = add

--- a/src/hooks/use-native-project-writes.ts
+++ b/src/hooks/use-native-project-writes.ts
@@ -2,9 +2,23 @@
 
 import { useMutation } from "convex/react";
 import type { FunctionArgs } from "convex/server";
+import { ConvexError } from "convex/values";
 import { createId } from "@paralleldrive/cuid2";
 import { useSession } from "@/lib/auth-client";
 import { mapNativeWriteError } from "@/lib/native-writes";
+// Concrete-module imports only (NOT the "@/lib/validations" or "@/server/projects"
+// barrels) — this file is imported by client components, and pulling in a barrel
+// that also re-exports server-only code trips Turbopack's scope-hoist merge
+// (`EcmascriptModuleContent::new_merged failed`). See the CLAUDE.md composition note.
+import { UserFacingError } from "@/lib/errors/user-facing-error";
+import { projectSchema, type ProjectFormValues } from "@/lib/validations/project";
+import { datePartsInTimezone } from "@/lib/project-number";
+import {
+  getProjectNumberConfig,
+  peekNextTemplateCode,
+  checkProjectNumberAvailable,
+} from "@/server/projects";
+import { useLocations } from "@/hooks/use-locations";
 import { api } from "../../convex/_generated/api";
 
 /**
@@ -108,21 +122,96 @@ export function useNativeProjectStatus(orgId: string | undefined) {
 }
 
 /**
- * Native browser-direct project WRITE hook — the simple id-based project-detail
- * writes (Phase 3): archive (status → CANCELLED) + template delete. Status has its
- * own dedicated `useNativeProjectStatus` (both consumers already use it); notes has
+ * Map a ConvexError thrown by createNative/updateNative/duplicateNative/
+ * saveAsTemplateNative/deleteNative back to the rich UserFacingError the deleted
+ * server actions (`createProject`/`updateProject`/`duplicateProject`/
+ * `saveAsTemplate`/`deleteProject` in src/server/projects.ts) used to throw, so the
+ * toast/inline-field UX is byte-for-byte identical whether the write ran on the
+ * legacy server-action path or browser-direct. Handles NOT_FOUND (source/target
+ * gone), DUPLICATE_PROJECT_CODE (number clash on duplicate/saveAsTemplate — create's
+ * own clash comes back as a `{created:false}` RETURN value, handled inline in
+ * `create()`, not through this mapper) and DELETE_GUARD (not-cancelled / template).
+ * Anything else falls through to the shared `mapNativeWriteError`.
+ */
+function mapProjectWriteError(e: unknown, isTemplate = false): unknown {
+  if (
+    e instanceof ConvexError &&
+    e.data &&
+    typeof e.data === "object" &&
+    "code" in e.data &&
+    typeof (e.data as { code: unknown }).code === "string"
+  ) {
+    const code = (e.data as { code: string }).code;
+    const message =
+      typeof (e.data as { message?: unknown }).message === "string"
+        ? (e.data as { message: string }).message
+        : undefined;
+    if (code === "NOT_FOUND") {
+      return new UserFacingError({
+        code: "NOT_FOUND",
+        title: "Project not found",
+        message: "This project was deleted or moved. Refresh the page to see the latest state.",
+      });
+    }
+    if (code === "DUPLICATE_PROJECT_CODE") {
+      return new UserFacingError({
+        code,
+        title: isTemplate ? "Template code already in use" : "Project code already in use",
+        message: message ?? `A ${isTemplate ? "template" : "project"} with that code already exists.`,
+        field: "projectNumber",
+      });
+    }
+    if (code === "DELETE_GUARD") {
+      return new UserFacingError({
+        code,
+        title: "Cannot delete this project",
+        message: message ?? "Only cancelled projects can be deleted.",
+        hint: "Set the project status to Cancelled first, then try again.",
+      });
+    }
+  }
+  return mapNativeWriteError(e);
+}
+
+/**
+ * Native browser-direct project WRITE hook — Phase 3 (Slice A: archive + template
+ * delete) + Phase 3 Slice B (create/update/duplicate/saveAsTemplate/remove, the
+ * former `createProject`/`updateProject`/`duplicateProject`/`saveAsTemplate`/
+ * `deleteProject` server actions in src/server/projects.ts, now calling the SAME
+ * already-prod-hardened `*Native` mutations directly with the user's token instead
+ * of relaying through a service-token server action). Status has its own dedicated
+ * `useNativeProjectStatus` (both consumers already use it); notes has
  * `useOptimisticProjectNotes`. Each method mints a client cuid for the audit row,
  * pins the actor to the verified session, and passes `now: Date.now()`.
  *
  * Security at the Convex boundary (USER token): assertWritesEnabled(project) +
- * enforceBrowserWriteLimit + requireOrgPermission(project, update|delete) +
+ * enforceBrowserWriteLimit + requireOrgPermission(project, create|update|delete) +
  * resolveActor (audit identity pinned to the verified token). ConvexError codes
- * map back to the same UserFacingError toasts via `mapNativeWriteError`.
+ * map back to the same UserFacingError toasts via `mapProjectWriteError`.
+ *
+ * `create`/`saveAsTemplate` need the org's auto-number config / next template code
+ * — small READ-ONLY server actions stay in place for these (`getProjectNumberConfig`,
+ * `peekNextTemplateCode`, `checkProjectNumberAvailable`, all in src/server/projects.ts)
+ * exactly like the pre-existing `peekNextProjectNumber` kept read. `duplicate`/
+ * `saveAsTemplate` money: `orgDefaultTaxRate` is resolved IN-MUTATION from the
+ * `orgSettings` mirror (`duplicateNative`/`saveAsTemplateNative` — hardened alongside
+ * this slice; a client-supplied value is accepted-but-ignored for expand-contract
+ * back-compat only). `remove` resolves `defaultLocationId` from the already-
+ * client-readable `useLocations(orgId)` reactive list (same source `getDefaultLocation`
+ * used to read server-side).
  */
 export function useProjectWrites(orgId: string | undefined) {
   const { data: session } = useSession();
   const archiveM = useMutation(api.projectWrites.archiveNative);
   const deleteTemplateM = useMutation(api.projectWrites.deleteTemplateNative);
+  const createM = useMutation(api.projectWrites.createNative);
+  const updateM = useMutation(api.projectWrites.updateNative);
+  const duplicateM = useMutation(api.projectWrites.duplicateNative);
+  const saveAsTemplateM = useMutation(api.projectWrites.saveAsTemplateNative);
+  const deleteM = useMutation(api.projectWrites.deleteNative);
+  const recalcM = useMutation(api.lineItemWrites.recalcNative);
+
+  const locations = useLocations(orgId);
 
   const enabled = !!orgId && !!session?.user;
 
@@ -157,5 +246,297 @@ export function useProjectWrites(orgId: string | undefined) {
     }
   };
 
-  return { enabled, archive, deleteTemplate };
+  /**
+   * Create a project (or template) browser-direct — the former `createProject`.
+   * Zod-validates the form data (mirrors the server's `projectSchema.parse`), then
+   * either allocates an auto number IN-mutation (`autoNumber` config) or passes a
+   * manual/template number directly. A manual/template number clash comes back as
+   * `{created:false}` (auto retries internally in `createNative`, so a single call
+   * suffices) — mirrors the server's hard-duplicate throw exactly, no client retry.
+   */
+  const create = async (
+    data: ProjectFormValues & { isTemplate?: boolean },
+  ): Promise<{ id: string }> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    const parsed = projectSchema.parse(data);
+    const isTemplate = data.isTemplate ?? false;
+
+    // Auto project-number config only matters on the non-template blank-code path
+    // (mirrors the server's `useAutoNumber` derivation) — skip the read otherwise.
+    const autoConfig =
+      !isTemplate && !parsed.projectNumber ? await getProjectNumberConfig() : null;
+    const useAutoNumber = !isTemplate && !parsed.projectNumber && !!autoConfig;
+
+    if (!isTemplate && !parsed.projectNumber && !useAutoNumber) {
+      throw new UserFacingError({
+        code: "MISSING_PROJECT_CODE",
+        title: "Project code is required",
+        message: "Enter a project code (e.g. P-2024-001) before saving.",
+        field: "projectNumber",
+      });
+    }
+
+    // Templates without an explicit code get a template code (pre-mutation is fine
+    // — no shared counter). Auto project numbers are allocated INSIDE createNative
+    // so the sequence bump and the create commit (or roll back) together.
+    const templateNumber =
+      isTemplate && !parsed.projectNumber ? await peekNextTemplateCode() : null;
+
+    const id = createId();
+    const now = new Date();
+    const baseArgs = {
+      id,
+      organizationId: orgId,
+      isTemplate,
+      name: parsed.name,
+      clientId: parsed.clientId || undefined,
+      status: parsed.status,
+      type: parsed.type,
+      description: parsed.description || undefined,
+      locationId: parsed.locationId || undefined,
+      siteContactName: parsed.siteContactName || undefined,
+      siteContactPhone: parsed.siteContactPhone || undefined,
+      siteContactEmail: parsed.siteContactEmail || undefined,
+      loadInDate: parsed.loadInDate?.getTime(),
+      loadInTime: parsed.loadInTime || undefined,
+      eventStartDate: parsed.eventStartDate?.getTime(),
+      eventStartTime: parsed.eventStartTime || undefined,
+      eventEndDate: parsed.eventEndDate?.getTime(),
+      eventEndTime: parsed.eventEndTime || undefined,
+      loadOutDate: parsed.loadOutDate?.getTime(),
+      loadOutTime: parsed.loadOutTime || undefined,
+      rentalStartDate: parsed.rentalStartDate?.getTime(),
+      rentalEndDate: parsed.rentalEndDate?.getTime(),
+      crewNotes: parsed.crewNotes || undefined,
+      internalNotes: parsed.internalNotes || undefined,
+      clientNotes: parsed.clientNotes || undefined,
+      defaultRentalPeriod: parsed.defaultRentalPeriod || undefined,
+      defaultRentalQuantity: parsed.defaultRentalQuantity || undefined,
+      taxRate: parsed.taxRate ?? undefined,
+      discountPercent: parsed.discountPercent ?? undefined,
+      depositPercent: parsed.depositPercent ?? undefined,
+      depositPaid: parsed.depositPaid ?? undefined,
+      invoicedTotal: parsed.invoicedTotal ?? undefined,
+      tags: parsed.tags,
+      createdAt: now.getTime(),
+      updatedAt: now.getTime(),
+    };
+
+    try {
+      const created = await createM({
+        ...baseArgs,
+        ...(useAutoNumber
+          ? {
+              autoNumber: {
+                format: autoConfig!.format,
+                reset: autoConfig!.reset,
+                padding: autoConfig!.padding,
+                parts: datePartsInTimezone(now, autoConfig!.timezone),
+              },
+            }
+          : { projectNumber: templateNumber ?? parsed.projectNumber! }),
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        auditId: createId(),
+      });
+      // A manual/template number clash is a hard duplicate (auto retries in-mutation).
+      if (!created.created) {
+        throw new UserFacingError({
+          code: "DUPLICATE_PROJECT_CODE",
+          title: "Project code already in use",
+          message: `A ${isTemplate ? "template" : "project"} with code "${templateNumber ?? parsed.projectNumber}" already exists.`,
+          field: "projectNumber",
+        });
+      }
+      return { id: created.id };
+    } catch (e) {
+      if (e instanceof UserFacingError) throw e;
+      throw mapProjectWriteError(e, isTemplate);
+    }
+  };
+
+  /**
+   * Update a project browser-direct — the former `updateProject`. Zod-validates,
+   * then re-checks the (possibly edited) project code isn't taken by a sibling —
+   * `updateNative` does NOT re-check uniqueness itself (only `createNative` does),
+   * so this backstop (reusing the same kept `checkProjectNumberAvailable` read the
+   * wizard already calls up-front for the inline field error) has to stay client-side.
+   * The blocked-forward-status blocking-comments gate now runs INSIDE `updateNative`
+   * itself, so it needs no client replication. Best-effort recalc mirrors the
+   * server's non-fatal try/catch when `taxRate` changes.
+   */
+  const update = async (
+    id: string,
+    data: ProjectFormValues,
+    isTemplate = false,
+  ): Promise<{ id: string }> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    const parsed = projectSchema.parse(data);
+
+    if (parsed.projectNumber) {
+      const { available } = await checkProjectNumberAvailable(parsed.projectNumber, id);
+      if (!available) {
+        throw new UserFacingError({
+          code: "DUPLICATE_PROJECT_CODE",
+          title: "Project code already in use",
+          message: `A ${isTemplate ? "template" : "project"} with code "${parsed.projectNumber}" already exists.`,
+          field: "projectNumber",
+        });
+      }
+    }
+
+    const set: Record<string, unknown> = {
+      projectNumber: parsed.projectNumber,
+      name: parsed.name,
+      status: parsed.status,
+      type: parsed.type,
+      tags: parsed.tags,
+      updatedAt: Date.now(),
+    };
+    const clear: string[] = [];
+    const setOrClear = (key: string, value: unknown) => {
+      if (value === null || value === undefined || value === "") clear.push(key);
+      else set[key] = value;
+    };
+    setOrClear("clientId", parsed.clientId || null);
+    setOrClear("description", parsed.description || null);
+    setOrClear("locationId", parsed.locationId || null);
+    setOrClear("siteContactName", parsed.siteContactName || null);
+    setOrClear("siteContactPhone", parsed.siteContactPhone || null);
+    setOrClear("siteContactEmail", parsed.siteContactEmail || null);
+    setOrClear("loadInDate", parsed.loadInDate?.getTime() ?? null);
+    setOrClear("loadInTime", parsed.loadInTime || null);
+    setOrClear("eventStartDate", parsed.eventStartDate?.getTime() ?? null);
+    setOrClear("eventStartTime", parsed.eventStartTime || null);
+    setOrClear("eventEndDate", parsed.eventEndDate?.getTime() ?? null);
+    setOrClear("eventEndTime", parsed.eventEndTime || null);
+    setOrClear("loadOutDate", parsed.loadOutDate?.getTime() ?? null);
+    setOrClear("loadOutTime", parsed.loadOutTime || null);
+    setOrClear("rentalStartDate", parsed.rentalStartDate?.getTime() ?? null);
+    setOrClear("rentalEndDate", parsed.rentalEndDate?.getTime() ?? null);
+    setOrClear("defaultRentalPeriod", parsed.defaultRentalPeriod || null);
+    setOrClear("defaultRentalQuantity", parsed.defaultRentalQuantity || null);
+    setOrClear("taxRate", parsed.taxRate ?? null);
+    setOrClear("crewNotes", parsed.crewNotes || null);
+    setOrClear("internalNotes", parsed.internalNotes || null);
+    setOrClear("clientNotes", parsed.clientNotes || null);
+    setOrClear("discountPercent", parsed.discountPercent ?? null);
+    setOrClear("depositPercent", parsed.depositPercent ?? null);
+    setOrClear("depositPaid", parsed.depositPaid ?? null);
+    setOrClear("invoicedTotal", parsed.invoicedTotal ?? null);
+
+    try {
+      await updateM({
+        id,
+        orgId,
+        set,
+        clear,
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        auditId: createId(),
+        now: Date.now(),
+      });
+    } catch (e) {
+      throw mapProjectWriteError(e, isTemplate);
+    }
+
+    // Recalculate totals if tax rate changed. Best-effort: the project patch already
+    // committed, so a transient recalc failure must not reject an otherwise-successful
+    // update. Totals are derived and self-heal on the next line-item write / recalc.
+    if (parsed.taxRate !== undefined) {
+      try {
+        await recalcM({ projectId: id, orgId, now: Date.now() });
+      } catch (e) {
+        console.error("post-update recalc failed (non-fatal):", e);
+      }
+    }
+
+    return { id };
+  };
+
+  /**
+   * Duplicate a project browser-direct — the former `duplicateProject`. The entire
+   * deep-copy (categories → groups → line items → PMs → recalc) runs in ONE atomic
+   * mutation. Org default tax rate is resolved IN-MUTATION from `orgSettings` — not
+   * sent from here.
+   */
+  const duplicate = async (
+    sourceId: string,
+    newProjectNumber: string,
+    newName: string,
+  ): Promise<{ id: string }> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    const newProjectId = createId();
+    try {
+      const result = await duplicateM({
+        sourceId,
+        newId: newProjectId,
+        newProjectNumber,
+        newName,
+        orgId,
+        now: Date.now(),
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        auditId: createId(),
+      });
+      return { id: result.id };
+    } catch (e) {
+      throw mapProjectWriteError(e, false);
+    }
+  };
+
+  /**
+   * Snapshot a project as a TEMPLATE browser-direct — the former `saveAsTemplate`.
+   * `templateNumber` comes from the kept `peekNextTemplateCode` read (mirrors the
+   * server's inline `generateTemplateCode` call). Org default tax rate is resolved
+   * IN-MUTATION from `orgSettings` — not sent from here.
+   */
+  const saveAsTemplate = async (
+    projectId: string,
+    templateName: string,
+  ): Promise<{ id: string }> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    const templateId = createId();
+    const templateNumber = await peekNextTemplateCode();
+    try {
+      const result = await saveAsTemplateM({
+        sourceId: projectId,
+        newId: templateId,
+        templateNumber,
+        templateName,
+        orgId,
+        now: Date.now(),
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+      });
+      return { id: result.id };
+    } catch (e) {
+      throw mapProjectWriteError(e, true);
+    }
+  };
+
+  /**
+   * Delete a project browser-direct — the former `deleteProject`. The full 8-step
+   * cascade (free checked-out assets/kits, cascade lines/crew/managers/tasks/
+   * services/grouping, purge the revenue rollup, then the row) runs atomically
+   * INSIDE `deleteNative`, including the CANCELLED + non-template re-checks — this
+   * only resolves `defaultLocationId` (mirrors the server's `getDefaultLocation`)
+   * from the already-subscribed `useLocations` list. Returns the freed asset/kit
+   * counts `deleteNative` computes in-mutation (never trusted from the client).
+   */
+  const remove = async (id: string): Promise<{ freedAssets: number; freedKits: number }> => {
+    if (!orgId || !session?.user) throw new Error("Not ready");
+    const defaultLocationId = locations?.find((l) => l.isDefault)?.id ?? null;
+    try {
+      const result = await deleteM({
+        id,
+        orgId,
+        defaultLocationId,
+        actor: { userId: session.user.id, userName: session.user.name ?? "" },
+        auditId: createId(),
+        now: Date.now(),
+      });
+      return { freedAssets: result.freedAssets, freedKits: result.freedKits };
+    } catch (e) {
+      throw mapProjectWriteError(e);
+    }
+  };
+
+  return { enabled, archive, deleteTemplate, create, update, duplicate, saveAsTemplate, remove };
 }

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { getOrgContext } from "@/lib/org-context";
 import { getClientById, getClientMap, attachClient } from "@/lib/clients-read";
 import { buildProjectEquipmentTree } from "@/lib/project-line-item-read";
 import { resolvePrimaryDateRange } from "@/lib/project-dates";
@@ -17,24 +17,15 @@ import {
   groupActiveLineItemsByProject,
   countTopLevelLineItemsByProject,
 } from "@/lib/line-item-count-read";
-import {
-  projectSchema,
-  type ProjectFormValues,
-} from "@/lib/validations/project";
 import type { ProjectStatus } from "@/generated/prisma/client";
 import { serialize } from "@/lib/serialize";
 import { computeOverbookedStatus } from "@/lib/availability";
-import { recalculateProjectTotals } from "@/server/line-items";
 import { getConvexClient, withConvexReadRetry } from "@/lib/convex-client";
 import { getProjectMediaFromConvex, withResolvedFile } from "@/lib/media-read";
 import { api } from "../../convex/_generated/api";
 import { type FilterValue } from "@/lib/table-utils";
 import { UserFacingError } from "@/lib/errors";
-import { getDefaultLocation, getLocationMap, getMappedLocationsByOrg, mapLocation } from "@/lib/locations-read";
-import { createId } from "@paralleldrive/cuid2";
-import { readOrgDefaultTaxRate } from "@/lib/org-settings-read";
-import { ConvexError } from "convex/values";
-import { assertNoBlockingComments } from "@/lib/blocking-comments-read";
+import { getLocationMap, getMappedLocationsByOrg, mapLocation } from "@/lib/locations-read";
 import {
   renderProjectNumber,
   scopeKeyFor,
@@ -52,16 +43,6 @@ type ProjectNumberConfig = {
   padding: number;
   timezone?: string;
 };
-
-const BLOCKED_FORWARD_PROJECT_STATUSES: ProjectStatus[] = [
-  "PREPPING",
-  "CHECKED_OUT",
-  "ON_SITE",
-];
-
-function isBlockedForwardProjectStatus(status: ProjectStatus | ProjectFormValues["status"] | null | undefined) {
-  return status ? BLOCKED_FORWARD_PROJECT_STATUSES.includes(status as ProjectStatus) : false;
-}
 
 /** Parse the org's auto project-number config from its settings metadata JSON. */
 function readProjectNumberConfig(metadata: string | null): ProjectNumberConfig | null {
@@ -84,37 +65,6 @@ function readProjectNumberConfig(metadata: string | null): ProjectNumberConfig |
   } catch {
     return null;
   }
-}
-
-/**
- * Atomically allocate the next auto project number inside a transaction. The
- * sequence counter is bumped with INSERT ... ON CONFLICT (race-free across
- * concurrent project creation); if the rendered number collides with an
- * existing (e.g. manually-entered) one, we bump again. Returns the number.
- */
-async function generateProjectNumber(
-  organizationId: string,
-  config: ProjectNumberConfig,
-  now: Date,
-): Promise<string> {
-  const parts = datePartsInTimezone(now, config.timezone);
-  const scopeKey = scopeKeyFor(config.reset, parts);
-  const convex = await getConvexClient();
-
-  for (let attempt = 0; attempt < 50; attempt++) {
-    // Atomic counter bump (Convex serializable mutation = race-free across concurrent
-    // creates — the ON CONFLICT … value+1 equivalent). cuid used only on first insert.
-    const sequence = await convex.mutation(api.projectNumberSequences.reserveNextNumber, {
-      organizationId,
-      scopeKey,
-      newId: createId(),
-      now: now.getTime(),
-    });
-    const number = renderProjectNumber(config.format, { parts, sequence, padding: config.padding });
-    const clash = await convex.query(api.projects.getByOrgAndNumber, { organizationId, projectNumber: number });
-    if (!clash) return number;
-  }
-  throw new Error("Could not generate a unique project number");
 }
 
 /**
@@ -160,12 +110,13 @@ export async function peekNextProjectNumber(override?: {
   const startSeq = (seqRow?.value ?? 0) + 1;
 
   // Skip past any rendered code that's already taken so the preview matches what
-  // `generateProjectNumber` will actually allocate. The counter can lag behind
-  // the real projects (codes entered manually, imported, or created before
-  // auto-numbering was switched on), in which case `startSeq` would render an
-  // already-used number — e.g. counter 0 → "260601" when 260601-260603 exist.
-  // Probe forward only; never persist (this is a preview, must not consume a number).
-  // Keep this skip loop in sync with `generateProjectNumber` above.
+  // `createNative`'s in-mutation auto-number allocation loop will actually allocate.
+  // The counter can lag behind the real projects (codes entered manually, imported,
+  // or created before auto-numbering was switched on), in which case `startSeq`
+  // would render an already-used number — e.g. counter 0 → "260601" when
+  // 260601-260603 exist. Probe forward only; never persist (this is a preview,
+  // must not consume a number). Keep this skip loop in sync with createNative
+  // (convex/projectWrites.ts).
   const takenNumbers = new Set(
     (await getProjectsByOrgMapped(organizationId)).map((p) => p.projectNumber),
   );
@@ -180,6 +131,24 @@ export async function peekNextProjectNumber(override?: {
   // Pathological: 50 consecutive codes taken. Fall back to the unskipped render
   // rather than hard-erroring the preview query.
   return renderProjectNumber(config.format, { parts, sequence: startSeq, padding: config.padding });
+}
+
+/**
+ * Read-only helper for the browser-direct create flow (Projects Slice B): resolves
+ * the org's auto project-number config the exact same way `createProject` used to
+ * (byte-for-byte — same `organization.metadata` Postgres source via
+ * `readProjectNumberConfig`), so `useProjectWrites().create()` can build the
+ * `autoNumber` arg for `createNative` client-side. The actual number ALLOCATION
+ * (reserve → render → clash-retry) still happens atomically inside `createNative` —
+ * this only supplies the config, never a resolved number.
+ */
+export async function getProjectNumberConfig(): Promise<ProjectNumberConfig | null> {
+  const { organizationId } = await getOrgContext();
+  const org = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: { metadata: true },
+  });
+  return readProjectNumberConfig(org?.metadata ?? null);
 }
 
 /**
@@ -212,6 +181,17 @@ async function generateTemplateCode(organizationId: string): Promise<string> {
     code = `TPL-${String(count + 2).padStart(4, "0")}`;
   }
   return code;
+}
+
+/**
+ * Read-only helper for the browser-direct saveAsTemplate flow (Projects Slice B):
+ * resolves the next template code (mirrors the server's former inline call before
+ * `saveAsTemplateNative`). No reservation — a rare clash on submit surfaces as
+ * DUPLICATE_PROJECT_CODE from the mutation itself, same as before.
+ */
+export async function peekNextTemplateCode(): Promise<string> {
+  const { organizationId } = await getOrgContext();
+  return generateTemplateCode(organizationId);
 }
 
 export async function getProjects(params?: {
@@ -538,119 +518,6 @@ export async function getProject(id: string) {
   });
 }
 
-export async function createProject(data: ProjectFormValues & { isTemplate?: boolean }) {
-  const { organizationId, userId, userName } = await requirePermission("project", "create");
-  const parsed = projectSchema.parse(data);
-
-  const isTemplate = data.isTemplate ?? false;
-
-  // Auto project-number config (null when the org hasn't enabled it).
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { metadata: true },
-  });
-  const autoConfig = readProjectNumberConfig(org?.metadata ?? null);
-  const useAutoNumber = !isTemplate && !parsed.projectNumber && !!autoConfig;
-
-  if (!isTemplate && !parsed.projectNumber && !useAutoNumber) {
-    throw new UserFacingError({
-      code: "MISSING_PROJECT_CODE",
-      title: "Project code is required",
-      message: "Enter a project code (e.g. P-2024-001) before saving.",
-      field: "projectNumber",
-    });
-  }
-
-  // Templates without an explicit code get a template code (pre-txn is fine —
-  // no shared counter). Auto project numbers are allocated INSIDE the txn so
-  // the sequence bump and the create commit (or roll back) together.
-  const templateNumber =
-    isTemplate && !parsed.projectNumber ? await generateTemplateCode(organizationId) : null;
-
-  // project is Convex-only now. Build the create args (dates → epoch-ms, nulls
-  // omitted); the project number is allocated + the row created together below.
-  const id = createId();
-  const now = new Date();
-  const baseArgs = {
-    id,
-    organizationId,
-    isTemplate,
-    name: parsed.name,
-    clientId: parsed.clientId || undefined,
-    status: parsed.status,
-    type: parsed.type,
-    description: parsed.description || undefined,
-    locationId: parsed.locationId || undefined,
-    siteContactName: parsed.siteContactName || undefined,
-    siteContactPhone: parsed.siteContactPhone || undefined,
-    siteContactEmail: parsed.siteContactEmail || undefined,
-    loadInDate: parsed.loadInDate?.getTime(),
-    loadInTime: parsed.loadInTime || undefined,
-    eventStartDate: parsed.eventStartDate?.getTime(),
-    eventStartTime: parsed.eventStartTime || undefined,
-    eventEndDate: parsed.eventEndDate?.getTime(),
-    eventEndTime: parsed.eventEndTime || undefined,
-    loadOutDate: parsed.loadOutDate?.getTime(),
-    loadOutTime: parsed.loadOutTime || undefined,
-    rentalStartDate: parsed.rentalStartDate?.getTime(),
-    rentalEndDate: parsed.rentalEndDate?.getTime(),
-    crewNotes: parsed.crewNotes || undefined,
-    internalNotes: parsed.internalNotes || undefined,
-    clientNotes: parsed.clientNotes || undefined,
-    defaultRentalPeriod: parsed.defaultRentalPeriod || undefined,
-    defaultRentalQuantity: parsed.defaultRentalQuantity || undefined,
-    taxRate: parsed.taxRate ?? undefined,
-    discountPercent: parsed.discountPercent ?? undefined,
-    depositPercent: parsed.depositPercent ?? undefined,
-    depositPaid: parsed.depositPaid ?? undefined,
-    invoicedTotal: parsed.invoicedTotal ?? undefined,
-    tags: parsed.tags,
-    createdAt: now.getTime(),
-    updatedAt: now.getTime(),
-  };
-
-  const convex = await getConvexClient();
-  // One audit id for the whole allocation loop — only the winning insert writes it.
-  const projectAuditId = createId();
-  let created: { created: boolean; id: string } | null = null;
-
-  // The auto-number allocation loop is folded INTO createNative (scopeKey →
-  // reserve sequence → render → clash-guard → retry, all in one transaction), so a
-  // single call suffices. Auto numbering passes the resolved config + date parts
-  // (computed here in the org timezone); manual/template pass the code directly.
-  created = await convex.mutation(api.projectWrites.createNative, {
-    ...baseArgs,
-    ...(useAutoNumber
-      ? {
-          autoNumber: {
-            format: autoConfig!.format,
-            reset: autoConfig!.reset,
-            padding: autoConfig!.padding,
-            parts: datePartsInTimezone(now, autoConfig!.timezone),
-          },
-        }
-      : { projectNumber: templateNumber ?? parsed.projectNumber! }),
-    actor: { userId, userName },
-    auditId: projectAuditId,
-  });
-  // A manual/template number clash is a hard duplicate (auto retries in-mutation).
-  if (!created.created) {
-    throw new UserFacingError({
-      code: "DUPLICATE_PROJECT_CODE",
-      title: "Project code already in use",
-      message: `A ${isTemplate ? "template" : "project"} with code "${templateNumber ?? parsed.projectNumber}" already exists.`,
-      field: "projectNumber",
-    });
-  }
-
-  const result = await getProjectByIdMapped(id, organizationId);
-  if (!result) throw new Error("Project create failed");
-
-  // The CREATE audit was written atomically in the mutation.
-
-  return serialize(result);
-}
-
 /**
  * Return-value availability check for a project code (the
  * `@@unique([organizationId, projectNumber])` guard). The create/edit wizard calls
@@ -674,218 +541,6 @@ export async function checkProjectNumberAvailable(
     convex.query(api.projects.getByOrgAndNumber, { organizationId, projectNumber: trimmed }),
   );
   return { available: !clash || clash.id === excludeProjectId };
-}
-
-export async function updateProject(id: string, data: ProjectFormValues) {
-  const { organizationId, userId, userName } = await requirePermission("project", "update");
-  const parsed = projectSchema.parse(data);
-
-  // Read the prior status so a project-form save that flips status into a
-  // blocked-forward state can be gated on blocking comments. (project is
-  // Convex-only — read the mapped row instead of Prisma.)
-  const before = await getProjectByIdMapped(id, organizationId);
-
-  if (
-    before &&
-    !before.isTemplate &&
-    before.status !== parsed.status &&
-    isBlockedForwardProjectStatus(parsed.status)
-  ) {
-    await assertNoBlockingComments(organizationId, id, {
-      actionLabel: `move this project to ${String(parsed.status).toLowerCase().replaceAll("_", " ")}`,
-    });
-  }
-
-  // Duplicate-code integrity guard. createProject enforces the
-  // @@unique([organizationId, projectNumber]) invariant at insert, but the edit
-  // path patched projectNumber blindly — editing a code to one a sibling already
-  // uses silently produced two projects sharing a number. Only check when the
-  // number actually changes. (The wizard also checks availability up-front via
-  // checkProjectNumberAvailable for an inline field error; this catches the edit
-  // race and any non-wizard caller, and feeds the API error envelope.)
-  if (parsed.projectNumber && before && parsed.projectNumber !== before.projectNumber) {
-    const dupCheck = await getConvexClient();
-    const clash = await withConvexReadRetry(() =>
-      dupCheck.query(api.projects.getByOrgAndNumber, {
-        organizationId,
-        projectNumber: parsed.projectNumber!,
-      }),
-    );
-    if (clash && clash.id !== id) {
-      throw new UserFacingError({
-        code: "DUPLICATE_PROJECT_CODE",
-        title: "Project code already in use",
-        message: `A ${before.isTemplate ? "template" : "project"} with code "${parsed.projectNumber}" already exists.`,
-        field: "projectNumber",
-      });
-    }
-  }
-
-  // project is Convex-only — patch via api.projects.patchProject. Value→set,
-  // empty/null→clear (mirrors the old `|| null` / `?? null` clear-to-null logic).
-  const set: Record<string, unknown> = {
-    projectNumber: parsed.projectNumber,
-    name: parsed.name,
-    status: parsed.status,
-    type: parsed.type,
-    tags: parsed.tags,
-    updatedAt: Date.now(),
-  };
-  const clear: string[] = [];
-  const setOrClear = (key: string, value: unknown) => {
-    if (value === null || value === undefined || value === "") clear.push(key);
-    else set[key] = value;
-  };
-  setOrClear("clientId", parsed.clientId || null);
-  setOrClear("description", parsed.description || null);
-  setOrClear("locationId", parsed.locationId || null);
-  setOrClear("siteContactName", parsed.siteContactName || null);
-  setOrClear("siteContactPhone", parsed.siteContactPhone || null);
-  setOrClear("siteContactEmail", parsed.siteContactEmail || null);
-  setOrClear("loadInDate", parsed.loadInDate?.getTime() ?? null);
-  setOrClear("loadInTime", parsed.loadInTime || null);
-  setOrClear("eventStartDate", parsed.eventStartDate?.getTime() ?? null);
-  setOrClear("eventStartTime", parsed.eventStartTime || null);
-  setOrClear("eventEndDate", parsed.eventEndDate?.getTime() ?? null);
-  setOrClear("eventEndTime", parsed.eventEndTime || null);
-  setOrClear("loadOutDate", parsed.loadOutDate?.getTime() ?? null);
-  setOrClear("loadOutTime", parsed.loadOutTime || null);
-  setOrClear("rentalStartDate", parsed.rentalStartDate?.getTime() ?? null);
-  setOrClear("rentalEndDate", parsed.rentalEndDate?.getTime() ?? null);
-  setOrClear("defaultRentalPeriod", parsed.defaultRentalPeriod || null);
-  setOrClear("defaultRentalQuantity", parsed.defaultRentalQuantity || null);
-  setOrClear("taxRate", parsed.taxRate ?? null);
-  setOrClear("crewNotes", parsed.crewNotes || null);
-  setOrClear("internalNotes", parsed.internalNotes || null);
-  setOrClear("clientNotes", parsed.clientNotes || null);
-  setOrClear("discountPercent", parsed.discountPercent ?? null);
-  setOrClear("depositPercent", parsed.depositPercent ?? null);
-  setOrClear("depositPaid", parsed.depositPaid ?? null);
-  setOrClear("invoicedTotal", parsed.invoicedTotal ?? null);
-
-  const convex = await getConvexClient();
-  // RBAC + patch/clear + UPDATE audit atomic. Zod validation stays above;
-  // recalc stays below (server-side, unchanged → totals identical).
-  await convex.mutation(api.projectWrites.updateNative, {
-    id,
-    orgId: organizationId,
-    set,
-    clear,
-    actor: { userId, userName },
-    auditId: createId(),
-    now: Date.now(),
-  });
-
-  // Recalculate totals if tax rate changed. Best-effort: the project patch already
-  // committed, so a transient recalc failure must not reject an otherwise-successful
-  // update (that surfaced as the spurious "Server Components render" error). Totals
-  // are derived and self-heal on the next line-item write / recalc.
-  if (parsed.taxRate !== undefined) {
-    try {
-      await recalculateProjectTotals(id);
-    } catch (e) {
-      console.error("post-update recalc failed (non-fatal):", e);
-    }
-  }
-
-  const updated = await getProjectByIdMapped(id, organizationId);
-  if (!updated) throw new Error("Project update failed");
-
-  return serialize(updated);
-}
-
-/**
- * Map a ConvexError thrown by duplicateNative / saveAsTemplateNative back to the
- * rich UserFacingError the legacy server path threw, so the toast UX is identical.
- * Handles the NOT_FOUND (source gone) + DUPLICATE_PROJECT_CODE (number clash) codes.
- */
-function mapProjectCopyError(e: unknown, isTemplate: boolean): unknown {
-  if (
-    e instanceof ConvexError &&
-    e.data &&
-    typeof e.data === "object" &&
-    "code" in e.data &&
-    typeof (e.data as { code: unknown }).code === "string"
-  ) {
-    const code = (e.data as { code: string }).code;
-    const message =
-      typeof (e.data as { message?: unknown }).message === "string"
-        ? (e.data as { message: string }).message
-        : undefined;
-    if (code === "NOT_FOUND") {
-      return new UserFacingError({
-        code: "NOT_FOUND",
-        title: "Project not found",
-        message: "This project was deleted or moved. Refresh the page to see the latest state.",
-      });
-    }
-    if (code === "DUPLICATE_PROJECT_CODE") {
-      return new UserFacingError({
-        code,
-        title: isTemplate ? "Template code already in use" : "Project code already in use",
-        message: message ?? `A ${isTemplate ? "template" : "project"} with that code already exists.`,
-        field: "projectNumber",
-      });
-    }
-  }
-  return e;
-}
-
-export async function duplicateProject(sourceId: string, newProjectNumber: string, newName: string) {
-  const { organizationId, userId, userName } = await requirePermission("project", "create");
-
-  const client = await getConvexClient();
-
-  // The entire deep-copy (categories → groups → line items → PMs → recalc)
-  // runs in ONE atomic mutation instead of N sequential server→Convex round-trips.
-  const newProjectId = createId();
-  const orgDefaultTaxRate = await readOrgDefaultTaxRate(organizationId);
-  try {
-    await client.mutation(api.projectWrites.duplicateNative, {
-      sourceId,
-      newId: newProjectId,
-      newProjectNumber,
-      newName,
-      orgId: organizationId,
-      orgDefaultTaxRate,
-      now: Date.now(),
-      actor: { userId, userName },
-      auditId: createId(),
-    });
-  } catch (e) {
-    throw mapProjectCopyError(e, false);
-  }
-  const nativeResult = await getProjectByIdMapped(newProjectId, organizationId);
-  if (!nativeResult) throw new Error("Project duplicate failed");
-  return serialize(nativeResult);
-}
-
-export async function saveAsTemplate(projectId: string, templateName: string) {
-  const { organizationId, userId, userName } = await requirePermission("project", "create");
-
-  // Create the template + copy its line items (grouping OMITTED) + recalc in
-  // ONE atomic mutation. generateTemplateCode stays server-side (Convex-mirror count).
-  const templateId = createId();
-  const templateNumber = await generateTemplateCode(organizationId);
-  const orgDefaultTaxRate = await readOrgDefaultTaxRate(organizationId);
-  const client = await getConvexClient();
-  try {
-    await client.mutation(api.projectWrites.saveAsTemplateNative, {
-      sourceId: projectId,
-      newId: templateId,
-      templateNumber,
-      templateName,
-      orgId: organizationId,
-      orgDefaultTaxRate,
-      now: Date.now(),
-      actor: { userId, userName },
-    });
-  } catch (e) {
-    throw mapProjectCopyError(e, true);
-  }
-  const nativeResult = await getProjectByIdMapped(templateId, organizationId);
-  if (!nativeResult) throw new Error("Template create failed");
-  return serialize(nativeResult);
 }
 
 export async function getTemplates() {
@@ -923,49 +578,6 @@ export async function getTemplates() {
 
   // Clients live in Convex — attach instead of a Prisma join.
   return serialize(await attachClient(organizationId, withCounts));
-}
-
-export async function deleteProject(id: string) {
-  const { organizationId, userId, userName } = await requirePermission("project", "delete");
-
-  // Only allow deleting cancelled projects. Project + line items are Convex-only
-  // (Phase C) — read the project scalars from Convex.
-  const project = await getProjectByIdMapped(id, organizationId);
-
-  if (!project) {
-    throw new UserFacingError({
-      code: "NOT_FOUND",
-      title: "Project not found",
-      message: "This project was deleted or moved. Refresh the page to see the latest state.",
-    });
-  }
-  if (project.status !== "CANCELLED") {
-    throw new UserFacingError({
-      code: "DELETE_GUARD",
-      title: "Cannot delete this project",
-      message: "Only cancelled projects can be deleted.",
-      hint: "Set the project status to Cancelled first, then try again.",
-    });
-  }
-
-  const convex = await getConvexClient();
-
-  // The full delete cascade runs atomically INSIDE Convex (deleteNative): it frees
-  // checked-out assets/kits (+ kit-serialized members) through the counter-safe
-  // path, cascades every line item + its units, deletes crew assignments (→ shifts
-  // + time entries), managers/tasks/services, grouping, the projectModelRevenues
-  // rollup, then the project row + DELETE audit — in ONE round-trip, no orphan
-  // window. The CANCELLED + non-template guards are re-checked there. We only
-  // resolve the org default location to pass through (mirrors getDefaultLocation).
-  const defaultLocation = await getDefaultLocation(organizationId);
-  await convex.mutation(api.projectWrites.deleteNative, {
-    id,
-    orgId: organizationId,
-    defaultLocationId: defaultLocation?.id ?? null,
-    actor: { userId, userName },
-    auditId: createId(),
-    now: Date.now(),
-  });
 }
 
 /** Get project milestone dates for call sheet dialog */


### PR DESCRIPTION
## Summary
- Final Phase-3 write domain: converts `createProject`/`updateProject`/`duplicateProject`/`saveAsTemplate`/`deleteProject` from service-token server actions to browser-direct `useMutation` calls into the already-prod-hardened `createNative`/`updateNative`/`duplicateNative`/`saveAsTemplateNative`/`deleteNative` mutations. `src/server/projects.ts` is now reads-only.
- Hardens the two mutations for their new browser-direct exposure (caught in review, fixed pre-merge, not deferred):
  - `duplicateNative`/`saveAsTemplateNative` now resolve `orgDefaultTaxRate` in-mutation from the `orgSettings` mirror instead of trusting a client-supplied value (same pattern as `lineItemWrites.ts`'s `recalcNative`); extracted the shared helper into `convex/lib/orgSettings.ts`.
  - `updateNative`/`createNative` validate money-adjacent fields (`taxRate`/`discountPercent`/`depositPercent`/`depositPaid`/`invoicedTotal`) via a new `assertProjectMoneyFields` guard, mirroring the existing line-item money guards — Convex's `v.number()`/`v.any()` don't bound or finite-check, and a browser caller bypasses the client Zod schema.
- New test coverage for both hardening fixes in `convex/projectWrites.test.ts`.

## Review
Two independent codex passes: first pass caught both money-trust gaps above (fixed before commit); second pass confirmed the fixes and confirmed a third flagged item (`createNative`'s manual-vs-auto number path selection) is pre-existing parity with the deleted server action, not a regression — documented in `FEATUREDOCS/54-convex-data-layer.md`.

## Test plan
- [x] `pnpm exec convex dev --once` (pushed to prod Convex, additive)
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 3682/3682 passing (260 files)
- [x] `npx next build` clean (no Turbopack barrel-merge errors)
- [ ] Live prod smoke: create → edit → delete a throwaway test project (post-merge, post-deploy)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>