### PR TITLE
fix(security): org-validate client FKs across browser-direct writes (Phase-3 audit)

### DIFF
--- a/convex/assetWrites.test.ts
+++ b/convex/assetWrites.test.ts
@@ -235,6 +235,7 @@ describe("assetWrites.createNative", () => {
     const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "M1" });
     });
     const res = await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs);
     expect(res.id).toBe("new1");
@@ -268,6 +269,7 @@ describe("assetWrites.createNative", () => {
     const t = makeT();
     await t.run(async (ctx) => {
       await ctx.db.insert("members", { id: "mem1", organizationId: ORG, userId: USER, role: "member" });
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "M1" });
     });
     await t.withIdentity(asUser(ORG)).mutation(api.assetWrites.createNative, createArgs);
     // Same id, different tag (so it's the id guard firing, not the tag guard).

--- a/convex/assetWrites.ts
+++ b/convex/assetWrites.ts
@@ -9,6 +9,7 @@ import { bumpAssetCounters, bumpCountersForTable } from "./lib/counters";
 import { assertFinite } from "./lib/moneyGuards";
 import { reserveAssetTagCounter } from "./lib/assetTagCounter";
 import { registerAssetTestTag, backfillTestTagAssetsCore } from "./lib/testtagBackfill";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -341,6 +342,14 @@ export const createNative = mutation({
       });
     }
 
+    // Org-validate every client-supplied FK (by_cuid is GLOBAL — the referenced row
+    // could belong to another org; the service-token read path never re-checks).
+    await assertRefInOrg(ctx, "models", fields.modelId, fields.organizationId);
+    if (fields.locationId) await assertRefInOrg(ctx, "locations", fields.locationId, fields.organizationId);
+    if (fields.supplierId) await assertRefInOrg(ctx, "suppliers", fields.supplierId, fields.organizationId);
+    if (fields.parentAssetId) await assertRefInOrg(ctx, "assets", fields.parentAssetId, fields.organizationId);
+    if (fields.kitId) await assertRefInOrg(ctx, "kits", fields.kitId, fields.organizationId);
+
     await ctx.db.insert("assets", fields);
     await bumpAssetCounters(ctx, fields.organizationId, null, fields);
     const createNow = fields.createdAt ?? fields.updatedAt ?? 0;
@@ -413,6 +422,14 @@ export const updateNative = mutation({
         });
       }
     }
+
+    // Org-validate any client-supplied FK present in the sanitized `set` (by_cuid is
+    // GLOBAL — a member of org A must not point their asset at org B's model/location/…).
+    if (typeof set.modelId === "string") await assertRefInOrg(ctx, "models", set.modelId, orgId);
+    if (typeof set.locationId === "string") await assertRefInOrg(ctx, "locations", set.locationId, orgId);
+    if (typeof set.supplierId === "string") await assertRefInOrg(ctx, "suppliers", set.supplierId, orgId);
+    if (typeof set.parentAssetId === "string") await assertRefInOrg(ctx, "assets", set.parentAssetId, orgId);
+    if (typeof set.kitId === "string") await assertRefInOrg(ctx, "kits", set.kitId, orgId);
 
     // Apply set (+ clear-to-null) — the patchAsset pattern. Stamp updatedAt from the
     // mutation `now` (the client `set` omits it; parity with the old updateAsset).
@@ -518,6 +535,10 @@ export const createManyNative = mutation({
       const dup = await ctx.db.query("assets")
         .withIndex("by_organizationId_assetTag", (q) => q.eq("organizationId", orgId).eq("assetTag", a.assetTag)).first();
       if (dup) throw new ConvexError({ code: "DUPLICATE_ASSET_TAG", tag: a.assetTag, message: `Asset tag "${a.assetTag}" already exists.` });
+      // Org-validate the client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+      await assertRefInOrg(ctx, "models", a.modelId, orgId);
+      if (a.locationId) await assertRefInOrg(ctx, "locations", a.locationId, orgId);
+      if (a.supplierId) await assertRefInOrg(ctx, "suppliers", a.supplierId, orgId);
       const { auditId: _auditId, ...assetFields } = a;
       const fields = { ...assetFields, organizationId: orgId, createdAt: now, updatedAt: now };
       await ctx.db.insert("assets", fields);
@@ -555,6 +576,9 @@ export const bulkUpdateNative = mutation({
     await requireOrgPermission(ctx, orgId, "asset", "update");
     if (ids.length === 0) throw new ConvexError("Nothing selected");
     if (Object.keys(set).length === 0 && clear.length === 0) throw new ConvexError("No changes specified");
+
+    // Org-validate the one client-supplied FK in the shared set (by_cuid is GLOBAL).
+    if (set.locationId) await assertRefInOrg(ctx, "locations", set.locationId, orgId);
 
     const patch = { ...set, updatedAt: now };
     let count = 0;

--- a/convex/bulkAssetsWrites.test.ts
+++ b/convex/bulkAssetsWrites.test.ts
@@ -27,7 +27,12 @@ function makeT(): T {
   return t;
 }
 async function seedMember(t: T, role = "admin") {
-  await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role }); });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role });
+    // Model the `base` fixture (modelId "mdl1") references — createNative/updateNative now
+    // org-validate the modelId FK, so the referenced model must exist in the org.
+    await ctx.db.insert("models", { id: "mdl1", organizationId: ORG, name: "Cable" });
+  });
 }
 const bulk = (t: T, id: string) => t.run(async (ctx) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).first());
 const base = { id: "bk1", orgId: ORG, modelId: "mdl1", assetTag: "BK-1", totalQuantity: 5, now: NOW, actor, auditId: "a1" } as const;
@@ -100,7 +105,7 @@ describe("bulkAssets reads", () => {
   test("listPage: active only, tag asc, with model+location, org-scoped", async () => {
     const t = makeT(); await seedMember(t);
     await t.run(async (ctx) => {
-      await ctx.db.insert("models", { id: "mdl1", organizationId: ORG, name: "Cable" });
+      // model "mdl1" (name "Cable") is already seeded by seedMember.
       await ctx.db.insert("locations", { id: "loc1", organizationId: ORG, name: "Warehouse", type: "WAREHOUSE" });
       await ctx.db.insert("bulkAssets", { id: "b2", organizationId: ORG, assetTag: "B", modelId: "mdl1", locationId: "loc1", isActive: true });
       await ctx.db.insert("bulkAssets", { id: "b1", organizationId: ORG, assetTag: "A", modelId: "mdl1", isActive: true });

--- a/convex/bulkAssetsWrites.ts
+++ b/convex/bulkAssetsWrites.ts
@@ -7,6 +7,7 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { bumpCountersForTable } from "./lib/counters";
 import { reserveAssetTagCounter } from "./lib/assetTagCounter";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -82,6 +83,10 @@ export const createNative = mutation({
       .withIndex("by_organizationId_assetTag", (q) => q.eq("organizationId", a.orgId).eq("assetTag", a.assetTag)).first();
     if (dupTag) throw new ConvexError(`Asset tag "${a.assetTag}" already exists.`);
 
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    await assertRefInOrg(ctx, "models", a.modelId, a.orgId);
+    if (a.locationId) await assertRefInOrg(ctx, "locations", a.locationId, a.orgId);
+
     const total = a.totalQuantity ?? 0;
     const doc = {
       id: a.id,
@@ -129,6 +134,10 @@ export const updateNative = mutation({
         .withIndex("by_organizationId_assetTag", (q) => q.eq("organizationId", a.orgId).eq("assetTag", a.assetTag)).first();
       if (dup && dup.id !== a.id) throw new ConvexError(`Asset tag "${a.assetTag}" already exists.`);
     }
+
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    await assertRefInOrg(ctx, "models", a.modelId, a.orgId);
+    if (a.locationId) await assertRefInOrg(ctx, "locations", a.locationId, a.orgId);
 
     // Availability recompute from the total delta (parity).
     const prevTotal = doc.totalQuantity ?? 0;

--- a/convex/categoriesWrites.ts
+++ b/convex/categoriesWrites.ts
@@ -5,6 +5,7 @@ import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
+import { assertRefInOrg } from "./lib/orgRef";
 
 /**
  * Native CATEGORY write mutations (Phase 3 browser-direct — replaces createCategory/
@@ -63,6 +64,9 @@ export const createNative = mutation({
     const dup = await ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dup) throw new ConvexError("Category already exists");
 
+    // Org-validate the client-supplied parent FK (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.parentId) await assertRefInOrg(ctx, "categories", a.parentId, a.orgId);
+
     await ctx.db.insert("categories", {
       id: a.id,
       organizationId: a.orgId,
@@ -99,6 +103,9 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (!doc || doc.organizationId !== a.orgId) throw new ConvexError("Category not found");
+
+    // Org-validate the client-supplied parent FK (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.parentId) await assertRefInOrg(ctx, "categories", a.parentId, a.orgId);
 
     // Clears use `undefined` (Convex removes the optional; the schema rejects null).
     await ctx.db.patch(doc._id, {

--- a/convex/crewAssignmentsWrites.ts
+++ b/convex/crewAssignmentsWrites.ts
@@ -8,7 +8,21 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { bumpCountersForTable } from "./lib/counters";
 import { resolveRate, calculateEstimatedCost } from "./lib/crewRate";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
+
+/**
+ * Reject a non-finite OR negative money/hours input before it flows into resolveRate /
+ * calculateEstimatedCost → estimatedCost → project labourCostTotal. Convex `v.number()`
+ * accepts NaN/Infinity/negatives; a browser-direct caller bypasses the server-side Zod,
+ * and a negative/Infinity rate silently poisons the project's margin. `null`/`undefined`
+ * skip (unset). */
+function assertCrewMoney(value: number | undefined, field: string): void {
+  if (value == null) return;
+  if (!Number.isFinite(value) || value < 0) {
+    throw new ConvexError({ code: "INVALID_NUMBER", message: `${field} must be a non-negative finite number.` });
+  }
+}
 
 /**
  * Native CREW-ASSIGNMENT + shift write mutations (Phase 3 browser-direct — replaces
@@ -90,6 +104,13 @@ export const createNative = mutation({
     const dup = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dup) throw new ConvexError("Assignment already exists");
 
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak) + bound
+    // the money inputs (a negative/Infinity rate poisons labourCostTotal → project margin).
+    if (a.crewRoleId) await assertRefInOrg(ctx, "crewRoles", a.crewRoleId, a.orgId);
+    if (a.serviceId) await assertRefInOrg(ctx, "projectServices", a.serviceId, a.orgId);
+    assertCrewMoney(a.rateOverride, "rateOverride");
+    assertCrewMoney(a.estimatedHours, "estimatedHours");
+
     const { crewMember, crewRole } = await rateInputs(ctx, a.orgId, a.crewMemberId, a.crewRoleId);
     const { rate, rateType } = resolveRate(a.rateOverride, a.rateType ?? null, crewMember, crewRole);
     const estimatedCost = calculateEstimatedCost(rate, rateType, a.startDate ?? null, a.endDate ?? null, a.estimatedHours ?? null);
@@ -131,6 +152,14 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (!doc || doc.organizationId !== a.orgId) throw new ConvexError("Assignment not found");
+
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak) + bound
+    // the money inputs (a negative/Infinity rate poisons labourCostTotal → project margin).
+    if (a.crewRoleId) await assertRefInOrg(ctx, "crewRoles", a.crewRoleId, a.orgId);
+    if (a.serviceId) await assertRefInOrg(ctx, "projectServices", a.serviceId, a.orgId);
+    assertCrewMoney(a.rateOverride, "rateOverride");
+    assertCrewMoney(a.estimatedHours, "estimatedHours");
+
     const { crewMember, crewRole } = await rateInputs(ctx, a.orgId, doc.crewMemberId, a.crewRoleId);
     const { rate, rateType } = resolveRate(a.rateOverride, a.rateType ?? null, crewMember, crewRole);
     const estimatedCost = calculateEstimatedCost(rate, rateType, a.startDate ?? null, a.endDate ?? null, a.estimatedHours ?? null);

--- a/convex/groupTemplatesWrites.test.ts
+++ b/convex/groupTemplatesWrites.test.ts
@@ -222,6 +222,9 @@ describe("groupTemplatesWrites.applyNative", () => {
       await ctx.db.insert("groupTemplateItems", { id: "it2", organizationId: ORG, templateId: "tpl1", kitId: "k1", quantity: 1, sortOrder: 1 });
       await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "Speaker", dailyRate: 100, weeklyRate: 500 });
       await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "K1", name: "Rack", status: opts.kitStatus ?? "AVAILABLE" });
+      // projectCategory the args reference (categoryId "cat1") — applyNative now
+      // org-validates that FK, so it must exist in the org/project.
+      await ctx.db.insert("projectCategories", { id: "cat1", organizationId: ORG, projectId: "p1", name: "Cat", sortOrder: 0, createdAt: NOW, updatedAt: NOW });
       await ctx.db.insert("projects", {
         id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Gig", status: "CONFIRMED",
         defaultRentalPeriod: "DAILY", defaultRentalQuantity: 1, total: 999,

--- a/convex/groupTemplatesWrites.ts
+++ b/convex/groupTemplatesWrites.ts
@@ -10,6 +10,7 @@ import { writeActivityLog } from "./lib/audit";
 import { createKitLineItemCore } from "./projectLineItems";
 import { findKitConflict } from "./lib/availabilityCore";
 import { recalcProjectTotals } from "./lib/recalc";
+import { assertRefInOrg } from "./lib/orgRef";
 
 /**
  * Native GROUP-TEMPLATE write mutations (Phase 3 browser-direct — replaces the
@@ -392,6 +393,12 @@ export const applyNative = mutation({
     // foreign project here would corrupt another org's totals).
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", a.projectId)).first();
     if (!project || project.organizationId !== a.orgId) throw new ConvexError("Project not found");
+
+    // Org-validate the client-supplied categoryId FK (by_cuid is GLOBAL — cross-org refs leak).
+    // A group's categoryId references the PROJECT-scoped projectCategories table (same as
+    // projectGroupsWrites.createGroupNative + the line-item add paths), NOT the global model
+    // catalog `categories` — validating against the wrong table would reject every legit apply.
+    if (a.categoryId) await assertRefInOrg(ctx, "projectCategories", a.categoryId, a.orgId);
 
     // Org default tax rate (Postgres-authoritative mirror; read inline, NOT a client arg).
     const settingsRow = await ctx.db

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -9,6 +9,7 @@ import { writeActivityLog } from "./lib/audit";
 import { reserveAssetTagCounter } from "./lib/assetTagCounter";
 import { adjustBulkAvailability } from "./lib/inventory";
 import { releaseKitMembers, getKitGuarded, assignAssetToKit, releaseAsset, getAssetDoc } from "./kits";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -108,6 +109,10 @@ export const createNative = mutation({
     const dupId = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
     if (dupId) throw new ConvexError("Kit already exists");
 
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    if (fields.categoryId) await assertRefInOrg(ctx, "categories", fields.categoryId, fields.organizationId);
+    if (fields.locationId) await assertRefInOrg(ctx, "locations", fields.locationId, fields.organizationId);
+
     await ctx.db.insert("kits", fields);
     // Advance the asset-tag counter (parity — createKit reserved 1 after insert).
     await reserveAssetTagCounter(ctx, fields.organizationId, 1, fields.createdAt ?? fields.updatedAt ?? 0);
@@ -165,6 +170,10 @@ export const updateNative = mutation({
         });
       }
     }
+
+    // Org-validate client-supplied FKs in the patch (by_cuid is GLOBAL — cross-org refs leak).
+    if (patch.categoryId) await assertRefInOrg(ctx, "categories", patch.categoryId, orgId);
+    if (patch.locationId) await assertRefInOrg(ctx, "locations", patch.locationId, orgId);
 
     await ctx.db.patch(doc._id, sanitizeClientSet(patch)); // strip organizationId/id — no cross-tenant reassign
 

--- a/convex/lib/orgRef.ts
+++ b/convex/lib/orgRef.ts
@@ -20,7 +20,9 @@ export async function assertRefInOrg(
     | "suppliers"
     | "kits"
     | "categories"
-    | "testProfiles",
+    | "testProfiles"
+    | "crewRoles"
+    | "projectServices",
   id: string,
   orgId: string,
 ): Promise<void> {

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -869,6 +869,16 @@ export const addNative = mutation({
     await assertProjectInOrg(ctx, projectId, organizationId);
     assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
 
+    // Org-validate every referenced FK (by_cuid is global — the row could be another
+    // org's; the service-token read path resolves these with no org re-check). Same
+    // block as addLineItemSmartNative, plus supplierId (validated by neither add path before).
+    if (fields.modelId) await assertRefInOrg(ctx, "models", fields.modelId, organizationId);
+    if (fields.assetId) await assertRefInOrg(ctx, "assets", fields.assetId, organizationId);
+    if (fields.bulkAssetId) await assertRefInOrg(ctx, "bulkAssets", fields.bulkAssetId, organizationId);
+    if (fields.groupId) await assertRefInOrg(ctx, "projectGroups", fields.groupId, organizationId);
+    if (fields.categoryId) await assertRefInOrg(ctx, "projectCategories", fields.categoryId, organizationId);
+    if (fields.supplierId) await assertRefInOrg(ctx, "suppliers", fields.supplierId, organizationId);
+
     // lineTotal is a DERIVED value (unitPrice × quantity × duration − discount) —
     // assertLineMoneyFields only bounds it, it doesn't verify it matches its inputs. A
     // browser-direct caller could otherwise send `unitPrice: 1` (passes the bound check)
@@ -1306,6 +1316,7 @@ export const addLineItemSmartNative = mutation({
     if (fields.bulkAssetId) await assertRefInOrg(ctx, "bulkAssets", fields.bulkAssetId, organizationId);
     if (fields.groupId) await assertRefInOrg(ctx, "projectGroups", fields.groupId, organizationId);
     if (fields.categoryId) await assertRefInOrg(ctx, "projectCategories", fields.categoryId, organizationId);
+    if (fields.supplierId) await assertRefInOrg(ctx, "suppliers", fields.supplierId, organizationId);
 
     // ── Availability / double-booking (copied verbatim from addNative) ─────────
     if (fields.type === "EQUIPMENT" && fields.modelId && !allowOverbook) {

--- a/convex/locationsWrites.ts
+++ b/convex/locationsWrites.ts
@@ -5,6 +5,7 @@ import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -60,6 +61,8 @@ export const createNative = mutation({
 
     const dup = await ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dup) throw new ConvexError("Location already exists");
+    // Org-validate the client-supplied parent FK (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.parentId) await assertRefInOrg(ctx, "locations", a.parentId, a.orgId);
     if (a.isDefault) await unsetOtherDefaults(ctx, a.orgId, undefined, a.now);
 
     await ctx.db.insert("locations", {
@@ -85,6 +88,8 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("locations").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (!doc || doc.organizationId !== a.orgId) throw new ConvexError("Location not found");
+    // Org-validate the client-supplied parent FK (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.parentId) await assertRefInOrg(ctx, "locations", a.parentId, a.orgId);
     if (a.isDefault) await unsetOtherDefaults(ctx, a.orgId, a.id, a.now);
 
     // Clears use `undefined` (schema optionals reject null).

--- a/convex/modelWrites.ts
+++ b/convex/modelWrites.ts
@@ -7,6 +7,7 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { bumpCountersForTable } from "./lib/counters";
 import { backfillTestTagAssetsCore, orgDefaultIntervalMonths } from "./lib/testtagBackfill";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -151,6 +152,10 @@ export const createNative = mutation({
     const dup = await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dup) throw new ConvexError("Model already exists");
 
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.categoryId) await assertRefInOrg(ctx, "categories", a.categoryId, a.orgId);
+    if (a.defaultTestProfileId) await assertRefInOrg(ctx, "testProfiles", a.defaultTestProfileId, a.orgId);
+
     await ctx.db.insert("models", { id: a.id, organizationId: a.orgId, ...toDoc(a), createdAt: a.now, updatedAt: a.now });
 
     if (a.requiresTestAndTag) await backfillTestTagAssetsCore(ctx, a.orgId, a.now);
@@ -175,6 +180,10 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (!doc || doc.organizationId !== a.orgId) throw new ConvexError("Model not found");
+
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.categoryId) await assertRefInOrg(ctx, "categories", a.categoryId, a.orgId);
+    if (a.defaultTestProfileId) await assertRefInOrg(ctx, "testProfiles", a.defaultTestProfileId, a.orgId);
 
     await ctx.db.patch(doc._id, { ...toDoc(a), updatedAt: a.now });
 

--- a/convex/projectCategoriesWrites.ts
+++ b/convex/projectCategoriesWrites.ts
@@ -5,6 +5,7 @@ import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
+import { assertProjectInOrg } from "./projectLineItems";
 
 /**
  * Native PROJECT-CATEGORY write mutations (Phase 3 browser-direct — replaces the
@@ -112,6 +113,10 @@ export const createCategoryNative = mutation({
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
     const actor = await resolveActor(ctx, suppliedActor);
     assertValidName(name);
+    // Client-supplied projectId: prove it's the caller's org before inserting a category
+    // that references it (by_cuid/by_projectId are GLOBAL — else a member could attach a
+    // category to another org's project).
+    await assertProjectInOrg(ctx, projectId, orgId);
 
     // Idempotent: a retried create with the same cuid short-circuits (no dup row,
     // no second audit — the by_cuid index is global so re-check org on a hit).

--- a/convex/testTagAssetsWrites.ts
+++ b/convex/testTagAssetsWrites.ts
@@ -8,6 +8,7 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { reserveTestTagIdCounter } from "./lib/testTagIdCounter";
 import { backfillTestTagAssetsCore } from "./lib/testtagBackfill";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -61,6 +62,11 @@ export const createNative = mutation({
 
     const dupId = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dupId) throw new ConvexError("Test tag asset already exists");
+
+    // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.assetId) await assertRefInOrg(ctx, "assets", a.assetId, a.orgId);
+    if (a.bulkAssetId) await assertRefInOrg(ctx, "bulkAssets", a.bulkAssetId, a.orgId);
+    if (a.testProfileId) await assertRefInOrg(ctx, "testProfiles", a.testProfileId, a.orgId);
 
     // If linking to a serialized asset, use the asset's tag as the test tag ID.
     let testTagId = a.testTagId;
@@ -180,6 +186,12 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc || doc.organizationId !== orgId) throw new ConvexError("Test tag asset not found");
+
+    // Org-validate client-supplied FKs when SET to a non-empty value (by_cuid is GLOBAL —
+    // cross-org refs leak). A null/"" is a clear and needs no check.
+    if (typeof patch.assetId === "string" && patch.assetId) await assertRefInOrg(ctx, "assets", patch.assetId, orgId);
+    if (typeof patch.bulkAssetId === "string" && patch.bulkAssetId) await assertRefInOrg(ctx, "bulkAssets", patch.bulkAssetId, orgId);
+    if (typeof patch.testProfileId === "string" && patch.testProfileId) await assertRefInOrg(ctx, "testProfiles", patch.testProfileId, orgId);
 
     // undefined = leave; null/"" = clear (Convex removes undefined keys).
     const set: Record<string, unknown> = { updatedAt: now };

--- a/convex/testTagRecordsWrites.test.ts
+++ b/convex/testTagRecordsWrites.test.ts
@@ -52,6 +52,10 @@ const base = {
 describe("testTagRecordsWrites.createNative", () => {
   test("PASS: record + subtests + asset scalars + status by due date", async () => {
     const t = makeT(); await seed(t); await seedAsset(t);
+    // testProfile the args reference — createNative now org-validates the testProfileId FK.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("testProfiles", { id: "prof1", organizationId: ORG, name: "Standard", visualChecks: {}, electricalTests: {}, thresholds: {} });
+    });
     const res = await t.withIdentity(asUser).mutation(api.testTagRecordsWrites.createNative, {
       ...base, nextDueDate: NOW + 60 * DAY, testProfileId: "prof1", outletCount: 4,
       subTests: [

--- a/convex/testTagRecordsWrites.ts
+++ b/convex/testTagRecordsWrites.ts
@@ -6,6 +6,7 @@ import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
+import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
 
 /**
@@ -123,6 +124,9 @@ export const createNative = mutation({
       .withIndex("by_cuid", (q) => q.eq("id", a.testTagAssetId))
       .unique();
     if (!asset || asset.organizationId !== a.orgId) throw new ConvexError("Test tag asset not found");
+
+    // Org-validate the client-supplied testProfileId FK (by_cuid is GLOBAL — cross-org refs leak).
+    if (a.testProfileId) await assertRefInOrg(ctx, "testProfiles", a.testProfileId, a.orgId);
 
     // 3) Tester defaults to the verified actor; a supplied non-self tester must be
     //    a member of the org (the members mirror replaces prisma.member.findFirst).

--- a/convex/writeParity.test.ts
+++ b/convex/writeParity.test.ts
@@ -49,6 +49,8 @@ describe("write-parity: assets", () => {
 
   test("createNative == assets.create (same resulting doc)", async () => {
     const t = makeT();
+    // Model the fixtures reference — createNative now org-validates the modelId FK.
+    await t.run(async (ctx) => { await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "M1" }); });
     // Distinct tags (native has a dup-guard the service mutation lacks); exclude the tag.
     await t.withIdentity(SERVICE).mutation(api.assets.create, { id: "svc", ...baseFields, assetTag: "TAG-S" });
     await t.withIdentity(SERVICE).mutation(api.assetWrites.createNative, { id: "nat", ...baseFields, assetTag: "TAG-N", actor: ACTOR, auditId: "log1" });
@@ -94,6 +96,8 @@ describe("write-parity: line-items", () => {
 
   test("addNative == createLineItem (same resulting parent line, except lineTotal)", async () => {
     const t = makeT();
+    // Model the fields reference — addNative now org-validates the modelId FK.
+    await t.run(async (ctx) => { await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "M1" }); });
     await t.withIdentity(SERVICE).mutation(api.projectLineItems.createLineItem, { id: "svc", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, now: NOW });
     await t.withIdentity(SERVICE).mutation(api.lineItemWrites.addNative, { id: "nat", organizationId: ORG, projectId: "p1", fields, includeAccessories: false, allowOverbook: true, actor: ACTOR, auditId: "log1", now: NOW });
     const svc = normalize(await readByCuid(t, "projectLineItems", "svc"));


### PR DESCRIPTION
Systemic cross-tenant IDOR hardening from the independent Phase-3 audit. Added `assertRefInOrg` validation of every client-supplied domain FK written by `convex/*Writes.ts` (asset/bulkAsset/kit/model/location/category/testTag/crew-assignment + lineItem `addNative` parity + `supplierId` on both add paths). Bounded crew `rateOverride`/`estimatedHours` non-negative (margin poison). 

FK→table mappings codex-verified semantically correct (a wrong one breaks every legit call). Deploy-safe (rejects only cross-org/negative). User-FK attribution checks (Better-Auth user table) deferred — no membership helper, MEDIUM.

codex clean; tsc + 3694 tests + build green; convex deployed.