### PR TITLE
chore(repo): add CODEOWNERS to route PR review (R-2.1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS — routes PR review requests to the responsible owner(s).
+# See POLICY.md R-2.1. Keep in sync with active maintainers.
+
+# Default: repo owner reviews anything not matched below.
+*                           @qubered
+
+# Backend data layer — schema, migrations, and Convex functions.
+/prisma/                    @qubered
+/convex/                    @qubered
+
+# Auth — sensitive, security-relevant surface.
+/src/lib/auth.ts            @qubered
+/src/lib/auth-client.ts     @qubered
+/src/lib/auth-server.ts     @qubered
+
+# CI/CD and deploy pipeline.
+/.github/workflows/         @qubered
+/Dockerfile                 @qubered
+/docker-entrypoint.sh       @qubered
+
+# Governing policy and hygiene-audit tracking.
+/POLICY.md                  @qubered
+/docs/exceptions.md         @qubered


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` mapping `prisma/`, `convex/`, the auth surface, CI workflows, and the governing policy docs to `@qubered` (the sole admin collaborator), with a repo-wide default fallback.
- Repo has active PR-review routing (24 branches, PRs #608-#813) but had no CODEOWNERS file — POLICY.md R-2.1 requires one.

## Test plan
- N/A — governance file only, no code paths affected.

Closes #816

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvH9RkmyCgTxvs42WQfJ7d)_