### PR TITLE
feat(ui): adopt next/image via AppImage for all raw <img> (#616)

### DIFF
--- a/docs/adr/0002-next-image-unoptimized.md
+++ b/docs/adr/0002-next-image-unoptimized.md
@@ -1,0 +1,45 @@
+# ADR-0002: Adopt next/image but serve app images unoptimized
+
+**Status:** Accepted (2026-07-18)
+
+## Context
+
+POLICY.md **R-8.1.4** (WEB profile, §8.1) requires the framework's optimizing image
+primitive (`next/image`) rather than raw `<img>` — for enforced dimensions (CLS), default
+lazy-loading, and modern-format optimization. The app rendered user-facing images with raw
+`<img>` (each with an `eslint-disable @next/next/no-img-element`).
+
+Every user-facing image in this app comes from a source the Next.js **image optimizer cannot
+process**:
+
+- **Auth-gated proxy.** Uploaded images are served from `/api/files/{storageId}`, which calls
+  `requireOrganization()` and 401s without a session, then org-scopes the file
+  (`src/app/api/files/[...path]/route.ts`). Next's optimizer fetches the source URL
+  **server-side, without the user's session cookie**, so an optimized fetch would 401 and
+  render a broken image.
+- **`blob:` object URLs** — client-side upload previews (`URL.createObjectURL`) aren't
+  fetchable server-side.
+- **`data:` URLs** — e.g. the generated 2FA QR code; there is nothing to optimize.
+
+Enabling optimization would therefore break images, and there is no safe remote host to
+allow-list (the proxy is intentionally private).
+
+## Decision
+
+Adopt `next/image` everywhere via a thin wrapper, **`AppImage`** (`src/components/ui/app-image.tsx`),
+that sets `unoptimized` by default. This keeps the R-8.1.4 wins that ARE achievable —
+enforced `width/height` or `fill` (CLS) and default lazy-loading below the fold — while
+bypassing the server optimizer that the auth-gated/blob/data sources can't support.
+
+Genuinely static/public assets (none today) should use `next/image` directly so they DO get
+optimized.
+
+## Consequences
+
+- All raw `<img>` tags and their `eslint-disable` suppressions are removed; image handling is
+  standardized through one primitive.
+- Modern-format/resize optimization is intentionally **not** applied to these dynamic images.
+  Revisit if image serving moves to unguessable public URLs (no per-request auth), at which
+  point `AppImage` could drop `unoptimized` and add `images.remotePatterns`.
+- `fill` usages require a positioned (`relative`) parent; the four affected containers were
+  updated accordingly.

--- a/src/app/(app)/account/page.tsx
+++ b/src/app/(app)/account/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import Link from "next/link";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { useServerMutation } from "@/hooks/use-server-mutation";
@@ -786,8 +787,7 @@ export default function AccountPage() {
               <div className="space-y-3">
                 {qrDataUrl && (
                   <div className="flex justify-center rounded-[var(--r)] bg-white p-4">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={qrDataUrl} alt="2FA QR code" width={200} height={200} />
+                    <AppImage src={qrDataUrl} alt="2FA QR code" width={200} height={200} />
                   </div>
                 )}
                 <details className="text-center">

--- a/src/app/(app)/maintenance/[id]/page.tsx
+++ b/src/app/(app)/maintenance/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useServerMutation } from "@/hooks/use-server-mutation";
@@ -197,10 +198,9 @@ function MaintenanceDetailContent({
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={cn("block aspect-square overflow-hidden rounded-[var(--r)] border border-line bg-paper-2 transition-opacity hover:opacity-90", focusRing)}
+                        className={cn("relative block aspect-square overflow-hidden rounded-[var(--r)] border border-line bg-paper-2 transition-opacity hover:opacity-90", focusRing)}
                       >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src={url} alt="" className="h-full w-full object-cover" />
+                        <AppImage src={url} alt="" fill sizes="(max-width: 768px) 50vw, 200px" className="object-cover" />
                       </a>
                     ))}
                   </div>

--- a/src/components/assets/asset-form.tsx
+++ b/src/components/assets/asset-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import { useRouter } from "next/navigation";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -419,10 +420,9 @@ export function AssetForm({ initialData, preselectedModelId }: AssetFormProps) {
           <div className="space-y-2 border-t border-line pt-3">
             <p className="t-overline text-faint">Preview</p>
             <div className="overflow-hidden rounded-[var(--r)] border border-line bg-card shadow-[var(--sh-card)]">
-              <div className="flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
+              <div className="relative flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
                 {modelImage ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={modelImage} alt={modelLabel ?? "Asset"} className="h-full w-full object-cover" />
+                  <AppImage src={modelImage} alt={modelLabel ?? "Asset"} fill sizes="(max-width: 768px) 100vw, 400px" className="object-cover" />
                 ) : (
                   <Package className="h-8 w-8 text-faint" strokeWidth={1.5} />
                 )}

--- a/src/components/assets/bulk-asset-form.tsx
+++ b/src/components/assets/bulk-asset-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import { useRouter } from "next/navigation";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -132,10 +133,9 @@ export function BulkAssetForm({ initialData, preselectedModelId }: BulkAssetForm
           <SmartFormRail eyebrow={isEditing ? "Editing" : "New bulk stock"} tip={helperTip} />
           <SmartFormPreview>
             <div className="overflow-hidden rounded-[var(--r)] border border-line bg-card shadow-[var(--sh-card)]">
-              <div className="flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
+              <div className="relative flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
                 {modelImage ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={modelImage} alt={modelLabel ?? "Bulk stock"} className="h-full w-full object-cover" />
+                  <AppImage src={modelImage} alt={modelLabel ?? "Bulk stock"} fill sizes="(max-width: 768px) 100vw, 400px" className="object-cover" />
                 ) : (
                   <Layers className="h-8 w-8 text-faint" strokeWidth={1.5} />
                 )}

--- a/src/components/assets/model-form.tsx
+++ b/src/components/assets/model-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import { useRouter } from "next/navigation";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -122,10 +123,9 @@ export function ModelForm({ initialData }: ModelFormProps) {
           <SmartFormRail eyebrow={isEditing ? "Editing" : "New model"} tip={helperTip} />
           <SmartFormPreview>
             <div className="overflow-hidden rounded-[var(--r)] border border-line bg-card shadow-[var(--sh-card)]">
-              <div className="flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
+              <div className="relative flex aspect-[5/3] items-center justify-center overflow-hidden bg-paper-2">
                 {previewImage ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={previewImage} alt={previewName} className="h-full w-full object-cover" />
+                  <AppImage src={previewImage} alt={previewName} fill sizes="(max-width: 768px) 100vw, 400px" className="object-cover" />
                 ) : (
                   <Package className="h-8 w-8 text-faint" strokeWidth={1.5} />
                 )}

--- a/src/components/collaboration/presence-avatar-stack.tsx
+++ b/src/components/collaboration/presence-avatar-stack.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AppImage } from "@/components/ui/app-image";
 import { getUserInitials, getForegroundColor } from "@/lib/collaboration-colors";
 import {
   Tooltip,
@@ -41,8 +42,7 @@ function PresenceAvatar({ userName, userColor, avatarUrl, mode, section, size = 
           aria-label={label}
         >
           {avatarUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={avatarUrl} alt={userName} className="h-full w-full object-cover" />
+            <AppImage src={avatarUrl} alt={userName} fill sizes="40px" className="object-cover" />
           ) : (
             <span className="font-medium leading-none">{initials}</span>
           )}

--- a/src/components/ui/app-image.smoke.test.tsx
+++ b/src/components/ui/app-image.smoke.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AppImage } from "@/components/ui/app-image";
+
+/**
+ * Smoke test: AppImage adopts next/image (R-8.1.4) but renders an <img> pointing
+ * at the original src (unoptimized — the app's images come from the auth-gated
+ * /api/files proxy + blob/data URLs; see ADR-0002), with lazy-loading on.
+ */
+describe("AppImage", () => {
+  it("renders an img with the given src and lazy loading (fixed size)", () => {
+    const { container } = render(
+      <AppImage src="/api/files/abc123" alt="model" width={200} height={200} />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    // unoptimized → the src is served as-is (no /_next/image optimizer rewrite).
+    expect(img!.getAttribute("src")).toBe("/api/files/abc123");
+    expect(img!.getAttribute("loading")).toBe("lazy");
+    expect(img!.getAttribute("alt")).toBe("model");
+  });
+
+  it("renders a fill image inside a positioned parent", () => {
+    const { container } = render(
+      <div style={{ position: "relative", width: 100, height: 100 }}>
+        <AppImage src="blob:local-preview" alt="" fill sizes="100px" className="object-cover" />
+      </div>,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("blob:local-preview");
+    expect(img!.className).toContain("object-cover");
+  });
+});

--- a/src/components/ui/app-image.tsx
+++ b/src/components/ui/app-image.tsx
@@ -1,0 +1,22 @@
+import Image, { type ImageProps } from "next/image";
+
+/**
+ * App image primitive (POLICY.md R-8.1.4) — adopts next/image for its dimension
+ * enforcement + default lazy-loading (CLS + below-the-fold wins) across the app's
+ * dynamic images.
+ *
+ * It defaults to `unoptimized` ON PURPOSE. Every user-facing image here comes from
+ * one of three sources the Next image optimizer cannot process:
+ *  - the auth-gated `/api/files/{storageId}` proxy (`requireOrganization`) — the
+ *    optimizer fetches server-side without the user's session cookie, so it would
+ *    401 and render broken images;
+ *  - `blob:` object URLs (client-side upload previews) — not fetchable server-side;
+ *  - `data:` URLs (e.g. generated 2FA QR codes) — nothing to optimize.
+ * See docs/adr/0002-next-image-unoptimized.md for the full rationale.
+ *
+ * For a genuinely static/public asset that SHOULD be optimized, use next/image
+ * directly instead of this wrapper.
+ */
+export function AppImage(props: ImageProps) {
+  return <Image unoptimized {...props} />;
+}

--- a/src/components/ui/photo-grid-input.tsx
+++ b/src/components/ui/photo-grid-input.tsx
@@ -18,6 +18,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { AppImage } from "@/components/ui/app-image";
 import { Camera, Loader2, X } from "lucide-react";
 
 interface PendingPhoto {
@@ -174,8 +175,7 @@ export function PhotoGridInput({
           key={url}
           className="relative aspect-square overflow-hidden rounded-md border bg-bg-inset"
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={url} alt="" className="h-full w-full object-cover" />
+          <AppImage src={url} alt="" fill sizes="(max-width: 768px) 50vw, 200px" className="object-cover" />
           <button
             type="button"
             onClick={() => removeExisting(url)}


### PR DESCRIPTION
Replaced all **7 raw `<img>`** tags (each with an `eslint-disable @next/next/no-img-element`) with `next/image` through a new **`AppImage`** wrapper (**R-8.1.4**).

`AppImage` defaults to `unoptimized` **on purpose**: every app image comes from a source the Next optimizer can't process — the auth-gated `/api/files/{storageId}` proxy (`requireOrganization` → the server-side optimizer has no user session and would 401), `blob:` upload previews, and `data:` URLs (2FA QR). We still gain enforced dimensions/`fill` (CLS) + default lazy-loading. Full rationale in **`docs/adr/0002-next-image-unoptimized.md`**.

- `fill` conversions add `relative` to the 4 containers that needed a positioned parent; avatar-stack + photo-grid were already relative.
- QR keeps explicit width/height; removed all `no-img-element` suppressions.
- Smoke test asserts the rendered `<img>` keeps the src un-rewritten + lazy loading + fill/object-cover.

tsc + lint (0 errors) + build + smoke test green.

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)