### PR TITLE
Fix R-8.7.3: extract SettingsCard component, dedupe 21 hand-copied wrappers

### DIFF
--- a/FEATUREDOCS/07-ui-components.md
+++ b/FEATUREDOCS/07-ui-components.md
@@ -52,6 +52,7 @@ banner comment warning not to revert it to `@base-ui/react/popover`.
 Shared layout components live in `src/components/layout/page-layouts.tsx`:
 
 - **ListPageLayout** / **FormPageLayout** / **DetailPageLayout** — page-level shells (header + content).
+- **SettingsCard** (`children`, `className?`) — the surface-ringed card wrapper (`rounded-lg bg-bg-surface p-5 surface-ring sm:p-6`) used to group settings/admin page sections; `FormPageLayout` is built on it. Single source of truth for that style (POLICY.md R-8.7.3) — never hand-write the class string, use `<SettingsCard>` instead, passing `className` for any extra layout classes (e.g. `flex items-center justify-between`).
 - **DetailLayout** + **DetailMain** + **DetailSidebar** — the two-column body of a detail page: a flexible main column beside a fixed-width (`lg:w-[340px]`) sticky sidebar, stacking below `lg`. All 10 detail pages use these — never hand-roll the `flex flex-col gap-6 lg:flex-row` shell.
 - **SidebarSection** (`title`, `divider?`) — one block inside a `DetailSidebar`: a `SectionHeader` plus content with a bottom divider. Pass `divider={false}` on the last section to drop the trailing rule.
 - **SectionHeader** — teal overline label chip.

--- a/src/app/(admin)/admin/organizations/page.tsx
+++ b/src/app/(admin)/admin/organizations/page.tsx
@@ -10,6 +10,7 @@ import {
   adminGetTheOrg,
   adminGetOrganizationDetails,
 } from "@/server/site-admin";
+import { SettingsCard } from "@/components/layout/page-layouts";
 
 export default function AdminOrganizationsPage() {
   const { data: theOrg, isLoading: orgLoading } = useServerQuery({
@@ -55,7 +56,7 @@ export default function AdminOrganizationsPage() {
         ) : (
           <>
             {/* Org Overview */}
-            <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+            <SettingsCard>
               <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary text-sm font-bold">
@@ -104,7 +105,7 @@ export default function AdminOrganizationsPage() {
                   </p>
                 </div>
               )}
-            </div>
+            </SettingsCard>
           </>
         )}
       </div>

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -5,6 +5,7 @@ import { useServerQuery } from "@/hooks/use-server-query";
 import { AdminShell } from "@/components/admin/admin-shell";
 import { getAdminDashboardStats } from "@/server/site-admin";
 import { Users, Building2, Shield } from "lucide-react";
+import { SettingsCard } from "@/components/layout/page-layouts";
 
 export default function AdminDashboardPage() {
   const { data } = useServerQuery({
@@ -53,7 +54,7 @@ export default function AdminDashboardPage() {
 
         <div className="grid gap-6 md:grid-cols-2">
           {/* Recent Users */}
-          <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+          <SettingsCard>
             <h3 className="t-heading mb-4">Recent Registrations</h3>
             {data?.recentUsers?.length === 0 ? (
               <p className="text-sm text-fg-3">No users yet.</p>
@@ -74,10 +75,10 @@ export default function AdminDashboardPage() {
                 )}
               </div>
             )}
-          </div>
+          </SettingsCard>
 
           {/* Recent Orgs */}
-          <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+          <SettingsCard>
             <h3 className="t-heading mb-4">Recent Organizations</h3>
             {data?.recentOrgs?.length === 0 ? (
               <p className="text-sm text-fg-3">
@@ -100,7 +101,7 @@ export default function AdminDashboardPage() {
                 )}
               </div>
             )}
-          </div>
+          </SettingsCard>
         </div>
       </div>
     </AdminShell>

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -16,6 +16,7 @@ import { Separator } from "@/components/ui/separator";
 import { IconPicker } from "@/components/admin/icon-picker";
 import { DynamicIcon } from "@/components/ui/dynamic-icon";
 import { getSiteSettings, updateSiteSettings } from "@/server/site-admin";
+import { SettingsCard } from "@/components/layout/page-layouts";
 
 export default function AdminSettingsPage() {
   const { data: settings, refetch } = useServerQuery({
@@ -68,7 +69,7 @@ export default function AdminSettingsPage() {
           </p>
         </div>
 
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <div className="mb-4">
             <h3 className="t-heading">Branding</h3>
             <p className="text-sm text-fg-3">
@@ -116,9 +117,9 @@ export default function AdminSettingsPage() {
               </p>
             </div>
           </div>
-        </div>
+        </SettingsCard>
 
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <div className="mb-4">
             <h3 className="t-heading">Registration</h3>
             <p className="text-sm text-fg-3">
@@ -156,9 +157,9 @@ export default function AdminSettingsPage() {
               </span>
             </div>
           </div>
-        </div>
+        </SettingsCard>
 
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <div className="mb-4">
             <h3 className="t-heading">Defaults</h3>
             <p className="text-sm text-fg-3">
@@ -197,7 +198,7 @@ export default function AdminSettingsPage() {
               </div>
             </div>
           </div>
-        </div>
+        </SettingsCard>
 
         <div className="flex justify-end">
           <Button

--- a/src/app/(app)/settings/assets/page.tsx
+++ b/src/app/(app)/settings/assets/page.tsx
@@ -15,7 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { updateOrganization } from "@/server/settings";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import { useCategoriesWithParent } from "@/hooks/use-categories";
@@ -62,7 +62,7 @@ export default function AssetsSettingsPage() {
   return (
     <FadeIn>
     <div className="space-y-6">
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <div className="space-y-6">
           <FormSection title="Asset Tags" description="Configure auto-incrementing asset tag format.">
             <div className="space-y-2">
@@ -145,10 +145,10 @@ export default function AssetsSettingsPage() {
             </Button>
           </div>
         )}
-      </div>
+      </SettingsCard>
 
       {canEdit && (
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <div className="space-y-6">
             <FormSection title="Categories" description="Organize your equipment into categories and subcategories.">
               <div>
@@ -174,7 +174,7 @@ export default function AssetsSettingsPage() {
               </div>
             </FormSection>
           </div>
-        </div>
+        </SettingsCard>
       )}
     </div>
     </FadeIn>

--- a/src/app/(app)/settings/billing/page.tsx
+++ b/src/app/(app)/settings/billing/page.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { updateOrganization } from "@/server/settings";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import { useCanDo } from "@/lib/use-permissions";
@@ -48,7 +48,7 @@ export default function BillingSettingsPage() {
 
   return (
     <FadeIn>
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <div className="space-y-6">
         <FormSection title="Billing" description="Currency and tax configuration for quotes and invoices.">
           <div className="space-y-2">
@@ -93,7 +93,7 @@ export default function BillingSettingsPage() {
           </Button>
         </div>
       )}
-    </div>
+    </SettingsCard>
     </FadeIn>
   );
 }

--- a/src/app/(app)/settings/branding/page.tsx
+++ b/src/app/(app)/settings/branding/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from "react";
 
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { BrandingSettings } from "@/components/settings/branding-settings";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -28,7 +28,7 @@ export default function BrandingSettingsPage() {
 
   return (
     <FadeIn>
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <FormSection
         title="Branding & Colors"
         description="Customize your organization's colors across the UI and PDF documents."
@@ -41,7 +41,7 @@ export default function BrandingSettingsPage() {
           />
         </div>
       </FormSection>
-    </div>
+    </SettingsCard>
     </FadeIn>
   );
 }

--- a/src/app/(app)/settings/calendars/page.tsx
+++ b/src/app/(app)/settings/calendars/page.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { useCanDo } from "@/lib/use-permissions";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { useServerMutation } from "@/hooks/use-server-mutation";
@@ -119,7 +119,7 @@ export default function CalendarSettingsPage() {
 
   return (
     <FadeIn>
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <FormSection
         title="Calendar Feeds"
         description="Subscribe to iCal feeds from Google Calendar, Apple Calendar, Outlook, or any calendar app. All feeds share a single token — regenerating invalidates all URLs."
@@ -187,7 +187,7 @@ export default function CalendarSettingsPage() {
           )}
         </div>
       </FormSection>
-    </div>
+    </SettingsCard>
     <DeleteDialog
       open={regenerateOpen}
       onOpenChange={setRegenerateOpen}

--- a/src/app/(app)/settings/displays/page.tsx
+++ b/src/app/(app)/settings/displays/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/dialog";
 import { useCanDo } from "@/lib/use-permissions";
 import { FadeIn } from "@/components/ui/motion";
+import { SettingsCard } from "@/components/layout/page-layouts";
 import {
   getDisplayTokens,
   createDisplayToken,
@@ -281,7 +282,7 @@ export default function DisplaySettingsPage() {
 
   return (
     <FadeIn>
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <div className="mb-4">
         <h3 className="t-heading text-fg flex items-center gap-2">
           <MonitorPlay className="h-4 w-4" />
@@ -595,7 +596,7 @@ export default function DisplaySettingsPage() {
         }}
         pending={regenerateMutation.isPending}
       />
-    </div>
+    </SettingsCard>
     </FadeIn>
   );
 }

--- a/src/app/(app)/settings/sso/page.tsx
+++ b/src/app/(app)/settings/sso/page.tsx
@@ -13,7 +13,7 @@ import { SSOProvisioningSection } from "@/components/settings/sso-provisioning";
 import { SSOGroupMappingSection } from "@/components/settings/sso-group-mapping";
 import { SSOLoginBehaviorSection } from "@/components/settings/sso-login-behavior";
 import { SSOPendingApprovals } from "@/components/settings/sso-pending-approvals";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { FadeIn } from "@/components/ui/motion";
 import type { OrgSSOSettings } from "@/lib/sso-types";
 import { toast } from "sonner";
@@ -52,7 +52,7 @@ export default function SSOSettingsPage() {
   return (
     <FadeIn>
     <div className="space-y-6">
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <div className="space-y-6">
           <FormSection
             title="Single Sign-On"
@@ -81,10 +81,10 @@ export default function SSOSettingsPage() {
             </div>
           </FormSection>
         </div>
-      </div>
+      </SettingsCard>
 
       {sso?.enabled && (
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <div className="space-y-6">
             <FormSection
               title="User Provisioning"
@@ -142,7 +142,7 @@ export default function SSOSettingsPage() {
               </FormSection>
             )}
           </div>
-        </div>
+        </SettingsCard>
       )}
     </div>
     </FadeIn>

--- a/src/app/(app)/settings/team/page.tsx
+++ b/src/app/(app)/settings/team/page.tsx
@@ -4,7 +4,7 @@
 import { Separator } from "@/components/ui/separator";
 import { InviteMember } from "@/components/settings/invite-member";
 import { MemberList } from "@/components/settings/member-list";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { useCanDo } from "@/lib/use-permissions";
 import { FadeIn } from "@/components/ui/motion";
 
@@ -14,7 +14,7 @@ export default function TeamSettingsPage() {
   return (
     <FadeIn>
     <div className="space-y-6">
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <FormSection
           title="Team Members"
           description="Invite and manage members of your organization."
@@ -29,7 +29,7 @@ export default function TeamSettingsPage() {
             <MemberList />
           </div>
         </FormSection>
-      </div>
+      </SettingsCard>
     </div>
     </FadeIn>
   );

--- a/src/app/(app)/settings/test-and-tag/page.tsx
+++ b/src/app/(app)/settings/test-and-tag/page.tsx
@@ -13,7 +13,7 @@ import { ChevronRight, ShieldCheck, Copy, Trash2, Plus, ExternalLink, Pencil } f
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { updateOrganization } from "@/server/settings";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import {
@@ -64,7 +64,7 @@ export default function TestTagSettingsPage() {
 
   return (
     <FadeIn>
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <div className="space-y-6">
         <FormSection title="Test & Tag" description="Configure test tag ID format and testing defaults.">
           <div className="space-y-2">
@@ -201,7 +201,7 @@ export default function TestTagSettingsPage() {
           </Button>
         </div>
       )}
-    </div>
+    </SettingsCard>
     </FadeIn>
   );
 }

--- a/src/app/(app)/settings/woocommerce/page.tsx
+++ b/src/app/(app)/settings/woocommerce/page.tsx
@@ -42,7 +42,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { FormSection } from "@/components/layout/page-layouts";
+import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import {
   Select,
   SelectContent,
@@ -201,7 +201,7 @@ export default function WooCommerceSettingsPage() {
 
       <form onSubmit={form.handleSubmit((d) => saveMutation.mutate(d))} className="space-y-6">
         {/* Enable/Disable */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6 flex items-center justify-between">
+        <SettingsCard className="flex items-center justify-between">
           <div>
             <Label>Enable Integration</Label>
             <p className="text-xs text-fg-3">
@@ -215,10 +215,10 @@ export default function WooCommerceSettingsPage() {
               <Switch checked={field.value} onCheckedChange={field.onChange} />
             )}
           />
-        </div>
+        </SettingsCard>
 
         {/* Connection */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <FormSection title="Connection" description="Configure the webhook connection between WooCommerce and RVLT Flow.">
             <div className="sm:col-span-2 space-y-4">
             <div className="space-y-2">
@@ -294,10 +294,10 @@ export default function WooCommerceSettingsPage() {
             </div>
             </div>
           </FormSection>
-        </div>
+        </SettingsCard>
 
         {/* Product Matching */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <FormSection title="Product Matching" description="How to match WooCommerce products to RVLT Flow models.">
             <div className="sm:col-span-2 space-y-4">
             <div className="space-y-2">
@@ -336,10 +336,10 @@ export default function WooCommerceSettingsPage() {
             )}
             </div>
           </FormSection>
-        </div>
+        </SettingsCard>
 
         {/* Date Field Mapping */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <FormSection
             title="Date Field Mapping"
             description="Map WooCommerce order meta fields to project dates."
@@ -437,10 +437,10 @@ export default function WooCommerceSettingsPage() {
             </div>
             </div>
           </FormSection>
-        </div>
+        </SettingsCard>
 
         {/* Location Mapping */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <FormSection title="Location Mapping" description="Map a WooCommerce order meta field to a project location. If the value matches an existing location it will be used; otherwise a new venue location is created automatically.">
             <div className="sm:col-span-2 space-y-4">
             <div className="space-y-2">
@@ -488,10 +488,10 @@ export default function WooCommerceSettingsPage() {
             </div>
             </div>
           </FormSection>
-        </div>
+        </SettingsCard>
 
         {/* Project Defaults */}
-        <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+        <SettingsCard>
           <FormSection title="Project Defaults">
             <div className="sm:col-span-2 space-y-4">
             <div className="space-y-2">
@@ -535,7 +535,7 @@ export default function WooCommerceSettingsPage() {
             </div>
             </div>
           </FormSection>
-        </div>
+        </SettingsCard>
 
         {/* WordPress Setup Guide */}
         <div className="rounded-lg bg-bg-surface surface-ring overflow-hidden">
@@ -605,7 +605,7 @@ export default function WooCommerceSettingsPage() {
       </form>
 
       {/* Order Logs */}
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <FormSection title="Recent Orders" description="Webhook deliveries and processing results.">
           <div className="sm:col-span-2">
           {!orderLogs?.items?.length ? (
@@ -660,7 +660,7 @@ export default function WooCommerceSettingsPage() {
           )}
           </div>
         </FormSection>
-      </div>
+      </SettingsCard>
     </div>
     </FadeIn>
   );

--- a/src/components/layout/page-layouts.tsx
+++ b/src/components/layout/page-layouts.tsx
@@ -169,6 +169,24 @@ export function FormSection({
   );
 }
 
+interface SettingsCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Surface-ringed card wrapper for settings-page sections — the single
+ * source of truth for the "rounded-lg bg-bg-surface p-5 surface-ring sm:p-6"
+ * style used across settings and admin pages.
+ */
+export function SettingsCard({ children, className }: SettingsCardProps) {
+  return (
+    <div className={cn("rounded-lg bg-bg-surface p-5 surface-ring sm:p-6", className)}>
+      {children}
+    </div>
+  );
+}
+
 interface FormPageLayoutProps {
   title: string;
   description?: string;
@@ -191,14 +209,14 @@ export function FormPageLayout({
   return (
     <div className={cn("space-y-4", className)}>
       <PageHeader title={title} description={description} />
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <div className="space-y-6">{children}</div>
         {actions && (
           <div className="mt-6 flex justify-end gap-2 border-t border-border pt-4">
             {actions}
           </div>
         )}
-      </div>
+      </SettingsCard>
     </div>
   );
 }

--- a/src/components/ui/notes-editor.tsx
+++ b/src/components/ui/notes-editor.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useIsViewer } from "@/lib/use-permissions";
+import { SettingsCard } from "@/components/layout/page-layouts";
 
 interface NotesEditorProps {
   title?: string;
@@ -45,17 +46,17 @@ export function NotesEditor({
 
   if (isViewer) {
     return (
-      <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+      <SettingsCard>
         <h3 className="t-heading text-fg mb-4">{title}</h3>
         <p className="whitespace-pre-wrap text-sm text-fg-3">
           {initialNotes || "No notes."}
         </p>
-      </div>
+      </SettingsCard>
     );
   }
 
   return (
-    <div className="rounded-lg bg-bg-surface p-5 surface-ring sm:p-6">
+    <SettingsCard>
       <div className="flex items-center justify-between mb-4">
         <h3 className="t-heading text-fg">{title}</h3>
         <Button
@@ -74,6 +75,6 @@ export function NotesEditor({
         placeholder={placeholder}
         className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-fg-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
       />
-    </div>
+    </SettingsCard>
   );
 }


### PR DESCRIPTION
## Summary

Closes #827 (tracked by #839, POLICY.md §8.7 audit, R-8.7.3).

- The card wrapper class `rounded-lg bg-bg-surface p-5 surface-ring sm:p-6` was hand-copied 15 times across `src/app/(app)/settings/*/page.tsx` and `src/components/ui/notes-editor.tsx`, despite the identical style already existing inline inside `FormPageLayout` (`src/components/layout/page-layouts.tsx`).
- Added a `SettingsCard` component as the single source of truth for that style; `FormPageLayout` now builds on it instead of duplicating the class.
- Replaced all 15 named occurrences, plus 6 more identical copies in `src/app/(admin)/admin/{page,settings/page,organizations/page}.tsx` that the original audit didn't count — leaving those would have recreated the same DRY violation immediately after "fixing" it.
- A brand/spacing change to this card style is now a one-line diff instead of a 20+ file diff.
- Documented `SettingsCard` in `FEATUREDOCS/07-ui-components.md`.

No behavioral or visual change — `SettingsCard` renders the exact same class string as before, just once.

## Testing

- `pnpm exec tsc --noEmit` — no new errors (pre-existing `@/generated/prisma/client` resolution errors are environment-only, confirmed unrelated via `git stash`)
- `pnpm exec eslint` on all touched files — 0 errors (only pre-existing warnings in untouched code paths)
- `pnpm test` — 3541/3541 tests passed (42 test files failed to *load*, same pre-existing Prisma-client generation issue, confirmed via `git stash` to predate this change)

## Checklist

- [x] New dependency? N/A — no new dependencies added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT7FtegPZ2Aj5tot5cpMia)_