### PR TITLE
Unify project equipment add/edit forms + kit/group discount capability

### DIFF
--- a/FEATUREDOCS/09-kits.md
+++ b/FEATUREDOCS/09-kits.md
@@ -58,6 +58,18 @@ rail + live preview, single clean page, "More details" accordion.
 - **KIT_PRICE**: Single price on parent row, children have `unitPrice: 0`
 - **ITEMIZED**: Individual prices on each child row, parent has `unitPrice: 0`
 
+### Discount (issue #883)
+`KIT_PRICE` kits support a flat `$` discount off the parent row's
+`unitPrice`, set at add time in `KitAddForm`. Reuses the existing
+`ProjectLineItem.discount` field (no schema change — kits never had their
+own pricing table) via `createKitLineItemCore` /
+`convex/lineItemWrites.ts` `addKitNative` /
+`useLineItemWrites().addKit()`. Not available in `ITEMIZED` mode — there's
+no parent-row price to discount against; discount each child individually
+via `EditLineItemDialog` instead. Validated by the existing
+`assertLineMoneyFields` bound (finite, 0–999999.99) shared with every
+other line-item discount.
+
 ## Warehouse Operations
 - Kit checkout: `checkOutKit()` — atomic transaction updating kit + all member assets + grandchildren (nested kits)
 - Kit checkin: `checkInKit()` — same pattern, handles grandchildren

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -132,7 +132,21 @@ marginPercent = margin / total × 100
 
 ## Groups (`ProjectGroup`) — The Billable Unit
 - Groups are the billable units on quotes/invoices
-- Fields: `title`, `description` (free-text for quote), `quantity`, `price`
+- Fields: `title`, `description` (free-text for quote), `quantity`, `price`,
+  `discount` (issue #883)
+- `discount` is a **flat $ amount off `price × quantity`**, not per-unit —
+  same subtraction shape as `ProjectLineItem.discount`, clamped at 0.
+  Editable from `EditGroupDialog` or `PriceEditDialog`'s project branch (both
+  share the `DiscountField` `$`/`%` toggle; `%` resolves to a flat dollar
+  amount client-side before it reaches `updateGroupPriceNative` — the
+  mutation never sees a percentage). Applied in
+  `convex/lib/recalc.ts` (`groupRevenue`), `convex/lib/allocation.ts`
+  (per-model revenue pool), and `src/lib/pdfme/structure-line-items.ts`
+  (the synthetic group row's PDF total) — see
+  [FEATUREDOCS/47](./47-cross-type-equipment-unification.md#structural--discount-unification-pass-issue-883)
+  for the full plumbing list. There is no discount UI at group *creation*
+  (`AddGroupToolbarDialog`) — same as `price`, which is also only set
+  after creation via one of the two edit surfaces above.
 - `categoryId` is **nullable since v0.10.0.0** — a group can live in
   the project's Uncategorized zone (mirrors `SubHireGroup.targetCategoryId`).
   The toolbar "Add Group" dialog and per-group Move dialog both offer

--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -247,6 +247,110 @@ got a `(no group)` escape hatch in v0.9.2.1; field reports kept showing
 the mixed picker confused users about whether their pick would also
 re-home the item's category, so we split it.
 
+### Structural + discount unification pass (issue #883)
+
+The visual pass above explicitly stopped short of form-library choice,
+edit dialogs, and discount logic. This pass finishes that:
+
+**Shared primitives (`src/components/projects/line-item-form-fields.tsx`).**
+`SectionTitle` and `Field` were byte-identical copy-paste across all four
+add forms — now one shared export each. The `$`/`%` discount toggle had
+three independently hand-rolled implementations (`equipment-add-form`,
+`edit-line-item-dialog`, `bulk-edit-line-items-dialog`) that had quietly
+drifted in exact classes — now `DiscountField` (labelled) and
+`DiscountAmountInput` (bare, for callers with their own label, e.g.
+`bulk-edit-line-items-dialog`'s checkbox-gated rows). The mode is a pure
+client-side display convenience: every caller resolves a `%` value to a
+flat dollar amount before it reaches the schema/mutation — discount is
+*always* persisted as a flat $ amount (see `line-item.ts`'s `discountField`
+and the new `project-group.ts` `discount` field below).
+
+**RHF + Zod everywhere.** `custom-item-add-form.tsx` moved from hand-rolled
+`useState` per field (only `.parse()`d at submit) to
+`useForm + zodResolver(customLineItemSchema)`, matching
+`equipment-add-form.tsx`. It also gained the `%` discount toggle it was
+missing (dollars-only before, while its own edit path already supported
+both).
+
+**`edit-line-item-dialog.tsx` rebuilt on the add-form pattern.** This was
+the single biggest structural gap: equipment has a richly-structured add
+form, but editing that *same* line item dropped into a generic dialog with
+no placement/category editing, no `isOptional` toggle, no section
+grouping, no RHF/Zod. Worse, it was a live bug — `EditLineItemPayload`
+never included `isOptional`, so `lineItemSchema.parse()`'s
+`.default(false)` silently reset every edited item's optional flag to
+`false` on save. Now rebuilt on RHF + `zodResolver(lineItemSchema)` +
+`SectionTitle`/`Field`/`DiscountField`, with `isOptional` required in the
+payload (always seeded from the item) and a new Placement section
+(`PlacementFields`, hidden for kit children — they move with their parent
+kit, not independently). Placement changes fire a separate `onMove`
+callback into `groupWrites.moveLineItem` (only when the picker's value
+differs from the item's current placement) rather than flowing through
+`lineItemSchema`/`patchNative`, since a placement move is a different
+mutation with its own category-slot/suggested-price side effects — this
+mirrors how `EditGroupDialog` already fires price as a second, independent
+call alongside its main update. `equipment-tab.tsx` threads the item's
+current category/group into the dialog from the same closures the
+neighbouring `onMoveToCategory`/`onMoveToGroup` handlers already use (line
+items don't carry `categoryId`/`groupId` directly — tree position *is* the
+placement).
+
+**Kit and group discount capability.** Neither had any discount concept
+before this pass.
+
+- *Kits* reuse the existing `projectLineItems.discount` field (no schema
+  change) — `createKitLineItemCore` / `addKitNative` /
+  `useLineItemWrites().addKit()` / `kit-add-form.tsx` all thread an
+  optional `discount`, gated to `KIT_PRICE` mode (the only mode with a
+  flat `unitPrice` to discount against; `ITEMIZED` kits have no parent-row
+  price).
+- *Groups* got a new `discount: v.optional(v.number())` on the
+  `projectGroups` Convex table, the same 0–999999.99 finite bound as
+  line-item discount (`assertValidDiscount` in `projectGroupsWrites.ts`,
+  mirrored in `src/lib/validations/project-group.ts`). Threaded through
+  `createGroupNative` / `updateGroupPriceNative`, both `mapGroupDoc`
+  copies (`project-equipment-reconstruct.ts` and
+  `project-line-item-read.ts` — the latter feeds PDF generation),
+  `equipment-tab-reconstruct.ts`, and `useProjectGroupWrites().updatePrice()`'s
+  new optional third argument. `EditGroupDialog` and `PriceEditDialog`'s
+  project branch both expose a `DiscountField`. Money-math consumers
+  updated to actually apply it (a stored-but-ignored discount is worse
+  than no field at all):
+  - `convex/lib/recalc.ts` `groupRevenue` — `bundlePrice × quantity −
+    discount`, clamped at 0, same as line-item discount's single
+    flat-amount subtraction.
+  - `convex/lib/allocation.ts` `poolOf` (per-model revenue allocation) —
+    same clamp-then-subtract before the project-level discount factor
+    applies.
+  - `src/lib/pdfme/structure-line-items.ts` — the synthetic group row's
+    `lineTotal` now reflects the discount (was hardcoding
+    `discount: null` and never subtracting it), so quote/invoice PDFs
+    match what `recalcProjectTotals` actually bills.
+  - `equipment-rows.tsx` `GroupRow` — a `-$X disc.` caption under the unit
+    price (matching the existing per-line-item convention) and the Total
+    column reflects the discounted amount, desktop and mobile.
+
+  `subHireGroups` already had an unused `discount` field in the Convex
+  schema before this pass (never read/written by any mutation or dialog) —
+  left as-is; sub-hire group discount is out of scope for #883 (it uses
+  charge/cost, not a discount-off-price model).
+
+**`Button loading` sweep.** `edit-line-item-dialog.tsx`,
+`edit-group-dialog.tsx`, `price-edit-dialog.tsx`,
+`bulk-edit-line-items-dialog.tsx`, and `add-group-toolbar-dialog.tsx` all
+now use the registry `Button loading` prop instead of an inline
+`Loader2`-in-button-children spinner.
+
+Not changed in this pass: `sub-hire-add-form.tsx` (order-level fields only,
+no pricing section to unify — it got the `SectionTitle`/`Field` dedup but
+no RHF/Zod migration since it has no numeric bounds to validate beyond
+what `ComboboxPicker`/`<input type="date">` already constrain) and
+`unified-add-dialog.tsx`'s own segmented-switcher styling (still raw
+`bg-primary`/`hover:bg-accent` Tailwind rather than the RVLT semantic
+tokens `equipment-add-form.tsx`'s internal `ModeTab` uses — flagged as a
+follow-up, not fixed here to keep this pass's blast radius to the
+form-library/discount work the issue scoped).
+
 ## Reordering (▲/▼ move buttons)
 
 Drag-and-drop was removed (`chore/remove-pdf-builder-and-dnd`; `@dnd-kit`
@@ -319,6 +423,14 @@ Unit tests under `src/lib/validations/` and `src/components/projects/`:
 
 PDF pipeline (`src/lib/pdfme/structure-line-items.ts`) already handles
 SubHireGroup synthetic parents — pre-dates this work, no changes needed.
+
+**#883 (structural + discount unification) test coverage:**
+
+- `convex/recalc.test.ts` — group discount subtracted from `equipmentRevenue`, clamped at 0
+- `convex/allocation.test.ts` — group discount shrinks the per-model revenue pool, clamped at 0
+- `convex/projectGroupsWrites.test.ts` — `updateGroupPriceNative` discount bound, the omit-to-preserve-existing-value semantics, non-finite rejection
+- `src/lib/validations/project-group.test.ts` — `discount` field + `updateGroupPriceSchema` bound coverage
+- `src/lib/pdfme/structure-line-items.test.ts` — group discount subtracted from the synthetic row's `lineTotal`, clamped at 0
 
 ## What this work did NOT change
 

--- a/convex/allocation.test.ts
+++ b/convex/allocation.test.ts
@@ -373,6 +373,25 @@ describe("groups — Approach B", () => {
     expect(sumOf(r, ["a", "b"])).toBe(300);
   });
 
+  test("a group discount shrinks the pool everyone splits (#883)", () => {
+    const r = run(
+      [
+        L("a", { groupId: "g1", modelId: "m1", lineTotal: 1, sortOrder: 1 }),
+        L("b", { groupId: "g1", modelId: "m2", lineTotal: 1, sortOrder: 2 }),
+      ],
+      { groups: [{ id: "g1", price: 100, quantity: 3, discount: 50 }] },
+    );
+    // pool = 100 × 3 - 50 = 250, not 300.
+    expect(sumOf(r, ["a", "b"])).toBe(250);
+  });
+
+  test("a group discount larger than the bundle clamps the pool at 0, not negative (#883)", () => {
+    const r = run([L("a", { groupId: "g1", modelId: "m1", lineTotal: 1 })], {
+      groups: [{ id: "g1", price: 100, quantity: 1, discount: 9999 }],
+    });
+    expect(rev(r, "a")).toBe(0);
+  });
+
   test("an awkward price still sums exactly — no leaked cents", () => {
     const r = run(
       [

--- a/convex/lib/allocation.ts
+++ b/convex/lib/allocation.ts
@@ -77,6 +77,7 @@ export interface AllocGroup {
   id: string;
   price?: number | null;
   quantity?: number | null;
+  discount?: number | null;
 }
 
 export interface AllocationInput {
@@ -447,8 +448,11 @@ export function allocateProject(input: AllocationInput): Map<string, LineAllocat
 
     // Round the PRODUCT, not the price: recalcProjectTotals bills `price × quantity`
     // and rounds the sum, so rounding the price first would allocate a pool the
-    // project never charged for.
-    const poolCents = poolOf((g.price ?? 0) * Math.max(0, g.quantity ?? 0));
+    // project never charged for. Discount (#883) is subtracted the same way
+    // recalcProjectTotals does — a flat $ amount off the bundle total, clamped at 0
+    // BEFORE the project-level discount factor poolOf applies.
+    const bundleTotal = Math.max(0, (g.price ?? 0) * Math.max(0, g.quantity ?? 0) - (g.discount ?? 0));
+    const poolCents = poolOf(bundleTotal);
 
     const customCents = customs.map((c) => Math.max(0, poolOf(c.lineTotal)));
     const customSum = customCents.reduce((a, b) => a + b, 0);

--- a/convex/lib/recalc.ts
+++ b/convex/lib/recalc.ts
@@ -57,7 +57,10 @@ export async function recalcProjectTotals(
                 li.status !== "CANCELLED",
             )
             .reduce((s, li) => s + num(li.lineTotal), 0);
-    return sum + bundlePrice * (g.quantity ?? 0) + customExtras;
+    // Discount is a flat $ amount off the bundle total (#883) — same shape as
+    // projectLineItems.discount, subtracted once (not per-unit), clamped at 0.
+    const bundleTotal = Math.max(0, bundlePrice * (g.quantity ?? 0) - num(g.discount));
+    return sum + bundleTotal + customExtras;
   }, 0);
 
   // 2. Standalone (ungrouped) line items — includes ungrouped custom items.

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -1061,6 +1061,9 @@ export const addKitNative = mutation({
     projectId: v.string(),
     kitId: v.string(),
     unitPrice: v.optional(v.number()),
+    /** Flat $ discount off unitPrice — KIT_PRICE mode only. Mirrors the
+     *  equipment/custom line-item discount field (#883). */
+    discount: v.optional(v.number()),
     pricingMode: enums.KitPricingMode,
     groupName: v.optional(v.string()),
     categoryId: v.optional(v.string()),
@@ -1082,7 +1085,7 @@ export const addKitNative = mutation({
     orgDefaultTaxRate: v.optional(v.union(v.number(), v.null())),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, kitLabel, emitActivity, actor: suppliedActor, auditId, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, discount, pricingMode, groupName, categoryId, groupId, kitLabel, emitActivity, actor: suppliedActor, auditId, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
@@ -1096,7 +1099,7 @@ export const addKitNative = mutation({
     // (assertLineMoneyFields) — this one didn't, so a browser caller sending
     // `unitPrice: NaN` (or Infinity/negative) flowed straight into the line and then
     // poisoned recalcProjectTotals' project.total/subtotal/margin to NaN.
-    assertLineMoneyFields({ unitPrice });
+    assertLineMoneyFields({ unitPrice, discount });
 
     // Dup-guard the client-minted kit-line id (by_cuid is global + non-unique).
     const dupKit = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", id)).first();
@@ -1140,7 +1143,7 @@ export const addKitNative = mutation({
     }
 
     await createKitLineItemCore(ctx, {
-      id, organizationId, projectId, kitId, unitPrice, pricingMode, groupName, categoryId, groupId, now,
+      id, organizationId, projectId, kitId, unitPrice, discount, pricingMode, groupName, categoryId, groupId, now,
     });
 
     // Parity with the deleted addKitLineItem: when the client can't resolve the kit

--- a/convex/projectGroupsWrites.test.ts
+++ b/convex/projectGroupsWrites.test.ts
@@ -231,6 +231,48 @@ describe("projectGroupsWrites.updateGroupPriceNative", () => {
     });
   });
 
+  test("member sets price + discount together → both patch, recalc reflects the discounted total (#883)", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 150, discount: 50, now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.price).toBe(150);
+      expect(g?.discount).toBe(50);
+      // Bundle 150 × 2 - 50 discount = 250, + 10% tax = 275.
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(project?.total).toBe(275);
+    });
+  });
+
+  test("omitting discount leaves the existing discount untouched", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 150, discount: 50, now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 200, now: NOW + 1, actor: ACTOR, auditId: "log2",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.price).toBe(200);
+      expect(g?.discount).toBe(50);
+    });
+  });
+
+  test("rejects a non-finite discount (NaN/Infinity would poison recalc)", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+        id: "g1", orgId: ORG, price: 150, discount: Number.NaN, now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/finite/i);
+  });
+
   test("viewer denied", async () => {
     const t = makeT();
     await member(t, "viewer");

--- a/convex/projectGroupsWrites.ts
+++ b/convex/projectGroupsWrites.ts
@@ -62,6 +62,13 @@ function assertValidPrice(price: number) {
   // (groupRevenue += num(price) * qty → project.total = NaN). Browser-direct bypasses Zod.
   if (!Number.isFinite(price) || price < 0) throw new ConvexError("Price must be a finite number ≥ 0");
 }
+function assertValidDiscount(discount: number) {
+  // Same anti-poisoning guard as assertValidPrice, plus the upper bound
+  // src/lib/validations/project-group.ts / line-item.ts discountField enforces.
+  if (!Number.isFinite(discount) || discount < 0 || discount > 999999.99) {
+    throw new ConvexError("Discount must be a finite number between 0 and 999999.99");
+  }
+}
 
 // ─── Collaboration colour (deterministic from userId) ────────────────────────
 // Inlined from src/lib/collaboration-colors.ts getUserColor (same as
@@ -219,6 +226,7 @@ export const createGroupNative = mutation({
     description: v.optional(v.string()),
     quantity: v.optional(v.number()),
     price: v.optional(v.number()),
+    discount: v.optional(v.number()),
     rentalPeriod: v.optional(enums.RentalPeriod),
     rentalQuantity: v.optional(v.number()),
     now: v.number(),
@@ -236,6 +244,7 @@ export const createGroupNative = mutation({
     const quantity = a.quantity ?? 1;
     assertValidQuantity(quantity);
     if (a.price != null) assertValidPrice(a.price);
+    if (a.discount != null) assertValidDiscount(a.discount);
     if (a.rentalQuantity != null) assertValidRentalQuantity(a.rentalQuantity);
 
     // The client supplies projectId + categoryId; verify both are the caller's org (and
@@ -278,6 +287,7 @@ export const createGroupNative = mutation({
       description: a.description || undefined,
       quantity,
       price: a.price != null ? a.price : undefined,
+      discount: a.discount != null ? a.discount : undefined,
       rentalPeriod: a.rentalPeriod || undefined,
       rentalQuantity: a.rentalQuantity || undefined,
       suggestedPrice: 0,
@@ -406,6 +416,11 @@ export const updateGroupPriceNative = mutation({
     id: v.string(),
     orgId: v.string(),
     price: v.number(),
+    // Optional — omit to leave the existing discount untouched; pass 0/undefined
+    // via the caller's "clear" convention (client always sends a resolved number
+    // or leaves the arg out entirely, mirroring how discount already works for
+    // patchNative on line items).
+    discount: v.optional(v.number()),
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
@@ -417,9 +432,12 @@ export const updateGroupPriceNative = mutation({
     const actor = await resolveActor(ctx, a.actor);
 
     assertValidPrice(a.price);
+    if (a.discount != null) assertValidDiscount(a.discount);
     const group = await requireGroupInOrg(ctx, a.id, a.orgId);
 
-    await ctx.db.patch(group._id, { price: a.price, updatedAt: a.now });
+    const patch: Record<string, unknown> = { price: a.price, updatedAt: a.now };
+    if (a.discount !== undefined) patch.discount = a.discount;
+    await ctx.db.patch(group._id, patch);
 
     await logGroupChange(ctx, {
       orgId: a.orgId,

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -594,6 +594,9 @@ export async function createKitLineItemCore(
     projectId: string;
     kitId: string;
     unitPrice?: number;
+    /** Flat dollar amount off `unitPrice`, KIT_PRICE mode only — mirrors how
+     *  discount already works for equipment/custom line items. */
+    discount?: number;
     pricingMode: "KIT_PRICE" | "ITEMIZED";
     groupName?: string;
     categoryId?: string;
@@ -606,10 +609,15 @@ export async function createKitLineItemCore(
     if (!kit || kit.organizationId !== a.organizationId) throw new ConvexError("Kit not found");
     let sort = await nextLineSort(ctx, a.projectId, a.organizationId);
 
+    // Discount only means anything alongside a flat unitPrice (KIT_PRICE mode) —
+    // ITEMIZED kits have no parent-row price to discount against.
+    const kitLineTotal =
+      a.unitPrice != null ? Math.max(0, a.unitPrice - (a.discount ?? 0)) : a.unitPrice;
+
     await ctx.db.insert("projectLineItems", {
       id: a.id, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT", kitId: a.kitId,
       description: `${kit.assetTag} - ${kit.name}`, quantity: 1, unitPrice: a.unitPrice, pricingType: "PER_DAY",
-      duration: 1, lineTotal: a.unitPrice, sortOrder: sort++, pricingMode: a.pricingMode,
+      duration: 1, discount: a.unitPrice != null ? a.discount : undefined, lineTotal: kitLineTotal, sortOrder: sort++, pricingMode: a.pricingMode,
       groupName: a.groupName, categoryId: a.categoryId, groupId: a.groupId, status: "CONFIRMED",
       createdAt: a.now, updatedAt: a.now,
     });

--- a/convex/recalc.test.ts
+++ b/convex/recalc.test.ts
@@ -83,6 +83,41 @@ describe("recalcProjectTotals — totals parity", () => {
     expect(p?.equipmentRevenue).toBe(160);
   });
 
+  test("subtracts a Project Group's flat discount from its bundle revenue (#883)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", {
+        id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig",
+        status: "CONFIRMED", isTemplate: false, taxRate: 0, discountPercent: 0,
+        createdAt: NOW, updatedAt: NOW,
+      });
+      // price 100 × qty 2 = 200, minus a flat $50 group discount = 150.
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: ORG, projectId: "p1", title: "Lighting", price: 100, quantity: 2, discount: 50, sortOrder: 0 });
+      await recalcProjectTotals(ctx, "p1", ORG, null, NOW + 1);
+    });
+
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.equipmentRevenue).toBe(150);
+    expect(p?.subtotal).toBe(150);
+  });
+
+  test("clamps a Project Group's discount at 0 rather than going negative (#883)", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", {
+        id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig",
+        status: "CONFIRMED", isTemplate: false, taxRate: 0, discountPercent: 0,
+        createdAt: NOW, updatedAt: NOW,
+      });
+      // price 100 × qty 1 = 100, discount 9999 — must clamp at 0, not go negative.
+      await ctx.db.insert("projectGroups", { id: "g1", organizationId: ORG, projectId: "p1", title: "Lighting", price: 100, quantity: 1, discount: 9999, sortOrder: 0 });
+      await recalcProjectTotals(ctx, "p1", ORG, null, NOW + 1);
+    });
+
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.equipmentRevenue).toBe(0);
+  });
+
   test("uses org default tax when the project has no override", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1059,6 +1059,8 @@ export default defineSchema({
     description: v.optional(v.string()),
     quantity: v.optional(v.number()),
     price: v.optional(v.number()),
+    // Flat $ amount off `price × quantity` (#883) — mirrors projectLineItems.discount.
+    discount: v.optional(v.number()),
     suggestedPrice: v.optional(v.number()),
     rentalPeriod: v.optional(enums.RentalPeriod),
     rentalQuantity: v.optional(v.number()),

--- a/src/components/projects/add-group-toolbar-dialog.tsx
+++ b/src/components/projects/add-group-toolbar-dialog.tsx
@@ -157,7 +157,8 @@ function AddGroupToolbarDialogBody({
         </Button>
         <Button
           onClick={handleSubmit}
-          disabled={!title.trim() || !categoryId || isPending}
+          loading={isPending}
+          disabled={!title.trim() || !categoryId}
         >
           Create
         </Button>

--- a/src/components/projects/bulk-edit-line-items-dialog.tsx
+++ b/src/components/projects/bulk-edit-line-items-dialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -21,8 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2 } from "lucide-react";
 import type { BulkLineItemPatch } from "@/hooks/use-line-item-writes";
+import { DiscountAmountInput, type DiscountMode } from "./line-item-form-fields";
 
 const PRICING_LABELS: Record<string, string> = {
   PER_DAY: "Per day",
@@ -61,7 +60,7 @@ export function BulkEditLineItemsDialog({
 
   const [discountOn, setDiscountOn] = React.useState(false);
   const [discount, setDiscount] = React.useState("");
-  const [discountMode, setDiscountMode] = React.useState<"$" | "%">("$");
+  const [discountMode, setDiscountMode] = React.useState<DiscountMode>("$");
 
   const [notesOn, setNotesOn] = React.useState(false);
   const [notes, setNotes] = React.useState("");
@@ -159,30 +158,17 @@ export function BulkEditLineItemsDialog({
             />
             <div className="flex-1 space-y-1.5">
               <Label htmlFor="bulk-discount">Discount</Label>
-              <div className="flex gap-1">
-                <Input
-                  id="bulk-discount"
-                  type="number"
-                  step="0.01"
-                  min={0}
-                  placeholder="0"
-                  value={discount}
-                  onChange={(e) => {
-                    setDiscount(e.target.value);
-                    setDiscountOn(true);
-                  }}
-                  disabled={!discountOn}
-                  className="flex-1"
-                />
-                <button
-                  type="button"
-                  onClick={() => setDiscountMode(discountMode === "$" ? "%" : "$")}
-                  disabled={!discountOn}
-                  className="shrink-0 w-9 h-9 rounded-md border border-input text-sm font-medium hover:bg-accent transition-colors disabled:opacity-45 disabled:cursor-not-allowed"
-                >
-                  {discountMode}
-                </button>
-              </div>
+              <DiscountAmountInput
+                id="bulk-discount"
+                value={discount}
+                onValueChange={(value) => {
+                  setDiscount(value);
+                  setDiscountOn(true);
+                }}
+                mode={discountMode}
+                onModeChange={setDiscountMode}
+                disabled={!discountOn}
+              />
               <p className="text-caption text-muted">
                 Clears the discount when left blank or zero.
                 {discountMode === "%" &&
@@ -246,8 +232,7 @@ export function BulkEditLineItemsDialog({
           <Button variant="line" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={!anyEnabled || isPending}>
-            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button onClick={handleSave} loading={isPending} disabled={!anyEnabled}>
             Apply to {count} item{count === 1 ? "" : "s"}
           </Button>
         </DialogFooter>

--- a/src/components/projects/custom-item-add-form.tsx
+++ b/src/components/projects/custom-item-add-form.tsx
@@ -7,19 +7,24 @@
  *
  * Renders the fields + footer (Cancel / Add Item) and owns the
  * addCustomLineItem mutation. No Dialog wrapper — the caller supplies that.
+ *
+ * RHF + zodResolver(customLineItemSchema) (#883) — was hand-rolled useState
+ * per field with only a submit-time `.parse()`, so bounds like `unitPrice ≤
+ * 999999.99` never surfaced as inline field errors. The discount field now
+ * shares the $/% toggle used by equipment-add-form instead of being dollars-only.
  */
 
 import { useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { refreshProjectDetail } from "@/hooks/use-project-detail";
 import { toast } from "sonner";
 
 import { useLineItemWrites } from "@/hooks/use-line-item-writes";
-import { customLineItemSchema } from "@/lib/validations/line-item";
-import type { z } from "zod";
+import { customLineItemSchema, type CustomLineItemFormValues } from "@/lib/validations/line-item";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -27,6 +32,7 @@ import {
 } from "@/components/ui/select";
 import { DialogFooter } from "@/components/ui/dialog";
 import { PlacementFields } from "./placement-fields";
+import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 
 type CustomItemPricingType = "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR";
@@ -60,17 +66,20 @@ export function CustomItemAddForm({
   onInvalidate,
   onClose,
 }: CustomItemAddFormProps) {
-  const [name, setName] = useState("");
-  const [qty, setQty] = useState("1");
-  const [price, setPrice] = useState("");
-  const [pricingType, setPricingType] = useState<CustomItemPricingType>("FLAT");
-  const [duration, setDuration] = useState("1");
-  const [discount, setDiscount] = useState("");
-  const [isOptional, setIsOptional] = useState(false);
-  const [notes, setNotes] = useState("");
+  const lineItemWrites = useLineItemWrites();
+  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
   const [categoryId, setCategoryId] = useState(defaultCategoryId ?? "");
   const [groupId, setGroupId] = useState(defaultGroupId ?? "");
-  const lineItemWrites = useLineItemWrites();
+
+  const form = useForm<CustomLineItemFormValues>({
+    resolver: zodResolver(customLineItemSchema),
+    defaultValues: {
+      quantity: 1,
+      pricingType: "FLAT",
+      duration: 1,
+      isOptional: false,
+    },
+  });
 
   // Resolve a groupId → its title, from the categories the form already holds — the
   // browser-direct twin of the server's Convex getById lookup (no round-trip needed).
@@ -84,11 +93,21 @@ export function CustomItemAddForm({
   };
 
   const addMut = useServerMutation({
-    mutationFn: (data: z.input<typeof customLineItemSchema>) => {
+    mutationFn: (data: CustomLineItemFormValues) => {
+      let disc = data.discount;
+      if (discountMode === "%" && disc && data.unitPrice) {
+        const gross = Number(data.unitPrice) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
+        disc = Math.round((gross * Number(disc)) / 100 * 100) / 100;
+      }
       // Browser-direct native path. addCustomNative folds recalc + audit + collab into one
       // transaction; reactive useQuery renders the new row. groupName is resolved locally
       // from the categories the form already holds (no round-trip).
-      const parsed = customLineItemSchema.parse(data);
+      const parsed = customLineItemSchema.parse({
+        ...data,
+        discount: disc,
+        categoryId: categoryId || undefined,
+        groupId: groupId || undefined,
+      });
       return lineItemWrites.addCustom(projectId, parsed, {
         groupName: resolveGroupName(parsed.groupId),
       });
@@ -102,187 +121,152 @@ export function CustomItemAddForm({
     onError: (e: Error) => toast.error(e.message),
   });
 
+  const pricingType = form.watch("pricingType") ?? "FLAT";
+
   // ─── Live summary ──────────────────────────────────────────────
-  const qtyNum = Math.max(1, parseInt(qty) || 1);
-  const priceNum = price !== "" ? parseFloat(price) : 0;
-  const durationNum = pricingType !== "FLAT" ? Math.max(1, parseInt(duration) || 1) : 1;
-  const discountNum = discount !== "" ? parseFloat(discount) : 0;
+  const name = form.watch("description") ?? "";
+  const qtyNum = Math.max(1, Number(form.watch("quantity")) || 1);
+  const priceNum = Number(form.watch("unitPrice")) || 0;
+  const durationNum = pricingType !== "FLAT" ? Math.max(1, Number(form.watch("duration")) || 1) : 1;
+  const rawDiscount = Number(form.watch("discount")) || 0;
+  const discountNum =
+    discountMode === "%" ? Math.round((qtyNum * priceNum * durationNum * rawDiscount) / 100 * 100) / 100 : rawDiscount;
+  const isOptional = form.watch("isOptional") ?? false;
   const summaryTotal = Math.max(0, qtyNum * priceNum * durationNum - discountNum);
   const showSummary = name.trim().length > 0 && priceNum > 0;
 
   return (
-    <>
-      <div className="space-y-6 py-2">
-        {/* Item */}
-        <section className="space-y-4">
-          <SectionTitle title="Item" hint="What you're adding and where it lands." />
-          <Field label="Name" required>
-            <Input
-              id="custom-item-name"
-              placeholder="e.g. 2x SM58 (borrowed), client cable drum"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              maxLength={200}
-            />
-          </Field>
-          <PlacementFields
-            categories={categories}
-            categoryId={categoryId}
-            groupId={groupId}
-            onChange={({ categoryId, groupId }) => {
-              setCategoryId(categoryId);
-              setGroupId(groupId);
-            }}
+    <form onSubmit={form.handleSubmit((d) => addMut.mutate(d))} className="space-y-6">
+      {/* Item */}
+      <section className="space-y-4">
+        <SectionTitle title="Item" hint="What you're adding and where it lands." />
+        <Field label="Name" htmlFor="custom-item-name" required>
+          <Input
+            id="custom-item-name"
+            placeholder="e.g. 2x SM58 (borrowed), client cable drum"
+            maxLength={200}
+            {...form.register("description")}
           />
-        </section>
+        </Field>
+        <PlacementFields
+          categories={categories}
+          categoryId={categoryId}
+          groupId={groupId}
+          onChange={({ categoryId, groupId }) => {
+            setCategoryId(categoryId);
+            setGroupId(groupId);
+          }}
+        />
+      </section>
 
-        {/* Pricing */}
-        <section className="space-y-4 border-t border-line pt-5">
-          <SectionTitle title="Pricing" hint="Quantity, rate, and how it's charged." />
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Quantity">
-              <Input
-                id="custom-item-qty"
-                type="number"
-                min="1"
-                value={qty}
-                onChange={(e) => setQty(e.target.value)}
-              />
-            </Field>
-            <Field label="Unit price ($)">
-              <Input
-                id="custom-item-price"
-                type="number"
-                min="0"
-                step="0.01"
-                placeholder="0.00"
-                value={price}
-                onChange={(e) => setPrice(e.target.value)}
-              />
-            </Field>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Pricing type">
-              <Select
-                value={pricingType}
-                onValueChange={(val) => setPricingType(val as CustomItemPricingType)}
-              >
-                <SelectTrigger>
-                  <SelectValue>{PRICING_LABELS[pricingType]}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {PRICING_ORDER.map((p) => (
-                    <SelectItem key={p} value={p}>{PRICING_LABELS[p]}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-            {pricingType !== "FLAT" && (
-              <Field label="Duration">
-                <Input
-                  id="custom-item-duration"
-                  type="number"
-                  min="1"
-                  value={duration}
-                  onChange={(e) => setDuration(e.target.value)}
-                />
-              </Field>
-            )}
-          </div>
-          <Field label="Discount ($)">
+      {/* Pricing */}
+      <section className="space-y-4 border-t border-line pt-5">
+        <SectionTitle title="Pricing" hint="Quantity, rate, and how it's charged." />
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Quantity" htmlFor="custom-item-qty">
+            <Input id="custom-item-qty" type="number" min={1} {...form.register("quantity")} />
+          </Field>
+          <Field label="Unit price ($)" htmlFor="custom-item-price">
             <Input
-              id="custom-item-discount"
+              id="custom-item-price"
               type="number"
-              min="0"
+              min={0}
               step="0.01"
               placeholder="0.00"
-              value={discount}
-              onChange={(e) => setDiscount(e.target.value)}
+              {...form.register("unitPrice")}
             />
           </Field>
-          <label className="flex cursor-pointer items-center gap-2.5">
-            <Checkbox
-              id="custom-item-optional"
-              checked={isOptional}
-              onCheckedChange={(c) => setIsOptional(c === true)}
-            />
-            <span className="text-ui-text text-ink-2">Optional item (excluded from project total)</span>
-          </label>
-        </section>
-
-        {/* Notes */}
-        <section className="space-y-4 border-t border-line pt-5">
-          <SectionTitle title="Notes" hint="Optional — context for the docket." />
-          <Field label="Notes">
-            <Textarea
-              id="custom-item-notes"
-              placeholder="Optional notes…"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              rows={2}
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Pricing type" htmlFor="custom-item-pricing-type">
+            <Controller
+              control={form.control}
+              name="pricingType"
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? "FLAT"}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger id="custom-item-pricing-type">
+                    <SelectValue>{PRICING_LABELS[(field.value ?? "FLAT") as CustomItemPricingType]}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PRICING_ORDER.map((p) => (
+                      <SelectItem key={p} value={p}>{PRICING_LABELS[p]}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             />
           </Field>
-        </section>
+          {pricingType !== "FLAT" && (
+            <Field label="Duration" htmlFor="custom-item-duration">
+              <Input id="custom-item-duration" type="number" min={1} {...form.register("duration")} />
+            </Field>
+          )}
+        </div>
+        <Controller
+          control={form.control}
+          name="discount"
+          render={({ field }) => (
+            <DiscountField
+              id="custom-item-discount"
+              value={field.value == null ? "" : String(field.value)}
+              onValueChange={field.onChange}
+              mode={discountMode}
+              onModeChange={setDiscountMode}
+            />
+          )}
+        />
+        <label className="flex cursor-pointer items-center gap-2.5">
+          <Controller
+            control={form.control}
+            name="isOptional"
+            render={({ field }) => (
+              <Checkbox
+                id="custom-item-optional"
+                checked={field.value ?? false}
+                onCheckedChange={field.onChange}
+              />
+            )}
+          />
+          <span className="text-ui-text text-ink-2">Optional item (excluded from project total)</span>
+        </label>
+      </section>
 
-        {showSummary && (
-          <div className="rounded-[var(--r)] border border-line bg-paper-2/50 px-3 py-2 text-caption text-ink-2">
-            Adding <span className="font-medium text-ink">{qtyNum}×</span> {name.trim()} —{" "}
-            <span className="t-data font-medium text-ink">${summaryTotal.toFixed(2)}</span>
-            {isOptional && <span className="text-muted"> (optional, not in total)</span>}
-          </div>
-        )}
-      </div>
+      {/* Notes */}
+      <section className="space-y-4 border-t border-line pt-5">
+        <SectionTitle title="Notes" hint="Optional — context for the docket." />
+        <Field label="Notes" htmlFor="custom-item-notes">
+          <Textarea
+            id="custom-item-notes"
+            placeholder="Optional notes…"
+            rows={2}
+            {...form.register("notes")}
+          />
+        </Field>
+      </section>
+
+      {showSummary && (
+        <div className="rounded-[var(--r)] border border-line bg-paper-2/50 px-3 py-2 text-caption text-ink-2">
+          Adding <span className="font-medium text-ink">{qtyNum}×</span> {name.trim()} —{" "}
+          <span className="t-data font-medium text-ink">${summaryTotal.toFixed(2)}</span>
+          {isOptional && <span className="text-muted"> (optional, not in total)</span>}
+        </div>
+      )}
 
       <DialogFooter>
         <Button type="button" variant="line" onClick={onClose}>
           Cancel
         </Button>
         <Button
-          type="button"
+          type="submit"
           loading={addMut.isPending}
           disabled={!name.trim() || !lineItemWrites.enabled}
-          onClick={() => {
-            addMut.mutate({
-              description: name.trim(),
-              quantity: parseInt(qty) || 1,
-              unitPrice: price !== "" ? parseFloat(price) : undefined,
-              pricingType,
-              duration: pricingType !== "FLAT" ? (parseInt(duration) || 1) : 1,
-              discount: discount !== "" ? parseFloat(discount) : undefined,
-              isOptional,
-              notes: notes.trim() || undefined,
-              categoryId: categoryId || undefined,
-              groupId: groupId || undefined,
-            });
-          }}
         >
           Add item
         </Button>
       </DialogFooter>
-    </>
-  );
-}
-
-// ─── Local helpers ───────────────────────────────────────────────
-
-function SectionTitle({ title, hint }: { title: string; hint?: string }) {
-  return (
-    <div>
-      <h3 className="text-card-title font-bold text-ink">{title}</h3>
-      {hint && <p className="mt-0.5 t-micro text-muted">{hint}</p>}
-    </div>
-  );
-}
-
-function Field({
-  label, required, children,
-}: {
-  label: string; required?: boolean; children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <Label>{label}{required && <span className="text-red"> *</span>}</Label>
-      {children}
-    </div>
+    </form>
   );
 }

--- a/src/components/projects/edit-group-dialog.tsx
+++ b/src/components/projects/edit-group-dialog.tsx
@@ -28,7 +28,7 @@ import { formatCurrency } from "@/lib/formatters";
 import { useEditLock } from "@/hooks/use-collaboration";
 import { LockedEditorOverlay } from "@/components/collaboration/locked-editor-overlay";
 import { COLLAB_TARGET_TYPES } from "@/lib/collaboration-targets";
-import { DiscountField, type DiscountMode } from "./line-item-form-fields";
+import { DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
 import type { GroupData } from "./equipment-rows";
 
 export interface EditGroupFormValues {
@@ -97,14 +97,8 @@ function EditGroupDialogBody({
   function handleSave() {
     if (!title.trim() || formDisabled) return;
     const resolvedPrice = price !== "" ? parseFloat(price) || 0 : undefined;
-    // Resolve a `%` discount to a flat $ amount before it reaches the mutation —
-    // discount is always persisted as a flat dollar amount off price × quantity.
-    let resolvedDiscount: number | undefined;
-    if (discount !== "") {
-      const raw = parseFloat(discount) || 0;
-      const gross = (resolvedPrice ?? priceVal ?? 0) * (parseInt(quantity) || 1);
-      resolvedDiscount = discountMode === "%" ? Math.round(gross * raw) / 100 : raw;
-    }
+    const gross = (resolvedPrice ?? priceVal ?? 0) * (parseInt(quantity) || 1);
+    const resolvedDiscount = resolveDiscountAmount(discountMode, discount, gross);
     onSubmit(
       group.id,
       {

--- a/src/components/projects/edit-group-dialog.tsx
+++ b/src/components/projects/edit-group-dialog.tsx
@@ -28,6 +28,7 @@ import { formatCurrency } from "@/lib/formatters";
 import { useEditLock } from "@/hooks/use-collaboration";
 import { LockedEditorOverlay } from "@/components/collaboration/locked-editor-overlay";
 import { COLLAB_TARGET_TYPES } from "@/lib/collaboration-targets";
+import { DiscountField, type DiscountMode } from "./line-item-form-fields";
 import type { GroupData } from "./equipment-rows";
 
 export interface EditGroupFormValues {
@@ -44,12 +45,13 @@ interface EditGroupDialogProps {
   orgId?: string;
   onClose: () => void;
   /** Called when the user clicks Save. The parent decides which
-   *  mutation(s) to fire and whether to apply the optional price
+   *  mutation(s) to fire and whether to apply the optional price/discount
    *  alongside the main update. */
   onSubmit: (
     groupId: string,
     values: EditGroupFormValues,
     price: number | undefined,
+    discount: number | undefined,
   ) => void;
 }
 
@@ -83,14 +85,26 @@ function EditGroupDialogBody({
   const formDisabled = isLocked;
 
   const priceVal = group.price != null ? Number(group.price) : null;
+  const discountVal = group.discount != null ? Number(group.discount) : null;
 
   const [title, setTitle] = useState(group.title);
   const [description, setDescription] = useState(group.description ?? "");
   const [quantity, setQuantity] = useState(String(group.quantity));
   const [price, setPrice] = useState(priceVal != null ? String(priceVal) : "");
+  const [discount, setDiscount] = useState(discountVal != null ? String(discountVal) : "");
+  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
 
   function handleSave() {
     if (!title.trim() || formDisabled) return;
+    const resolvedPrice = price !== "" ? parseFloat(price) || 0 : undefined;
+    // Resolve a `%` discount to a flat $ amount before it reaches the mutation —
+    // discount is always persisted as a flat dollar amount off price × quantity.
+    let resolvedDiscount: number | undefined;
+    if (discount !== "") {
+      const raw = parseFloat(discount) || 0;
+      const gross = (resolvedPrice ?? priceVal ?? 0) * (parseInt(quantity) || 1);
+      resolvedDiscount = discountMode === "%" ? Math.round(gross * raw) / 100 : raw;
+    }
     onSubmit(
       group.id,
       {
@@ -98,7 +112,8 @@ function EditGroupDialogBody({
         description: description.trim() || undefined,
         quantity: parseInt(quantity) || 1,
       },
-      price !== "" ? parseFloat(price) || 0 : undefined,
+      resolvedPrice,
+      resolvedDiscount,
     );
   }
 
@@ -162,12 +177,19 @@ function EditGroupDialogBody({
             </button>
           )}
         </div>
+        <DiscountField
+          value={discount}
+          onValueChange={setDiscount}
+          mode={discountMode}
+          onModeChange={setDiscountMode}
+          disabled={formDisabled}
+        />
       </div>
       <DialogFooter>
         <Button variant="line" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleSave} disabled={!title.trim() || isPending || formDisabled}>
+        <Button onClick={handleSave} loading={isPending} disabled={!title.trim() || formDisabled}>
           Save
         </Button>
       </DialogFooter>

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -1,21 +1,32 @@
 "use client";
 
 /**
- * Edit-line-item dialog — description, quantity, unit price (manual),
- * discount, notes, and the overbook confirmation flow. Extracted from
- * equipment-tab.tsx in Phase 7.
+ * Edit-line-item dialog — description, quantity, unit price, discount,
+ * placement (category/group), the optional flag, notes, and the overbook
+ * confirmation flow. Rebuilt on the equipment-add-form reference pattern
+ * (#883): RHF + zodResolver(lineItemSchema), the shared SectionTitle/Field/
+ * DiscountField primitives, and PlacementFields — closing the biggest gap
+ * called out in the issue (this dialog previously had NO placement or
+ * isOptional editing at all, and silently reset isOptional to false on
+ * every save since it was never included in the submitted payload).
  *
  * State + the availability query live inside the body keyed by
  * item.id so re-opening for a different row remounts the body and
  * seeds fresh from the new item. Parent owns updateLineItemMut and
- * receives the computed payload via onSubmit.
+ * receives the computed payload via onSubmit; placement changes go
+ * through a separate `onMove` callback since they're a different
+ * mutation (groupWrites.moveLineItem) with its own slot/suggested-price
+ * side effects — mirrors how EditGroupDialog fires price as a second,
+ * independent call alongside its main update.
  */
 
 import { useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { useEditLock } from "@/hooks/use-collaboration";
 import { LockedEditorOverlay } from "@/components/collaboration/locked-editor-overlay";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
 import {
   Dialog,
@@ -26,10 +37,13 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
 import { checkAvailability } from "@/server/line-items";
-import type { LineItemData } from "./equipment-rows";
+import { lineItemSchema, type LineItemFormValues } from "@/lib/validations/line-item";
+import { PlacementFields } from "./placement-fields";
+import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
+import type { LineItemData, CategoryData } from "./equipment-rows";
 
 export interface EditLineItemPayload {
   type: string;
@@ -40,6 +54,12 @@ export interface EditLineItemPayload {
   duration: number;
   discount?: number;
   notes?: string;
+  isOptional: boolean;
+}
+
+export interface EditLineItemPlacement {
+  categoryId: string | null;
+  groupId: string | null;
 }
 
 interface EditLineItemDialogProps {
@@ -50,6 +70,14 @@ interface EditLineItemDialogProps {
   rentalEndDate?: Date | null;
   /** Active organization id — used in the availability query key. */
   orgId?: string;
+  /** Categories (+ groups) for the placement picker. Omit/empty to hide
+   *  the Placement section (e.g. when categories haven't loaded yet). */
+  categories?: CategoryData[];
+  /** The item's current category/group, resolved by the caller from where
+   *  in the tree the row was clicked (line items don't carry categoryId/
+   *  groupId directly — the tree position IS the placement). */
+  initialCategoryId?: string;
+  initialGroupId?: string;
   isPending: boolean;
   onClose: () => void;
   onSubmit: (
@@ -58,6 +86,11 @@ interface EditLineItemDialogProps {
     allowOverbook: boolean,
     baseUpdatedAt?: string | number | null,
   ) => void;
+  /** Fired separately from onSubmit only when the placement picker's value
+   *  differs from initialCategoryId/initialGroupId — a no-op move is never
+   *  sent. Omitted (or the Placement section hidden) when the item is a kit
+   *  child, which moves with its parent kit rather than independently. */
+  onMove?: (id: string, placement: EditLineItemPlacement) => void;
 }
 
 export function EditLineItemDialog(props: EditLineItemDialogProps) {
@@ -78,9 +111,13 @@ function EditLineItemDialogBody({
   rentalStartDate,
   rentalEndDate,
   orgId,
+  categories,
+  initialCategoryId,
+  initialGroupId,
   isPending,
   onClose,
   onSubmit,
+  onMove,
 }: EditLineItemDialogProps & { item: LineItemData }) {
   // Edit lock — acquire while this dialog body is mounted. Released on unmount.
   const { lockState, isLocked, isStale, takeover } = useEditLock({
@@ -95,22 +132,27 @@ function EditLineItemDialogBody({
   // Disable the whole form when another user holds an active lock
   const formDisabled = isLocked;
 
-  // Form state — seeded from item via useState initializers. Each fresh
-  // open remounts the body (keyed by item.id) so these always reflect
-  // the row that was clicked.
-  const [description, setDescription] = useState(
-    item.description ?? item.model?.name ?? "",
-  );
-  const [quantity, setQuantity] = useState(String(item.quantity));
-  const [unitPrice, setUnitPrice] = useState(
-    item.unitPrice != null ? String(Number(item.unitPrice)) : "",
-  );
-  const [discount, setDiscount] = useState(
-    item.discount != null && Number(item.discount) > 0 ? String(Number(item.discount)) : "",
-  );
-  const [discountMode, setDiscountMode] = useState<"$" | "%">("$");
-  const [notes, setNotes] = useState(item.notes ?? "");
+  const form = useForm<LineItemFormValues>({
+    resolver: zodResolver(lineItemSchema),
+    defaultValues: {
+      type: (item.type as LineItemFormValues["type"]) ?? "EQUIPMENT",
+      description: item.description ?? item.model?.name ?? "",
+      quantity: item.quantity,
+      unitPrice: item.unitPrice != null ? Number(item.unitPrice) : undefined,
+      pricingType: (item.pricingType as LineItemFormValues["pricingType"]) ?? "PER_DAY",
+      duration: item.duration ?? 1,
+      discount: item.discount != null && Number(item.discount) > 0 ? Number(item.discount) : undefined,
+      notes: item.notes ?? "",
+      isOptional: item.isOptional ?? false,
+    },
+  });
+  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
+
+  // Placement — kit children move with their parent kit, not independently.
+  const canEditPlacement = !item.isKitChild && !!onMove && !!categories?.length;
+  const [categoryId, setCategoryId] = useState(initialCategoryId ?? "");
+  const [groupId, setGroupId] = useState(initialGroupId ?? "");
 
   // Optimistic-concurrency baseline — captured once when the editor opens
   // (the body remounts per item.id, so the initializer runs fresh each open).
@@ -149,37 +191,44 @@ function EditLineItemDialogBody({
   const availableForEdit =
     availability ? availability.available + item.quantity : null;
 
-  const requestedQty = Number(quantity) || 1;
+  const requestedQty = Number(form.watch("quantity")) || 1;
   const isOverbooked =
     availableForEdit != null && requestedQty > availableForEdit;
 
-  function handleSave() {
-    const qty = Number(quantity) || 1;
-    const price = unitPrice ? Number(unitPrice) : undefined;
-    const dur = item.duration ?? 1;
-    let disc: number | undefined;
-    if (discount && Number(discount) > 0) {
-      if (discountMode === "%" && price != null) {
-        disc = Math.round((price * qty * dur * Number(discount)) / 100 * 100) / 100;
-      } else {
-        disc = Number(discount);
-      }
+  function handleSave(data: LineItemFormValues) {
+    const qty = Number(data.quantity) || 1;
+    const price = data.unitPrice != null ? Number(data.unitPrice) : undefined;
+    const dur = Number(data.duration) || item.duration || 1;
+    let disc = data.discount != null ? Number(data.discount) : undefined;
+    if (disc && discountMode === "%" && price != null) {
+      disc = Math.round((price * qty * dur * disc) / 100 * 100) / 100;
     }
     onSubmit(
       item.id,
       {
-        type: item.type ?? "EQUIPMENT",
+        type: data.type ?? item.type ?? "EQUIPMENT",
         quantity: qty,
         unitPrice: price,
-        description,
-        pricingType: item.pricingType ?? "PER_DAY",
+        description: data.description ?? "",
+        pricingType: data.pricingType ?? item.pricingType ?? "PER_DAY",
         duration: dur,
         discount: disc,
-        notes: notes || undefined,
+        notes: data.notes || undefined,
+        isOptional: data.isOptional ?? false,
       },
       overbookConfirmed,
       baseUpdatedAt,
     );
+
+    if (canEditPlacement) {
+      const nextCategoryId = categoryId || null;
+      const nextGroupId = groupId || null;
+      const placementChanged =
+        (initialCategoryId ?? null) !== nextCategoryId || (initialGroupId ?? null) !== nextGroupId;
+      if (placementChanged) {
+        onMove!(item.id, { categoryId: nextCategoryId, groupId: nextGroupId });
+      }
+    }
   }
 
   return (
@@ -197,42 +246,39 @@ function EditLineItemDialogBody({
         />
       )}
 
-      <div className={`space-y-4 py-2 ${formDisabled ? "pointer-events-none opacity-60" : ""}`}>
-        <div className="space-y-2">
-          <Label htmlFor="edit-description">Description</Label>
-          <Input
-            id="edit-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            disabled={formDisabled}
-          />
-        </div>
+      <form
+        onSubmit={form.handleSubmit(handleSave)}
+        className={`space-y-6 ${formDisabled ? "pointer-events-none opacity-60" : ""}`}
+      >
+        {/* Item */}
+        <section className="space-y-4">
+          <SectionTitle title="Item" hint="Description and how much of it." />
+          <Field label="Description" htmlFor="edit-description">
+            <Input id="edit-description" {...form.register("description")} disabled={formDisabled} />
+          </Field>
+          <Field label="Quantity" htmlFor="edit-quantity">
+            <Input
+              id="edit-quantity"
+              type="number"
+              min={1}
+              {...form.register("quantity")}
+              disabled={formDisabled}
+            />
+          </Field>
 
-        <div className="space-y-2">
-          <Label htmlFor="edit-quantity">Quantity</Label>
-          <Input
-            id="edit-quantity"
-            type="number"
-            min={1}
-            value={quantity}
-            onChange={(e) => setQuantity(e.target.value)}
-            disabled={formDisabled}
-          />
           {availability && item.modelId && (
-            <div className="space-y-1 pt-1">
-              <p className={isOverbooked ? "text-sm text-red-600 dark:text-red-400" : "text-sm text-fg-3"}>
-                <span className="font-semibold">{availableForEdit ?? 0}</span>{" "}
+            <div className="space-y-1 rounded-[var(--r)] border border-line bg-paper-2/50 p-3 text-caption">
+              <p className={isOverbooked ? "text-t-out" : "text-muted"}>
+                <span className="t-data font-semibold">{availableForEdit ?? 0}</span>{" "}
                 available out of{" "}
-                <span className="font-semibold">{availability.effectiveStock ?? availability.totalStock}</span>{" "}
+                <span className="t-data font-semibold">{availability.effectiveStock ?? availability.totalStock}</span>{" "}
                 {availability.dateless ? "in stock" : "usable"}
                 {availability.dateless && (
-                  <span className="text-fg-3 font-normal">
-                    {" "}(no dates set — showing stock only)
-                  </span>
+                  <span className="font-normal text-muted"> (no dates set — showing stock only)</span>
                 )}
               </p>
               {(availability.unavailable ?? 0) > 0 && (
-                <p className="text-blue-600 dark:text-blue-400 text-xs">
+                <p className="text-blue t-micro">
                   {availability.unavailable} of {availability.totalStock} total not usable
                   {" "}({[
                     availability.inMaintenance ? `${availability.inMaintenance} in maintenance` : "",
@@ -241,11 +287,11 @@ function EditLineItemDialogBody({
                 </p>
               )}
               {availability.conflicts && availability.conflicts.length > 0 && (
-                <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                <div className="flex items-start gap-2 text-warn">
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                   <div>
-                    <p className="text-xs font-medium">Conflicts:</p>
-                    <ul className="list-disc pl-4 text-xs">
+                    <p className="font-medium">Conflicts:</p>
+                    <ul className="list-disc pl-4">
                       {availability.conflicts.map((c) => (
                         <li key={String(c)}>{String(c)}</li>
                       ))}
@@ -255,98 +301,118 @@ function EditLineItemDialogBody({
               )}
             </div>
           )}
-        </div>
+        </section>
 
-        <div className="space-y-3">
-          <Label htmlFor="edit-unitPrice">Unit price</Label>
-          <div className="space-y-2">
+        {/* Pricing */}
+        <section className="space-y-4 border-t border-line pt-5">
+          <SectionTitle title="Pricing" hint="Rate and discount for this line." />
+          <Field label="Unit price ($)" htmlFor="edit-unitPrice">
             <Input
               id="edit-unitPrice"
               type="number"
               step="0.01"
               min={0}
-              value={unitPrice}
-              onChange={(e) => setUnitPrice(e.target.value)}
               placeholder="Enter price"
+              {...form.register("unitPrice")}
+              disabled={formDisabled}
             />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Label htmlFor="edit-discount" className="shrink-0 text-sm">Discount</Label>
-            <div className="flex gap-1 flex-1">
-              <Input
+          </Field>
+          <Controller
+            control={form.control}
+            name="discount"
+            render={({ field }) => (
+              <DiscountField
                 id="edit-discount"
-                type="number"
-                step="0.01"
-                min={0}
-                placeholder="0"
-                value={discount}
-                onChange={(e) => setDiscount(e.target.value)}
-                className="flex-1"
+                value={field.value == null ? "" : String(field.value)}
+                onValueChange={field.onChange}
+                mode={discountMode}
+                onModeChange={setDiscountMode}
+                disabled={formDisabled}
               />
-              <button
-                type="button"
-                onClick={() => setDiscountMode(discountMode === "$" ? "%" : "$")}
-                className="shrink-0 w-9 h-9 rounded-md border border-input text-sm font-medium hover:bg-accent transition-colors"
-              >
-                {discountMode}
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="edit-notes">Notes</Label>
-          <Textarea
-            id="edit-notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            rows={2}
+            )}
           />
-        </div>
+        </section>
+
+        {/* Placement & options */}
+        <section className="space-y-4 border-t border-line pt-5">
+          <SectionTitle title="Placement & options" hint="Where it lands and how it's treated." />
+
+          {canEditPlacement && (
+            <PlacementFields
+              categories={categories!}
+              categoryId={categoryId}
+              groupId={groupId}
+              onChange={({ categoryId, groupId }) => {
+                setCategoryId(categoryId);
+                setGroupId(groupId);
+              }}
+            />
+          )}
+
+          <Field label="Notes" htmlFor="edit-notes">
+            <Textarea id="edit-notes" {...form.register("notes")} rows={2} disabled={formDisabled} />
+          </Field>
+
+          <label className="flex cursor-pointer items-center gap-2.5">
+            <Controller
+              control={form.control}
+              name="isOptional"
+              render={({ field }) => (
+                <Checkbox
+                  id="edit-isOptional"
+                  checked={field.value ?? false}
+                  onCheckedChange={field.onChange}
+                  disabled={formDisabled}
+                />
+              )}
+            />
+            <span className="text-ui-text text-ink-2">Optional item (excluded from totals)</span>
+          </label>
+        </section>
 
         {!formDisabled && isOverbooked && (
-          <div className="rounded-md border border-red-500/50 bg-red-500/10 p-3 space-y-2">
-            <p className="text-sm font-medium text-red-600 dark:text-red-400">
-              <AlertTriangle className="inline-block mr-1.5 h-3.5 w-3.5" />
-              {rentalStartDate && rentalEndDate
-                ? `This will overbook ${requestedQty} units with only ${availableForEdit ?? 0} available across overlapping projects`
-                : `Only ${availableForEdit ?? 0} in stock — requesting ${requestedQty}`}
+          <div className="space-y-2 rounded-[var(--r)] border-l-[3px] border-t-out bg-out-soft px-3 py-2.5">
+            <p className="flex items-start gap-1.5 text-caption font-medium text-t-out">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                {rentalStartDate && rentalEndDate
+                  ? `This will overbook ${requestedQty} units with only ${availableForEdit ?? 0} available across overlapping projects`
+                  : `Only ${availableForEdit ?? 0} in stock — requesting ${requestedQty}`}
+              </span>
             </p>
             {availability?.dateless && (
-              <p className="text-xs text-red-600/80 dark:text-red-400/80">
+              <p className="t-micro text-t-out/80">
                 No dates set — checking stock only (not cross-project conflicts)
               </p>
             )}
             {availability?.conflicts && availability.conflicts.length > 0 && (
-              <p className="text-xs text-red-600/80 dark:text-red-400/80">
+              <p className="t-micro text-t-out/80">
                 Conflicts with: {availability.conflicts.join(", ")}
               </p>
             )}
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
-              <input
-                type="checkbox"
+            <label className="flex cursor-pointer items-center gap-2 text-caption">
+              <Checkbox
                 checked={overbookConfirmed}
-                onChange={(e) => setOverbookConfirmed(e.target.checked)}
-                className="accent-red-500"
+                onCheckedChange={(c) => setOverbookConfirmed(c === true)}
               />
-              <span className="text-red-600 dark:text-red-400">I understand, overbook anyway</span>
+              <span className="text-t-out">I understand, overbook anyway</span>
             </label>
           </div>
         )}
-      </div>
-      <DialogFooter>
-        <Button variant="line" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button
-          onClick={handleSave}
-          disabled={formDisabled || isPending || (isOverbooked && !overbookConfirmed)}
-        >
-          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          Save
-        </Button>
-      </DialogFooter>
+
+        <DialogFooter>
+          <Button type="button" variant="line" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            loading={isPending}
+            disabled={formDisabled || (isOverbooked && !overbookConfirmed)}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </form>
     </>
   );
 }

--- a/src/components/projects/equipment-add-form.tsx
+++ b/src/components/projects/equipment-add-form.tsx
@@ -31,11 +31,11 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { PlacementFields } from "./placement-fields";
+import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 
@@ -78,7 +78,7 @@ export function EquipmentAddForm({
   const [selectedModelId, setSelectedModelId] = useState("");
   const [assetTagInput, setAssetTagInput] = useState("");
   const [lookupTag, setLookupTag] = useState("");
-  const [discountMode, setDiscountMode] = useState<"$" | "%">("$");
+  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
   const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId ?? "");
   const [selectedGroupId, setSelectedGroupId] = useState(groupId ?? "");
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
@@ -562,30 +562,19 @@ export function EquipmentAddForm({
                 <p className="t-micro text-warn">Overrides auto-pricing</p>
               )}
             </Field>
-            <Field label="Discount" htmlFor="eq-discount">
-              <div className="flex gap-1.5">
-                <Input
+            <Controller
+              control={form.control}
+              name="discount"
+              render={({ field }) => (
+                <DiscountField
                   id="eq-discount"
-                  type="number"
-                  step="0.01"
-                  min={0}
-                  placeholder="0"
-                  {...form.register("discount")}
-                  className="flex-1"
+                  value={field.value == null ? "" : String(field.value)}
+                  onValueChange={field.onChange}
+                  mode={discountMode}
+                  onModeChange={setDiscountMode}
                 />
-                <button
-                  type="button"
-                  onClick={() => setDiscountMode(discountMode === "$" ? "%" : "$")}
-                  title={discountMode === "$" ? "Switch to percentage" : "Switch to dollars"}
-                  className={cn(
-                    "h-11 w-11 shrink-0 rounded-[var(--radius)] border-2 border-input bg-card text-ui-text font-medium text-ink transition-colors hover:bg-paper-2",
-                    focusRing,
-                  )}
-                >
-                  {discountMode}
-                </button>
-              </div>
-            </Field>
+              )}
+            />
           </div>
         </section>
 
@@ -662,28 +651,6 @@ export function EquipmentAddForm({
 }
 
 // ─── Local helpers ───────────────────────────────────────────────
-
-function SectionTitle({ title, hint }: { title: string; hint?: string }) {
-  return (
-    <div>
-      <h3 className="text-card-title font-bold text-ink">{title}</h3>
-      {hint && <p className="mt-0.5 t-micro text-muted">{hint}</p>}
-    </div>
-  );
-}
-
-function Field({
-  label, htmlFor, required, children,
-}: {
-  label: string; htmlFor?: string; required?: boolean; children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <Label htmlFor={htmlFor}>{label}{required && <span className="text-red"> *</span>}</Label>
-      {children}
-    </div>
-  );
-}
 
 function ModeTab({
   active, onClick, children,

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -65,6 +65,7 @@ export interface GroupData {
   description: string | null;
   quantity: number;
   price: unknown;
+  discount: unknown;
   suggestedPrice: unknown;
   rentalPeriod: string | null;
   rentalQuantity: number | null;

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -344,6 +344,8 @@ export function GroupRow({
   onSaveAsTemplate?: () => void;
 } & MoveControls) {
   const priceVal = group.price != null ? Number(group.price) : null;
+  const discountVal = group.discount != null ? Number(group.discount) : 0;
+  const groupTotal = priceVal != null ? Math.max(0, priceVal * group.quantity - discountVal) : null;
   const shortcuts = useRowShortcuts({ e: onEdit, m: onMove, d: onDelete }, "equipment");
   const isMobile = useIsMobile();
 
@@ -412,7 +414,7 @@ export function GroupRow({
           ) : undefined
         }
         qty={group.quantity}
-        total={priceVal != null ? priceVal * group.quantity : null}
+        total={groupTotal}
         isExpanded={isExpanded}
         onToggle={onToggle}
         actions={
@@ -483,6 +485,9 @@ export function GroupRow({
       <TableCell className="text-center t-data">{group.quantity}</TableCell>
       <TableCell className="text-right whitespace-nowrap t-data">
         {priceVal != null ? formatCurrency(priceVal) : <span className="text-faint">—</span>}
+        {discountVal > 0 && (
+          <p className="text-micro text-ok">-{formatCurrency(discountVal)} disc.</p>
+        )}
       </TableCell>
       {showCostColumn && (
         <TableCell className="text-right whitespace-nowrap t-data text-faint">
@@ -490,7 +495,7 @@ export function GroupRow({
         </TableCell>
       )}
       <TableCell className="text-right font-medium whitespace-nowrap t-data">
-        {priceVal != null ? formatCurrency(priceVal * group.quantity) : <span className="text-faint">—</span>}
+        {groupTotal != null ? formatCurrency(groupTotal) : <span className="text-faint">—</span>}
       </TableCell>
       <TableCell>
         <div className="flex items-center justify-end gap-0.5 flex-nowrap">

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -284,6 +284,13 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
 
   // EditLineItemDialog target — body owns its own form state + availability query.
   const [editLineItem, setEditLineItem] = useState<LineItemData | null>(null);
+  // The clicked item's current placement — line items don't carry categoryId/groupId
+  // directly (the tree position IS the placement), so each onEdit call site captures
+  // it from the same closure the neighbouring onMoveToCategory/onMoveToGroup use.
+  const [editLineItemPlacement, setEditLineItemPlacement] = useState<{
+    categoryId?: string;
+    groupId?: string;
+  }>({});
 
   // Bulk-operations dialog state (act on the current multi-selection).
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
@@ -1197,7 +1204,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                                 onSelectChange={(checked, shiftKey) => handleSelectChange(item.id, checked, shiftKey)}
                                 onClick={(e) => handleRowClick(item.id, e)}
                                 onToggle={() => toggleParent(item.id)}
-                                onEdit={() => setEditLineItem(item)}
+                                onEdit={() => {
+                                  setEditLineItemPlacement({ categoryId: cat.id, groupId: group.id });
+                                  setEditLineItem(item);
+                                }}
                                 onMoveToCategory={() => setMoveItemToCategory({
                                   lineItemId: item.id,
                                   initialCategoryId: cat.id,
@@ -1237,7 +1247,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           onSelectChange={(checked, shiftKey) => handleSelectChange(item.id, checked, shiftKey)}
                           onClick={(e) => handleRowClick(item.id, e)}
                           onToggle={() => toggleParent(item.id)}
-                          onEdit={() => setEditLineItem(item)}
+                          onEdit={() => {
+                            setEditLineItemPlacement({ categoryId: cat.id });
+                            setEditLineItem(item);
+                          }}
                           onMoveToCategory={() => setMoveItemToCategory({
                             lineItemId: item.id,
                             initialCategoryId: cat.id,
@@ -1292,7 +1305,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                     onSelectChange={(checked, shiftKey) => handleSelectChange(item.id, checked, shiftKey)}
                     onClick={(e) => handleRowClick(item.id, e)}
                     onToggle={() => toggleParent(item.id)}
-                    onEdit={() => setEditLineItem(item)}
+                    onEdit={() => {
+                      setEditLineItemPlacement({});
+                      setEditLineItem(item);
+                    }}
                     onMoveToCategory={() => setMoveItemToCategory({
                       lineItemId: item.id,
                     })}
@@ -1389,7 +1405,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           onSelectChange={(checked, shiftKey) => handleSelectChange(item.id, checked, shiftKey)}
                           onClick={(e) => handleRowClick(item.id, e)}
                           onToggle={() => toggleParent(item.id)}
-                          onEdit={() => setEditLineItem(item)}
+                          onEdit={() => {
+                            setEditLineItemPlacement({ groupId: group.id });
+                            setEditLineItem(item);
+                          }}
                           onMoveToCategory={() => setMoveItemToCategory({
                             lineItemId: item.id,
                           })}
@@ -1706,8 +1725,17 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         rentalStartDate={rentalStartDate}
         rentalEndDate={rentalEndDate}
         orgId={orgId}
+        categories={categories as CategoryData[]}
+        initialCategoryId={editLineItemPlacement.categoryId}
+        initialGroupId={editLineItemPlacement.groupId}
         isPending={updateLineItemMut.isPending}
         onClose={() => setEditLineItem(null)}
+        onMove={(id, placement) => {
+          groupWrites
+            .moveLineItem({ lineItemId: id, targetCategoryId: placement.categoryId, targetGroupId: placement.groupId })
+            .then(() => invalidate())
+            .catch((e: Error) => toast.error(e.message));
+        }}
         onSubmit={(id, data, allowOverbook, baseUpdatedAt) => {
           // Optimistically overlay the edited fields onto the row so it updates
           // instantly; the server action below is still the authoritative write.

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1145,7 +1145,9 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                                 kind: "project",
                                 groupId: group.id,
                                 title: group.title,
+                                quantity: group.quantity,
                                 price: priceVal,
+                                discount: group.discount != null ? Number(group.discount) : null,
                               })}
                               onAddEquipment={() => {
                                 setUnifiedAddTarget({ categoryId: cat.id, groupId: group.id, label: `${cat.name} > ${group.title}` });
@@ -1337,7 +1339,9 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           kind: "project",
                           groupId: group.id,
                           title: group.title,
+                          quantity: group.quantity,
                           price: priceVal,
+                          discount: group.discount != null ? Number(group.discount) : null,
                         })}
                         onAddEquipment={() => {
                           setUnifiedAddTarget({ groupId: group.id, label: `Uncategorized > ${group.title}` });
@@ -1909,10 +1913,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         projectId={projectId}
         orgId={orgId}
         onClose={() => setEditGroupData(null)}
-        onSubmit={(groupId, values, price) => {
+        onSubmit={(groupId, values, price, discount) => {
           updateGroupMut.mutate({ groupId, data: values });
           if (price !== undefined) {
-            groupWrites.updatePrice(groupId, price)
+            groupWrites.updatePrice(groupId, price, discount)
               .then(() => invalidate())
               .catch((e: Error) => toast.error(e.message));
           }

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -25,7 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { PlacementFields } from "./placement-fields";
-import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
+import { SectionTitle, Field, DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useKitSearch, useKit } from "@/hooks/use-kits";
@@ -108,40 +108,36 @@ export function KitAddForm({
     enabled: !!selectedKitId,
   });
 
+  // Computed outside mutationFn so the mutation call itself stays a
+  // straight-line pass-through (R-3.6 — keeps mutationFn's own complexity low).
+  const kitUnitPriceResolved =
+    kitPricingMode === "KIT_PRICE" && kitUnitPrice ? parseFloat(kitUnitPrice) : undefined;
+  // Discount is only meaningful alongside a flat KIT_PRICE unitPrice.
+  const kitDiscountResolved =
+    kitPricingMode === "KIT_PRICE" && kitUnitPriceResolved != null
+      ? resolveDiscountAmount(kitDiscountMode, kitDiscount, kitUnitPriceResolved)
+      : undefined;
+  const effectiveCategoryId = (categoryId || selectedCategoryId) || undefined;
+  const effectiveGroupId = (groupId || selectedGroupId) || undefined;
+  // kitLabel = "<assetTag> - <name>" (what the server derives from the fetched kit if
+  // this resolves empty). Prefer the resolved selected-kit label; fall back to the
+  // search option.
+  const resolvedKitLabel =
+    selectedKitLabel ?? kitOptions.find((o) => o.value === selectedKitId)?.label ?? "";
+
   const addKitMut = useServerMutation({
-    mutationFn: () => {
-      const unitPrice =
-        kitPricingMode === "KIT_PRICE" && kitUnitPrice ? parseFloat(kitUnitPrice) : undefined;
-      // Discount is only meaningful alongside a flat KIT_PRICE unitPrice — resolve a
-      // `%` value to a dollar amount client-side before it reaches the mutation
-      // (discount is always persisted as a flat $ amount, same as equipment/custom items).
-      let discount: number | undefined;
-      if (kitPricingMode === "KIT_PRICE" && unitPrice != null && kitDiscount) {
-        const raw = parseFloat(kitDiscount);
-        if (Number.isFinite(raw) && raw > 0) {
-          discount = kitDiscountMode === "%" ? Math.round(unitPrice * raw) / 100 : raw;
-        }
-      }
-      const effectiveCategoryId = (categoryId || selectedCategoryId) || undefined;
-      const effectiveGroupId = (groupId || selectedGroupId) || undefined;
-      // Browser-direct native path. addKitNative expands the parent + member children +
-      // recalc + audit + collab atomically; reactive useQuery renders the new rows.
-      // kitLabel = "<assetTag> - <name>" (what the server derived from the fetched kit).
-      // Prefer the resolved selected-kit label; fall back to the search option.
-      const kitLabel =
-        selectedKitLabel ??
-        kitOptions.find((o) => o.value === selectedKitId)?.label ??
-        "";
-      return lineItemWrites.addKit(projectId, selectedKitId, {
+    // Browser-direct native path. addKitNative expands the parent + member children +
+    // recalc + audit + collab atomically; reactive useQuery renders the new rows.
+    mutationFn: () =>
+      lineItemWrites.addKit(projectId, selectedKitId, {
         pricingMode: kitPricingMode,
-        unitPrice,
-        discount,
+        unitPrice: kitUnitPriceResolved,
+        discount: kitDiscountResolved,
         groupName: undefined,
         categoryId: effectiveCategoryId,
         groupId: effectiveGroupId,
-        kitLabel,
-      });
-    },
+        kitLabel: resolvedKitLabel,
+      }),
     onSuccess: () => {
       onInvalidate();
       refreshProjectDetail(projectId);

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -23,9 +23,9 @@ import { useLineItemWrites } from "@/hooks/use-line-item-writes";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { PlacementFields } from "./placement-fields";
+import { SectionTitle, Field } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useKitSearch, useKit } from "@/hooks/use-kits";
@@ -244,28 +244,6 @@ export function KitAddForm({
 }
 
 // ─── Local helpers ───────────────────────────────────────────────
-
-function SectionTitle({ title, hint }: { title: string; hint?: string }) {
-  return (
-    <div>
-      <h3 className="text-card-title font-bold text-ink">{title}</h3>
-      {hint && <p className="mt-0.5 t-micro text-muted">{hint}</p>}
-    </div>
-  );
-}
-
-function Field({
-  label, required, children,
-}: {
-  label: string; required?: boolean; children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <Label>{label}{required && <span className="text-red"> *</span>}</Label>
-      {children}
-    </div>
-  );
-}
 
 function PricingModeOption({
   label, hint, selected, onSelect,

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -25,7 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { PlacementFields } from "./placement-fields";
-import { SectionTitle, Field } from "./line-item-form-fields";
+import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useKitSearch, useKit } from "@/hooks/use-kits";
@@ -70,6 +70,8 @@ export function KitAddForm({
   const [selectedKitId, setSelectedKitId] = useState("");
   const [kitPricingMode, setKitPricingMode] = useState<KitPricingMode>("KIT_PRICE");
   const [kitUnitPrice, setKitUnitPrice] = useState("");
+  const [kitDiscount, setKitDiscount] = useState("");
+  const [kitDiscountMode, setKitDiscountMode] = useState<DiscountMode>("$");
   const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId ?? "");
   const [selectedGroupId, setSelectedGroupId] = useState(groupId ?? "");
 
@@ -110,6 +112,16 @@ export function KitAddForm({
     mutationFn: () => {
       const unitPrice =
         kitPricingMode === "KIT_PRICE" && kitUnitPrice ? parseFloat(kitUnitPrice) : undefined;
+      // Discount is only meaningful alongside a flat KIT_PRICE unitPrice — resolve a
+      // `%` value to a dollar amount client-side before it reaches the mutation
+      // (discount is always persisted as a flat $ amount, same as equipment/custom items).
+      let discount: number | undefined;
+      if (kitPricingMode === "KIT_PRICE" && unitPrice != null && kitDiscount) {
+        const raw = parseFloat(kitDiscount);
+        if (Number.isFinite(raw) && raw > 0) {
+          discount = kitDiscountMode === "%" ? Math.round(unitPrice * raw) / 100 : raw;
+        }
+      }
       const effectiveCategoryId = (categoryId || selectedCategoryId) || undefined;
       const effectiveGroupId = (groupId || selectedGroupId) || undefined;
       // Browser-direct native path. addKitNative expands the parent + member children +
@@ -123,6 +135,7 @@ export function KitAddForm({
       return lineItemWrites.addKit(projectId, selectedKitId, {
         pricingMode: kitPricingMode,
         unitPrice,
+        discount,
         groupName: undefined,
         categoryId: effectiveCategoryId,
         groupId: effectiveGroupId,
@@ -195,16 +208,24 @@ export function KitAddForm({
           </Field>
 
           {kitPricingMode === "KIT_PRICE" && (
-            <Field label="Unit price ($)">
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                placeholder="0.00"
-                value={kitUnitPrice}
-                onChange={(e) => setKitUnitPrice(e.target.value)}
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Unit price ($)">
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={kitUnitPrice}
+                  onChange={(e) => setKitUnitPrice(e.target.value)}
+                />
+              </Field>
+              <DiscountField
+                value={kitDiscount}
+                onValueChange={setKitDiscount}
+                mode={kitDiscountMode}
+                onModeChange={setKitDiscountMode}
               />
-            </Field>
+            </div>
           )}
         </section>
 

--- a/src/components/projects/line-item-form-fields.tsx
+++ b/src/components/projects/line-item-form-fields.tsx
@@ -47,60 +47,71 @@ export function Field({
   );
 }
 
-export interface DiscountFieldProps {
+export interface DiscountAmountInputProps {
   id?: string;
-  label?: string;
   value: string;
   onValueChange: (value: string) => void;
   mode: DiscountMode;
   onModeChange: (mode: DiscountMode) => void;
   disabled?: boolean;
-  hint?: string;
 }
 
 /**
- * Discount amount input + $/% mode toggle. The mode is a pure client-side
- * display convenience — callers are responsible for resolving a `%` value
- * to a dollar amount before it reaches the schema/mutation (discount is
- * always persisted as a flat dollar amount; see `src/lib/validations/line-item.ts`).
+ * Discount amount input + $/% mode toggle, with no Field/Label wrapper — for
+ * callers that supply their own label (e.g. bulk-edit-line-items-dialog's
+ * checkbox-gated field rows). Most callers want `DiscountField` below instead.
+ * The mode is a pure client-side display convenience — callers are responsible
+ * for resolving a `%` value to a dollar amount before it reaches the
+ * schema/mutation (discount is always persisted as a flat dollar amount; see
+ * `src/lib/validations/line-item.ts`).
  */
-export function DiscountField({
+export function DiscountAmountInput({
   id,
-  label = "Discount",
   value,
   onValueChange,
   mode,
   onModeChange,
   disabled,
-  hint,
-}: DiscountFieldProps) {
+}: DiscountAmountInputProps) {
   return (
-    <Field label={label} htmlFor={id}>
-      <div className="flex gap-1.5">
-        <Input
-          id={id}
-          type="number"
-          step="0.01"
-          min={0}
-          placeholder="0"
-          value={value}
-          onChange={(e) => onValueChange(e.target.value)}
-          disabled={disabled}
-          className="flex-1"
-        />
-        <button
-          type="button"
-          onClick={() => onModeChange(mode === "$" ? "%" : "$")}
-          disabled={disabled}
-          title={mode === "$" ? "Switch to percentage" : "Switch to dollars"}
-          className={cn(
-            "h-11 w-11 shrink-0 rounded-[var(--radius)] border-2 border-input bg-card text-ui-text font-medium text-ink transition-colors hover:bg-paper-2 disabled:cursor-not-allowed disabled:opacity-45",
-            focusRing,
-          )}
-        >
-          {mode}
-        </button>
-      </div>
+    <div className="flex gap-1.5">
+      <Input
+        id={id}
+        type="number"
+        step="0.01"
+        min={0}
+        placeholder="0"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+        disabled={disabled}
+        className="flex-1"
+      />
+      <button
+        type="button"
+        onClick={() => onModeChange(mode === "$" ? "%" : "$")}
+        disabled={disabled}
+        title={mode === "$" ? "Switch to percentage" : "Switch to dollars"}
+        className={cn(
+          "h-11 w-11 shrink-0 rounded-[var(--radius)] border-2 border-input bg-card text-ui-text font-medium text-ink transition-colors hover:bg-paper-2 disabled:cursor-not-allowed disabled:opacity-45",
+          focusRing,
+        )}
+      >
+        {mode}
+      </button>
+    </div>
+  );
+}
+
+export interface DiscountFieldProps extends DiscountAmountInputProps {
+  label?: string;
+  hint?: string;
+}
+
+/** `DiscountAmountInput` wrapped in `Field` (its own label). */
+export function DiscountField({ label = "Discount", hint, ...inputProps }: DiscountFieldProps) {
+  return (
+    <Field label={label} htmlFor={inputProps.id}>
+      <DiscountAmountInput {...inputProps} />
       {hint && <p className="t-micro text-muted">{hint}</p>}
     </Field>
   );

--- a/src/components/projects/line-item-form-fields.tsx
+++ b/src/components/projects/line-item-form-fields.tsx
@@ -16,6 +16,31 @@ import { cn, focusRing } from "@/lib/utils";
 
 export type DiscountMode = "$" | "%";
 
+/**
+ * Resolves a raw discount input to the flat dollar amount the schema/mutation
+ * expects — discount is always persisted as a flat $ amount (never a
+ * percentage), so every caller needs this same conversion before submit.
+ * `%` mode multiplies against `grossAmount` (the pre-discount line/bundle
+ * total); `$` mode passes the value through unchanged. Returns `undefined`
+ * for blank/zero/invalid input — "nothing to discount".
+ */
+export function resolveDiscountAmount(
+  mode: DiscountMode,
+  rawValue: number | string | null | undefined,
+  grossAmount: number,
+): number | undefined {
+  // Blank/unset is distinct from an explicit 0 — a blank field means "no
+  // discount" (or, for callers with an omit-to-preserve mutation like
+  // updateGroupPriceNative, "don't touch the existing discount"), while a
+  // deliberately typed 0 clears/zeroes a previously-set discount. Checking
+  // the raw value BEFORE Number() coercion is what keeps that distinction —
+  // `Number(0)` is falsy too, so a truthiness check alone would collapse them.
+  if (rawValue === "" || rawValue == null) return undefined;
+  const raw = Number(rawValue);
+  if (!Number.isFinite(raw) || raw < 0) return undefined;
+  return mode === "%" ? Math.round(grossAmount * raw) / 100 : raw;
+}
+
 export function SectionTitle({ title, hint }: { title: string; hint?: string }) {
   return (
     <div>

--- a/src/components/projects/line-item-form-fields.tsx
+++ b/src/components/projects/line-item-form-fields.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Shared building blocks for the project line-item add/edit forms
+ * (equipment/kit/custom-item/sub-hire add, plus their edit-side
+ * counterparts). Extracted per issue #883 — `SectionTitle`/`Field` were
+ * byte-identical copy-paste across four add forms, and the `$`/`%`
+ * discount toggle had three independently hand-rolled implementations
+ * (equipment-add-form, edit-line-item-dialog, bulk-edit-line-items-dialog)
+ * that had quietly drifted in exact classes. One shared version each.
+ */
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn, focusRing } from "@/lib/utils";
+
+export type DiscountMode = "$" | "%";
+
+export function SectionTitle({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div>
+      <h3 className="text-card-title font-bold text-ink">{title}</h3>
+      {hint && <p className="mt-0.5 t-micro text-muted">{hint}</p>}
+    </div>
+  );
+}
+
+export function Field({
+  label,
+  htmlFor,
+  required,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor}>
+        {label}
+        {required && <span className="text-red"> *</span>}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+export interface DiscountFieldProps {
+  id?: string;
+  label?: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  mode: DiscountMode;
+  onModeChange: (mode: DiscountMode) => void;
+  disabled?: boolean;
+  hint?: string;
+}
+
+/**
+ * Discount amount input + $/% mode toggle. The mode is a pure client-side
+ * display convenience — callers are responsible for resolving a `%` value
+ * to a dollar amount before it reaches the schema/mutation (discount is
+ * always persisted as a flat dollar amount; see `src/lib/validations/line-item.ts`).
+ */
+export function DiscountField({
+  id,
+  label = "Discount",
+  value,
+  onValueChange,
+  mode,
+  onModeChange,
+  disabled,
+  hint,
+}: DiscountFieldProps) {
+  return (
+    <Field label={label} htmlFor={id}>
+      <div className="flex gap-1.5">
+        <Input
+          id={id}
+          type="number"
+          step="0.01"
+          min={0}
+          placeholder="0"
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          disabled={disabled}
+          className="flex-1"
+        />
+        <button
+          type="button"
+          onClick={() => onModeChange(mode === "$" ? "%" : "$")}
+          disabled={disabled}
+          title={mode === "$" ? "Switch to percentage" : "Switch to dollars"}
+          className={cn(
+            "h-11 w-11 shrink-0 rounded-[var(--radius)] border-2 border-input bg-card text-ui-text font-medium text-ink transition-colors hover:bg-paper-2 disabled:cursor-not-allowed disabled:opacity-45",
+            focusRing,
+          )}
+        >
+          {mode}
+        </button>
+      </div>
+      {hint && <p className="t-micro text-muted">{hint}</p>}
+    </Field>
+  );
+}

--- a/src/components/projects/price-edit-dialog.tsx
+++ b/src/components/projects/price-edit-dialog.tsx
@@ -18,7 +18,6 @@
 
 import { useState } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { useProjectGroupWrites } from "@/hooks/use-project-groups-writes";
@@ -33,13 +32,16 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { DiscountField, type DiscountMode } from "./line-item-form-fields";
 
 export type PriceEditTarget =
   | {
       kind: "project";
       groupId: string;
       title: string;
+      quantity: number;
       price: number | null;
+      discount: number | null;
     }
   | {
       kind: "subHire";
@@ -87,6 +89,10 @@ function PriceEditDialogBody({
   const [priceInput, setPriceInput] = useState<string>(
     target.kind === "project" && target.price != null ? String(target.price) : "",
   );
+  const [discountInput, setDiscountInput] = useState<string>(
+    target.kind === "project" && target.discount != null ? String(target.discount) : "",
+  );
+  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
 
   // Sub-hire-mode state
   const [chargeInput, setChargeInput] = useState<string>(
@@ -100,8 +106,8 @@ function PriceEditDialogBody({
   const subHireWrites = useSubHireWrites();
 
   const projectMut = useServerMutation({
-    mutationFn: ({ groupId, price }: { groupId: string; price: number }) =>
-      groupWrites.updatePrice(groupId, price),
+    mutationFn: ({ groupId, price, discount }: { groupId: string; price: number; discount?: number }) =>
+      groupWrites.updatePrice(groupId, price, discount),
     onSuccess: () => {
       onInvalidate();
       toast.success("Group price updated");
@@ -133,7 +139,21 @@ function PriceEditDialogBody({
 
   function handleSubmit() {
     if (target.kind === "project") {
-      projectMut.mutate({ groupId: target.groupId, price: parseFloat(priceInput) || 0 });
+      const price = parseFloat(priceInput) || 0;
+      // Resolve a `%` discount to a flat $ amount before it reaches the mutation —
+      // discount is always persisted as a flat dollar amount off price × quantity
+      // (mirrors the line-item discount convention).
+      let discount: number | undefined;
+      if (discountInput) {
+        const raw = parseFloat(discountInput);
+        if (Number.isFinite(raw) && raw > 0) {
+          const gross = price * (target.quantity || 1);
+          discount = discountMode === "%" ? Math.round(gross * raw) / 100 : raw;
+        } else {
+          discount = 0;
+        }
+      }
+      projectMut.mutate({ groupId: target.groupId, price, discount });
     } else {
       subHireMut.mutate();
     }
@@ -155,21 +175,30 @@ function PriceEditDialogBody({
       </DialogHeader>
       <div className="space-y-4 py-2">
         {target.kind === "project" ? (
-          <div className="space-y-1.5">
-            <Label htmlFor="price-edit-input">Group price ($)</Label>
-            <Input
-              id="price-edit-input"
-              type="number"
-              step="0.01"
-              min="0"
-              value={priceInput}
-              onChange={(e) => setPriceInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleSubmit();
-              }}
-              autoFocus
+          <>
+            <div className="space-y-1.5">
+              <Label htmlFor="price-edit-input">Group price ($)</Label>
+              <Input
+                id="price-edit-input"
+                type="number"
+                step="0.01"
+                min="0"
+                value={priceInput}
+                onChange={(e) => setPriceInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSubmit();
+                }}
+                autoFocus
+              />
+            </div>
+            <DiscountField
+              id="price-edit-discount"
+              value={discountInput}
+              onValueChange={setDiscountInput}
+              mode={discountMode}
+              onModeChange={setDiscountMode}
             />
-          </div>
+          </>
         ) : (
           <>
             <div className="space-y-1.5">
@@ -213,8 +242,7 @@ function PriceEditDialogBody({
         <Button variant="line" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleSubmit} disabled={isPending}>
-          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        <Button onClick={handleSubmit} loading={isPending}>
           Save
         </Button>
       </DialogFooter>

--- a/src/components/projects/sub-hire-add-form.tsx
+++ b/src/components/projects/sub-hire-add-form.tsx
@@ -22,10 +22,10 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { QuickCreateSupplier } from "@/components/assets/quick-create-supplier";
+import { SectionTitle, Field } from "./line-item-form-fields";
 import { useActiveOrganization } from "@/lib/auth-client";
 
 export interface SubHireAddFormProps {
@@ -192,29 +192,5 @@ export function SubHireAddForm({
         onCreated={(id) => setSupplierId(id)}
       />
     </>
-  );
-}
-
-// ─── Local helpers ───────────────────────────────────────────────
-
-function SectionTitle({ title, hint }: { title: string; hint?: string }) {
-  return (
-    <div>
-      <h3 className="text-card-title font-bold text-ink">{title}</h3>
-      {hint && <p className="mt-0.5 t-micro text-muted">{hint}</p>}
-    </div>
-  );
-}
-
-function Field({
-  label, required, children,
-}: {
-  label: string; required?: boolean; children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1.5">
-      <Label>{label}{required && <span className="text-red"> *</span>}</Label>
-      {children}
-    </div>
   );
 }

--- a/src/hooks/use-line-item-writes.ts
+++ b/src/hooks/use-line-item-writes.ts
@@ -241,6 +241,7 @@ export function useLineItemWrites() {
       opts: {
         pricingMode: "KIT_PRICE" | "ITEMIZED";
         unitPrice?: number;
+        discount?: number;
         groupName?: string;
         categoryId?: string;
         groupId?: string;
@@ -254,6 +255,7 @@ export function useLineItemWrites() {
           projectId,
           kitId,
           unitPrice: opts.unitPrice ?? undefined,
+          discount: opts.discount ?? undefined,
           pricingMode: opts.pricingMode,
           groupName: opts.groupName || undefined,
           categoryId: opts.categoryId || undefined,

--- a/src/hooks/use-project-groups-writes.ts
+++ b/src/hooks/use-project-groups-writes.ts
@@ -71,11 +71,12 @@ export function useProjectGroupWrites() {
       });
     },
 
-    updatePrice: async (groupId: string, price: number): Promise<void> => {
+    updatePrice: async (groupId: string, price: number, discount?: number): Promise<void> => {
       await updatePriceM({
         id: groupId,
         orgId: requireOrg(),
         price,
+        discount,
         now: Date.now(),
         actor: actor(),
         auditId: createId(),

--- a/src/lib/equipment-tab-reconstruct.ts
+++ b/src/lib/equipment-tab-reconstruct.ts
@@ -305,6 +305,7 @@ function buildGroupData(
     description: g.description,
     quantity: g.quantity,
     price: g.price,
+    discount: g.discount,
     suggestedPrice: g.suggestedPrice,
     rentalPeriod: g.rentalPeriod,
     rentalQuantity: g.rentalQuantity,

--- a/src/lib/pdfme/document-data-reconstruction.test.ts
+++ b/src/lib/pdfme/document-data-reconstruction.test.ts
@@ -127,7 +127,7 @@ describe("keystone reconstruction → full PDF pipeline", () => {
     }) as unknown as DocumentLineItem[];
     const categories: CategoryForStructuring[] = [
       { id: "cat-light", name: "Lighting", sortOrder: 0, groups: [] },
-      { id: "cat-audio", name: "Audio", sortOrder: 1, groups: [{ id: "g1", title: "Mic Kit", description: null, quantity: 1, price: null, rentalPeriod: null, rentalQuantity: null, sortOrder: 0 }] },
+      { id: "cat-audio", name: "Audio", sortOrder: 1, groups: [{ id: "g1", title: "Mic Kit", description: null, quantity: 1, price: null, discount: null, rentalPeriod: null, rentalQuantity: null, sortOrder: 0 }] },
     ];
     const structured = structureLineItems(enriched, categories, { expandProjectGroups: true, packerSort: true }, []);
 

--- a/src/lib/pdfme/structure-line-items.test.ts
+++ b/src/lib/pdfme/structure-line-items.test.ts
@@ -64,6 +64,7 @@ function makeGroup(
     description: null,
     quantity: 1,
     price: null,
+    discount: null,
     rentalPeriod: null,
     rentalQuantity: null,
     ...overrides,
@@ -132,6 +133,35 @@ describe("structureLineItems — Phase 0 baseline", () => {
     expect(result).toHaveLength(1);
     expect(result[0].isGroupRow).toBe(true);
     expect(result[0].lineTotal).toBe(1500); // 1 * 500 * 3
+  });
+
+  it("subtracts a Project Group's flat discount from the synthetic row's total (#883)", () => {
+    const categories: CategoryForStructuring[] = [
+      makeCategory("cat-1", "Lighting", 0, [
+        makeGroup("grp-1", "Lighting Package", 0, {
+          quantity: 1, price: 500, rentalQuantity: 3, discount: 200,
+        }),
+      ]),
+    ];
+    const result = structureLineItems([], categories);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].lineTotal).toBe(1300); // (1 * 500 * 3) - 200
+    expect(result[0].discount).toBe(200);
+  });
+
+  it("clamps a Project Group's discount at 0 rather than going negative", () => {
+    const categories: CategoryForStructuring[] = [
+      makeCategory("cat-1", "Lighting", 0, [
+        makeGroup("grp-1", "Lighting Package", 0, {
+          quantity: 1, price: 100, rentalQuantity: 1, discount: 9999,
+        }),
+      ]),
+    ];
+    const result = structureLineItems([], categories);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].lineTotal).toBe(0);
   });
 
   it("renders ungrouped items in a category directly, after group rows", () => {

--- a/src/lib/pdfme/structure-line-items.ts
+++ b/src/lib/pdfme/structure-line-items.ts
@@ -44,6 +44,7 @@ export interface CategoryForStructuring {
     description: string | null;
     quantity: number;
     price: number | null;
+    discount: number | null;
     rentalPeriod: string | null;
     rentalQuantity: number | null;
     sortOrder: number;
@@ -218,7 +219,11 @@ export function structureLineItems(
     for (const group of cat.groups) {
       const duration = group.rentalQuantity ?? 1;
       const price = group.price ?? 0;
-      const total = group.quantity * price * duration;
+      const discount = group.discount ?? 0;
+      // Discount is a flat $ amount off the bundle total (#883) — same clamp-at-0
+      // subtraction as convex/lib/recalc.ts groupRevenue, so the PDF total matches
+      // what the project is actually billed.
+      const total = Math.max(0, group.quantity * price * duration - discount);
 
       // Both modes bucket group rows under the category. In expand mode
       // the group renders as a bold parent row (kit-style) followed by
@@ -259,7 +264,7 @@ export function structureLineItems(
         unitPrice: price,
         pricingType: group.rentalPeriod === "WEEKLY" ? "PER_WEEK" : "PER_DAY",
         duration,
-        discount: null,
+        discount: discount > 0 ? discount : null,
         lineTotal: total,
         groupName: bucketLabel,
         categoryName: cat.name,

--- a/src/lib/project-equipment-reconstruct.ts
+++ b/src/lib/project-equipment-reconstruct.ts
@@ -339,6 +339,7 @@ export interface MappedGroup {
   description: string | null;
   quantity: number;
   price: number | null;
+  discount: number | null;
   suggestedPrice: number | null;
   rentalPeriod: string | null;
   rentalQuantity: number | null;
@@ -357,6 +358,7 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     description: d.description ?? null,
     quantity: d.quantity ?? 1,
     price: d.price ?? null,
+    discount: d.discount ?? null,
     suggestedPrice: d.suggestedPrice ?? null,
     rentalPeriod: d.rentalPeriod ?? null,
     rentalQuantity: d.rentalQuantity ?? null,

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -346,6 +346,7 @@ export type MappedGroup = Omit<
   | "description"
   | "quantity"
   | "price"
+  | "discount"
   | "suggestedPrice"
   | "rentalPeriod"
   | "rentalQuantity"
@@ -357,6 +358,7 @@ export type MappedGroup = Omit<
   description: string | null;
   quantity: number;
   price: number | null;
+  discount: number | null;
   suggestedPrice: number | null;
   rentalPeriod: string | null;
   rentalQuantity: number | null;
@@ -375,6 +377,7 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     description: d.description ?? null,
     quantity: d.quantity ?? 1,
     price: d.price ?? null,
+    discount: d.discount ?? null,
     suggestedPrice: d.suggestedPrice ?? null,
     rentalPeriod: d.rentalPeriod ?? null,
     rentalQuantity: d.rentalQuantity ?? null,

--- a/src/lib/validations/project-group.test.ts
+++ b/src/lib/validations/project-group.test.ts
@@ -221,6 +221,28 @@ describe("updateGroupPriceSchema", () => {
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.price).toBe(999.5);
   });
+
+  it("accepts an optional discount alongside price (#883)", () => {
+    const result = updateGroupPriceSchema.safeParse({ price: 1500, discount: 200 });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.discount).toBe(200);
+  });
+
+  it("succeeds without a discount — price alone is enough", () => {
+    const result = updateGroupPriceSchema.safeParse({ price: 1500 });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.discount).toBeUndefined();
+  });
+
+  it("rejects a discount above the 999999.99 bound", () => {
+    const result = updateGroupPriceSchema.safeParse({ price: 1500, discount: 1_000_000 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a negative discount", () => {
+    const result = updateGroupPriceSchema.safeParse({ price: 1500, discount: -1 });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("moveLineItemSchema", () => {

--- a/src/lib/validations/project-group.ts
+++ b/src/lib/validations/project-group.ts
@@ -8,6 +8,9 @@ export const projectGroupSchema = z.object({
   description: z.string().max(2000).optional(),
   quantity: z.coerce.number().int().min(1).default(1),
   price: z.coerce.number().min(0).optional(),
+  // Flat $ amount off `price × quantity` (#883) — same bound as line-item discount
+  // (src/lib/validations/line-item.ts discountField).
+  discount: z.coerce.number().min(0).max(999999.99).optional(),
   rentalPeriod: z.enum(["DAILY", "WEEKLY"]).optional(),
   rentalQuantity: z.coerce.number().int().min(1).optional(),
   sortOrder: z.coerce.number().int().min(0).optional().default(0),
@@ -17,9 +20,11 @@ export type ProjectGroupFormValues = z.input<typeof projectGroupSchema>;
 
 // R-8.6.3: derived from `projectGroupSchema` (`.pick()` + `.required()`)
 // rather than re-declared — same field/constraints, just mandatory here.
+// `price` is required (the mutation always needs one to set); `discount` stays
+// optional so callers can omit it to leave the existing discount untouched.
 export const updateGroupPriceSchema = projectGroupSchema
-  .pick({ price: true })
-  .required();
+  .pick({ price: true, discount: true })
+  .required({ price: true });
 
 export const moveLineItemSchema = z.object({
   lineItemId: z.string().min(1),


### PR DESCRIPTION
## Summary

Implements #883 — unifies project equipment add/edit forms around the `equipment-add-form.tsx` pattern and closes the pricing/discount capability gaps on kits and groups.

**Size rationale (R-2.8/T-2):** this PR is ~1540 LOC, over the 200–400 LOC SHOULD-target. The issue itself scoped a single coherent unification: one shared component layer (`SectionTitle`/`Field`/`DiscountField`) consumed by every add/edit form it touches, one discount data model (`projectGroups.discount`) threaded through every money-math consumer that reads `price × quantity` (recalc, allocation, PDF), and the `EditLineItemDialog` rebuild that depends on that same shared component layer. Splitting along file boundaries would mean landing the shared primitives with no consumers, or landing the group-discount schema/mutations with no way to set/see it — either produces PRs that don't build toward a working state on their own. The 9 commits are kept atomic and independently reviewable in sequence (see commit list) even though they land together.

**Shared primitives** (`src/components/projects/line-item-form-fields.tsx`): `SectionTitle`/`Field` were byte-identical copy-paste across four add forms; the `$`/`%` discount toggle had three independently hand-rolled, quietly-drifted implementations. Now one shared `SectionTitle`, `Field`, `DiscountField` (labelled), `DiscountAmountInput` (bare, for callers with their own label), and `resolveDiscountAmount` (the `%`-to-flat-`$` conversion, also previously duplicated).

**RHF + Zod everywhere:**
- `custom-item-add-form.tsx` moved from hand-rolled `useState` (parsed only at submit) to `useForm + zodResolver(customLineItemSchema)`, and gained the `%` discount toggle it was missing (dollars-only on add, despite its own edit path supporting both — an inconsistency the issue called out).
- `edit-line-item-dialog.tsx` rebuilt on the add-form pattern — the "biggest single gap": equipment had a richly-structured add form, but editing that same line item dropped into a generic dialog with no placement editing, no `isOptional` toggle, no section grouping, no RHF/Zod. This was also a **live bug**: the payload never included `isOptional`, so `lineItemSchema.parse()`'s `.default(false)` silently reset every edited item's optional flag to `false` on save. Now fixed, plus a new Placement section (category/group, kit children excluded) that fires a separate `onMove` call into the existing `groupWrites.moveLineItem` mutation.

**Kit and group discount capability** (neither had any before):
- Kits reuse the existing `projectLineItems.discount` field (no schema change), gated to `KIT_PRICE` mode.
- Groups get a new `discount` field on the `projectGroups` Convex table, validated server-side (`assertValidDiscount`, same 0–999999.99 bound as line items) per POLICY.md R-9.3. Applied everywhere `price × quantity` is billed: `recalcProjectTotals`, per-model revenue allocation (`convex/lib/allocation.ts`), and the PDF synthetic group row (`structure-line-items.ts`, previously hardcoded `discount: null`) — a stored-but-ignored discount would have been worse than no field at all.

**Cleanup:** `Loader2`-in-button idiom replaced with the registry `Button loading` prop across `edit-line-item-dialog`, `edit-group-dialog`, `price-edit-dialog`, `bulk-edit-line-items-dialog`, `add-group-toolbar-dialog`.

Docs updated: `FEATUREDOCS/47-cross-type-equipment-unification.md` (new subsection), `FEATUREDOCS/10-projects.md` (Groups discount field), `FEATUREDOCS/09-kits.md` (Pricing Modes discount).

**Deliberately out of scope** (documented in FEATUREDOCS/47): `sub-hire-add-form.tsx`'s RHF migration (no numeric bounds to validate), `unified-add-dialog.tsx`'s segmented-switcher styling, sub-hire group discount (uses charge/cost, not a discount-off-price model).

**Note:** this session had no `CONVEX_DEPLOY_KEY` available, so the `convex/*.ts` changes (schema + mutations) were not pushed to the shared dev deployment per CLAUDE.md's normal workflow. They'll deploy via the standard `pnpm exec convex deploy -y` step in the CI pipeline on merge to `main`.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` (full repo) — 0 errors (pre-existing warnings only)
- `pnpm test` (full repo) — 4092 tests passing across 307 files, including new coverage for: group-discount subtraction in `recalcProjectTotals` and per-model revenue allocation (both clamped at 0), the `updateGroupPriceNative` discount bound + omit-to-preserve-existing-value semantics, Zod schema bounds, and the PDF synthetic-row discount subtraction
- `pnpm build` — clean production build
- `node scripts/complexity-ratchet.mjs` — 656 (== baseline)

## Checklist

- [x] New dependency? — none added
