### PR TITLE
refactor(adapters): fence vendor SDK imports to adapters (R-8.10.1, #652)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,6 +124,33 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    // Vendor SDKs must be imported only from their adapter module (POLICY.md R-8.10.1):
+    // maps → @/lib/maps-sdk; Resend → src/lib/email.ts (Next) or convex/emailActions.ts
+    // (Convex — two runtimes, one adapter each). Sentry is exempt: Next dictates its
+    // config-file locations (sentry.*.config.ts / instrumentation*.ts), which are the
+    // sanctioned error-capture boundary (§8.9).
+    files: ["src/**/*.{ts,tsx}", "convex/**/*.ts"],
+    ignores: ["src/lib/maps-sdk.ts", "src/lib/email.ts", "convex/emailActions.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@vis.gl/react-google-maps",
+              message: "Import maps primitives from @/lib/maps-sdk (R-8.10.1).",
+            },
+            {
+              name: "resend",
+              message:
+                "Use the email adapter (src/lib/email.ts or convex/emailActions.ts) (R-8.10.1).",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/components/providers/google-maps-provider.tsx
+++ b/src/components/providers/google-maps-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { APIProvider } from "@vis.gl/react-google-maps";
+import { APIProvider } from "@/lib/maps-sdk";
 
 export function GoogleMapsProvider({ children }: { children: React.ReactNode }) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;

--- a/src/components/ui/address-input.tsx
+++ b/src/components/ui/address-input.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { MapPin } from "lucide-react";
-import { useMapsLibrary } from "@vis.gl/react-google-maps";
+import { useMapsLibrary } from "@/lib/maps-sdk";
 import { cn } from "@/lib/utils";
 import {
   DEBOUNCE_MS,

--- a/src/components/ui/address-map-inner.tsx
+++ b/src/components/ui/address-map-inner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { Map, AdvancedMarker, Pin, InfoWindow, useMap } from "@vis.gl/react-google-maps";
+import { Map, AdvancedMarker, Pin, InfoWindow, useMap } from "@/lib/maps-sdk";
 import { ExternalLink } from "lucide-react";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";

--- a/src/lib/maps-sdk.ts
+++ b/src/lib/maps-sdk.ts
@@ -1,0 +1,15 @@
+/**
+ * Google Maps adapter (POLICY.md R-8.10.1): the single module that imports the
+ * `@vis.gl/react-google-maps` SDK. UI imports the primitives from here, so swapping
+ * or upgrading the maps vendor touches only this file. Direct SDK imports elsewhere
+ * are blocked by `no-restricted-imports` in eslint.config.mjs.
+ */
+export {
+  APIProvider,
+  Map,
+  AdvancedMarker,
+  Pin,
+  InfoWindow,
+  useMap,
+  useMapsLibrary,
+} from "@vis.gl/react-google-maps";


### PR DESCRIPTION
Refactor 1 of 6 (effort-only column). Funnels the Google Maps SDK through a single `src/lib/maps-sdk.ts` adapter (3 components repointed via pure re-export) and adds a blocking `no-restricted-imports` rule fencing `@vis.gl/react-google-maps` + `resend`. Resend keeps one adapter per runtime (Next/Convex); Sentry exempt (framework config locations).

Verified: lint 0 errors, tsc clean, depcruise + any-ratchet hold, 3780 tests unaffected (pure re-export).

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)