### PR TITLE
§8.10 remediation: retry default email/storage sends, add storage/PostHog test fakes

### DIFF
--- a/FEATUREDOCS/18-media-storage.md
+++ b/FEATUREDOCS/18-media-storage.md
@@ -14,6 +14,23 @@
 vendor responses are untrusted input (POLICY.md R-8.10.3), same pattern as
 `resendSendResponseSchema` in `email.ts` and `placeResultSchema` in `address-input.tsx`.
 
+## Upload Retry (POLICY.md R-8.10.3)
+`uploadToS3()` wraps the mint-URL + POST-bytes round trip in `retryWithBackoff`
+(`src/lib/retry-with-backoff.ts`, shared with `email.ts`'s `sendEmail()`): 3 attempts,
+jittered exponential backoff. A fresh upload URL is minted on **every** attempt — Convex
+upload URLs are one-time-use, so re-POSTing a URL from a failed attempt isn't safe to
+assume works. Only transient failures retry (network errors, 429, 5xx); a 4xx other than
+429 fails immediately via `HttpStatusError`/`isRetryableHttpStatus`. `deleteFromS3` /
+`getServeInfo` are not retried — read/delete calls aren't on the same auth-critical,
+synchronous request path the upload retry was added to close.
+
+## Test Fake
+`src/lib/storage-fake.ts`'s `createFakeStorage()` is the deterministic, inspectable
+counterpart to `uploadToS3`/`deleteFromS3`/`getServeInfo` for unit tests (POLICY.md
+R-8.10.4) — an in-memory `storageKey -> bytes` map, mirroring the `email-fake.ts` pattern.
+It is not wired into `storage.ts` via dependency injection; tests that need a fake import
+it directly in place of the real functions.
+
 ## File Proxy (`GET /api/files/[...path]`)
 - Record-based auth (replaced the old S3 org-prefixed-key path check): looks up the
   file's org via `getServeInfo(storageKey)` (`src/lib/storage.ts`, backed by the

--- a/FEATUREDOCS/61-observability.md
+++ b/FEATUREDOCS/61-observability.md
@@ -69,6 +69,14 @@ fixed `"server"` distinctId (no user PII). `instrumentation.ts`'s `onRequestErro
 `src/lib/process-safety.ts`'s uncaught-exception/unhandled-rejection net both report through
 it. Dynamically imported so it never loads in the edge runtime (posthog-node is Node-only).
 
+## Test Fake
+
+`src/lib/posthog-fake.ts`'s `createFakePostHog()` is the deterministic, inspectable
+counterpart to `captureServerException`/`captureServerEvent` for unit tests (POLICY.md
+R-8.10.4) — an in-memory capture recorder, mirroring the `email-fake.ts` pattern. It is
+not wired into `posthog-server.ts` via dependency injection; tests that need a fake import
+it directly in place of the real functions.
+
 ## Sourcemaps (readable stack traces)
 
 `next.config.ts` wraps the Next config with `withPostHogConfig` from `@posthog/nextjs-config`
@@ -196,3 +204,6 @@ See `CLAUDE.md` → Environment Variables → Analytics + error tracking.
   registered with zero enforcement). Live $ computation and 80%-threshold alerting are
   deferred pending a persistent monthly counter or a query-capable PostHog key; see "Vendor
   cost budget tracking" above for the concrete target numbers already worked out.
+- v6 (#829): `posthog-fake.ts` added — the PostHog server adapter had no fake/local
+  implementation for tests, unlike `email-fake.ts`/`maps-fake.ts` (R-8.10.4 is a per-adapter
+  clause).

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const sendMock = vi.hoisted(() => vi.fn());
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: sendMock };
+  },
+}));
+vi.mock("@/lib/vendor-cost-tracking", () => ({ reportVendorUsage: vi.fn() }));
+
+async function loadEmailModule() {
+  vi.resetModules();
+  process.env.RESEND_API_KEY = "re_test_key_1234567890";
+  return import("@/lib/email");
+}
+
+describe("sendEmail retry (POLICY.md R-8.10.3)", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.useRealTimers();
+    sendMock.mockReset();
+  });
+
+  it("retries a transient Resend error and succeeds", async () => {
+    sendMock
+      .mockResolvedValueOnce({ data: null, error: { message: "rate limited" } })
+      .mockResolvedValueOnce({ data: { id: "email_123" }, error: null });
+
+    const { sendEmail } = await loadEmailModule();
+    vi.useFakeTimers();
+
+    const promise = sendEmail({ to: "a@x.com", subject: "hi", html: "<p>hi</p>" });
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(result).toEqual({ id: "email_123" });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting retries on a persistent failure", async () => {
+    sendMock.mockResolvedValue({ data: null, error: { message: "down" } });
+
+    const { sendEmail } = await loadEmailModule();
+    vi.useFakeTimers();
+
+    const promise = sendEmail({ to: "a@x.com", subject: "hi", html: "<p>hi</p>" });
+    const assertion = expect(promise).rejects.toThrow("Failed to send email: down");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+
+    expect(sendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds without retrying on the first try", async () => {
+    sendMock.mockResolvedValueOnce({ data: { id: "email_456" }, error: null });
+
+    const { sendEmail } = await loadEmailModule();
+    const result = await sendEmail({ to: "a@x.com", subject: "hi", html: "<p>hi</p>" });
+
+    expect(result).toEqual({ id: "email_456" });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,6 +2,7 @@ import { Resend } from "resend";
 import { z } from "zod";
 import { env } from "@/env";
 import { logger } from "@/lib/logger";
+import { retryWithBackoff } from "@/lib/retry-with-backoff";
 import { reportVendorUsage } from "@/lib/vendor-cost-tracking";
 
 // Vendor responses are untrusted input (POLICY.md R-8.10.3): validate the shape.
@@ -32,6 +33,57 @@ export interface EmailAttachment {
   contentType?: string;
 }
 
+/**
+ * Bounded retry with backoff (POLICY.md R-8.10.3) — this is the DEFAULT inline send
+ * path used directly by auth.ts/sso.ts/org-members.ts/settings.ts/site-admin.ts/
+ * test-tag-reminders.ts, including auth-critical flows (password reset, invitations,
+ * SSO approval). Previously a single transient Resend blip failed the whole request;
+ * only the newer Convex-scheduled path (convex/emailActions.ts) had retry.
+ */
+async function sendViaResend(args: {
+  to: string;
+  subject: string;
+  html: string;
+  attachments?: EmailAttachment[];
+}): Promise<unknown> {
+  try {
+    return await retryWithBackoff(
+      async () => {
+        const result = await getResend().emails.send({
+          from: env.EMAIL_FROM,
+          to: args.to,
+          subject: args.subject,
+          html: args.html,
+          attachments: args.attachments?.map((a) => ({
+            filename: a.filename,
+            content:
+              typeof a.content === "string"
+                ? Buffer.from(a.content, "utf8")
+                : a.content,
+            contentType: a.contentType,
+          })),
+        });
+        if (result.error) {
+          throw new Error(`Failed to send email: ${result.error.message}`);
+        }
+        return result.data;
+      },
+      {
+        onRetry: (error, attempt) =>
+          logger.warn("[Email] send failed, retrying", {
+            attempt,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+      },
+    );
+  } catch (error) {
+    logger.error("[Email] send failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
 export async function sendEmail({
   to,
   subject,
@@ -54,25 +106,7 @@ export async function sendEmail({
     return { id: "dev-mock" };
   }
 
-  const { data, error } = await getResend().emails.send({
-    from: env.EMAIL_FROM,
-    to,
-    subject,
-    html,
-    attachments: attachments?.map((a) => ({
-      filename: a.filename,
-      content:
-        typeof a.content === "string"
-          ? Buffer.from(a.content, "utf8")
-          : a.content,
-      contentType: a.contentType,
-    })),
-  });
-
-  if (error) {
-    logger.error("[Email] send failed", { error: error.message });
-    throw new Error(`Failed to send email: ${error.message}`);
-  }
+  const data = await sendViaResend({ to, subject, html, attachments });
 
   const parsed = resendSendResponseSchema.safeParse(data);
   if (!parsed.success) {

--- a/src/lib/posthog-fake.test.ts
+++ b/src/lib/posthog-fake.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createFakePostHog } from "@/lib/posthog-fake";
+
+describe("createFakePostHog", () => {
+  it("captures exceptions in order with their context", async () => {
+    const posthog = createFakePostHog();
+    const err1 = new Error("first");
+    const err2 = new Error("second");
+
+    await posthog.captureException(err1, { requestId: "req_1" });
+    await posthog.captureException(err2);
+
+    expect(posthog.exceptions).toHaveLength(2);
+    expect(posthog.exceptions[0]).toEqual({ error: err1, context: { requestId: "req_1" } });
+    expect(posthog.exceptions[1]).toEqual({ error: err2, context: undefined });
+  });
+
+  it("captures events in order with their properties", async () => {
+    const posthog = createFakePostHog();
+
+    await posthog.captureEvent("slow_query", { durationMs: 150 });
+    await posthog.captureEvent("vendor_usage");
+
+    expect(posthog.events).toEqual([
+      { event: "slow_query", properties: { durationMs: 150 } },
+      { event: "vendor_usage", properties: undefined },
+    ]);
+  });
+
+  it("clear() resets both captured exceptions and events", async () => {
+    const posthog = createFakePostHog();
+    await posthog.captureException(new Error("x"));
+    await posthog.captureEvent("x");
+
+    posthog.clear();
+
+    expect(posthog.exceptions).toHaveLength(0);
+    expect(posthog.events).toHaveLength(0);
+  });
+});

--- a/src/lib/posthog-fake.ts
+++ b/src/lib/posthog-fake.ts
@@ -1,0 +1,60 @@
+/**
+ * In-memory fake for the server-side PostHog client (POLICY.md R-8.10.4 —
+ * every adapter should have a local/fake implementation for tests). Mirrors
+ * the `captureServerException` / `captureServerEvent` signatures
+ * (`@/lib/posthog-server`) so tests can assert what WOULD be captured without
+ * hitting PostHog, and without depending on `POSTHOG_KEY` being set.
+ */
+
+export interface FakeCapturedException {
+  error: unknown;
+  context?: Record<string, string | number | boolean>;
+}
+
+export interface FakeCapturedEvent {
+  event: string;
+  properties?: Record<string, string | number | boolean>;
+}
+
+export interface FakePostHogTransport {
+  /** Drop-in for `captureServerException`. */
+  captureException: (
+    error: unknown,
+    context?: Record<string, string | number | boolean>,
+  ) => Promise<void>;
+  /** Drop-in for `captureServerEvent`. */
+  captureEvent: (
+    event: string,
+    properties?: Record<string, string | number | boolean>,
+  ) => Promise<void>;
+  /** Exceptions captured so far, in capture order. */
+  readonly exceptions: readonly FakeCapturedException[];
+  /** Events captured so far, in capture order. */
+  readonly events: readonly FakeCapturedEvent[];
+  /** Reset captured state between tests. */
+  clear: () => void;
+}
+
+export function createFakePostHog(): FakePostHogTransport {
+  const exceptions: FakeCapturedException[] = [];
+  const events: FakeCapturedEvent[] = [];
+
+  return {
+    captureException: async (error, context) => {
+      exceptions.push({ error, context });
+    },
+    captureEvent: async (event, properties) => {
+      events.push({ event, properties });
+    },
+    get exceptions() {
+      return exceptions;
+    },
+    get events() {
+      return events;
+    },
+    clear: () => {
+      exceptions.length = 0;
+      events.length = 0;
+    },
+  };
+}

--- a/src/lib/retry-with-backoff.test.ts
+++ b/src/lib/retry-with-backoff.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  HttpStatusError,
+  isRetryableHttpStatus,
+  retryWithBackoff,
+} from "@/lib/retry-with-backoff";
+
+describe("retryWithBackoff", () => {
+  it("returns the result on first success without retrying", async () => {
+    const run = vi.fn().mockResolvedValue("ok");
+    const result = await retryWithBackoff(run, { baseDelayMs: 1 });
+    expect(result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failing call and succeeds within maxAttempts", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("ok");
+    const onRetry = vi.fn();
+    const result = await retryWithBackoff(run, { baseDelayMs: 1, onRetry });
+    expect(result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(expect.any(Error), 1);
+  });
+
+  it("throws the last error once maxAttempts is exhausted", async () => {
+    const err = new Error("persistent");
+    const run = vi.fn().mockRejectedValue(err);
+    await expect(
+      retryWithBackoff(run, { baseDelayMs: 1, maxAttempts: 3 }),
+    ).rejects.toThrow("persistent");
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops immediately when shouldRetry returns false", async () => {
+    const err = new Error("non-retryable");
+    const run = vi.fn().mockRejectedValue(err);
+    await expect(
+      retryWithBackoff(run, {
+        baseDelayMs: 1,
+        maxAttempts: 3,
+        shouldRetry: () => false,
+      }),
+    ).rejects.toThrow("non-retryable");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to 3 total attempts", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("fail"));
+    await expect(retryWithBackoff(run, { baseDelayMs: 1 })).rejects.toThrow();
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("isRetryableHttpStatus", () => {
+  it("treats 429 and 5xx as retryable", () => {
+    expect(isRetryableHttpStatus(429)).toBe(true);
+    expect(isRetryableHttpStatus(500)).toBe(true);
+    expect(isRetryableHttpStatus(503)).toBe(true);
+  });
+
+  it("treats other 4xx as non-retryable", () => {
+    expect(isRetryableHttpStatus(400)).toBe(false);
+    expect(isRetryableHttpStatus(401)).toBe(false);
+    expect(isRetryableHttpStatus(404)).toBe(false);
+  });
+});
+
+describe("HttpStatusError", () => {
+  it("carries the status code", () => {
+    const err = new HttpStatusError("boom", 503);
+    expect(err.status).toBe(503);
+    expect(err.message).toBe("boom");
+    expect(err.name).toBe("HttpStatusError");
+  });
+});

--- a/src/lib/retry-with-backoff.ts
+++ b/src/lib/retry-with-backoff.ts
@@ -1,0 +1,72 @@
+/**
+ * Bounded retry-with-backoff for a single outbound vendor call (POLICY.md
+ * R-8.10.3). Sized for SYNCHRONOUS in-request paths (`email.ts`, `storage.ts`)
+ * where a caller is blocked waiting — seconds-scale backoff, not the
+ * minutes-scale backoff of the durable webhook/scheduled-email queues
+ * (`webhooks/deliver.ts`, `convex/emailActions.ts`), which retry off the
+ * request path and can afford to wait longer.
+ *
+ * Mirrors the jittered-backoff shape already proven in `withConvexReadRetry`
+ * (convex-client.ts): jitter (R-9.6) spreads retries from the same transient
+ * blip instead of a synchronized retry storm against the vendor.
+ */
+
+export interface RetryOptions {
+  /** Total attempts including the first. Default 3 (2 retries). */
+  maxAttempts?: number;
+  /** Base delay in ms before the second attempt; doubles each subsequent attempt. */
+  baseDelayMs?: number;
+  /** Return false to stop retrying this error immediately. Default: always retry. */
+  shouldRetry?: (error: unknown) => boolean;
+  /** Called before each retry (not on the final, non-retried failure). */
+  onRetry?: (error: unknown, attempt: number) => void;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 300;
+
+export async function retryWithBackoff<T>(
+  run: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const baseDelayMs = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= maxAttempts || (opts.shouldRetry && !opts.shouldRetry(error))) {
+        throw error;
+      }
+      opts.onRetry?.(error, attempt);
+      await sleep(backoffDelayMs(baseDelayMs, attempt));
+    }
+  }
+}
+
+function backoffDelayMs(baseDelayMs: number, attempt: number): number {
+  // Jittered exponential backoff (R-9.6) — spreads retries from the same
+  // transient blip instead of a synchronized retry storm against the vendor.
+  return baseDelayMs * 2 ** (attempt - 1) * (0.5 + Math.random() * 0.5);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Thrown by an HTTP-backed vendor call so `shouldRetry` can key off the status code. */
+export class HttpStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "HttpStatusError";
+  }
+}
+
+/** 429 (rate limit) and 5xx are transient; other 4xx are the caller's fault — don't retry those. */
+export function isRetryableHttpStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}

--- a/src/lib/storage-fake.test.ts
+++ b/src/lib/storage-fake.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createFakeStorage } from "@/lib/storage-fake";
+
+describe("createFakeStorage", () => {
+  it("uploads and captures files in order with stable keys", async () => {
+    const storage = createFakeStorage();
+    const r1 = await storage.upload(Buffer.from("one"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "one.png",
+      mimeType: "image/png",
+    });
+    const r2 = await storage.upload(Buffer.from("two"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_2",
+      fileName: "two.png",
+      mimeType: "image/png",
+    });
+
+    expect(r1.storageKey).toBe("fake-storage-1");
+    expect(r1.url).toBe("/api/files/fake-storage-1");
+    expect(r2.storageKey).toBe("fake-storage-2");
+    expect(storage.files).toHaveLength(2);
+    expect(storage.files.map((f) => f.fileName)).toEqual(["one.png", "two.png"]);
+  });
+
+  it("getServeInfo returns the stored file's info, or null if unknown", async () => {
+    const storage = createFakeStorage();
+    const { storageKey } = await storage.upload(Buffer.from("hello"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "hello.png",
+      mimeType: "image/png",
+    });
+
+    const info = await storage.getServeInfo(storageKey);
+    expect(info).toEqual({
+      organizationId: "org_1",
+      url: "/api/files/fake-storage-1",
+      contentType: "image/png",
+      size: 5,
+      fileName: "hello.png",
+    });
+
+    expect(await storage.getServeInfo("nope")).toBeNull();
+  });
+
+  it("delete removes the file", async () => {
+    const storage = createFakeStorage();
+    const { storageKey } = await storage.upload(Buffer.from("x"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "x.png",
+      mimeType: "image/png",
+    });
+
+    await storage.delete(storageKey);
+    expect(await storage.getServeInfo(storageKey)).toBeNull();
+    expect(storage.files).toHaveLength(0);
+  });
+
+  it("clear() resets captured state", async () => {
+    const storage = createFakeStorage();
+    await storage.upload(Buffer.from("x"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "x.png",
+      mimeType: "image/png",
+    });
+    storage.clear();
+    expect(storage.files).toHaveLength(0);
+  });
+});

--- a/src/lib/storage-fake.ts
+++ b/src/lib/storage-fake.ts
@@ -1,0 +1,75 @@
+/**
+ * In-memory fake for file storage (POLICY.md R-8.10.4 — every adapter should
+ * have a local/fake implementation for tests). Mirrors the `uploadToS3` /
+ * `deleteFromS3` / `getServeInfo` / `getProxyUrl` surface (`@/lib/storage`) so
+ * tests can assert what was stored without hitting Convex `_storage`.
+ */
+import type { ServeInfo, UploadResult } from "@/lib/storage";
+
+export interface FakeStoredFile {
+  storageKey: string;
+  bytes: Buffer;
+  organizationId: string;
+  folder: string;
+  entityId: string;
+  fileName: string;
+  mimeType: string;
+  url: string;
+}
+
+export interface FakeStorage {
+  /** Drop-in for `uploadToS3` — records the bytes and returns a stable key. */
+  upload: (
+    file: Buffer,
+    options: {
+      organizationId: string;
+      folder: string;
+      entityId: string;
+      fileName: string;
+      mimeType: string;
+    },
+  ) => Promise<UploadResult>;
+  /** Drop-in for `deleteFromS3`. */
+  delete: (storageKey: string) => Promise<void>;
+  /** Drop-in for `getServeInfo`. Null if the key was never uploaded (or was deleted). */
+  getServeInfo: (storageKey: string) => Promise<ServeInfo | null>;
+  /** Everything currently stored, in upload order. */
+  readonly files: readonly FakeStoredFile[];
+  /** Reset captured state between tests. */
+  clear: () => void;
+}
+
+export function createFakeStorage(): FakeStorage {
+  const byKey = new Map<string, FakeStoredFile>();
+  let counter = 0;
+
+  return {
+    upload: async (file, options) => {
+      counter += 1;
+      const storageKey = `fake-storage-${counter}`;
+      const url = `/api/files/${storageKey}`;
+      byKey.set(storageKey, { storageKey, bytes: file, url, ...options });
+      return { storageKey, url };
+    },
+    delete: async (storageKey) => {
+      byKey.delete(storageKey);
+    },
+    getServeInfo: async (storageKey) => {
+      const file = byKey.get(storageKey);
+      if (!file) return null;
+      return {
+        organizationId: file.organizationId,
+        url: file.url,
+        contentType: file.mimeType,
+        size: file.bytes.length,
+        fileName: file.fileName,
+      };
+    },
+    get files() {
+      return Array.from(byKey.values());
+    },
+    clear: () => {
+      byKey.clear();
+    },
+  };
+}

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const convexMock = vi.hoisted(() => ({ query: vi.fn(), mutation: vi.fn() }));
+vi.mock("@/lib/convex-client", () => ({
+  getConvexClient: vi.fn(async () => convexMock),
+}));
+
+vi.mock("@/lib/fetch-with-timeout", () => ({ fetchWithTimeout: vi.fn() }));
+
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+import { uploadToS3 } from "@/lib/storage";
+
+const fetchMock = vi.mocked(fetchWithTimeout);
+
+// Convex's generated `api` object is a Proxy that mints a fresh reference on
+// every property access (no stable identity, no toString) — so distinguish
+// calls by argument shape instead of `fn === api.files.generateUploadUrl`.
+function isGenerateUploadUrlCall(args: unknown): boolean {
+  return typeof args === "object" && args !== null && !("storageId" in args);
+}
+
+function jsonResponse(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  let urlCounter = 0;
+  convexMock.mutation.mockImplementation(async (_fn: unknown, args: unknown) => {
+    if (isGenerateUploadUrlCall(args)) {
+      urlCounter += 1;
+      return `https://upload.example/${urlCounter}`;
+    }
+    return null; // register
+  });
+});
+
+describe("uploadToS3 retry (POLICY.md R-8.10.3)", () => {
+  it("retries a transient (5xx) upload failure and succeeds", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(503))
+      .mockResolvedValueOnce(jsonResponse(200, { storageId: "storage_1" }));
+
+    const promise = uploadToS3(Buffer.from("bytes"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "a.png",
+      mimeType: "image/png",
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(result).toEqual({ storageKey: "storage_1", url: "/api/files/storage_1" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // A fresh (one-time-use) upload URL is minted on every attempt.
+    const generateCalls = convexMock.mutation.mock.calls.filter(([, args]) =>
+      isGenerateUploadUrlCall(args),
+    );
+    expect(generateCalls).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it("does not retry a non-retryable (4xx) upload failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(400));
+
+    await expect(
+      uploadToS3(Buffer.from("bytes"), {
+        organizationId: "org_1",
+        folder: "avatars",
+        entityId: "ent_1",
+        fileName: "a.png",
+        mimeType: "image/png",
+      }),
+    ).rejects.toThrow("Convex storage upload failed: 400");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting retries on a persistent transient failure", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(jsonResponse(500));
+
+    const promise = uploadToS3(Buffer.from("bytes"), {
+      organizationId: "org_1",
+      folder: "avatars",
+      entityId: "ent_1",
+      fileName: "a.png",
+      mimeType: "image/png",
+    });
+    const assertion = expect(promise).rejects.toThrow("Convex storage upload failed: 500");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { getConvexClient } from "@/lib/convex-client";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+import { logger } from "@/lib/logger";
+import {
+  HttpStatusError,
+  isRetryableHttpStatus,
+  retryWithBackoff,
+} from "@/lib/retry-with-backoff";
 import { api } from "../../convex/_generated/api";
 
 // Vendor responses are untrusted input (POLICY.md R-8.10.3): validate the shape.
@@ -43,14 +49,36 @@ export async function uploadToS3(
   },
 ): Promise<UploadResult> {
   const convex = await getConvexClient();
-  const uploadUrl = await convex.mutation(api.files.generateUploadUrl, {});
-  const res = await fetchWithTimeout(uploadUrl, {
-    method: "POST",
-    headers: { "Content-Type": options.mimeType },
-    // Buffer isn't in the DOM BodyInit types; a plain Uint8Array view is.
-    body: new Uint8Array(file),
-  });
-  if (!res.ok) throw new Error(`Convex storage upload failed: ${res.status}`);
+  // Bounded retry with backoff (POLICY.md R-8.10.3) — the upload URL is minted
+  // fresh on every attempt (it's one-time-use, so re-POSTing a URL that already
+  // failed isn't safe to assume works) and the whole mint+POST round trip is
+  // retried on a transient failure. 3 attempts, jittered exponential backoff.
+  // Only retry transient failures: network errors (no status) and 429/5xx: a
+  // 4xx other than 429 is the caller's fault and retrying won't help.
+  const res = await retryWithBackoff(
+    async () => {
+      const uploadUrl = await convex.mutation(api.files.generateUploadUrl, {});
+      const r = await fetchWithTimeout(uploadUrl, {
+        method: "POST",
+        headers: { "Content-Type": options.mimeType },
+        // Buffer isn't in the DOM BodyInit types; a plain Uint8Array view is.
+        body: new Uint8Array(file),
+      });
+      if (!r.ok) {
+        throw new HttpStatusError(`Convex storage upload failed: ${r.status}`, r.status);
+      }
+      return r;
+    },
+    {
+      shouldRetry: (error) =>
+        !(error instanceof HttpStatusError) || isRetryableHttpStatus(error.status),
+      onRetry: (error, attempt) =>
+        logger.warn("[Storage] upload failed, retrying", {
+          attempt,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+    },
+  );
   const parsed = convexUploadResponseSchema.safeParse(await res.json());
   if (!parsed.success) {
     throw new Error(`Unexpected Convex upload response: ${parsed.error.message}`);


### PR DESCRIPTION
## Summary

Closes both open findings tracked in #840 (§8.10 External integrations, 2026-07-23 audit):

- Closes #828 (R-8.10.3, Major) — the default (non-Convex-scheduled) email and storage
  send paths had no retry, only the newer gated Convex-scheduled email path did.
  `sendEmail()` (`src/lib/email.ts`) and `uploadToS3()` (`src/lib/storage.ts`) now wrap
  their vendor calls in a new shared `retryWithBackoff` helper
  (`src/lib/retry-with-backoff.ts`) — 3 attempts, jittered exponential backoff. This is
  the path auth-critical flows go through directly (password reset, invitations, SSO
  approval via `auth.ts`/`sso.ts`/`org-members.ts`/`settings.ts`/`site-admin.ts`/
  `test-tag-reminders.ts`). The storage retry mints a fresh (one-time-use) upload URL on
  every attempt and only retries transient failures (network errors, 429, 5xx) via a new
  `HttpStatusError`/`isRetryableHttpStatus` pair — a non-429 4xx fails immediately.

- Closes #829 (R-8.10.4, Minor) — `src/lib/storage.ts` and `src/lib/posthog-server.ts`
  had no fake/local implementation for tests, unlike `email-fake.ts`/`maps-fake.ts`.
  Added `storage-fake.ts` (in-memory `storageKey -> bytes` map) and `posthog-fake.ts`
  (capture recorder), mirroring the existing `email-fake.ts` pattern.

FEATUREDOCS/18-media-storage.md and FEATUREDOCS/61-observability.md updated in the same
PR per POLICY.md R-5.2/R-5.3.

## Testing

- `pnpm exec vitest run` — full unit suite passes (the ~42 failing files are a pre-existing
  sandbox gap: `@/generated/prisma/client` isn't generated in this environment, unrelated
  to this diff — confirmed identical failures on `main` before these changes)
- New tests: `retry-with-backoff.test.ts`, `email.test.ts` (mocks the `resend` package to
  exercise the retry-then-succeed and exhausted-retries paths), `storage.test.ts` (mocks
  Convex client + `fetchWithTimeout`), `storage-fake.test.ts`, `posthog-fake.test.ts`
- `pnpm exec eslint` clean on all touched/new files

## Checklist

- [x] New dependency? N/A — no new dependencies added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuuVgVyprHCqYp9mWisepH)_