### PR TITLE
fix(R-9.6): bound api/files upstream fetch with a timeout

### DIFF
--- a/FEATUREDOCS/18-media-storage.md
+++ b/FEATUREDOCS/18-media-storage.md
@@ -39,6 +39,8 @@ it directly in place of the real functions.
 - Returns 403 if org mismatch (prevents unauthorized access); 404 if no matching file record
 - Exception: `organizationId === "avatars"` allowed without org validation (global)
 - Streams file from S3
+- Upstream fetch to the Convex file-storage URL uses `fetchWithTimeout` (`src/lib/fetch-with-timeout.ts`,
+  R-9.6) so a hung storage host can't hold the Node-runtime route open indefinitely
 
 ## Photo Resolution Cascade
 - `resolveAssetPhotoUrl(asset, model)`: asset primary photo → model primary photo → null

--- a/src/app/api/files/[...path]/route.ts
+++ b/src/app/api/files/[...path]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
 import { getServeInfo } from "@/lib/storage";
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
 
 export const runtime = "nodejs";
 
@@ -36,7 +37,7 @@ export async function GET(
   }
 
   try {
-    const upstream = await fetch(info.url);
+    const upstream = await fetchWithTimeout(info.url);
     if (!upstream.ok || !upstream.body) {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }


### PR DESCRIPTION
## Summary

- `src/app/api/files/[...path]/route.ts` proxied to Convex file-storage URLs via a bare `fetch(info.url)` with no `AbortController`/timeout — if the upstream storage host hung, this Node-runtime API route would hold the connection open indefinitely.
- Replaced with the existing `fetchWithTimeout` helper (`src/lib/fetch-with-timeout.ts`), matching the pattern already used in `convex/scheduledJobs.ts`, `convex/lib/errorReporting.ts`, and `src/server/sso.ts`.
- Updated `FEATUREDOCS/18-media-storage.md` to document the timeout on the file proxy route.

Fixes #863 (POLICY.md R-9.6, §9B — WEB profile). Closes the last open finding tracked by #874.

## Testing

- `pnpm exec tsc --noEmit -p .` — no errors in the changed file (pre-existing unrelated errors in this sandbox stem from a missing generated Prisma client, since there's no `.env`/`DATABASE_URL` here)
- `pnpm exec eslint "src/app/api/files/[...path]/route.ts"` — no new warnings/errors introduced
- `pnpm test` — 3575/3575 tests pass; the 42 failing test *files* fail only on `@/generated/prisma/client` import resolution (same pre-existing environment gap, unrelated to this change)

## Checklist

- [x] No new dependency — reuses the existing `fetchWithTimeout` helper


---
_Generated by [Claude Code](https://claude.ai/code/session_01UfnBULnvGhVSKhsn1CRjMG)_