### PR TITLE
feat(obs): structured logger + scrubbing + request-id (R-8.9.5, #622)

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 import { z } from "zod";
 import { env } from "@/env";
+import { logger } from "@/lib/logger";
 
 // Vendor responses are untrusted input (POLICY.md R-8.10.3): validate the shape.
 const resendSendResponseSchema = z.object({ id: z.string().min(1) });
@@ -43,11 +44,11 @@ export async function sendEmail({
 }) {
   if (!env.RESEND_API_KEY || env.RESEND_API_KEY === "re_xxxxxxxxxxxxxxxxxxxx") {
     if (process.env.NODE_ENV === "development") {
-      console.log(`[Email] Would send to ${to}: ${subject}`);
-      console.log(`[Email] HTML: ${html.substring(0, 200)}...`);
-      if (attachments?.length) {
-        console.log(`[Email] Attachments: ${attachments.map((a) => a.filename).join(", ")}`);
-      }
+      // Dev-mode: don't log the recipient address (PII, R-8.12.4).
+      logger.info("[Email] dev-mode — not sent", {
+        subject,
+        attachments: attachments?.map((a) => a.filename),
+      });
     }
     return { id: "dev-mock" };
   }
@@ -68,7 +69,7 @@ export async function sendEmail({
   });
 
   if (error) {
-    console.error("[Email] Send failed:", error);
+    logger.error("[Email] send failed", { error: error.message });
     throw new Error(`Failed to send email: ${error.message}`);
   }
 

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger, scrub } from "./logger";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("logger scrubbing", () => {
+  it("redacts sensitive keys at any depth", () => {
+    const out = scrub({
+      email: "a@b.com",
+      nested: { password: "hunter2", ok: 1, token: "abc" },
+      list: [{ apiKey: "k" }],
+    }) as Record<string, unknown>;
+    expect(out.email).toBe("[redacted]");
+    expect((out.nested as Record<string, unknown>).password).toBe("[redacted]");
+    expect((out.nested as Record<string, unknown>).ok).toBe(1);
+    expect(((out.list as unknown[])[0] as Record<string, unknown>).apiKey).toBe(
+      "[redacted]",
+    );
+  });
+
+  it("emits one structured JSON line with level + message", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logger.error("boom", { requestId: "r1", detail: "x" });
+    expect(spy).toHaveBeenCalledOnce();
+    const rec = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(rec.level).toBe("error");
+    expect(rec.message).toBe("boom");
+    expect(rec.requestId).toBe("r1");
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,45 @@
+/**
+ * Structured, levelled logger (POLICY.md R-8.9.5). Emits one JSON line per event so
+ * logs are machine-parseable and levelled; a correlation/request id is attached when
+ * provided (set by middleware as `x-request-id`, threaded via `meta.requestId`).
+ *
+ * Sensitive data MUST NOT be logged: keys matching SENSITIVE are redacted from `meta`
+ * (defence-in-depth on top of not passing PII in the first place). Covered by
+ * logger.test.ts.
+ */
+type Level = "debug" | "info" | "warn" | "error";
+
+const SENSITIVE =
+  /(pass(word|phrase)?|secret|token|authorization|cookie|api[-_]?key|jwt|ssn|creditcard|email|phone|dateofbirth|dob|icaltoken)/i;
+
+export function scrub(value: unknown, depth = 0): unknown {
+  if (depth > 5 || value == null) return value;
+  if (Array.isArray(value)) return value.map((v) => scrub(v, depth + 1));
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = SENSITIVE.test(k) ? "[redacted]" : scrub(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+function emit(level: Level, message: string, meta?: Record<string, unknown>) {
+  const record: Record<string, unknown> = { level, message, ts: new Date().toISOString() };
+  if (meta && Object.keys(meta).length) {
+    const scrubbed = scrub(meta) as Record<string, unknown>;
+    if (scrubbed.requestId != null) record.requestId = scrubbed.requestId;
+    record.meta = scrubbed;
+  }
+  const line = JSON.stringify(record);
+  // console is just the transport; Sentry still captures error/warn.
+  (level === "error" ? console.error : level === "warn" ? console.warn : console.log)(line);
+}
+
+export const logger = {
+  debug: (message: string, meta?: Record<string, unknown>) => emit("debug", message, meta),
+  info: (message: string, meta?: Record<string, unknown>) => emit("info", message, meta),
+  warn: (message: string, meta?: Record<string, unknown>) => emit("warn", message, meta),
+  error: (message: string, meta?: Record<string, unknown>) => emit("error", message, meta),
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,10 @@ const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // Correlation id for log/error tracing (POLICY.md R-8.9.5): reuse an inbound
+  // x-request-id or mint one; forwarded to server code and returned to the client.
+  const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
+
   // CVE-2025-29927: Strip x-middleware-subrequest header to prevent middleware bypass
   if (request.headers.has("x-middleware-subrequest")) {
     return new NextResponse(null, { status: 403 });
@@ -44,7 +48,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  const response = NextResponse.next();
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-request-id", requestId);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("x-request-id", requestId);
   addSecurityHeaders(response);
   return response;
 }


### PR DESCRIPTION
Structured JSON logger with sensitive-key scrubbing (+ test — the control R-8.9.5 asks for), an x-request-id correlation id minted/forwarded by middleware, and the email adapter adopted as the pattern (also fixes a PII-in-logs issue: recipient email was logged in dev). Full console-migration + AsyncLocalStorage propagation is the architectural follow-up.

Verified: tsc clean, lint 0, tests pass.

Refs #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)