### PR TITLE
fix(a11y): move focus to the new step's heading on wizard transitions (#894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **R-8.1.7** (#894) — The "Create a project" wizard (`/projects/new`) silently lost keyboard
+  focus on every step transition: clicking Continue/Back unmounts the just-clicked button, and
+  with no explicit target the browser fell back to `document.body`, forcing keyboard/screen-reader
+  users to re-Tab from the top of the page after every step. `ProjectWizard`
+  (`src/components/projects/project-wizard.tsx`) now focuses a `tabIndex={-1}` step heading after
+  every non-initial step change; step 0 keeps its existing `autoFocus` on the Name field instead
+  (which already re-fires correctly since the step content remounts).
+
 - **R-5.3** (#900, tracked under #905) — Fixed `scripts/check-docs-npm-npx.mjs`'s detection
   logic itself, the actual root cause of this rule's 4th recurrence (#731, #820, #856 only ever
   fixed scope/diff-vs-full-repo). `BAD`'s `npm run` branch required a non-whitespace char with

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -64,6 +64,15 @@ retired). Routes:
   only); the user accepts or overrides. `next()` blocks step 0 if blank (the Zod
   schema still allows blank for auto-gen, so the requirement is enforced in the
   wizard).
+- **Step-transition focus management (R-8.1.7, #894).** Continue/Back unmounts the
+  just-clicked button, so the wizard explicitly moves focus on every step change
+  instead of leaving it to the browser's `document.body` fallback (WCAG "focus is
+  never silently lost"). A `tabIndex={-1}` heading ("Step N: <label>") sits at the
+  top of the step-content card and is focused via `stepHeadingRef` in a `useEffect`
+  keyed on `step`, skipping the very first render. Step 0 is excluded from that
+  effect — its Name field already carries `autoFocus`, which re-fires on every
+  (re)mount (the step content is conditionally rendered, so returning to step 0
+  remounts the field) and would otherwise race the heading-focus effect.
 - **Schedule step — one calendar, not six pickers.** The hire window is a single
   date range chosen via `RangeCalendar` (`src/components/ui/range-calendar.tsx`,
   a custom date-fns range calendar — no external calendar dep) plus duration

--- a/docs/a11y-manual-checklist.md
+++ b/docs/a11y-manual-checklist.md
@@ -109,21 +109,23 @@ treating it as a finding — several were test-harness artifacts (see notes belo
 |------|--------|--------|
 | 3. Sign out | Dashboard nav walk; account menu opened with `Enter`, closed with `Escape` (focus returns to trigger), re-opened and navigated to "Sign out" with real `ArrowDown` presses, activated with `Enter`; confirmed the session is actually invalidated (a post-sign-out visit to `/dashboard` bounces to `/login`) | ✅ Clean |
 | 4. Register / onboarding | Registration form and the org-creation form both filled and submitted keyboard-only (`Tab` between fields, `Enter` to submit); confirmed onboarding actually completes (revisiting `/onboarding` redirects to `/dashboard`) | ✅ Clean |
-| 5. Create a project (revenue path) | Keyboard walk through the 4-step wizard (Basics → Schedule → Site → Review → Create job) | ⚠️ One confirmed finding — see below (filed as #894) |
+| 5. Create a project (revenue path) | Keyboard walk through the 4-step wizard (Basics → Schedule → Site → Review → Create job) | ✅ Clean now — one finding found and **fixed** in a follow-up PR, see below |
 | 6. Add line items + pricing (revenue path) | Keyboard-only: "Add" menu (`Enter` + `ArrowDown` + `Enter`), item dialog (tab-strip + form fields), model search combobox, "Add to project" | ✅ Clean now — one finding found and **fixed** in this PR, see below |
 | 7. Availability check (revenue path) | Inline availability panel (async Convex query) renders "1 available" with no overbook warning, exercised as part of the same keyboard flow as flow 6 | ✅ Clean |
 | 8. Warehouse check-out | Pick tab, header checkbox (`Space`), Prep | ✅ Clean once the interaction was scripted correctly — see the "Assign assets" dialog root-cause below |
 | 9. Warehouse check-in / return | Deployed tab, header checkbox, Return; confirmed item moves from Deployed(0)→Returned(1) | ✅ Clean |
 | 10. Create inventory | Model creation + serialized asset creation, both keyboard-only; server-generated asset tag confirmed visible on the detail page | ✅ Clean |
 
-**Finding — flow 5, Create-project wizard loses focus on every step transition (open, filed as
-[#894](https://github.com/TwoToned/gearflow/issues/894)):** clicking "Continue" unmounts the
-just-clicked button; nothing moves focus to the new step, so `document.activeElement` falls back
-to `<body>`. Confirmed directly (not inferred from a tab-walk diff) — a script read
-`document.activeElement` immediately before and after a `Continue` click and observed the drop
-to `body`. A keyboard/screen-reader user loses their place after every step and must re-navigate
-from the top of the page. Criterion 3 (focus never silently lost). Not a hard blocker (Tab still
-reaches the content eventually) but a real, repeated disorientation in the primary revenue path.
+**Finding — flow 5, Create-project wizard loses focus on every step transition (filed as
+[#894](https://github.com/TwoToned/gearflow/issues/894), FIXED in a follow-up PR):** clicking
+"Continue" unmounts the just-clicked button; nothing moved focus to the new step, so
+`document.activeElement` fell back to `<body>`. Confirmed directly (not inferred from a tab-walk
+diff) — a script read `document.activeElement` immediately before and after a `Continue` click
+and observed the drop to `body`. A keyboard/screen-reader user lost their place after every step
+and had to re-navigate from the top of the page. Criterion 3 (focus never silently lost). Fixed:
+`ProjectWizard` (`src/components/projects/project-wizard.tsx`) now focuses a `tabIndex={-1}`
+step heading after every non-initial step change (step 0 is left to its Name field's existing
+`autoFocus`). See `FEATUREDOCS/10-projects.md`.
 
 **Finding — flow 6, unlabeled equipment-dialog fields (FIXED in this PR):**
 `equipment-add-form.tsx`'s local `Field` wrapper rendered `<Label>` with no `htmlFor`, so the
@@ -171,8 +173,7 @@ Turbopack-crash class (`docs/e2e-harness.md`) reproduced live mid-pass; switched
 already does.
 
 **Compliance:** POLICY.md R-8.1.7's manual-checklist requirement is now met for all 10 critical
-flows — flows 1-2 (2026-07-23 entry above) plus flows 3-10 (this entry). One WCAG finding fixed
-in this PR (flow 6 labels); one tracked as a follow-up ([#894](https://github.com/TwoToned/gearflow/issues/894),
-flow 5 focus loss) rather than blocking closure — it's a real but non-blocking finding, exactly
-the "log it and file a follow-up" path this checklist's procedure calls for. Closing #858 and
-#870.
+flows — flows 1-2 (2026-07-23 entry above) plus flows 3-10 (this entry). Two WCAG findings were
+logged from this pass and both are now fixed: flow 6 labels (fixed in this PR) and flow 5 focus
+loss ([#894](https://github.com/TwoToned/gearflow/issues/894), fixed in a follow-up PR). Closing
+#858 and #870.

--- a/src/components/projects/__tests__/project-wizard-focus.smoke.test.tsx
+++ b/src/components/projects/__tests__/project-wizard-focus.smoke.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// Regression guard for #894 (R-8.1.7): the wizard's Continue/Back buttons
+// unmount on step change, and without an explicit focus target the browser
+// falls back to document.body — a silent focus loss for keyboard/screen-reader
+// users. The fix lands focus on the new step's heading after every transition
+// (except step 0, whose Name field already autoFocuses on mount).
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: { id: "org1" } }),
+  useSession: () => ({ data: { user: { id: "user1" } } }),
+}));
+vi.mock("@/hooks/use-server-mutation", () => ({
+  useServerMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/use-server-query", () => ({
+  useServerQuery: () => ({ data: undefined }),
+}));
+vi.mock("@/hooks/use-native-project-writes", () => ({
+  useProjectWrites: () => ({ create: vi.fn(), update: vi.fn() }),
+}));
+vi.mock("@/hooks/use-project-managers-writes", () => ({
+  useProjectManagerWrites: () => ({ set: vi.fn() }),
+}));
+vi.mock("@/hooks/use-clients", () => ({
+  useClientSearch: () => [],
+  useClient: () => undefined,
+}));
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: (v: unknown) => v,
+}));
+vi.mock("@/hooks/use-locations", () => ({
+  useLocations: () => [],
+}));
+vi.mock("@/hooks/use-org-tags", () => ({
+  useOrgTags: () => [],
+}));
+vi.mock("@/server/org-members", () => ({
+  getOrgMembers: vi.fn(async () => ({ members: [] })),
+}));
+vi.mock("@/server/projects", () => ({
+  peekNextProjectNumber: vi.fn(async () => "PROJ-0001"),
+  checkProjectNumberAvailable: vi.fn(async () => ({ available: true })),
+}));
+vi.mock("@/components/clients/quick-create-client", () => ({
+  QuickCreateClient: () => null,
+}));
+vi.mock("@/components/assets/quick-create-location", () => ({
+  QuickCreateLocation: () => null,
+}));
+
+import { ProjectWizard } from "../project-wizard";
+
+describe("ProjectWizard (focus management, #894)", () => {
+  it("moves focus to the new step's heading on Continue, instead of falling back to body", async () => {
+    render(<ProjectWizard />);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Summer Festival 2026"), {
+      target: { value: "Splendour Main Stage" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/PROJ-2026-0001/), {
+      target: { value: "PROJ-0099" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+
+    const heading = await screen.findByText(/Step 2: Schedule/);
+    expect(document.activeElement).toBe(heading);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it("does not steal focus from the autoFocused Name field on initial render", () => {
+    render(<ProjectWizard />);
+    const nameInput = screen.getByPlaceholderText("e.g. Summer Festival 2026");
+    expect(document.activeElement).toBe(nameInput);
+  });
+});

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useForm, Controller, type Path, type UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -126,6 +126,21 @@ export function ProjectWizard({
   const [quickClient, setQuickClient] = useState(false);
   const [quickLocation, setQuickLocation] = useState(false);
   const [managerIds, setManagerIds] = useState<string[]>(initialManagerIds);
+
+  // WCAG "focus is never silently lost" (R-8.1.7, #894): the just-clicked
+  // Continue/Back button unmounts on step change, and without an explicit
+  // target focus falls back to document.body. Land it on the new step's
+  // heading instead. Step 0 is excluded — its Name field already autoFocuses
+  // on (re)mount, which fires during commit, before this effect would run.
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const isInitialStepRender = useRef(true);
+  useEffect(() => {
+    if (isInitialStepRender.current) {
+      isInitialStepRender.current = false;
+      return;
+    }
+    if (step !== 0) stepHeadingRef.current?.focus();
+  }, [step]);
 
   const { data: nextProjectNumber } = useServerQuery({
     queryKey: ["project-number-next", orgId],
@@ -314,6 +329,13 @@ export function ProjectWizard({
       <form onSubmit={form.handleSubmit((d) => mutation.mutate(d))} className="mt-6 grid gap-6 lg:grid-cols-[1fr_280px]">
         {/* Step content */}
         <div className="rounded-[var(--r-lg)] border border-line bg-card p-5 shadow-[var(--sh-card)] sm:p-6">
+          <h2
+            ref={stepHeadingRef}
+            tabIndex={-1}
+            className={cn("t-overline mb-4 rounded-[var(--r)] text-faint", focusRing)}
+          >
+            Step {step + 1}: {STEPS[step].label}
+          </h2>
           {step === 0 && (
             <div className="space-y-5">
               <Field label="Name" required error={form.formState.errors.name?.message}>


### PR DESCRIPTION
## Summary

- Fixes #894: the "Create a project" wizard (`/projects/new`, also used for edit and template create) silently dropped keyboard focus on every step transition. Clicking Continue/Back unmounts the just-clicked button, and with no explicit focus target the browser fell back to `document.body` — a repeated disorientation for keyboard-only and screen-reader users on the primary revenue-path flow (POLICY.md R-8.1.7, WCAG "focus is never silently lost").
- `ProjectWizard` (`src/components/projects/project-wizard.tsx`) now renders a `tabIndex={-1}` step heading ("Step N: <label>") at the top of the step-content card and focuses it via a `useEffect` keyed on `step`, skipping the very first render so it doesn't fight the initial paint.
- Step 0 is excluded from that effect: its Name field already carries `autoFocus`, which re-fires correctly on every (re)mount because the step content is conditionally rendered — adding heading-focus there would race and override it.
- Updated `FEATUREDOCS/10-projects.md` and `docs/a11y-manual-checklist.md` (flow 5 is now clean) and added a `CHANGELOG.md` entry per repo policy on docs-in-the-same-PR.

## Testing

- Added `src/components/projects/__tests__/project-wizard-focus.smoke.test.tsx`: renders the wizard, fills the Basics step, clicks Continue, and asserts `document.activeElement` is the new step's heading (not `document.body`); also asserts the Name field still autoFocuses on initial render.
- `pnpm exec vitest run src/components/projects/` — all 44 relevant tests pass (2 pre-existing failures in unrelated suites are due to a missing generated Prisma client in this sandbox, confirmed present before this change too).
- `pnpm exec eslint src/components/projects/project-wizard.tsx ...test.tsx` — no new errors (only pre-existing complexity/line-count warnings on this already-large component).
- `pnpm exec tsc --noEmit` — confirmed the pre-existing `project-wizard.tsx` implicit-`any` warnings are unchanged (same 3 warnings, shifted by the added line count) and unrelated to this diff.

## Checklist

- [x] New dependency? N/A — no new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLrESzHRfrqBq69ci5KP9T)_