### PR TITLE
fix(env): add NATIVE_EMAIL_SIDEEFFECTS to src/env.ts Zod schema (R-7.2)

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -98,5 +98,11 @@ describe("env validation", () => {
     const { env } = await loadEnv({});
     expect(env.RESEND_API_KEY).toBeUndefined();
     expect(env.CRON_SECRET).toBeUndefined();
+    expect(env.NATIVE_EMAIL_SIDEEFFECTS).toBeUndefined();
+  });
+
+  it("accepts NATIVE_EMAIL_SIDEEFFECTS when set", async () => {
+    const { env } = await loadEnv({ NATIVE_EMAIL_SIDEEFFECTS: "true" });
+    expect(env.NATIVE_EMAIL_SIDEEFFECTS).toBe("true");
   });
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,6 +38,11 @@ const serverEnvSchema = z.object({
   // Email (optional — logs to console if unset)
   RESEND_API_KEY: z.string().optional(),
   EMAIL_FROM: z.string().default("RVLT Flow <flow@rvlt.app>"),
+  // Phase 6b flag — see src/lib/native-writes.ts. Read directly via process.env
+  // there (not via `env.NATIVE_EMAIL_SIDEEFFECTS`) so the schema's only job is
+  // catching a typo'd/undocumented var name; the boolean coercion stays local
+  // to the call site.
+  NATIVE_EMAIL_SIDEEFFECTS: z.string().optional(),
 
   // (File storage moved to Convex `_storage`; the S3/Garage env vars were removed.)
 


### PR DESCRIPTION
## Summary

Closes #857 / #869 (tracking).

- The `.env.example` half of #857 was already fixed by 645a81e (closed #823/#836) — all four vars (`NATIVE_EMAIL_SIDEEFFECTS`, `NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED`, `ENABLE_CONVEX_CRONS`, `CONVEX_CRON_TARGET_URL`) are already documented there as commented-out entries. No change needed.
- The remaining gap was the Zod schema: `NEXT_PUBLIC_SITE_ADMIN_REG_ENABLED` was already validated in `src/env.ts`, but `NATIVE_EMAIL_SIDEEFFECTS` wasn't. It's read via `process.env.NATIVE_EMAIL_SIDEEFFECTS` in `src/lib/native-writes.ts` (part of the Next.js app), so it belongs in the schema — added as `z.string().optional()`, matching the existing flag style.
- **`ENABLE_CONVEX_CRONS` and `CONVEX_CRON_TARGET_URL` are deliberately *not* added to `src/env.ts`.** Both are read only in `convex/scheduledJobs.ts`, which runs in the separate Convex deployment bundle — that file already has a comment explaining these are "duplicated here (not imported) since convex/ is a separate deployment bundle from src/". Adding them to `src/env.ts`'s schema would validate nothing real: the Next.js app doesn't consume them, and the Convex deployment never parses this file. `convex/scheduledJobs.ts` already throws at call time if either is unset once the flag is flipped on (lines 62-67) — that's the correct fail-fast backstop for a serverless deployment with no single boot moment, and it was already in place before this PR.
- `.env.local.example` and `.env.convex.example` (also named in #857's title) don't need these vars either — they're scoped to a different variable set (shared-dev-Convex auth-bridge overrides, and self-hosted Convex docker-compose config respectively), not a general app env reference.

## Testing

- `pnpm exec vitest run src/env.test.ts` — added two tests: `NATIVE_EMAIL_SIDEEFFECTS` defaults to `undefined`, and is accepted/preserved when set.
- `pnpm test` — full suite, 4035 tests passed.
- `pnpm lint` — 0 errors on touched files.

## Checklist

- [x] No new dependency.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WzGwXbnLR4GxbmJ39vExyF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzGwXbnLR4GxbmJ39vExyF)_