### PR TITLE
fix(posthog): empty NEXT_PUBLIC_POSTHOG_HOST silently misroutes ingestion

### DIFF
--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -26,8 +26,13 @@ import { capture, AnalyticsEvent } from "@/lib/analytics";
  * convention at emit sites (see src/lib/analytics.ts), not by the SDK.
  */
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+// `||`, not `??`: an unset GitHub Actions repo variable is inlined at build
+// time as an empty string, not undefined — `?? default` never catches that,
+// so posthog-js gets api_host: "" and silently sends everything same-origin
+// instead of to PostHog (production symptom: requests to /e, /array/*, /flags
+// on this app's own domain, 307-redirected into the login page).
 const posthogHost =
-  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+  process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
 
 // The SDK (~50 KB gzip) is dynamically imported so it lands in its own async
 // chunk, NOT the entry-route First Load JS (keeps the bundle-ratchet gate green).

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -16,11 +16,15 @@ import { logger } from "@/lib/logger";
  * Short flush window because serverless/edge-ish handlers may freeze between
  * requests — we flush after each capture rather than relying on the interval.
  */
+// `||`, not `??`: NEXT_PUBLIC_POSTHOG_HOST is inlined at build time, and an
+// unset GitHub Actions repo variable is inlined as an empty string, not
+// undefined — `?? default` never catches that, silently pointing the CLI at
+// api_host: "" instead of the real ingestion host.
 const key =
-  process.env.POSTHOG_KEY ?? process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "";
+  process.env.POSTHOG_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY || "";
 const host =
-  process.env.POSTHOG_HOST ??
-  process.env.NEXT_PUBLIC_POSTHOG_HOST ??
+  process.env.POSTHOG_HOST ||
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ||
   "https://us.i.posthog.com";
 
 let client: PostHog | null = null;


### PR DESCRIPTION
**Hotfix found during prod verification of #650/#713.** After the sourcemap fix deployed, PostHog was still showing zero events. Two HAR captures (login page, home page after auth) from prod showed why:

```
307 GET https://flow.rvlt.app/array/phc_.../config.js
307 GET https://flow.rvlt.app/array/phc_.../config?...
308 POST https://flow.rvlt.app/flags/?...
```

Every PostHog SDK request was going to **`flow.rvlt.app` itself**, not `us.i.posthog.com` — and the app's own auth guard was 307/308-redirecting them into the login page (one even 405'd). PostHog received nothing, even though the ingestion key was correctly baked into the bundle.

## Root cause

`src/components/providers/posthog-provider.tsx` and `src/lib/posthog-server.ts` both resolved the host as:

```ts
process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com"
```

`NEXT_PUBLIC_POSTHOG_HOST` was never set as a GitHub Actions repo variable. An unset `${{ vars.X }}` reference resolves to an **empty string**, not absent — so it's inlined into the build as `""`, not `undefined`. `?? default` only falls back on `null`/`undefined`, so `"" ?? default` stays `""`. `posthog-js` treats an empty `api_host` as same-origin, which is exactly what the HAR shows.

## Fix

Switched both to `||`, which treats `""` the same as unset. `next.config.ts`'s sourcemap-upload host resolution was unaffected — `@posthog/nextjs-config`'s own `resolveConfig` already normalizes with `||` internally.

## Verified

tsc · eslint · relevant unit tests (`analytics.test.ts`, `process-safety.test.ts`) green.

Refs #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRMAaQ1UWo7Lbwm4KweGV)_