### PR TITLE
feat(observability): slow-query detection + per-endpoint p95 SLOs (closes #643, #651)

### DIFF
--- a/FEATUREDOCS/61-observability.md
+++ b/FEATUREDOCS/61-observability.md
@@ -45,6 +45,30 @@ skip (R-8.9.2). `POSTHOG_CLI_TOKEN` is passed to the Docker build as a **BuildKi
 mount** (not a build-arg) so the write-scoped personal API key never lands in an image layer;
 `POSTHOG_CLI_ENV_ID` and `POSTHOG_RELEASE_VERSION` (`github.sha`) are ordinary build-args.
 
+## Latency budgets (T-9 query timing, T-P6 per-endpoint SLOs)
+
+Two Prisma/Convex-level extensions time every call and report crossings of the README.md
+R-0.4 budget registry thresholds through `captureServerEvent()` (`src/lib/posthog-server.ts`,
+a general-purpose sibling of `captureServerException`). Both share the same two-tier severity
+shape (structured log always; PostHog event only past the "slow" line; `incident: true` past
+a second, higher line) and are never allowed to throw or alter the wrapped call's result:
+
+- **`src/lib/prisma-query-timing.ts`** (`withQueryTiming`, wired into the `prisma` singleton in
+  `src/lib/prisma.ts`) — times every Prisma query via a Client Extension. `> 100ms` (T-9
+  interactive-path p95) emits `slow_query`; `> 1000ms` escalates to an incident.
+- **`src/lib/convex-op-timing.ts`** (`withConvexOpTiming`, wired into the singleton in
+  `src/lib/convex-client.ts`) — times every `query`/`mutation` the app server sends to Convex
+  via `getFunctionName()` (`convex/server`) for the op name. `> 300ms` (T-P6 "API" p95 target)
+  emits `convex_op_latency`; `> 1000ms` escalates to an incident. This measures the Convex leg
+  only — a server action making several sequential Convex calls (or Convex + Prisma work) can
+  still miss the end-to-end budget with every individual call under 300ms; there is no
+  request-wide wrapper today (would need either an OTEL pipeline or per-action instrumentation
+  across ~30 `src/server/*.ts` files — out of scope here, revisit if the per-call signal proves
+  insufficient).
+
+Both events feed p95 alerts in PostHog once real traffic is flowing (same pattern as the CWV
+alerts in R-8.1.5 — created only after confirming live event volume, not speculatively before).
+
 ## Env vars
 
 See `CLAUDE.md` → Environment Variables → Analytics + error tracking.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -15,8 +15,10 @@
 /** Canonical event names. Add here, reference by constant — never inline a string. */
 export const AnalyticsEvent = {
   // Performance / latency budget instrumentation (README.md budget registry).
-  // WebVital -> T-7 (Core Web Vitals). ConvexOpLatency is unwired — reserved
-  // for T-P6 (per-endpoint SLOs, R-8.9.6/#651), not yet emitted anywhere.
+  // WebVital -> T-7 (Core Web Vitals). ConvexOpLatency -> T-P6 (per-endpoint
+  // SLOs, R-8.9.6/#651): emitted server-side by
+  // src/lib/convex-op-timing.ts for every Convex query/mutation the app
+  // server makes (the backend leg of most interactive server actions).
   WebVital: "web_vital",
   ConvexOpLatency: "convex_op_latency",
   // Product usage (extend as needed — keep PII out of properties).

--- a/src/lib/convex-client.ts
+++ b/src/lib/convex-client.ts
@@ -1,6 +1,7 @@
 import { ConvexHttpClient } from "convex/browser";
 import { env } from "@/env";
 import { getConvexServiceToken } from "./convex-auth";
+import { withConvexOpTiming } from "./convex-op-timing";
 
 /**
  * Server-side Convex client (Phase 3 of the Convex migration; Phase 5 auth bridge).
@@ -31,7 +32,7 @@ export async function getConvexClient(): Promise<ConvexHttpClient> {
         "Convex is not configured — set CONVEX_SELF_HOSTED_URL (or NEXT_PUBLIC_CONVEX_URL).",
       );
     }
-    client = new ConvexHttpClient(url);
+    client = withConvexOpTiming(new ConvexHttpClient(url));
   }
   const token = await getConvexServiceToken();
   if (token !== attachedToken) {

--- a/src/lib/convex-op-timing.test.ts
+++ b/src/lib/convex-op-timing.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { reportIfSlowConvexOp, withConvexOpTiming, SLOW_OP_MS, INCIDENT_OP_MS } from "./convex-op-timing";
+
+const phCapture = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+);
+vi.mock("@/lib/posthog-server", () => ({
+  captureServerEvent: (...args: unknown[]) => phCapture(...args),
+}));
+
+const getFunctionNameMock = vi.fn<(ref: unknown) => string>();
+vi.mock("convex/server", () => ({
+  getFunctionName: (ref: unknown) => getFunctionNameMock(ref),
+}));
+
+describe("reportIfSlowConvexOp", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    phCapture.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("does nothing for an op at or under the slow line", () => {
+    reportIfSlowConvexOp("crewMembers:list", "query", SLOW_OP_MS);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(phCapture).not.toHaveBeenCalled();
+  });
+
+  it("warns + captures (non-incident) between the slow and incident lines", () => {
+    reportIfSlowConvexOp("crewMembers:list", "query", SLOW_OP_MS + 1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(phCapture).toHaveBeenCalledWith("convex_op_latency", {
+      name: "crewMembers:list",
+      kind: "query",
+      duration_ms: SLOW_OP_MS + 1,
+      incident: false,
+    });
+  });
+
+  it("errors + captures as an incident above the incident line", () => {
+    reportIfSlowConvexOp("crewMembers:patchMember", "mutation", INCIDENT_OP_MS + 1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(phCapture).toHaveBeenCalledWith("convex_op_latency", {
+      name: "crewMembers:patchMember",
+      kind: "mutation",
+      duration_ms: INCIDENT_OP_MS + 1,
+      incident: true,
+    });
+  });
+});
+
+describe("withConvexOpTiming", () => {
+  beforeEach(() => {
+    phCapture.mockClear();
+    getFunctionNameMock.mockReset();
+  });
+
+  it("wraps query/mutation, passes results through, and reports slowness", async () => {
+    getFunctionNameMock.mockImplementation((ref) => ref as string);
+    const rawQuery = vi.fn(() => Promise.resolve("query-result"));
+    const rawMutation = vi.fn(
+      () => new Promise((resolve) => setTimeout(() => resolve("mutation-result"), SLOW_OP_MS + 5)),
+    );
+    const fakeClient = {
+      query: rawQuery,
+      mutation: rawMutation,
+    };
+
+    const wrapped = withConvexOpTiming(fakeClient as never);
+
+    const queryResult = await wrapped.query("crewMembers:list" as never, {} as never);
+    expect(queryResult).toBe("query-result");
+    expect(rawQuery).toHaveBeenCalledWith("crewMembers:list", {});
+    expect(phCapture).not.toHaveBeenCalled(); // fast — under SLOW_OP_MS
+
+    const mutationResult = await wrapped.mutation("crewMembers:patchMember" as never, {} as never);
+    expect(mutationResult).toBe("mutation-result");
+    expect(phCapture).toHaveBeenCalledTimes(1);
+    expect(phCapture.mock.calls[0]?.[1]).toMatchObject({
+      name: "crewMembers:patchMember",
+      kind: "mutation",
+    });
+  });
+
+  it("still reports and rethrows when the wrapped call fails", async () => {
+    getFunctionNameMock.mockImplementation((ref) => ref as string);
+    const boom = new Error("boom");
+    const rawQuery = vi.fn(
+      () =>
+        new Promise((_, reject) =>
+          setTimeout(() => reject(boom), SLOW_OP_MS + 5),
+        ),
+    );
+    const fakeClient = { query: rawQuery, mutation: vi.fn() };
+
+    const wrapped = withConvexOpTiming(fakeClient as never);
+
+    await expect(wrapped.query("crewMembers:list" as never, {} as never)).rejects.toThrow("boom");
+    expect(phCapture).toHaveBeenCalledTimes(1);
+    expect(phCapture.mock.calls[0]?.[1]).toMatchObject({ name: "crewMembers:list", kind: "query" });
+  });
+});

--- a/src/lib/convex-op-timing.ts
+++ b/src/lib/convex-op-timing.ts
@@ -1,0 +1,79 @@
+import "server-only";
+import { getFunctionName } from "convex/server";
+import type { ConvexHttpClient } from "convex/browser";
+import { logger } from "@/lib/logger";
+import { captureServerEvent } from "@/lib/posthog-server";
+import { AnalyticsEvent } from "@/lib/analytics";
+
+/**
+ * T-P6 per-endpoint p95 SLO (README.md R-0.4, R-9.11/R-8.9.6): 300ms is the
+ * "API" target, so a Convex round-trip (the backend leg of most interactive
+ * server actions/API routes) is flagged past that line; > 1s escalates to an
+ * incident, mirroring the two-tier severity used for T-9 query timing
+ * (src/lib/prisma-query-timing.ts). This measures the Convex leg only, not
+ * the whole request — an action doing several sequential Convex calls plus
+ * Prisma work can still exceed budget with every individual call under 300ms.
+ */
+export const SLOW_OP_MS = 300;
+export const INCIDENT_OP_MS = 1000;
+
+type ConvexOpKind = "query" | "mutation" | "action";
+
+/**
+ * Report a completed Convex op's duration if it crosses the slow line —
+ * structured log line (always) + a best-effort `convex_op_latency` PostHog
+ * event (for the p95 alert). Never throws — latency instrumentation must
+ * never become a new source of request failures.
+ */
+export function reportIfSlowConvexOp(
+  name: string,
+  kind: ConvexOpKind,
+  durationMs: number,
+): void {
+  if (durationMs <= SLOW_OP_MS) return;
+  const incident = durationMs > INCIDENT_OP_MS;
+  logger[incident ? "error" : "warn"](
+    `[convex] slow ${kind}: ${name} took ${durationMs}ms`,
+    { name, kind, durationMs, incident },
+  );
+  void captureServerEvent(AnalyticsEvent.ConvexOpLatency, {
+    name,
+    kind,
+    duration_ms: durationMs,
+    incident,
+  });
+}
+
+/**
+ * Wrap a ConvexHttpClient's `query`/`mutation` methods with timing. Mutates
+ * and returns the same instance (the client is a lazily-created process
+ * singleton in src/lib/convex-client.ts, so this only runs once per process).
+ * `action` is intentionally left unwrapped — it's not used from src/server today.
+ */
+export function withConvexOpTiming(client: ConvexHttpClient): ConvexHttpClient {
+  type QueryMethod = ConvexHttpClient["query"];
+  type MutationMethod = ConvexHttpClient["mutation"];
+
+  const rawQuery: QueryMethod = client.query.bind(client);
+  const rawMutation: MutationMethod = client.mutation.bind(client);
+
+  client.query = (async (query, ...args) => {
+    const start = performance.now();
+    try {
+      return await rawQuery(query, ...args);
+    } finally {
+      reportIfSlowConvexOp(getFunctionName(query), "query", Math.round(performance.now() - start));
+    }
+  }) as QueryMethod;
+
+  client.mutation = (async (mutation, ...args) => {
+    const start = performance.now();
+    try {
+      return await rawMutation(mutation, ...args);
+    } finally {
+      reportIfSlowConvexOp(getFunctionName(mutation), "mutation", Math.round(performance.now() - start));
+    }
+  }) as MutationMethod;
+
+  return client;
+}

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -53,3 +53,23 @@ export async function captureServerException(
     logger.warn("[posthog] failed to capture server exception", { err });
   }
 }
+
+/**
+ * Capture a server-side metric/event to PostHog (e.g. slow_query, R-8.3.2).
+ * Same fixed `"server"` distinctId and never-throw contract as
+ * captureServerException — this is telemetry, it must never affect the
+ * caller's control flow or latency budget.
+ */
+export async function captureServerEvent(
+  event: string,
+  properties?: Record<string, string | number | boolean>,
+): Promise<void> {
+  const ph = getClient();
+  if (!ph) return;
+  try {
+    ph.capture({ distinctId: "server", event, properties });
+    await ph.flush();
+  } catch (err) {
+    logger.warn("[posthog] failed to capture server event", { err, event });
+  }
+}

--- a/src/lib/prisma-query-timing.test.ts
+++ b/src/lib/prisma-query-timing.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  reportIfSlow,
+  withQueryTiming,
+  SLOW_QUERY_MS,
+  INCIDENT_QUERY_MS,
+} from "./prisma-query-timing";
+
+const phCapture = vi.fn<(...args: unknown[]) => Promise<void>>(() =>
+  Promise.resolve(),
+);
+vi.mock("@/lib/posthog-server", () => ({
+  captureServerEvent: (...args: unknown[]) => phCapture(...args),
+}));
+
+describe("reportIfSlow", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    phCapture.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("does nothing for a query at or under the slow-query line", () => {
+    reportIfSlow("user", "findFirst", SLOW_QUERY_MS);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(phCapture).not.toHaveBeenCalled();
+  });
+
+  it("warns + captures (non-incident) between the slow and incident lines", () => {
+    reportIfSlow("user", "findMany", SLOW_QUERY_MS + 1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(phCapture).toHaveBeenCalledWith("slow_query", {
+      model: "user",
+      operation: "findMany",
+      duration_ms: SLOW_QUERY_MS + 1,
+      incident: false,
+    });
+  });
+
+  it("errors + captures as an incident above the incident line", () => {
+    reportIfSlow("session", "create", INCIDENT_QUERY_MS + 1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(phCapture).toHaveBeenCalledWith("slow_query", {
+      model: "session",
+      operation: "create",
+      duration_ms: INCIDENT_QUERY_MS + 1,
+      incident: true,
+    });
+  });
+});
+
+describe("withQueryTiming", () => {
+  it("passes the query result through unchanged and still reports slowness", async () => {
+    phCapture.mockClear();
+    const fakeClient = {
+      $extends(config: {
+        query: {
+          $allModels: {
+            $allOperations: (args: {
+              model?: string;
+              operation: string;
+              args: unknown;
+              query: (args: unknown) => Promise<unknown>;
+            }) => Promise<unknown>;
+          };
+        };
+      }) {
+        return config; // capture the extension config for direct invocation below
+      },
+    };
+
+    const extended = withQueryTiming(fakeClient as never) as unknown as {
+      query: { $allModels: { $allOperations: (args: never) => Promise<unknown> } };
+    };
+    const slowQuery = () =>
+      new Promise((resolve) => setTimeout(() => resolve("ok"), SLOW_QUERY_MS + 5));
+
+    const result = await extended.query.$allModels.$allOperations({
+      model: "asset",
+      operation: "update",
+      args: {},
+      query: slowQuery,
+    } as never);
+
+    expect(result).toBe("ok");
+    expect(phCapture).toHaveBeenCalledTimes(1);
+    expect(phCapture.mock.calls[0]?.[1]).toMatchObject({ model: "asset", operation: "update" });
+  });
+});

--- a/src/lib/prisma-query-timing.ts
+++ b/src/lib/prisma-query-timing.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { logger } from "@/lib/logger";
+import { captureServerEvent } from "@/lib/posthog-server";
+
+/**
+ * T-9 interactive-path latency budget (README.md R-0.4): p95 < 100ms is the
+ * "slow" line, > 1s is an incident. Analytics/batch/report paths register
+ * their own budgets per R-0.4 — this extension has no way to distinguish an
+ * interactive request from a batch job, so it flags every query against the
+ * interactive default; a batch path that's expectedly > 100ms will show up
+ * here and should be read with that context, not treated as a regression.
+ */
+export const SLOW_QUERY_MS = 100;
+export const INCIDENT_QUERY_MS = 1000;
+
+/**
+ * Report a completed query's duration if it crosses the slow-query line —
+ * structured log line (always) + a best-effort `slow_query` PostHog event
+ * (for the p95 alert). Pulled out of the Prisma extension below so the
+ * threshold/reporting logic is unit-testable without a real Prisma client.
+ * Never throws — latency instrumentation must never become a new source of
+ * request failures.
+ */
+export function reportIfSlow(model: string, operation: string, durationMs: number): void {
+  if (durationMs <= SLOW_QUERY_MS) return;
+  const incident = durationMs > INCIDENT_QUERY_MS;
+  logger[incident ? "error" : "warn"](
+    `[db] slow query: ${model}.${operation} took ${durationMs}ms`,
+    { model, operation, durationMs, incident },
+  );
+  void captureServerEvent("slow_query", { model, operation, duration_ms: durationMs, incident });
+}
+
+/**
+ * Prisma Client Extension (R-8.3.2): times every query and hands the result
+ * to `reportIfSlow`, without altering the query's result or throwing on its
+ * own account.
+ */
+export function withQueryTiming(client: PrismaClient): PrismaClient {
+  return client.$extends({
+    name: "query-timing",
+    query: {
+      $allModels: {
+        async $allOperations({ model, operation, args, query }: {
+          model?: string;
+          operation: string;
+          args: unknown;
+          query: (args: unknown) => Promise<unknown>;
+        }) {
+          const start = performance.now();
+          try {
+            return await query(args);
+          } finally {
+            reportIfSlow(model ?? "raw", operation, Math.round(performance.now() - start));
+          }
+        },
+      },
+    },
+  }) as unknown as PrismaClient;
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -4,6 +4,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
 import { env } from "@/env";
 import { buildRuntimeDatabaseUrl } from "./db-url";
+import { withQueryTiming } from "./prisma-query-timing";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
@@ -50,7 +51,8 @@ function buildAdapter(): PrismaPg {
   return new PrismaPg(globalForPrisma.prismaTestPool);
 }
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter: buildAdapter() });
+export const prisma =
+  globalForPrisma.prisma ?? withQueryTiming(new PrismaClient({ adapter: buildAdapter() }));
 
 // Cache the singleton everywhere except prod (covers dev AND test, so repeated
 // module evaluation under Vitest reuses the one client + its one pinned pool).


### PR DESCRIPTION
**Closes #643 and #651.** Two closely-related latency-budget instrumentation commits landed on
this branch back to back, so they're going out in one PR — same pattern (Prisma/Convex Client
Extension timing wrapper + PostHog event) applied to two call sites.

## #643 — Slow-query detection (T-9)

- **`src/lib/prisma-query-timing.ts`** — a Prisma Client Extension (`withQueryTiming`) that times
  every query via `$allModels.$allOperations` and reports against the T-9 interactive-path
  latency budget (README.md R-0.4, p95 < 100ms):
  - `> 100ms`: structured `logger.warn` + best-effort `slow_query` PostHog event (`incident: false`)
  - `> 1000ms`: escalates to `logger.error` + the same event with `incident: true`
- Wired into the `prisma` singleton (`src/lib/prisma.ts`).
- Added `captureServerEvent(event, properties)` to `src/lib/posthog-server.ts` — a general-purpose
  sibling to the existing `captureServerException` (same fixed `"server"` distinctId, no PII,
  fire-and-forget + per-call flush).

## #651 — Per-endpoint p95 SLOs (T-P6)

- **`src/lib/convex-op-timing.ts`** — the same timing pattern applied to the app server's Convex
  calls: wraps the `ConvexHttpClient` singleton's `query`/`mutation` methods, using
  `getFunctionName()` (`convex/server`) to attribute events per Convex function.
  - `> 300ms` (T-P6 "API" p95 target): `convex_op_latency` event (previously scaffolded in
    `AnalyticsEvent.ConvexOpLatency` but never wired)
  - `> 1000ms`: escalates to an incident, same shape as `slow_query`
- Wired into the singleton in `src/lib/convex-client.ts`.
- **Known, documented gap** (see `FEATUREDOCS/61-observability.md`): this measures the Convex leg
  of a request only, not full server-action/API-route wall time. There's no single dispatcher
  every `src/server/*.ts` action funnels through the way `requirePermission()`/`getOrgContext()`
  are close to one, and a true request-wide wrapper would mean either adopting OpenTelemetry or
  touching ~30 action files individually — out of scope here, called out explicitly rather than
  silently claimed as full coverage.

## Verified

- `pnpm exec eslint` — 0 errors on all touched files.
- `pnpm exec tsc --noEmit` — clean.
- Unit tests: 4/4 (`prisma-query-timing.test.ts`) + 5/5 (`convex-op-timing.test.ts`) passing.
- Full suite: 3826/3826 passing.
- Hygiene gates: any-ratchet, knip-ratchet, depcruise, collect-ratchet, check-client-routes,
  `pnpm audit --audit-level high` (0 high/critical) — all green.
- `pnpm run build` completes successfully with both extensions wired into their singletons.

## Still needed (real traffic required, same pattern as the CWV alerts)

PostHog alerts on `slow_query` and `convex_op_latency` against their respective p95 targets still
need to be created — but only once this is live and receiving real query volume, mirroring how
the Core Web Vitals alerts (#617) were created only after confirming live event flow.

Refs #643, #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRMAaQ1UWo7Lbwm4KweGV)_