### PR TITLE
Fix ROI Revenue Attributed: unpriced-group audit + booked-scope window

### DIFF
--- a/FEATUREDOCS/57-revenue-allocation-roi.md
+++ b/FEATUREDOCS/57-revenue-allocation-roi.md
@@ -166,10 +166,41 @@ calls — no server action in between; `src/server/roi.ts` doesn't exist).
 
 Both cap their scans and return `truncated`, which the UI surfaces as a banner. A capped scan that
 silently under-reports looks exactly like a fleet that isn't earning. When the caps start biting,
-the fix is a scheduled org-level aggregate, not a bigger cap.
+the fix is a scheduled org-level aggregate, not a bigger cap. In practice this doesn't bite a small
+org — `PROJECT_SCAN_CAP` (1500) and `ROLLUP_READ_BUDGET` (10,000 rollup rows) are both far above
+what a few hundred projects ever produce, so if a fleet report looks short on a small org, the
+`truncated` banner is not why — see "Why revenue looks low" below.
 
 `projectModelRevenues` is a **pure cache** — safe to delete and rebuild from the line items at any
 time by re-running the backfill.
+
+### Why revenue looks low
+
+The #1 cause: **an unpriced group carrying real gear.** `recalcProjectTotals` bills grouped
+equipment as `group.price × group.quantity` — a grouped line item's own `lineTotal` never reaches
+revenue (see "Why it was needed" above). If a group's `price` is `0`/unset, the gear inside it
+reports $0 in **both** the project's own total **and** ROI — restructuring a project into groups
+(e.g. a historical-data backfill done through the app) fixes the *shape* of the data but not the
+*price*, and it's easy to move gear into a group without noticing the group itself was never given
+a flat price.
+
+`api.roi.zeroPricedGroups` (`convex/roi.ts`) finds these: every group in a counted-status project
+with `price ?? 0 === 0` that still contains a non-cancelled, non-optional, non-custom line with a
+`modelId`. It returns the group's `suggestedPrice` (the same cost-weighted hint the group-price UI
+shows) as a hint of what it's probably worth — never treated as the answer, since it's a cost
+proxy, not what the client was actually charged. Surfaced as a collapsible banner on `/assets/roi`
+(`useZeroPricedGroups`, `src/hooks/use-roi.ts`) linking straight to the offending project — that's
+the fix, not a bigger cap or a recompute; the number is faithfully reporting $0 because the group
+really has no price on file.
+
+The #2 cause: **scope/window, not data.** The default view is `earned` (COMPLETED + INVOICED
+only) over the trailing 12 months — a fleet mostly sitting in `CONFIRMED`/`CHECKED_OUT` or with a
+lot of history outside the last year will look emptier than "all the money we've made". Switch to
+"Including booked work" + "All time" before assuming the allocation itself is wrong.
+
+Related gotcha: `defaultRoiWindow(scope)` leaves `to` **open** for `booked` scope specifically —
+capping it at `now` (as `earned` does) would hide the future-dated `CONFIRMED`/`PREPPING` bookings
+that scope exists to show, forcing a second switch to "All time" just to see next week's job.
 
 ## Files
 
@@ -179,7 +210,7 @@ time by re-running the backfill.
 | `convex/lib/recalc.ts` | Calls it, at the tail of every project recompute. |
 | `convex/revenueAllocation.ts` | Standalone recompute (legacy path + backfill) and paginated project ids. |
 | `convex/kitAllocations.ts` | Kit split: composition view, replace-all, clear. |
-| `convex/roi.ts` | `getModelRoi`, `fleetRevenue`, `fleetInventory`. |
+| `convex/roi.ts` | `getModelRoi`, `fleetRevenue`, `fleetInventory`, `zeroPricedGroups`. |
 | `src/lib/roi.ts` | `computeRoi`, status scopes, window, formatting. |
 | `src/hooks/use-roi.ts` | Browser-direct: joins the two fleet queries client-side (one-shot, not reactive — a ROI report has no liveness need). |
 | `convex/kitAllocationsWrites.ts` | Browser-direct RBAC + validation + audit for the kit split. |

--- a/convex/roi.test.ts
+++ b/convex/roi.test.ts
@@ -236,6 +236,76 @@ describe("getModelRoi — tenant isolation", () => {
   });
 });
 
+describe("zeroPricedGroups — flags gear that can't earn revenue", () => {
+  test("flags an unpriced group carrying real gear, ignores a priced one and a customs-only one", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", {
+        id: "p1", organizationId: ORG, projectNumber: "P1", name: "Wedding Gig",
+        status: "COMPLETED", isTemplate: false, createdAt: NOW, updatedAt: NOW,
+      });
+      // Unpriced group with real gear inside — the case this report exists to catch.
+      await ctx.db.insert("projectGroups", {
+        id: "g_unpriced", organizationId: ORG, projectId: "p1", title: "RF Kit",
+        quantity: 1, suggestedPrice: 450,
+      });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", groupId: "g_unpriced", modelId: "rx",
+      });
+      // A cancelled line inside the same group must not count toward gearLineCount.
+      await ctx.db.insert("projectLineItems", {
+        id: "l1b", organizationId: ORG, projectId: "p1", groupId: "g_unpriced", modelId: "rx",
+        status: "CANCELLED",
+      });
+      // Priced group — not flagged, its gear earns normally.
+      await ctx.db.insert("projectGroups", {
+        id: "g_priced", organizationId: ORG, projectId: "p1", title: "Lighting Package",
+        price: 900, quantity: 1,
+      });
+      await ctx.db.insert("projectLineItems", {
+        id: "l2", organizationId: ORG, projectId: "p1", groupId: "g_priced", modelId: "par",
+      });
+      // Unpriced group with only a custom item, no gear — not flagged (nothing of
+      // ours to attribute; the custom item bills on its own per recalc.ts).
+      await ctx.db.insert("projectGroups", {
+        id: "g_customs_only", organizationId: ORG, projectId: "p1", title: "Freight",
+        quantity: 1,
+      });
+      await ctx.db.insert("projectLineItems", {
+        id: "l3", organizationId: ORG, projectId: "p1", groupId: "g_customs_only",
+        isCustomItem: true,
+      });
+    });
+
+    const res = await asService(t).query(api.roi.zeroPricedGroups, { orgId: ORG, statuses: COUNTED });
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0]).toMatchObject({
+      projectId: "p1", groupId: "g_unpriced", groupTitle: "RF Kit",
+      gearLineCount: 1, suggestedPrice: 450,
+    });
+    expect(res.truncated).toBe(false);
+  });
+
+  test("only scans counted-status projects", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", {
+        id: "quote", organizationId: ORG, projectNumber: "Q1", name: "Just a quote",
+        status: "QUOTED", isTemplate: false, createdAt: NOW, updatedAt: NOW,
+      });
+      await ctx.db.insert("projectGroups", {
+        id: "g1", organizationId: ORG, projectId: "quote", title: "RF Kit", quantity: 1,
+      });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "quote", groupId: "g1", modelId: "rx",
+      });
+    });
+
+    const res = await asService(t).query(api.roi.zeroPricedGroups, { orgId: ORG, statuses: COUNTED });
+    expect(res.rows).toHaveLength(0);
+  });
+});
+
 describe("status gating lives in Convex, not only in the server action", () => {
   test("a caller asking for QUOTED revenue gets nothing", async () => {
     const t = convexTest(schema, modules);

--- a/convex/roi.ts
+++ b/convex/roi.ts
@@ -277,6 +277,89 @@ export const fleetRevenue = query({
 });
 
 /**
+ * Groups in counted-status projects that carry real gear but have no flat price.
+ *
+ * `recalcProjectTotals` bills grouped equipment as `group.price × group.quantity` —
+ * a grouped line item's own `lineTotal` never reaches revenue (see
+ * FEATUREDOCS/57-revenue-allocation-roi.md). An unpriced group containing gear
+ * therefore reports $0 for that gear in BOTH the project's own total AND ROI — this
+ * is the #1 cause of "ROI is lower than what we actually sold". It's the single
+ * most actionable data-quality signal for this report, so it gets its own query
+ * rather than being buried in a per-project drill-down.
+ *
+ * `suggestedPrice` (cost-weighted, computed the same way the group-price UI
+ * suggests one) is returned as a hint of what the group is probably worth — never
+ * treated as the answer, since it's a cost proxy, not what the client was actually
+ * charged.
+ */
+export const zeroPricedGroups = query({
+  args: {
+    orgId: v.string(),
+    statuses: v.array(v.string()),
+  },
+  handler: async (ctx, { orgId, statuses }) => {
+    await requireOrgRead(ctx, orgId);
+    const counted = countableStatuses(statuses);
+
+    const scanned = await ctx.db
+      .query("projects")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+      .order("desc")
+      .take(PROJECT_SCAN_CAP);
+
+    const inScope = scanned.filter((p) => !p.isTemplate && counted.has(p.status ?? ""));
+
+    const rows: {
+      projectId: string;
+      projectNumber: string;
+      projectName: string;
+      groupId: string;
+      groupTitle: string;
+      gearLineCount: number;
+      suggestedPrice: number | null;
+    }[] = [];
+    let rowsRead = 0;
+    let truncated = scanned.length === PROJECT_SCAN_CAP;
+
+    for (const p of inScope) {
+      if (rowsRead >= ROLLUP_READ_BUDGET) {
+        truncated = true;
+        break;
+      }
+      const [groups, lines] = await Promise.all([
+        ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", p.id)).collect(),
+        ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", p.id)).collect(),
+      ]);
+      rowsRead += groups.length + lines.length;
+
+      for (const g of groups) {
+        if (Number(g.price ?? 0) > 0) continue;
+        const gearLines = lines.filter(
+          (l) =>
+            l.groupId === g.id &&
+            l.status !== "CANCELLED" &&
+            l.isOptional !== true &&
+            l.isCustomItem !== true &&
+            l.modelId != null,
+        );
+        if (gearLines.length === 0) continue;
+        rows.push({
+          projectId: p.id,
+          projectNumber: p.projectNumber,
+          projectName: p.name,
+          groupId: g.id,
+          groupTitle: g.title,
+          gearLineCount: gearLines.length,
+          suggestedPrice: g.suggestedPrice ?? null,
+        });
+      }
+    }
+
+    return { rows, truncated };
+  },
+});
+
+/**
  * The capital side: every active model and how many units of it we own.
  *
  * Scans assets org-wide ONCE and tallies, rather than per-model, so models with

--- a/src/components/assets/model-roi-tab.tsx
+++ b/src/components/assets/model-roi-tab.tsx
@@ -46,7 +46,7 @@ export function ModelRoiTab({ modelId }: { modelId: string }) {
   const [scope, setScope] = useState<RoiScope>("earned");
   const [allTime, setAllTime] = useState(false);
 
-  const window = useMemo(() => (allTime ? undefined : defaultRoiWindow()), [allTime]);
+  const window = useMemo(() => (allTime ? undefined : defaultRoiWindow(scope)), [allTime, scope]);
 
   const { data, isLoading } = useModelRoi(modelId, { scope, from: window?.from, to: window?.to });
 

--- a/src/components/roi/fleet-roi.tsx
+++ b/src/components/roi/fleet-roi.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useFleetRoi, type FleetRoiData } from "@/hooks/use-roi";
+import { useFleetRoi, useZeroPricedGroups, type FleetRoiData } from "@/hooks/use-roi";
 import { formatCurrency } from "@/lib/formatters";
 import { defaultRoiWindow, ROI_SCOPE_LABELS, type RoiScope } from "@/lib/roi";
 import { PaybackBar } from "@/components/roi/payback-bar";
@@ -58,9 +58,10 @@ export function FleetRoi() {
   const [asc, setAsc] = useState(false);
   const [q, setQ] = useState("");
 
-  const window = useMemo(() => (allTime ? undefined : defaultRoiWindow()), [allTime]);
+  const window = useMemo(() => (allTime ? undefined : defaultRoiWindow(scope)), [allTime, scope]);
 
   const { data, isLoading } = useFleetRoi({ scope, from: window?.from, to: window?.to });
+  const { data: zeroPriced } = useZeroPricedGroups(scope);
 
   const rows = useMemo(() => {
     if (!data) return [];
@@ -109,6 +110,42 @@ export function FleetRoi() {
             {data.projectsCounted} projects. Narrow the window for exact figures.
           </p>
         </div>
+      )}
+
+      {zeroPriced && zeroPriced.rows.length > 0 && (
+        <details className="rounded-md border border-warn/40 bg-warn-soft">
+          <summary className="flex cursor-pointer list-none items-start gap-3 p-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warn" />
+            <span className="text-caption text-ink-2">
+              {zeroPriced.rows.length} group{zeroPriced.rows.length === 1 ? "" : "s"} with real
+              gear but no price set — that gear is reporting $0 revenue here (and on the
+              project itself).{" "}
+              <span className="text-link">Show groups</span>
+              {zeroPriced.truncated && " (partial — hit the scan limit)"}
+            </span>
+          </summary>
+          <ul className="space-y-1 border-t border-warn/40 px-3 py-2">
+            {zeroPriced.rows.map((r) => (
+              <li
+                key={`${r.projectId}:${r.groupId}`}
+                className="flex flex-wrap items-baseline justify-between gap-x-3 text-caption text-ink-2"
+              >
+                <span>
+                  <Link href={`/projects/${r.projectId}`} className="text-link hover:underline">
+                    {r.projectNumber} — {r.projectName}
+                  </Link>{" "}
+                  · &ldquo;{r.groupTitle}&rdquo; ({r.gearLineCount} gear line
+                  {r.gearLineCount === 1 ? "" : "s"})
+                </span>
+                <span className="text-faint">
+                  {r.suggestedPrice != null
+                    ? `suggested ${formatCurrency(r.suggestedPrice)}`
+                    : "no suggested price"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </details>
       )}
 
       <div className="flex flex-wrap items-center gap-2">

--- a/src/hooks/use-roi.ts
+++ b/src/hooks/use-roi.ts
@@ -125,6 +125,52 @@ export function useFleetRoi(opts: {
   return { data, isLoading: data === undefined };
 }
 
+export type ZeroPricedGroupsData = (typeof api.roi.zeroPricedGroups)["_returnType"];
+
+/**
+ * The "why is my ROI low" diagnostic: groups in counted-status projects that carry
+ * real gear but have no flat price, so that gear silently reports $0. Scoped to
+ * `scope` (earned/booked) like the fleet report, but NOT date-windowed — a
+ * mispriced group is a data problem regardless of which window happens to be
+ * selected, and hiding it behind "Last 12 months" would just resurface the same
+ * confusion the next time someone narrows the window.
+ */
+export function useZeroPricedGroups(scope: RoiScope): {
+  data: ZeroPricedGroupsData | undefined;
+  isLoading: boolean;
+} {
+  const convex = useConvex();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const key = `${orgId ?? ""}|${scope}`;
+
+  const [raw, setRaw] = useState<{ key: string; value: ZeroPricedGroupsData } | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!orgId) {
+      setRaw(undefined);
+      return;
+    }
+    let cancelled = false;
+    convex
+      .query(api.roi.zeroPricedGroups, { orgId, statuses: statusesForScope(scope) })
+      .then((value) => {
+        if (!cancelled) setRaw({ key, value });
+      })
+      .catch(() => {
+        /* report read is best-effort; leave loading state */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [convex, orgId, scope, key]);
+
+  const data = raw && raw.key === key ? raw.value : undefined;
+  return { data, isLoading: data === undefined };
+}
+
 type ModelRoiQuery = (typeof api.roi.getModelRoi)["_returnType"];
 
 export type ModelRoiData = ModelRoiQuery & {

--- a/src/lib/roi.test.ts
+++ b/src/lib/roi.test.ts
@@ -83,10 +83,17 @@ describe("statusesForScope", () => {
 });
 
 describe("defaultRoiWindow", () => {
-  test("is the trailing twelve months", () => {
+  test("earned scope is the trailing twelve months, capped at now", () => {
     const now = new Date("2026-07-10T00:00:00Z").getTime();
-    const { from, to } = defaultRoiWindow(now);
+    const { from, to } = defaultRoiWindow("earned", now);
     expect(to).toBe(now);
+    expect(new Date(from).toISOString()).toBe("2025-07-10T00:00:00.000Z");
+  });
+
+  test("booked scope leaves `to` open so future bookings aren't hidden", () => {
+    const now = new Date("2026-07-10T00:00:00Z").getTime();
+    const { from, to } = defaultRoiWindow("booked", now);
+    expect(to).toBeUndefined();
     expect(new Date(from).toISOString()).toBe("2025-07-10T00:00:00.000Z");
   });
 });

--- a/src/lib/roi.ts
+++ b/src/lib/roi.ts
@@ -41,12 +41,23 @@ export const ROI_SCOPE_LABELS: Record<RoiScope, string> = {
   booked: "Including booked work",
 };
 
-/** Trailing-12-months window, the default the reports open on. */
-export function defaultRoiWindow(now: number = Date.now()): { from: number; to: number } {
-  const to = now;
+/**
+ * Trailing-12-months window, the default the reports open on.
+ *
+ * `to` is left open (undefined) for `booked` scope: that scope exists specifically
+ * to surface committed FUTURE work (a CONFIRMED shoot next month), and capping `to`
+ * at `now` would hide exactly the rows it's for — a user would have to also switch
+ * to "All time" to see next week's booking, which reads as "the number is wrong"
+ * rather than "the window is wrong". `earned` scope is inherently historical
+ * (COMPLETED/INVOICED), so it keeps the `to: now` cap.
+ */
+export function defaultRoiWindow(
+  scope: RoiScope,
+  now: number = Date.now(),
+): { from: number; to?: number } {
   const d = new Date(now);
   d.setFullYear(d.getFullYear() - 1);
-  return { from: d.getTime(), to };
+  return scope === "booked" ? { from: d.getTime() } : { from: d.getTime(), to: now };
 }
 
 export interface RoiMetrics {


### PR DESCRIPTION
## Summary

Investigates why Fleet ROI's "Revenue attributed" reads lower than actual gear sales, even with scope set to "Including booked work" + "All time".

- **`zeroPricedGroups` audit** (`convex/roi.ts`) — `recalcProjectTotals` bills grouped equipment as `group.price × quantity`, never the members' own `lineTotal`. A group whose *structure* was corrected (e.g. during a historical backfill) but never given a flat `price` silently reports $0 for that gear in both the project total and ROI. This query finds every such group in a counted-status project and is surfaced as a collapsible warning banner on `/assets/roi`, linking straight to the offending project with a cost-weighted suggested price.
- **`defaultRoiWindow` fix** (`src/lib/roi.ts`) — the trailing-12-months window always capped `to` at `now()`, so switching to "Including booked work" alone couldn't surface a future-dated CONFIRMED/PREPPING booking; users had to also flip to "All time". Booked scope now leaves the window open-ended going forward.
- Docs: new "Why revenue looks low" section in `FEATUREDOCS/57-revenue-allocation-roi.md` covering both causes, plus a note that the read-budget caps (1,500 projects / 10,000 rollup rows) are not the issue at small org scale.

## Testing

- `pnpm exec vitest run src/lib/roi.test.ts convex/roi.test.ts` — 26 passed (includes 2 new `defaultRoiWindow` cases and 2 new `zeroPricedGroups` cases: flags an unpriced group with real gear, ignores a priced group and a customs-only group; only scans counted-status projects)
- `pnpm exec vitest run src/components/assets/__tests__/model-roi-tab.smoke.test.tsx` — 3 passed (unaffected by the `defaultRoiWindow` signature change)
- `pnpm exec tsc --noEmit` — no new errors introduced (pre-existing errors in this checkout are all unrelated missing-generated-Prisma-client, not touched by this change)
- `pnpm exec eslint` on all changed files — 0 errors (pre-existing warning patterns only, matching the rest of the file)

## Checklist

- [x] New dependency? N/A — no new dependencies added.

**Note:** `convex/roi.ts` needs `pnpm exec convex deploy` (handled automatically by the deploy pipeline on merge to `main`) before `zeroPricedGroups` is live in production.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LHhVHGco6xujYaGi3mHXw)_