### PR TITLE
fix(security): close cross-tenant IDOR + money-forgery gaps in browser-direct writes

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -101,6 +101,7 @@ import type * as lib_lineItemUnits from "../lib/lineItemUnits.js";
 import type * as lib_lineTotal from "../lib/lineTotal.js";
 import type * as lib_moneyGuards from "../lib/moneyGuards.js";
 import type * as lib_notificationPreferences from "../lib/notificationPreferences.js";
+import type * as lib_orgRef from "../lib/orgRef.js";
 import type * as lib_orgSettings from "../lib/orgSettings.js";
 import type * as lib_permissionsCore from "../lib/permissionsCore.js";
 import type * as lib_projectNumber from "../lib/projectNumber.js";
@@ -312,6 +313,7 @@ declare const fullApi: ApiFromModules<{
   "lib/lineTotal": typeof lib_lineTotal;
   "lib/moneyGuards": typeof lib_moneyGuards;
   "lib/notificationPreferences": typeof lib_notificationPreferences;
+  "lib/orgRef": typeof lib_orgRef;
   "lib/orgSettings": typeof lib_orgSettings;
   "lib/permissionsCore": typeof lib_permissionsCore;
   "lib/projectNumber": typeof lib_projectNumber;

--- a/convex/lib/moneyGuards.ts
+++ b/convex/lib/moneyGuards.ts
@@ -83,6 +83,7 @@ export function assertProjectMoneyFields(f: {
   depositPercent?: number | null;
   depositPaid?: number | null;
   invoicedTotal?: number | null;
+  defaultRentalQuantity?: number | null;
 }): void {
   if (f.taxRate != null) {
     if (!Number.isFinite(f.taxRate) || f.taxRate < 0 || f.taxRate > 100) {
@@ -107,6 +108,14 @@ export function assertProjectMoneyFields(f: {
   if (f.invoicedTotal != null) {
     if (!Number.isFinite(f.invoicedTotal) || f.invoicedTotal < 0) {
       throw new ConvexError({ code: "INVALID_INVOICED_TOTAL", message: "Invoiced total must be a non-negative finite number." });
+    }
+  }
+  if (f.defaultRentalQuantity != null) {
+    // Not itself money, but feeds addLineItemSmartNative's auto-pricing as `autoDuration`
+    // (unbounded/NaN here poisons a subsequently-added line's lineTotal, then the
+    // project's recalculated totals). Bounds mirror line-item `duration`'s cap.
+    if (!Number.isFinite(f.defaultRentalQuantity) || !Number.isInteger(f.defaultRentalQuantity) || f.defaultRentalQuantity < 1 || f.defaultRentalQuantity > 3650) {
+      throw new ConvexError({ code: "INVALID_DEFAULT_RENTAL_QUANTITY", message: "Default rental quantity must be a whole number between 1 and 3650." });
     }
   }
 }

--- a/convex/lib/orgRef.ts
+++ b/convex/lib/orgRef.ts
@@ -1,0 +1,20 @@
+import { ConvexError } from "convex/values";
+import type { MutationCtx } from "../_generated/server";
+
+/**
+ * Org-validate a client-supplied FK id against `by_cuid` (a GLOBAL index — the row could
+ * belong to another org). Throws if the referenced row is missing or cross-org. Shared by
+ * lineItemWrites.ts and projectWrites.ts — every table in the union carries `id` (by_cuid)
+ * + `organizationId`.
+ */
+export async function assertRefInOrg(
+  ctx: MutationCtx,
+  table: "models" | "assets" | "bulkAssets" | "projectGroups" | "projectCategories" | "clients",
+  id: string,
+  orgId: string,
+): Promise<void> {
+  const doc = await ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).first();
+  if (!doc || doc.organizationId !== orgId) {
+    throw new ConvexError({ code: "FORBIDDEN", message: `Referenced ${table} not found in your organization.` });
+  }
+}

--- a/convex/lib/rateLimiter.ts
+++ b/convex/lib/rateLimiter.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from "convex/values";
 import { RateLimiter, MINUTE } from "@convex-dev/rate-limiter";
 import { components } from "../_generated/api";
 import type { MutationCtx } from "../_generated/server";
@@ -38,4 +39,22 @@ export async function enforceBrowserWriteLimit(ctx: MutationCtx): Promise<void> 
   const auth = await getAuthContext(ctx);
   if (!auth || auth.kind !== "user") return;
   await rateLimiter.limit(ctx, "browserWrite", { key: auth.userId, throws: true });
+}
+
+/** Per-call cap for `ids`/`items` arrays on bulk browser-direct mutations
+ *  (removeManyNative/patchManyNative/reorderNative/…). `enforceBrowserWriteLimit`
+ *  costs ONE token per call regardless of array size (deliberately, so a legit bulk
+ *  action isn't rate-limited per-item) — without a size cap, a single call with an
+ *  oversized array becomes an uncapped amplification vector: one rate-limit token
+ *  buys N point-queries/writes inside one transaction. 500 comfortably covers the
+ *  largest real bulk UI action (select-all on a big project) with headroom. */
+const MAX_BULK_ITEMS = 500;
+
+export function assertBulkSizeOk(count: number): void {
+  if (count > MAX_BULK_ITEMS) {
+    throw new ConvexError({
+      code: "BULK_TOO_LARGE",
+      message: `Bulk operation exceeds the ${MAX_BULK_ITEMS}-item limit (got ${count}). Split it into smaller batches.`,
+    });
+  }
 }

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -169,6 +169,39 @@ describe("lineItemWrites.patchNative", () => {
       t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { lineTotal: Number.NaN, updatedAt: NOW }, clear: [] }),
     ).rejects.toThrow();
   });
+  test("recomputes lineTotal server-side — a forged value disconnected from unitPrice/quantity is ignored", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", quantity: 1, unitPrice: 10, duration: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    // Real inputs (unitPrice 10 × quantity 2 × duration 1 = 20) but a forged lineTotal
+    // of 999999 — the forged value must be discarded, not written verbatim.
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, { ...pargs, set: { quantity: 2, lineTotal: 999999, updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.lineTotal).toBe(20);
+    });
+  });
+  test("recompute survives a stale clear:['lineTotal'] alongside pricing inputs (merge-delete must not wipe the recomputed value)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", quantity: 1, unitPrice: 10, duration: 1, status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false });
+    });
+    // A payload that both sets a real unitPrice AND (inconsistently/maliciously) asks
+    // to clear lineTotal — the clear must be reconciled away, not win, since the line
+    // IS priced (10 × 1 × 1 = 10). Also forces the `clear.length > 0` merge-replace path.
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, {
+      ...pargs,
+      set: { unitPrice: 10, updatedAt: NOW },
+      clear: ["lineTotal", "notes"],
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.lineTotal).toBe(10);
+    });
+  });
 });
 
 describe("lineItemWrites.addCustomNative", () => {
@@ -219,6 +252,18 @@ describe("lineItemWrites.addCustomNative", () => {
       expect(li).toBeNull();
     });
   });
+  test("recomputes lineTotal server-side — a forged value is ignored (unitPrice 200 × qty 1 = 200, not 999999)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, {
+      ...cargs,
+      fields: { ...cargs.fields, lineTotal: 999999 },
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "cust1")).first();
+      expect(li?.lineTotal).toBe(200);
+    });
+  });
 });
 
 describe("lineItemWrites.addNative", () => {
@@ -244,6 +289,18 @@ describe("lineItemWrites.addNative", () => {
     const t = makeT();
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, aargs)).rejects.toThrow(/insufficient permissions/i);
+  });
+  test("recomputes lineTotal server-side — a forged value is ignored (unitPrice 15 × qty 2 = 30, not 999999)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addNative, {
+      ...aargs,
+      fields: { ...aargs.fields, lineTotal: 999999 },
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "new1")).first();
+      expect(li?.lineTotal).toBe(30);
+    });
   });
 });
 
@@ -496,6 +553,19 @@ describe("lineItemWrites.addKitNative", () => {
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs)).rejects.toThrow(/insufficient permissions/i);
   });
 
+  test("rejects a non-finite unitPrice (would poison recalc to NaN)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => { await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "L", status: "AVAILABLE", condition: "GOOD", isActive: true, createdAt: NOW, updatedAt: NOW }); });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, { ...kargs, unitPrice: Number.NaN }),
+    ).rejects.toThrow();
+    await t.run(async (ctx) => {
+      const parent = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "kl1")).first();
+      expect(parent).toBeNull(); // nothing inserted
+    });
+  });
+
   test("throws KIT_UNAVAILABLE when the kit is IN_MAINTENANCE (unconditional)", async () => {
     const t = makeT();
     await member(t, "member");
@@ -521,6 +591,36 @@ describe("lineItemWrites.addKitNative", () => {
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addKitNative, kargs),
     ).rejects.toThrow(/KIT-1 is on P2/i);
+  });
+});
+
+describe("lineItemWrites bulk-size cap", () => {
+  // Array size, not per-item body, so build cheap oversized arrays inline.
+  const bigIds = Array.from({ length: 501 }, (_, i) => `id-${i}`);
+
+  test("removeManyNative rejects an oversized ids array (DoS amplification guard)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.removeManyNative, { ids: bigIds, orgId: ORG, actor: ACTOR, auditId: "log1", now: NOW }),
+    ).rejects.toThrow(/exceeds the 500-item limit/i);
+  });
+
+  test("patchManyNative rejects an oversized ids array", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchManyNative, { ids: bigIds, orgId: ORG, patch: {}, actor: ACTOR, auditId: "log1", now: NOW }),
+    ).rejects.toThrow(/exceeds the 500-item limit/i);
+  });
+
+  test("reorderNative rejects an oversized items array", async () => {
+    const t = makeT();
+    await member(t, "member");
+    const items = bigIds.map((id, i) => ({ id, sortOrder: i }));
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, { orgId: ORG, items, now: NOW }),
+    ).rejects.toThrow(/exceeds the 500-item limit/i);
   });
 });
 

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -4,13 +4,14 @@ import type { MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
-import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { enforceBrowserWriteLimit, assertBulkSizeOk } from "./lib/rateLimiter";
 import { sanitizeClientSet } from "./lib/sanitizeSet";
 import { assertLineMoneyFields } from "./lib/moneyGuards";
 import { roundCurrency, computeLineTotal } from "./lib/lineTotal";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import { resolveOrgDefaultTaxRate } from "./lib/orgSettings";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 import { expandAccessoryChildLines } from "./lib/fulfillment";
 import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
@@ -181,6 +182,7 @@ export const removeManyNative = mutation({
   handler: async (ctx, { ids, orgId, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
+    assertBulkSizeOk(ids.length);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -304,6 +306,43 @@ export const patchNative = mutation({
     assertLineMoneyFields(setObj as {
       quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
     });
+
+    // lineTotal is a DERIVED value — assertLineMoneyFields only bounds it, it never
+    // verifies it matches unitPrice×quantity×duration−discount. The legit client
+    // (buildLineItemSetClear) already computes it this exact way on every call, so this
+    // is a no-op for real traffic; it closes the gap where a browser-direct caller sends
+    // `set: {lineTotal: 999999}` with no matching price inputs. Effective values merge
+    // this patch's set/clear over the doc's current values (same pattern the quantity-
+    // increase availability check above uses).
+    {
+      const clearSetForMoney = new Set(clear.filter((k) => !LINE_NEVER_CLEAR.has(k)));
+      const effUnitPrice = clearSetForMoney.has("unitPrice")
+        ? undefined
+        : ((setObj.unitPrice as number | undefined) ?? (doc.unitPrice != null ? Number(doc.unitPrice) : undefined));
+      const effQuantity = clearSetForMoney.has("quantity")
+        ? (doc.quantity ?? 0)
+        : ((setObj.quantity as number | undefined) ?? (doc.quantity ?? 0));
+      const effDuration = clearSetForMoney.has("duration")
+        ? 1
+        : ((setObj.duration as number | undefined) ?? doc.duration ?? 1);
+      const effDiscount = clearSetForMoney.has("discount")
+        ? undefined
+        : ((setObj.discount as number | undefined) ?? (doc.discount != null ? Number(doc.discount) : undefined));
+      const recomputed = calcLineTotalNative(effUnitPrice, effQuantity, effDuration, effDiscount);
+      // Reconcile BOTH directions against a client-supplied `clear` — if the client
+      // separately sent `clear: ["lineTotal"]` (e.g. a stale/inconsistent payload)
+      // alongside inputs that DO price the line, leaving "lineTotal" in `clear` would
+      // let the merge-and-delete pass below wipe out the value just set here, silently
+      // zeroing a priced line's contribution to recalcProjectTotals.
+      const clearIdx = clear.indexOf("lineTotal");
+      if (recomputed == null) {
+        delete setObj.lineTotal;
+        if (clearIdx === -1) clear.push("lineTotal");
+      } else {
+        setObj.lineTotal = recomputed;
+        if (clearIdx !== -1) clear.splice(clearIdx, 1);
+      }
+    }
 
     // Availability re-check on a quantity INCREASE (parity with updateLineItem's
     // server-side re-check). Only EQUIPMENT, model-backed, non-sub-hire lines that grow
@@ -444,6 +483,7 @@ export const patchManyNative = mutation({
   handler: async (ctx, { ids, orgId, patch, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
+    assertBulkSizeOk(ids.length);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
 
@@ -579,23 +619,6 @@ function calcLineTotalNative(
 }
 
 /**
- * Org-validate a client-supplied FK id against `by_cuid` (a GLOBAL index — the row could
- * belong to another org). Throws if the referenced row is missing or cross-org. All five
- * tables carry `id` (by_cuid) + `organizationId`.
- */
-async function assertRefInOrg(
-  ctx: MutationCtx,
-  table: "models" | "assets" | "bulkAssets" | "projectGroups" | "projectCategories",
-  id: string,
-  orgId: string,
-): Promise<void> {
-  const doc = await ctx.db.query(table).withIndex("by_cuid", (q) => q.eq("id", id)).first();
-  if (!doc || doc.organizationId !== orgId) {
-    throw new ConvexError({ code: "FORBIDDEN", message: `Referenced ${table} not found in your organization.` });
-  }
-}
-
-/**
  * Recompute + persist a project group's suggested price (mirrors the server
  * calculateSuggestedPrice + projectGroupsWrites.recomputeGroupSuggestedById). No-op if
  * the group is gone / cross-org. Uses the shared computeGroupSuggestedPrice port.
@@ -722,6 +745,11 @@ export const addCustomNative = mutation({
 
     assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
 
+    // lineTotal is a DERIVED value — see addNative's comment for the full rationale.
+    // The legit client already computes it this exact way (use-line-item-writes.ts
+    // addCustom), so this is a no-op for real traffic and only closes the forgery gap.
+    const computedLineTotal = calcLineTotalNative(fields.unitPrice, fields.quantity, fields.duration ?? 1, fields.discount);
+
     // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
     // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
     const dup = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
@@ -735,6 +763,7 @@ export const addCustomNative = mutation({
       type: "EQUIPMENT",
       isCustomItem: true,
       ...fields,
+      lineTotal: computedLineTotal ?? undefined,
       sortOrder,
       createdAt: now,
       updatedAt: now,
@@ -840,6 +869,14 @@ export const addNative = mutation({
     await assertProjectInOrg(ctx, projectId, organizationId);
     assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
 
+    // lineTotal is a DERIVED value (unitPrice × quantity × duration − discount) —
+    // assertLineMoneyFields only bounds it, it doesn't verify it matches its inputs. A
+    // browser-direct caller could otherwise send `unitPrice: 1` (passes the bound check)
+    // with a wildly larger `lineTotal`, forging the line's — and the project's — totals.
+    // Recompute it server-side (byte-parity with calculateLineTotal), same as
+    // addLineItemSmartNative/patchMany already do; ignore whatever the client sent.
+    const computedLineTotal = calcLineTotalNative(fields.unitPrice, fields.quantity, fields.duration ?? 1, fields.discount);
+
     // Dup-guard the client-minted id (by_cuid is global + non-unique) — a reused id
     // both breaks .unique() reads AND (with the unit cascade) enables a cross-org delete.
     const dupLine = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
@@ -926,6 +963,7 @@ export const addNative = mutation({
       organizationId,
       projectId,
       ...fields,
+      lineTotal: computedLineTotal ?? undefined,
       status: "CONFIRMED",
       sortOrder,
       createdAt: now,
@@ -1010,6 +1048,12 @@ export const addKitNative = mutation({
     // The client supplies projectId; verify it's the caller's org before reading it or
     // sweeping its lines (by_cuid is global) — same guard addNative applies.
     await assertProjectInOrg(ctx, projectId, organizationId);
+
+    // Every other add* mutation in this file bounds unitPrice/lineTotal before insert
+    // (assertLineMoneyFields) — this one didn't, so a browser caller sending
+    // `unitPrice: NaN` (or Infinity/negative) flowed straight into the line and then
+    // poisoned recalcProjectTotals' project.total/subtotal/margin to NaN.
+    assertLineMoneyFields({ unitPrice });
 
     // Dup-guard the client-minted kit-line id (by_cuid is global + non-unique).
     const dupKit = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
@@ -1126,6 +1170,7 @@ export const reorderNative = mutation({
   handler: async (ctx, { orgId, items, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
+    assertBulkSizeOk(items.length);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     for (const it of items) {
       const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).first();

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -233,6 +233,38 @@ describe("projectWrites.updateNative", () => {
       t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { depositPaid: -50, updatedAt: NOW }, clear: [] }),
     ).rejects.toThrow(/deposit paid/i);
   });
+  test("rejects a cross-org clientId (IDOR guard — a forged clientId must not leak another org's client record)", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "foreign-client", organizationId: "other_org", name: "Foreign Co", createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { clientId: "foreign-client", updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/not found in your organization/i);
+  });
+  test("accepts a same-org clientId", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("clients", { id: "own-client", organizationId: ORG, name: "Own Co", createdAt: NOW, updatedAt: NOW });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { clientId: "own-client", updatedAt: NOW }, clear: [] });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.clientId).toBe("own-client");
+    });
+  });
+  test("rejects an out-of-bounds defaultRentalQuantity / non-finite rental dates (poisons auto-pricing / defeats double-booking)", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { defaultRentalQuantity: Number.NaN, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/default rental quantity/i);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, { ...uargs, set: { rentalStartDate: Number.NaN, updatedAt: NOW }, clear: [] }),
+    ).rejects.toThrow(/rentalStartDate/);
+  });
 });
 
 describe("projectWrites.createNative", () => {
@@ -285,6 +317,16 @@ describe("projectWrites.createNative", () => {
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, invoicedTotal: -1 } as typeof cargs),
     ).rejects.toThrow(/invoiced total/i);
+  });
+  test("rejects a cross-org clientId on create (IDOR guard)", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" });
+      await ctx.db.insert("clients", { id: "foreign-client", organizationId: "other_org", name: "Foreign Co", createdAt: NOW, updatedAt: NOW });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, clientId: "foreign-client" } as typeof cargs),
+    ).rejects.toThrow(/not found in your organization/i);
   });
 });
 

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -6,7 +6,8 @@ import { reserveProjectNumberCounter } from "./lib/projectNumberCounter";
 import { renderProjectNumber, scopeKeyFor } from "./lib/projectNumber";
 import { recalcProjectTotals } from "./lib/recalc";
 import { resolveOrgDefaultTaxRate } from "./lib/orgSettings";
-import { assertProjectMoneyFields } from "./lib/moneyGuards";
+import { assertProjectMoneyFields, assertFinite } from "./lib/moneyGuards";
+import { assertRefInOrg } from "./lib/orgRef";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
@@ -277,7 +278,25 @@ export const updateNative = mutation({
       depositPercent: typeof setObj.depositPercent === "number" ? setObj.depositPercent : undefined,
       depositPaid: typeof setObj.depositPaid === "number" ? setObj.depositPaid : undefined,
       invoicedTotal: typeof setObj.invoicedTotal === "number" ? setObj.invoicedTotal : undefined,
+      defaultRentalQuantity: typeof setObj.defaultRentalQuantity === "number" ? setObj.defaultRentalQuantity : undefined,
     });
+
+    // rentalStartDate/rentalEndDate feed the double-booking overlap check in
+    // convex/lib/availabilityCore.ts (`start <= end && end >= start` comparisons) — every
+    // comparison against NaN evaluates false in JS, so a forged `rentalStartDate: NaN`
+    // would silently make every overlap check report "no conflict" and defeat the
+    // double-booking guard for this project's future line-item adds.
+    assertFinite(typeof setObj.rentalStartDate === "number" ? setObj.rentalStartDate : undefined, "rentalStartDate");
+    assertFinite(typeof setObj.rentalEndDate === "number" ? setObj.rentalEndDate : undefined, "rentalEndDate");
+
+    // Org-validate a reassigned clientId — `set` is v.any(), and clientId is read via a
+    // GLOBAL by_cuid index (src/lib/clients-read.ts getClientById), never re-checked
+    // against the project's org at that read site. Without this, a browser-direct caller
+    // could point their own project at another org's client and leak its full PII record
+    // (name/contact/billing address) onto their project detail page.
+    if (typeof setObj.clientId === "string") {
+      await assertRefInOrg(ctx, "clients", setObj.clientId, orgId);
+    }
 
     // A general update that also moves the status FORWARD into PREPPING/CHECKED_OUT/ON_SITE
     // must clear the blocking-comment gate too (parity with the server updateProject path).
@@ -358,8 +377,18 @@ export const createNative = mutation({
     assertProjectMoneyFields({
       taxRate: fields.taxRate, discountPercent: fields.discountPercent,
       depositPercent: fields.depositPercent, depositPaid: fields.depositPaid,
-      invoicedTotal: fields.invoicedTotal,
+      invoicedTotal: fields.invoicedTotal, defaultRentalQuantity: fields.defaultRentalQuantity,
     });
+
+    // See updateNative's comment — NaN here defeats the double-booking overlap check.
+    assertFinite(fields.rentalStartDate, "rentalStartDate");
+    assertFinite(fields.rentalEndDate, "rentalEndDate");
+
+    // Org-validate clientId — see updateNative's comment for the full leak scenario
+    // this closes (a global by_cuid client read with no org re-check downstream).
+    if (fields.clientId) {
+      await assertRefInOrg(ctx, "clients", fields.clientId, fields.organizationId);
+    }
 
     // Dup-guard the client-minted cuid first (applies to both number paths). The
     // projectNumber clash-guard below is org-scoped and doesn't catch a cross-org

--- a/convex/writeParity.test.ts
+++ b/convex/writeParity.test.ts
@@ -92,7 +92,7 @@ describe("write-parity: assets", () => {
 describe("write-parity: line-items", () => {
   const fields = { type: "EQUIPMENT" as const, modelId: "m1", description: "Light", quantity: 2, unitPrice: 15 };
 
-  test("addNative == createLineItem (same resulting parent line)", async () => {
+  test("addNative == createLineItem (same resulting parent line, except lineTotal)", async () => {
     const t = makeT();
     await t.withIdentity(SERVICE).mutation(api.projectLineItems.createLineItem, { id: "svc", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, now: NOW });
     await t.withIdentity(SERVICE).mutation(api.lineItemWrites.addNative, { id: "nat", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, allowOverbook: true, actor: ACTOR, auditId: "log1", now: NOW });
@@ -101,6 +101,15 @@ describe("write-parity: line-items", () => {
     // sortOrder differs (svc got 0, nat got 1) — normalize it.
     delete (svc as Record<string, unknown>).sortOrder;
     delete (nat as Record<string, unknown>).sortOrder;
+    // lineTotal is a DELIBERATE divergence (security hardening, not a parity bug):
+    // createLineItem is a raw insert with no legitimate callers (grep-confirmed dead —
+    // trusts whatever `fields` it's handed verbatim); addNative now ALWAYS recomputes
+    // lineTotal server-side from unitPrice×quantity×duration−discount rather than
+    // trusting a client-supplied value, closing a same-org invoice-forgery gap a
+    // browser-direct caller could otherwise exploit. 15×2×1 = 30 is the correct value
+    // for this fixture's fields (unitPrice:15, quantity:2, no duration ⇒ 1).
+    expect((nat as Record<string, unknown>).lineTotal).toBe(30);
+    delete (nat as Record<string, unknown>).lineTotal;
     expect(nat).toEqual(svc);
   });
 

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -210,12 +210,16 @@ export async function buildDocumentData(
   // The line-item tree + categories come from Convex via buildDocumentLineItemData
   // (model/supplier/kit/asset/bulkAsset + per-line category/group selects, units in
   // the SELECT shape). client / location / subHire supplier are also Convex.
-  const [docData, locationMap, supplierMap, client] = await Promise.all([
+  const [docData, locationMap, supplierMap, clientRaw] = await Promise.all([
     buildDocumentLineItemData(projectId, organizationId),
     getLocationMap(organizationId),
     getSupplierMap(organizationId),
     projectRow.clientId ? getClientById(projectRow.clientId) : Promise.resolve(null),
   ]);
+  // getClientById resolves by a GLOBAL by_cuid index — re-check org ownership (see
+  // src/server/projects.ts getProject for the full rationale). A forged/stale
+  // cross-org clientId must not leak another org's billing details onto a PDF.
+  const client = clientRaw && clientRaw.organizationId === organizationId ? clientRaw : null;
   const project = {
     ...projectRow,
     client,

--- a/src/server/projects.ts
+++ b/src/server/projects.ts
@@ -411,7 +411,7 @@ export async function getProject(id: string) {
   // pmRows → media → location → equipment tree → client). At this app's data scale
   // the cost is round-trip COUNT × RTT, not payload, so collapsing the sequential
   // waterfall is the win.
-  const [pmRows, media0, locationMap, equipmentTree, client] = await Promise.all([
+  const [pmRows, media0, locationMap, equipmentTree, clientRaw] = await Promise.all([
     convexForProject.query(api.projectManagers.listByProject, { projectId: id, orgId: organizationId }),
     getProjectMediaFromConvex(id),
     projectScalars.locationId ? getLocationMap(organizationId) : Promise.resolve(null),
@@ -421,6 +421,11 @@ export async function getProject(id: string) {
     projectScalars.clientId ? getClientById(projectScalars.clientId) : Promise.resolve(null),
   ]);
   const media = withResolvedFile(media0);
+  // getClientById resolves by a GLOBAL by_cuid index — re-check org ownership here
+  // (defense in depth; the mutation-side FK is now org-validated too, but a project's
+  // clientId could still be stale/foreign from before that fix, or from a future write
+  // path that forgets the check). A foreign client must render as absent, not leaked.
+  const client = clientRaw && clientRaw.organizationId === organizationId ? clientRaw : null;
   const { categories, lineItems: topLineItems } = equipmentTree;
 
   // WAVE 2 — pmUsers (needs pmRows' ids) + overbooking (needs the line-item tree),

--- a/src/server/warehouse.ts
+++ b/src/server/warehouse.ts
@@ -38,11 +38,14 @@ export async function getProjectForWarehouse(projectId: string) {
   // ONE parallel wave (was 3 SEQUENTIAL round-trips: line-item tree → client →
   // location). All independent of each other — each needs only projectId/orgId or
   // the project scalars already read above.
-  const [lineItems, client, locationMap] = await Promise.all([
+  const [lineItems, clientRaw, locationMap] = await Promise.all([
     buildWarehouseLineItems(projectId, organizationId),
     project.clientId ? getClientById(project.clientId) : Promise.resolve(null),
     project.locationId ? getLocationMap(organizationId) : Promise.resolve(null),
   ]);
+  // getClientById resolves by a GLOBAL by_cuid index — re-check org ownership (see
+  // src/server/projects.ts getProject for the full rationale).
+  const client = clientRaw && clientRaw.organizationId === organizationId ? clientRaw : null;
   const location = project.locationId && locationMap ? locationMap.get(project.locationId) ?? null : null;
   return serialize({ ...project, lineItems, client, location });
 }
@@ -876,7 +879,10 @@ export async function getProjectPullSheet(projectId: string) {
   // Convex-attached tree as `project.lineItems` too (not the model/supplier-less
   // raw Prisma rows) so the payload stays byte-identical to the old include even
   // though current consumers read `groups`, not `project.lineItems`.
-  const client = project.clientId ? await getClientById(project.clientId) : null;
+  const clientRaw = project.clientId ? await getClientById(project.clientId) : null;
+  // getClientById resolves by a GLOBAL by_cuid index — re-check org ownership (see
+  // src/server/projects.ts getProject for the full rationale).
+  const client = clientRaw && clientRaw.organizationId === organizationId ? clientRaw : null;
   const location = project.locationId ? locationMap.get(project.locationId) ?? null : null;
   return serialize({
     project: { ...project, lineItems: attachedLineItems, client, location },


### PR DESCRIPTION
## Summary
Fixes from an independent adversarial security re-audit of this session's browser-direct Convex write surface (line-items + projects Slices A/B, PRs #584-#588). All findings were confirmed by reproduction before fixing, per the audit's own threat model: a malicious/buggy Convex client calling these mutations directly, bypassing the app's UI hooks entirely.

- **CRITICAL — cross-tenant client PII leak (IDOR).** `updateNative`/`createNative` (`convex/projectWrites.ts`) never org-validated a client-supplied `clientId`. Combined with 3 read-side call sites resolving a client by a *global* `by_cuid` index with no org re-check (`src/server/projects.ts` `getProject`, `src/server/warehouse.ts` x2, `src/lib/pdfme/build-document-data.ts`), a forged/stale cross-org `clientId` could leak another org's client name/contact/billing address onto a project page, warehouse view, or generated PDF. Fixed with a shared `assertRefInOrg` (extracted to `convex/lib/orgRef.ts`) on the write side, plus defense-in-depth org re-checks on all 3 reads.
- **CRITICAL — `addKitNative` had zero money validation** on `unitPrice`; a `NaN`/`Infinity` value poisoned the line and then the project's recalculated totals.
- **CRITICAL — `lineTotal` forgery.** `addNative`/`addCustomNative`/`patchNative` trusted a client-supplied `lineTotal` verbatim (bounds-checked but never verified against unitPrice×quantity×duration−discount), enabling same-org invoice forgery. Now always recomputed server-side, matching `addLineItemSmartNative`/`patchManyNative`'s existing pattern. A codex review pass on this fix caught a follow-up bug — `patchNative`'s recompute could be silently wiped by a stale client `clear: ["lineTotal"]` — fixed and regression-tested.
- **CRITICAL (medium confidence) — unguarded rental dates.** `rentalStartDate`/`rentalEndDate` could be set to `NaN`, silently defeating every double-booking overlap comparison (`NaN` comparisons are always `false` in JS).
- **MEDIUM — `defaultRentalQuantity` unguarded**, feeding `addLineItemSmartNative`'s auto-pricing duration.
- **MEDIUM — unbounded bulk arrays.** `removeManyNative`/`patchManyNative`/`reorderNative` had no cap on `ids`/`items` length; the per-user rate limiter charges one token per *call* regardless of array size, so an oversized array was an uncapped amplification vector. Added a 500-item cap (`assertBulkSizeOk`).

One pre-existing test (`writeParity.test.ts`) updated to reflect the `addNative`/`createLineItem` divergence — `createLineItem` has zero non-test callers (confirmed dead), so exact parity with it is no longer the right bar; the new value (30) is the mathematically correct `lineTotal` for the fixture's inputs.

## Review
Two codex passes: first caught both the `lineTotal`-forgery-guard gaps needing a fix plan; second (after fixes) caught the `patchNative` `clear` reconciliation bug above, which was fixed and covered by a new regression test before this PR.

## Test plan
- [x] `pnpm exec convex dev --once` (pushed to prod Convex, additive)
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 3694/3694 passing (260 files), including 15 new tests covering every fix
- [x] `npx next build` clean

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>