### PR TITLE
feat(lib): boundedMap concurrency limiter (R-9.7, #658)

### DIFF
--- a/src/lib/bounded-map.test.ts
+++ b/src/lib/bounded-map.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { boundedMap } from "./bounded-map";
+
+describe("boundedMap", () => {
+  it("preserves order and maps every item", async () => {
+    const out = await boundedMap([1, 2, 3, 4], 2, async (n) => n * 10);
+    expect(out).toEqual([10, 20, 30, 40]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await boundedMap(Array.from({ length: 20 }, (_, i) => i), 3, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it("handles an empty list and rejects a bad limit", async () => {
+    expect(await boundedMap([], 4, async (x) => x)).toEqual([]);
+    await expect(boundedMap([1], 0, async (x) => x)).rejects.toThrow();
+  });
+});

--- a/src/lib/bounded-map.ts
+++ b/src/lib/bounded-map.ts
@@ -1,0 +1,27 @@
+/**
+ * Concurrency-bounded async map (POLICY.md R-9.7): runs `fn` over `items` with at
+ * most `limit` promises in flight, preserving input order. Use this — never an
+ * unbounded `Promise.all(items.map(...))` — for any fan-out over unbounded or
+ * collection-sized input, especially calls to a single external vendor/host.
+ *
+ *   const results = await boundedMap(ids, 8, (id) => fetchThing(id));
+ */
+export async function boundedMap<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (limit < 1) throw new Error("boundedMap: limit must be >= 1");
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+}


### PR DESCRIPTION
Adds the explicit concurrency-limiting tool (`boundedMap`, tested) for fan-outs over unbounded input. The audit found no current unbounded vendor fan-out (adapters don't fan out), so this provides the documented safeguard for future use. tsc + lint clean, 3 tests.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)