### PR TITLE
feat(api): schema-validate request bodies (R-8.6.4, #647)

### DIFF
--- a/src/app/api/auth/sso/org-lookup/route.ts
+++ b/src/app/api/auth/sso/org-lookup/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { readValidatedBody } from "@/lib/api-validation";
 
 // Simple in-memory rate limiter: 5 requests per minute per IP
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
@@ -24,17 +26,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  let body: { email?: string };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
+  const parsed = await readValidatedBody(
+    request,
+    z.object({ email: z.string().email() }),
+  );
+  if (!parsed.ok) return parsed.response;
 
-  const email = body.email?.toLowerCase()?.trim();
-  if (!email || !email.includes("@")) {
-    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
-  }
+  const email = parsed.data.email.toLowerCase().trim();
 
   const domain = email.split("@")[1];
 

--- a/src/app/api/crew/avatar/route.ts
+++ b/src/app/api/crew/avatar/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { requireSession } from "@/lib/auth-server";
+import { readValidatedBody } from "@/lib/api-validation";
 import { validateCsrfOrigin } from "@/lib/csrf";
 import { uploadToS3, deleteFromS3, ensureBucket, storageKeyFromUrl } from "@/lib/storage";
 import { getOrgContext } from "@/lib/org-context";
@@ -111,11 +113,12 @@ export async function DELETE(request: NextRequest) {
   const { organizationId } = await getOrgContext();
 
   try {
-    const { crewMemberId } = await request.json();
-
-    if (!crewMemberId) {
-      return NextResponse.json({ error: "No crew member ID provided" }, { status: 400 });
-    }
+    const parsed = await readValidatedBody(
+      request,
+      z.object({ crewMemberId: z.string().min(1) }),
+    );
+    if (!parsed.ok) return parsed.response;
+    const { crewMemberId } = parsed.data;
 
     const member = await getCrewMemberById(crewMemberId);
     if (!member || member.organizationId !== organizationId) {

--- a/src/lib/api-validation.test.ts
+++ b/src/lib/api-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { readValidatedBody } from "./api-validation";
+
+const schema = z.object({ email: z.string().email() });
+const req = (body: string) =>
+  new Request("http://localhost/api", { method: "POST", body });
+
+describe("readValidatedBody", () => {
+  it("returns parsed data for a valid body", async () => {
+    const r = await readValidatedBody(req('{"email":"a@b.com"}'), schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.email).toBe("a@b.com");
+  });
+
+  it("400s on invalid JSON", async () => {
+    const r = await readValidatedBody(req("not json"), schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.response.status).toBe(400);
+  });
+
+  it("400s on schema mismatch", async () => {
+    const r = await readValidatedBody(req('{"email":"nope"}'), schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.response.status).toBe(400);
+  });
+});

--- a/src/lib/api-validation.ts
+++ b/src/lib/api-validation.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+
+type ValidatedBody<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Read and schema-validate a JSON request body (POLICY.md R-8.6.4). Requiring a
+ * schema argument is the point: no route can read a body without validating it.
+ * Returns a discriminated result so callers keep their own auth/flow control:
+ *
+ *   const parsed = await readValidatedBody(request, z.object({ id: z.string() }));
+ *   if (!parsed.ok) return parsed.response;
+ *   const { id } = parsed.data;
+ */
+export async function readValidatedBody<T>(
+  request: Request,
+  schema: z.ZodType<T>,
+): Promise<ValidatedBody<T>> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid request body", details: parsed.error.flatten() },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, data: parsed.data };
+}


### PR DESCRIPTION
Refactor 2 of 6. Adds `readValidatedBody(request, schema)` (can't read a body without a schema — R-8.6.4) and applies it to the 2 routes that read a JSON body without validation. The '22 routes' was misleading: only 3 read a body, 2 were raw. Auth/CSRF/rate-limit preserved; unit test added.

Verified: tsc clean, lint 0, depcruise + any-ratchet hold, coverage 49.5% > 48% floor, 3783 tests pass.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)