### PR TITLE
test(validation): enforce Zod↔Convex field-set parity via drift guard (#618)

### DIFF
--- a/convex/bulkAssetsWrites.ts
+++ b/convex/bulkAssetsWrites.ts
@@ -31,7 +31,7 @@ import * as enums from "./lib/validators";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const bulkFields = {
+export const bulkFields = {
   modelId: v.string(),
   assetTag: v.string(),
   totalQuantity: v.optional(v.number()),

--- a/convex/categoriesWrites.ts
+++ b/convex/categoriesWrites.ts
@@ -17,7 +17,7 @@ import { assertRefInOrg } from "./lib/orgRef";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const categoryFields = {
+export const categoryFields = {
   name: v.string(),
   parentId: v.optional(v.string()),
   description: v.optional(v.string()),

--- a/convex/checkItemsWrites.ts
+++ b/convex/checkItemsWrites.ts
@@ -46,7 +46,7 @@ async function orgKit(ctx: MutationCtx, orgId: string, id: string) {
 
 // ─── Check Item Library ─────────────────────────────────────────────────────
 
-const checkItemFields = {
+export const checkItemFields = {
   label: v.string(),
   description: v.optional(v.string()),
   type: v.optional(CheckItemType),

--- a/convex/checkRecords.ts
+++ b/convex/checkRecords.ts
@@ -76,7 +76,7 @@ export const create = mutation({
   },
 });
 
-const checkRecordFields = {
+export const checkRecordFields = {
   id: v.string(),
   organizationId: v.string(),
   context: enums.CheckContext,

--- a/convex/clientWrites.ts
+++ b/convex/clientWrites.ts
@@ -19,7 +19,7 @@ import * as enums from "./lib/validators";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const clientFields = {
+export const clientFields = {
   name: v.string(),
   type: v.optional(enums.ClientType),
   contactName: v.optional(v.string()),

--- a/convex/crewAssignmentsWrites.ts
+++ b/convex/crewAssignmentsWrites.ts
@@ -36,7 +36,7 @@ function assertCrewMoney(value: number | undefined, field: string): void {
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const assignmentFields = {
+export const assignmentFields = {
   crewMemberId: v.string(),
   crewRoleId: v.optional(v.string()),
   serviceId: v.optional(v.string()),

--- a/convex/crewTimeEntriesWrites.ts
+++ b/convex/crewTimeEntriesWrites.ts
@@ -19,7 +19,7 @@ import { calculateTotalHours } from "./lib/crewTimeHours";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const entryFields = {
+export const entryFields = {
   assignmentId: v.optional(v.string()),
   crewMemberId: v.string(),
   description: v.optional(v.string()),

--- a/convex/locationsWrites.ts
+++ b/convex/locationsWrites.ts
@@ -19,7 +19,7 @@ import * as enums from "./lib/validators";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const locationFields = {
+export const locationFields = {
   name: v.string(),
   address: v.optional(v.string()),
   latitude: v.optional(v.union(v.number(), v.null())),

--- a/convex/modelWrites.ts
+++ b/convex/modelWrites.ts
@@ -29,7 +29,7 @@ import * as enums from "./lib/validators";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const modelFields = {
+export const modelFields = {
   name: v.string(),
   manufacturer: v.optional(v.string()),
   modelNumber: v.optional(v.string()),

--- a/convex/subTestRecords.ts
+++ b/convex/subTestRecords.ts
@@ -54,7 +54,7 @@ export const listByRecordIds = query({
   },
 });
 
-const subTestFields = {
+export const subTestFields = {
   id: v.string(),
   testTagRecordId: v.string(),
   label: v.string(),

--- a/convex/suppliersWrites.ts
+++ b/convex/suppliersWrites.ts
@@ -16,7 +16,7 @@ import { writeActivityLog } from "./lib/audit";
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-const supplierFields = {
+export const supplierFields = {
   name: v.string(),
   contactName: v.optional(v.string()),
   email: v.optional(v.string()),

--- a/convex/userNotificationPreferences.ts
+++ b/convex/userNotificationPreferences.ts
@@ -127,7 +127,7 @@ export const remove = mutation({
 // can only ever read/write their OWN row. This replaces the getNotificationPreferences
 // / updateNotificationPreferences server actions in src/server/notification-preferences.ts.
 
-const prefFields = {
+export const prefFields = {
   overdueMaintenance: v.boolean(),
   overdueReturn: v.boolean(),
   upcomingProject: v.boolean(),

--- a/convex/validationDrift.test.ts
+++ b/convex/validationDrift.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Validation drift guard (POLICY.md R-8.6.1 — single source of truth).
+ *
+ * The client Zod schemas (src/lib/validations/*) and the Convex browser-direct
+ * arg validators (the `*Fields` objects in convex/*Writes.ts) describe the SAME
+ * business fields at two trust boundaries. They intentionally differ in
+ * OPTIONALITY (client input has defaults/coercion; server args are structural),
+ * so we don't mechanically derive one from the other — that would silently make
+ * optional args required and reject valid writes.
+ *
+ * What we DO enforce here: the two must carry the SAME FIELD SET. Adding or
+ * removing a field on one side without the other is drift — this test fails until
+ * they're reconciled, which is the guarantee R-8.6.1 asks for. Per-pair `allow`
+ * lists document any deliberate, reviewed divergence.
+ */
+import { describe, expect, it } from "vitest";
+
+import { clientFields } from "./clientWrites";
+import { assignmentFields } from "./crewAssignmentsWrites";
+import { entryFields } from "./crewTimeEntriesWrites";
+import { checkRecordFields } from "./checkRecords";
+import { categoryFields } from "./categoriesWrites";
+import { checkItemFields } from "./checkItemsWrites";
+import { bulkFields } from "./bulkAssetsWrites";
+import { prefFields } from "./userNotificationPreferences";
+import { modelFields } from "./modelWrites";
+import { locationFields } from "./locationsWrites";
+import { supplierFields } from "./suppliersWrites";
+import { subTestFields } from "./subTestRecords";
+
+import { clientSchema } from "@/lib/validations/client";
+import { crewAssignmentSchema, crewTimeEntrySchema } from "@/lib/validations/crew";
+import { checkRecordSchema, checkItemSchema } from "@/lib/validations/check-item";
+import { categorySchema } from "@/lib/validations/category";
+import { bulkAssetSchema, locationSchema } from "@/lib/validations/asset";
+import { notificationPreferenceSchema } from "@/lib/validations/notification-preferences";
+import { modelSchema } from "@/lib/validations/model";
+import { supplierSchema } from "@/lib/validations/supplier";
+import { subTestRecordSchema } from "@/lib/validations/test-tag";
+
+/** Unwrap a Zod schema (through .refine/.default/.optional wrappers) to its object shape keys. */
+function zodKeys(schema: unknown): string[] {
+  type Wrap = { schema?: unknown; innerType?: unknown; in?: unknown };
+  type Node = { shape?: Record<string, unknown>; _def?: Wrap; def?: Wrap };
+  let cur = schema as Node | null | undefined;
+  for (let i = 0; i < 8 && cur; i++) {
+    if (cur.shape) return Object.keys(cur.shape);
+    const def = cur._def ?? cur.def;
+    cur = (def?.schema ?? def?.innerType ?? def?.in ?? null) as Node | null;
+  }
+  throw new Error("could not resolve object shape from schema");
+}
+
+interface Pair {
+  name: string;
+  zod: unknown;
+  convex: Record<string, unknown>;
+  /** Keys deliberately present on only one side (reviewed). */
+  allowZodOnly?: string[];
+  allowConvexOnly?: string[];
+}
+
+const PAIRS: Pair[] = [
+  { name: "client", zod: clientSchema, convex: clientFields },
+  {
+    name: "crewAssignment",
+    zod: crewAssignmentSchema,
+    convex: assignmentFields,
+    // `generateShifts` is a client-only form control (asks the server to spawn
+    // shifts); it isn't a persisted assignment field.
+    allowZodOnly: ["generateShifts"],
+  },
+  { name: "crewTimeEntry", zod: crewTimeEntrySchema, convex: entryFields },
+  {
+    name: "checkRecord",
+    zod: checkRecordSchema,
+    convex: checkRecordFields,
+    // The client submits { checkItemId, notes, photos, result, value }; the server
+    // record additionally carries identity, the resolved target refs, denormalised
+    // snapshots, and audit stamps — all server-managed, never client input.
+    allowConvexOnly: [
+      "assetId", "bulkAssetId", "checkItemLabelSnapshot", "checkItemTypeSnapshot",
+      "context", "id", "kitId", "lineItemId", "lineItemUnitId", "organizationId",
+      "performedAt", "performedById",
+    ],
+  },
+  { name: "category", zod: categorySchema, convex: categoryFields },
+  { name: "checkItem", zod: checkItemSchema, convex: checkItemFields },
+  { name: "bulkAsset", zod: bulkAssetSchema, convex: bulkFields },
+  { name: "notificationPreference", zod: notificationPreferenceSchema, convex: prefFields },
+  { name: "model", zod: modelSchema, convex: modelFields },
+  { name: "location", zod: locationSchema, convex: locationFields },
+  { name: "supplier", zod: supplierSchema, convex: supplierFields },
+  {
+    name: "subTestRecord",
+    zod: subTestRecordSchema,
+    convex: subTestFields,
+    // id + createdAt + the parent FK are server-managed.
+    allowConvexOnly: ["createdAt", "id", "testTagRecordId"],
+  },
+];
+
+describe("validation field-set parity (Zod client ↔ Convex server) — R-8.6.1", () => {
+  it.each(PAIRS)("$name: Convex validator and Zod schema share one field set", (pair) => {
+    const zod = new Set(zodKeys(pair.zod));
+    const convex = new Set(Object.keys(pair.convex));
+    (pair.allowZodOnly ?? []).forEach((k) => zod.delete(k));
+    (pair.allowConvexOnly ?? []).forEach((k) => convex.delete(k));
+
+    const zodOnly = [...zod].filter((k) => !convex.has(k)).sort();
+    const convexOnly = [...convex].filter((k) => !zod.has(k)).sort();
+
+    expect(
+      { zodOnly, convexOnly },
+      `Drift in "${pair.name}": these fields exist on only one side. Reconcile the ` +
+        `Zod schema (src/lib/validations) and the Convex *Fields validator, or add a ` +
+        `documented allow entry in validationDrift.test.ts.`,
+    ).toEqual({ zodOnly: [], convexOnly: [] });
+  });
+});

--- a/docs/adr/0003-validation-drift-guard.md
+++ b/docs/adr/0003-validation-drift-guard.md
@@ -1,0 +1,45 @@
+# ADR-0003: Enforce Zod↔Convex validation single-source via a drift guard
+
+**Status:** Accepted (2026-07-18)
+
+## Context
+
+POLICY.md **R-8.6.1** requires a single source of truth for validation. The app
+validates the same business fields at two trust boundaries:
+
+- **Client input** — Zod schemas in `src/lib/validations/*` (used by the form
+  `zodResolver`). These are input-shaped: defaults, coercion, `.email()`, `.max()`,
+  cross-field `.refine()`, `z.literal("")` unions.
+- **Server args** — the `*Fields` `v.*` validator objects in `convex/*Writes.ts`, the
+  browser-direct write boundary. These are structural and mostly optional.
+
+The two are hand-maintained and can drift (a field added to one and not the other).
+
+We evaluated mechanically deriving the Convex validators from the Zod schemas with
+`convex-helpers`' `zodToConvexFields`. **It is not safe here:** the bridge does not
+preserve optionality — fields with a Zod `.default()` or `.optional().or(...)` come out
+**required**. Dropping those into the browser-direct mutations would make Convex reject
+inputs it currently accepts — a live regression on the money/tenant write surface (the
+exact surface where prior CRITICAL IDOR/money bugs were found). The two layers
+legitimately differ in optionality, so a pure derivation is the wrong tool.
+
+## Decision
+
+Keep the two definitions but **enforce that they can never drift out of field-set
+sync**, which is the guarantee R-8.6.1 actually needs. `convex/validationDrift.test.ts`
+imports each Zod schema and its paired Convex `*Fields` object and asserts they carry
+the **same field set**. Deliberate divergences (client-only form controls like
+`generateShifts`; server-managed fields like `id`/`organizationId`/audit stamps/FK
+snapshots) are documented per-pair via explicit `allow` lists. The `*Fields` objects are
+`export`ed so the guard can introspect them. Twelve domains are covered today; new domains
+are added to the `PAIRS` table.
+
+## Consequences
+
+- Adding/removing a field on one side without the other fails CI until reconciled —
+  single-source-of-truth consistency is enforced with **zero runtime change** to the
+  security-sensitive validators (no regression risk).
+- The guard checks field-set parity, not per-field type/optionality equivalence (those
+  differ by design between the layers). A future initiative could restructure each schema
+  to make a safe, optionality-preserving derivation possible; until then this guard holds
+  the invariant. See ADR rationale above for why the mechanical derivation was rejected.


### PR DESCRIPTION
The client Zod schemas and the Convex browser-direct arg validators (`*Fields` in `convex/*Writes.ts`) describe the same fields at two boundaries and could silently drift (**R-8.6.1**).

**Mechanical derivation was evaluated and rejected** (proven unsafe): `convex-helpers`' `zodToConvexFields` does not preserve optionality — Zod `.default()`/`.optional().or()` fields come out **required**, which would make the browser-direct mutations reject currently-valid input → a live regression on the money/tenant surface (where the prior CRITICAL bugs lived). The two layers differ in optionality by design. Full rationale in **`docs/adr/0003-validation-drift-guard.md`**.

Instead: **enforce field-set parity** so the two can never drift.
- `convex/validationDrift.test.ts` asserts each Zod schema and its paired Convex `*Fields` object share one field set (**12 domains**). Deliberate divergences (client-only controls; server-managed id/org/audit/FK) are documented per-pair via `allow` lists.
- Exported the 12 `*Fields` objects for introspection (no behaviour change).

**Zero runtime change** to the validators → single-source consistency is now CI-enforced with no regression risk. 12/12 green; tsc + lint clean.

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)