### PR TITLE
perf(bundle): code-split Google Maps SDK out of the shared bundle (#645)

### DIFF
--- a/src/components/providers/google-maps-provider.tsx
+++ b/src/components/providers/google-maps-provider.tsx
@@ -1,17 +1,45 @@
 "use client";
 
-import { APIProvider } from "@/lib/maps-sdk";
+import { useEffect, useState, type ComponentType } from "react";
 
+interface ApiProviderProps {
+  apiKey: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides the Google Maps context to the whole app WITHOUT shipping the maps
+ * SDK in the shared/first-load bundle (POLICY.md R-8.1.3). `@vis.gl/react-google-maps`
+ * is ~1.3 MB unpacked and was statically imported here in the root layout, so it
+ * loaded on every page even though only address forms/maps use it.
+ *
+ * We now import the SDK lazily (client-only, via `import()`), and — critically —
+ * render `children` unconditionally the whole time. Before the SDK resolves we
+ * render a bare fragment; once it resolves we swap in the real `<APIProvider>`.
+ * Children never unmount, so there is no first-paint flash. Maps are never
+ * first-paint content, and `address-map-inner` is itself dynamically imported,
+ * so consumers pick up the context as soon as it mounts.
+ */
 export function GoogleMapsProvider({ children }: { children: React.ReactNode }) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const [ApiProvider, setApiProvider] =
+    useState<ComponentType<ApiProviderProps> | null>(null);
 
-  if (!apiKey) {
-    return <>{children}</>;
-  }
+  useEffect(() => {
+    if (!apiKey) return;
+    let active = true;
+    void import("@/lib/maps-sdk").then((mod) => {
+      if (active) {
+        setApiProvider(() => mod.APIProvider as ComponentType<ApiProviderProps>);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [apiKey]);
 
-  return (
-    <APIProvider apiKey={apiKey}>
-      {children}
-    </APIProvider>
-  );
+  // Children render immediately, with or without the maps context loaded.
+  if (!apiKey || !ApiProvider) return <>{children}</>;
+
+  return <ApiProvider apiKey={apiKey}>{children}</ApiProvider>;
 }


### PR DESCRIPTION
The root layout wraps the app in `<GoogleMapsProvider>`, which **statically imported** `@vis.gl/react-google-maps` (~1.3 MB unpacked) — so the maps SDK shipped in the first-load JS **shared by every page**, though only address forms/maps use it (**R-8.1.3**).

`GoogleMapsProvider` now imports the SDK lazily (client-only `import()` in an effect) and renders `children` unconditionally — a bare fragment until the SDK resolves, then it swaps in the real `<APIProvider>`. Children never unmount → no first-paint flash; SSR and initial client render both = bare fragment (no hydration mismatch). Maps are never first-paint content and `address-map-inner` is already dynamic.

**Verified** via `next build`: `APIProvider` now appears in only **3 of 159** client chunks (maps routes + the async maps chunk), not the shared-by-all bundle.

PDF renderers (pdfme) run in server API routes (not the client bundle), and the QR generator on `/account` is already `await import("qrcode")` — so maps was the remaining first-paint offender.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)