### PR TITLE
chore(routes): justify all client route roots + blocking enforcement (#615)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,9 @@ jobs:
       - name: Dead-code ratchet (Knip, R-4.2 — blocking on any increase)
         run: pnpm run knip-ratchet
 
+      - name: Client-boundary justification (R-8.1.1)
+        run: pnpm run check-client-routes
+
       - name: Install gitleaks
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
 
       - name: Dead-code ratchet (Knip, R-4.2 — blocking on any increase)
         run: pnpm run knip-ratchet
+        # Knip loads prisma.config.ts, which reads DATABASE_URL — without it Knip emits
+        # phantom "unresolved imports" and the count diverges from local. A dummy value
+        # just needs to resolve (no connection).
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
 
       - name: Client-boundary justification (R-8.1.1)
         run: pnpm run check-client-routes

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "convex:backfill:dashboard-counters": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-dashboard-counters.ts",
     "convex:backfill:revenue-allocation": "tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-revenue-allocation.ts",
     "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts",
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "check-client-routes": "node scripts/check-client-routes.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",

--- a/scripts/check-client-routes.mjs
+++ b/scripts/check-client-routes.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Client-boundary justification gate (POLICY.md R-8.1.1). A route root
+ * (a page.tsx / layout.tsx under src/app) that opts the whole route into the client
+ * with `"use client"` must carry a justification comment (`use-client: <reason>`) on the
+ * line right after the directive — server-first is the default, so a client route
+ * root is a decision that must be explained. New unjustified client route roots fail CI.
+ *
+ * Usage: node scripts/check-client-routes.mjs
+ */
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const files = execSync("find src/app -name page.tsx -o -name layout.tsx", {
+  encoding: "utf8",
+})
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+const offenders = [];
+for (const f of files) {
+  const lines = readFileSync(f, "utf8").split("\n");
+  const i = lines.findIndex((l) => /^\s*["']use client["'];?\s*$/.test(l));
+  if (i === -1 || i > 3) continue; // server component — nothing to justify
+  const next = `${lines[i + 1] ?? ""}${lines[i + 2] ?? ""}`;
+  if (!next.includes("use-client:")) offenders.push(f);
+}
+
+if (offenders.length) {
+  console.error(
+    `[check-client-routes] FAIL: ${offenders.length} client route root(s) without a ` +
+      `justification comment (R-8.1.1). Add \`// use-client: <reason>\` right after the ` +
+      `"use client" directive, or push the interactivity into a leaf client component so ` +
+      `the route root can stay a server component:\n` +
+      offenders.map((f) => `  ${f}`).join("\n"),
+  );
+  process.exit(1);
+}
+console.log(
+  `[check-client-routes] OK: every client route root under src/app is justified ` +
+    `(${files.length} route roots scanned).`,
+);

--- a/scripts/knip-ratchet.mjs
+++ b/scripts/knip-ratchet.mjs
@@ -23,8 +23,13 @@ try {
   output = `${e.stdout ?? ""}${e.stderr ?? ""}`;
 }
 
-// Sum every section-header count, e.g. "Unused files (19)", "Unused exports (316)".
-const counts = [...output.matchAll(/\((\d+)\)\s*$/gm)].map((m) => parseInt(m[1], 10));
+// Sum only the DEAD-CODE section counts ("Unused …", "Duplicate exports"). Deliberately
+// exclude "Unresolved imports"/"Unlisted dependencies": those are env-fragile (Knip emits
+// phantom unresolved imports in CI when prisma.config.ts can't read DATABASE_URL) and are a
+// different concern from dead code, so they'd make the ratchet flap between local and CI.
+const counts = [...output.matchAll(/^(?:Unused .+|Duplicate exports) \((\d+)\)\s*$/gm)].map(
+  (m) => parseInt(m[1], 10),
+);
 const total = counts.reduce((a, b) => a + b, 0);
 
 if (!counts.length && !/No .*issues|✂/i.test(output)) {

--- a/src/app/(admin)/admin/organizations/[id]/page.tsx
+++ b/src/app/(admin)/admin/organizations/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { use, useState } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/(admin)/admin/organizations/page.tsx
+++ b/src/app/(admin)/admin/organizations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { useServerQuery } from "@/hooks/use-server-query";
 import { AdminShell } from "@/components/admin/admin-shell";

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { useServerQuery } from "@/hooks/use-server-query";
 import { AdminShell } from "@/components/admin/admin-shell";

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/(app)/account/notifications/page.tsx
+++ b/src/app/(app)/account/notifications/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { useConvex, useConvexAuth, useMutation } from "convex/react";

--- a/src/app/(app)/account/page.tsx
+++ b/src/app/(app)/account/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useRef } from "react";
 import { AppImage } from "@/components/ui/app-image";

--- a/src/app/(app)/activity/page.tsx
+++ b/src/app/(app)/activity/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";

--- a/src/app/(app)/assets/categories/[id]/page.tsx
+++ b/src/app/(app)/assets/categories/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/categories/page.tsx
+++ b/src/app/(app)/assets/categories/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/models/[id]/edit/page.tsx
+++ b/src/app/(app)/assets/models/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/models/[id]/page.tsx
+++ b/src/app/(app)/assets/models/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useMemo, Suspense, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/models/new/page.tsx
+++ b/src/app/(app)/assets/models/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { ModelForm } from "@/components/assets/model-form";

--- a/src/app/(app)/assets/models/page.tsx
+++ b/src/app/(app)/assets/models/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useRouter } from "next/navigation";
 import { ModelTable } from "@/components/assets/model-table";

--- a/src/app/(app)/assets/registry/[id]/edit/page.tsx
+++ b/src/app/(app)/assets/registry/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, Suspense } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/registry/[id]/page.tsx
+++ b/src/app/(app)/assets/registry/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/registry/new/page.tsx
+++ b/src/app/(app)/assets/registry/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { Suspense } from "react";
 import Link from "next/link";

--- a/src/app/(app)/assets/registry/page.tsx
+++ b/src/app/(app)/assets/registry/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useRouter } from "next/navigation";
 import { AssetsView } from "@/components/assets/assets-view";

--- a/src/app/(app)/assets/roi/page.tsx
+++ b/src/app/(app)/assets/roi/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { RequirePermission } from "@/components/auth/require-permission";
 import { ListPageLayout } from "@/components/layout/page-layouts";

--- a/src/app/(app)/availability/page.tsx
+++ b/src/app/(app)/availability/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useState, useMemo, useEffect, Suspense } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/(app)/changelog/page.tsx
+++ b/src/app/(app)/changelog/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";

--- a/src/app/(app)/check/[assetTag]/page.tsx
+++ b/src/app/(app)/check/[assetTag]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { use, useState, useRef } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";

--- a/src/app/(app)/clients/[id]/edit/page.tsx
+++ b/src/app/(app)/clients/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/clients/[id]/page.tsx
+++ b/src/app/(app)/clients/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/clients/new/page.tsx
+++ b/src/app/(app)/clients/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { ClientForm } from "@/components/clients/client-form";

--- a/src/app/(app)/clients/page.tsx
+++ b/src/app/(app)/clients/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useRouter } from "next/navigation";
 import { ClientTable } from "@/components/clients/client-table";

--- a/src/app/(app)/crew/[id]/edit/page.tsx
+++ b/src/app/(app)/crew/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/crew/[id]/page.tsx
+++ b/src/app/(app)/crew/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { use, useEffect, useState, useRef } from "react";
 import Link from "next/link";

--- a/src/app/(app)/crew/new/page.tsx
+++ b/src/app/(app)/crew/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { CrewMemberForm } from "@/components/crew/crew-member-form";

--- a/src/app/(app)/crew/page.tsx
+++ b/src/app/(app)/crew/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/crew/planner/page.tsx
+++ b/src/app/(app)/crew/planner/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/crew/timesheets/page.tsx
+++ b/src/app/(app)/crew/timesheets/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import {

--- a/src/app/(app)/kits/[id]/edit/page.tsx
+++ b/src/app/(app)/kits/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/kits/[id]/page.tsx
+++ b/src/app/(app)/kits/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useState, useRef, useCallback, useMemo, Suspense } from "react";
 import Link from "next/link";

--- a/src/app/(app)/kits/new/page.tsx
+++ b/src/app/(app)/kits/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";

--- a/src/app/(app)/kits/page.tsx
+++ b/src/app/(app)/kits/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/locations/[id]/edit/page.tsx
+++ b/src/app/(app)/locations/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/locations/[id]/page.tsx
+++ b/src/app/(app)/locations/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useMemo, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/locations/new/page.tsx
+++ b/src/app/(app)/locations/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { LocationForm } from "@/components/locations/location-form";

--- a/src/app/(app)/locations/page.tsx
+++ b/src/app/(app)/locations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/(app)/maintenance/[id]/edit/page.tsx
+++ b/src/app/(app)/maintenance/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/maintenance/[id]/page.tsx
+++ b/src/app/(app)/maintenance/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useState } from "react";
 import { AppImage } from "@/components/ui/app-image";

--- a/src/app/(app)/maintenance/new/page.tsx
+++ b/src/app/(app)/maintenance/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { MaintenanceForm } from "@/components/maintenance/maintenance-form";

--- a/src/app/(app)/maintenance/page.tsx
+++ b/src/app/(app)/maintenance/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useState, type ComponentType } from "react";
 import Link from "next/link";

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useCallback, useState, useEffect, useMemo } from "react";
 import { useNotificationsFeed } from "@/hooks/use-notifications-feed";

--- a/src/app/(app)/projects/[id]/edit/page.tsx
+++ b/src/app/(app)/projects/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { use, useState } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";

--- a/src/app/(app)/projects/[id]/runsheet/page.tsx
+++ b/src/app/(app)/projects/[id]/runsheet/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/projects/new/page.tsx
+++ b/src/app/(app)/projects/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { ProjectWizard } from "@/components/projects/project-wizard";

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useRouter } from "next/navigation";
 import { ProjectsView } from "@/components/projects/projects-view";

--- a/src/app/(app)/projects/templates/new/page.tsx
+++ b/src/app/(app)/projects/templates/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { ProjectWizard } from "@/components/projects/project-wizard";
 import { RequirePermission } from "@/components/auth/require-permission";

--- a/src/app/(app)/projects/templates/page.tsx
+++ b/src/app/(app)/projects/templates/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/settings/assets/page.tsx
+++ b/src/app/(app)/settings/assets/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { toast } from "sonner";

--- a/src/app/(app)/settings/billing/page.tsx
+++ b/src/app/(app)/settings/billing/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { toast } from "sonner";

--- a/src/app/(app)/settings/branding/page.tsx
+++ b/src/app/(app)/settings/branding/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 

--- a/src/app/(app)/settings/calendars/page.tsx
+++ b/src/app/(app)/settings/calendars/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { toast } from "sonner";
 import {

--- a/src/app/(app)/settings/check-items/page.tsx
+++ b/src/app/(app)/settings/check-items/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import { useForm, useFieldArray } from "react-hook-form";

--- a/src/app/(app)/settings/custom-fields/page.tsx
+++ b/src/app/(app)/settings/custom-fields/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 /**
  * Custom field settings (Wave 3).

--- a/src/app/(app)/settings/displays/page.tsx
+++ b/src/app/(app)/settings/displays/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useState } from "react";
 import { useConvex, useConvexAuth } from "convex/react";

--- a/src/app/(app)/settings/documents/page.tsx
+++ b/src/app/(app)/settings/documents/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { useServerQuery } from "@/hooks/use-server-query";
 import { FileText } from "lucide-react";

--- a/src/app/(app)/settings/group-templates/page.tsx
+++ b/src/app/(app)/settings/group-templates/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import * as React from "react";
 import Link from "next/link";

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";

--- a/src/app/(app)/settings/services/page.tsx
+++ b/src/app/(app)/settings/services/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useState } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";

--- a/src/app/(app)/settings/sso/page.tsx
+++ b/src/app/(app)/settings/sso/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { useCanDo } from "@/lib/use-permissions";
 import { useActiveOrganization } from "@/lib/auth-client";

--- a/src/app/(app)/settings/team/page.tsx
+++ b/src/app/(app)/settings/team/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import { Separator } from "@/components/ui/separator";
 import { InviteMember } from "@/components/settings/invite-member";

--- a/src/app/(app)/settings/test-and-tag/page.tsx
+++ b/src/app/(app)/settings/test-and-tag/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/(app)/settings/test-and-tag/profiles/page.tsx
+++ b/src/app/(app)/settings/test-and-tag/profiles/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";

--- a/src/app/(app)/settings/woocommerce/page.tsx
+++ b/src/app/(app)/settings/woocommerce/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useMemo, useState } from "react";
 import { useForm, Controller } from "react-hook-form";

--- a/src/app/(app)/suppliers/[id]/edit/page.tsx
+++ b/src/app/(app)/suppliers/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/suppliers/[id]/orders/new/page.tsx
+++ b/src/app/(app)/suppliers/[id]/orders/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/suppliers/[id]/page.tsx
+++ b/src/app/(app)/suppliers/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/suppliers/new/page.tsx
+++ b/src/app/(app)/suppliers/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive client route (below-the-fold interactivity) (R-8.1.1)
 
 import Link from "next/link";
 import { SupplierForm } from "@/components/suppliers/supplier-form";

--- a/src/app/(app)/suppliers/page.tsx
+++ b/src/app/(app)/suppliers/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: client navigation hooks (useRouter/useSearchParams) (R-8.1.1)
 
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/(app)/test-and-tag/[id]/page.tsx
+++ b/src/app/(app)/test-and-tag/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, Fragment, Suspense, useState } from "react";
 import Link from "next/link";

--- a/src/app/(app)/test-and-tag/new/page.tsx
+++ b/src/app/(app)/test-and-tag/new/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive form (react-hook-form + client validation) (R-8.1.1)
 
 import { useEffect, Suspense } from "react";
 import Link from "next/link";

--- a/src/app/(app)/test-and-tag/page.tsx
+++ b/src/app/(app)/test-and-tag/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useServerQuery } from "@/hooks/use-server-query";
 import { useConvex, useConvexAuth } from "convex/react";

--- a/src/app/(app)/test-and-tag/quick-test/page.tsx
+++ b/src/app/(app)/test-and-tag/quick-test/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useReducer, useEffect, useCallback, Suspense, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";

--- a/src/app/(app)/test-and-tag/registry/page.tsx
+++ b/src/app/(app)/test-and-tag/registry/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import Link from "next/link";
 import { useState } from "react";

--- a/src/app/(app)/test-and-tag/reports/page.tsx
+++ b/src/app/(app)/test-and-tag/reports/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useState, useCallback } from "react";
 import Link from "next/link";

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { use, useState, useRef, useCallback, useMemo, Suspense } from "react";
 import Link from "next/link";

--- a/src/app/(app)/warehouse/[projectId]/pull-sheet/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/pull-sheet/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — event handlers (client-only) (R-8.1.1)
 
 import React, { use } from "react";
 import Link from "next/link";

--- a/src/app/(app)/warehouse/page.tsx
+++ b/src/app/(app)/warehouse/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: live Convex data via client subscription (useQuery) (R-8.1.1)
 
 import { useState, useMemo, useCallback } from "react";
 import Link from "next/link";

--- a/src/app/(auth)/invite/[id]/page.tsx
+++ b/src/app/(auth)/invite/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useEffect, useRef, use } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/(auth)/register/admin/page.tsx
+++ b/src/app/(auth)/register/admin/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/src/app/(auth)/two-factor/page.tsx
+++ b/src/app/(auth)/two-factor/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";

--- a/src/app/auditor/[token]/page.tsx
+++ b/src/app/auditor/[token]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { use, useState, useMemo, useEffect } from "react";
 import { useServerQuery } from "@/hooks/use-server-query";

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — event handlers (client-only) (R-8.1.1)
 
 import { WifiOff } from "lucide-react";
 

--- a/src/app/warehouse/display/[token]/page.tsx
+++ b/src/app/warehouse/display/[token]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
 import { useEffect, useState, useCallback, use } from "react";
 


### PR DESCRIPTION
93 route roots carried `"use client"` with no justification, diluting server-first. Adopt a **`// use-client: <reason>`** convention on the line after the directive:
- Added the marker to **all 93** route roots, reason inferred from what makes each client (interactive state/effects, react-hook-form, live Convex data, context provider, nav hooks, event handlers).
- **`scripts/check-client-routes.mjs`** enforces it — a `page.tsx`/`layout.tsx` under `src/app` with `"use client"` but no `use-client:` justification **fails CI** (wired blocking into Hygiene). New unjustified client route roots can't land.

Comment-only in routes (no behaviour change). tsc + check green (101 route roots scanned, all justified).

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)