### PR TITLE
Fix §8.3 backend/database hygiene findings (R-8.3.2, R-8.3.3, R-8.3.4)

### DIFF
--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -58,6 +58,11 @@ Plus, on every mutation:
 - **Per-row org re-check on GLOBAL-index fetches.** `by_cuid`, `by_modelId`, and
   friends are *global* indexes; a fetched doc's `organizationId` must be re-checked
   against the caller's org or you have a cross-tenant read/write.
+- **Kit-by-cuid goes through `getKitByCuid` (`convex/lib/kits.ts`), never an inlined
+  `ctx.db.query("kits").withIndex("by_cuid", ...)`.** One accessor for a global index
+  means one place to get the org re-check right, instead of ~30 independent chances
+  to forget it (R-8.3.4). Callers still MUST check the returned doc's
+  `organizationId` — the helper doesn't scope by org.
 - **Client-supplied FKs are org-validated** via `convex/lib/orgRef.ts`
   (`assertRefInOrg` / `assertMemberInOrg`). Because the service-token server reads
   bypass read-side org scoping, **write-side FK validation is the only reliable

--- a/convex/checkItemsWrites.ts
+++ b/convex/checkItemsWrites.ts
@@ -6,6 +6,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { CheckItemType } from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Native CHECK-ITEM write mutations (Phase 3 browser-direct — replaces the
@@ -40,7 +41,7 @@ async function orgModel(ctx: MutationCtx, orgId: string, id: string) {
   return doc && doc.organizationId === orgId ? doc : null;
 }
 async function orgKit(ctx: MutationCtx, orgId: string, id: string) {
-  const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+  const doc = await getKitByCuid(ctx, id);
   return doc && doc.organizationId === orgId ? doc : null;
 }
 

--- a/convex/checkRecordWrites.ts
+++ b/convex/checkRecordWrites.ts
@@ -11,6 +11,7 @@ import { runPredictiveMaintenance, type PmPlanEntry } from "./lib/checkPredictiv
 import { completeCheckAndDeprepLineCore, prepItemCore } from "./checkRecordOps";
 import { checkinItemsCore } from "./warehouseOps";
 import * as enums from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Browser-direct CHECK-RECORD writes (Phase 3 — the densest warehouse-check state
@@ -109,7 +110,7 @@ async function assertBulkAssetInOrg(ctx: MutationCtx, bulkAssetId: string, orgId
 }
 
 async function assertKitInOrg(ctx: MutationCtx, kitId: string, orgId: string): Promise<void> {
-  const k = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).unique();
+  const k = await getKitByCuid(ctx, kitId);
   if (!k || k.organizationId !== orgId) throw new ConvexError("Kit not found");
 }
 

--- a/convex/crewDashboard.ts
+++ b/convex/crewDashboard.ts
@@ -146,11 +146,12 @@ export const upcomingShifts = query({
     const startOfToday = new Date(nowMs).setHours(0, 0, 0, 0);
     const orgAssignmentIds = new Set(g.assignments.map((a) => a.id));
     const assignById = new Map(g.assignments.map((a) => [a.id, a]));
-    // crewShifts have no org column — scope via the org's assignment ids.
-    const shifts: { id: string; assignmentId: string; date: number; status?: string; callTime?: string; endTime?: string; breakMinutes?: number; location?: string; notes?: string }[] = [];
-    for (const id of orgAssignmentIds) {
-      for (const s of await ctx.db.query("crewShifts").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect()) shifts.push(s);
-    }
+    // crewShifts have no org column — scope via the org's assignment ids. Batched in
+    // parallel (R-8.3.2) instead of one sequential round-trip per assignment.
+    const shiftLists = await Promise.all(
+      Array.from(orgAssignmentIds, (id) => ctx.db.query("crewShifts").withIndex("by_assignmentId", (q) => q.eq("assignmentId", id)).collect()),
+    );
+    const shifts = shiftLists.flat();
     return shifts
       .filter((s) => s.status === "SCHEDULED" && s.date >= startOfToday && orgAssignmentIds.has(s.assignmentId))
       .sort((a, b) => cmpAscNulls(a.date, b.date))

--- a/convex/equipmentTab.ts
+++ b/convex/equipmentTab.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * BROWSER-facing composite for the project EQUIPMENT EDITING TAB (Phase 5 native
@@ -103,7 +104,7 @@ async function readEquipmentTab(ctx: QueryCtx, projectId: string, orgId: string)
   const [assetDocs, bulkDocs, kitDocs, modelDocs, supplierDocs] = await Promise.all([
     byCuid(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     byCuid(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
-    byCuid(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    byCuid(refKitIds.map((id) => getKitByCuid(ctx, id))),
     byCuid(refModelIds.map((id) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     byCuid(refSupplierIds.map((id) => ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
   ]);

--- a/convex/groupTemplatesWrites.ts
+++ b/convex/groupTemplatesWrites.ts
@@ -11,6 +11,7 @@ import { createKitLineItemCore } from "./projectLineItems";
 import { findKitConflict } from "./lib/availabilityCore";
 import { recalcProjectTotals } from "./lib/recalc";
 import { assertRefInOrg } from "./lib/orgRef";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Native GROUP-TEMPLATE write mutations (Phase 3 browser-direct — replaces the
@@ -499,7 +500,7 @@ export const applyNative = mutation({
     for (const item of templateItems) {
       if (!item.kitId) continue;
       const kitId = item.kitId; // hoist so the narrowing survives the closure below
-      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+      const kit = await getKitByCuid(ctx, kitId);
       const label = kit?.assetTag ?? kitId;
       if (!kit || kit.organizationId !== a.orgId) {
         kitWarnings.push(`${label}: kit not found`);

--- a/convex/kitAllocations.ts
+++ b/convex/kitAllocations.ts
@@ -3,6 +3,7 @@ import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgRead } from "./lib/auth";
 import { suggestKitAllocation, allocationCoversKit } from "./lib/allocation";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Per-MODEL revenue allocation for a kit (see docs/revenue-allocation-design.md).
@@ -52,7 +53,7 @@ export const getKitAllocation = query({
   handler: async (ctx, { kitId, orgId }) => {
     await requireOrgRead(ctx, orgId);
 
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+    const kit = await getKitByCuid(ctx, kitId);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError(`kit not found: ${kitId}`);
 
     const quantities = await kitModelQuantities(ctx, kitId);

--- a/convex/kitAllocationsWrites.ts
+++ b/convex/kitAllocationsWrites.ts
@@ -5,6 +5,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { kitModelQuantities } from "./kitAllocations";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Native KIT-REVENUE-ALLOCATION write mutations (Phase 3 browser-direct — replaces the
@@ -35,7 +36,7 @@ export const replaceNative = mutation({
     await requireOrgPermission(ctx, orgId, "kit", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+    const kit = await getKitByCuid(ctx, kitId);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError(`kit not found: ${kitId}`);
 
     if (rows.length > 0) {
@@ -114,7 +115,7 @@ export const clearNative = mutation({
     await requireOrgPermission(ctx, orgId, "kit", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+    const kit = await getKitByCuid(ctx, kitId);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError(`kit not found: ${kitId}`);
 
     const rows = await ctx.db

--- a/convex/kitDetail.ts
+++ b/convex/kitDetail.ts
@@ -3,6 +3,7 @@ import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
 import { pick, USER_PUBLIC_FIELDS, FILE_URL_FIELDS } from "./lib/dto";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * BROWSER-facing composite for the KIT detail page (Phase 2 native reads). Returns
@@ -15,7 +16,7 @@ import { pick, USER_PUBLIC_FIELDS, FILE_URL_FIELDS } from "./lib/dto";
  * page never renders them). Returns null when the kit is missing / cross-org.
  */
 async function readKitDetail(ctx: QueryCtx, kitId: string, orgId: string) {
-  const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).unique();
+  const kit = await getKitByCuid(ctx, kitId);
   if (!kit || kit.organizationId !== orgId) return null;
 
   const [serialized, bulk, lineItemsAll, scanLogsAll, media] = await Promise.all([

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -11,6 +11,7 @@ import { adjustBulkAvailability } from "./lib/inventory";
 import { releaseKitMembers, getKitGuarded, assignAssetToKit, releaseAsset, getAssetDoc } from "./kits";
 import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Native KIT write mutations (Phase 5) — same shape as convex/assetWrites.ts:
@@ -106,7 +107,7 @@ export const createNative = mutation({
     }
     // The assetTag guard is org-scoped and does NOT catch a cross-org cuid collision —
     // dup-guard the client-minted id too (else another org's kit getById .unique() crashes).
-    const dupId = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
+    const dupId = await getKitByCuid(ctx, fields.id);
     if (dupId) throw new ConvexError("Kit already exists");
 
     // Org-validate client-supplied FKs (by_cuid is GLOBAL — cross-org refs leak).
@@ -152,7 +153,7 @@ export const updateNative = mutation({
     await requireOrgPermission(ctx, orgId, "kit", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
-    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const doc = await getKitByCuid(ctx, id);
     if (!doc) throw new ConvexError("Kit not found: " + id);
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
@@ -212,7 +213,7 @@ export const updateNotesNative = mutation({
     await requireOrgPermission(ctx, orgId, "kit", "update");
     const actor = await resolveActor(ctx, suppliedActor);
 
-    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const doc = await getKitByCuid(ctx, id);
     if (!doc) throw new ConvexError("Kit not found: " + id);
     if (doc.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
@@ -251,7 +252,7 @@ export const archiveNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "kit", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const kit = await getKitByCuid(ctx, id);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
     if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be archived" });
     await releaseKitMembers(ctx, id, orgId, now);
@@ -273,7 +274,7 @@ export const deleteNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "kit", "delete");
     const actor = await resolveActor(ctx, suppliedActor);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    const kit = await getKitByCuid(ctx, id);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError({ code: "NOT_FOUND", message: "Kit not found" });
     if (kit.status !== "AVAILABLE") throw new ConvexError({ code: "KIT_NOT_AVAILABLE", message: "Only AVAILABLE kits can be deleted" });
 

--- a/convex/kits.ts
+++ b/convex/kits.ts
@@ -7,6 +7,7 @@ import { bumpAssetCounters } from "./lib/counters";
 import { adjustBulkAvailability } from "./lib/inventory";
 import { matchesSearch, compareValues, paginateItems } from "./lib/listQuery";
 import * as enums from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Thin CRUD for Kit (Convex table "kits"). GENERATED — Phase 2/5.
@@ -32,7 +33,7 @@ export const list = query({
 export const getById = query({
   args: { id: v.string() },
   handler: async (ctx, { id }) => {
-    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    const doc = await getKitByCuid(ctx, id);
     await requireOrgReadDoc(ctx, doc);
     return doc;
   },
@@ -171,7 +172,7 @@ export const deletability = query({
   }),
   handler: async (ctx, { orgId, id }) => {
     await requireOrgRead(ctx, orgId);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    const kit = await getKitByCuid(ctx, id);
     if (!kit || kit.organizationId !== orgId) throw new ConvexError("Kit not found");
 
     const referencingLineItems = (
@@ -212,7 +213,7 @@ export const listByIds = query({
     const unique = [...new Set(ids)];
     if (unique.length > 1000) throw new ConvexError("kits.listByIds: too many ids (max 1000)");
     const docs = await Promise.all(
-      unique.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique()),
+      unique.map((id) => getKitByCuid(ctx, id)),
     );
     return docs.filter((d): d is NonNullable<typeof d> => d !== null && d.organizationId === orgId);
   },
@@ -337,7 +338,7 @@ export const createIfMissing = mutation({
   },
   handler: async (ctx, args) => {
     await requireService(ctx);
-    const existing = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", args.id)).unique();
+    const existing = await getKitByCuid(ctx, args.id);
     if (existing) return { _id: existing._id, created: false };
     const _id = await ctx.db.insert("kits", args);
     return { _id, created: true };
@@ -377,7 +378,7 @@ export const update = mutation({
   },
   handler: async (ctx, { id, patch }) => {
     await requireService(ctx);
-    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    const doc = await getKitByCuid(ctx, id);
     if (!doc) throw new ConvexError("kits not found: " + id);
     const safePatch = { ...patch };
     delete safePatch.organizationId;
@@ -390,7 +391,7 @@ export const remove = mutation({
   args: { id: v.string() },
   handler: async (ctx, { id }) => {
     await requireService(ctx);
-    const doc = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    const doc = await getKitByCuid(ctx, id);
     if (!doc) throw new ConvexError("kits not found: " + id);
     // Revenue allocation has no FK to cascade through (Convex-only table). Without
     // this, a recreated kit reusing the id would inherit the old kit's split.
@@ -412,7 +413,7 @@ export const remove = mutation({
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function getKitGuarded(ctx: MutationCtx, kitId: string, organizationId: string) {
-  const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).unique();
+  const kit = await getKitByCuid(ctx, kitId);
   if (!kit || kit.organizationId !== organizationId) throw new ConvexError("Kit not found");
   if (kit.status !== "AVAILABLE") throw new ConvexError("Items can only be added to/removed from AVAILABLE kits");
   return kit;
@@ -583,7 +584,7 @@ export const archiveCascade = mutation({
   args: { organizationId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", a.kitId)).unique();
+    const kit = await getKitByCuid(ctx, a.kitId);
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     if (kit.status !== "AVAILABLE") throw new ConvexError("Only AVAILABLE kits can be archived");
     await releaseKitMembers(ctx, a.kitId, a.organizationId, a.now);
@@ -596,7 +597,7 @@ export const deleteCascade = mutation({
   args: { organizationId: v.string(), kitId: v.string(), now: v.number() },
   handler: async (ctx, a) => {
     await requireService(ctx);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", a.kitId)).unique();
+    const kit = await getKitByCuid(ctx, a.kitId);
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     if (kit.status !== "AVAILABLE") throw new ConvexError("Only AVAILABLE kits can be deleted");
     await releaseKitMembers(ctx, a.kitId, a.organizationId, a.now);

--- a/convex/lib/kits.ts
+++ b/convex/lib/kits.ts
@@ -1,0 +1,8 @@
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+
+// `by_cuid` is a global (non-org-scoped) Convex index — this is the single accessor for
+// it (R-8.3.4). Callers MUST still check the returned doc's `organizationId` before
+// trusting it; this helper does not scope by org.
+export async function getKitByCuid(ctx: QueryCtx | MutationCtx, id: string) {
+  return await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+}

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -13,6 +13,7 @@ import { recalcProjectTotals } from "./lib/recalc";
 import { resolveOrgDefaultTaxRate } from "./lib/orgSettings";
 import { assertRefInOrg } from "./lib/orgRef";
 import * as enums from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 import { expandAccessoryChildLines } from "./lib/fulfillment";
 import { createKitLineItemCore, assertProjectInOrg } from "./projectLineItems";
 import {
@@ -907,7 +908,7 @@ export const addNative = mutation({
         // (a) Kit membership — a kit asset must be booked via the kit workflow.
         const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", fields.assetId!)).unique();
         if (asset && asset.organizationId === organizationId && asset.kitId) {
-          const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", asset.kitId!)).unique();
+          const kit = await getKitByCuid(ctx, asset.kitId!);
           const kitTag = kit && kit.organizationId === organizationId ? kit.assetTag : asset.kitId;
           throw new ConvexError({
             code: "ASSET_IN_KIT",
@@ -1072,7 +1073,7 @@ export const addKitNative = mutation({
     // Kit availability enforcement (parity with addKitLineItem, src/server/line-items.ts:
     // 811-860). UNCONDITIONAL — no allowOverbook for kits. (createKitLineItemCore re-reads
     // + org-validates the kit; this pre-read is only for the guards.)
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).unique();
+    const kit = await getKitByCuid(ctx, kitId);
     if (kit && kit.organizationId === organizationId) {
       // (a) Block truly unavailable kits (allow checked-out — the date check handles those).
       if (kit.status === "IN_MAINTENANCE" || kit.status === "INCOMPLETE") {
@@ -1328,7 +1329,7 @@ export const addLineItemSmartNative = mutation({
       if (fields.assetId) {
         const asset = await ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", fields.assetId!)).unique();
         if (asset && asset.organizationId === organizationId && asset.kitId) {
-          const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", asset.kitId!)).unique();
+          const kit = await getKitByCuid(ctx, asset.kitId!);
           const kitTag = kit && kit.organizationId === organizationId ? kit.assetTag : asset.kitId;
           throw new ConvexError({
             code: "ASSET_IN_KIT",

--- a/convex/members.ts
+++ b/convex/members.ts
@@ -50,7 +50,7 @@ export const listAll = query({
   args: {},
   handler: async (ctx) => {
     await requireService(ctx);
-    const rows = await ctx.db.query("members").collect();
+    const rows = await ctx.db.query("members").collect(); // r9.8-ok: small platform-wide table, auth-mirror reconcile utility
     return rows.map((r) => ({
       id: r.id,
       organizationId: r.organizationId,

--- a/convex/orgExport.ts
+++ b/convex/orgExport.ts
@@ -116,7 +116,7 @@ export const listOrgIds = query({
   args: {},
   handler: async (ctx) => {
     await requireService(ctx);
-    const orgs = await ctx.db.query("organizations").collect();
+    const orgs = await ctx.db.query("organizations").collect(); // r9.8-ok: tenant-count table, admin/script-only listing
     return orgs.map((o) => o.id);
   },
 });

--- a/convex/projectEquipment.ts
+++ b/convex/projectEquipment.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireService, requireOrgPermission } from "./lib/auth";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * ONE-round-trip read of everything `buildProjectEquipmentTree` needs to rebuild a
@@ -50,7 +51,7 @@ async function readBundle(ctx: QueryCtx, projectId: string, orgId: string) {
   const [assetDocs, bulkDocs, kitDocs, modelDocs, supplierDocs] = await Promise.all([
     Promise.all(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     Promise.all(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
-    Promise.all(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    Promise.all(refKitIds.map((id) => getKitByCuid(ctx, id))),
     Promise.all(refModelIds.map((id) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     Promise.all(refSupplierIds.map((id) => ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
   ]);

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -9,6 +9,7 @@ import { writeActivityLog } from "./lib/audit";
 import { ensureBulkUnit, ensureSerialisedUnit, expandAccessoryChildLines, syncLineItemRollup } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
 import * as enums from "./lib/validators";
+import { getKitByCuid } from "./lib/kits";
 
 /**
  * Thin CRUD for ProjectLineItem (Convex table "projectLineItems"). GENERATED — Phase 2/5.
@@ -601,7 +602,7 @@ export async function createKitLineItemCore(
   },
 ): Promise<{ id: string }> {
     await assertProjectInOrg(ctx, a.projectId, a.organizationId);
-    const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", a.kitId)).unique();
+    const kit = await getKitByCuid(ctx, a.kitId);
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     let sort = await nextLineSort(ctx, a.projectId, a.organizationId);
 

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -10,6 +10,7 @@ import { assertProjectMoneyFields, assertFinite } from "./lib/moneyGuards";
 import { assertRefInOrg } from "./lib/orgRef";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
+import { getKitByCuid } from "./lib/kits";
 import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
 import { enqueueWebhookEvent } from "./lib/webhookEnqueue";
 
@@ -585,7 +586,7 @@ export const deleteNative = mutation({
     // Step 2 — free checked-out kits inline (status AVAILABLE + location; kits have
     // no counter). Leave the kit's location untouched when there's no default.
     for (const kitId of checkedOutKitIds) {
-      const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+      const kit = await getKitByCuid(ctx, kitId);
       if (!kit || kit.organizationId !== orgId) continue;
       await ctx.db.patch(kit._id, {
         status: "AVAILABLE",

--- a/convex/siteSettings.ts
+++ b/convex/siteSettings.ts
@@ -16,7 +16,7 @@ export const list = query({
   args: {},
   handler: async (ctx, _args) => {
     await requireService(ctx);
-    return await ctx.db.query("siteSettings").collect();
+    return await ctx.db.query("siteSettings").collect(); // r9.8-ok: small singleton-scale config table
   },
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -34,7 +34,7 @@ export const listAll = query({
   args: {},
   handler: async (ctx) => {
     await requireService(ctx);
-    const rows = await ctx.db.query("users").collect();
+    const rows = await ctx.db.query("users").collect(); // r9.8-ok: small platform-wide table, auth-mirror reconcile utility
     return rows.map((r) => ({ id: r.id, email: r.email ?? null, name: r.name ?? null }));
   },
 });

--- a/convex/warehouseDetail.ts
+++ b/convex/warehouseDetail.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
+import { getKitByCuid } from "./lib/kits";
 
 
 /**
@@ -48,7 +49,7 @@ async function readWarehouseDetail(ctx: QueryCtx, projectId: string, orgId: stri
   const [assetDocs, bulkDocs, kitDocs, modelDocs, supplierDocs] = await Promise.all([
     pr(refAssetIds.map((id) => ctx.db.query("assets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     pr(refBulkIds.map((id) => ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
-    pr(refKitIds.map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
+    pr(refKitIds.map((id) => getKitByCuid(ctx, id))),
     pr(refModelIds.map((id) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
     pr(refSupplierIds.map((id) => ctx.db.query("suppliers").withIndex("by_cuid", (q) => q.eq("id", id)).unique())),
   ]);

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -16,6 +16,7 @@ import {
   checkinAccessoryChildren,
 } from "./lib/fulfillment";
 import { nextOrdinal } from "./lib/lineItemUnits";
+import { getKitByCuid as kitByCuid } from "./lib/kits";
 
 /**
  * Warehouse checkout / check-in — Convex port of warehouse.ts checkOutItems /
@@ -339,9 +340,6 @@ async function linesByAsset(ctx: Ctx, assetId: string, organizationId: string) {
 
 // ── Kit checkout / checkin helpers ───────────────────────────────────────────
 
-async function kitByCuid(ctx: Ctx, id: string) {
-  return await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
-}
 async function kitParentLine(ctx: Ctx, projectId: string, organizationId: string, kitId: string) {
   const rows = await ctx.db.query("projectLineItems").withIndex("by_kitId", (q) => q.eq("kitId", kitId)).collect();
   return rows.find((r) => r.projectId === projectId && r.organizationId === organizationId && !r.isKitChild) ?? null;

--- a/convex/warehouseWrites.ts
+++ b/convex/warehouseWrites.ts
@@ -32,6 +32,7 @@ import {
   defaultLocationId,
 } from "./warehouseOps";
 import { assertNoBlockingCommentsInMutation } from "./lib/blockingCommentsGate";
+import { getKitByCuid } from "./lib/kits";
 import { enqueueWebhookEvent } from "./lib/webhookEnqueue";
 
 /**
@@ -79,7 +80,7 @@ async function requireLineInProject(ctx: MutationCtx, lineItemId: string, orgId:
 }
 
 async function requireKitInOrg(ctx: MutationCtx, kitId: string, orgId: string): Promise<void> {
-  const k = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+  const k = await getKitByCuid(ctx, kitId);
   if (!k || k.organizationId !== orgId) throw new ConvexError("Kit not found");
 }
 
@@ -108,7 +109,7 @@ async function loadAssetInOrg(ctx: MutationCtx, assetId: string, orgId: string) 
 }
 
 async function loadKitInOrg(ctx: MutationCtx, kitId: string, orgId: string) {
-  const kit = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+  const kit = await getKitByCuid(ctx, kitId);
   if (!kit || kit.organizationId !== orgId) throw new ConvexError("Kit not found");
   return kit;
 }
@@ -809,7 +810,7 @@ export const forceReturnKits = mutation({
     // simply has no name) BEFORE the batch — names are unchanged by the force-return.
     const nameById = new Map<string, string>();
     for (const kitId of unique) {
-      const k = await ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", kitId)).first();
+      const k = await getKitByCuid(ctx, kitId);
       if (k && k.organizationId === a.orgId) nameById.set(k.id, `${k.assetTag} - ${k.name}`);
     }
 

--- a/scripts/collect-ratchet.mjs
+++ b/scripts/collect-ratchet.mjs
@@ -1,22 +1,32 @@
 #!/usr/bin/env node
 /**
- * Unbounded-read ratchet (POLICY.md R-9.8). Counts org-wide `.collect()` scans —
- * a query narrowed only by an `by_organizationId*` index and then `.collect()`ed,
- * i.e. "read every row for this org" on a growable table. These are the R-9.8
- * hazard: they scan without an upper bound as data grows.
+ * Unbounded-read ratchet (POLICY.md R-9.8). Counts two hazard categories, both
+ * `.collect()`ed without an upper bound as data grows:
+ *
+ *  A. ORG-WIDE — a query narrowed only by an `by_organizationId*` index, i.e.
+ *     "read every row for this org" on a growable table.
+ *  B. NO-INDEX — a query with no `.withIndex(...)` at all, i.e. "read every row in
+ *     the table" platform-wide. Strictly broader/riskier than (A): not even
+ *     narrowed to one org. (#740 — the original org-index-only check covered only
+ *     a narrow slice of the repo's 665 non-test `.collect()` calls; this is the
+ *     first widening called for there. Other non-org, non-pure-scan `.collect()`s
+ *     — e.g. narrowed by a compound org index's second key, or by a parent id —
+ *     stay out of scope: those are bounded-by-domain reads, not the R-9.8 hazard,
+ *     and flagging them needs case-by-case review this pattern-match can't do.)
  *
  * Like the any-ratchet and dependency-cruiser baselines, this is a RATCHET: the
- * count may not exceed the committed baseline. New org-wide `.collect()`s fail CI;
- * as existing ones are bounded/paginated, lower the baseline. It never blocks the
- * legitimately-bounded reads (by parent id, single-doc lookups, aggregations that
- * need the full set) — only the org-wide full scans.
+ * combined count may not exceed the committed baseline. New unbounded `.collect()`s
+ * fail CI; as existing ones are bounded/paginated, lower the baseline. It never
+ * blocks legitimately-bounded reads (by parent id, single-doc lookups, aggregations
+ * that need the full set) — only the org-wide and whole-table full scans.
  *
- * JUSTIFICATION MARKER: a read that legitimately needs the whole per-org set (an
- * aggregation, or a small bounded-by-domain set) is exempted by putting `r9.8-ok`
- * in a comment on/near the query (within the same withIndex→.collect() window, or
- * the line just above it), e.g. `// r9.8-ok: aggregation over one project`. The
- * ratchet counts only UNJUSTIFIED org-wide collects — closing #625 means driving
- * that to 0 (every org-wide collect is either bounded/paginated or marked).
+ * JUSTIFICATION MARKER: a read that legitimately needs the whole set (an
+ * aggregation, or a small bounded-by-domain/platform-scale table) is exempted by
+ * putting `r9.8-ok` in a comment on/near the query (on the matched line itself, or
+ * the line just above it), e.g. `// r9.8-ok: aggregation over one project` or
+ * `// r9.8-ok: small platform-wide table`. The ratchet counts only UNJUSTIFIED
+ * collects — closing #625/#740 means driving that to 0 (every org-wide or
+ * whole-table collect is either bounded/paginated or marked).
  *
  * Usage: node scripts/collect-ratchet.mjs [--write]
  */
@@ -27,7 +37,14 @@ const CONVEX_DIR = "convex";
 const BASELINE_FILE = ".collect-ratchet-baseline";
 const MARKER = "r9.8-ok";
 
-function countOrgWideCollects() {
+function isJustified(lines, i) {
+  // Justification must be line-precise — on the matched line itself or the line
+  // immediately above it. (Not the whole window: in a dense Promise.all a marker on
+  // one collect would leak onto adjacent unrelated reads.)
+  return lines[i].includes(MARKER) || (i > 0 && lines[i - 1].includes(MARKER));
+}
+
+function countUnboundedCollects() {
   let total = 0;
   let unjustified = 0;
   const perFile = {};
@@ -35,13 +52,23 @@ function countOrgWideCollects() {
     if (!name.endsWith(".ts") || name.endsWith(".test.ts")) continue;
     const lines = readFileSync(join(CONVEX_DIR, name), "utf8").split("\n");
     for (let i = 0; i < lines.length; i++) {
-      // Only the PURE org index (`by_organizationId"`, exact) is an unbounded org-wide
-      // scan. A compound `by_organizationId_x` index is narrowed by that second key
-      // (one asset / one status / …) by design — bounded, not the R-9.8 hazard — so it
-      // isn't matched here. Matching the exact index name (not a prefix) also avoids the
-      // false positive where the `.eq().eq()` chain sits on a continuation line.
-      if (!/withIndex\("by_organizationId"/.test(lines[i])) continue;
+      // Category A — only the PURE org index (`by_organizationId"`, exact) is an
+      // unbounded org-wide scan. A compound `by_organizationId_x` index is narrowed
+      // by that second key (one asset / one status / …) by design — bounded, not
+      // the R-9.8 hazard — so it isn't matched here. Matching the exact index name
+      // (not a prefix) also avoids the false positive where the `.eq().eq()` chain
+      // sits on a continuation line.
+      const isOrgWide = /withIndex\("by_organizationId"/.test(lines[i]);
+      // Category B — a literal-table-name query with no `.withIndex(` anywhere in
+      // the window before its `.collect()`. Dynamic table names (`query(table)`)
+      // are intentionally not matched — the ratchet only reasons about literal
+      // strings it can grep.
+      const queryMatch = !isOrgWide && /ctx\.db\.query\("[a-zA-Z0-9_]+"\)/.test(lines[i]);
+      if (!isOrgWide && !queryMatch) continue;
+
       const window = lines.slice(i, i + 4).join("\n");
+      if (queryMatch && window.includes(".withIndex(")) continue; // indexed — out of scope for category B
+
       if (
         window.includes(".collect()") &&
         !window.includes(".take(") &&
@@ -49,12 +76,7 @@ function countOrgWideCollects() {
         !window.includes(".unique()")
       ) {
         total++;
-        // Justification must be line-precise — on the withIndex line itself or the line
-        // immediately above it. (Not the whole window: in a dense Promise.all a marker on
-        // one collect would leak onto adjacent unrelated reads.)
-        const justified =
-          lines[i].includes(MARKER) || (i > 0 && lines[i - 1].includes(MARKER));
-        if (!justified) {
+        if (!isJustified(lines, i)) {
           unjustified++;
           perFile[name] = (perFile[name] ?? 0) + 1;
         }
@@ -64,11 +86,11 @@ function countOrgWideCollects() {
   return { total, unjustified, perFile };
 }
 
-const { total, unjustified, perFile } = countOrgWideCollects();
+const { total, unjustified, perFile } = countUnboundedCollects();
 
 if (process.argv.includes("--write")) {
   writeFileSync(BASELINE_FILE, `${unjustified}\n`);
-  console.log(`[collect-ratchet] wrote baseline: ${unjustified} unjustified (of ${total} org-wide)`);
+  console.log(`[collect-ratchet] wrote baseline: ${unjustified} unjustified (of ${total} unbounded-shape)`);
   process.exit(0);
 }
 
@@ -82,10 +104,10 @@ try {
 
 if (unjustified > baseline) {
   console.error(
-    `[collect-ratchet] FAIL: unjustified org-wide .collect() scans rose to ${unjustified} ` +
-      `(baseline ${baseline}, of ${total} org-wide total).\n` +
-      `New unbounded org-wide reads are not allowed (R-9.8). Bound them (parent index, .take,\n` +
-      `pagination via convex/lib/pagination.ts), or if the full per-org set is genuinely\n` +
+    `[collect-ratchet] FAIL: unjustified unbounded .collect() scans rose to ${unjustified} ` +
+      `(baseline ${baseline}, of ${total} org-wide/whole-table total).\n` +
+      `New unbounded reads are not allowed (R-9.8). Bound them (parent index, .take,\n` +
+      `pagination via convex/lib/pagination.ts), or if the full org/table set is genuinely\n` +
       `needed add a "r9.8-ok: <reason>" comment. Offenders by file:`,
   );
   for (const [f, n] of Object.entries(perFile).sort((a, b) => b[1] - a[1])) {
@@ -97,11 +119,11 @@ if (unjustified > baseline) {
 if (unjustified < baseline) {
   console.log(
     `[collect-ratchet] improved: ${unjustified} unjustified < baseline ${baseline} ` +
-      `(of ${total} org-wide). Lower the baseline: node scripts/collect-ratchet.mjs --write`,
+      `(of ${total} org-wide/whole-table). Lower the baseline: node scripts/collect-ratchet.mjs --write`,
   );
 } else {
   console.log(
-    `[collect-ratchet] OK: ${unjustified} unjustified org-wide .collect() scans ` +
-      `(baseline ${baseline}, of ${total} org-wide total). Target: 0.`,
+    `[collect-ratchet] OK: ${unjustified} unjustified unbounded .collect() scans ` +
+      `(baseline ${baseline}, of ${total} org-wide/whole-table total). Target: 0.`,
   );
 }


### PR DESCRIPTION
## Summary

Fixes the three findings tracked in #771 (POLICY.md §8.3 audit, 2026-07-22):

- **#739 (R-8.3.2)** — N+1 query in `convex/crewDashboard.ts` `upcomingShifts()`: a `crewShifts` lookup ran sequentially inside a `for` loop over every assignment id. Batched via `Promise.all`, matching the pattern already used elsewhere in the file (`crewGraph`, `stats`).
- **#741 (R-8.3.4)** — the `kits.by_cuid` global-index lookup was inlined ~30× across 18 files despite an existing (unexported) helper. Extracted a single `getKitByCuid()` accessor to `convex/lib/kits.ts` and replaced every inlined call site, standardizing on `.unique()` (already the majority pattern, and the invariant `kitWrites.ts`'s dup-guard comment already assumed). One accessor for a global, non-org-scoped index means one place to get the org re-check right instead of ~30 independent chances to forget it.
- **#740 (R-8.3.3)** — the `collect-ratchet` CI check only flagged the narrow "pure `by_organizationId` index" `.collect()` case (~219 of 665 non-test `.collect()` calls repo-wide). Widened it to also flag whole-table full-scan `.collect()` calls (no `.withIndex()` at all) — strictly riskier since they're not even narrowed to one tenant. Found and justified (`r9.8-ok`) the 4 existing sites this newly covers, all small/bounded SERVICE-only tables. Baseline stays at 0 unjustified. (Other non-org, non-full-scan `.collect()` calls — narrowed by a compound index's second key or a parent id — stay out of scope; those need case-by-case review a pattern-match can't safely automate.)

Docs: updated `FEATUREDOCS/54-convex-data-layer.md` with the `getKitByCuid` convention.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 288 files / 3828 tests pass
- [x] `pnpm exec eslint` on all touched files — 0 errors (pre-existing warnings only, none newly introduced)
- [x] `node scripts/collect-ratchet.mjs` — OK: 0 unjustified (baseline 0, of 222 org-wide/whole-table total)

Closes #739, #740, #741, #771.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhByai6yt2hnex963exnAM)_