### PR TITLE
Observability: request-id correlation, PostHog identify, Convex error forwarding (§8.9 audit)

### DIFF
--- a/FEATUREDOCS/61-observability.md
+++ b/FEATUREDOCS/61-observability.md
@@ -25,6 +25,42 @@ Emit events only through `src/lib/analytics.ts` (`capture()` + `AnalyticsEvent` 
 single source of truth for event names, isomorphic and no-op-safe. Event properties must stay
 cuid-only (R-8.12.4) — enforced by convention at emit sites, not by the SDK.
 
+`src/lib/analytics.ts` also exposes `identify()`/`resetAnalyticsIdentity()`, called from
+`src/components/providers/posthog-identify.tsx` (mounted once in `(app)/layout.tsx`, alongside
+`OrgActivator`). It identifies the PostHog person as the **org-membership cuid**
+(`RoleData.memberId` from `/api/current-role` — the Prisma `Member.id`, not the raw Better Auth
+user id or any name/email) once a session + org resolve, and resets on sign-out so a shared
+device (e.g. the warehouse floor PWA) doesn't carry the previous member's identity into the next
+session (POLICY.md R-8.9.4 — errors/sessions must carry an opaque internal user ID).
+
+## Request correlation (`x-request-id`)
+
+`src/middleware.ts` mints/reuses an `x-request-id` on **every** branch — including the
+public/token early-returns (`/api/calendar/*`, `/api/crew/respond/*`, `/api/cron/*`, etc.) and
+the login-redirect response, not just the authenticated path. It's forwarded both as a response
+header and into the downstream request headers.
+
+Rather than threading a `requestId` argument through every `logger.*` call site,
+`src/lib/request-context.ts` exposes an ambient `AsyncLocalStorage` (mirroring
+`request-actor.ts`'s `ActorContext` seam) — `runWithRequestId()` / `getAmbientRequestId()`.
+`src/lib/logger.ts` reads the ambient value automatically via a getter registered from
+`instrumentation.ts` at process start (kept as a **registered function**, not a static import,
+because `logger.ts` is isomorphic — imported by client components — and `request-context.ts`
+pulls in `node:async_hooks`, which can't land in the browser bundle).
+
+Wired at two entry points today:
+- **`src/lib/api-validation.ts`'s `withValidatedBody`** wraps handler execution in
+  `runWithRequestId`, so any `logger.*` call a JSON-body API route makes auto-carries the
+  correlation id.
+- **`instrumentation.ts`'s `onRequestError`** reads `x-request-id` directly off the error
+  request and passes it (plus a best-effort opaque actor id from `getSession()`) into
+  `captureServerException`'s PostHog context.
+
+**Scope note:** this covers the JSON-body API route surface and the error-reporting path, not
+every session-based server action or GET route — there's no single choke point for those today
+(the same gap `runWithActor`'s `ActorContext` has for the non-API-key path). Extend by wrapping
+another entry point in `runWithRequestId` if a gap surfaces.
+
 ## Server
 
 `src/lib/posthog-server.ts` — a `posthog-node` singleton authenticated with the same public
@@ -70,6 +106,36 @@ a second, higher line) and are never allowed to throw or alter the wrapped call'
 
 Both events feed p95 alerts in PostHog once real traffic is flowing (same pattern as the CWV
 alerts in R-8.1.5 — created only after confirming live event volume, not speculatively before).
+`convex-op-timing.ts` additionally tags both the log line and the PostHog event with the ambient
+`x-request-id` (above) when one is present — a de facto trace id correlating the Convex leg back
+to the originating Next.js request (POLICY.md R-8.9.6). A true W3C `traceparent` propagated into
+the Convex function body itself would need threading a trace id through every query/mutation's
+args across all ~43 `*Writes.ts` domain modules — out of scope here.
+
+## Convex job/cron error forwarding
+
+Convex function/cron errors used to land only in the Convex dashboard — never forwarded
+anywhere (POLICY.md R-8.9.1). `convex/lib/errorReporting.ts`'s `reportConvexJobError()` is a raw
+`fetch` POST to PostHog's `/capture/` HTTP API (not the `posthog-node` SDK — Convex actions run
+in Convex Cloud's own deployment, a separate runtime from `src/`, so they can't import
+`posthog-server.ts`). Wired into `convex/scheduledJobs.ts`'s `invokeCronRoute` — the single
+funnel both durable cron executors (`runNotificationEmails`, `runTestTagReminders`) go through —
+so a failure is reported to PostHog as a `$exception` event before the original error is
+re-thrown (Convex's own cron-run log still records it too; reporting is best-effort and never
+masks the real failure). Requires `POSTHOG_KEY` set on the **Convex** deployment (`pnpm exec
+convex env set POSTHOG_KEY <phc_...>` — separate from the Next.js `.env`); inert until set.
+
+**Scope note:** this covers the two cron executors, not the other 43 `*Writes.ts` domain
+mutation modules. See `docs/convex-observability-runbook.md` for the optional blanket
+function-level log-stream (needs interactive Convex dashboard access).
+
+## Crash-free sessions (T-13)
+
+A "Crash-free sessions (T-13)" PostHog insight (id `10376263`) computes
+`(1 - unique_session($exception) / unique_session($pageview)) * 100` — the README.md R-0.4
+budget registry's ≥99.5% floor. **The paired threshold alert could not be created**: the
+project's PostHog plan is at its 5-alert cap. See `docs/convex-observability-runbook.md` for the
+exact alert config to add once a slot frees up.
 
 ## Env vars
 
@@ -79,7 +145,12 @@ See `CLAUDE.md` → Environment Variables → Analytics + error tracking.
 
 - v1: PostHog SDK wired alongside Sentry (analytics + Web Vitals only).
 - v2: PostHog Error Tracking added, capturing alongside Sentry (additive, safe rollback).
-- v3 (this doc): Sentry fully removed — `@sentry/nextjs`, `sentry.*.config.ts`,
+- v3: Sentry fully removed — `@sentry/nextjs`, `sentry.*.config.ts`,
   `instrumentation-client.ts` (Sentry-only, no PostHog equivalent needed), and all
   `SENTRY_*`/`NEXT_PUBLIC_SENTRY_*` env vars deleted. Sourcemap upload wired into the deploy
   build to close out #650.
+- v4 (this doc, #776): `x-request-id` correlation fixed to cover every middleware branch and
+  auto-thread into `logger.*`/`onRequestError`; `posthog.identify()` wired to the org-membership
+  cuid with sign-out reset; Convex cron/job failures forwarded to PostHog; Convex-op telemetry
+  correlated with the originating request id; crash-free-sessions (T-13) insight created
+  (alert blocked on the PostHog plan's 5-alert cap — see the runbook).

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ overrides and project-specific (§13B) values:
 | T-P5 Max flaky-quarantine size | **10 tests** | Quarantine caps at 10; beyond that the suite is failing, not flaky. |
 | T-P6 Per-endpoint p95 SLOs | **300 ms API · 1 s page** | Interactive-endpoint targets. Instrumented (`src/lib/convex-op-timing.ts`, R-9.11/R-8.9.6/#623) — emits `convex_op_latency` past 300 ms, flags `incident` past 1 s. **Alerted in PostHog**: "convex_op_latency p95 above 1000ms" fires if the p95 duration of already-slow ops crosses the 1 s incident line. |
 | T-P7 Queue lag/age alert | **> 5 minutes** | Instrumented (`src/lib/queue-lag-timing.ts`, wired into the webhook delivery cron, R-9.10/#623) — emits `queue_lag` to PostHog past the 5-min threshold. **PostHog alert not created yet**: pending confirmed live ingestion, same pattern as the CWV alerts (created only after confirming real event flow, not speculatively before). |
+| T-13 Crash-free sessions | **default** (≥ 99.5%) | Accept the §13 default. **Measured** via the "Crash-free sessions (T-13)" PostHog insight (`(1 - unique_session($exception) / unique_session($pageview)) * 100`, R-8.9.4/#776). **Alert not created**: the project's PostHog plan is at its 5-alert cap (see `docs/convex-observability-runbook.md`) — needs a plan upgrade or an existing alert freed before the T-13 threshold alert can be added. |
 
 Values marked ⚠ *provisional* satisfy the R-0.4 registration requirement but carry business/legal
 judgment — the owner should confirm them. Registration binds the value; several rules still require

--- a/convex/lib/errorReporting.ts
+++ b/convex/lib/errorReporting.ts
@@ -1,0 +1,64 @@
+/**
+ * Forward a Convex job/cron failure to PostHog Error Tracking (POLICY.md R-8.9.1
+ * — "Convex jobs/cron have no error-capture pipeline").
+ *
+ * Deliberately a raw `fetch` to PostHog's HTTP capture API, not the `posthog-node`
+ * SDK: Convex actions run in Convex Cloud's own deployment, a separate runtime
+ * from the Next.js app (`src/`), so this file can't import `src/lib/posthog-server.ts`
+ * — and a POST to `/capture/` needs no SDK dependency at all.
+ *
+ * Requires `POSTHOG_KEY` set on the CONVEX deployment (`pnpm exec convex env set
+ * POSTHOG_KEY <phc_...>` — separate from the Next.js `.env`; reuse the same
+ * public write-only ingestion key `NEXT_PUBLIC_POSTHOG_KEY` already uses).
+ * **Inert (no-op) if unset**, matching `posthog-server.ts`'s "no key -> nothing
+ * sent" convention — so an unconfigured deployment doesn't fail cron runs, it
+ * just doesn't get error visibility until the key is set.
+ *
+ * Never throws: error reporting must never mask or replace the original
+ * failure. Callers still throw/propagate the real error themselves (Convex's
+ * own dashboard cron-run log is the durable record; this is the forwarding leg
+ * that was missing).
+ */
+export async function reportConvexJobError(
+  source: string,
+  error: unknown,
+  context?: Record<string, string | number | boolean>,
+): Promise<void> {
+  const key = process.env.POSTHOG_KEY;
+  if (!key) return;
+
+  const host = (process.env.POSTHOG_HOST || "https://us.i.posthog.com").replace(/\/+$/, "");
+  const message = error instanceof Error ? error.message : String(error);
+  const type = error instanceof Error ? error.name || "Error" : "Error";
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  try {
+    await fetch(`${host}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: key,
+        event: "$exception",
+        // No end-user identity here — this is a job/cron failure, not a
+        // request; "server" mirrors the fixed distinctId posthog-server.ts
+        // uses for Next.js server exceptions.
+        distinct_id: "server",
+        properties: {
+          // Minimal $exception_list — type/value only (no frame-level
+          // stacktrace parsing), enough for PostHog Error Tracking to group
+          // and alert on. The raw stack still goes out as $exception_stack
+          // for the properties panel.
+          $exception_list: [
+            { type, value: message, mechanism: { handled: false, synthetic: false } },
+          ],
+          $exception_source: "convex",
+          source,
+          ...(stack ? { $exception_stack: stack } : {}),
+          ...context,
+        },
+      }),
+    });
+  } catch {
+    // Best-effort — must never mask the original job failure.
+  }
+}

--- a/convex/scheduledJobs.ts
+++ b/convex/scheduledJobs.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
+import { reportConvexJobError } from "./lib/errorReporting";
 
 /**
  * Phase 6a — Convex durable cron executors.
@@ -39,6 +40,11 @@ import { internalAction } from "./_generated/server";
  * status summary. Throws on a non-2xx response so the failure surfaces in the
  * Convex dashboard's cron run log (a failed run is logged; the next scheduled
  * run proceeds normally — no retry storm, and the executor is idempotent).
+ *
+ * Also forwards any failure to PostHog (`reportConvexJobError`, R-8.9.1) before
+ * throwing — the Convex dashboard's cron log was previously the ONLY place a
+ * failure was visible; this is the missing forwarding leg. Reporting is
+ * best-effort and never swallows or replaces the thrown error.
  */
 async function invokeCronRoute(
   path: string,
@@ -50,28 +56,33 @@ async function invokeCronRoute(
     return { skipped: true };
   }
 
-  const baseUrl = process.env.CONVEX_CRON_TARGET_URL;
-  const secret = process.env.CRON_SECRET;
-  if (!baseUrl || !secret) {
-    throw new Error(
-      `[convex-cron] CONVEX_CRON_TARGET_URL and CRON_SECRET must both be set on the ` +
-        `Convex deployment to run ${path}`,
-    );
-  }
+  try {
+    const baseUrl = process.env.CONVEX_CRON_TARGET_URL;
+    const secret = process.env.CRON_SECRET;
+    if (!baseUrl || !secret) {
+      throw new Error(
+        `[convex-cron] CONVEX_CRON_TARGET_URL and CRON_SECRET must both be set on the ` +
+          `Convex deployment to run ${path}`,
+      );
+    }
 
-  const url = `${baseUrl.replace(/\/+$/, "")}${path}`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${secret}` },
-  });
-  const body = await res.text();
-  if (!res.ok) {
-    throw new Error(
-      `[convex-cron] ${path} failed: ${res.status} ${body.slice(0, 500)}`,
-    );
+    const url = `${baseUrl.replace(/\/+$/, "")}${path}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${secret}` },
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `[convex-cron] ${path} failed: ${res.status} ${body.slice(0, 500)}`,
+      );
+    }
+    console.log(`[convex-cron] ${path} ok: ${res.status}`);
+    return { status: res.status, body };
+  } catch (err) {
+    await reportConvexJobError(`cron:${path}`, err, { path });
+    throw err;
   }
-  console.log(`[convex-cron] ${path} ok: ${res.status}`);
-  return { status: res.status, body };
 }
 
 /**

--- a/docs/convex-observability-runbook.md
+++ b/docs/convex-observability-runbook.md
@@ -29,26 +29,62 @@ docker exec <app> npx tsx scripts/toggle-write-killswitch.ts status
 
 ## Observability
 
-- **Function metrics (primary):** the Convex dashboard
+- **Function metrics (primary), owner: Jayden Nawotka.** The Convex dashboard
   (`dashboard.convex.dev/t/two-toned/gearflow-prod/useful-cuttlefish-334`) →
   Functions/Health gives per-function call volume, error rate, and latency
   percentiles for every query/mutation/action. This is the source of truth for the
   mutation-surface health signal.
-- **Failure alerting (to wire in the dashboard):** Convex Cloud → Settings →
-  Integrations supports a **log stream** (Axiom/Datadog) + failure webhooks. Point a
-  webhook at PostHog/Slack keyed on function errors so a spike pages an operator. The
-  app already has PostHog Error Tracking (`NEXT_PUBLIC_POSTHOG_KEY`) for the Next.js
-  side; the Convex-side stream is the remaining dashboard-config step (needs Convex
-  dashboard access — not doable headlessly from CI).
+- **Cron/job failure alerting (R-8.9.1) — wired.** `convex/lib/errorReporting.ts`'s
+  `reportConvexJobError` forwards every `scheduledJobs.ts` cron-executor failure
+  (`invokeCronRoute` — covers both `runNotificationEmails` and
+  `runTestTagReminders`) to PostHog as a `$exception` event, before re-throwing so
+  the Convex dashboard's own cron-run log still records it too. Requires
+  `POSTHOG_KEY` set on the **Convex** deployment (`pnpm exec convex env set
+  POSTHOG_KEY <phc_...>` — the same public write-only key `NEXT_PUBLIC_POSTHOG_KEY`
+  uses; separate from the Next.js `.env`). Inert until that's set.
+  **Scope note:** this covers the two durable cron executors, not every one of the
+  43 `*Writes.ts` domain mutation modules — a blanket log-stream (below) still adds
+  value for full function-level coverage.
+- **Blanket function-level log stream (optional, still a manual step):** Convex
+  Cloud → Settings → Integrations supports a **log stream** (Axiom/Datadog) +
+  failure webhooks covering every function, not just the two crons above. Point a
+  webhook at PostHog/Slack keyed on function errors for full-surface coverage. This
+  needs interactive Convex dashboard access, so it's not doable headlessly — owner:
+  Jayden Nawotka.
 - **Domain anomaly signals already emitting alerts:**
   - **Auth-mirror drift** — `scripts/auth-mirror-reconcile.ts` (daily cron) emails +
     exits non-zero on any drift/parity break.
   - **WooCommerce order failures** — `wooCommerceOrderLogs` rows with status `FAILED`
     (query the table / dashboard).
   - **Webhook delivery stalls** — `webhookDeliveries` dead/failed rows.
+- **Request correlation (R-8.9.5/R-8.9.6):** `middleware.ts` mints/forwards
+  `x-request-id` on every branch (public/token routes included). It auto-threads
+  into `logger.*` calls via an ambient `AsyncLocalStorage` (`src/lib/request-context.ts`,
+  registered from `instrumentation.ts`) for any request run inside
+  `withValidatedBody` (`src/lib/api-validation.ts`), and into `onRequestError`'s
+  PostHog error context alongside a best-effort opaque actor id
+  (`instrumentation.ts`). `src/lib/convex-op-timing.ts` reuses the same ambient
+  request id as a de facto trace id on the `convex_op_latency` PostHog event and
+  slow-op log line, correlating the Convex leg back to the originating Next.js
+  request — a true W3C `traceparent` into the Convex function body itself would
+  need threading a trace id through every query/mutation's args, which is out of
+  scope here.
+- **PostHog dashboards/insights/alerts, owner: Jayden Nawotka.** Covers the CWV
+  (T-7), slow_query (T-9), convex_op_latency (T-P6), queue_lag (T-P7), and
+  crash-free-sessions (T-13) insights/alerts referenced from README.md's budget
+  registry.
 
-## Remaining ops step (not code)
+## Remaining ops steps (not code)
 
-Wire the Convex dashboard **log stream → PostHog/Slack** + a failure-rate alert
-threshold. Everything code-side (kill-switch, the guard convention, the domain
-alerts) is in place; the external alert sink is a one-time dashboard configuration.
+1. Set `POSTHOG_KEY` on the Convex deployment so the cron-failure forwarding above
+   actually sends (currently inert — no key set yet).
+2. Optionally wire the Convex dashboard **log stream → PostHog/Slack** for
+   full function-level (not just cron) failure coverage — needs interactive
+   dashboard access.
+3. **Crash-free-sessions alert (T-13) is blocked on PostHog's 5-alert plan cap** —
+   the insight ("Crash-free sessions (T-13)", id 10376263) is created and ready,
+   but the project's PostHog plan already has 5/5 alert slots used (CWV combined,
+   LCP, slow_query, convex_op_latency, queue_lag). Either upgrade the plan or
+   retire/consolidate an existing alert to free a slot, then create the alert:
+   condition `absolute_value`, bounds `{lower: 99.5}`, type `absolute`,
+   `TrendsAlertConfig` `series_index: 0` (the formula series).

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -8,10 +8,36 @@ export async function register() {
     // intermittent-502 failure mode). See src/lib/process-safety.ts.
     const { installProcessSafetyNet } = await import("./src/lib/process-safety");
     installProcessSafetyNet("web");
+
+    // Auto-thread the x-request-id correlation id (POLICY.md R-8.9.5) into every
+    // logger.* call made within a request's async subtree, without touching each
+    // call site. Node-only (async_hooks) — see src/lib/logger.ts for why this is
+    // registered rather than statically imported there.
+    const { getAmbientRequestId } = await import("./src/lib/request-context");
+    const { setAmbientRequestIdGetter } = await import("./src/lib/logger");
+    setAmbientRequestIdGetter(getAmbientRequestId);
   }
 }
 
 import type { Instrumentation } from "next";
+
+/**
+ * Best-effort opaque actor id for error context (POLICY.md R-8.9.4 — "opaque
+ * internal user ID ... never name/email/phone"). `getSession()` reads
+ * `next/headers` `headers()` internally, which Next.js keeps available inside
+ * `onRequestError` for exactly this purpose. Never throws: an anonymous/public
+ * request, or a session lookup racing process shutdown, must not block error
+ * reporting.
+ */
+async function resolveActorIdForErrorContext(): Promise<string | undefined> {
+  try {
+    const { getSession } = await import("./src/lib/auth-server");
+    const session = await getSession();
+    return session?.user.id;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Forward server-side request errors to PostHog Error Tracking. Dynamically
@@ -25,9 +51,14 @@ export const onRequestError: Instrumentation.onRequestError = async (
   if (process.env.NEXT_RUNTIME === "nodejs") {
     try {
       const { captureServerException } = await import("./src/lib/posthog-server");
+      const rawRequestId = request.headers["x-request-id"];
+      const requestId = Array.isArray(rawRequestId) ? rawRequestId[0] : rawRequestId;
+      const actorId = await resolveActorIdForErrorContext();
       await captureServerException(err, {
         route: context.routePath ?? "",
         method: request.method ?? "",
+        ...(requestId ? { requestId } : {}),
+        ...(actorId ? { actorId } : {}),
       });
     } catch {
       // reporting must never crash the handler

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -9,6 +9,7 @@ import MiraContextProvider from "@/components/providers/mira-context-provider";
 import { getSession } from "@/lib/auth-server";
 import { getTheOrg } from "@/lib/single-org";
 import { OrgActivator } from "@/components/providers/org-activator";
+import { PostHogIdentify } from "@/components/providers/posthog-identify";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const session = await getSession();
@@ -32,6 +33,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         <BrandingProvider>
           <MiraContextProvider>
             <OrgActivator />
+            <PostHogIdentify />
             <DynamicFavicon />
             <AppSidebar />
             <SidebarInset className="min-h-0 min-w-0 overflow-x-clip">

--- a/src/app/api/current-role/route.ts
+++ b/src/app/api/current-role/route.ts
@@ -8,22 +8,22 @@ export async function GET() {
   try {
     const session = await getSession();
     if (!session) {
-      return NextResponse.json({ role: null, roleName: null, permissions: null });
+      return NextResponse.json({ role: null, roleName: null, permissions: null, memberId: null });
     }
 
     const org = await getTheOrg();
     const orgId = org?.id;
     if (!orgId) {
-      return NextResponse.json({ role: null, roleName: null, permissions: null });
+      return NextResponse.json({ role: null, roleName: null, permissions: null, memberId: null });
     }
 
     const member = await prisma.member.findFirst({
       where: { organizationId: orgId, userId: session.user.id },
-      select: { role: true },
+      select: { id: true, role: true },
     });
 
     if (!member) {
-      return NextResponse.json({ role: null, roleName: null, permissions: null });
+      return NextResponse.json({ role: null, roleName: null, permissions: null, memberId: null });
     }
 
     // Built-in roles only (custom roles were removed).
@@ -33,6 +33,10 @@ export async function GET() {
       role: member.role,
       roleName: member.role,
       permissions,
+      // Opaque org-membership cuid for PostHog `identify()` (POLICY.md R-8.9.4) —
+      // deliberately the Member row id, not the raw Better Auth user id, so a
+      // person's identity is scoped per-org-membership like the rest of RBAC.
+      memberId: member.id,
     });
   } catch {
     return NextResponse.json({ role: null, roleName: null, permissions: null });

--- a/src/components/providers/posthog-identify.tsx
+++ b/src/components/providers/posthog-identify.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { authClient, useActiveOrganization } from "@/lib/auth-client";
+import { useCurrentRoleResource } from "@/hooks/use-current-role";
+import { ensureInit } from "@/components/providers/posthog-provider";
+import { identify, resetAnalyticsIdentity } from "@/lib/analytics";
+
+/**
+ * Identifies the PostHog person once a session + org membership resolve
+ * (POLICY.md R-8.9.4 — errors/sessions must carry an opaque internal user ID).
+ *
+ * Uses the org-membership cuid (`RoleData.memberId`, `/api/current-role`), never
+ * the raw Better Auth user id or any name/email — see the PII rule in
+ * `analytics.ts`. Resets the identity on sign-out so a shared/kiosk device
+ * (e.g. the warehouse floor PWA) doesn't carry the previous member's identity
+ * into the next session.
+ *
+ * Mounted once in the authenticated app shell (`(app)/layout.tsx`), alongside
+ * `OrgActivator` — both need a resolved session + active org.
+ */
+export function PostHogIdentify() {
+  const { data: session, isPending: sessionPending } = authClient.useSession();
+  const { data: activeOrg } = useActiveOrganization();
+  const { data: roleData } = useCurrentRoleResource(activeOrg?.id);
+  const identifiedMemberId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (sessionPending) return;
+
+    if (!session) {
+      if (identifiedMemberId.current) {
+        resetAnalyticsIdentity();
+        identifiedMemberId.current = null;
+      }
+      return;
+    }
+
+    const memberId = roleData?.memberId;
+    if (!memberId || identifiedMemberId.current === memberId) return;
+
+    void ensureInit().then((ready) => {
+      if (!ready) return;
+      identify(memberId);
+      identifiedMemberId.current = memberId;
+    });
+  }, [session, sessionPending, roleData?.memberId]);
+
+  return null;
+}

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -39,7 +39,12 @@ const posthogHost =
 let initState: "idle" | "loading" | "ready" | "inert" = "idle";
 let initPromise: Promise<boolean> | null = null;
 
-function ensureInit(): Promise<boolean> {
+/**
+ * Exported so other client components (PostHogIdentify) can await SDK readiness
+ * before calling identify()/capture() directly, without re-implementing the
+ * init/inert/dedup state machine below.
+ */
+export function ensureInit(): Promise<boolean> {
   if (typeof window === "undefined") return Promise.resolve(false);
   if (initState === "ready") return Promise.resolve(true);
   if (initState === "inert") return Promise.resolve(false);

--- a/src/hooks/use-current-role.ts
+++ b/src/hooks/use-current-role.ts
@@ -26,11 +26,13 @@ export interface RoleData {
   role: string | null;
   roleName: string | null;
   permissions: PermissionMap | null;
+  /** Opaque org-membership cuid, for PostHog `identify()` (POLICY.md R-8.9.4). */
+  memberId: string | null;
 }
 
 async function fetchCurrentRole(): Promise<RoleData> {
   const res = await fetch("/api/current-role");
-  if (!res.ok) return { role: null, roleName: null, permissions: null };
+  if (!res.ok) return { role: null, roleName: null, permissions: null, memberId: null };
   return res.json();
 }
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { capture, AnalyticsEvent } from "./analytics";
+import { capture, identify, resetAnalyticsIdentity, AnalyticsEvent } from "./analytics";
 
 describe("analytics.capture", () => {
   afterEach(() => {
@@ -33,5 +33,33 @@ describe("analytics.capture", () => {
   it("exposes stable canonical event names", () => {
     expect(AnalyticsEvent.PageView).toBe("$pageview");
     expect(AnalyticsEvent.WebVital).toBe("web_vital");
+  });
+});
+
+describe("analytics.identify / resetAnalyticsIdentity (R-8.9.4)", () => {
+  afterEach(() => {
+    delete (window as { posthog?: unknown }).posthog;
+  });
+
+  it("forwards the opaque distinctId to window.posthog.identify", () => {
+    const spy = vi.fn();
+    window.posthog = { capture: vi.fn(), identify: spy };
+    identify("member_abc123");
+    expect(spy).toHaveBeenCalledExactlyOnceWith("member_abc123");
+  });
+
+  it("no-ops identify() when PostHog is not initialised", () => {
+    expect(() => identify("member_abc123")).not.toThrow();
+  });
+
+  it("forwards to window.posthog.reset on sign-out", () => {
+    const spy = vi.fn();
+    window.posthog = { capture: vi.fn(), reset: spy };
+    resetAnalyticsIdentity();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("no-ops resetAnalyticsIdentity() when PostHog is not initialised", () => {
+    expect(() => resetAnalyticsIdentity()).not.toThrow();
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -38,7 +38,11 @@ type Props = Record<string, string | number | boolean | null | undefined>;
 declare global {
   interface Window {
     /** Set by posthog-provider.tsx after init; undefined until then / when unconfigured. */
-    posthog?: { capture: (event: string, properties?: Props) => void };
+    posthog?: {
+      capture: (event: string, properties?: Props) => void;
+      identify?: (distinctId: string) => void;
+      reset?: () => void;
+    };
   }
 }
 
@@ -52,4 +56,24 @@ export function capture(event: AnalyticsEventName, properties?: Props): void {
   const ph = window.posthog;
   if (!ph || typeof ph.capture !== "function") return;
   ph.capture(event, properties);
+}
+
+/**
+ * Identify the current PostHog person (POLICY.md R-8.9.4 — opaque actor id in
+ * error/observability context). `distinctId` MUST be an opaque cuid, never a
+ * name/email/phone (R-8.12.4) — see PostHogIdentify, the only call site.
+ */
+export function identify(distinctId: string): void {
+  if (typeof window === "undefined") return;
+  const ph = window.posthog;
+  if (!ph || typeof ph.identify !== "function") return;
+  ph.identify(distinctId);
+}
+
+/** Clear the identified person (sign-out) so a shared device doesn't carry the identity forward. */
+export function resetAnalyticsIdentity(): void {
+  if (typeof window === "undefined") return;
+  const ph = window.posthog;
+  if (!ph || typeof ph.reset !== "function") return;
+  ph.reset();
 }

--- a/src/lib/api-validation.ts
+++ b/src/lib/api-validation.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { z } from "zod";
+import { runWithRequestId } from "@/lib/request-context";
 
 type ValidatedBody<T> =
   | { ok: true; data: T }
@@ -69,6 +70,10 @@ export function withValidatedBody<T, C = undefined>(
   return async (request: Request, context?: C): Promise<Response> => {
     const parsed = await readValidatedBody(request, schema);
     if (!parsed.ok) return parsed.response;
-    return handler(parsed.data, request, context as C);
+    // Auto-thread the x-request-id correlation id (POLICY.md R-8.9.5) into every
+    // logger.* call the handler makes, without the handler passing it explicitly.
+    const requestId = request.headers.get("x-request-id");
+    if (!requestId) return handler(parsed.data, request, context as C);
+    return runWithRequestId(requestId, () => handler(parsed.data, request, context as C));
   };
 }

--- a/src/lib/convex-op-timing.test.ts
+++ b/src/lib/convex-op-timing.test.ts
@@ -13,12 +13,18 @@ vi.mock("convex/server", () => ({
   getFunctionName: (ref: unknown) => getFunctionNameMock(ref),
 }));
 
+let ambientRequestId: string | undefined;
+vi.mock("@/lib/request-context", () => ({
+  getAmbientRequestId: () => ambientRequestId,
+}));
+
 describe("reportIfSlowConvexOp", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     phCapture.mockClear();
+    ambientRequestId = undefined;
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -26,6 +32,18 @@ describe("reportIfSlowConvexOp", () => {
   afterEach(() => {
     warnSpy.mockRestore();
     errorSpy.mockRestore();
+  });
+
+  it("correlates the PostHog event with the ambient x-request-id when present (R-8.9.6)", () => {
+    ambientRequestId = "req-abc-123";
+    reportIfSlowConvexOp("crewMembers:list", "query", SLOW_OP_MS + 1);
+    expect(phCapture).toHaveBeenCalledWith("convex_op_latency", {
+      name: "crewMembers:list",
+      kind: "query",
+      duration_ms: SLOW_OP_MS + 1,
+      incident: false,
+      request_id: "req-abc-123",
+    });
   });
 
   it("does nothing for an op at or under the slow line", () => {

--- a/src/lib/convex-op-timing.ts
+++ b/src/lib/convex-op-timing.ts
@@ -4,6 +4,7 @@ import type { ConvexHttpClient } from "convex/browser";
 import { logger } from "@/lib/logger";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { AnalyticsEvent } from "@/lib/analytics";
+import { getAmbientRequestId } from "@/lib/request-context";
 
 /**
  * T-P6 per-endpoint p95 SLO (README.md R-0.4, R-9.11/R-8.9.6): 300ms is the
@@ -32,15 +33,23 @@ export function reportIfSlowConvexOp(
 ): void {
   if (durationMs <= SLOW_OP_MS) return;
   const incident = durationMs > INCIDENT_OP_MS;
+  // Cross-service correlation (POLICY.md R-8.9.6): no W3C traceparent crosses
+  // into the Convex function itself (that would mean threading a trace id
+  // through every query/mutation's args — out of scope here), but reusing the
+  // ambient x-request-id (R-8.9.5) as a de facto trace id — the remediation's
+  // own suggestion — ties this Convex-leg timing back to the Next.js request
+  // that triggered it, in both the log line and the PostHog event.
+  const requestId = getAmbientRequestId();
   logger[incident ? "error" : "warn"](
     `[convex] slow ${kind}: ${name} took ${durationMs}ms`,
-    { name, kind, durationMs, incident },
+    { name, kind, durationMs, incident, ...(requestId ? { requestId } : {}) },
   );
   void captureServerEvent(AnalyticsEvent.ConvexOpLatency, {
     name,
     kind,
     duration_ms: durationMs,
     incident,
+    ...(requestId ? { request_id: requestId } : {}),
   });
 }
 

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { logger, scrub } from "./logger";
+import { logger, scrub, setAmbientRequestIdGetter } from "./logger";
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  setAmbientRequestIdGetter(() => undefined);
+});
 
 describe("logger scrubbing", () => {
   it("redacts sensitive keys at any depth", () => {
@@ -26,5 +29,21 @@ describe("logger scrubbing", () => {
     expect(rec.level).toBe("error");
     expect(rec.message).toBe("boom");
     expect(rec.requestId).toBe("r1");
+  });
+
+  it("auto-threads the ambient requestId when meta.requestId isn't passed explicitly (R-8.9.5)", () => {
+    setAmbientRequestIdGetter(() => "ambient-r2");
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logger.warn("slow op", { detail: "x" });
+    const rec = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(rec.requestId).toBe("ambient-r2");
+  });
+
+  it("prefers an explicit meta.requestId over the ambient one", () => {
+    setAmbientRequestIdGetter(() => "ambient-r2");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logger.error("boom", { requestId: "explicit-r3" });
+    const rec = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(rec.requestId).toBe("explicit-r3");
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,13 +1,30 @@
 /**
  * Structured, levelled logger (POLICY.md R-8.9.5). Emits one JSON line per event so
  * logs are machine-parseable and levelled; a correlation/request id is attached when
- * provided (set by middleware as `x-request-id`, threaded via `meta.requestId`).
+ * provided (set by middleware as `x-request-id`), either explicitly via
+ * `meta.requestId` or ambiently (see {@link setAmbientRequestIdGetter} below).
  *
  * Sensitive data MUST NOT be logged: keys matching SENSITIVE are redacted from `meta`
  * (defence-in-depth on top of not passing PII in the first place). Covered by
  * logger.test.ts.
  */
 type Level = "debug" | "info" | "warn" | "error";
+
+/**
+ * Server-only ambient requestId source, registered by `instrumentation.ts` at
+ * process start. Deliberately NOT a static import of `request-context.ts` — this
+ * file is isomorphic (imported by "use client" code, e.g. posthog-provider.tsx),
+ * and `request-context.ts` pulls in `node:async_hooks`, which cannot land in the
+ * browser bundle. Registering a plain function keeps `logger.ts` free of any
+ * Node-only import; on the client this just stays unset and `emit` falls back to
+ * whatever `meta.requestId` was passed explicitly (usually nothing).
+ */
+let ambientRequestIdGetter: (() => string | undefined) | undefined;
+
+/** Called once from `instrumentation.ts` (Node runtime only) to enable auto-threading. */
+export function setAmbientRequestIdGetter(getter: () => string | undefined): void {
+  ambientRequestIdGetter = getter;
+}
 
 const SENSITIVE =
   /(pass(word|phrase)?|secret|token|authorization|cookie|api[-_]?key|jwt|ssn|creditcard|email|phone|dateofbirth|dob|icaltoken)/i;
@@ -31,6 +48,12 @@ function emit(level: Level, message: string, meta?: Record<string, unknown>) {
     const scrubbed = scrub(meta) as Record<string, unknown>;
     if (scrubbed.requestId != null) record.requestId = scrubbed.requestId;
     record.meta = scrubbed;
+  }
+  // Explicit meta.requestId always wins; otherwise fall back to the ambient one
+  // set by middleware + threaded via runWithRequestId (request-context.ts).
+  if (record.requestId == null) {
+    const ambient = ambientRequestIdGetter?.();
+    if (ambient != null) record.requestId = ambient;
   }
   const line = JSON.stringify(record);
   // This IS the logger's transport; all other app logging must go through `logger.*`

--- a/src/lib/request-context.ts
+++ b/src/lib/request-context.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Ambient request id (POLICY.md R-8.9.5) — the correlation id minted/forwarded by
+ * `middleware.ts` as `x-request-id`.
+ *
+ * Mirrors the ActorContext pattern in `request-actor.ts`: rather than threading a
+ * `requestId` argument through every `logger.*` call site (hundreds of them), the
+ * request entry point (`withValidatedBody`, `onRequestError`) runs the rest of the
+ * request inside {@link runWithRequestId}, and `logger.ts` reads the ambient value
+ * automatically via {@link getAmbientRequestId}. Plain `next/headers` `headers()`
+ * can't serve this role — it's async in the App Router, and `logger.emit` is
+ * synchronous — so this uses the same `node:async_hooks` seam as the actor context.
+ *
+ * Anything running outside `runWithRequestId` (a cron/script/background job with no
+ * inbound request) sees `undefined` and logs without a requestId, unchanged.
+ */
+const requestIdStorage = new AsyncLocalStorage<string>();
+
+/** Run `fn` with `requestId` as the ambient correlation id for its entire async subtree. */
+export function runWithRequestId<T>(requestId: string, fn: () => T): T {
+  return requestIdStorage.run(requestId, fn);
+}
+
+/** The ambient request id, or undefined when running outside a tracked request. */
+export function getAmbientRequestId(): string | undefined {
+  return requestIdStorage.getStore();
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -30,3 +30,36 @@ describe("middleware — session redirect gating", () => {
     expect(redirectsToLogin(middleware(req("/api/crew/respond/tok")))).toBe(false);
   });
 });
+
+describe("middleware — x-request-id correlation (R-8.9.5)", () => {
+  it("mints x-request-id on the response even for a public route", () => {
+    const res = middleware(req("/login"));
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("mints x-request-id on the response for a public token-based route", () => {
+    const res = middleware(req("/api/calendar/tok/feed"));
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("mints x-request-id even on the login-redirect response", () => {
+    const res = middleware(req("/dashboard"));
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("reuses an inbound x-request-id instead of minting a new one", () => {
+    const r = req("/login");
+    r.headers.set("x-request-id", "inbound-id-123");
+    const res = middleware(r);
+    expect(res.headers.get("x-request-id")).toBe("inbound-id-123");
+  });
+
+  it("forwards x-request-id to the downstream request (readable via request.headers), not just the response", () => {
+    const res = middleware(req("/api/calendar/tok/feed"));
+    // NextResponse.next({ request }) mirrors the rewritten request headers back
+    // onto the response's `x-middleware-request-*` headers in the test/edge
+    // runtime — this is how we assert the request-side header was actually set,
+    // not just the response header.
+    expect(res.headers.get("x-middleware-request-x-request-id")).toBeTruthy();
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,10 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Correlation id for log/error tracing (POLICY.md R-8.9.5): reuse an inbound
-  // x-request-id or mint one; forwarded to server code and returned to the client.
+  // x-request-id or mint one; forwarded to server code and returned to the client
+  // on EVERY branch below (including the public/token early-returns) — a route
+  // handler that only sees the request half of a public route must still be able
+  // to read it via `headers().get("x-request-id")`.
   const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
 
   // CVE-2025-29927: Strip x-middleware-subrequest header to prevent middleware bypass
@@ -14,9 +17,13 @@ export function middleware(request: NextRequest) {
     return new NextResponse(null, { status: 403 });
   }
 
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-request-id", requestId);
+  const forwardedRequest = { headers: requestHeaders };
+
   // Allow public routes
   if (publicRoutes.some((route) => pathname.startsWith(route))) {
-    return NextResponse.next();
+    return withRequestId(NextResponse.next({ request: forwardedRequest }), requestId);
   }
 
   // Allow public token-based routes (no session required)
@@ -34,7 +41,7 @@ export function middleware(request: NextRequest) {
     pathname.startsWith("/api/auditor/") ||
     pathname.startsWith("/api/cron/")
   ) {
-    return NextResponse.next();
+    return withRequestId(NextResponse.next({ request: forwardedRequest }), requestId);
   }
 
   // Check for session token cookie (Better Auth uses this)
@@ -45,14 +52,17 @@ export function middleware(request: NextRequest) {
   if (!sessionToken) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("callbackUrl", pathname);
-    return NextResponse.redirect(loginUrl);
+    return withRequestId(NextResponse.redirect(loginUrl), requestId);
   }
 
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-request-id", requestId);
-  const response = NextResponse.next({ request: { headers: requestHeaders } });
-  response.headers.set("x-request-id", requestId);
+  const response = NextResponse.next({ request: forwardedRequest });
   addSecurityHeaders(response);
+  return withRequestId(response, requestId);
+}
+
+/** Attach the correlation id to the outbound response (all branches, not just the authed path). */
+function withRequestId(response: NextResponse, requestId: string): NextResponse {
+  response.headers.set("x-request-id", requestId);
   return response;
 }
 


### PR DESCRIPTION
## Summary

Fixes the four §8.9 Observability findings from the 2026-07-22 audit tracked in #776.

- **#756 (R-8.9.5)** — `x-request-id` was minted but skipped on every public/token route and never actually consumed anywhere. `middleware.ts` now forwards it on every branch; `src/lib/request-context.ts` adds an ambient `AsyncLocalStorage` (mirroring the existing `ActorContext` seam) so `logger.ts` auto-threads the id without touching every call site; wired into `withValidatedBody` (API routes) and `onRequestError`.
- **#755 (R-8.9.4)** — `posthog.identify()` was never called client-side and error context carried no actor id. Added `PostHogIdentify` (identifies the org-membership cuid, resets on sign-out), threaded a best-effort opaque actor id into `onRequestError`'s PostHog context, and created the "Crash-free sessions (T-13)" PostHog insight.
- **#757 (R-8.9.6)** — No cross-service trace context existed. Reused the ambient `x-request-id` as a de facto trace id on Convex-op timing telemetry (log line + `convex_op_latency` PostHog event), and named explicit owners for the Convex/PostHog dashboards in the runbook.
- **#754 (R-8.9.1)** — Convex cron/job errors only landed in the Convex dashboard. Added `convex/lib/errorReporting.ts` (`reportConvexJobError`, a raw `fetch` to PostHog's `/capture/` API since Convex actions run in a separate runtime from `src/`), wired into the single funnel both durable cron executors go through.

## Known gap (external constraint, not code)

The crash-free-sessions (T-13) PostHog **alert** could not be created — the project's PostHog plan is already at its 5-alert cap. The insight is created and ready; documented in `docs/convex-observability-runbook.md` with the exact alert config to add once a slot is freed (plan upgrade or retiring an existing alert). Left as a decision for a human rather than unilaterally deleting an existing production alert.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 289 files / 3968 tests passing (new tests added for middleware, logger, analytics, convex-op-timing)
- [x] `pnpm exec eslint` — no new errors/warnings (middleware complexity warning pre-existed before this change, verified via diff)
- [x] `pnpm build` — production build succeeds, all routes compile
- [ ] Convex changes (`convex/scheduledJobs.ts`, `convex/lib/errorReporting.ts`) could not be pushed to a live Convex dev deployment from this session (no `CONVEX_DEPLOY_KEY` available) — will deploy via the normal `pnpm exec convex deploy -y` step in `build-image.yml` on merge to `main`
- [ ] `POSTHOG_KEY` needs to be set on the Convex deployment (`pnpm exec convex env set POSTHOG_KEY <phc_...>`) for the new cron-error forwarding to actually send — currently inert without it

Closes #754
Closes #755
Closes #756
Closes #757
Closes #776


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmebPv5z4owo8ryf3iW6mw)_