### PR TITLE
ci(security): pre-commit secret scan + gitleaks blocking (R-7.3) + email validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,9 @@ jobs:
           retention-days: 7
 
   hygiene:
-    # Hygiene gates. The dependency vulnerability scan (R-6.6) is BLOCKING — the tree
-    # is clean at high+. The dead-code (R-4.2) and secret (R-7.3) scans start advisory
-    # (continue-on-error) so they surface findings without failing CI; flip them blocking
-    # once the pre-existing burn-down is cleared. NOT in build's `needs`.
+    # Hygiene gates. BLOCKING: dependency vuln scan (R-6.6), secret scan (R-7.3),
+    # import-cycle (R-3.5), any-ratchet (R-8.2.2). Dead-code (Knip, R-4.2) stays
+    # advisory (continue-on-error) until its burn-down clears. NOT in build's `needs`.
     name: Hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -192,9 +191,8 @@ jobs:
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
 
-      - name: Secret scan (gitleaks, advisory)
+      - name: Secret scan (gitleaks)
         run: gitleaks detect --source . --no-git --redact -c .gitleaks.toml
-        continue-on-error: true
 
   build:
     name: Build

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,4 +14,9 @@ paths = [
   '''.*/__tests__/.*''',
   '''.*\.test\.(ts|tsx)$''',
   '''pnpm-lock\.yaml$''',
+  # Build/generated artifacts (gitignored; vendored crypto libs ship test keys).
+  '''\.next/.*''',
+  '''(^|/)(dist|build|coverage|playwright-report|test-results)/.*''',
+  '''sbom\.cyclonedx\.json$''',
+  '''src/generated/.*''',
 ]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+# Secret scan on staged changes (POLICY.md R-7.3). Skips gracefully if gitleaks
+# isn't installed locally — CI enforces it as a blocking gate regardless.
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --redact -c .gitleaks.toml
+else
+  echo "⚠ gitleaks not installed — skipping local secret scan (CI enforces it)."
+  echo "  Install: https://github.com/gitleaks/gitleaks#installing"
+fi

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "convex:crud": "node scripts/generate-convex-crud.cjs .",
     "convex:backfill:dashboard-counters": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-dashboard-counters.ts",
     "convex:backfill:revenue-allocation": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-revenue-allocation.ts",
-    "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts"
+    "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts",
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -105,6 +106,7 @@
     "eslint": "^10.4.1",
     "eslint-config-next": "16.2.7",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "knip": "^6.27.0",
     "prisma": "^7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.4.1(jiti@2.7.0))
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -5241,6 +5244,11 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -11051,9 +11059,9 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-jsx-walk@2.0.0: {}
 
@@ -12368,6 +12376,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -12679,6 +12691,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -14461,7 +14475,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -14765,8 +14779,8 @@ snapshots:
   vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.15
       rollup: 4.61.1
       tinyglobby: 0.2.17
@@ -14848,11 +14862,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.23.0
+      enhanced-resolve: 5.24.2
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,9 @@
 import { Resend } from "resend";
+import { z } from "zod";
 import { env } from "@/env";
+
+// Vendor responses are untrusted input (POLICY.md R-8.10.3): validate the shape.
+const resendSendResponseSchema = z.object({ id: z.string().min(1) });
 
 // Lazily construct the Resend client. Building it at module scope throws
 // "Missing API key" when RESEND_API_KEY is unset, which breaks `next build`
@@ -68,7 +72,11 @@ export async function sendEmail({
     throw new Error(`Failed to send email: ${error.message}`);
   }
 
-  return data;
+  const parsed = resendSendResponseSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(`Unexpected Resend response: ${parsed.error.message}`);
+  }
+  return parsed.data;
 }
 
 export function invitationEmail({


### PR DESCRIPTION
Effort-only column, batch 1. Verified: tree scan clean, tsc clean, lint 0 errors, frozen install OK.

## Closes (1)
- **#611 (Major, R-7.3)** — completes all three secret-scan layers: **pre-commit** (husky runs `gitleaks protect --staged`, degrades gracefully if gitleaks isn't installed), **CI blocking** (gitleaks flipped from advisory), and **full-history** (the quarterly sweep). Allowlisted build/generated dirs in `.gitleaks.toml` (the local 42 hits were all `.next/` vendored crypto libs — gitignored, never in CI).

## Partial
- **#654 (R-8.10.3)** — schema-validate the Resend response (Google Places SDK-typed responses pending).

## Reclassified after inspection (NOT effort-only free — see PR discussion)
- **#617** — the bundle is genuinely **2.21 MB** and the size-limit config sums all chunks rather than measuring per-route first-load JS; needs a measurement redesign, not a flip.
- **#619** — 241 hex literals, almost all legitimate (PDF/canvas/email/theme-color, not CSS-token UI); a blanket rule would be noise.
- **#626 remainder** — knip blocking needs a 317-export burn-down; integration-in-CI needs Convex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)