### PR TITLE
Hide Warehouse and Add gear quick actions on mobile dashboard

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -116,8 +116,8 @@ export default function DashboardPage() {
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
             <Button asChild variant="halo"><Link href="/projects/new"><Plus className="h-4 w-4" /> New job</Link></Button>
-            <Button asChild variant="line"><Link href="/warehouse"><ScanBarcode className="h-4 w-4" /> Warehouse</Link></Button>
-            <Button asChild variant="line"><Link href="/assets/registry/new"><Boxes className="h-4 w-4" /> Add gear</Link></Button>
+            <Button asChild variant="line" className="hidden sm:inline-flex"><Link href="/warehouse"><ScanBarcode className="h-4 w-4" /> Warehouse</Link></Button>
+            <Button asChild variant="line" className="hidden sm:inline-flex"><Link href="/assets/registry/new"><Boxes className="h-4 w-4" /> Add gear</Link></Button>
           </div>
         </div>
       </FadeIn>


### PR DESCRIPTION
## Summary
- On the dashboard's mobile view, only the red "New job" quick action button should show. The "Warehouse" and "Add gear" buttons now hide below the `sm` breakpoint and reappear at `sm` and up.

## Test plan
- [ ] Load `/dashboard` on a mobile viewport (< 640px) and confirm only "New job" shows
- [ ] Load `/dashboard` at `sm` width and up and confirm all three buttons show as before

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3pUacuSwnTkxS2Y16afTn)_