### PR TITLE
docs(csv): close the Phase-3 CSV bulk-import throughput benchmark

### DIFF
--- a/FEATUREDOCS/20-csv-import-export.md
+++ b/FEATUREDOCS/20-csv-import-export.md
@@ -34,3 +34,39 @@ prop: `"models"`, `"assets"`, and `"rates"` (the rates-only import). The models
 table (`src/components/assets/model-table.tsx`) exposes an **Import Rates** button
 (gated on `model:update`) alongside Export/Import. Recommended flow: **Export →
 fill the rate columns in a spreadsheet → Import Rates**.
+
+## Performance (Phase-3 DoD benchmark, 2026-07-17)
+
+`importAssetsCSV` was benchmarked against prod via `scripts/benchmark-csv-import.ts`
+(the closing item on the original Phase-3 DoD, which called for a throughput check
+"vs the 16k-write/1s-CPU Convex budget"). Results:
+
+| Rows | Concurrency | Wall clock | ms/row |
+|---|---|---|---|
+| 200 | 1 | 111.8s | 559.0 |
+| 500 | 1 | 265.0s | 530.0 |
+| 1000 | 1 | 527.7s | 527.7 |
+| 500 | 4 (2000 total) | 1048.6s | 524.3 |
+
+**Finding: the 16k-write/1s-CPU budget doesn't apply here, and that's the problem.**
+That budget concerns a single Convex mutation's internal write count — but
+`importAssetsCSV` does the opposite of batching: it calls `getConvexClient()` and
+issues one `api.assets.create`/`patchAsset` mutation **per CSV row**, sequentially
+awaited inside a `for` loop in the Next.js server action. So it never risks the
+per-mutation budget (each mutation writes exactly one row), but it also never gets
+the wall-clock benefit of batching — throughput is pure server→Convex round-trip
+latency × row count, a flat **~525-530ms/row regardless of single-call row count
+(200-1000) or concurrent callers (1 vs 4, even at 2000 total rows — no contention,
+but no speedup either)**. A 1000-row import takes **~8.8 minutes** in one blocking
+server-action call — well past any reasonable request timeout or acceptable UI
+wait, for a CSV size a real customer could plausibly upload.
+
+**Not fixed in this pass** (out of scope for a benchmark-only DoD item; flagged as
+a follow-up). The fix, if/when CSV import volume becomes a real usage pattern, is
+the same pattern already applied to line-items/projects this session: collapse the
+per-row loop into ONE backend-local Convex mutation that loops `rows` inside a
+single transaction (see `convex/lineItemWrites.ts` `removeManyNative`/
+`patchManyNative` for the established shape), which trades N round-trips for one —
+at which point the 16k-write/1s-CPU per-mutation budget *does* become the relevant
+constraint, and would need its own row-count cap (mirroring `assertBulkSizeOk` in
+`convex/lib/rateLimiter.ts`).

--- a/scripts/benchmark-csv-import.ts
+++ b/scripts/benchmark-csv-import.ts
@@ -1,0 +1,114 @@
+/**
+ * Phase-3 DoD benchmark: CSV bulk-asset-import throughput.
+ *
+ * Measures importAssetsCSV (src/server/csv.ts) wall-clock at 50/200/500/1000 rows
+ * per call, at 1/4/8 concurrent import calls, against a dedicated throwaway model.
+ * Every asset it creates is deleted again immediately after each measurement point
+ * (never left sitting in the org) — the throwaway model is deleted at the end.
+ *
+ * Runs importAssetsCSV for real (through requirePermission("asset","import") via
+ * runWithActor, exactly like an API-key caller would), so this measures the actual
+ * code path, not a synthetic approximation.
+ *
+ * Usage: pnpm tsx --env-file=.env --env-file=.env.local scripts/benchmark-csv-import.ts
+ */
+import { createId } from "@paralleldrive/cuid2";
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { runWithActor } from "@/lib/request-actor";
+import { importAssetsCSV } from "@/server/csv";
+import { api } from "../convex/_generated/api";
+
+// Round 1 (RUN_ID qx9303n8) already measured rows=50 at concurrency=1/4/8 with
+// ~530ms/row in every case — concurrency doesn't change per-row throughput (no
+// contention/speedup). This round fills in the still-unmeasured single-call
+// row-count curve, plus one larger-scale concurrency check to confirm the
+// no-speedup trend holds at volume. Kept lean (not the full 4×3 cross-product)
+// because the constant per-row rate already answers the concurrency question —
+// see scripts/benchmark-csv-import.ts git history / the report for round 1's data.
+const MATRIX: Array<{ rowCount: number; concurrency: number }> = [
+  { rowCount: 200, concurrency: 1 },
+  { rowCount: 500, concurrency: 1 },
+  { rowCount: 1000, concurrency: 1 },
+  { rowCount: 500, concurrency: 4 },
+];
+const RUN_ID = createId().slice(0, 8);
+
+function buildCsv(rowCount: number, modelName: string, tagPrefix: string): string {
+  const lines = ["assetTag,modelName,status,condition"];
+  for (let i = 0; i < rowCount; i++) {
+    lines.push(`${tagPrefix}-${i},${modelName},AVAILABLE,GOOD`);
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const org = await prisma.organization.findFirst();
+  if (!org) throw new Error("No organization found.");
+  const owner = await prisma.member.findFirst({ where: { organizationId: org.id, role: "owner" }, include: { user: true } });
+  if (!owner) throw new Error("No owner member found.");
+  const actor = { organizationId: org.id, userId: owner.userId, userName: owner.user?.name ?? "Benchmark", actorType: "session" as const };
+  console.log(`Org: ${org.name} (${org.id}) — actor: ${owner.user?.email}`);
+
+  // getConvexClient() is called FRESH before every mutation/query below (never a
+  // cached reference held across the loop) — the service token has a ~5-6min TTL
+  // and round 1 died mid-run from exactly this (InvalidAuthHeader: token expired).
+  const modelId = createId();
+  const modelName = `BENCH-MODEL-${RUN_ID}`;
+  await (await getConvexClient()).mutation(api.models.createIfMissing, {
+    id: modelId,
+    organizationId: org.id,
+    name: modelName,
+    assetType: "SERIALIZED",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  console.log(`Seeded throwaway model ${modelName} (${modelId})`);
+
+  type Row = { rowCount: number; concurrency: number; ms: number; created: number; errors: number };
+  const results: Row[] = [];
+
+  for (const { rowCount, concurrency } of MATRIX) {
+    const tagPrefix = `BENCH-${RUN_ID}-${rowCount}x${concurrency}`;
+    const csvs = Array.from({ length: concurrency }, (_, c) => buildCsv(rowCount, modelName, `${tagPrefix}-${c}`));
+
+    const start = performance.now();
+    const outcomes = await Promise.all(
+      csvs.map((csv) => runWithActor(actor, () => importAssetsCSV(csv))),
+    );
+    const ms = performance.now() - start;
+
+    const created = outcomes.reduce((s, o) => s + o.created, 0);
+    const errors = outcomes.reduce((s, o) => s + o.errors.length, 0);
+    results.push({ rowCount, concurrency, ms, created, errors });
+    console.log(
+      `rows=${rowCount} concurrency=${concurrency} → ${ms.toFixed(0)}ms, created=${created}, errors=${errors}` +
+        (errors > 0 ? ` (sample: ${JSON.stringify(outcomes.find((o) => o.errors.length)?.errors[0])})` : ""),
+    );
+
+    // Clean up immediately — never leave benchmark rows sitting in the org.
+    const listConvex = await getConvexClient();
+    const created_assets = await listConvex.query(api.assets.list, { orgId: org.id });
+    const toDelete = created_assets.filter((a: { assetTag: string; id: string }) => a.assetTag.startsWith(tagPrefix));
+    for (const a of toDelete as { id: string }[]) {
+      await (await getConvexClient()).mutation(api.assets.remove, { id: a.id });
+    }
+    console.log(`  cleaned up ${toDelete.length} assets`);
+  }
+
+  await (await getConvexClient()).mutation(api.models.remove, { id: modelId });
+  console.log(`Cleaned up model ${modelName}.`);
+
+  console.log("\n=== Results ===");
+  console.log("rows\tconcurrency\tms\tms/row\tcreated\terrors");
+  for (const r of results) {
+    console.log(`${r.rowCount}\t${r.concurrency}\t${r.ms.toFixed(0)}\t${(r.ms / (r.rowCount * r.concurrency)).toFixed(2)}\t${r.created}\t${r.errors}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
Closes the last open item on the original Phase-3 DoD: a CSV bulk-import throughput benchmark. Ran `importAssetsCSV` against prod at 200/500/1000 rows and 1/4 concurrent callers (up to 2000 total rows), cleaning up every throwaway asset/model it created (verified 0 orphans after each run).

**Finding:** ~525-530ms/row, flat across every row count (200-1000) and concurrency level (1 vs 4) tested — no batching, no contention, no speedup from concurrency. A 1000-row import takes **~8.8 minutes** in one blocking server-action call. The DoD's framing ("vs the 16k-write/1s-CPU Convex budget") doesn't apply as-is: `importAssetsCSV` issues one Convex mutation *per row* instead of batching rows into a single mutation, so it's bottlenecked by round-trip count × latency, not the per-mutation write budget.

Documented in `FEATUREDOCS/20-csv-import-export.md` (new Performance section) with the fix path if CSV import volume becomes a real usage pattern — collapse the per-row loop into one backend-local Convex mutation, mirroring the `removeManyNative`/`patchManyNative` pattern already established for line-items this session. **Not fixed here** — this PR is benchmark + documentation only, per the original DoD scope.

`scripts/benchmark-csv-import.ts` is kept as a reusable script for re-running this in the future.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint scripts/benchmark-csv-import.ts` clean
- [x] `npm test` — 3694/3694 passing (unaffected, docs + script only)
- [x] Ran for real against prod: 4 data points, 0 errors, all throwaway rows + the throwaway model cleaned up (double-verified 0 orphaned `BENCH-*` rows remain)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>