### PR TITLE
fix(nav): single-flight guard on mobile bottom nav to stop rubber-banding

### DIFF
--- a/FEATUREDOCS/06-pages-layouts.md
+++ b/FEATUREDOCS/06-pages-layouts.md
@@ -17,6 +17,23 @@ div.app-shell (fixed inset-0 on mobile, relative on desktop)
 └── MobileNav (shrink-0, hidden on md+)
 ```
 
+**`MobileNav` (`src/components/layout/mobile-nav.tsx`) single-flight navigation guard.**
+Mobile bug: rapidly tapping one bottom-nav tab then a different one could snap the
+user back to the first tab — the App Router doesn't guarantee two overlapping soft
+navigations resolve in the order they were triggered (vercel/next.js#83386), and
+mobile's higher latency widens the race window a lot versus desktop. This is a
+distinct bug class from the `useServerMutation` stale-navigation guard (see
+FEATUREDOCS/54 — that one gates a mutation's `onSuccess` `router.push` on the
+triggering view still being mounted; this one guards two competing plain
+navigations). `useSingleFlightNavClick` replaces `next/link`'s `<Link>` with a
+`router.push`-driven `<a onClick>` (same reason `app-sidebar.tsx`'s desktop
+`NavLink` isn't a plain `<Link>`, though for a different underlying bug) that
+tracks one pending destination in a ref: a second tap on a *different* tab while
+a navigation is still in flight is dropped, and a 1.5s safety-valve timeout clears
+the guard if a navigation stalls so the bar never gets stuck. Tapping the
+already-pending or already-active tab is always a no-op. Regression test:
+`src/components/layout/__tests__/mobile-nav.test.tsx`.
+
 **Admin Layout** (`src/app/(admin)/admin/layout.tsx`): Server-side role check + `AdminShell` component with own responsive sidebar
 
 **Auth Layout** (`src/app/(auth)/layout.tsx`): Centered card, no sidebar

--- a/src/components/layout/__tests__/mobile-nav.test.tsx
+++ b/src/components/layout/__tests__/mobile-nav.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+/**
+ * Regression for the mobile "rubber banding" bug: tapping a bottom-nav tab, then
+ * immediately tapping a DIFFERENT tab before the first navigation lands, could
+ * fire two overlapping router.push calls. Next.js App Router doesn't guarantee
+ * ordering between two in-flight soft navigations (vercel/next.js#83386) — the
+ * slower first one can resolve after the second and snap the user back to it.
+ * MobileNav's single-flight guard should drop the second tap while the first is
+ * still pending, and accept new taps again once the pathname lands.
+ */
+
+const push = vi.fn();
+let currentPathname = "/dashboard";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => currentPathname,
+}));
+
+import { MobileNav } from "@/components/layout/mobile-nav";
+
+beforeEach(() => {
+  push.mockClear();
+  currentPathname = "/dashboard";
+});
+
+describe("MobileNav", () => {
+  it("ignores a second tab tap while the first navigation is still in flight", () => {
+    const { rerender } = render(<MobileNav />);
+
+    fireEvent.click(screen.getByText("Jobs"));
+    fireEvent.click(screen.getByText("Warehouse"));
+
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith("/projects");
+
+    // Simulate the first navigation landing.
+    currentPathname = "/projects";
+    rerender(<MobileNav />);
+
+    fireEvent.click(screen.getByText("Warehouse"));
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(push).toHaveBeenLastCalledWith("/warehouse");
+  });
+
+  it("does not navigate when tapping the already-active tab", () => {
+    render(<MobileNav />);
+    fireEvent.click(screen.getByText("Dashboard"));
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   FolderOpen,
@@ -11,6 +11,15 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn, focusRing } from "@/lib/utils";
+
+// A pending Link navigation triggered by a fast second tap on another bottom-nav
+// item can resolve after the second one has already landed, snapping the user
+// back to the first tab (Next.js App Router soft-navigation race — see
+// vercel/next.js#83386, worse on mobile's higher latency). Single-flight guard:
+// ignore taps while a nav-triggered transition to a DIFFERENT tab is still in
+// flight; a 1.5s safety-valve timeout clears it if a navigation stalls so the
+// bar never gets stuck.
+const PENDING_NAV_TIMEOUT_MS = 1500;
 
 // DESIGN.md §16 — mobile bottom nav is the 5 daily-operator workflows:
 // Dashboard / Jobs / Warehouse / Crew / Assets. Settings lives in the
@@ -32,6 +41,52 @@ const navItems: MobileNavItem[] = [
   { href: "/assets/registry", icon: Package, label: "Assets", matchPrefix: "/assets" },
 ];
 
+/** See PENDING_NAV_TIMEOUT_MS above for why this exists. */
+function useSingleFlightNavClick(pathname: string) {
+  const router = useRouter();
+  const pendingHrefRef = useRef<string | null>(null);
+  const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleared whenever pathname changes (the in-flight navigation landed) or the
+  // safety-valve timeout fires.
+  useEffect(() => {
+    pendingHrefRef.current = null;
+    if (pendingTimeoutRef.current) {
+      clearTimeout(pendingTimeoutRef.current);
+      pendingTimeoutRef.current = null;
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingTimeoutRef.current) clearTimeout(pendingTimeoutRef.current);
+    };
+  }, []);
+
+  return useCallback(
+    (href: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+      // Let modified clicks (open in new tab, etc.) behave natively.
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      e.preventDefault();
+
+      // A tap on the currently-pending destination (impatient double-tap) or on
+      // the current tab is a no-op either way.
+      if (pendingHrefRef.current === href || pathname === href) return;
+      // A tap on a DIFFERENT tab while one navigation is already in flight is the
+      // race precondition — ignore it and let the in-flight one land.
+      if (pendingHrefRef.current) return;
+
+      pendingHrefRef.current = href;
+      pendingTimeoutRef.current = setTimeout(() => {
+        pendingHrefRef.current = null;
+        pendingTimeoutRef.current = null;
+      }, PENDING_NAV_TIMEOUT_MS);
+      router.push(href);
+    },
+    [router, pathname]
+  );
+}
+
 /**
  * Mobile bottom navigation bar (< md).
  * Rendered in the layout flow (not fixed) — the parent app-shell is a flex
@@ -40,6 +95,7 @@ const navItems: MobileNavItem[] = [
  */
 export function MobileNav() {
   const pathname = usePathname();
+  const handleClick = useSingleFlightNavClick(pathname);
 
   return (
     <nav
@@ -53,9 +109,10 @@ export function MobileNav() {
             : pathname === item.href || pathname.startsWith(item.href + "/");
 
           return (
-            <Link
+            <a
               key={item.href}
               href={item.href}
+              onClick={handleClick(item.href)}
               aria-current={isActive ? "page" : undefined}
               className={cn(
                 "flex h-14 flex-1 flex-col items-center justify-center gap-1 rounded-[var(--r)] transition-colors",
@@ -65,7 +122,7 @@ export function MobileNav() {
             >
               <item.icon className="size-[22px]" aria-hidden />
               <span className="text-[11px] font-medium leading-none">{item.label}</span>
-            </Link>
+            </a>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary

Fixes #893 — on mobile, rapidly tapping one bottom-nav tab then a different one before the first navigation lands could snap the user back to the first tab ("rubber banding").

- `MobileNav` (`src/components/layout/mobile-nav.tsx`) used a plain `next/link` `<Link>` per tab. Next.js's App Router doesn't guarantee that two overlapping soft navigations resolve in the order they were triggered — a known, still-open upstream issue class ([vercel/next.js#83386](https://github.com/vercel/next.js/issues/83386)). A slower first navigation can resolve *after* a faster second one and overwrite it. Mobile's higher latency/slower CPU widens this race window a lot vs. desktop, which is why it presented as "sometimes, on mobile."
- Replaced `<Link>` with `useSingleFlightNavClick`, a `router.push`-driven click handler that tracks one pending destination in a ref: a second tap on a *different* tab while a navigation is in flight is dropped (the in-flight one is left to land), with a 1.5s safety-valve timeout so the bar can't get permanently stuck. Tapping the already-pending or already-active tab is a no-op.
- This is a distinct bug class from the desktop fix in `a8e6280a` (`useServerMutation`'s stale-navigation guard, which gates a mutation's `onSuccess`-triggered `router.push` on the triggering view still being mounted). I audited the rest of the codebase for that same unguarded-async-navigate pattern and found no other unguarded call sites, so that fix remains comprehensive for the mutation-triggered race — this PR addresses the separate plain-navigation race.
- Documented in `FEATUREDOCS/06-pages-layouts.md`.

## Testing

- New regression test: `src/components/layout/__tests__/mobile-nav.test.tsx` — asserts a second tap on a different tab while a navigation is pending is dropped, and that taps are accepted again once the pathname lands.
- `pnpm exec vitest run src/components/layout/__tests__/mobile-nav.test.tsx` — passing.
- `pnpm exec eslint` on changed files — clean.
- `pnpm exec tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in this sandbox are from a missing generated Prisma client, no `.env`/DB in this environment).
- **Not manually verified on a live mobile device/browser** — this sandbox has no `.env`/DB configured to run `pnpm dev` against. Recommend a real-device pass (rapid bottom-nav tab switching) before merge.

## Checklist

- [x] No new dependency


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc3DAUJcpuLiS4trB4yraW)_