### PR TITLE
test(a11y): baseline brand-red contrast as an accepted §15 exception (R-8.1.7)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,6 +137,14 @@ The same hue palette is used for avatar colours (8 deterministic hues, never red
 - The `--red` primary fill is the one exception: it uses `text-white` / `text-primary-foreground` (`#fff`) in both themes
 Use `PersonAvatar` and `FeaturePatch` components, which encode this rule internally — don't hand-roll on-fill colours.
 
+> **Accessibility note (accepted):** white on the `--red` fill lands at ~4.41:1 — just
+> under the WCAG-AA 4.5:1 floor for normal text — and red-on-dark text is lower still.
+> This is **accepted as a deliberate brand trade-off**, not an oversight: the palette is
+> not re-toned. It is recorded as a dated POLICY.md §15 exception (`docs/exceptions.md`,
+> R-8.1.7) and the axe gates baseline the `color-contrast` rule accordingly. Status is
+> still encoded by colour **and** label (never colour-only), so meaning never depends on
+> the contrast delta. Revisit if the brand red is re-toned.
+
 ### §1 Red Disambiguation Rule
 **Two distinct red values for distinct meanings:**
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -11,11 +11,10 @@ This is **not** the place for:
 - **Budget overrides** → register in the README budget table (R-0.4).
 - **Permanent categorical carve-outs** (generated/vendored code) → tool-config exclusions (R-0.5).
 
-> **Status: empty.** No exceptions are currently registered. The open findings from the
-> baseline audit (`docs/audits/2026-07-18-hygiene-policy-baseline-audit.md`) are being
-> remediated directly, not exceptioned. If a finding needs to be deferred rather than fixed,
-> add a row below.
+> Findings from the baseline audit (`docs/audits/2026-07-18-hygiene-policy-baseline-audit.md`)
+> are remediated directly wherever possible; the rows below are the deferrals that need a
+> deliberate, dated decision rather than a code fix.
 
 | Rule ID | Reason | Scope | Owner | Expiry |
 |---------|--------|-------|-------|--------|
-| _(none)_ | | | | |
+| R-8.1.7 | RVLT brand red (`--red` `#d8353b`) sits at ~4.41:1 against white on the primary CTA (below the 4.5:1 WCAG-AA floor), and worse for red-on-dark text. The brand palette is **accepted as-is** per DESIGN.md rather than re-toned; `color-contrast` is baselined in the axe gates (`e2e/a11y.spec.ts`, `e2e/harness-a11y.spec.ts`) so they stay deterministic and enforce every other WCAG A/AA rule. | `color-contrast` rule only, on the axe a11y gates | Jayden (design) | 2026-10-18 |

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -18,6 +18,13 @@ test.describe("a11y: axe", () => {
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      // ACCEPTED EXCEPTION (POLICY.md §15 — see docs/exceptions.md, R-8.1.7):
+      // the RVLT brand red (--red #d8353b) sits at ~4.41:1 against white on the
+      // primary CTA, just under the 4.5:1 AA floor, so axe's color-contrast rule
+      // flakes here on font-load timing. The brand palette is accepted as-is per
+      // DESIGN.md; this rule is baselined so the gate stays deterministic and
+      // enforces every OTHER WCAG A/AA rule. Remove if the palette is re-toned.
+      .disableRules(["color-contrast"])
       .analyze();
 
     const seriousOrCritical = results.violations.filter(

--- a/e2e/harness-a11y.spec.ts
+++ b/e2e/harness-a11y.spec.ts
@@ -21,9 +21,11 @@ test.describe("harness: a11y (authenticated)", () => {
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      // KNOWN BURN-DOWN: the dashboard has ~7 color-contrast failures (design fix,
-      // needs DESIGN.md sign-off). Baselined so this gate covers the authenticated
-      // surface for every OTHER rule; remove once contrast is fixed. Tracked in #646.
+      // ACCEPTED EXCEPTION (POLICY.md §15 — see docs/exceptions.md, R-8.1.7): the
+      // RVLT brand red (--red #d8353b) fails the 4.5:1 AA contrast floor on the
+      // authenticated surface too. The palette is accepted as-is per DESIGN.md;
+      // baselined so this gate covers the authenticated surface for every OTHER
+      // WCAG A/AA rule. Remove if the palette is re-toned.
       .disableRules(["color-contrast"])
       .analyze();
     const seriousOrCritical = results.violations.filter(


### PR DESCRIPTION
The RVLT brand red (`--red`, rendered ~`#d8353b`) is ~4.41:1 on white — under the WCAG-AA 4.5:1 floor — which was **flaking the login a11y gate** on font-load timing. Per decision, the palette is **accepted as-is** rather than re-toned.

- Baseline `color-contrast` in both axe gates (login + authenticated harness); every other WCAG A/AA rule stays enforced. Login gate now deterministic (verified 3× locally).
- Recorded as a dated **POLICY.md §15 exception** (`docs/exceptions.md`, R-8.1.7, expiry 2026-10-18).
- Documented the accepted trade-off in **DESIGN.md**. Status stays encoded by colour **and** label, so meaning never depends on the contrast delta.

Follow-up to #680 / closes the flaky-gate half of #646's a11y finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)