### PR TITLE
fix(R-4.4): add removal condition to getNextAssetTag deprecation marker

### DIFF
--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -128,7 +128,11 @@ export async function reserveTestTagIds(count = 1): Promise<string[]> {
   return reserveTestTagIdsConvex(organizationId, count);
 }
 
-/** @deprecated Use peekNextAssetTags for preview, reserveAssetTags for creation */
+/**
+ * @deprecated Use peekNextAssetTags for preview, reserveAssetTags for creation.
+ * Removal condition: delete once no callers remain (grep `getNextAssetTag`). Tracked:
+ * POLICY.md R-4.4.
+ */
 export async function getNextAssetTag(): Promise<string> {
   const tags = await peekNextAssetTags(1);
   return tags[0];


### PR DESCRIPTION
## Summary

- `src/server/settings.ts:131`'s `@deprecated` marker on `getNextAssetTag` pointed callers to `peekNextAssetTags`/`reserveAssetTags` but had no removal condition or expiry, unlike the two compliant markers in `src/lib/storage.ts`.
- Added a removal condition ("delete once no callers remain") and the `POLICY.md R-4.4` citation, matching the existing `storage.ts` pattern.

Fixes #855, closes tracking issue #867.

## Testing

- `pnpm exec eslint src/server/settings.ts` — no new errors/warnings introduced (1 pre-existing unrelated warning).

## Checklist

- [x] No new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QKwL8WHoy4vnpyn21JyfWm)_