### PR TITLE
fix(R-8.6.2): mirror Zod bounds server-side for Test&Tag / Sub-Hire Native mutations

### DIFF
--- a/convex/subHiresWrites.test.ts
+++ b/convex/subHiresWrites.test.ts
@@ -165,6 +165,23 @@ describe("createSubHireNative", () => {
       }),
     ).rejects.toThrow(/insufficient permissions/i);
   });
+
+  test("rejects out-of-bounds supplierReference/notes (R-8.6.2 server-side mirror of subHireSchema)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await seedSupplier(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.createSubHireNative, {
+        id: "sh1", orgId: ORG, supplierId: "sup1", projectId: "p1", showOnDocs: false, supplierReference: "x".repeat(201), now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/Supplier reference/i);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.createSubHireNative, {
+        id: "sh1", orgId: ORG, supplierId: "sup1", projectId: "p1", showOnDocs: false, notes: "x".repeat(2001), now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/Notes/i);
+  });
 });
 
 // ─── updateSubHireNative ──────────────────────────────────────────────────────
@@ -212,6 +229,18 @@ describe("updateSubHireNative", () => {
         id: "sh1", orgId: ORG, supplierId: "sup1", showOnDocs: false, now: NOW, actor: ACTOR, auditId: "logu",
       }),
     ).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("rejects out-of-bounds supplierReference/notes", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedSupplier(t);
+    await seedSubHire(t, "sh1", ORG, { projectId: undefined });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.updateSubHireNative, {
+        id: "sh1", orgId: ORG, supplierId: "sup1", showOnDocs: false, supplierReference: "x".repeat(201), now: NOW, actor: ACTOR, auditId: "logu",
+      }),
+    ).rejects.toThrow(/Supplier reference/i);
   });
 });
 
@@ -404,6 +433,19 @@ describe("addSubHireItemNative", () => {
       }),
     ).rejects.toThrow(/insufficient permissions/i);
   });
+
+  test("rejects an out-of-bounds description (R-8.6.2 server-side mirror of subHireItemSchema)", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t);
+    await seedSupplier(t);
+    await seedSubHire(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.addSubHireItemNative, {
+        id: "it1", orgId: ORG, subHireId: "sh1", ...itemInput, description: "x".repeat(501), now: NOW, actor: ACTOR, auditId: "loga",
+      }),
+    ).rejects.toThrow(/Description/i);
+  });
 });
 
 // ─── updateSubHireItemNative ──────────────────────────────────────────────────
@@ -563,6 +605,17 @@ describe("createSubHireGroupNative", () => {
     await expect(
       t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.createSubHireGroupNative, { id: "g1", orgId: ORG, subHireId: "sh1", title: "Kit", now: NOW, actor: ACTOR, auditId: "logg" }),
     ).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("rejects an out-of-bounds title (R-8.6.2 server-side mirror of subHireGroupSchema)", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await seedProject(t);
+    await seedSupplier(t);
+    await seedSubHire(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.subHiresWrites.createSubHireGroupNative, { id: "g1", orgId: ORG, subHireId: "sh1", title: "x".repeat(201), now: NOW, actor: ACTOR, auditId: "logg" }),
+    ).rejects.toThrow(/Group title/i);
   });
 });
 

--- a/convex/subHiresWrites.ts
+++ b/convex/subHiresWrites.ts
@@ -10,6 +10,7 @@ import { recalcProjectTotals } from "./lib/recalc";
 import { recalcSubHireTotals, upsertSupplierModelRate } from "./lib/subHireTotals";
 import { regenerateSubHireLines } from "./lib/subHireLineGen";
 import { reserveSubHireOrderNumberCounter } from "./lib/subHireOrderCounter";
+import { assertStrLen } from "./lib/fieldGuards";
 import { createId } from "@paralleldrive/cuid2";
 import * as enums from "./lib/validators";
 
@@ -201,6 +202,10 @@ export const createSubHireNative = mutation({
     // FK: supplier + (optional) project must be the caller's org; default placement
     // targets must belong to that project (no cross-tenant/-project dangling reference).
     const supplier = await requireSupplierInOrg(ctx, a.supplierId, a.orgId);
+    // R-8.6.2: mirror subHireSchema's bounds (client Zod validation is bypassable by
+    // any caller hitting this Native mutation directly).
+    assertStrLen(a.supplierReference, "Supplier reference", { max: 200 });
+    assertStrLen(a.notes, "Notes", { max: 2000 });
     const projectId = a.projectId || null;
     if (projectId) await requireProjectInOrg(ctx, projectId, a.orgId);
     if (a.defaultTargetGroupId) await assertTargetGroup(ctx, a.defaultTargetGroupId, a.orgId, projectId);
@@ -276,6 +281,8 @@ export const updateSubHireNative = mutation({
     const actor = await resolveActor(ctx, a.actor);
 
     const existing = await requireSubHireInOrg(ctx, a.id, a.orgId);
+    assertStrLen(a.supplierReference, "Supplier reference", { max: 200 }); // R-8.6.2: mirror subHireSchema
+    assertStrLen(a.notes, "Notes", { max: 2000 });
 
     // FK: new supplier. projectId is NOT changed here (see the safe-merge note below), so any
     // placement default is validated against the sub-hire's EXISTING project.
@@ -473,6 +480,7 @@ const itemInputArgs = {
 
 function assertItemMoney(a: { description: string; quantity: number; unitCost: number; unitCharge: number; duration: number; discount: number }) {
   if (!a.description) throw new ConvexError("Description is required");
+  assertStrLen(a.description, "Description", { max: 500 }); // R-8.6.2: mirror subHireItemSchema
   assertIntMin1(a.quantity, "Quantity");
   assertFiniteMin0(a.unitCost, "Cost");
   assertFiniteMin0(a.unitCharge, "Charge");
@@ -716,6 +724,7 @@ const groupInputArgs = {
 
 function assertGroupMoney(a: { title: string; quantity?: number; cost?: number | null; charge?: number | null; discount?: number }) {
   if (!a.title) throw new ConvexError("Group title is required");
+  assertStrLen(a.title, "Group title", { max: 200 }); // R-8.6.2: mirror subHireGroupSchema
   assertIntMin1(a.quantity ?? 1, "Quantity");
   if (a.cost != null) assertFiniteMin0(a.cost, "Cost");
   if (a.charge != null) assertFiniteMin0(a.charge, "Charge");

--- a/convex/testProfilesWrites.test.ts
+++ b/convex/testProfilesWrites.test.ts
@@ -77,6 +77,14 @@ describe("testProfile writes", () => {
     expect(seedRes.created).toBe(1); // "Base" skipped
   });
 
+  test("create/update reject out-of-bounds fields (R-8.6.2 server-side mirror of testProfileSchema)", async () => {
+    const t = makeT(); await seedMember(t); await seedProfile(t, "p1");
+    await expect(t.withIdentity(asUser).mutation(api.testProfilesWrites.createNative, { id: "p2", orgId: ORG, name: "x".repeat(201), ...CHECKS, now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Name/i);
+    await expect(t.withIdentity(asUser).mutation(api.testProfilesWrites.createNative, { id: "p2", orgId: ORG, name: "Ok", subTestLabel: "x".repeat(51), ...CHECKS, now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Sub-test label/i);
+    await expect(t.withIdentity(asUser).mutation(api.testProfilesWrites.createNative, { id: "p2", orgId: ORG, name: "Ok", defaultSubTestCount: 51, ...CHECKS, now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Default sub-test count/i);
+    await expect(t.withIdentity(asUser).mutation(api.testProfilesWrites.updateNative, { id: "p1", orgId: ORG, name: "x".repeat(201), now: NOW, actor, auditId: "a2" })).rejects.toThrow(/Name/i);
+  });
+
   test("cross-org update rejected; viewer RBAC rejected", async () => {
     const t = makeT(); await seedMember(t); await seedProfile(t, "pX", {}, OTHER);
     await expect(t.withIdentity(asUser).mutation(api.testProfilesWrites.updateNative, { id: "pX", orgId: ORG, name: "hijack", now: NOW, actor, auditId: "a1" })).rejects.toThrow(/not found/i);

--- a/convex/testProfilesWrites.ts
+++ b/convex/testProfilesWrites.ts
@@ -5,6 +5,7 @@ import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
+import { assertStrLen, assertNumRange } from "./lib/fieldGuards";
 import * as enums from "./lib/validators";
 
 /**
@@ -57,6 +58,11 @@ export const createNative = mutation({
     await requireOrgPermission(ctx, a.orgId, "testTag", "create");
     const actor = await resolveActor(ctx, a.actor);
     if (!a.name || a.name.trim().length < 1) throw new ConvexError("Name is required");
+    // R-8.6.2: mirror testProfileSchema's bounds (client Zod validation is bypassable
+    // by any caller hitting this Native mutation directly).
+    assertStrLen(a.name, "Name", { max: 200 });
+    assertStrLen(a.subTestLabel, "Sub-test label", { min: 1, max: 50 });
+    assertNumRange(a.defaultSubTestCount, "Default sub-test count", { min: 1, max: 50, integer: true });
 
     if ((await orgProfiles(ctx, a.orgId)).some((p) => p.name === a.name)) throw new ConvexError(`A profile named "${a.name}" already exists`);
     const dup = await ctx.db.query("testProfiles").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
@@ -91,6 +97,9 @@ export const updateNative = mutation({
 
     const doc = await orgProfile(ctx, a.orgId, a.id);
     if (!doc) throw new ConvexError("Test profile not found");
+    assertStrLen(a.name, "Name", { min: 1, max: 200 });
+    assertStrLen(a.subTestLabel, "Sub-test label", { min: 1, max: 50 });
+    assertNumRange(a.defaultSubTestCount, "Default sub-test count", { min: 1, max: 50, integer: true });
     if (a.name && a.name !== doc.name && (await orgProfiles(ctx, a.orgId)).some((p) => p.id !== a.id && p.name === a.name)) {
       throw new ConvexError(`A profile named "${a.name}" already exists`);
     }
@@ -172,6 +181,9 @@ export const seedDefaultsNative = mutation({
     let firstId = "";
     let created = 0;
     for (const p of a.profiles) {
+      assertStrLen(p.name, "Name", { min: 1, max: 200 });
+      assertStrLen(p.subTestLabel, "Sub-test label", { min: 1, max: 50 });
+      assertNumRange(p.defaultSubTestCount, "Default sub-test count", { min: 1, max: 50, integer: true });
       if (seen.has(p.name)) continue;
       const dupId = await ctx.db.query("testProfiles").withIndex("by_cuid", (q) => q.eq("id", p.id)).first();
       if (dupId) continue;

--- a/convex/testTagAssetsWrites.test.ts
+++ b/convex/testTagAssetsWrites.test.ts
@@ -90,6 +90,25 @@ describe("testTagAssetsWrites", () => {
     await expect(t.withIdentity({ subject: USER, orgId: ORG, role: "viewer" }).mutation(api.testTagAssetsWrites.createNative, { id: "z", orgId: ORG, description: "d", now: NOW, actor, auditId: "a2" })).rejects.toThrow(/Forbidden|permission/i);
   });
 
+  test("create rejects out-of-bounds fields (R-8.6.2 server-side mirror of testTagAssetSchema)", async () => {
+    const t = makeT(); await seedMember(t);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, testTagId: "x".repeat(51), description: "d", now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Test Tag ID/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, description: "x".repeat(501), now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Description/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, description: "d", make: "x".repeat(201), now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Make/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, description: "d", testIntervalMonths: 121, now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Test interval/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, description: "d", outletCount: 0, now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Outlet count/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.createNative, { id: "tt1", orgId: ORG, description: "d", notes: "x".repeat(2001), now: NOW, actor, auditId: "a1" })).rejects.toThrow(/Notes/i);
+  });
+
+  test("update rejects out-of-bounds patch fields; clearing with null is unaffected", async () => {
+    const t = makeT(); await seedMember(t);
+    await t.run(async (ctx) => { await ctx.db.insert("testTagAssets", { id: "tt1", organizationId: ORG, testTagId: "T1", description: "d", equipmentClass: "CLASS_I", applianceType: "APPLIANCE", status: "NOT_YET_TESTED", isActive: true }); });
+    await expect(t.withIdentity(asUser).mutation(api.testTagAssetsWrites.updateNative, { id: "tt1", orgId: ORG, patch: { location: "x".repeat(201) }, now: NOW })).rejects.toThrow(/Location/i);
+    // null (clear) is not length-checked
+    await t.withIdentity(asUser).mutation(api.testTagAssetsWrites.updateNative, { id: "tt1", orgId: ORG, patch: { location: null }, now: NOW });
+    expect((await tta(t, "tt1"))?.location).toBeUndefined();
+  });
+
   test("backfill registers T&T for a T&T-model asset", async () => {
     const t = makeT(); await seedMember(t);
     await t.run(async (ctx) => {

--- a/convex/testTagAssetsWrites.ts
+++ b/convex/testTagAssetsWrites.ts
@@ -8,6 +8,7 @@ import { writeActivityLog } from "./lib/audit";
 import { reserveTestTagIdCounter } from "./lib/testTagIdCounter";
 import { backfillTestTagAssetsCore } from "./lib/testtagBackfill";
 import { assertRefInOrg } from "./lib/orgRef";
+import { assertStrLen, assertNumRange } from "./lib/fieldGuards";
 import * as enums from "./lib/validators";
 
 /**
@@ -58,6 +59,17 @@ export const createNative = mutation({
     await requireOrgPermission(ctx, a.orgId, "testTag", "create");
     const actor = await resolveActor(ctx, a.actor);
     if (!a.description || a.description.trim().length < 1) throw new ConvexError("Description is required");
+    // R-8.6.2: mirror testTagAssetSchema's bounds (client Zod validation is bypassable
+    // by any caller hitting this Native mutation directly).
+    assertStrLen(a.testTagId, "Test Tag ID", { max: 50 });
+    assertStrLen(a.description, "Description", { max: 500 });
+    assertStrLen(a.make, "Make", { max: 200 });
+    assertStrLen(a.modelName, "Model", { max: 200 });
+    assertStrLen(a.serialNumber, "Serial number", { max: 200 });
+    assertStrLen(a.location, "Location", { max: 200 });
+    assertNumRange(a.testIntervalMonths, "Test interval", { min: 1, max: 120, integer: true });
+    assertNumRange(a.outletCount, "Outlet count", { min: 1, max: 50, integer: true });
+    assertStrLen(a.notes, "Notes", { max: 2000 });
 
     const dupId = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", a.id)).first();
     if (dupId) throw new ConvexError("Test tag asset already exists");
@@ -126,6 +138,11 @@ export const createFromBulkNative = mutation({
     await requireOrgPermission(ctx, a.orgId, "testTag", "create");
     const actor = await resolveActor(ctx, a.actor);
     if (a.ids.length === 0) throw new ConvexError("Count must be at least 1");
+    assertStrLen(a.description, "Description", { max: 500 });
+    assertStrLen(a.make, "Make", { max: 200 });
+    assertStrLen(a.modelName, "Model", { max: 200 });
+    assertStrLen(a.location, "Location", { max: 200 });
+    assertNumRange(a.testIntervalMonths, "Test interval", { min: 1, max: 120, integer: true });
 
     const bulk = await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", a.bulkAssetId)).first();
     if (!bulk || bulk.organizationId !== a.orgId) throw new ConvexError("Bulk asset not found");
@@ -185,6 +202,16 @@ export const updateNative = mutation({
 
     const doc = await ctx.db.query("testTagAssets").withIndex("by_cuid", (q) => q.eq("id", id)).first();
     if (!doc || doc.organizationId !== orgId) throw new ConvexError("Test tag asset not found");
+
+    // R-8.6.2: mirror testTagAssetSchema's bounds (null/undefined = leave-or-clear, skipped).
+    assertStrLen(patch.description, "Description", { max: 500 });
+    assertStrLen(patch.make, "Make", { max: 200 });
+    assertStrLen(patch.modelName, "Model", { max: 200 });
+    assertStrLen(patch.serialNumber, "Serial number", { max: 200 });
+    assertStrLen(patch.location, "Location", { max: 200 });
+    assertNumRange(patch.testIntervalMonths, "Test interval", { min: 1, max: 120, integer: true });
+    assertNumRange(patch.outletCount, "Outlet count", { min: 1, max: 50, integer: true });
+    assertStrLen(patch.notes, "Notes", { max: 2000 });
 
     // Org-validate client-supplied FKs when SET to a non-empty value (by_cuid is GLOBAL —
     // cross-org refs leak). A null/"" is a clear and needs no check.

--- a/convex/testTagRecordsWrites.test.ts
+++ b/convex/testTagRecordsWrites.test.ts
@@ -163,6 +163,19 @@ describe("testTagRecordsWrites.createNative", () => {
       ...base, nextDueDate: NOW + DAY,
     })).rejects.toThrow(/Forbidden|permission/i);
   });
+
+  test("rejects out-of-bounds fields (R-8.6.2 server-side mirror of testTagRecordSchema/subTestRecordSchema)", async () => {
+    const t = makeT(); await seed(t); await seedAsset(t);
+    await expect(t.withIdentity(asUser).mutation(api.testTagRecordsWrites.createNative, {
+      ...base, nextDueDate: NOW + DAY, testerName: "x".repeat(201),
+    })).rejects.toThrow(/Tester name/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagRecordsWrites.createNative, {
+      ...base, nextDueDate: NOW + DAY, failureNotes: "x".repeat(2001),
+    })).rejects.toThrow(/Failure notes/i);
+    await expect(t.withIdentity(asUser).mutation(api.testTagRecordsWrites.createNative, {
+      ...base, nextDueDate: NOW + DAY, subTests: [{ id: "s1", label: "x".repeat(101), sortOrder: 0 }],
+    })).rejects.toThrow(/Sub-test label/i);
+  });
 });
 
 describe("testTagRecords reads", () => {

--- a/convex/testTagRecordsWrites.ts
+++ b/convex/testTagRecordsWrites.ts
@@ -7,6 +7,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { assertRefInOrg } from "./lib/orgRef";
+import { assertStrLen } from "./lib/fieldGuards";
 import * as enums from "./lib/validators";
 
 /**
@@ -117,6 +118,17 @@ export const createNative = mutation({
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, a.orgId, "testTag", "create");
     const actor = await resolveActor(ctx, a.actor);
+
+    // R-8.6.2: mirror testTagRecordSchema/subTestRecordSchema's bounds (client Zod
+    // validation is bypassable by any caller hitting this Native mutation directly).
+    assertStrLen(a.testerName, "Tester name", { max: 200 });
+    assertStrLen(a.visualNotes, "Visual notes", { max: 2000 });
+    assertStrLen(a.functionalTestNotes, "Functional test notes", { max: 2000 });
+    assertStrLen(a.failureNotes, "Failure notes", { max: 2000 });
+    for (const st of a.subTests ?? []) {
+      assertStrLen(st.label, "Sub-test label", { max: 100 });
+      assertStrLen(st.notes, "Sub-test notes", { max: 2000 });
+    }
 
     // 2) Fetch the parent T&T asset + per-row org re-check (by_cuid is GLOBAL).
     const asset = await ctx.db


### PR DESCRIPTION
## Summary

Closes #902 (tracked by #907). POLICY.md R-8.6.2 requires that Convex Native mutations callable directly from the browser mirror their paired Zod schema's business constraints (string length, numeric bounds) server-side, since the client-side `.parse()` is bypassable by any caller with a valid session hitting the mutation directly. Four `*Writes.ts` files in the Test & Tag / Sub-Hire feature area were missing these checks:

- `convex/testTagAssetsWrites.ts` — `createNative`/`createFromBulkNative`/`updateNative` only checked `description` non-empty; `testTagId` (≤50), `make`/`modelName`/`serialNumber`/`location` (≤200), `testIntervalMonths` (1–120), `outletCount` (1–50), and `notes` (≤2000) were unenforced.
- `convex/testProfilesWrites.ts` — `createNative`/`updateNative`/`seedDefaultsNative` only checked `name` non-empty; `subTestLabel` (≤50) and `defaultSubTestCount` (1–50) were unenforced.
- `convex/testTagRecordsWrites.ts` — `createNative` had no bound on `testerName` (≤200), `visualNotes`/`functionalTestNotes`/`failureNotes` (≤2000), or `subTestArg.label` (≤100).
- `convex/subHiresWrites.ts` — `createSubHireNative`/`updateSubHireNative` never checked `supplierReference` (≤200) or `notes` (≤2000); the shared `assertItemMoney`/`assertGroupMoney` helpers validated money/quantity fields but not `description` (≤500) or `title` (≤200).

All new checks use the existing `convex/lib/fieldGuards.ts` primitives (`assertStrLen`/`assertNumRange`), matching the pattern already used by `suppliersWrites.ts` and other compliant files. `null` (explicit clear) is still skipped, matching existing semantics; only over-length/out-of-range values are rejected.

## Testing

- Added targeted tests to each of the four existing `*.test.ts` files asserting the new mutations reject out-of-bounds input and that clearing a field with `null` still works.
- `pnpm exec vitest run` — all 4079 tests pass (307 files).
- `pnpm exec tsc --noEmit` — no new type errors in the touched files.
- `pnpm exec eslint` on all touched files — 0 errors (pre-existing complexity warnings only, unrelated to this change).

## Checklist

- [x] No new dependency added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwsXQTc2bsXXueQpZX611u)_