### PR TITLE
Fix remaining easy CodeQL alerts (verified dead-code + one more security guard)

### DIFF
--- a/convex/projectServicesWrites.ts
+++ b/convex/projectServicesWrites.ts
@@ -909,7 +909,7 @@ export const generateServicesNative = mutation({
     for (const tmpl of templatesToUse) {
       const { date, endDate } = getServiceDateForType(tmpl.type, dateBundle);
       if (date == null) continue;
-      if (tmpl.type === "LABOUR" && date != null && endDate != null && endDate > date) {
+      if (tmpl.type === "LABOUR" && endDate != null && endDate > date) {
         for (let cur = date; cur <= endDate; cur += DAY) {
           const key = `${tmpl.type}:${dayKeyOf(cur)}`;
           if (!existingKey.has(key)) {

--- a/src/lib/convex-client.ts
+++ b/src/lib/convex-client.ts
@@ -81,7 +81,7 @@ export function toConvexValue(value: unknown): unknown {
   if (value === null || value === undefined) return undefined;
   if (value instanceof Date) return value.getTime();
   // Prisma Decimal exposes toNumber(); duck-type it without importing the type.
-  if (typeof value === "object" && value !== null && "toNumber" in value && typeof (value as { toNumber: unknown }).toNumber === "function") {
+  if (typeof value === "object" && "toNumber" in value && typeof (value as { toNumber: unknown }).toNumber === "function") {
     return (value as { toNumber: () => number }).toNumber();
   }
   return value;

--- a/src/lib/pdfme/plugins/gearflow-data-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-data-table.ts
@@ -121,7 +121,7 @@ export const gearflowDataTable: Plugin<DataTableSchema> = {
           }
         }
       } else if (config.rows) {
-        currentY = drawRows(page, config.rows, config, colWidths, x, currentY, width, regular, bold, pdfLib, 0);
+        drawRows(page, config.rows, config, colWidths, x, currentY, width, regular, bold, pdfLib, 0);
       }
     })();
   },

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -305,7 +305,6 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
       // their items continuing onto the next page (Eng review finding).
       const minBodyRowHeight = fontSize + rowPadding * 2;
       if (currentY - (ghHeight + minBodyRowHeight) < bottomBoundary) {
-        overflow = true;
         break;
       }
       page.drawRectangle({

--- a/src/lib/serialize.ts
+++ b/src/lib/serialize.ts
@@ -9,7 +9,7 @@ import { isDangerousObjectKey } from "@/lib/safe-object-key";
  */
 export function serialize<T>(data: T): T {
   if (data === null || data === undefined) return data;
-  if (typeof data === "object" && data !== null && "toNumber" in data && typeof (data as Record<string, unknown>).toNumber === "function") {
+  if (typeof data === "object" && "toNumber" in data && typeof (data as Record<string, unknown>).toNumber === "function") {
     return (data as unknown as { toNumber(): number }).toNumber() as T;
   }
   if (data instanceof Date) return data;

--- a/src/lib/table-utils.ts
+++ b/src/lib/table-utils.ts
@@ -3,6 +3,8 @@
  * Used by server actions to translate DataTable filter state into Prisma queries.
  */
 
+import { isDangerousObjectKey } from "@/lib/safe-object-key";
+
 export type FilterType = "enum" | "text" | "date" | "number" | "boolean";
 
 export type FilterValue =
@@ -88,16 +90,20 @@ export function buildFilterWhere(
 function setNestedWhere(obj: Record<string, unknown>, path: string, value: unknown) {
   const parts = path.split(".");
   if (parts.length === 1) {
+    if (isDangerousObjectKey(path)) return;
     obj[path] = value;
     return;
   }
 
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
+    if (isDangerousObjectKey(parts[i])) return;
     if (!current[parts[i]] || typeof current[parts[i]] !== "object") {
       current[parts[i]] = {};
     }
     current = current[parts[i]] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  if (isDangerousObjectKey(lastKey)) return;
+  current[lastKey] = value;
 }

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -339,10 +339,9 @@ export async function processWooCommerceOrder(
       updatedAt: projectCreatedAt,
     });
     let createResult = await convex.mutation(api.projects.createWithUniqueNumber, buildProjectArgs(projectNumber));
-    let finalProjectNumber = projectNumber;
     if (!createResult.created) {
-      finalProjectNumber = `${projectNumber}-${Date.now().toString(36).slice(-4)}`;
-      createResult = await convex.mutation(api.projects.createWithUniqueNumber, buildProjectArgs(finalProjectNumber));
+      const retryProjectNumber = `${projectNumber}-${Date.now().toString(36).slice(-4)}`;
+      createResult = await convex.mutation(api.projects.createWithUniqueNumber, buildProjectArgs(retryProjectNumber));
       if (!createResult.created) throw new Error("Could not allocate a unique web-order project number");
     }
     const project = await getProjectByIdMapped(projectId, orgId);


### PR DESCRIPTION
## Summary

Follow-up to #885 (merged) — handles the "needs a short look-around first" bucket from the
CodeQL audit. All 7 items here turned out to be genuinely easy once investigated, verified
line-by-line rather than removed on the strength of the CodeQL label alone:

- **`js/prototype-pollution-utility`** (#3, `table-utils.ts`) — confirmed via call-site audit
  that `setNestedWhere`'s `path` always comes from server-defined `columnDefs`, not raw
  request input, so it wasn't reachable today. Guarded anyway (reusing the
  `isDangerousObjectKey` helper from #885) since it's a shared utility.
- **`js/comparison-between-incompatible-types`** ×3 (#15, #19, #20) — each verified
  individually to be a dead check already excluded by an earlier early-return/guard in the
  same function. Pure dead-code removal.
- **`js/useless-assignment-to-local`** ×3 (#22, #23, #24) — each traced end-to-end (not just
  the flagged line) given this codebase's documented history of silent PDF-pipeline bugs from
  this exact shape of issue. All three confirmed genuinely dead with no downstream reader.

**Deliberately excluded**: the 3 sibling `js/comparison-between-incompatible-types` alerts in
`src/app/(app)/warehouse/[projectId]/page.tsx` (#16, #17, #18). Those turned out NOT to be
dead code — they're a real operator-precedence bug (`!x != null` always evaluates `true`)
that currently mis-filters sub-hire equipment items. Being fixed and live-verified in the
warehouse flow separately, not bundled into this "verified safe" PR.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 303 test files / 4034 tests, all passing
- [x] `node scripts/knip-ratchet.mjs` — 480/480 (learned this lesson the hard way on #885 —
      checked explicitly this time before pushing)
- [x] `depcruise-ratchet.mjs`, `any-ratchet.sh`, `collect-ratchet.mjs`,
      `check-migration-drift.mjs` — all clean
- [ ] CI green on this PR