### PR TITLE
feat(observability): register + alert Core Web Vitals p75 (closes #617)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,10 @@ env vars are no longer read. `UPLOAD_MAX_SIZE_MB` (default 50) caps upload size.
   needed for local dev (`pnpm dev`/`pnpm build` never require them). The real deploy build
   (Dockerfile) hardcodes `POSTHOG_SOURCEMAPS_REQUIRED=true`, so a missing token/env-id there
   fails the build loudly rather than silently skipping the upload (R-8.9.2).
-- Registered budgets/SLOs alerted through PostHog live in `docs/thresholds.md`. The provider
-  is PII-hardened (no autocapture/replay; cuid-only event props) — see `docs/pii-inventory.md`.
+- Registered budgets/SLOs (README.md budget registry, R-0.4) are alerted through PostHog
+  where the underlying event exists today — Core Web Vitals (T-7) has three p75 alerts
+  ("CWV p75 — LCP/INP/CLS" insights, R-8.1.5). The provider is PII-hardened (no
+  autocapture/replay; cuid-only event props) — see `docs/pii-inventory.md`.
 
 **Other:**
 - `PASSKEY_RP_ID` — WebAuthn relying party ID (default: `localhost`)

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ overrides and project-specific (§13B) values:
 | Threshold | Value | Rationale |
 |---|---|---|
 | T-5 Coverage | **48% floor** (default 80%) | Honest current baseline (~49–50%) over the declared scope, **enforced in CI as a ratchet** (`test:coverage`); climbing toward 80%. |
+| T-7 Core Web Vitals p75 | **default** (LCP ≤ 2.5 s, INP ≤ 200 ms, CLS ≤ 0.1) | Accept the §13 default. **Alerted in PostHog** at 80% of each bound (LCP 2000 ms / INP 160 ms / CLS 0.08) via the "CWV p75 — LCP/INP/CLS" insights + alerts on `$web_vitals`; bundle-size half of R-8.1.5 enforced in CI (`bundle-ratchet`, blocking). |
+| T-8 Route JS/CSS budget | **default** (≤ 170 KB soft, 300 KB hard) | Accept the §13 default; **enforced in CI as a blocking ratchet** (`bundle-ratchet.mjs`, R-8.1.5). |
 | T-9 Interactive query latency | **default** (p95 < 100 ms; > 1 s = incident) | Accept the §13 default for interactive request paths. |
 | T-P1 Audit-log retention | **2 years** | Activity log (`activityLogs`) retained 24 months for operational/dispute history. |
 | T-P2 PII retention | **Active relationship + 12 months** ⚠ *provisional — owner/legal to confirm* | Client/crew/user PII kept for the active business relationship, purged 12 months after account/org deletion. Deletion path tracked in R-8.12.2. |

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -97,7 +97,8 @@ function ensureInit(): Promise<boolean> {
 
 function useCaptureWebVitals() {
   useReportWebVitals((metric) => {
-    // Maps to the interactive-latency budget in docs/thresholds.md (T-9).
+    // Maps to the Core Web Vitals budget registered in README.md (T-7);
+    // alerting lives in PostHog (see the "CWV p75 —" insights/alerts, R-8.1.5).
     // Await init so a vital that fires before the SDK chunk loads isn't lost.
     void ensureInit().then((ready) => {
       if (!ready) return;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -14,7 +14,9 @@
 
 /** Canonical event names. Add here, reference by constant — never inline a string. */
 export const AnalyticsEvent = {
-  // Performance / latency budget instrumentation (docs/thresholds.md T-9).
+  // Performance / latency budget instrumentation (README.md budget registry).
+  // WebVital -> T-7 (Core Web Vitals). ConvexOpLatency is unwired — reserved
+  // for T-P6 (per-endpoint SLOs, R-8.9.6/#651), not yet emitted anywhere.
   WebVital: "web_vital",
   ConvexOpLatency: "convex_op_latency",
   // Product usage (extend as needed — keep PII out of properties).


### PR DESCRIPTION
**Closes #617** (R-8.1.5). Bundle-size blocking was already done in a prior PR; this closes the remaining half — CWV measurement existed (Web Vitals capture shipped with the PostHog migration) but had no alerting, now that PostHog is actually live.

## What

- **Three PostHog insights + alerts**, each a daily p75 trend on `$web_vitals` (LCP/INP/CLS), firing at **80% of the registered T-7 good threshold**: LCP 2000ms, INP 160ms, CLS 0.08. Subscribed to the org owner.
- **README.md budget registry**: added T-7 (Core Web Vitals) and T-8 (route JS/CSS budget) rows documenting the alerting/enforcement evidence — they were accepting the POLICY.md §13 defaults but weren't listed, so the registry didn't show the CI/alerting wiring that already existed (T-8) or now exists (T-7).
- **Fixed a dangling doc reference**: `docs/thresholds.md` was cited in three places (`CLAUDE.md`, `posthog-provider.tsx`, `analytics.ts`) but never actually created in the earlier PostHog PR — the real budget registry lives in `README.md`. Also corrected a mislabeled threshold ID: Web Vitals capture was commented as mapping to "T-9" (interactive DB query latency — a completely different rule), when the correct ID is **T-7** (Core Web Vitals p75).

## Insights created

- [CWV p75 — LCP](https://us.posthog.com/project/520134/insights/tEM1akvY)
- [CWV p75 — INP](https://us.posthog.com/project/520134/insights/MCpjgHGX)
- [CWV p75 — CLS](https://us.posthog.com/project/520134/insights/2N490FDA)

## Verified

tsc · eslint clean on the changed files (comment/doc changes only — no logic touched).

Refs #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRMAaQ1UWo7Lbwm4KweGV)_