### PR TITLE
fix(security): org-validate client user-FKs in crew/maintenance (Phase-3 audit)

### DIFF
--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertRefInOrg, assertMemberInOrg } from "./lib/orgRef";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { sanitizeClientSet } from "./lib/sanitizeSet";
@@ -68,6 +69,11 @@ export const createNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, fields.organizationId, "crew", "create");
     const actor = await resolveActor(ctx, suppliedActor);
+
+    // Org-validate the client-supplied FKs written onto the crew member row (both are
+    // resolved via GLOBAL by_cuid/by_org_user elsewhere without re-checking org).
+    if (fields.crewRoleId) await assertRefInOrg(ctx, "crewRoles", fields.crewRoleId, fields.organizationId);
+    if (fields.userId) await assertMemberInOrg(ctx, fields.organizationId, fields.userId);
 
     // Server-side boundary parity with crewMemberSchema (the form's zodResolver + the
     // hook's .parse cover the UI path; this guards any direct mutation caller).
@@ -141,6 +147,10 @@ export const updateNative = mutation({
     // Apply set (+ clear-to-null) — the patchMember pattern.
     const NEVER_CLEAR = new Set(["id", "organizationId"]);
     const setObj = sanitizeClientSet(set); // strip organizationId/id — no cross-tenant reassign
+    // Org-validate reassigned FKs; the linked user is validated only when CHANGED so a
+    // former member on an existing row can still be re-saved.
+    if (typeof setObj.crewRoleId === "string") await assertRefInOrg(ctx, "crewRoles", setObj.crewRoleId, orgId);
+    if (typeof setObj.userId === "string" && setObj.userId !== doc.userId) await assertMemberInOrg(ctx, orgId, setObj.userId);
     const { _id, _creationTime, ...beforeRest } = doc;
     const afterRest: Record<string, unknown> = { ...beforeRest, ...setObj };
     for (const k of clear) { if (!NEVER_CLEAR.has(k)) delete afterRest[k]; }

--- a/convex/lib/orgRef.ts
+++ b/convex/lib/orgRef.ts
@@ -31,3 +31,21 @@ export async function assertRefInOrg(
     throw new ConvexError({ code: "FORBIDDEN", message: `Referenced ${table} not found in your organization.` });
   }
 }
+
+/**
+ * Org-validate a client-supplied USER-id FK (reportedById/assignedToId/linked userId) —
+ * the Better-Auth `user` table has no organizationId, so membership is checked via the
+ * `member` table's global `by_org_user` index. Throws if the user is not a member of the
+ * caller's org (prevents attributing a row to — and leaking the name of — a foreign user).
+ * Callers should only validate a user id that is NEW/changed, so a former member on an old
+ * row can still be re-saved.
+ */
+export async function assertMemberInOrg(ctx: MutationCtx, orgId: string, userId: string): Promise<void> {
+  const mem = await ctx.db
+    .query("members")
+    .withIndex("by_org_user", (q) => q.eq("organizationId", orgId).eq("userId", userId))
+    .first();
+  if (!mem) {
+    throw new ConvexError({ code: "FORBIDDEN", message: "Referenced user is not a member of your organization." });
+  }
+}

--- a/convex/maintenanceWrites.ts
+++ b/convex/maintenanceWrites.ts
@@ -3,6 +3,7 @@ import { mutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
+import { assertMemberInOrg } from "./lib/orgRef";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
@@ -220,6 +221,11 @@ export const createNative = mutation({
     await requireOrgPermission(ctx, a.orgId, "maintenance", "create");
     const actor = await resolveActor(ctx, a.actor);
 
+    // Client-supplied reporter/assignee user FKs — validate org membership (the Better-Auth
+    // user table has no org column; a foreign user id would leak that user's name on reads).
+    if (a.reportedById) await assertMemberInOrg(ctx, a.orgId, a.reportedById);
+    if (a.assignedToId) await assertMemberInOrg(ctx, a.orgId, a.assignedToId);
+
     const assetIds = Array.from(new Set(a.assetLinks.map((l) => l.assetId)));
     if (assetIds.length === 0) throw new ConvexError("At least one asset is required");
 
@@ -351,6 +357,11 @@ export const updateNative = mutation({
     if (!record || record.organizationId !== a.orgId) {
       throw new ConvexError("Maintenance record not found");
     }
+
+    // Validate reporter/assignee membership only when CHANGED, so a record whose original
+    // reporter/assignee has since left the org can still be edited/re-saved.
+    if (a.reportedById && a.reportedById !== record.reportedById) await assertMemberInOrg(ctx, a.orgId, a.reportedById);
+    if (a.assignedToId && a.assignedToId !== record.assignedToId) await assertMemberInOrg(ctx, a.orgId, a.assignedToId);
 
     const links = await existingLinks(ctx, a.id);
     const existingAssetIds = links.map((l) => l.assetId);


### PR DESCRIPTION
Closes the last MEDIUM finding from the independent Phase-3 audit — crewWrites + maintenanceWrites wrote client user-FKs (crew linked userId, maintenance reportedById/assignedToId) unvalidated, leaking a foreign user's name. New `assertMemberInOrg` (members by_org_user). Also fixes a crewRoleId domain-FK miss (PR #593 covered crewAssignments, not crewWrites). UPDATE validates user FKs only when CHANGED (no former-member legit-break). codex clean; tsc + tests + build green; convex deployed.