### PR TITLE
chore(migration): dated removal marker on last NATIVE_* fork + de-stale docstrings (#635)

### DIFF
--- a/convex/activityLogWrites.ts
+++ b/convex/activityLogWrites.ts
@@ -9,7 +9,7 @@ import { requireService } from "./lib/auth";
  * mutations (convex/lib/audit.ts `writeActivityLog`). The other ~39 domains still emit
  * audit via `logActivity` (src/lib/activity-log.ts, a Postgres write). To make the
  * activity-log SCREENS readable from Convex, every `logActivity` call also mirrors its
- * row here (behind `NATIVE_ACTIVITY_WRITES`), so Convex holds the COMPLETE history.
+ * row here (browser-direct; the NATIVE_ACTIVITY_WRITES legacy gate was removed in the cutover), so Convex holds the COMPLETE history.
  *
  * Idempotent by cuid (`createIfMissing` convention): a retried/duplicate `logActivity`
  * mirror must not double-insert. `id` + `createdAt` are caller-supplied (a cuid +

--- a/convex/crewWrites.ts
+++ b/convex/crewWrites.ts
@@ -17,7 +17,7 @@ const CREW_AUDIT_FIELDS = ["firstName", "lastName", "email", "phone", "type", "s
  * Native CREW write mutations (Phase 5) — same pattern as assetWrites/kitWrites:
  * RBAC(requireOrgPermission "crew") + atomic audit(writeActivityLog) in one
  * transaction. Additive; the generated convex/crewMembers.ts service mutations are
- * untouched. Gated behind NATIVE_CREW_WRITES in src/server/crew.ts.
+ * untouched. Browser-direct (the NATIVE_CREW_WRITES legacy server-action gate was removed in the cutover).
  *
  * Covers create + update (crew has no unique-tag invariant). deleteCrewMember has a
  * multi-table scheduling cascade (assignments → shifts/time-entries, availability) —

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -17,7 +17,7 @@ import * as enums from "./lib/validators";
  * ADDITIVE (the generated convex/kits.ts service mutations are untouched), each
  * enforcing RBAC(requireOrgPermission) + invariants + atomic audit(writeActivityLog)
  * in one transaction. `actor`/`auditId`/`now` are caller-generated (deterministic).
- * Gated live behind NATIVE_KIT_WRITES in src/server/kits.ts.
+ * Browser-direct (the NATIVE_KIT_WRITES legacy server-action gate was removed in the cutover).
  *
  * Covers create/update/notes (the clean writes). archive/delete use the existing
  * cascade mutations (kits.archiveCascade / deleteCascade) + their own status guards —

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -38,7 +38,7 @@ import { enqueueWebhookEvent } from "./lib/webhookEnqueue";
  *
  * removeNative mirrors removeLineItemCascade (convex/projectLineItems.ts) + adds the
  * child-removal guard (kit/accessory children can't be removed directly) + the DELETE
- * audit, all atomic. Gated behind NATIVE_LINEITEM_WRITES.
+ * audit, all atomic. Browser-direct (the NATIVE_LINEITEM_WRITES legacy server-action gate was removed in the cutover).
  */
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
@@ -1204,7 +1204,7 @@ export const reorderNative = mutation({
  *
  * orgDefaultTaxRate is resolved in-mutation from orgSettings (the source of truth), so
  * a browser caller can't spoof a money-affecting tax rate.
- * Gated behind NATIVE_RECALC; parity with the server-side math is proven by
+ * Browser-direct native recalc (the NATIVE_RECALC legacy gate was removed in the cutover); parity with the server-side math is proven by
  * convex/recalc.test.ts (recalcProjectTotals, the shared core).
  */
 export const recalcNative = mutation({

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -36,7 +36,7 @@ import { deleteAllForProjectCore } from "./projectCategories";
  * The financial writes (createProject/updateProject and every line-item write) call
  * recalculateProjectTotals and are deliberately NOT here — those stay server-side so
  * the totals math is untouched (parity preserved by construction) until they get the
- * dedicated recalc-parity treatment. Gated behind NATIVE_PROJECT_WRITES.
+ * dedicated recalc-parity treatment. Browser-direct (the NATIVE_PROJECT_WRITES legacy server-action gate was removed in the cutover).
  */
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });

--- a/src/lib/email-side-effect.ts
+++ b/src/lib/email-side-effect.ts
@@ -33,5 +33,7 @@ export async function deliverSideEffectEmail(args: {
     });
     return;
   }
+  // REMOVE-BY 2026-10-18 (R-4.5): legacy inline-send fork — delete once
+  // NATIVE_EMAIL_SIDEEFFECTS is confirmed stable in prod (see native-writes.ts).
   await sendEmail({ to: args.to, subject: args.subject, html: args.html });
 }

--- a/src/lib/native-writes.ts
+++ b/src/lib/native-writes.ts
@@ -12,6 +12,12 @@ import { UserFacingError } from "@/lib/errors/user-facing-error";
  * instead of an inline `sendEmail()` on the request path. Server-side runtime env
  * (Coolify, no rebuild), default OFF. Flip only after the Convex deployment has
  * `RESEND_API_KEY` + `EMAIL_FROM` set and a preview dogfood confirms delivery.
+ *
+ * REMOVE-BY 2026-10-18 (POLICY.md R-4.5 — dated removal condition): this is the last
+ * remaining NATIVE_* legacy fork. Once `NATIVE_EMAIL_SIDEEFFECTS=true` has run in prod
+ * through a full cycle with confirmed delivery, delete the legacy inline-`sendEmail`
+ * branch in `email-side-effect.ts`, make the Convex-scheduler path unconditional, and
+ * drop this flag. Blocked only on setting `RESEND_API_KEY`/`EMAIL_FROM` on prod Convex.
  */
 export const nativeEmailSideEffects = (): boolean =>
   process.env.NATIVE_EMAIL_SIDEEFFECTS === "true";


### PR DESCRIPTION
**#635** — the browser-direct cutover already removed the legacy write paths for `NATIVE_LINEITEM/PROJECT/CREW/KIT/ACTIVITY/RECALC` (verified: no runtime gate remains); they survived only as misleading `Gated behind NATIVE_X` docstrings, now corrected.

The one live fork — **`NATIVE_EMAIL_SIDEEFFECTS`** (inline `sendEmail` vs the Convex durable scheduler) — now has a **dated removal condition** (REMOVE-BY 2026-10-18): delete the inline branch + flag once confirmed stable in prod, blocked only on `RESEND_API_KEY`/`EMAIL_FROM` on prod Convex.

Comment-only. tsc + lint clean.

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)