### PR TITLE
chore(convex): delete dead line-item/service bulk mutations

### DIFF
--- a/FEATUREDOCS/59-bulk-operations.md
+++ b/FEATUREDOCS/59-bulk-operations.md
@@ -49,6 +49,19 @@ checkboxes + a header select-all) and act on the whole selection at once:
   ≥1 item is selected — a shared "{n} selected + actions + Clear" bar extracted
   from the Assets pattern (`asset-table.tsx`). Escape clears the selection.
 
+> **⚠️ Superseded (Phase 3 browser-direct).** The server-action layer this
+> section describes (`src/server/line-items.ts`, `src/server/project-groups.ts`)
+> is gone — line-item bulk ops are now browser-direct via
+> `convex/lineItemWrites.ts` (`removeManyNative`/`patchManyNative`/
+> `reorderNative`, called through `src/hooks/use-line-item-writes.ts`), which
+> fold the same single-transaction batching + org-scoping this section
+> documents, plus a 500-item size cap and in-mutation `lineTotal` recompute
+> (never trusts a client-supplied value). The `projectLineItems.listByIdsForOrg`
+> / `patchMany` / `removeManyCascade` and `projectServices.removeManyCascade` /
+> `patchManyStatus` mutations named below were deleted as dead code once their
+> only callers (these server actions) were removed — kept here as a historical
+> record of the pre-migration design, not a description of current behavior.
+
 ## Server actions (batched)
 
 Each bulk action is **one server-action call → one bulk Convex mutation**. The

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -8,7 +8,6 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { ensureBulkUnit, ensureSerialisedUnit, expandAccessoryChildLines, syncLineItemRollup } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
-import { sanitizeClientSet } from "./lib/sanitizeSet";
 import * as enums from "./lib/validators";
 
 /**
@@ -727,89 +726,6 @@ export const removeLineItemCascade = mutation({
 });
 
 // ─── Bulk (multi-select) operations ────────────────────────────────────────
-// Each of these collapses an N-item bulk action into a SINGLE mutation/query
-// round-trip: the loop runs backend-local inside one Convex transaction instead
-// of the server firing one server→Convex call per item. Rows are org-scoped per
-// item (by_cuid is a global index — see CLAUDE.md), foreign/child rows skipped.
-// The caller recalcs affected projects + writes one bulk audit afterwards.
-
-/** Fetch many line items by cuid in one round-trip, row-scoped to the org (skips
- *  foreign rows — by_cuid is a global index). Used by the bulk edit/move server
- *  actions to compute per-item patches without an N-read fan-out. */
-export const listByIdsForOrg = query({
-  args: { ids: v.array(v.string()), orgId: v.string() },
-  handler: async (ctx, { ids, orgId }) => {
-    await requireService(ctx);
-    const out = [];
-    for (const id of ids) {
-      const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-      if (doc && doc.organizationId === orgId) out.push(doc);
-    }
-    return out;
-  },
-});
-
-/** Bulk cascade-delete N lines in one round-trip. Skips foreign-org and child
- *  (isKitChild) rows. Returns affected projectIds so the caller recalcs once. */
-export const removeManyCascade = mutation({
-  args: { ids: v.array(v.string()), orgId: v.string() },
-  handler: async (ctx, { ids, orgId }) => {
-    await requireService(ctx);
-    const projectIds = new Set<string>();
-    let removed = 0;
-    let skipped = 0;
-    for (const id of ids) {
-      const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-      if (!line || line.organizationId !== orgId) { skipped++; continue; }
-      if (line.isKitChild) { skipped++; continue; }
-      const children = await ctx.db
-        .query("projectLineItems")
-        .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", id))
-        .collect();
-      for (const c of children) await deleteLineWithUnits(ctx, c._id, c.id);
-      await deleteLineWithUnits(ctx, line._id, line.id);
-      projectIds.add(line.projectId);
-      removed++;
-    }
-    return { removed, skipped, projectIds: [...projectIds] };
-  },
-});
-
-/** Bulk patch/replace N lines in one round-trip. Each item carries its own
- *  set/clear (the caller precomputes per-row discount + lineTotal for edit, or
- *  groupId/categoryId for move). Skips foreign-org rows. Returns affected projectIds. */
-export const patchMany = mutation({
-  args: {
-    orgId: v.string(),
-    items: v.array(v.object({ id: v.string(), set: v.any(), clear: v.array(v.string()) })),
-  },
-  handler: async (ctx, { orgId, items }) => {
-    await requireService(ctx);
-    const projectIds = new Set<string>();
-    let updated = 0;
-    let skipped = 0;
-    for (const it of items) {
-      const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).unique();
-      if (!doc || doc.organizationId !== orgId) { skipped++; continue; }
-      const set = sanitizeClientSet(it.set, ["projectId"]); // strip organizationId/id/projectId
-      if (it.clear.length === 0) {
-        await ctx.db.patch(doc._id, set);
-      } else {
-        const { _id, _creationTime, ...rest } = doc;
-        const merged: Record<string, unknown> = { ...rest, ...set };
-        for (const k of it.clear) {
-          if (LINE_NEVER_CLEAR.has(k)) continue;
-          delete merged[k];
-        }
-        await ctx.db.replace(doc._id, merged as typeof rest);
-      }
-      projectIds.add(doc.projectId);
-      updated++;
-    }
-    return { updated, skipped, projectIds: [...projectIds] };
-  },
-});
-
 /** Atomic reorder: assign sortOrder = index (+ optional groupName) per id. */
 export const reorderLineItems = mutation({
   args: {

--- a/convex/projectServices.ts
+++ b/convex/projectServices.ts
@@ -1,7 +1,6 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
-import { bumpCountersForTable } from "./lib/counters";
 import * as enums from "./lib/validators";
 
 /**
@@ -248,84 +247,5 @@ export const patchService = mutation({
     for (const k of clear ?? []) patch[k] = undefined;
     await ctx.db.patch(doc._id, patch);
     return doc._id;
-  },
-});
-
-// ─── Bulk (multi-select) operations ────────────────────────────────────────
-// One mutation round-trip for an N-service bulk action instead of one
-// server→Convex call per row. Org-scoped per row; foreign rows skipped.
-
-/** Bulk status change across N services. */
-export const patchManyStatus = mutation({
-  args: {
-    ids: v.array(v.string()),
-    orgId: v.string(),
-    status: enums.ServiceStatus,
-    now: v.number(),
-  },
-  handler: async (ctx, { ids, orgId, status, now }) => {
-    await requireService(ctx);
-    const projectIds = new Set<string>();
-    let updated = 0;
-    let skipped = 0;
-    for (const id of ids) {
-      const doc = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-      if (!doc || doc.organizationId !== orgId) { skipped++; continue; }
-      await ctx.db.patch(doc._id, { status, updatedAt: now });
-      projectIds.add(doc.projectId);
-      updated++;
-    }
-    return { updated, skipped, projectIds: [...projectIds] };
-  },
-});
-
-/**
- * Bulk cascade-delete N services in one pass. Mirrors deleteProjectService per
- * row: removes the synthetic line item (+ children + units), the service's crew
- * assignments (+ shifts + linked time entries), then the service itself.
- */
-export const removeManyCascade = mutation({
-  args: { ids: v.array(v.string()), orgId: v.string() },
-  handler: async (ctx, { ids, orgId }) => {
-    await requireService(ctx);
-    const projectIds = new Set<string>();
-    let deleted = 0;
-    let skipped = 0;
-    for (const id of ids) {
-      const service = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-      if (!service || service.organizationId !== orgId) { skipped++; continue; }
-
-      // Synthetic line item cascade (children + units + the line).
-      if (service.lineItemId) {
-        const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", service.lineItemId!)).unique();
-        if (line) {
-          const children = await ctx.db
-            .query("projectLineItems")
-            .withIndex("by_parentLineItemId", (q) => q.eq("parentLineItemId", line.id))
-            .collect();
-          for (const c of [...children, line]) {
-            const units = await ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", c.id)).collect();
-            for (const u of units) await ctx.db.delete(u._id);
-            await ctx.db.delete(c._id);
-          }
-        }
-      }
-
-      // The service's crew assignments (+ shifts + linked time entries).
-      const assignments = await ctx.db.query("crewAssignments").withIndex("by_serviceId", (q) => q.eq("serviceId", id)).collect();
-      for (const a of assignments) {
-        const shifts = await ctx.db.query("crewShifts").withIndex("by_assignmentId", (q) => q.eq("assignmentId", a.id)).collect();
-        for (const s of shifts) await ctx.db.delete(s._id);
-        const entries = await ctx.db.query("crewTimeEntries").withIndex("by_assignmentId", (q) => q.eq("assignmentId", a.id)).collect();
-        for (const e of entries) await ctx.db.delete(e._id);
-        await ctx.db.delete(a._id);
-        await bumpCountersForTable(ctx, "crewAssignments", a, null);
-      }
-
-      await ctx.db.delete(service._id);
-      projectIds.add(service.projectId);
-      deleted++;
-    }
-    return { deleted, skipped, projectIds: [...projectIds] };
   },
 });

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -602,8 +602,8 @@ export const deleteNative = mutation({
     for (const a of assignments) await deleteCrewAssignmentCascadeCore(ctx, a);
 
     // Step 6 — project managers / tasks / services (org-filtered inline deletes).
-    // NOT projectServices.removeManyCascade — that would re-cascade lines/crew we
-    // already handled above.
+    // NOT a bulk-cascade helper — that would re-cascade lines/crew we already
+    // handled above.
     const pms = (
       await ctx.db.query("projectManagers").withIndex("by_projectId", (q) => q.eq("projectId", id)).collect()
     ).filter((r) => r.organizationId === orgId);


### PR DESCRIPTION
## Summary
- Deletes `projectLineItems.listByIdsForOrg`/`removeManyCascade`/`patchMany` and `projectServices.removeManyCascade`/`patchManyStatus` — the service-token CRUD helpers behind the now-deleted `src/server/line-items.ts`/`src/server/project-groups.ts` bulk-action server actions (superseded by browser-direct `removeManyNative`/`patchManyNative`/`reorderNative` in PRs #584/#585). Confirmed zero non-test callers repo-wide before deleting.
- Removes the now-orphaned `sanitizeClientSet`/`bumpCountersForTable` imports these left behind.
- Marks the relevant section of `FEATUREDOCS/59-bulk-operations.md` as superseded/historical rather than rewriting it (it documents the pre-migration server-action design).

This is part of the Phase 3 close-out hygiene sweep (`docs/phase-3-continuation-session-prompt-5.md` §3). Note: a broader repo-wide grep during this pass surfaced ~400 other Convex CRUD mirror mutations (e.g. `assets.create` vs the mandated `createIfMissing`) with no static caller — likely dead post-Postgres-decommission, but NOT touched here; that's a much larger cleanup that needs individual verification (possible dynamic dispatch) rather than a bulk delete, flagged separately for follow-up.

## Test plan
- [x] `pnpm exec convex dev --once` (pushed to prod Convex, deletion is safe/additive from the app's perspective — nothing called these)
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 3694/3694 passing (260 files, unchanged — these functions had zero test coverage)
- [x] `npx next build` clean
- [x] codex review clean (two trivial nits fixed: stale code comment, EOF whitespace)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>