### PR TITLE
Bump js-yaml/brace-expansion overrides to clear Hygiene audit gate

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   serialize-javascript@<7.0.3: '>=7.0.3'
   hono@<4.12.25: '>=4.12.25'
   ws@>=8.0.0 <8.21.0: '>=8.21.0'
-  brace-expansion@<5.0.7: '>=5.0.7'
-  js-yaml@<4.3.0: '>=4.3.0'
+  brace-expansion@<5.0.8: '>=5.0.8'
+  js-yaml@<5.2.2: '>=5.2.2'
   fast-uri@<3.1.4: '>=3.1.4'
   sharp@<0.35.0: '>=0.35.0'
   postcss: '>=8.5.12'
@@ -3729,9 +3729,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5183,8 +5183,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -10656,7 +10656,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10872,7 +10872,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -12246,7 +12246,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -12551,15 +12551,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,8 +11,12 @@
 #   serialize-javascript  (next-pwa build)   <7.0.3
 #   hono                  (prisma dev tools)  <4.12.25
 #   ws                    (convex runtime)    8.0.0–8.20.x
-#   brace-expansion       (next-pwa/eslint/shadcn transitive) multiple ranges <5.0.7
-#   js-yaml               (shadcn>cosmiconfig)  <4.3.0
+#   brace-expansion       (next-pwa/eslint/shadcn transitive) multiple ranges <5.0.8
+#                          — GHSA-mh99-v99m-4gvg (2026-07-24 audit, supersedes the
+#                          earlier <5.0.7 floor, which a new advisory caught up to)
+#   js-yaml               (shadcn>cosmiconfig)  <5.2.2 — GHSA-pm4m-ph32-ghv5
+#                          (2026-07-24 audit, supersedes the earlier <4.3.0 floor —
+#                          cosmiconfig has since moved to a js-yaml 5.x requirement)
 #   fast-uri              (better-auth>prisma)  <3.1.4
 #   sharp                 (next's own optional dep, pulled in nested under
 #                          better-auth/next-pwa>next)  <0.35.0 — the direct
@@ -32,8 +36,8 @@ overrides:
   serialize-javascript@<7.0.3: '>=7.0.3'
   hono@<4.12.25: '>=4.12.25'
   ws@>=8.0.0 <8.21.0: '>=8.21.0'
-  brace-expansion@<5.0.7: '>=5.0.7'
-  js-yaml@<4.3.0: '>=4.3.0'
+  brace-expansion@<5.0.8: '>=5.0.8'
+  js-yaml@<5.2.2: '>=5.2.2'
   fast-uri@<3.1.4: '>=3.1.4'
   sharp@<0.35.0: '>=0.35.0'
   postcss: '>=8.5.12'


### PR DESCRIPTION
## Summary

`pnpm audit --audit-level high` (the **Hygiene** CI gate, POLICY.md R-6.6) started
failing on `main` — 2 new high-severity advisories that the existing
`pnpm-workspace.yaml` security overrides no longer covered:

- **`js-yaml`** (`shadcn>cosmiconfig>js-yaml`) — [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5).
  The old floor (`>=4.3.0`) let it resolve into the newly-flagged vulnerable range
  (`>=5.0.0 <=5.2.1`, since cosmiconfig's own requirement moved to js-yaml 5.x).
  Bumped the floor to `>=5.2.2`.
- **`brace-expansion`** (transitive under `@ducanh2912/next-pwa`'s workbox build,
  75 paths) — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg).
  The old floor (`>=5.0.7`) is exactly the version the new advisory flags. Bumped the
  floor to `>=5.0.8`.

Both are **dev-only build tooling** (shadcn CLI, next-pwa's workbox build plugin) —
neither ships in the runtime bundle. This is a pure override-range bump in
`pnpm-workspace.yaml` (+ the resulting `pnpm-lock.yaml` diff); no `package.json`
dependency changed.

Confirmed base-branch-wide (not specific to any one PR): both #847 and #848 — two
unrelated, already-open PRs — were independently failing the identical Hygiene check
for the identical reason before this fix.

## Testing

- `pnpm audit --audit-level high` — now passes (0 high; 2 pre-existing, untouched
  moderate advisories remain, which this gate doesn't fail on)
- `pnpm install --frozen-lockfile` — succeeds (matches the CI install step exactly)
- `pnpm run check-dependency-justification` — `OK: no new dependencies added`
- `pnpm test` — full unit suite unaffected (3541/3541 real tests pass; the ~42 files
  that fail to *load* are a pre-existing sandbox gap — `@/generated/prisma/client`
  isn't generated in this environment — confirmed unrelated via `git stash`)
- `pnpm exec eslint` — 0 errors (only pre-existing warnings in untouched files)

## Checklist

- [x] New dependency? N/A — no new dependencies added, only a security-override
  version bump for two already-overridden transitive packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuuVgVyprHCqYp9mWisepH)_