### PR TITLE
Add churn×complexity hotspot tooling (R-11.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "collect-ratchet": "node scripts/collect-ratchet.mjs",
     "knip-ratchet": "node scripts/knip-ratchet.mjs",
     "complexity-ratchet": "node scripts/complexity-ratchet.mjs",
+    "hotspots": "node scripts/hotspots.mjs",
     "size": "size-limit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/hotspots.mjs
+++ b/scripts/hotspots.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Churn × complexity hotspot report (POLICY.md R-11.2). Refactoring priority
+ * should be driven by hotspots, not complexity alone — a file that's complex
+ * but never touched is lower risk than a file that's both complex and
+ * constantly changed. This combines git commit churn per file over a
+ * lookback window with the same ESLint `complexity` rule the
+ * complexity-ratchet uses, scored as churn × complexity-violation-count.
+ *
+ * Usage: node scripts/hotspots.mjs [--days=180] [--top=20] [--json]
+ */
+import { execSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const arg = args.find((a) => a.startsWith(`--${name}=`));
+  return arg ? parseInt(arg.split("=")[1], 10) : fallback;
+};
+const days = flag("days", 180);
+const top = flag("top", 20);
+const asJson = args.includes("--json");
+
+function churnByFile() {
+  const raw = execSync(
+    `git log --since="${days} days ago" --name-only --pretty=format:`,
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  const counts = new Map();
+  for (const line of raw.split("\n")) {
+    const file = line.trim();
+    if (!file) continue;
+    counts.set(file, (counts.get(file) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function complexityByFile() {
+  let raw;
+  try {
+    raw = execSync(
+      'pnpm exec eslint . --format json --rule \'{"complexity":["warn",10]}\'',
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+  } catch (e) {
+    raw = e.stdout ?? "";
+  }
+
+  let results;
+  try {
+    results = JSON.parse(raw);
+  } catch {
+    console.error(
+      "[hotspots] could not parse ESLint JSON output — did it run?\n" +
+        raw.slice(0, 500),
+    );
+    process.exit(2);
+  }
+
+  const cwd = `${process.cwd()}/`;
+  const counts = new Map();
+  for (const file of results) {
+    const violations = file.messages.filter((m) => m.ruleId === "complexity");
+    if (violations.length === 0) continue;
+    const relPath = file.filePath.startsWith(cwd)
+      ? file.filePath.slice(cwd.length)
+      : file.filePath;
+    counts.set(relPath, violations.length);
+  }
+  return counts;
+}
+
+const churn = churnByFile();
+const complexity = complexityByFile();
+
+const files = new Set([...churn.keys(), ...complexity.keys()]);
+const hotspots = [...files]
+  .map((file) => {
+    const churnCount = churn.get(file) ?? 0;
+    const complexityCount = complexity.get(file) ?? 0;
+    return { file, churn: churnCount, complexity: complexityCount, score: churnCount * complexityCount };
+  })
+  .filter((h) => h.score > 0)
+  .sort((a, b) => b.score - a.score)
+  .slice(0, top);
+
+if (asJson) {
+  console.log(JSON.stringify(hotspots, null, 2));
+} else {
+  console.log(`# Churn × Complexity Hotspots (R-11.2, last ${days}d, top ${top})`);
+  console.log();
+  if (hotspots.length === 0) {
+    console.log(
+      "No files with both churn and complexity violations in this window.",
+    );
+  } else {
+    console.log("| Score | Churn (commits) | Complexity violations | File |");
+    console.log("|---|---|---|---|");
+    for (const h of hotspots) {
+      console.log(`| ${h.score} | ${h.churn} | ${h.complexity} | \`${h.file}\` |`);
+    }
+    console.log();
+    console.log(
+      "Highest-scoring files are the best refactoring ROI: frequently changed AND complex.",
+    );
+  }
+}

--- a/scripts/quarterly-sweep.sh
+++ b/scripts/quarterly-sweep.sh
@@ -56,7 +56,13 @@ if [ -f docs/exceptions.md ]; then
   echo "- Exceptions with expiry dates in the past (convert to failures): ${expired:-none}"
 else echo "- docs/exceptions.md missing"; fi
 
-section "9. Critical-doc review cadence (R-5.5 / T-14)"
+section "9. Churn × complexity hotspots (R-11.2)"
+if command -v pnpm >/dev/null; then
+  node scripts/hotspots.mjs --days=180 --top=10 2>&1 | sed 's/^/  /' || echo "  hotspots script unavailable"
+else echo "- pnpm unavailable — run \`node scripts/hotspots.mjs\` manually"; fi
+echo "Use this to prioritize refactoring — highest score = most churn × most complex."
+
+section "10. Critical-doc review cadence (R-5.5 / T-14)"
 if command -v pnpm >/dev/null; then
   pnpm run check-docs-review-cadence 2>&1 | sed 's/^/  /' || true
 else
@@ -64,7 +70,7 @@ else
 fi
 echo "(This workflow's own CI step — .github/workflows/quarterly-sweep.yml — fails the run, not just this report, when a critical doc is stale.)"
 
-section "10. Manual review checklist"
+section "11. Manual review checklist"
 cat <<'EOF'
 - [ ] Alert-rule audit + flaky-quarantine review (R-8.9.3 / R-8.8.4)
 - [ ] Backup-restore test (R-8.11.5) — record the drill result in the runbook


### PR DESCRIPTION
## Summary

- Adds `scripts/hotspots.mjs`: a churn×complexity hotspot report per POLICY.md R-11.2. It combines git commit churn per file (over a configurable lookback window) with the same ESLint `complexity` rule the `complexity-ratchet` uses, scoring files as `churn × complexity-violation-count` so refactoring effort can be prioritized by files that are both frequently changed *and* complex — not complexity alone (the existing retro-skill "hotspot analysis" was churn-only).
- Adds a `pnpm run hotspots` script entry.
- Wires the report into `scripts/quarterly-sweep.sh` (new section 9) so it's reviewed on the same cadence as the rest of the R-12.1 quarterly hygiene sweep.

Usage: `node scripts/hotspots.mjs [--days=180] [--top=20] [--json]`

## Testing

- `node --check scripts/hotspots.mjs` and `bash -n scripts/quarterly-sweep.sh` — syntax OK.
- Ran `node scripts/hotspots.mjs --days=365 --top=10` locally against this repo — produced a sensible ranked table (e.g. `convex/warehouseOps.ts` top-scored with 4 commits × 16 complexity violations).
- Verified `--json` mode emits valid JSON.
- Ran the full `scripts/quarterly-sweep.sh` locally to confirm the new section renders in context with the rest of the report.

## Checklist

- [x] New dependency? N/A — no new dependencies added.

Fixes #864
Closes #875 once merged and re-audited (tracking issue for the §11 Metrics round-3 finding)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kvv8G4VRYiAeii3BGSubTe)_