### PR TITLE
fix(security): locationId cross-tenant IDOR + project-service money forgery (Phase-3 audit)

### DIFF
--- a/convex/lib/orgRef.ts
+++ b/convex/lib/orgRef.ts
@@ -9,7 +9,18 @@ import type { MutationCtx } from "../_generated/server";
  */
 export async function assertRefInOrg(
   ctx: MutationCtx,
-  table: "models" | "assets" | "bulkAssets" | "projectGroups" | "projectCategories" | "clients",
+  table:
+    | "models"
+    | "assets"
+    | "bulkAssets"
+    | "projectGroups"
+    | "projectCategories"
+    | "clients"
+    | "locations"
+    | "suppliers"
+    | "kits"
+    | "categories"
+    | "testProfiles",
   id: string,
   orgId: string,
 ): Promise<void> {

--- a/convex/projectServicesWrites.ts
+++ b/convex/projectServicesWrites.ts
@@ -62,7 +62,9 @@ function calculateServiceLineTotal(
   discount: number | undefined,
 ): number | null {
   if (unitPrice == null || unitPrice === 0) return null;
-  const disc = discount ?? 0;
+  // Clamp the discount non-negative here too (defense-in-depth): a negative discount must
+  // never add to the line total even if a caller reaches this without the guard above.
+  const disc = Math.max(0, discount ?? 0);
   return Math.max(0, round(unitPrice - disc));
 }
 
@@ -161,6 +163,16 @@ function buildServiceFields(a: ServiceInput) {
   assertFinite(a.unitPrice, "unitPrice");
   assertFinite(a.discount, "discount");
   assertFinite(a.costTotal, "costTotal");
+  // Bound money NON-NEGATIVE (browser-direct bypasses the server Zod min(0)). A negative
+  // discount would INFLATE the customer-facing service line total (max(0, unitPrice - disc)
+  // → serviceRevenue → project total); a negative costTotal would INFLATE project margin
+  // (margin = total - costs). Both are money forgery, so reject them.
+  if (a.unitPrice != null && a.unitPrice < 0)
+    throw new ConvexError({ code: "INVALID_MONEY", message: "Service unit price cannot be negative." });
+  if (a.discount != null && a.discount < 0)
+    throw new ConvexError({ code: "INVALID_MONEY", message: "Service discount cannot be negative." });
+  if (a.costTotal != null && a.costTotal < 0)
+    throw new ConvexError({ code: "INVALID_MONEY", message: "Service cost cannot be negative." });
   const serviceDate = a.date ?? null;
   let serviceEndDate = a.endDate ?? serviceDate;
   if (!MULTI_DAY_TYPES.has(a.type)) serviceEndDate = serviceDate;

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -297,6 +297,14 @@ export const updateNative = mutation({
     if (typeof setObj.clientId === "string") {
       await assertRefInOrg(ctx, "clients", setObj.clientId, orgId);
     }
+    // Same class as clientId (a sibling the earlier IDOR fix missed): locationId is
+    // resolved by service-token server reads (crew-calendar/project-services) via a GLOBAL
+    // by_cuid `getLocationById` that no-ops requireOrgReadDoc for service tokens — so a
+    // browser-direct caller could point their project at another org's location and leak
+    // its name + physical street address. Validate on write (the only reliable guard).
+    if (typeof setObj.locationId === "string") {
+      await assertRefInOrg(ctx, "locations", setObj.locationId, orgId);
+    }
 
     // A general update that also moves the status FORWARD into PREPPING/CHECKED_OUT/ON_SITE
     // must clear the blocking-comment gate too (parity with the server updateProject path).
@@ -388,6 +396,10 @@ export const createNative = mutation({
     // this closes (a global by_cuid client read with no org re-check downstream).
     if (fields.clientId) {
       await assertRefInOrg(ctx, "clients", fields.clientId, fields.organizationId);
+    }
+    // locationId — same cross-tenant leak class as clientId (see updateNative's comment).
+    if (fields.locationId) {
+      await assertRefInOrg(ctx, "locations", fields.locationId, fields.organizationId);
     }
 
     // Dup-guard the client-minted cuid first (applies to both number paths). The


### PR DESCRIPTION
Independent Phase-3 re-audit found two confirmed holes #589 missed on the browser-direct write surface:

1. **Cross-tenant IDOR (HIGH):** `projectWrites` validated client `clientId` but not `locationId` — a member could point their project at another org's location and leak its name + street address (service-token server reads resolve it unfiltered). Now `assertRefInOrg`-validated on write.
2. **Money forgery (HIGH):** `projectServicesWrites` only `assertFinite`'d discount/costTotal — a negative discount inflated the customer-facing total, a negative costTotal inflated margin. Now bounded non-negative + a defense-in-depth clamp.

Deploy-safe (rejects only cross-org/negative that legit callers never send). codex clean; tsc + tests + build green; convex deployed.