### PR TITLE
test(e2e): seeded-auth verification harness — self-hosted Convex (#621)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ package-lock.json
 # Playwright E2E artifacts
 playwright-report/
 test-results/
+
+# Local E2E harness temp (self-hosted Convex push tmpdir)
+.convex-tmp/

--- a/docs/critical-flows.md
+++ b/docs/critical-flows.md
@@ -13,7 +13,7 @@ list" clause is partially met (auth entry ✅; sign-in + revenue path pending).
 | # | Flow | Steps | E2E coverage |
 |---|------|-------|--------------|
 | 1 | **Login page loads** | Unauthenticated visit to `/login` renders the sign-in entry form (+ axe a11y, zero serious/critical WCAG 2 A/AA) | ✅ `e2e/smoke.spec.ts`, `e2e/a11y.spec.ts` (CI-gated) |
-| 2 | **Sign in** | Email + password → authenticated → lands on dashboard | ⬜ pending (needs seeded test user) |
+| 2 | **Sign in / register** | Register/sign in → authenticated → lands on dashboard | 🟡 proven via the seeded harness (`e2e/harness-auth.spec.ts`, `E2E_HARNESS=1`); see `docs/e2e-harness.md`. CI automation pending. |
 | 3 | **Sign out** | Authenticated → sign out → session invalidated, back to `/login` | ⬜ pending |
 | 4 | **Register / onboarding** | New account → create/join org → onboarding completes | ⬜ pending |
 | 5 | **Create a project** (revenue path) | New project with a client → saved, visible in list | ⬜ pending |

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -1,0 +1,51 @@
+# Seeded-auth E2E harness
+
+The missing piece for authenticated E2E (POLICY.md R-8.8.3 / #621): a local
+**self-hosted Convex** backend the app can talk to, so tests can exercise
+authenticated, data-backed flows — not just the client-rendered `/login` page.
+
+**Status: proven working locally.** `scripts/e2e-harness-up.sh` stands up Convex,
+pushes the schema, and wires auth; `e2e/harness-auth.spec.ts` then registers a user
+and reaches the authenticated dashboard (verified). CI automation is the remaining
+finish (see below).
+
+## How it works
+
+Self-hosted Convex (`docker-compose.convex.yml`, `ghcr.io/get-convex/convex-backend`)
+runs on **local-disk storage — no S3 needed** — backed by a `gearflow_convex` Postgres
+DB. The harness pushes the app's schema/functions to it and sets two deployment env
+vars so the backend trusts the app's Better Auth ES256 JWTs:
+
+- `CONVEX_AUTH_ISSUER` = the app origin (`http://localhost:3000`)
+- `CONVEX_AUTH_JWKS_URL` = `http://host.docker.internal:3000/api/auth/jwks` (reachable
+  from the Convex container)
+
+The push writes `NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210` to `.env.local`, so the
+app connects to the local backend.
+
+## Run it
+
+```bash
+bash scripts/e2e-harness-up.sh     # boots Convex, pushes schema, wires auth
+pnpm dev                           # in another terminal
+E2E_HARNESS=1 pnpm exec playwright test --project=chromium e2e/harness-auth.spec.ts
+bash scripts/e2e-harness-down.sh   # tear down
+```
+
+**Gotcha (already handled by the up script):** Better Auth encrypts its JWKS private
+key with `BETTER_AUTH_SECRET`. A stale `jwks` row from a *different* secret makes
+sign-up fail with "Failed to decrypt private key" — the up script clears it so it
+regenerates. A fresh Better Auth DB avoids it entirely; the first registered user
+bootstraps as admin.
+
+## Remaining finish (scoped)
+
+1. **CI automation** — run this in the `e2e` job: `docker compose up` the Convex
+   backend (service or step), generate the admin key, push the schema, `pnpm dev`,
+   then `E2E_HARNESS=1 playwright test`. The cross-container `host.docker.internal`
+   JWKS reach is the one thing to validate on the GitHub runner.
+2. **Seed domain data + write the revenue-path specs** (project → line-items →
+   availability → check-out → return) now that authenticated pages render.
+3. This harness also unblocks verifying the deferred refactors (#616 images, #625
+   pagination, #618 validation, #645 code-split, #655 templates, #646 axe pages) by
+   driving the real authenticated app.

--- a/e2e/harness-auth.spec.ts
+++ b/e2e/harness-auth.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Seeded-auth E2E keystone (POLICY.md R-8.8.3 / #621). Runs ONLY against the local
+ * verification harness (self-hosted Convex + a fresh Better Auth DB) — start it with
+ * `bash scripts/e2e-harness-up.sh` and run with `E2E_HARNESS=1`. Skipped otherwise so
+ * it never runs in the default CI job (which has no harness). See docs/e2e-harness.md.
+ *
+ * Proves the authenticated path end-to-end: a fresh registration becomes the bootstrap
+ * admin and reaches the dashboard, with the app talking to the local Convex backend.
+ */
+test.describe("harness: authenticated flow", () => {
+  test.skip(
+    !process.env.E2E_HARNESS,
+    "requires the seeded Convex harness (E2E_HARNESS=1)",
+  );
+
+  test("register → authenticated dashboard", async ({ page }) => {
+    const email = `e2e+${Date.now()}@harness.local`;
+    await page.goto("/register");
+    await page.getByLabel(/name/i).first().fill("E2E Harness");
+    await page.getByLabel(/email/i).first().fill(email);
+    await page.getByLabel(/password/i).first().fill("harness-password-123");
+    await page
+      .getByRole("button", { name: /create|register|sign up/i })
+      .first()
+      .click();
+
+    // First user bootstraps as admin and lands on the dashboard (or onboarding).
+    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+  });
+});

--- a/scripts/e2e-harness-down.sh
+++ b/scripts/e2e-harness-down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Tear down the seeded-auth E2E harness (see scripts/e2e-harness-up.sh).
+set -uo pipefail
+cd "$(dirname "$0")/.."
+docker compose -f docker-compose.convex.yml down -v 2>&1 | tail -2
+echo "Convex harness stopped. (App .env.local still points at the local Convex — remove"
+echo "NEXT_PUBLIC_CONVEX_URL from .env.local to point back at your dev deployment.)"

--- a/scripts/e2e-harness-up.sh
+++ b/scripts/e2e-harness-up.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Stand up the seeded-auth E2E verification harness (POLICY.md R-8.8.3 / #621).
+#
+# Runs a SELF-HOSTED Convex backend (docker) on local disk storage (no S3 needed),
+# pushes the app's schema/functions, and wires the auth JWKS trust so Better Auth
+# JWTs validate against it. After this, start the app (`pnpm dev`) and run authenticated
+# Playwright specs — the app talks to the local Convex (NEXT_PUBLIC_CONVEX_URL is written
+# to .env.local by the push).
+#
+# Prereqs: docker, a local Postgres on :5432 (postgres/postgres), pnpm install done.
+# Usage:   bash scripts/e2e-harness-up.sh   (tear down: bash scripts/e2e-harness-down.sh)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONVEX_URL=http://127.0.0.1:3210
+APP_ORIGIN=${APP_ORIGIN:-http://localhost:3000}
+
+echo "==> Postgres db for the Convex backend"
+PGPASSWORD=postgres createdb -h localhost -U postgres gearflow_convex 2>/dev/null || true
+
+echo "==> .env.convex.local (local-disk storage, no S3)"
+if [ ! -f .env.convex.local ]; then
+  cat > .env.convex.local <<ENV
+INSTANCE_SECRET=$(openssl rand -hex 32)
+POSTGRES_URL=postgres://postgres:postgres@host.docker.internal:5432
+DO_NOT_REQUIRE_SSL=1
+ENV
+fi
+
+echo "==> boot self-hosted Convex backend"
+docker compose -f docker-compose.convex.yml up -d backend
+for i in $(seq 1 30); do
+  curl -sf --max-time 3 "$CONVEX_URL/version" >/dev/null 2>&1 && break
+  sleep 2
+done
+
+echo "==> admin key"
+ADMIN_KEY=$(docker compose -f docker-compose.convex.yml exec -T backend ./generate_admin_key.sh 2>/dev/null | tail -1 | tr -d '\r')
+
+export CONVEX_SELF_HOSTED_URL="$CONVEX_URL"
+export CONVEX_SELF_HOSTED_ADMIN_KEY="$ADMIN_KEY"
+export CONVEX_TMPDIR="$PWD/.convex-tmp"
+mkdir -p "$CONVEX_TMPDIR"
+
+echo "==> auth JWKS trust (Convex validates the app's Better Auth ES256 JWTs)"
+pnpm exec convex env set CONVEX_AUTH_ISSUER "$APP_ORIGIN" >/dev/null
+pnpm exec convex env set CONVEX_AUTH_JWKS_URL "http://host.docker.internal:3000/api/auth/jwks" >/dev/null
+
+echo "==> push schema + functions"
+pnpm exec convex dev --once
+
+echo "==> reset the app's Better Auth JWKS (key is encrypted with BETTER_AUTH_SECRET;"
+echo "    a stale row from a different secret breaks sign-up). Regenerated on next use."
+PGPASSWORD=postgres psql -h localhost -U postgres -d "${APP_DB:-gearflow}" \
+  -c 'DELETE FROM jwks;' >/dev/null 2>&1 || true
+
+echo "==> ready. Convex at $CONVEX_URL (NEXT_PUBLIC_CONVEX_URL written to .env.local)."
+echo "    Start the app: pnpm dev   |   Run E2E: pnpm test:e2e --project=chromium"


### PR DESCRIPTION
Builds and **proves** the keystone that unblocks the entire verification-dependent group: a local **self-hosted Convex** backend the app authenticates against, so E2E can exercise real authenticated flows.

## What's proven (verified locally end-to-end)
- Self-hosted Convex (`docker-compose.convex.yml`) boots on **local-disk storage — no S3**.
- Schema/functions push to it; auth JWKS trust wired (Convex validates the app's Better Auth ES256 JWTs via `host.docker.internal`).
- **`e2e/harness-auth.spec.ts` registers a user and reaches the authenticated `/dashboard`** against the local Convex. ✅

## Contents
- `scripts/e2e-harness-up.sh` / `-down.sh` — fully scripted boot + schema push + auth wiring + stale-JWKS clear.
- `e2e/harness-auth.spec.ts` — the authenticated keystone test, **gated on `E2E_HARNESS=1`** so the default CI job (no harness) skips it and stays green.
- `docs/e2e-harness.md` — how it works + the scoped CI-automation finish.

## Why it matters
This is the "external dependency" I kept flagging — now largely solved. It unblocks the revenue-path E2E specs (#621) **and** verifying the deferred refactors (#616 images, #625 pagination, #618 validation, #645 code-split, #655 templates, #646 axe) against a real authenticated app.

Refs #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)