### PR TITLE
fix(#859): lint-ban @ts-ignore/@ts-nocheck outright (R-8.2.2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,10 +90,17 @@ const eslintConfig = [
         "warn",
         { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true },
       ],
+      // `any` stays "warn": the count is ratcheted instead of lint-banned outright
+      // (R-8.2.2 explicitly allows "count ratcheted (never grows)" as the interim
+      // control — see docs/exceptions.md R-8.2.2, expiry 2026-10-23). CI enforcement
+      // is `scripts/any-ratchet.sh` (`pnpm run any-ratchet`), not this lint level.
       "@typescript-eslint/no-explicit-any": "warn",
-      // Ban @ts-ignore / @ts-nocheck; allow described @ts-expect-error (R-8.2.2).
+      // Ban @ts-ignore / @ts-nocheck outright (R-8.2.2 has no ratchet allowance for
+      // these — count is 0, so "error" costs nothing and closes the gap where "warn"
+      // let a future PR add one without failing CI). Described @ts-expect-error stays
+      // allowed.
       "@typescript-eslint/ban-ts-comment": [
-        "warn",
+        "error",
         {
           "ts-ignore": true,
           "ts-nocheck": true,


### PR DESCRIPTION
## Summary

Closes #859, #871.

- `@typescript-eslint/ban-ts-comment` flips from `"warn"` to `"error"`. Current `@ts-ignore`/`@ts-nocheck` count is 0, so this is a zero-risk change — it just closes the gap where a future PR could add one without failing CI (`pnpm run lint` has no `--max-warnings 0`, so warn-only rules never gate a merge).
- `@typescript-eslint/no-explicit-any` **stays** `"warn"` by design: POLICY.md R-8.2.2 explicitly allows "count ratcheted (never grows)" as the interim control for `any`, and that's already covered by the dated §15 exception in `docs/exceptions.md` (expiry 2026-10-23) plus the CI-blocking `scripts/any-ratchet.sh` gate (currently holding at 137, wired into `ci.yml`). No code change needed there — the audit's "no ratchet or CI gate stopping growth" finding predates that mechanism landing.

## Testing

- `pnpm run lint` — 0 errors (1529 pre-existing warnings, unrelated to this change)
- `bash scripts/any-ratchet.sh` — ratchet holds (137/137)
- `pnpm exec vitest run` — 3575 tests passed; the 42 failing test files all fail identically on a missing `@/generated/prisma/client` (pre-existing environment gap in this checkout — no `DATABASE_URL` to run `prisma generate`), unrelated to this diff
- `pnpm exec tsc --noEmit` — pre-existing errors only (same missing generated-client + a handful of unrelated implicit-any sites), confirmed identical before/after this change via `git stash`

## Checklist

- [x] No new dependency

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjzDrjKQVE4dTV5YG5PzVv)_