### PR TITLE
fix(deploy): Dockerfile pnpm 11 + copy pnpm-workspace.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 # curl: required by Coolify's container health check (slim has neither curl nor wget)
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g pnpm@9
+RUN npm install -g pnpm@11.7.0
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The prior merge (#601) tracked `pnpm-workspace.yaml` for dependency overrides (a pnpm 10+ feature), which broke the prod image build: the Dockerfile installed `pnpm@9` and didn't COPY the workspace file, so `pnpm install --frozen-lockfile` failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

Fix: bump the Dockerfile to `pnpm@11.7.0` (matches `packageManager`) and COPY `pnpm-workspace.yaml`.

**Verified locally:** full `docker build` succeeds end-to-end — frozen install clean (`Done in 16.9s using pnpm v11.7.0`), `✓ Compiled successfully`, 83 static pages generated, image exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)