### PR TITLE
feat(privacy): verifiable user-erasure + registered retention (#614)

### DIFF
--- a/docs/pii-inventory.md
+++ b/docs/pii-inventory.md
@@ -41,11 +41,32 @@ Sentry `beforeSend` (`sentry.server.config.ts`, `instrumentation-client.ts`) str
 `user.email`, `user.ip_address`, and `authorization`/`cookie` headers before send. URLs use
 opaque cuids, not names/emails.
 
-## Known gaps (tracked in the baseline audit)
+## Retention periods (T-P2)
 
-- **R-8.12.2 (retention + deletion):** no registered per-class retention (T-P2) and no
-  end-to-end user-erasure workflow (delete request → verifiable removal incl. search indexes
-  and backups). **Open.**
-- **T-P3 backups:** daily Convex export, 90-day retention (`convex-backup.yml`).
+Registered per PII class. **Durations marked ⟨confirm⟩ are placeholder defaults — the data
+owner must set the real value per legal/compliance obligation before these are authoritative.**
+
+| PII class | Store | Retention | Erasure path |
+|---|---|---|---|
+| User identity (name, email, auth creds) | Postgres (Better Auth) | until account deletion | `adminDeleteUser` → **`verifyUserErased`** (R-8.12.2) |
+| Session / token | Postgres | session TTL / on sign-out | cascades on user delete |
+| Crew PII (DOB, rates, contact, ical token) | Convex `crewMembers` | ⟨confirm — e.g. until archived + 30d⟩ | crew delete + user-erasure sweep (⚠️ `crewMember.userId` link not yet scrubbed — see gap) |
+| Activity / audit logs (actor name) | Convex `activityLogs` / Postgres | ⟨confirm — e.g. 7y for audit⟩ | retained for audit; actor refs scrubbed on erasure |
+| Uploaded files | Convex `_storage` / `storedFiles` | until owner deletes | `/api/files` delete |
+| Backups | Convex export | 90 days (T-P3, `convex-backup.yml`) | ⚠️ point-in-time — erasure not yet propagated to backups |
+
+## User-erasure workflow (R-8.12.2)
+
+`adminDeleteUser` (site-admin) runs a cross-org GDPR sweep — deletes the Postgres identity
+(sessions/accounts cascade), removes the Convex `users` mirror (which also clears search
+indexes), deletes the user's authored kit/scan/test records, and scrubs their FK references
+on line-items / projects / maintenance. It then calls **`verifyUserErased`**, which confirms
+the identity PII is gone from Postgres + the Convex mirror and logs a warning if anything
+remains — making the erasure **verifiable**, not fire-and-forget.
+
+**Remaining gaps (need owner input / infra):** (1) the retention durations above marked
+⟨confirm⟩; (2) `crewMember.userId` is not yet scrubbed on erasure (a Convex `scrubUserRefs`
+mutation on `crewWrites` would close it); (3) erasure is not propagated into the 90-day
+backups (a restore-then-re-erase or crypto-shred process — infra decision).
 
 _Review this inventory at each quarterly sweep (§12) and whenever a PII field is added._

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -2,6 +2,7 @@
 
 import { createId } from "@paralleldrive/cuid2";
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
 import { removeUserFromConvex } from "@/lib/user-mirror";
 import {
   upsertMemberMirror,
@@ -600,6 +601,10 @@ export async function adminDeleteUser(userId: string) {
   // Remove the user from the Convex `users` mirror (best-effort).
   await removeUserFromConvex(userId);
 
+  // Verifiable removal (POLICY.md R-8.12.2): confirm the user's IDENTITY PII is actually
+  // gone from both stores after the sweep, so the erasure is auditable, not fire-and-forget.
+  const verification = await verifyUserErased(userId);
+
   const theOrg = await getTheOrg();
   if (theOrg) {
     await logActivity({
@@ -610,11 +615,51 @@ export async function adminDeleteUser(userId: string) {
       entityType: "user",
       entityId: userId,
       entityName: targetUser?.name || userId,
-      summary: `Deleted user ${targetUser?.name || userId}`,
+      summary: `Deleted user ${targetUser?.name || userId}` +
+        (verification.erased ? " — erasure verified" : ` — WARNING: PII remains (${verification.remaining.join(", ")})`),
+    });
+  }
+  if (!verification.erased) {
+    logger.error("[erasure] user PII remains after deletion (R-8.12.2)", {
+      userId,
+      remaining: verification.remaining,
     });
   }
 
-  return { success: true };
+  return { success: true, verification };
+}
+
+/**
+ * Verify a user's identity PII is gone from every store after an erasure
+ * (POLICY.md R-8.12.2). Read-only: returns which stores still reference the user so the
+ * erasure is auditable. Convex search indexes update automatically when the `users`
+ * mirror row is removed, so a clean mirror means the user is unsearchable there too.
+ */
+export async function verifyUserErased(
+  userId: string,
+): Promise<{ erased: boolean; remaining: string[] }> {
+  const remaining: string[] = [];
+
+  // Postgres (Better Auth identity tables — sessions/accounts cascade off `user`).
+  const [pgUser, pgSession, pgAccount] = await Promise.all([
+    prisma.user.findUnique({ where: { id: userId }, select: { id: true } }),
+    prisma.session.findFirst({ where: { userId }, select: { id: true } }),
+    prisma.account.findFirst({ where: { userId }, select: { id: true } }),
+  ]);
+  if (pgUser) remaining.push("postgres:user");
+  if (pgSession) remaining.push("postgres:session");
+  if (pgAccount) remaining.push("postgres:account");
+
+  // Convex `users` mirror (drives cross-domain name/email resolution + search).
+  try {
+    const convex = await getConvexClient();
+    const mirror = await convex.query(api.users.getById, { id: userId });
+    if (mirror) remaining.push("convex:users-mirror");
+  } catch {
+    remaining.push("convex:unverified");
+  }
+
+  return { erased: remaining.length === 0, remaining };
 }
 
 export async function forceDisable2FA(userId: string) {

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -635,7 +635,7 @@ export async function adminDeleteUser(userId: string) {
  * erasure is auditable. Convex search indexes update automatically when the `users`
  * mirror row is removed, so a clean mirror means the user is unsearchable there too.
  */
-export async function verifyUserErased(
+async function verifyUserErased(
   userId: string,
 ): Promise<{ erased: boolean; remaining: string[] }> {
   const remaining: string[] = [];


### PR DESCRIPTION
`adminDeleteUser` already ran a thorough cross-org GDPR sweep but was **fire-and-forget** with **no registered retention**. My part of R-8.12.2:

- **`verifyUserErased(userId)`** — read-only check that the user's identity PII is gone from Postgres (user/session/account) + the Convex `users` mirror. `adminDeleteUser` runs it, records *"erasure verified"* (or a WARNING) in the audit log, and errors if PII persists → **verifiable**, not fire-and-forget.
- **`docs/pii-inventory.md`** — registers per-PII-class **retention periods (T-P2)** + documents the erasure workflow + remaining gaps.

**The input this needs from you:** the retention **durations** marked ⟨confirm⟩ (legal call); scrubbing `crewMember.userId` (a Convex `scrubUserRefs` mutation); and propagating erasure into the 90-day **backups** (infra). So this **Refs**, not closes, #614.

tsc + lint clean.

Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)