### PR TITLE
docs: add ADR-0004, the perf-regression defect workflow (#657)

### DIFF
--- a/docs/adr/0004-perf-regression-defect-workflow.md
+++ b/docs/adr/0004-perf-regression-defect-workflow.md
@@ -15,51 +15,110 @@ nothing to route. #623 made every budget in the README's R-0.4 registry machine-
 #656 gave every one of them a PostHog alert. With the gates now real, R-9.5 needs an actual
 answer: when one fires, what happens next?
 
-The budgets split into two categories with different natural owners:
+Regressions are caught in two different ways, which matters for *when* an issue gets filed but
+not for *whether* one does:
 
 1. **Build-time, CI-blocking gates** — the JS bundle regression ratchet (`bundle-ratchet.mjs`)
-   and the CSS bundle budget (`size-limit`, R-8.7.5). These run on every PR and fail the build.
+   and the CSS bundle budget (`size-limit`, R-8.7.5). These run on every PR and fail the build
+   before the regression ever reaches `main`.
 2. **Runtime PostHog alerts** — CWV (`LCP`/combined `INP+CLS`), `slow_query` (T-9),
    `convex_op_latency` (T-P6), `queue_lag` (T-P7). These fire against live production traffic,
    independent of any PR.
 
 ## Decision
 
-**Category 1 (CI-blocking) is already compliant — no new process needed.** A failing
-bundle-ratchet or CSS-budget check blocks the PR from merging. The PR itself is the tracking
-artifact, the PR author is the owner by construction (they can't merge until it's fixed or a
-POLICY.md §15 exception is registered), and this satisfies R-9.5's "owner + defect workflow"
-requirement without any additional tooling.
+**Every regression caught by an R-9.5-covered gate — CI-blocking or a runtime alert — gets a
+`perf:`-prefixed GitHub issue.** A blocked PR is not, on its own, enough of a record: it
+disappears once the regression is fixed and the PR merges clean, with no trace that it ever
+happened. Filing an issue either way gives a permanent, greppable history (`is:issue "perf:"
+in:title`) — useful for spotting a budget that keeps getting regressed by different PRs, which a
+one-off blocked PR would never surface.
 
-**Category 2 (runtime alerts) gets a lightweight manual process**, proportionate to this
-being a solo-maintainer project (README's `Owner:` line names one person for the whole repo) —
-not a webhook-to-issue automation pipeline, which would be disproportionate engineering effort
-for this finding's `severity:minor` / `effort:medium` audit rating:
+### Trigger
 
-1. All five PostHog alerts (`LCP`, combined `INP+CLS`, `slow_query`, `convex_op_latency`,
-   `queue_lag`) are subscribed to the budget owner (currently Jayden, matching README's `Owner:`
-   line and the R-9.12 cost-budget owner convention already in place).
-2. On receiving an alert notification, the owner opens a GitHub issue in this repo:
-   - Title prefixed `perf:` (e.g. `perf: LCP p75 crossed 2000ms`), so these are greppable via
-     `is:issue "perf:" in:title` without needing a dedicated label.
-   - Body links the firing PostHog insight/alert and states the budget row it corresponds to
-     (T-7/T-9/T-P6/T-P7 from README's R-0.4 table).
-   - Assigned to an owner (default: the budget owner, same person, unless the regression is
-     clearly scoped to a specific recent PR/author).
-3. The issue is triaged and closed like any other bug — through the normal PR-review workflow,
-   not a special performance-only process. If the alert is a false positive or the regression is
-   accepted, that's a POLICY.md §15 exception in `docs/exceptions.md`, not a silent close.
+- **Category 1 (CI-blocking):** file the `perf:` issue as soon as the gate fails on a PR — don't
+  wait for it to be fixed or merged. Link the failing PR/check run in the issue body.
+- **Category 2 (runtime alerts):** file only once an alert has fired on **2 consecutive daily
+  evaluations**, not on an isolated first firing. All five alerts run on a `daily`
+  `calculation_interval`, so this means the underlying condition has held for roughly 48 hours —
+  enough to filter a one-day traffic blip while still catching a real regression fast. This is a
+  default, not a hard rule: tighten it per-alert (e.g. file on the first firing) if a specific
+  budget turns out to need faster response, or loosen it if a particular alert is noisier than
+  expected.
+  - **Exception:** an isolated but *severe* spike (e.g. an outage-adjacent latency event) can
+    still warrant filing immediately on first firing — that's a judgment call for whoever sees
+    the alert, not something the 2-day rule should block.
 
-This is a **process** decision, not a code change — there is nothing to merge for Category 2
-beyond this ADR. It closes the loop that #623 (enforcement) and #656 (alerting) opened, without
-building bespoke automation a one-person team doesn't yet need.
+### Scope
+
+Applies to any budget/gate governed by R-9.5's language ("bundle growth, CWV/latency
+degradation, CI-time growth") once it's enforced — not only the five budgets alerted via #656.
+README's T-5 (coverage) row is already a blocking CI ratchet today, so it's in scope now; any
+future gate that graduates from advisory to blocking or alerted (a11y, CI-time itself, etc.)
+joins this workflow automatically, no ADR update needed to add it.
+
+### Ownership
+
+- **Default owner:** whoever's PR most recently touched the affected code/config path. For
+  Category 1 this is simply the PR author (they're already blocked from merging until it's
+  resolved). For Category 2, trace the regression to its likely originating change (`git log`/
+  `git blame` on the affected area, or the most recent deploy before the alert first fired).
+- **If no single PR is clearly attributable** (gradual drift, an external dependency update, an
+  infra-level cause) — default to the budget owner, Jayden, matching README's `Owner:` line.
+- **Backup owner: Penar.** If the primary owner hasn't triaged within the target window (below),
+  reassign to Penar. *Open item: this assumes Penar has repo access and enough context to act on
+  a reassigned perf issue — worth confirming that's actually true before relying on it in a real
+  incident, rather than discovering the gap when an issue is stuck.*
+
+### Triage & resolution
+
+- **"Triaged"** = assigned + acknowledged (a comment or reaction confirming someone has seen it
+  and intends to act). It does **not** require a fix to already be in progress.
+- **Target: triage within the same week the issue is filed.** This is a soft internal target,
+  not a new POLICY.md `MUST` — R-9.5 doesn't specify an SLA, and this repo has no on-call
+  rotation to enforce a hard one. Missing the target isn't itself a defect; it's a signal.
+- If the primary owner hasn't triaged within the week, reassign to Penar.
+- **The issue stays open until the regression is actually resolved** — root-caused and fixed, or
+  reverted. Acknowledging it, or opening a separate follow-up issue for a larger investigation,
+  does not close the original; it stays open until the regression itself is gone.
+
+### False positives / accepted regressions
+
+Always go through a POLICY.md **§15 exception** in `docs/exceptions.md` (rule ID, reason, scope,
+owner, expiry) — never closed with just a comment, regardless of how minor it looks. Close the
+`perf:` issue referencing the exception entry once it's registered.
+
+### Naming
+
+`perf:` title prefix (e.g. `perf: LCP p75 crossed 2000ms`, `perf: bundle-ratchet failed on PR
+#812`). No dedicated GitHub label — kept lightweight while the workflow is still new enough that
+its shape might change.
+
+## Revisit / automate trigger
+
+Manual filing stays the default until **any** of the following:
+
+- The team grows past one person (a second regular contributor beyond the backup-owner role), or
+- **3 or more `perf:` issues are filed within a rolling 90-day window** — a sign alert/gate
+  volume has outgrown what manual triage handles cleanly, or
+- **Same-week triage is missed twice**, even after backup-owner reassignment — a signal the
+  manual step itself isn't working, not just that the target is aggressive.
+
+At that point, build a PostHog webhook → GitHub Issues Action to auto-file (mirroring the
+existing GHCR/Coolify webhook pattern already in `build-image.yml`) rather than continuing to
+rely on someone remembering to check their alert inbox or watch CI.
 
 ## Consequences
 
-- R-9.5 is satisfied for both regression categories without new infrastructure.
-- The manual step in Category 2 is a real gap: a missed or ignored PostHog notification means a
-  regression goes untracked. Revisit if the team grows past one person, or if alert volume makes
-  manual triage unreliable — at that point, a PostHog webhook → GitHub Issues Action (mirroring
-  how `build-image.yml` already calls external webhooks) is the natural next step.
-- No new GitHub label was created (`perf:` title prefix instead) to avoid repo-config churn for
-  a workflow that may still change shape as it's used in practice.
+- Every regression caught by any R-9.5-covered gate now leaves a permanent record, including
+  ones CI stopped from ever reaching `main` — this is new process overhead on routine PR fixes
+  (e.g. a dependency bump that grows the bundle by a few KB now also means opening an issue, not
+  just fixing the diff). Accepted as the cost of the historical record; a high `perf:` count
+  driven mostly by Category 1 noise would itself be a signal to reconsider filing on every
+  CI-blocked regression, per the revisit trigger above.
+- The 2-consecutive-day filter on runtime alerts is a deliberate trade: it accepts a ~24-48h
+  detection delay on borderline regressions in exchange for not filing on every noisy blip. The
+  severe-spike exception exists for when that trade is wrong for a specific event, but relies on
+  a human noticing and choosing to override the default.
+- Reassignment to Penar as backup owner is untested — confirm access/context before treating it
+  as a reliable escalation path rather than a theoretical one.

--- a/docs/adr/0004-perf-regression-defect-workflow.md
+++ b/docs/adr/0004-perf-regression-defect-workflow.md
@@ -1,0 +1,65 @@
+# ADR-0004: Route performance regressions through the standard defect workflow
+
+**Status:** Accepted (2026-07-22)
+
+## Context
+
+POLICY.md **R-9.5** (WEB profile, §9A): *"Performance regressions are bugs: bundle growth,
+CWV/latency degradation, CI-time growth each get an owner and enter the defect workflow."* Its
+remediation note (from the 2026-07-18 post-remediation audit, tracked as issue #657) is:
+*"Once gates block, route perf regressions into the defect workflow with an owner."*
+
+Before #623/#656, this rule was moot — several of the underlying gates were advisory or dead
+(the CSS bundle check was never wired into CI; queue lag had no monitoring at all), so there was
+nothing to route. #623 made every budget in the README's R-0.4 registry machine-enforced, and
+#656 gave every one of them a PostHog alert. With the gates now real, R-9.5 needs an actual
+answer: when one fires, what happens next?
+
+The budgets split into two categories with different natural owners:
+
+1. **Build-time, CI-blocking gates** — the JS bundle regression ratchet (`bundle-ratchet.mjs`)
+   and the CSS bundle budget (`size-limit`, R-8.7.5). These run on every PR and fail the build.
+2. **Runtime PostHog alerts** — CWV (`LCP`/combined `INP+CLS`), `slow_query` (T-9),
+   `convex_op_latency` (T-P6), `queue_lag` (T-P7). These fire against live production traffic,
+   independent of any PR.
+
+## Decision
+
+**Category 1 (CI-blocking) is already compliant — no new process needed.** A failing
+bundle-ratchet or CSS-budget check blocks the PR from merging. The PR itself is the tracking
+artifact, the PR author is the owner by construction (they can't merge until it's fixed or a
+POLICY.md §15 exception is registered), and this satisfies R-9.5's "owner + defect workflow"
+requirement without any additional tooling.
+
+**Category 2 (runtime alerts) gets a lightweight manual process**, proportionate to this
+being a solo-maintainer project (README's `Owner:` line names one person for the whole repo) —
+not a webhook-to-issue automation pipeline, which would be disproportionate engineering effort
+for this finding's `severity:minor` / `effort:medium` audit rating:
+
+1. All five PostHog alerts (`LCP`, combined `INP+CLS`, `slow_query`, `convex_op_latency`,
+   `queue_lag`) are subscribed to the budget owner (currently Jayden, matching README's `Owner:`
+   line and the R-9.12 cost-budget owner convention already in place).
+2. On receiving an alert notification, the owner opens a GitHub issue in this repo:
+   - Title prefixed `perf:` (e.g. `perf: LCP p75 crossed 2000ms`), so these are greppable via
+     `is:issue "perf:" in:title` without needing a dedicated label.
+   - Body links the firing PostHog insight/alert and states the budget row it corresponds to
+     (T-7/T-9/T-P6/T-P7 from README's R-0.4 table).
+   - Assigned to an owner (default: the budget owner, same person, unless the regression is
+     clearly scoped to a specific recent PR/author).
+3. The issue is triaged and closed like any other bug — through the normal PR-review workflow,
+   not a special performance-only process. If the alert is a false positive or the regression is
+   accepted, that's a POLICY.md §15 exception in `docs/exceptions.md`, not a silent close.
+
+This is a **process** decision, not a code change — there is nothing to merge for Category 2
+beyond this ADR. It closes the loop that #623 (enforcement) and #656 (alerting) opened, without
+building bespoke automation a one-person team doesn't yet need.
+
+## Consequences
+
+- R-9.5 is satisfied for both regression categories without new infrastructure.
+- The manual step in Category 2 is a real gap: a missed or ignored PostHog notification means a
+  regression goes untracked. Revisit if the team grows past one person, or if alert volume makes
+  manual triage unreliable — at that point, a PostHog webhook → GitHub Issues Action (mirroring
+  how `build-image.yml` already calls external webhooks) is the natural next step.
+- No new GitHub label was created (`perf:` title prefix instead) to avoid repo-config churn for
+  a workflow that may still change shape as it's used in practice.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,6 @@ Number files `NNNN-kebab-title.md`, starting at `0001`.
 | # | Title | Status |
 |---|---|---|
 | [0001](0001-track-pnpm-workspace-and-pin-toolchain.md) | Track pnpm-workspace.yaml and pin the pnpm/Node toolchain | Accepted |
+| [0002](0002-next-image-unoptimized.md) | Adopt next/image but serve app images unoptimized | Accepted |
+| [0003](0003-validation-drift-guard.md) | Enforce Zod↔Convex validation single-source via a drift guard | Accepted |
+| [0004](0004-perf-regression-defect-workflow.md) | Route performance regressions through the standard defect workflow | Accepted |


### PR DESCRIPTION
## Summary
- Adds ADR-0004 documenting how POLICY.md R-9.5 ("performance regressions are bugs... enter the defect workflow with an owner") is satisfied now that #623 made every budget machine-enforced and #656 gave every one of them a PostHog alert.
- Both CI-blocking regressions (bundle/CSS ratchets) and runtime-alert regressions (CWV, slow_query, convex_op_latency, queue_lag) now get a `perf:`-prefixed GitHub issue — a blocked PR alone leaves no historical record once it's fixed and merged.
- Ownership defaults to whoever's PR touched the affected area, falling back to the budget owner (Jayden) only when nothing's attributable; Penar is backup owner on a same-week triage miss.
- Runtime alerts file after 2 consecutive daily firings (not the first), with an explicit override for isolated severe spikes.
- Scope covers any R-9.5-governed gate as it's enforced, not just the five budgets alerted via #656.
- Concrete automate-trigger defined (team grows past one person, 3+ perf issues in a rolling 90 days, or the same-week SLA missed twice) — at that point, revisit with a PostHog webhook → GitHub Issues Action.
- Backfills the ADR index (`docs/adr/README.md`), which was missing entries for ADR-0002 and ADR-0003.

Closes #657.

## Test plan
- [x] Docs-only change — no code paths affected.
- [x] `docs/adr/README.md` index cross-checked against `docs/adr/*.md` files on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwD5ezKU5MUPSt8zKgcM6f)_