### PR TITLE
docs(env): add missing env vars to .env.example (R-7.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # ── Email (Resend; logs to console if unset) ──────────────────────────────────
 RESEND_API_KEY=
 EMAIL_FROM="RVLT Flow <flow@rvlt.app>"
+# NATIVE_EMAIL_SIDEEFFECTS=true
 
 # ── File uploads (bytes are stored in Convex file storage; no S3/MinIO) ───────
 UPLOAD_MAX_SIZE_MB=50
@@ -25,6 +26,7 @@ PLATFORM_NAME=RVLT Flow
 # ADMIN_REGISTRATION_TOKEN / SITE_ADMIN_SECRET_TOKEN — admin registration token
 SITE_ADMIN_SECRET_TOKEN=change-me-at-least-32-chars
 SITE_ADMIN_REGISTRATION_ENABLED=true
+# NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED=true
 
 # ── Google Maps ───────────────────────────────────────────────────────────────
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
@@ -57,6 +59,10 @@ NEXT_PUBLIC_CONVEX_URL=https://<your-dev-deployment>.convex.cloud
 # NEXT_PUBLIC_CONVEX_SITE_URL=https://<your-dev-deployment>.convex.site
 # Deploy key for `convex dev --once` / `convex deploy` (Convex dashboard → Settings).
 CONVEX_DEPLOY_KEY=
+# Convex-side cron dispatch — set ON THE CONVEX DEPLOYMENT (dashboard env vars),
+# NOT in this file. Dormant until ENABLE_CONVEX_CRONS=true (see convex/crons.ts).
+# ENABLE_CONVEX_CRONS=true
+# CONVEX_CRON_TARGET_URL=https://flow.rvlt.app
 
 # Auth bridge. These are set ON THE
 # CONVEX DEPLOYMENT (dashboard env vars), NOT in this file — convex/auth.config.ts


### PR DESCRIPTION
## Summary
- `.env.example` was missing 4 environment variables that are actually read via `process.env.*`: `NATIVE_EMAIL_SIDEEFFECTS` (`src/lib/native-writes.ts`), `NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED` (`src/app/(admin)/admin/settings/page.tsx`), `ENABLE_CONVEX_CRONS` and `CONVEX_CRON_TARGET_URL` (`convex/scheduledJobs.ts`)
- Added all four to `.env.example` (names only, commented out — no values needed), matching the file's existing section style
- Documentation-only change, no code touched

## Test plan
- [x] Verified all four variables are genuinely read via `process.env.*` at their cited call sites
- N/A — no code behavior changed

Closes #823, closes #836

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB4xJ5oEtdX8MGE6khusQ6)_