### PR TITLE
Fix §5 documentation findings from 2026-07-23 audit (#820, #821)

### DIFF
--- a/FEATUREDOCS/02-project-structure.md
+++ b/FEATUREDOCS/02-project-structure.md
@@ -59,7 +59,7 @@ src/
 │                           # HMAC/external API, email/iCal, CSV/Node — full list in
 │                           # FEATUREDOCS/54). NOT a place for new domain CRUD; new
 │                           # entities get a Convex table + *Writes.ts mutations instead.
-├── generated/prisma/       # Prisma generated client (gitignored, run `npx prisma generate`)
+├── generated/prisma/       # Prisma generated client (gitignored, run `pnpm exec prisma generate`)
 └── middleware.ts           # Auth check, route protection
 
 prisma/schema.prisma        # Better Auth + audit models ONLY (16 models) — the

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -10,7 +10,7 @@ reviewed at the quarterly sweep (R-12.1).
 These gate the Convex-native (browser-direct) write path per domain. While a flag is off, writes
 run through the legacy `src/server/*` server actions; when on, they run through the native
 `convex/*Writes.ts` mutations. They exist only for the duration of the Prisma→Convex migration
-(see [[convex-native-phase-progress]] in project notes).
+(see the per-domain removal conditions in the table below).
 
 **Removal condition (all):** once the domain's native write path is confirmed in prod, remove the
 flag AND delete the corresponding legacy server-action path (this also closes R-4.5 migration


### PR DESCRIPTION
## Summary
- Fix stale `npx prisma generate` in `FEATUREDOCS/02-project-structure.md:62` → `pnpm exec prisma generate`, matching the convention documented in CLAUDE.md/ARCHITECTURE.md/README.md (R-5.3).
- Replace the unlinked, ownerless external reference `[[convex-native-phase-progress]] in project notes` in `docs/feature-flags.md:13` with an in-repo pointer to the removal-condition table already on the same page (R-5.1).

## Test plan
- [x] Both changes are single-line doc fixes, no code/behavior affected
- [x] Grepped `FEATUREDOCS/**/*.md` and `docs/**/*.md` for other stray `npx prisma`/`npx convex` references — none remain in the audited §5 scope
- [x] Grepped the repo for other unlinked `[[...]]`-style external references — none found outside the one instance fixed here

Closes #820
Closes #821

Resolves the two open findings tracked in #834 — once merged, a re-audit of POLICY.md §5 should confirm the section is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe1S9yMXCrSAz5vmQALDAr)_