### PR TITLE
feat(privacy): scrub crewMembers.userId on erasure + document backup bound (closes #614)

### DIFF
--- a/convex/crewMembers.test.ts
+++ b/convex/crewMembers.test.ts
@@ -16,6 +16,7 @@ type T = TestConvex<typeof schema>;
 const ORG = "org_1";
 const USER = "user_1";
 const asUser = { subject: USER, orgId: ORG };
+const SERVICE = { subject: "gearflow-service", svc: true };
 
 function makeT(): T {
   const t = convexTest(schema, modules);
@@ -109,5 +110,49 @@ describe("crewMembers.listPage", () => {
     });
     const result = await t.withIdentity({ subject: "user_2", orgId: "org_2" }).query(api.crewMembers.listPage, { orgId: "org_2" });
     expect(result.items).toEqual([]);
+  });
+});
+
+describe("crewMembers.scrubUserRefs (R-8.12.2, #614)", () => {
+  test("clears userId on every crew-member row linked to the erased account, across orgs", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(
+        (await ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "CM1")).unique())!._id,
+        { userId: "erased-user" },
+      );
+      // Second org, same erased user linked to a different crew profile.
+      await ctx.db.insert("members", { id: "m2", organizationId: "org_2", userId: "erased-user", role: "owner" });
+      await ctx.db.insert("crewMembers", {
+        id: "CM3", organizationId: "org_2", firstName: "Cara", lastName: "Lee",
+        userId: "erased-user",
+      });
+    });
+
+    const result = await t.withIdentity(SERVICE).mutation(api.crewMembers.scrubUserRefs, { userId: "erased-user" });
+    expect(result.scrubbed).toBe(2);
+
+    const stillLinked = await t.withIdentity(SERVICE).query(api.crewMembers.existsByUserId, { userId: "erased-user" });
+    expect(stillLinked).toBe(false);
+
+    // Unrelated crew member (CM2, no userId) is untouched.
+    const cm2 = await t.run((ctx) => ctx.db.query("crewMembers").withIndex("by_cuid", (q) => q.eq("id", "CM2")).unique());
+    expect(cm2?.userId).toBeUndefined();
+  });
+
+  test("is a no-op when no crew member is linked to the user", async () => {
+    const t = makeT();
+    await seed(t);
+    const result = await t.withIdentity(SERVICE).mutation(api.crewMembers.scrubUserRefs, { userId: "nobody" });
+    expect(result.scrubbed).toBe(0);
+  });
+
+  test("rejects a non-service caller", async () => {
+    const t = makeT();
+    await seed(t);
+    await expect(
+      t.withIdentity(asUser).mutation(api.crewMembers.scrubUserRefs, { userId: USER }),
+    ).rejects.toThrow();
   });
 });

--- a/convex/crewMembers.ts
+++ b/convex/crewMembers.ts
@@ -276,6 +276,39 @@ export const remove = mutation({
   },
 });
 
+// Service-only existence check for the erasure verification step
+// (verifyUserErased, R-8.12.2, #614) — confirms scrubUserRefs actually worked.
+export const existsByUserId = query({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    await requireService(ctx);
+    const doc = await ctx.db
+      .query("crewMembers")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+    return doc !== null;
+  },
+});
+
+// GDPR erasure sweep (R-8.12.2, #614): clear the crewMember.userId link to a
+// deleted platform account. `by_userId` is a global index, so this scrubs
+// every org's crew-member rows in one query — no per-org loop needed (unlike
+// maintenanceRecords.scrubUserRefs, which has no such index).
+export const scrubUserRefs = mutation({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    await requireService(ctx);
+    const docs = await ctx.db
+      .query("crewMembers")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    for (const doc of docs) {
+      await ctx.db.patch(doc._id, { userId: undefined });
+    }
+    return { scrubbed: docs.length };
+  },
+});
+
 // ── CUSTOM (Phase C) — NOT emitted by the CRUD generator; re-add on regen. ──
 // Patch with explicit field CLEARING. `set` applies non-null values; every name
 // in `clear` is set to undefined → Convex removes the optional field (the

--- a/docs/pii-inventory.md
+++ b/docs/pii-inventory.md
@@ -3,7 +3,7 @@
 Satisfies POLICY.md **R-8.12.1** (classify personal data: what is stored, where, and why).
 **New PII fields MUST update this file in the same PR** (R-5.2 / R-8.12.1).
 
-**Owner:** Jayden Nawotka · **Last reviewed:** 2026-07-18
+**Owner:** Jayden Nawotka · **Last reviewed:** 2026-07-22
 
 Two persistence systems hold data (see CLAUDE.md dual-backend note):
 
@@ -56,30 +56,34 @@ occasionally contain user input), but no locals, cookies, or auth headers.
 
 ## Retention periods (T-P2)
 
-Registered per PII class. **Durations marked ⟨confirm⟩ are placeholder defaults — the data
-owner must set the real value per legal/compliance obligation before these are authoritative.**
+Registered per PII class. Owner-confirmed 2026-07-22 (README.md R-0.4 budget registry).
 
 | PII class | Store | Retention | Erasure path |
 |---|---|---|---|
-| User identity (name, email, auth creds) | Postgres (Better Auth) | until account deletion | `adminDeleteUser` → **`verifyUserErased`** (R-8.12.2) |
+| User identity (name, email, auth creds) | Postgres (Better Auth) | active relationship + 12 months (T-P2) | `adminDeleteUser` → **`verifyUserErased`** (R-8.12.2) |
 | Session / token | Postgres | session TTL / on sign-out | cascades on user delete |
-| Crew PII (DOB, rates, contact, ical token) | Convex `crewMembers` | ⟨confirm — e.g. until archived + 30d⟩ | crew delete + user-erasure sweep (⚠️ `crewMember.userId` link not yet scrubbed — see gap) |
-| Activity / audit logs (actor name) | Convex `activityLogs` / Postgres | ⟨confirm — e.g. 7y for audit⟩ | retained for audit; actor refs scrubbed on erasure |
+| Crew PII (DOB, rates, contact, ical token) | Convex `crewMembers` | active relationship + 12 months (T-P2) | crew delete + user-erasure sweep; `crewMember.userId` link scrubbed via `crewMembers.scrubUserRefs` |
+| Activity / audit logs (actor name) | Convex `activityLogs` / Postgres | 2 years (T-P1) | retained for audit; actor refs scrubbed on erasure |
 | Uploaded files | Convex `_storage` / `storedFiles` | until owner deletes | `/api/files` delete |
-| Backups | Convex export | 90 days (T-P3, `convex-backup.yml`) | ⚠️ point-in-time — erasure not yet propagated to backups |
+| Backups | Convex export | 90 days (T-P3, `convex-backup.yml`) | point-in-time — see bound below |
 
 ## User-erasure workflow (R-8.12.2)
 
 `adminDeleteUser` (site-admin) runs a cross-org GDPR sweep — deletes the Postgres identity
 (sessions/accounts cascade), removes the Convex `users` mirror (which also clears search
 indexes), deletes the user's authored kit/scan/test records, and scrubs their FK references
-on line-items / projects / maintenance. It then calls **`verifyUserErased`**, which confirms
-the identity PII is gone from Postgres + the Convex mirror and logs a warning if anything
-remains — making the erasure **verifiable**, not fire-and-forget.
+on line-items / projects / maintenance / **crew members** (`crewMembers.scrubUserRefs`, #614).
+It then calls **`verifyUserErased`**, which confirms the identity PII is gone from Postgres,
+the Convex mirror, and any linked `crewMembers` row, and logs a warning if anything remains —
+making the erasure **verifiable**, not fire-and-forget.
 
-**Remaining gaps (need owner input / infra):** (1) the retention durations above marked
-⟨confirm⟩; (2) `crewMember.userId` is not yet scrubbed on erasure (a Convex `scrubUserRefs`
-mutation on `crewWrites` would close it); (3) erasure is not propagated into the 90-day
-backups (a restore-then-re-erase or crypto-shred process — infra decision).
+**Backup exposure bound:** `convex-backup.yml` takes a full daily export retained as a
+GitHub Actions artifact for exactly 90 days (`retention-days: 90`), then GitHub deletes it
+automatically — no manual purge step exists or is needed. A user erased today may still
+appear in a backup snapshot taken *before* the erasure, for up to 90 days after that
+snapshot was taken, after which it is gone by construction. We do not retroactively edit
+already-created snapshot archives (this is pre-launch, non-customer data — disproportionate
+for the current risk level); if/when that changes, revisit as a scoped R-15 exception or a
+restore-then-re-erase drill.
 
 _Review this inventory at each quarterly sweep (§12) and whenever a PII field is added._

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -595,6 +595,9 @@ export async function adminDeleteUser(userId: string) {
     ...allOrgsForSweep.map((org) => () =>
       convexForDelete.mutation(api.maintenanceRecords.scrubUserRefs, { organizationId: org.id, userId }),
     ),
+    // crewMembers.userId links a crew profile to this platform account (R-8.12.2,
+    // #614) — by_userId is a global index, so one call covers every org.
+    () => convexForDelete.mutation(api.crewMembers.scrubUserRefs, { userId }),
   ];
   await runWithConcurrency(deletionTasks, 20);
 
@@ -653,8 +656,12 @@ async function verifyUserErased(
   // Convex `users` mirror (drives cross-domain name/email resolution + search).
   try {
     const convex = await getConvexClient();
-    const mirror = await convex.query(api.users.getById, { id: userId });
+    const [mirror, crewMemberLink] = await Promise.all([
+      convex.query(api.users.getById, { id: userId }),
+      convex.query(api.crewMembers.existsByUserId, { userId }),
+    ]);
     if (mirror) remaining.push("convex:users-mirror");
+    if (crewMemberLink) remaining.push("convex:crewMembers.userId");
   } catch {
     remaining.push("convex:unverified");
   }


### PR DESCRIPTION
**Closes #614.** PR #706 confirmed verifiable erasure + registered retention, but explicitly flagged two remaining gaps needing owner input/infra. Owner input landed (PII retention + cost budgets confirmed, PR #718); this closes the infra half.

## What

- **`convex/crewMembers.ts` `scrubUserRefs`** — clears the `crewMember.userId` link to a deleted platform account. `by_userId` is a global index, so one call covers every org (unlike `maintenanceRecords.scrubUserRefs`, which has no such index and loops per-org). Wired into `adminDeleteUser`'s existing GDPR sweep.
- **`existsByUserId`** — service-only check used by `verifyUserErased` so the crew-member link is included in the auditable erasure verification, not just Postgres + the Convex users mirror.
- **`docs/pii-inventory.md`** — documents the backup exposure bound instead of building retroactive snapshot-scrubbing infra: `convex-backup.yml`'s GitHub Actions artifacts already self-expire at exactly 90 days (`retention-days: 90`) with no manual purge step. An erased user may appear in a pre-erasure snapshot for up to that window, then it's gone by construction. Retroactively editing already-created archives is disproportionate for pre-launch, non-customer data (the workflow's own header comment says as much); revisit via a scoped R-15 exception if that changes.
- Retention table updated with the owner-confirmed T-P1 (2yr audit log) / T-P2 (12mo PII) values, replacing the `⟨confirm⟩` placeholders now resolved in README.md's R-0.4 registry (#718).

## Verified

tsc · eslint (0 errors) · full test suite (3817/3817, +3 new `scrubUserRefs`/`existsByUserId` cases).

**Needs attention before/after merge:** this sandbox has no `CONVEX_DEPLOY_KEY`, so `pnpm exec convex dev --once` could not be run here per CLAUDE.md's Convex-edit convention. The function will reach prod via the normal deploy pipeline (`build-image.yml`'s `convex deploy -y` step, which has its own secret) on merge — but if anyone wants it in the shared dev deployment sooner, that needs a manual `pnpm exec convex dev --once` push.

Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRMAaQ1UWo7Lbwm4KweGV)_