### PR TITLE
refactor(obs): route all app logging through the structured logger + enforce (#622)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -125,6 +125,22 @@ const eslintConfig = [
     },
   },
   {
+    // App logging must go through the structured logger (POLICY.md R-8.9.5): raw
+    // console.* is unlevelled, unscrubbed, and carries no correlation id. The two
+    // legitimate low-level uses (the logger's own transport + the crash-time floor
+    // in process-safety) carry an inline eslint-disable with a reason.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "**/*.test.{ts,tsx}",
+      "**/*.spec.{ts,tsx}",
+      "**/__tests__/**",
+      "src/generated/**",
+    ],
+    rules: {
+      "no-console": "error",
+    },
+  },
+  {
     // No hardcoded color literals in UI components — use design tokens (POLICY.md
     // R-8.7.1) so a brand-color change is a one-line diff. Excludes legitimate
     // non-CSS contexts: canvas (favicon), browser theme-color meta, the brand-default

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireSession } from "@/lib/auth-server";
 import { validateCsrfOrigin } from "@/lib/csrf";
 import { prisma } from "@/lib/prisma";
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ url });
   } catch (error) {
-    console.error("Avatar upload error:", error);
+    logger.error("Avatar upload error", { error: error });
     return NextResponse.json({ error: "Upload failed." }, { status: 500 });
   }
 }
@@ -127,7 +128,7 @@ export async function DELETE(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Avatar delete error:", error);
+    logger.error("Avatar delete error", { error: error });
     return NextResponse.json({ error: "Failed to remove avatar." }, { status: 500 });
   }
 }

--- a/src/app/api/crew/avatar/route.ts
+++ b/src/app/api/crew/avatar/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { z } from "zod";
 import { requireSession } from "@/lib/auth-server";
 import { readValidatedBody } from "@/lib/api-validation";
@@ -95,7 +96,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ url });
   } catch (error) {
-    console.error("Crew avatar upload error:", error);
+    logger.error("Crew avatar upload error", { error: error });
     return NextResponse.json({ error: "Upload failed." }, { status: 500 });
   }
 }
@@ -140,7 +141,7 @@ export async function DELETE(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Crew avatar delete error:", error);
+    logger.error("Crew avatar delete error", { error: error });
     return NextResponse.json({ error: "Failed to remove image." }, { status: 500 });
   }
 }

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { env } from "@/env";
 import {
   pruneStaleNotificationEmailLogs,
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
     const pruned = await pruneStaleNotificationEmailLogs();
     return NextResponse.json({ ...result, prunedLogs: pruned });
   } catch (e) {
-    console.error("[Cron] Notification emails failed:", e);
+    logger.error("[Cron] Notification emails failed", { error: e });
     return NextResponse.json(
       { error: e instanceof Error ? e.message : String(e) },
       { status: 500 },

--- a/src/app/api/cron/test-tag-reminders/route.ts
+++ b/src/app/api/cron/test-tag-reminders/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { recalculateAllTestTagStatuses, sendTestTagReminderDigests } from "@/server/test-tag-reminders";
 import { env } from "@/env";
 
@@ -29,7 +30,7 @@ export async function POST(request: NextRequest) {
     const result = await sendTestTagReminderDigests();
     return NextResponse.json({ ...result, statusesUpdated });
   } catch (e) {
-    console.error("[Cron] Test tag reminders failed:", e);
+    logger.error("[Cron] Test tag reminders failed", { error: e });
     return NextResponse.json(
       { error: (e as Error).message },
       { status: 500 }

--- a/src/app/api/documents/[projectId]/route.tsx
+++ b/src/app/api/documents/[projectId]/route.tsx
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
 import { generatePdf } from "@/lib/pdfme/generate-pdf";
 import type { DocumentType } from "@/lib/pdfme/types";
@@ -45,7 +46,7 @@ export async function GET(
       },
     });
   } catch (error) {
-    console.error("PDF generation error:", error);
+    logger.error("PDF generation error", { error: error });
     return NextResponse.json(
       { error: "PDF generation failed", details: String(error) },
       { status: 500 }

--- a/src/app/api/documents/call-sheet/[projectId]/route.tsx
+++ b/src/app/api/documents/call-sheet/[projectId]/route.tsx
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
 import { generateCallSheetPdf } from "@/lib/pdfme/generate-pdf";
 
@@ -78,7 +79,7 @@ export async function GET(
       },
     });
   } catch (error) {
-    console.error("Call sheet PDF generation error:", error);
+    logger.error("Call sheet PDF generation error", { error: error });
     return NextResponse.json(
       { error: "PDF generation failed", details: String(error) },
       { status: 500 }

--- a/src/app/api/documents/template-preview/route.tsx
+++ b/src/app/api/documents/template-preview/route.tsx
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
 import { buildSampleDocumentData } from "@/lib/pdfme/sample-document-data";
 import { generatePdfFromSettings, generatePdfFromSections } from "@/lib/pdfme/generate-pdf";
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (err) {
-    console.error("Template preview generation failed:", err);
+    logger.error("Template preview generation failed", { error: err });
     return NextResponse.json(
       { error: "Failed to generate preview" },
       { status: 500 }

--- a/src/app/api/documents/timeline/[projectId]/route.tsx
+++ b/src/app/api/documents/timeline/[projectId]/route.tsx
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { generate } from "@pdfme/generator";
 import { requireOrganization } from "@/lib/auth-server";
 import { getProjectServicesFromConvex } from "@/lib/project-service-read";
@@ -95,7 +96,7 @@ export async function GET(
       },
     });
   } catch (error) {
-    console.error("Timeline PDF generation error:", error);
+    logger.error("Timeline PDF generation error", { error: error });
     return NextResponse.json(
       { error: "PDF generation failed", details: String(error) },
       { status: 500 }

--- a/src/app/api/files/[...path]/route.ts
+++ b/src/app/api/files/[...path]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
 import { getServeInfo } from "@/lib/storage";
 
@@ -58,7 +59,7 @@ export async function GET(
 
     return new NextResponse(upstream.body, { headers });
   } catch (error) {
-    console.error("File serve error:", error);
+    logger.error("File serve error", { error: error });
     return NextResponse.json({ error: "File not found" }, { status: 404 });
   }
 }

--- a/src/app/api/integrations/woocommerce/webhook/route.ts
+++ b/src/app/api/integrations/woocommerce/webhook/route.ts
@@ -1,4 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@/lib/logger";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../../../../../convex/_generated/api";
 import { getTheOrg } from "@/lib/single-org";
@@ -106,7 +107,7 @@ export async function POST(request: Request) {
 
   // 12. Process the order asynchronously — respond 200 immediately
   processWooCommerceOrder(orgId, order, integration).catch((err) => {
-    console.error("[WooCommerce] Background processing error:", err);
+    logger.error("[WooCommerce] Background processing error", { error: err });
   });
 
   // 13. Respond 200 immediately (WooCommerce retries on non-200)

--- a/src/app/api/test-tag-reports/[reportType]/route.tsx
+++ b/src/app/api/test-tag-reports/[reportType]/route.tsx
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { requireOrganization } from "@/lib/auth-server";
 import { readOrgSettingsBlob } from "@/lib/org-settings-read";
@@ -235,7 +236,7 @@ export async function GET(
       },
     });
   } catch (e) {
-    console.error("Report generation error:", e);
+    logger.error("Report generation error", { error: e });
     return NextResponse.json({ error: e instanceof Error ? e.message : "Report generation failed" }, { status: 500 });
   }
 }

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { type FunctionArgs } from "convex/server";
 import { createId } from "@paralleldrive/cuid2";
 import { requireOrganization } from "@/lib/auth-server";
@@ -141,7 +142,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(fileUpload);
   } catch (error) {
-    console.error("Upload error:", error);
+    logger.error("Upload error", { error: error });
     return NextResponse.json(
       { error: "Upload failed. Please try again." },
       { status: 500 }

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { logger } from "@/lib/logger";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -39,9 +40,9 @@ export class GlobalErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error) {
     if (process.env.NODE_ENV === "development") {
-      console.warn(
+      logger.warn(
         "GlobalErrorBoundary: caught DOM manipulation error, recovering…",
-        error.message
+        { error: error.message }
       );
     }
   }

--- a/src/components/providers/convex-provider.tsx
+++ b/src/components/providers/convex-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { ConvexReactClient, ConvexProviderWithAuth } from "convex/react";
+import { logger } from "@/lib/logger";
 import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import { authClient } from "@/lib/auth-client";
 import { fetchConvexAccessToken } from "@/lib/convex-token-fetch";
@@ -78,7 +79,7 @@ export function ConvexClientProvider({
   // per-domain migration, so nothing depends on Convex until its domain lands.
   if (!client) {
     if (process.env.NODE_ENV !== "production") {
-      console.warn(
+      logger.warn(
         "[convex] NEXT_PUBLIC_CONVEX_URL is not set — Convex provider is inert.",
       );
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from "zod";
+import { logger } from "@/lib/logger";
 
 const serverEnvSchema = z.object({
   // Core (required)
@@ -123,7 +124,7 @@ const parsed = validated.data;
 // Warn on missing optional config rather than hard-fail
 if (parsed.NODE_ENV !== "test") {
   if (!parsed.RESEND_API_KEY) {
-    console.warn(
+    logger.warn(
       "[env] RESEND_API_KEY is not set — emails will log to console instead of being sent.",
     );
   }

--- a/src/hooks/use-collaboration.ts
+++ b/src/hooks/use-collaboration.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback, useMemo } from "react";
+import { logger } from "@/lib/logger";
 import { useMutation } from "convex/react";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { api } from "../../convex/_generated/api";
@@ -82,7 +83,7 @@ export function usePresence(options: UsePresenceOptions) {
             mode: "viewing",
           })
         : Promise.resolve(),
-    onError: (e) => console.warn("[presence] heartbeat failed", e),
+    onError: (e) => logger.warn("[presence] heartbeat failed", { error: e }),
   });
 
   const clearMut = useServerMutation({
@@ -203,7 +204,7 @@ export function useEditLock(options: UseEditLockOptions) {
       orgId
         ? acquireLockM({ orgId, entityType, entityId, targetType, targetId, ...ownerFields(), clientSessionId: sid })
         : Promise.resolve(null),
-    onError: (e) => console.warn("[lock] acquire failed", e),
+    onError: (e) => logger.warn("[lock] acquire failed", { error: e }),
   });
 
   const heartbeatMut = useServerMutation({
@@ -223,7 +224,7 @@ export function useEditLock(options: UseEditLockOptions) {
       orgId
         ? takeoverLockM({ orgId, entityType, entityId, targetType, targetId, ...ownerFields(), clientSessionId: sid })
         : Promise.resolve(null),
-    onError: (e) => console.warn("[lock] takeover failed", e),
+    onError: (e) => logger.warn("[lock] takeover failed", { error: e }),
   });
 
   useEffect(() => {

--- a/src/hooks/use-native-project-writes.ts
+++ b/src/hooks/use-native-project-writes.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "convex/react";
+import { logger } from "@/lib/logger";
 import type { FunctionArgs } from "convex/server";
 import { ConvexError } from "convex/values";
 import { createId } from "@paralleldrive/cuid2";
@@ -445,7 +446,7 @@ export function useProjectWrites(orgId: string | undefined) {
       try {
         await recalcM({ projectId: id, orgId, now: Date.now() });
       } catch (e) {
-        console.error("post-update recalc failed (non-fatal):", e);
+        logger.error("post-update recalc failed (non-fatal)", { error: e });
       }
     }
 

--- a/src/hooks/use-server-mutation.ts
+++ b/src/hooks/use-server-mutation.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { logger } from "@/lib/logger";
 
 /**
  * Server-action mutation hook (Phase 6 of the Convex migration — React Query
@@ -105,7 +106,7 @@ export function useServerMutation<TData = unknown, TVariables = void>(
         try {
           await cb();
         } catch (cbErr) {
-          console.error("useServerMutation callback threw:", cbErr);
+          logger.error("useServerMutation callback threw", { error: cbErr });
         }
       };
 

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,4 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@/lib/logger";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -44,7 +45,7 @@ export async function logActivity(input: LogActivityInput): Promise<void> {
       createdAt: Date.now(),
     });
   } catch (error) {
-    console.error("Failed to record activity to Convex:", error);
+    logger.error("Failed to record activity to Convex", { error: error });
   }
 }
 
@@ -84,7 +85,7 @@ export async function logActivityMany(inputs: LogActivityInput[]): Promise<void>
       })),
     });
   } catch (error) {
-    console.error("Failed to record activity batch to Convex:", error);
+    logger.error("Failed to record activity batch to Convex", { error: error });
   }
 }
 

--- a/src/lib/blocking-comments-read.ts
+++ b/src/lib/blocking-comments-read.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { logger } from "@/lib/logger";
 
 import { getConvexClient } from "@/lib/convex-client";
 import { evaluateBlockingGate } from "@/lib/blocking-comments-gate";
@@ -96,7 +97,7 @@ export async function assertNoBlockingComments(
   try {
     summary = await getProjectBlockingSummary(orgId, projectId);
   } catch (error) {
-    console.error("Failed to read blocking comments before warehouse action", error);
+    logger.error("Failed to read blocking comments before warehouse action", { error: error });
     throw new Error(
       "Can't verify blocking comments right now, so this action is paused. Try again once collaboration status is reachable.",
     );

--- a/src/lib/collaboration-activity.ts
+++ b/src/lib/collaboration-activity.ts
@@ -1,4 +1,5 @@
 import { getConvexClient } from "@/lib/convex-client";
+import { logger } from "@/lib/logger";
 import { api } from "../../convex/_generated/api";
 import { getUserColor } from "@/lib/collaboration-colors";
 
@@ -57,6 +58,6 @@ export async function writeCollabActivityEvent(
       metadata: event.metadata,
     });
   } catch (error) {
-    console.error("Failed to write collab activity event:", error);
+    logger.error("Failed to write collab activity event", { error: error });
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -33,7 +33,9 @@ function emit(level: Level, message: string, meta?: Record<string, unknown>) {
     record.meta = scrubbed;
   }
   const line = JSON.stringify(record);
-  // console is just the transport; Sentry still captures error/warn.
+  // This IS the logger's transport; all other app logging must go through `logger.*`
+  // (enforced by the no-console lint rule).
+  // eslint-disable-next-line no-console
   (level === "error" ? console.error : level === "warn" ? console.warn : console.log)(line);
 }
 

--- a/src/lib/member-mirror.ts
+++ b/src/lib/member-mirror.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -50,7 +51,7 @@ async function runMirror(
       // Prisma write — never leave Convex granting what Prisma is about to revoke.
       throw err;
     }
-    console.error(`[member-mirror] ${label} failed (best-effort):`, err);
+    logger.error(`[member-mirror] ${label} failed (best-effort)`, { error: err });
   }
 }
 

--- a/src/lib/process-safety.ts
+++ b/src/lib/process-safety.ts
@@ -26,6 +26,9 @@ export function installProcessSafetyNet(scope: string): void {
     // Log + report, but do NOT exit. An unhandled rejection is usually isolated
     // to one async chain; the process itself is still healthy. Crashing the
     // whole server over it is exactly what produced the user-visible 502s.
+    // Crash-time floor: minimal work in a process-fault handler; the structured
+    // logger is bypassed on purpose here.
+    // eslint-disable-next-line no-console
     console.error(`[${scope}] unhandledRejection:`, reason);
     capture(reason, scope, "unhandledRejection");
   });
@@ -34,6 +37,8 @@ export function installProcessSafetyNet(scope: string): void {
     // An uncaught exception leaves the process in an undefined state. Log +
     // report + flush, then exit(1) so pm2 restarts a clean process rather than
     // serving from a corrupt one.
+    // Crash-time floor (see above).
+    // eslint-disable-next-line no-console
     console.error(`[${scope}] uncaughtException:`, err);
     try {
       Sentry.captureException(err, { tags: { net: "uncaughtException", scope } });

--- a/src/lib/user-mirror.ts
+++ b/src/lib/user-mirror.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 import { getConvexClient } from "@/lib/convex-client";
 import { api } from "../../convex/_generated/api";
 
@@ -41,7 +42,7 @@ export async function mirrorUserToConvex(userId: string): Promise<void> {
     });
   } catch (err) {
     // Swallow — never block the auth/profile flow on a mirror failure.
-    console.error(`[user-mirror] failed to mirror user ${userId}:`, err);
+    logger.error(`[user-mirror] failed to mirror user ${userId}`, { error: err });
   }
 }
 
@@ -54,6 +55,6 @@ export async function removeUserFromConvex(userId: string): Promise<void> {
     const convex = await getConvexClient();
     await convex.mutation(api.users.remove, { id: userId });
   } catch (err) {
-    console.error(`[user-mirror] failed to remove user ${userId} from mirror:`, err);
+    logger.error(`[user-mirror] failed to remove user ${userId} from mirror`, { error: err });
   }
 }

--- a/src/server/org-members.ts
+++ b/src/server/org-members.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 import { getOrgContext, requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { sendEmail, roleChangedEmail, removedFromOrgEmail } from "@/lib/email";
@@ -147,7 +148,7 @@ export async function changeMemberRole(memberId: string, newRole: string) {
   });
   if (org && target.user.email) {
     const emailContent = roleChangedEmail({ orgName: org.name, newRole });
-    sendEmail({ to: target.user.email, ...emailContent }).catch(console.error);
+    sendEmail({ to: target.user.email, ...emailContent }).catch((e) => logger.error("async task failed", { error: e }));
   }
 
   return { success: true };
@@ -206,7 +207,7 @@ export async function removeOrgMember(memberId: string) {
   });
   if (org && target.user.email) {
     const emailContent = removedFromOrgEmail({ orgName: org.name });
-    sendEmail({ to: target.user.email, ...emailContent }).catch(console.error);
+    sendEmail({ to: target.user.email, ...emailContent }).catch((e) => logger.error("async task failed", { error: e }));
   }
 
   return { success: true };

--- a/src/server/sso.ts
+++ b/src/server/sso.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 import { getConvexClient } from "@/lib/convex-client";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
 import { api } from "../../convex/_generated/api";
@@ -356,7 +357,7 @@ export async function approveSSOUser(approvalId: string, role?: string) {
       dashboardUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard`,
       platformName: pName,
     }),
-  }).catch(console.error);
+  }).catch((e) => logger.error("async task failed", { error: e }));
 
   return { success: true };
 }
@@ -405,7 +406,7 @@ export async function rejectSSOUser(approvalId: string, note?: string) {
       note,
       platformName: pName,
     }),
-  }).catch(console.error);
+  }).catch((e) => logger.error("async task failed", { error: e }));
 
   return { success: true };
 }


### PR DESCRIPTION
The structured logger (correlation id + scrubbing + test) shipped earlier; this finishes #622 by **migrating the ~30 remaining raw `console.*` calls** in `src/` to `logger.*` and **enforcing** it.

- Every app-logging `console.*` (API routes, mirrors, hooks, providers, error-boundary, activity-log, cron, reports, env) → the levelled logger with structured `{ error }` meta.
- The two legitimate low-level uses keep raw console with an inline `eslint-disable` + reason: the logger's own transport, and the process-safety crash-time floor.
- Added **`no-console: error`** (ESLint, `src/`-scoped, tests excluded) so new raw `console.*` can't regress — the enforcement half of R-8.9.5.

tsc + lint (0 errors) + build + logger tests green.

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)