### PR TITLE
feat(e2e): CI-automate seeded-auth harness + revenue-path specs (closes #621)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,83 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  e2e-harness:
+    # Seeded-auth E2E over the primary revenue path (POLICY.md R-8.8.3, #621):
+    # project -> line items -> availability -> check-out -> return. Needs a REAL
+    # Convex backend (unlike the `e2e` job's dummy Convex URL) because these flows
+    # write and read actual domain data. Runs a self-hosted Convex backend in Docker
+    # against its own Postgres db on the same service Postgres instance, exactly as
+    # documented in docs/e2e-harness.md / scripts/e2e-harness-up.sh (proven working
+    # locally). NOT blocking yet: the docker-in-CI networking path (the backend
+    # container reaching the app's JWKS endpoint via host.docker.internal) hasn't
+    # been exercised on a GitHub-hosted runner before — flip continue-on-error off
+    # once a run has gone green here.
+    name: E2E (seeded harness — revenue path)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: gearflow_harness
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gearflow_harness
+      BETTER_AUTH_SECRET: ci-e2e-harness-secret-string-at-least-32-chars
+      BETTER_AUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      APP_DB: gearflow_harness
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm exec prisma generate
+
+      - name: Sync schema to throwaway DB
+        run: pnpm exec prisma db push
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Stand up the seeded Convex harness
+        run: bash scripts/e2e-harness-up.sh
+
+      - name: Run E2E (seeded harness, chromium)
+        run: pnpm exec playwright test --project=chromium e2e/harness-auth.spec.ts e2e/harness-a11y.spec.ts e2e/harness-cookie-flags.spec.ts e2e/harness-revenue-path.spec.ts
+        env:
+          E2E_HARNESS: "1"
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-harness-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Tear down the seeded Convex harness
+        if: always()
+        run: bash scripts/e2e-harness-down.sh
+
   integration:
     # Integration tests against a real migrated Postgres (POLICY.md R-10.1, R-8.8).
     # Postgres-only mode: INTEGRATION_CONVEX is unset, so the Convex-service-token

--- a/FEATUREDOCS/36-testing.md
+++ b/FEATUREDOCS/36-testing.md
@@ -70,6 +70,18 @@ Every Zod validation schema has exhaustive tests covering:
 - Refine logic (e.g., lat/lng pairs must both be present)
 - Boundary values and edge cases
 
+## E2E (Playwright)
+
+Two CI jobs in `.github/workflows/ci.yml`:
+
+- **`e2e`** — smoke + a11y (critical-flows #1) against a dummy Convex URL, blocking.
+- **`e2e-harness`** — seeded-auth flows (critical-flows #2, #5-9: sign-in through the
+  primary revenue path — project → line items → availability → check-out → return)
+  against a real self-hosted Convex backend stood up in Docker
+  (`scripts/e2e-harness-up.sh`). `continue-on-error: true` pending a verified green
+  run on a GitHub-hosted runner. See `docs/e2e-harness.md` and
+  `docs/critical-flows.md` (R-8.8.3) for the full flow list and status.
+
 ## CI Integration
 
 The GitHub Actions deploy pipeline runs `npm test` after Prisma client generation and before migrations/build. Deploys fail fast if any test fails.

--- a/docs/critical-flows.md
+++ b/docs/critical-flows.md
@@ -4,27 +4,31 @@ The E2E smoke suite (`e2e/`, Playwright) MUST cover 100% of this list, and it MU
 and block every deploy (POLICY.md **R-8.8.3**). At minimum this list covers **auth** and the
 **primary revenue path**. Update this list in the same PR that adds or changes a critical flow.
 
-**Status:** the list is defined and the E2E suite **runs blocking in CI** (the `e2e` job in
-`.github/workflows/ci.yml`: Postgres service + Playwright chromium against a dummy Convex URL).
-Flow #1 is covered with a functional smoke **and** an axe a11y check (R-8.1.7). Flows 2+ need a
-seeded auth user and are the remaining R-8.8.3 work — until they're covered, the "100% of the
-list" clause is partially met (auth entry ✅; sign-in + revenue path pending).
+**Status:** the list is defined. Flow #1 runs **blocking** in CI (the `e2e` job in
+`.github/workflows/ci.yml`: Postgres service + Playwright chromium against a dummy Convex URL)
+with a functional smoke **and** an axe a11y check (R-8.1.7). Flows 2 and 5-9 (the primary
+revenue path) are covered by seeded-harness specs (`e2e/harness-*.spec.ts`,
+`docs/e2e-harness.md`) that run in the **`e2e-harness` job**, currently `continue-on-error:
+true` pending a green run on a real GitHub-hosted runner (the docker-in-CI networking path
+hasn't been exercised there yet — see that job's comment in `ci.yml`). Flows 3, 4, and 10 (as a
+standalone flow) remain unwritten.
 
 | # | Flow | Steps | E2E coverage |
 |---|------|-------|--------------|
-| 1 | **Login page loads** | Unauthenticated visit to `/login` renders the sign-in entry form (+ axe a11y, zero serious/critical WCAG 2 A/AA) | ✅ `e2e/smoke.spec.ts`, `e2e/a11y.spec.ts` (CI-gated) |
-| 2 | **Sign in / register** | Register/sign in → authenticated → lands on dashboard | 🟡 proven via the seeded harness (`e2e/harness-auth.spec.ts`, `E2E_HARNESS=1`); see `docs/e2e-harness.md`. CI automation pending. |
+| 1 | **Login page loads** | Unauthenticated visit to `/login` renders the sign-in entry form (+ axe a11y, zero serious/critical WCAG 2 A/AA) | ✅ `e2e/smoke.spec.ts`, `e2e/a11y.spec.ts` (CI-gated, blocking) |
+| 2 | **Sign in / register** | Register/sign in → authenticated → lands on dashboard | ✅ `e2e/harness-auth.spec.ts` (`E2E_HARNESS=1`, `e2e-harness` CI job, non-blocking pending a verified green run) |
 | 3 | **Sign out** | Authenticated → sign out → session invalidated, back to `/login` | ⬜ pending |
 | 4 | **Register / onboarding** | New account → create/join org → onboarding completes | ⬜ pending |
-| 5 | **Create a project** (revenue path) | New project with a client → saved, visible in list | ⬜ pending |
-| 6 | **Add line items + pricing** (revenue path) | Add gear/models to a project → totals compute server-side | ⬜ pending |
-| 7 | **Availability check** (revenue path) | Overlapping booking is flagged; no double-book | ⬜ pending |
-| 8 | **Warehouse check-out** | Project gear checked out (per-unit) from the warehouse | ⬜ pending |
-| 9 | **Warehouse check-in / return** | Checked-out gear returned; status + history update | ⬜ pending |
-| 10 | **Create inventory** | Create a model/asset → asset tag generated | ⬜ pending |
+| 5 | **Create a project** (revenue path) | New project with a client → saved, visible in list | ✅ `e2e/harness-revenue-path.spec.ts` (name-only project; client is optional so this run skips it) |
+| 6 | **Add line items + pricing** (revenue path) | Add gear/models to a project → totals compute server-side | ✅ `e2e/harness-revenue-path.spec.ts` (own-stock, by-model) |
+| 7 | **Availability check** (revenue path) | Overlapping booking is flagged; no double-book | ✅ `e2e/harness-revenue-path.spec.ts` (asserts the inline availability panel renders with no overbook warning for a 1-asset/1-unit request) |
+| 8 | **Warehouse check-out** | Project gear checked out (per-unit) from the warehouse | ✅ `e2e/harness-revenue-path.spec.ts` (Pick → Prep → Deploy) |
+| 9 | **Warehouse check-in / return** | Checked-out gear returned; status + history update | ✅ `e2e/harness-revenue-path.spec.ts` (Deployed → Return) |
+| 10 | **Create inventory** | Create a model/asset → asset tag generated | 🟡 exercised as setup within `e2e/harness-revenue-path.spec.ts` (model + serialized asset), not yet its own standalone flow test |
 
 **Primary revenue path** = flows 5 → 6 → 7 → 8 → 9 (project creation through check-out/return),
-where pricing and availability are server-authoritative (R-9.3).
+where pricing and availability are server-authoritative (R-9.3). Covered end-to-end by
+`e2e/harness-revenue-path.spec.ts`, not yet verified against a real CI run (see above).
 
 ## Running
 

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -4,10 +4,16 @@ The missing piece for authenticated E2E (POLICY.md R-8.8.3 / #621): a local
 **self-hosted Convex** backend the app can talk to, so tests can exercise
 authenticated, data-backed flows — not just the client-rendered `/login` page.
 
-**Status: proven working locally.** `scripts/e2e-harness-up.sh` stands up Convex,
-pushes the schema, and wires auth; `e2e/harness-auth.spec.ts` then registers a user
-and reaches the authenticated dashboard (verified). CI automation is the remaining
-finish (see below).
+**Status: proven working locally, CI automation added but not yet verified green.**
+`scripts/e2e-harness-up.sh` stands up Convex, pushes the schema, and wires auth;
+`e2e/harness-auth.spec.ts` then registers a user and reaches the authenticated
+dashboard (verified locally). The `e2e-harness` job in `.github/workflows/ci.yml` runs
+the same script + the full harness spec set (auth, a11y, cookie flags, and the
+primary revenue path) in CI, but is `continue-on-error: true` until a run has
+actually gone green there — the docker-in-CI networking path (the self-hosted Convex
+container reaching the app's JWKS endpoint via `host.docker.internal` from a
+GitHub-hosted runner rather than a developer laptop) hasn't been exercised yet. Flip
+`continue-on-error` off once it has.
 
 ## How it works
 
@@ -40,12 +46,18 @@ bootstraps as admin.
 
 ## Remaining finish (scoped)
 
-1. **CI automation** — run this in the `e2e` job: `docker compose up` the Convex
-   backend (service or step), generate the admin key, push the schema, `pnpm dev`,
-   then `E2E_HARNESS=1 playwright test`. The cross-container `host.docker.internal`
-   JWKS reach is the one thing to validate on the GitHub runner.
-2. **Seed domain data + write the revenue-path specs** (project → line-items →
-   availability → check-out → return) now that authenticated pages render.
+1. **CI automation** — done: a dedicated `e2e-harness` job (separate from the
+   dummy-Convex `e2e` job) runs `scripts/e2e-harness-up.sh` then the harness spec set
+   with `E2E_HARNESS=1`, tearing down via `scripts/e2e-harness-down.sh` in an
+   `if: always()` step. **Not yet verified green in CI** — the one thing left to
+   validate on the GitHub runner is the cross-container `host.docker.internal` JWKS
+   reach; the job runs `continue-on-error: true` until that's confirmed (see
+   `docs/critical-flows.md`).
+2. **Seed domain data + write the revenue-path specs** — done:
+   `e2e/harness-revenue-path.spec.ts` covers project → line-items → availability →
+   check-out → return (critical-flows #5-9), creating its own model + serialized
+   asset first since there's no seed-data API reachable from Playwright, only the
+   real UI.
 3. This harness also unblocks verifying the deferred refactors (#616 images, #625
    pagination, #618 validation, #645 code-split, #655 templates, #646 axe pages) by
    driving the real authenticated app.

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -70,15 +70,17 @@ test.describe("harness: primary revenue path", () => {
       await page.goto("/projects/new");
       await page.getByPlaceholder("e.g. Summer Festival 2026").fill(projectName);
 
-      // Project code auto-fills asynchronously (peekNextProjectNumber, a server
-      // query) shortly after mount — project-wizard.tsx's next() step-0 guard
-      // blocks advancing while it's still empty, re-showing the SAME "Continue"
-      // button rather than erroring loudly, which reads as a hang, not a
-      // validation failure. Wait for it to actually populate first.
+      // Project code normally auto-fills asynchronously (peekNextProjectNumber,
+      // a server query) shortly after mount, and project-wizard.tsx's next()
+      // step-0 guard blocks advancing while it's still empty — re-showing the
+      // SAME "Continue" button rather than erroring loudly, which reads as a
+      // hang rather than a validation failure. Under CI load that fetch can be
+      // slow enough to matter, so type a code directly instead of waiting on
+      // it — a real user hitting the same lag would do exactly this.
       const projectCodeInput = page.locator(
         "xpath=//input[@placeholder='e.g. Summer Festival 2026']/parent::div/following-sibling::div[1]//input",
       );
-      await expect(projectCodeInput).not.toHaveValue("", { timeout: 15000 });
+      await projectCodeInput.fill(`E2E-${unique}`);
 
       // Basics -> Schedule -> Site -> Review: every other field is optional, so
       // three plain "Continue" clicks get through from here.

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -28,7 +28,7 @@ test.describe("harness: primary revenue path", () => {
     // Postgres + Convex; under this environment's demonstrated latency (100-
     // 300ms even for simple queries) that easily exceeds 30s in total even
     // though every individual step is fast enough on its own.
-    test.setTimeout(150_000);
+    test.setTimeout(180_000);
 
     const unique = Date.now();
     const email = `e2e+revenue-${unique}@harness.local`;
@@ -118,7 +118,7 @@ test.describe("harness: primary revenue path", () => {
       // a while, so wait for the SPECIFIC "1 available" text (not just the
       // generic "available out of" phrase, which matches the placeholder too)
       // before asserting there's no overbook warning.
-      await expect(page.getByText(/1 available/i)).toBeVisible({ timeout: 20000 });
+      await expect(page.getByText(/1 available/i)).toBeVisible({ timeout: 40000 });
       await expect(page.getByText(/overbook/i)).toHaveCount(0);
 
       await page.getByRole("button", { name: "Add to project" }).click();

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -38,6 +38,18 @@ test.describe("harness: primary revenue path", () => {
       await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
     });
 
+    await test.step("complete onboarding (create the org) if needed", async () => {
+      // The (app) layout redirects every route to /onboarding until an org
+      // exists (src/app/(app)/layout.tsx) — a fresh registration on this harness
+      // has no org yet, so this step is required before any protected page
+      // (the model/asset/project forms below) will render at all.
+      if (new URL(page.url()).pathname === "/onboarding") {
+        await page.getByLabel("Organization name").fill(`Revenue Path Org ${unique}`);
+        await page.getByRole("button", { name: "Create organization" }).click();
+        await expect(page).toHaveURL(/\/dashboard\b/, { timeout: 20000 });
+      }
+    });
+
     await test.step("create an equipment model (flow 10: create inventory)", async () => {
       await page.goto("/assets/models/new");
       await page.getByPlaceholder("e.g. Shure SM58").fill(modelName);

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -21,6 +21,15 @@ test.describe("harness: primary revenue path", () => {
   );
 
   test("project -> line item -> availability -> check-out -> return", async ({ page }) => {
+    // Playwright's default test timeout is 30s — a budget for the WHOLE test,
+    // not per test.step. This flow chains register -> onboard -> model ->
+    // asset -> project (4 wizard steps) -> line item + an async availability
+    // check -> warehouse pipeline across several page loads, each hitting
+    // Postgres + Convex; under this environment's demonstrated latency (100-
+    // 300ms even for simple queries) that easily exceeds 30s in total even
+    // though every individual step is fast enough on its own.
+    test.setTimeout(150_000);
+
     const unique = Date.now();
     const email = `e2e+revenue-${unique}@harness.local`;
     const modelName = `E2E Revenue Model ${unique}`;

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -127,7 +127,11 @@ test.describe("harness: primary revenue path", () => {
     });
 
     await test.step("check the gear out through the warehouse pipeline (flow 8)", async () => {
-      await page.getByRole("link", { name: "Warehouse" }).click();
+      // getByRole("link", { name: "Warehouse" }) is ambiguous: the app sidebar's
+      // global nav item (-> /warehouse) and the mobile nav both use the exact
+      // same label, alongside this project page's own button (-> /warehouse/
+      // [projectId]). Scope by href to target the project-specific one only.
+      await page.locator(`a[href="/warehouse/${projectId}"]`).click();
       await expect(page).toHaveURL(new RegExp(`/warehouse/${projectId}$`));
 
       await page.getByRole("tab", { name: /^Pick/ }).click();

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -69,8 +69,19 @@ test.describe("harness: primary revenue path", () => {
     await test.step("create a project (flow 5)", async () => {
       await page.goto("/projects/new");
       await page.getByPlaceholder("e.g. Summer Festival 2026").fill(projectName);
-      // Basics -> Schedule -> Site -> Review: every field but Name/Project code
-      // (auto-filled) is optional, so three plain "Continue" clicks get through.
+
+      // Project code auto-fills asynchronously (peekNextProjectNumber, a server
+      // query) shortly after mount — project-wizard.tsx's next() step-0 guard
+      // blocks advancing while it's still empty, re-showing the SAME "Continue"
+      // button rather than erroring loudly, which reads as a hang, not a
+      // validation failure. Wait for it to actually populate first.
+      const projectCodeInput = page.locator(
+        "xpath=//input[@placeholder='e.g. Summer Festival 2026']/parent::div/following-sibling::div[1]//input",
+      );
+      await expect(projectCodeInput).not.toHaveValue("", { timeout: 15000 });
+
+      // Basics -> Schedule -> Site -> Review: every other field is optional, so
+      // three plain "Continue" clicks get through from here.
       await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("button", { name: "Continue" }).click();

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -104,7 +104,12 @@ test.describe("harness: primary revenue path", () => {
       // Availability check (flow 7) is inline and automatic here: with exactly
       // one asset created above and quantity defaulted to 1, it renders
       // "1 available out of 1 ..." with no overbook warning/checkbox to confirm.
-      await expect(page.getByText(/available out of/i)).toBeVisible();
+      // The check itself is async (a Convex query) and can start from a 0/0
+      // placeholder before the real count resolves — under CI load that can take
+      // a while, so wait for the SPECIFIC "1 available" text (not just the
+      // generic "available out of" phrase, which matches the placeholder too)
+      // before asserting there's no overbook warning.
+      await expect(page.getByText(/1 available/i)).toBeVisible({ timeout: 20000 });
       await expect(page.getByText(/overbook/i)).toHaveCount(0);
 
       await page.getByRole("button", { name: "Add to project" }).click();

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -63,7 +63,9 @@ test.describe("harness: primary revenue path", () => {
       await page.goto("/assets/models/new");
       await page.getByPlaceholder("e.g. Shure SM58").fill(modelName);
       await page.getByRole("button", { name: "Create model" }).click();
-      await expect(page).toHaveURL(/\/assets\/models\/[^/]+$/, { timeout: 20000 });
+      // Exclude the literal "new" segment (the create page itself) — see the
+      // comment on the project-creation assertion below for why this matters.
+      await expect(page).toHaveURL(/\/assets\/models\/(?!new$)[^/]+$/, { timeout: 20000 });
     });
 
     await test.step("create a serialized asset for the model (asset tag auto-generated)", async () => {
@@ -72,7 +74,7 @@ test.describe("harness: primary revenue path", () => {
       await page.getByPlaceholder("Search models").fill(modelName);
       await page.getByRole("button", { name: modelName, exact: true }).click();
       await page.getByRole("button", { name: "Create asset" }).click();
-      await expect(page).toHaveURL(/\/assets\/registry\/[^/]+$/, { timeout: 20000 });
+      await expect(page).toHaveURL(/\/assets\/registry\/(?!new$)[^/]+$/, { timeout: 20000 });
     });
 
     await test.step("create a project (flow 5)", async () => {
@@ -97,7 +99,14 @@ test.describe("harness: primary revenue path", () => {
       await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("button", { name: "Create job" }).click();
-      await expect(page).toHaveURL(/\/projects\/[^/]+$/, { timeout: 20000 });
+      // NOT /\/projects\/[^/]+$/ — that trivially matches the literal
+      // "/projects/new" creation page itself (the segment "new" satisfies
+      // "one or more non-slash characters" just as well as a real id), so the
+      // assertion resolved instantly without ever waiting for the real
+      // navigation, and every downstream use of `projectId` (extracted from
+      // the URL right after) silently captured the string "new" instead of
+      // an id. Exclude it explicitly so this actually waits for creation.
+      await expect(page).toHaveURL(/\/projects\/(?!new$)[^/]+$/, { timeout: 20000 });
     });
 
     const projectId = new URL(page.url()).pathname.split("/")[2]!;

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Primary revenue path (POLICY.md R-8.8.3 / #621, docs/critical-flows.md flows
+ * 5-9): create a project, add a line item, see availability render, check the
+ * gear out through the warehouse pipeline, then return it. Runs ONLY against
+ * the seeded verification harness (self-hosted Convex + a fresh Better Auth
+ * DB) — start it with `bash scripts/e2e-harness-up.sh` and run with
+ * `E2E_HARNESS=1`. See docs/e2e-harness.md.
+ *
+ * There's no seed-data API reachable from Playwright, only the real UI, so
+ * this test creates its own model + serialized asset before creating the
+ * project — that's what makes the line item deployable/returnable through the
+ * warehouse (a line item added as a bare "Custom" item has no model/asset and
+ * can't be checked out).
+ */
+test.describe("harness: primary revenue path", () => {
+  test.skip(
+    !process.env.E2E_HARNESS,
+    "requires the seeded Convex harness (E2E_HARNESS=1)",
+  );
+
+  test("project -> line item -> availability -> check-out -> return", async ({ page }) => {
+    const unique = Date.now();
+    const email = `e2e+revenue-${unique}@harness.local`;
+    const modelName = `E2E Revenue Model ${unique}`;
+    const projectName = `E2E Revenue Path ${unique}`;
+
+    await test.step("register (first user bootstraps as admin)", async () => {
+      await page.goto("/register");
+      await page.getByLabel(/name/i).first().fill("Revenue Path Test");
+      await page.getByLabel(/email/i).first().fill(email);
+      await page.getByLabel(/password/i).first().fill("harness-password-123");
+      await page
+        .getByRole("button", { name: /create|register|sign up/i })
+        .first()
+        .click();
+      await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    });
+
+    await test.step("create an equipment model (flow 10: create inventory)", async () => {
+      await page.goto("/assets/models/new");
+      await page.getByPlaceholder("e.g. Shure SM58").fill(modelName);
+      await page.getByRole("button", { name: "Create model" }).click();
+      await expect(page).toHaveURL(/\/assets\/models\/[^/]+$/, { timeout: 20000 });
+    });
+
+    await test.step("create a serialized asset for the model (asset tag auto-generated)", async () => {
+      await page.goto("/assets/registry/new");
+      await page.getByRole("button", { name: "Select a model" }).click();
+      await page.getByPlaceholder("Search models").fill(modelName);
+      await page.getByRole("button", { name: modelName, exact: true }).click();
+      await page.getByRole("button", { name: "Create asset" }).click();
+      await expect(page).toHaveURL(/\/assets\/registry\/[^/]+$/, { timeout: 20000 });
+    });
+
+    await test.step("create a project (flow 5)", async () => {
+      await page.goto("/projects/new");
+      await page.getByPlaceholder("e.g. Summer Festival 2026").fill(projectName);
+      // Basics -> Schedule -> Site -> Review: every field but Name/Project code
+      // (auto-filled) is optional, so three plain "Continue" clicks get through.
+      await page.getByRole("button", { name: "Continue" }).click();
+      await page.getByRole("button", { name: "Continue" }).click();
+      await page.getByRole("button", { name: "Continue" }).click();
+      await page.getByRole("button", { name: "Create job" }).click();
+      await expect(page).toHaveURL(/\/projects\/[^/]+$/, { timeout: 20000 });
+    });
+
+    const projectId = new URL(page.url()).pathname.split("/")[2]!;
+
+    await test.step("add the model as a line item + pricing (flow 6)", async () => {
+      await page.getByRole("button", { name: "Add", exact: true }).click();
+      await page.getByRole("menuitem", { name: "Add item" }).click();
+      await page.getByRole("tab", { name: "Own stock" }).click();
+      await page.getByRole("button", { name: "Search models" }).click();
+      await page.getByPlaceholder(/Search by name/).fill(modelName);
+      await page.getByRole("button", { name: modelName, exact: true }).click();
+
+      // Availability check (flow 7) is inline and automatic here: with exactly
+      // one asset created above and quantity defaulted to 1, it renders
+      // "1 available out of 1 ..." with no overbook warning/checkbox to confirm.
+      await expect(page.getByText(/available out of/i)).toBeVisible();
+      await expect(page.getByText(/overbook/i)).toHaveCount(0);
+
+      await page.getByRole("button", { name: "Add to project" }).click();
+      // The dialog closes on a successful add.
+      await expect(page.getByRole("button", { name: "Add to project" })).toBeHidden();
+    });
+
+    await test.step("check the gear out through the warehouse pipeline (flow 8)", async () => {
+      await page.getByRole("link", { name: "Warehouse" }).click();
+      await expect(page).toHaveURL(new RegExp(`/warehouse/${projectId}$`));
+
+      await page.getByRole("tab", { name: /^Pick/ }).click();
+      await page.locator("table thead").getByRole("checkbox").click();
+      await page.getByRole("button", { name: /^Prep/ }).click();
+
+      await page.getByRole("tab", { name: /^Prepped/ }).click();
+      await page.locator("table thead").getByRole("checkbox").click();
+      await page.getByRole("button", { name: /^Deploy/ }).click();
+
+      await expect(page.getByRole("tab", { name: /^Deployed \(1\)/ })).toBeVisible();
+    });
+
+    await test.step("return the gear (flow 9)", async () => {
+      await page.getByRole("tab", { name: /^Deployed/ }).click();
+      await page.locator("table thead").getByRole("checkbox").click();
+      // Condition defaults to "Good" — happy path needs no extra input.
+      await page.getByRole("button", { name: /^Return/ }).click();
+
+      await expect(page.getByRole("tab", { name: /^Returned \(1\)/ })).toBeVisible();
+      await expect(page.getByRole("tab", { name: /^Deployed \(0\)/ })).toBeVisible();
+    });
+  });
+});

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { organization } from "@/lib/auth-client";
-import { getTheOrgId, invalidateTheOrgCache } from "@/server/public-org";
+import { getTheOrgId, invalidateTheOrgCache, mirrorMyMembership } from "@/server/public-org";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -63,6 +63,11 @@ export default function OnboardingPage() {
         // redirect gates on it, and would otherwise keep seeing "no org yet"
         // for up to 5 minutes after this create.
         await invalidateTheOrgCache();
+        // The org plugin's own create path never mirrors the new owner's
+        // membership into Convex (only src/server/site-admin.ts's admin-driven
+        // path does) — without this, every Convex-authorized action afterward
+        // fails with "not a member of this organization".
+        await mirrorMyMembership(result.data!.id);
         toast.success("Organization created!");
         router.push("/dashboard");
       }

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { organization } from "@/lib/auth-client";
-import { getTheOrgId } from "@/server/public-org";
+import { getTheOrgId, invalidateTheOrgCache } from "@/server/public-org";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -59,6 +59,10 @@ export default function OnboardingPage() {
         await organization.setActive({
           organizationId: result.data!.id,
         });
+        // Bust getTheOrg()'s 5-minute cache — the (app) layout's onboarding
+        // redirect gates on it, and would otherwise keep seeing "no org yet"
+        // for up to 5 minutes after this create.
+        await invalidateTheOrgCache();
         toast.success("Organization created!");
         router.push("/dashboard");
       }

--- a/src/components/collaboration/comment-thread-panel.tsx
+++ b/src/components/collaboration/comment-thread-panel.tsx
@@ -378,7 +378,7 @@ export function CommentThreadPanel({
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger>
+      <SheetTrigger asChild>
         {children ?? (
           <Button size="sm" variant="ghost" className="relative h-7 gap-1 px-2 text-xs">
             <MessageCircle className="h-3.5 w-3.5" />

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -72,7 +72,11 @@ export const auth = betterAuth({
   },
   plugins: [
     organization({
-      allowUserToCreateOrganization: false,
+      // Single-org app (organizationLimit below): self-serve org creation is
+      // only for the one-time bootstrap (src/app/(auth)/onboarding/page.tsx),
+      // never for adding a second org once one exists — otherwise no user
+      // could ever get past onboarding on a fresh deployment (R-8.4 auth).
+      allowUserToCreateOrganization: async () => !(await getTheOrg()),
       organizationLimit: 1,
       creatorRole: "owner",
       memberRoleHierarchy: ["owner", "admin", "manager", "member", "warehouse", "viewer"],

--- a/src/server/public-org.ts
+++ b/src/server/public-org.ts
@@ -3,6 +3,8 @@
 import { getTheOrg, invalidateOrgCache } from "@/lib/single-org";
 import { serialize } from "@/lib/serialize";
 import { getOrgLoginInfo } from "./sso";
+import { getSession } from "@/lib/auth-server";
+import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
 
 /**
  * Returns the single org's ID. Safe to call without session context.
@@ -44,4 +46,29 @@ export async function getSingleOrgSSOInfo() {
  */
 export async function invalidateTheOrgCache(): Promise<void> {
   invalidateOrgCache();
+}
+
+/**
+ * Mirror the CALLING session's own membership in `organizationId` into Convex.
+ * Called by the onboarding page right after `organization.create()` +
+ * `setActive()` succeed.
+ *
+ * The self-serve `organization.create()` client call (Better Auth's own
+ * organization plugin) creates the Postgres Organization + Member rows
+ * directly — unlike `adminCreateOrganization` (src/server/site-admin.ts), it
+ * has no way to also call `upsertMemberMirrorByOrgUser`, since that mirror
+ * write lives in this app's code, not the plugin's. Without this, the
+ * bootstrap owner has a real Postgres membership but no Convex-side one, and
+ * every Convex-authorized action (creating a model, a project, ...) fails
+ * with "not a member of this organization" — the app is otherwise unusable
+ * immediately after onboarding.
+ *
+ * Safe for any caller: `upsertMemberMirrorByOrgUser` reads the Postgres
+ * Member row for (org, user) first and no-ops if it doesn't exist, so this
+ * can only mirror a membership that's already real — never fabricate one.
+ */
+export async function mirrorMyMembership(organizationId: string): Promise<void> {
+  const session = await getSession();
+  if (!session) return;
+  await upsertMemberMirrorByOrgUser(organizationId, session.user.id);
 }

--- a/src/server/public-org.ts
+++ b/src/server/public-org.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getTheOrg } from "@/lib/single-org";
+import { getTheOrg, invalidateOrgCache } from "@/lib/single-org";
 import { serialize } from "@/lib/serialize";
 import { getOrgLoginInfo } from "./sso";
 
@@ -33,4 +33,15 @@ export async function getSingleOrgSSOInfo() {
   if (!org) return null;
   const info = await getOrgLoginInfo(org.slug);
   return info ? serialize(info) : null;
+}
+
+/**
+ * Bust the 5-minute in-process `getTheOrg()` cache. Called by the onboarding
+ * page right after the bootstrap org is created — without this, `getTheOrg()`
+ * (and everything that gates on it, e.g. the (app) layout's onboarding
+ * redirect) can keep serving the cached "no org yet" null for up to 5 minutes
+ * after a successful create.
+ */
+export async function invalidateTheOrgCache(): Promise<void> {
+  invalidateOrgCache();
 }


### PR DESCRIPTION
**Closes #621.** Finishes the two remaining scoped items from `docs/e2e-harness.md`
(POLICY.md R-8.8.3): CI automation for the seeded-auth harness, and the primary
revenue-path specs (`docs/critical-flows.md` flows #5-9).

**The harness surfaced two real, previously-unnoticed bootstrap bugs along the way**
(see below) — a fresh deployment could never actually finish onboarding and start
using the app. Both fixed in this PR since they directly blocked the E2E work and
are correctness bugs independent of it.

## What

- **`e2e/harness-revenue-path.spec.ts`** — register → complete onboarding → create a
  model + serialized asset → create a project → add a line item by model (own-stock)
  → inline availability check (no overbook) → warehouse check-out (Pick → Prep →
  Deploy) → return.
- **`.github/workflows/ci.yml`** — new `e2e-harness` job (separate from the existing
  dummy-Convex `e2e` job): stands up a throwaway Postgres + the self-hosted Convex
  backend via `scripts/e2e-harness-up.sh`, runs the full harness spec set with
  `E2E_HARNESS=1`, tears down via `scripts/e2e-harness-down.sh`.
- **`docs/critical-flows.md`**, **`docs/e2e-harness.md`**, **`FEATUREDOCS/36-testing.md`**
  updated to reflect the new coverage.

## Two bugs found + fixed in the bootstrap flow

**1. Org creation was unconditionally blocked.** `src/lib/auth.ts` had
`allowUserToCreateOrganization: false` hardcoded, with `organizationLimit: 1`. Per
Better Auth's own route logic, a literal `false` blocks all client-side org creation
with no admin/first-user bypass — and the onboarding page's `organization.create()`
is the only org-creation path in the codebase, so a genuinely fresh deployment could
never get past `/onboarding`, ever. Fixed: `allowUserToCreateOrganization` is now a
function allowing creation only while no org exists yet (`!(await getTheOrg())`).
Also fixed a compounding cache-staleness bug: `getTheOrg()` caches for 5 minutes and
the `(app)` layout's redirect gates on it, so a successful create could still bounce
back to `/onboarding` for up to 5 minutes without busting that cache
(`invalidateTheOrgCache()`, called right after `setActive()`).

**2. The newly-created owner was never a member in Convex.** With #1 fixed, the flow
got further but then failed on every Convex-authorized action — "not a member of
this organization" (`convex/modelWrites.ts`), "organization mismatch"
(`convex/dashboardCounters.ts`) — immediately after landing on `/dashboard`. Root
cause: two parallel org-creation code paths, only one of which mirrors membership
into Convex. `src/server/site-admin.ts`'s `adminCreateOrganization` (the
site-admin-driven path) creates the org + Member row in a transaction and explicitly
calls `upsertMemberMirrorByOrgUser`; the onboarding page instead calls Better Auth's
own `organization.create()` client SDK directly, which has no way to also invoke
this app's mirror helper. The existing `user.create.after` hook doesn't cover this
either — it only auto-mirrors membership when a new user joins an *already-existing*
org, and for the bootstrapping user there's no org yet at registration time. Fixed by
adding `mirrorMyMembership(organizationId)` (`src/server/public-org.ts`) — mirrors the
calling session's own membership, safe for any caller since the underlying helper
reads the real Postgres row first and no-ops if it doesn't exist — called from the
onboarding page right after `setActive()`.

## CI signal (this is why these were caught)

Three `e2e-harness` runs so far: (1) harness setup itself worked (3/4 specs passed),
new revenue-path spec failed on a missing onboarding step in the test; (2) onboarding
step added, failed on bug #1 above; (3) bug #1 fixed, failed on bug #2 above. All
three fixes are pushed. Neither `src/lib/auth.ts` nor the onboarding page has
existing unit coverage (Better Auth's instance needs a real DB adapter) — the
`e2e-harness` job is the actual verification loop for all of this.

## Verified

- `pnpm exec eslint` — 0 errors (one pre-existing, unrelated max-lines-per-function
  warning on the onboarding component).
- `pnpm exec tsc --noEmit` — clean.
- Full unit suite: 3826/3826 passing.
- All hygiene gates green (any-ratchet, knip-ratchet, depcruise, collect-ratchet,
  check-client-routes).
- `ci.yml` parses as valid YAML.

## Known limitation

This sandbox has no Docker daemon, so I couldn't execute the harness locally — the
`e2e-harness` CI job (`continue-on-error: true` for now) is the real verification
loop, and it's what caught both bugs above across three iterations. Flip that flag
off once a run goes green — see the job's comment in `ci.yml`.

Refs #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRMAaQ1UWo7Lbwm4KweGV)_