### PR TITLE
ROI: sum per-asset purchase price for serialised-model fleet cost

### DIFF
--- a/FEATUREDOCS/57-revenue-allocation-roi.md
+++ b/FEATUREDOCS/57-revenue-allocation-roi.md
@@ -135,13 +135,37 @@ ROI is measured against the capital actually deployed:
 
 ```
 unitsOwned = active assets + SUM(active bulkAssets.totalQuantity)
-fleetCost  = replacementCost × unitsOwned
-payback    = revenue / fleetCost
+
+# Serialised: SUM per asset — not a uniform multiply. Each unit's own purchase
+# price wins if it has one; models bought at different times/prices are not
+# forced onto one number (gearflow#798).
+serialisedCost = SUM over each owned asset of:
+  asset.purchasePrice
+  else model.defaultPurchasePrice
+  else model.replacementCost
+  else 0                              -- no signal for this unit
+
+# Bulk: unchanged — one rate for the whole stock line, out of scope for #798
+# (bulkAssets.purchasePricePerUnit is a separate, already-per-unit field a
+# future issue can wire up).
+bulkCost  = replacementCost × SUM(active bulkAssets.totalQuantity)
+
+fleetCost = (serialisedCost + bulkCost), or NULL if unitsOwned == 0 or the sum is $0
+payback   = revenue / fleetCost
 ```
 
-Not `revenue / replacementCost` — that overstates ROI by exactly the unit count, worst for the
-models bought in the largest numbers. A model with no replacement cost, or none left in the fleet,
-reports `—`: not `0` (looks like a dud), not `∞` (looks like a triumph).
+Not `revenue / replacementCost × unitsOwned` — that overstates ROI by exactly the unit count
+(worst for the models bought in the largest numbers) AND assumes every unit cost the same, which
+is untrue the moment a model's assets were bought at different prices over time. A model with no
+cost signal anywhere — no asset purchase price, no model-level purchase price or replacement
+cost — or none left in the fleet, reports `—`: not `0` (looks like a dud), not `∞` (looks like a
+triumph). A raw per-asset/bulk sum of exactly `$0` is treated identically to "no signal" — it's
+indistinguishable from "nothing priced it" and the alternative (reporting $0 fleet cost) reads as
+infinite ROI on a progress bar.
+
+The fallback chain is per-ASSET, not per-model: two units of the same model can legitimately
+resolve through different rungs of the chain (one has its own `purchasePrice`, the sibling falls
+back to `model.replacementCost`) and both contribute to the same model's `fleetCost` total.
 
 ### Surfaces
 
@@ -202,6 +226,27 @@ Related gotcha: `defaultRoiWindow(scope)` leaves `to` **open** for `booked` scop
 capping it at `now` (as `earned` does) would hide the future-dated `CONFIRMED`/`PREPPING` bookings
 that scope exists to show, forcing a second switch to "All time" just to see next week's job.
 
+### Fleet cost fallback chain (gearflow#798)
+
+Serialised-asset fleet cost is a per-asset chain, not a single model-wide scalar:
+`asset.purchasePrice ?? model.defaultPurchasePrice ?? model.replacementCost`. The middle rung was
+a deliberate choice, not a guess (POLICY.md R-3.1 — recorded here so it isn't re-litigated):
+`defaultPurchasePrice` is the semantically correct fallback ("what we generally pay for this
+model" vs. `replacementCost`'s "what it'd cost to replace it today"), but falling through further
+to `replacementCost` when `defaultPurchasePrice` is also unset matters — `replacementCost` is the
+field every other ROI/allocation surface already populates (kit-allocation weighting, the
+allocation engine's `rateFactor` derivation), so skipping it would silently regress models that
+report a real fleet cost today back to `—` purely because `defaultPurchasePrice` was never
+backfilled.
+
+Every rung is treated as "no signal" when it's `≤ 0`, not just when it's unset — the long-standing
+"a zero replacement cost is unknown, not free capital" rule (`src/lib/roi.test.ts`), now applied
+uniformly across the whole chain (`positiveCost` in `convex/roi.ts`).
+
+`bulkAssets` are explicitly out of scope: their fleet cost stays `replacementCost × totalQuantity`
+(`bulkAssets.purchasePricePerUnit` is a separate, already-per-unit field a future issue could wire
+up the same way).
+
 ## Files
 
 | Path | Role |
@@ -210,7 +255,7 @@ that scope exists to show, forcing a second switch to "All time" just to see nex
 | `convex/lib/recalc.ts` | Calls it, at the tail of every project recompute. |
 | `convex/revenueAllocation.ts` | Standalone recompute (legacy path + backfill) and paginated project ids. |
 | `convex/kitAllocations.ts` | Kit split: composition view, replace-all, clear. |
-| `convex/roi.ts` | `getModelRoi`, `fleetRevenue`, `fleetInventory`, `zeroPricedGroups`. |
+| `convex/roi.ts` | `getModelRoi`, `fleetRevenue`, `fleetInventory`, `zeroPricedGroups`, `fleetCapitalFor` (the per-asset fleet-cost chain). |
 | `src/lib/roi.ts` | `computeRoi`, status scopes, window, formatting. |
 | `src/hooks/use-roi.ts` | Browser-direct: joins the two fleet queries client-side (one-shot, not reactive — a ROI report has no liveness need). |
 | `convex/kitAllocationsWrites.ts` | Browser-direct RBAC + validation + audit for the kit split. |

--- a/convex/roi.test.ts
+++ b/convex/roi.test.ts
@@ -95,6 +95,111 @@ describe("getModelRoi — status + date filtering", () => {
   });
 });
 
+/**
+ * The gearflow#798 fallback chain: `asset.purchasePrice ?? model.defaultPurchasePrice
+ * ?? model.replacementCost`, decided per asset — not a uniform `replacementCost ×
+ * unitsOwned` multiply. `getModelRoi` and `fleetInventory` share this via
+ * `fleetCapitalFor`/`assetCost`, so both are exercised here.
+ */
+describe("fleet cost — per-asset purchase-price chain (gearflow#798)", () => {
+  test("sums each asset's OWN purchase price — not a uniform multiply", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver", replacementCost: 999 });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1", purchasePrice: 1000 });
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "rx", assetTag: "A2", purchasePrice: 1500 });
+      await ctx.db.insert("assets", { id: "a3", organizationId: ORG, modelId: "rx", assetTag: "A3", purchasePrice: 2000 });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(4500); // 1000 + 1500 + 2000, NOT 999 × 3
+
+    const inv = await asService(t).query(api.roi.fleetInventory, { orgId: ORG });
+    expect(inv.rows.find((r) => r.modelId === "rx")?.fleetCost).toBe(4500);
+  });
+
+  test("falls back to model.defaultPurchasePrice before model.replacementCost", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", {
+        id: "rx", organizationId: ORG, name: "Receiver", defaultPurchasePrice: 800, replacementCost: 500,
+      });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1" });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(800); // defaultPurchasePrice wins, not replacementCost
+  });
+
+  test("falls all the way to replacementCost when defaultPurchasePrice is also unset", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver", replacementCost: 300 });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1" });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(300);
+  });
+
+  test("mixes real purchase prices with fallbacks within the same model", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver", replacementCost: 100 });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1", purchasePrice: 900 });
+      await ctx.db.insert("assets", { id: "a2", organizationId: ORG, modelId: "rx", assetTag: "A2" }); // falls back to 100
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(1000);
+  });
+
+  test("no cost signal anywhere reports fleetCost null, not $0 — units are owned but unpriced", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver" });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1" });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.unitsOwned).toBe(1);
+    expect(roi.fleetCost).toBeNull();
+
+    const inv = await asService(t).query(api.roi.fleetInventory, { orgId: ORG });
+    expect(inv.rows.find((r) => r.modelId === "rx")?.fleetCost).toBeNull();
+  });
+
+  test("a zero or negative value at any rung of the chain is treated as no signal, not free capital", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", {
+        id: "rx", organizationId: ORG, name: "Receiver", defaultPurchasePrice: -5, replacementCost: 250,
+      });
+      await ctx.db.insert("assets", { id: "a1", organizationId: ORG, modelId: "rx", assetTag: "A1", purchasePrice: 0 });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(250); // 0 and -5 both skipped; replacementCost is the first real signal
+  });
+
+  test("bulk stock is unchanged: replacementCost × totalQuantity, purchasePricePerUnit ignored", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver", replacementCost: 50 });
+      // purchasePricePerUnit set but out of scope for #798 — must not affect the sum.
+      await ctx.db.insert("bulkAssets", {
+        id: "b1", organizationId: ORG, modelId: "rx", assetTag: "B1", totalQuantity: 4, purchasePricePerUnit: 9999,
+      });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.fleetCost).toBe(200); // 50 × 4, not 9999 × 4
+  });
+
+  test("zero units owned reports fleetCost null even with a real replacementCost on file", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "rx", organizationId: ORG, name: "Receiver", replacementCost: 500 });
+    });
+    const roi = await asService(t).query(api.roi.getModelRoi, { orgId: ORG, modelId: "rx", statuses: COUNTED });
+    expect(roi.unitsOwned).toBe(0);
+    expect(roi.fleetCost).toBeNull();
+  });
+});
+
 describe("fleetRevenue — status + date filtering", () => {
   test("aggregates by model across counted projects only, tracking projectCount", async () => {
     const t = convexTest(schema, modules);

--- a/convex/roi.ts
+++ b/convex/roi.ts
@@ -62,17 +62,45 @@ const ATTRIBUTABLE_STATUSES = new Set([
 const countableStatuses = (requested: readonly string[]): Set<string> =>
   new Set(requested.filter((s) => ATTRIBUTABLE_STATUSES.has(s)));
 
+/** A cost field is only a signal if it's a real positive number — mirrors the
+ * long-standing "a zero replacement cost is unknown, not free capital" rule
+ * (src/lib/roi.test.ts), now applied uniformly to every field in the fallback chain. */
+const positiveCost = (v: number | null | undefined): number | null => (v != null && v > 0 ? v : null);
+
+type CostModel = { defaultPurchasePrice?: number | null; replacementCost?: number | null } | null | undefined;
+
 /**
- * Units of a model we actually own — serialised assets plus bulk stock on hand.
+ * One serialised asset's contribution to fleet cost: what we actually paid for it,
+ * else the model's general purchase price, else its replacement cost. Falls
+ * through to 0 (no signal) rather than inventing a number — see FEATUREDOCS/57 and
+ * gearflow#798 for why this chain, not `replacementCost` alone.
+ */
+const assetCost = (asset: { purchasePrice?: number | null }, model: CostModel): number =>
+  positiveCost(asset.purchasePrice) ?? positiveCost(model?.defaultPurchasePrice) ?? positiveCost(model?.replacementCost) ?? 0;
+
+/**
+ * Units of a model we actually own, and what it cost to acquire them.
+ *
+ * Serialised assets sum their OWN cost (mixed sources allowed — some units priced,
+ * some falling back). Bulk stock is unchanged: `replacementCost × totalQuantity`,
+ * out of scope for gearflow#798 (`bulkAssets.purchasePricePerUnit` is a separate,
+ * already-per-unit field a future issue can wire up).
+ *
+ * `fleetCost` is `null`, never `0`, when there is no capital to measure — no units
+ * owned, or units owned but not one of them (nor the model) carries any cost
+ * signal. A raw sum of $0 contributions is indistinguishable from "unpriced"; this
+ * is the ONE place that ambiguity gets resolved, so every caller downstream just
+ * sees a trustworthy null.
  *
  * `by_modelId` is NOT org-scoped. Every row it returns must be filtered on
  * `organizationId` or this counts another tenant's fleet.
  */
-async function unitsOwnedFor(
+async function fleetCapitalFor(
   ctx: QueryCtx,
   orgId: string,
   modelId: string,
-): Promise<{ unitsOwned: number; truncated: boolean }> {
+  model: CostModel,
+): Promise<{ unitsOwned: number; fleetCost: number | null; truncated: boolean }> {
   // Bounded: `.collect()` on a global index is unbounded, and blowing the read limit
   // throws the whole report. An undercounted denominator OVERSTATES payback, so a
   // truncated count has to be visible rather than quietly optimistic.
@@ -82,12 +110,21 @@ async function unitsOwnedFor(
   ]);
   const mine = <T extends { organizationId: string; isActive?: boolean }>(r: T) =>
     r.organizationId === orgId && r.isActive !== false;
+  const myAssets = assets.filter(mine);
+  const myBulk = bulk.filter(mine);
+
   // totalQuantity, not availableQuantity: ROI is about the capital we bought, not
   // how much of it happens to be on the shelf right now.
+  const bulkUnits = myBulk.reduce((s, b) => s + (b.totalQuantity ?? 0), 0);
+  const unitsOwned = myAssets.length + bulkUnits;
+
+  const assetCostSum = myAssets.reduce((s, a) => s + assetCost(a, model), 0);
+  const bulkCostSum = (positiveCost(model?.replacementCost) ?? 0) * bulkUnits;
+  const fleetCostRaw = assetCostSum + bulkCostSum;
+
   return {
-    unitsOwned:
-      assets.filter(mine).length +
-      bulk.filter(mine).reduce((s, b) => s + (b.totalQuantity ?? 0), 0),
+    unitsOwned,
+    fleetCost: unitsOwned > 0 && fleetCostRaw > 0 ? fleetCostRaw : null,
     truncated: assets.length === UNIT_SCAN_CAP || bulk.length === UNIT_SCAN_CAP,
   };
 }
@@ -153,16 +190,17 @@ export const getModelRoi = query({
 
     projects.sort((a, b) => (b.date ?? 0) - (a.date ?? 0));
     const revenueCents = projects.reduce((s, p) => s + Math.round(p.revenue * 100), 0);
-    const units = await unitsOwnedFor(ctx, orgId, modelId);
+    const capital = await fleetCapitalFor(ctx, orgId, modelId, model);
 
     return {
       modelId,
       modelName: model?.name ?? "Unknown model",
       replacementCost: model?.replacementCost ?? null,
-      unitsOwned: units.unitsOwned,
+      unitsOwned: capital.unitsOwned,
+      fleetCost: capital.fleetCost,
       revenue: revenueCents / 100,
       projects,
-      truncated: rollupsTruncated || units.truncated,
+      truncated: rollupsTruncated || capital.truncated,
     };
   },
 });
@@ -360,11 +398,12 @@ export const zeroPricedGroups = query({
 });
 
 /**
- * The capital side: every active model and how many units of it we own.
+ * The capital side: every active model, how many units of it we own, and what it
+ * cost to acquire them (see `fleetCapitalFor` for the per-asset/bulk cost chain).
  *
- * Scans assets org-wide ONCE and tallies, rather than per-model, so models with
- * zero revenue still appear. Those rows are the point of the report as much as the
- * earners are — dead capital doesn't announce itself.
+ * Scans assets org-wide ONCE and tallies per model, rather than querying per model,
+ * so models with zero revenue still appear. Those rows are the point of the report
+ * as much as the earners are — dead capital doesn't announce itself.
  */
 export const fleetInventory = query({
   args: { orgId: v.string() },
@@ -376,28 +415,38 @@ export const fleetInventory = query({
       ctx.db.query("assets").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).take(ASSET_CAP),
       ctx.db.query("bulkAssets").withIndex("by_organizationId", (q) => q.eq("organizationId", orgId)).take(BULK_ASSET_CAP),
     ]);
+    const modelsById = new Map(models.map((m) => [m.id, m]));
 
     const units = new Map<string, number>();
+    const costRaw = new Map<string, number>();
     for (const a of assets) {
       if (!a.modelId || a.isActive === false) continue;
       units.set(a.modelId, (units.get(a.modelId) ?? 0) + 1);
+      costRaw.set(a.modelId, (costRaw.get(a.modelId) ?? 0) + assetCost(a, modelsById.get(a.modelId)));
     }
     for (const b of bulk) {
       if (!b.modelId || b.isActive === false) continue;
-      units.set(b.modelId, (units.get(b.modelId) ?? 0) + (b.totalQuantity ?? 0));
+      const qty = b.totalQuantity ?? 0;
+      units.set(b.modelId, (units.get(b.modelId) ?? 0) + qty);
+      const rate = positiveCost(modelsById.get(b.modelId)?.replacementCost) ?? 0;
+      costRaw.set(b.modelId, (costRaw.get(b.modelId) ?? 0) + rate * qty);
     }
 
     return {
       rows: models
         .filter((m) => m.isActive !== false)
-        .map((m) => ({
-          modelId: m.id,
-          modelName: m.name,
-          manufacturer: m.manufacturer ?? null,
-          categoryId: m.categoryId ?? null,
-          replacementCost: m.replacementCost ?? null,
-          unitsOwned: units.get(m.id) ?? 0,
-        })),
+        .map((m) => {
+          const unitsOwned = units.get(m.id) ?? 0;
+          const raw = costRaw.get(m.id) ?? 0;
+          return {
+            modelId: m.id,
+            modelName: m.name,
+            manufacturer: m.manufacturer ?? null,
+            categoryId: m.categoryId ?? null,
+            fleetCost: unitsOwned > 0 && raw > 0 ? raw : null,
+            unitsOwned,
+          };
+        }),
       truncated:
         models.length === MODEL_CAP ||
         assets.length === ASSET_CAP ||

--- a/src/components/assets/model-roi-tab.tsx
+++ b/src/components/assets/model-roi-tab.tsx
@@ -168,7 +168,7 @@ export function ModelRoiTab({ modelId }: { modelId: string }) {
         <p className="text-caption text-muted">
           {data.unitsOwned === 0
             ? "No units of this model are in the fleet, so there is no capital to measure against."
-            : "Set a replacement cost on this model to see how far it is from paying for itself."}
+            : "Set a purchase price on this model's assets, or a default purchase price / replacement cost on the model, to see how far it is from paying for itself."}
         </p>
       ) : (
         <Panel>

--- a/src/components/roi/fleet-roi.tsx
+++ b/src/components/roi/fleet-roi.tsx
@@ -89,7 +89,7 @@ export function FleetRoi() {
           <Stat bright figure={formatCurrency(data.totalRevenue)} label="Revenue attributed" />
         </Panel>
         <Panel>
-          <Stat figure={formatCurrency(data.totalFleetCost)} label="Fleet replacement cost" />
+          <Stat figure={formatCurrency(data.totalFleetCost)} label="Fleet cost" />
         </Panel>
         <Panel>
           <Stat figure={`${earning}`} label={`Models earning (of ${data.rows.length})`} />

--- a/src/hooks/use-roi.ts
+++ b/src/hooks/use-roi.ts
@@ -92,7 +92,7 @@ export function useFleetRoi(opts: {
         manufacturer: m.manufacturer,
         categoryId: m.categoryId,
         projectCount: earned?.projectCount ?? 0,
-        ...computeRoi(earned?.revenue ?? 0, m.unitsOwned, m.replacementCost),
+        ...computeRoi(earned?.revenue ?? 0, m.unitsOwned, m.fleetCost),
       };
     });
 
@@ -214,7 +214,7 @@ export function useModelRoi(
     return {
       ...raw.value,
       scope,
-      ...computeRoi(raw.value.revenue, raw.value.unitsOwned, raw.value.replacementCost),
+      ...computeRoi(raw.value.revenue, raw.value.unitsOwned, raw.value.fleetCost),
     };
   }, [raw, key, scope]);
 

--- a/src/lib/roi.test.ts
+++ b/src/lib/roi.test.ts
@@ -8,16 +8,17 @@ import {
 } from "./roi";
 
 describe("computeRoi", () => {
-  test("measures against the whole fleet's capital, not one unit's", () => {
-    // The bug this exists to prevent: 8 receivers at $2,000 is $16,000 deployed.
-    // Dividing by a single unit's cost would report 12× instead of 1.5×.
-    const roi = computeRoi(24_000, 8, 2_000);
+  // `fleetCost` arrives PRE-SUMMED now (convex/roi.ts `fleetCapitalFor` does the
+  // per-asset/bulk mixing — see its own tests in convex/roi.test.ts). computeRoi is
+  // just division over whatever total it's handed.
+  test("payback is revenue over the pre-summed fleet cost", () => {
+    const roi = computeRoi(24_000, 8, 16_000);
     expect(roi.fleetCost).toBe(16_000);
     expect(roi.payback).toBe(1.5);
     expect(roi.revenuePerUnit).toBe(3_000);
   });
 
-  test("no replacement cost means no ROI — not zero, not infinity", () => {
+  test("no fleet cost means no ROI — not zero, not infinity", () => {
     const roi = computeRoi(5_000, 4, null);
     expect(roi.revenue).toBe(5_000);
     expect(roi.fleetCost).toBeNull();
@@ -32,8 +33,9 @@ describe("computeRoi", () => {
     expect(roi.revenuePerUnit).toBeNull();
   });
 
-  test("a zero replacement cost is treated as unknown, not as free capital", () => {
+  test("a zero (or negative) fleet cost is treated as unknown, not as free capital", () => {
     expect(computeRoi(100, 2, 0).payback).toBeNull();
+    expect(computeRoi(100, 2, -50).payback).toBeNull();
   });
 
   test("cost recovered clamps at 100% but payback keeps counting", () => {

--- a/src/lib/roi.ts
+++ b/src/lib/roi.ts
@@ -63,8 +63,7 @@ export function defaultRoiWindow(
 export interface RoiMetrics {
   revenue: number;
   unitsOwned: number;
-  replacementCost: number | null;
-  /** replacementCost × unitsOwned. Null when we can't know it. */
+  /** What it cost to acquire the units owned. Null when we can't know it. */
   fleetCost: number | null;
   /** revenue ÷ fleetCost. Null when there's no capital to measure against. */
   payback: number | null;
@@ -76,32 +75,36 @@ export interface RoiMetrics {
 }
 
 /**
- * ROI is measured against the capital actually deployed — replacement cost times
- * the number of units OWNED, not the cost of one unit. Dividing fleet revenue by a
- * single unit's cost overstates ROI by exactly the unit count, and overstates it
- * most for the models bought in the largest numbers: precisely the ones this report
- * exists to scrutinise.
+ * ROI is measured against the capital actually deployed, not the cost of one unit
+ * times a count: `fleetCost` arrives here PRE-SUMMED by the caller (`convex/roi.ts`
+ * `fleetCapitalFor` / `fleetInventory`), one asset's real purchase price at a time
+ * for serialised gear — falling back to the model's general purchase price, then its
+ * replacement cost, per asset — with bulk stock still `replacementCost ×
+ * totalQuantity` (see gearflow#798 / FEATUREDOCS/57-revenue-allocation-roi.md for
+ * why the chain, not a single scalar). This function has no opinion on any of
+ * that — it's pure division over whatever total it's handed.
  *
- * A model with no replacement cost, or none left in the fleet, has no ROI. Say so
- * with null — not 0 (looks like a dud) and not Infinity (looks like a triumph).
+ * A model with no fleet cost, or none left in the fleet, has no ROI. Say so with
+ * null — not 0 (looks like a dud) and not Infinity (looks like a triumph). A
+ * pre-summed total of exactly $0 is indistinguishable from "nothing priced it", so
+ * it's treated the same as null here — the caller already resolved that ambiguity
+ * per-asset; this is just the last line of defence.
  */
 export function computeRoi(
   revenue: number,
   unitsOwned: number,
-  replacementCost: number | null | undefined,
+  fleetCost: number | null | undefined,
 ): RoiMetrics {
-  const cost = replacementCost != null && replacementCost > 0 ? replacementCost : null;
-  const fleetCost = cost != null && unitsOwned > 0 ? cost * unitsOwned : null;
+  const cost = fleetCost != null && fleetCost > 0 && unitsOwned > 0 ? fleetCost : null;
 
   return {
     revenue,
     unitsOwned,
-    replacementCost: cost,
-    fleetCost,
-    payback: fleetCost ? revenue / fleetCost : null,
+    fleetCost: cost,
+    payback: cost ? revenue / cost : null,
     revenuePerUnit: unitsOwned > 0 ? revenue / unitsOwned : null,
-    costRecovered: fleetCost ? Math.min(1, Math.max(0, revenue / fleetCost)) : null,
-    stillToRecover: fleetCost ? Math.max(0, fleetCost - revenue) : null,
+    costRecovered: cost ? Math.min(1, Math.max(0, revenue / cost)) : null,
+    stillToRecover: cost ? Math.max(0, cost - revenue) : null,
   };
 }
 


### PR DESCRIPTION
Closes #798

## Summary

Fleet cost for serialised models was `replacementCost × unitsOwned` — a uniform multiply that assumes every unit of a model cost the same. Replaces it with a per-asset sum:

```
fleetCost(asset) = asset.purchasePrice
                 ?? model.defaultPurchasePrice
                 ?? model.replacementCost
                 ?? (no signal)
```

**Fallback decision (the issue's open question, resolved and recorded):** `defaultPurchasePrice` wins over `replacementCost` when both are set — it's the semantically correct "what we generally pay for this" field vs. `replacementCost`'s "what it'd cost to replace today". The chain still falls through to `replacementCost` when `defaultPurchasePrice` is unset, so models that already report a real fleet cost today don't silently regress to "—" just because `defaultPurchasePrice` was never backfilled. Recorded in `FEATUREDOCS/57-revenue-allocation-roi.md` per POLICY.md R-3.1 so it isn't re-guessed later.

- `convex/roi.ts` — new `assetCost`/`positiveCost` helpers; `unitsOwnedFor` renamed `fleetCapitalFor` and now returns a pre-summed `fleetCost` alongside `unitsOwned`; `fleetInventory` does the same per-model across the whole org in one pass. Bulk stock is explicitly unchanged (`replacementCost × totalQuantity`) — out of scope per the issue.
- `src/lib/roi.ts` — `computeRoi()`'s third argument is now the pre-summed `fleetCost` total, not a per-unit scalar it used to multiply by `unitsOwned`. `RoiMetrics.replacementCost` is removed (there's no longer a single per-unit number to report).
- `src/hooks/use-roi.ts` — both `useFleetRoi`/`useModelRoi` pass the new `fleetCost` field through instead of `replacementCost`.
- Copy: "Fleet replacement cost" → "Fleet cost" stat label, and the model ROI tab's empty-state message now mentions the purchase-price fallback chain.
- Invariants preserved: `fleetCost` is `null` (never `0`) when no units are owned, or when nothing anywhere (asset or model) carries a resolvable cost — matches the existing "zero replacement cost is unknown, not free capital" rule, now applied uniformly across every rung of the chain.

## Testing

- `pnpm exec vitest run src/lib/roi.test.ts convex/roi.test.ts src/components/assets/__tests__/model-roi-tab.smoke.test.tsx` — 37 passed, including 8 new cases in `convex/roi.test.ts` covering: per-asset summing (not a uniform multiply), the `defaultPurchasePrice` → `replacementCost` fallback order, mixed priced/unpriced assets on the same model, no-signal → null, zero/negative values treated as no-signal, bulk stock unchanged (`purchasePricePerUnit` ignored), and zero-units-owned → null even with a real `replacementCost` on file.
- `pnpm exec tsc --noEmit` — no new errors (pre-existing errors in this checkout are all unrelated missing-generated-Prisma-client)
- `pnpm exec eslint` on all changed files — 0 errors (pre-existing warning patterns only)

## Checklist

- [x] New dependency? N/A — no new dependencies added.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LHhVHGco6xujYaGi3mHXw)_