### PR TITLE
ci(prisma): migration-drift gate — schema.prisma needs a migration (#612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history so the migration-drift gate can merge-base against origin/main.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -221,6 +224,11 @@ jobs:
       # currently clean at high+; remaining low/moderate advisories are tracked, not gated.
       - name: Dependency vulnerability scan
         run: pnpm audit --audit-level high
+
+      - name: Migration drift (schema.prisma needs a migration, R-8.3.1)
+        run: |
+          git fetch --no-tags --depth=100 origin main:refs/remotes/origin/main || git fetch --no-tags origin main
+          pnpm run check-migration-drift
 
       - name: Import-cycle check (new cycles only, R-3.5)
         run: pnpm run depcruise

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "convex:auth:roundtrip": "tsx --env-file=.env --env-file=.env.local scripts/convex-auth-roundtrip.ts",
     "prepare": "husky || true",
     "check-client-routes": "node scripts/check-client-routes.mjs",
-    "bundle-ratchet": "node scripts/bundle-ratchet.mjs"
+    "bundle-ratchet": "node scripts/bundle-ratchet.mjs",
+    "check-migration-drift": "node scripts/check-migration-drift.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",

--- a/prisma/migrations/README.md
+++ b/prisma/migrations/README.md
@@ -1,0 +1,24 @@
+# Prisma migrations — policy (R-8.3.1)
+
+**`prisma/schema.prisma` is the authoritative source of the Postgres schema.** Every
+change to it MUST ship in the same PR as a migration under `prisma/migrations/`, enforced
+by the CI **migration-drift gate** (`scripts/check-migration-drift.mjs`, run in the
+Hygiene job): a PR that edits `schema.prisma` without adding a `migration.sql` fails.
+
+Add one with:
+
+```bash
+pnpm exec prisma migrate dev --name <describe-the-change>
+```
+
+Escape hatch for a deliberate **non-datamodel** edit to `schema.prisma` (a comment, a
+formatting change): put `[skip-migration-check]` in the PR's latest commit message.
+
+## Known limitation (why there's no full replay gate)
+
+A few early tables (e.g. `crew_role`) were created with `prisma db push` and never
+captured as migrations, so the history is **not replayable from zero** — `next build` /
+CI provision the DB with `prisma db push` (current schema) rather than `migrate deploy`.
+Reconciling the history (capturing those tables into a baseline migration) needs the prod
+schema and is tracked separately. Until then, the drift gate above prevents any **new**
+divergence, which is the R-8.3.1 concern.

--- a/scripts/check-migration-drift.mjs
+++ b/scripts/check-migration-drift.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Migration drift gate (POLICY.md R-8.3.1). The Postgres schema is authoritative
+ * (prisma/schema.prisma); every change to it MUST ship with a migration so the schema
+ * and the migration history can't silently diverge. This gate fails a PR that edits
+ * prisma/schema.prisma without adding a migration under prisma/migrations/.
+ *
+ * (A full `prisma migrate diff` replay isn't usable here: early tables were created via
+ * `db push` and never captured, so the history isn't replayable from zero — repairing
+ * that needs the prod schema. This gate stops NEW drift regardless.)
+ *
+ * Escape hatch: put `[skip-migration-check]` in the PR's latest commit message for a
+ * deliberate non-datamodel edit (e.g. a comment).
+ *
+ * Usage: node scripts/check-migration-drift.mjs [baseRef]
+ */
+import { execSync } from "node:child_process";
+
+const base = process.argv[2] || "origin/main";
+function git(cmd) {
+  return execSync(`git ${cmd}`, { encoding: "utf8" }).trim();
+}
+
+let range;
+try {
+  const mergeBase = git(`merge-base ${base} HEAD`);
+  range = `${mergeBase} HEAD`;
+} catch {
+  range = `${base} HEAD`;
+}
+const changed = git(`diff --name-only ${range}`).split("\n").filter(Boolean);
+
+const schemaChanged = changed.some((f) => f === "prisma/schema.prisma");
+const migrationAdded = changed.some((f) => /^prisma\/migrations\/.+\/migration\.sql$/.test(f));
+
+if (schemaChanged && !migrationAdded) {
+  const lastMsg = git("log -1 --format=%B");
+  if (lastMsg.includes("[skip-migration-check]")) {
+    console.log("[migration-drift] schema.prisma changed but [skip-migration-check] set — OK.");
+    process.exit(0);
+  }
+  console.error(
+    "[migration-drift] FAIL: prisma/schema.prisma changed without a migration (R-8.3.1).\n" +
+      "Run `pnpm exec prisma migrate dev --name <change>` and commit the generated migration,\n" +
+      "or add `[skip-migration-check]` to the commit message for a non-datamodel edit.",
+  );
+  process.exit(1);
+}
+console.log("[migration-drift] OK: no schema change, or a migration accompanies it.");


### PR DESCRIPTION
No drift check existed, and the history isn't replayable (early tables were `db push`ed, never captured — CI provisions via `db push`), so a strict `migrate diff` replay can't pass. **DB-free, git-based gate** instead:

- **`scripts/check-migration-drift.mjs`** fails a PR that edits `prisma/schema.prisma` without adding a `prisma/migrations/*/migration.sql` (escape: `[skip-migration-check]` for a non-datamodel edit). Wired **blocking** into Hygiene (`fetch-depth: 0` for merge-base). Verified: fails on a committed schema change without a migration; passes with the escape marker.
- **`prisma/migrations/README.md`** declares `schema.prisma` authoritative + documents the history-replay limitation.

Adds the drift gate + declares the schema authoritative (the finding's two options). The **history-replay repair** (capturing the db-push tables) needs **prod DB access** — that's the input from you.

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)