### PR TITLE
fix(warehouse): stop stale RETURNED-unit prepStatus from re-packing a deprepped line

### DIFF
--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -67,6 +67,21 @@ pool's quantity (matches how bulk deploy/return create whole unit rows). Legacy 
 lines (deployed via `checkOutDeployWholeLine`) restore their line counters directly and skip
 the unit rollup (which would otherwise zero them).
 
+**Footgun (fixed, gearflow#797): a RETURNED unit's `prepStatus` is stale history, never
+"live" state.** Returning a unit (`returnLineUnits`) flips its `status` to `RETURNED` but
+deliberately leaves `prepStatus` untouched (still `PACKED` from prep) — that field is kept
+as a record of what was packed, not a live flag. `deprepItemInner` (the "no check items
+configured on this model" direct-deprep path — see `warehouse-check-policy.ts`) resets the
+*line's* `prepStatus` to `PENDING` and then calls `syncLineItemRollup`, which re-derives
+`prepStatus` from the unit rows via `deriveOrderLinePrepStatus`. That helper used to promote
+the line back to `PACKED` the instant **any** unit had `prepStatus === "PACKED"` — including
+the just-returned unit whose `PACKED` was stale — silently reverting the deprep in the same
+mutation call (toast says "removed from prep"; the item never leaves the Returned tab).
+Fixed by excluding `RETURNED`/`CANCELLED` units from that check in both copies of the helper
+(`convex/lib/lineItemUnits.ts`, `src/lib/line-item-units.ts`). Reproduced 100% of the time
+for any returned item whose model has zero check items configured (models with check items
+route through `completeCheckAndDeprepLineCore` instead, which never calls the rollup).
+
 (Internal `TabsTrigger`/`TabsContent` values are unchanged — `pick-prep`, `check-out`,
 `check-in`, `deprep`, `deprepped` — only the visible labels are the stage names.) Items are
 **prepped** (packed) before being **deployed** (checked out), and **de-prepped** (return checks

--- a/convex/checkRecordOps.test.ts
+++ b/convex/checkRecordOps.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+//
+// gearflow#797 — regression: a returned line whose model has no check items
+// routes through the "direct deprep" path (deprepItemInner). That path
+// correctly resets line.prepStatus to PENDING, but then called
+// syncLineItemRollup, which re-derived prepStatus from the RETURNED unit's
+// still-PACKED prepStatus (return never clears it) and silently flipped the
+// line straight back to PACKED — so the item never left the Return tab for
+// De-prepped, even though the deprep mutation reported success. Fixed in
+// convex/lib/lineItemUnits.ts's deriveOrderLinePrepStatus by excluding
+// RETURNED/CANCELLED units from the "any unit PACKED ⇒ line PACKED" rule.
+import { convexTest, type TestConvex } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { register as registerShardedCounter } from "@convex-dev/sharded-counter/test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+type T = TestConvex<typeof schema>;
+const ORG = "org_1";
+const USER = "user_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+function makeT(): T {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t, "rateLimiter");
+  registerShardedCounter(t, "shardedCounter");
+  return t;
+}
+
+/** Seed a plain (non-kit) serialised line item, already prepped + deployed:
+ *  line + unit both CHECKED_OUT with prepStatus PACKED, mirroring a real
+ *  item that went out on a job (no check items configured on its model —
+ *  the condition that routes deprep through the buggy direct path). */
+async function seedDeployedItem(t: T) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "admin" });
+    await ctx.db.insert("users", { id: USER, name: "Alice", email: "a@x.com" });
+    await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Test", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("models", { id: "mdl1", organizationId: ORG, name: "Drum Shield", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("assets", { id: "as1", organizationId: ORG, modelId: "mdl1", assetTag: "AS1", status: "CHECKED_OUT", isActive: true, createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("projectLineItems", {
+      id: "L1", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", modelId: "mdl1", assetId: "as1",
+      quantity: 1, status: "CHECKED_OUT", prepStatus: "PACKED", createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("projectLineItemUnits", {
+      id: "u1", organizationId: ORG, lineItemId: "L1", ordinal: 1, assetId: "as1",
+      quantity: 1, returnedQuantity: 0, status: "CHECKED_OUT", prepStatus: "PACKED", createdAt: NOW, updatedAt: NOW,
+    });
+  });
+}
+
+const line = (t: T) => t.run(async (ctx) => ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "L1")).unique());
+const unit = (t: T) => t.run(async (ctx) => ctx.db.query("projectLineItemUnits").withIndex("by_lineItemId", (q) => q.eq("lineItemId", "L1")).unique());
+
+describe("gearflow#797 — return → direct deprep", () => {
+  test("returning then deprepping a checked-item-free item moves it out of the Return tab", async () => {
+    const t = makeT();
+    await seedDeployedItem(t);
+
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.checkinItems, {
+      organizationId: ORG, projectId: "p1", userId: USER,
+      items: [{ lineItemId: "L1", assetId: "as1", returnCondition: "GOOD" }],
+      now: NOW,
+    });
+
+    // Sanity: the return landed it in the Return tab (RETURNED + still PACKED).
+    let l = await line(t);
+    expect(l?.status).toBe("RETURNED");
+    expect(l?.prepStatus).toBe("PACKED");
+    // The unit's prepStatus is untouched by return — it stays PACKED as history.
+    expect((await unit(t))?.prepStatus).toBe("PACKED");
+
+    // Deprep via the direct (no-check-items) path, exactly like the warehouse
+    // page's "Deprep Selected" button for a model with zero check items.
+    await t.withIdentity(SERVICE).mutation(api.checkRecordOps.deprepItems, {
+      organizationId: ORG, projectId: "p1",
+      ops: [{ lineItemId: "L1", quantity: 1 }],
+      now: NOW,
+    });
+
+    l = await line(t);
+    expect(l?.status).toBe("RETURNED");
+    // Regression: this used to still read "PACKED" (bounced right back by
+    // syncLineItemRollup reading the untouched RETURNED unit), keeping the
+    // item stuck on the Return tab despite the "Removed from prep" toast.
+    expect(l?.prepStatus).not.toBe("PACKED");
+    expect(l?.prepStatus).toBe("PENDING");
+
+    // The RETURNED unit itself must survive as return-history — deprep
+    // must not delete it (it's excluded from deprepItemInner's removal set).
+    const u = await unit(t);
+    expect(u).not.toBeNull();
+    expect(u?.status).toBe("RETURNED");
+  });
+});

--- a/convex/lib/lineItemUnits.ts
+++ b/convex/lib/lineItemUnits.ts
@@ -75,7 +75,10 @@ export function deriveOrderLinePrepStatus(
   if (currentPrepStatus === "FLAGGED_FAULTY" || currentPrepStatus === "FLAGGED_TT_OVERDUE") {
     return currentPrepStatus;
   }
-  if (units.some((u) => u.prepStatus === "PACKED")) return "PACKED";
+  // RETURNED/CANCELLED units keep their prepStatus as return-time history (return
+  // never clears it) — they must not re-promote the line to PACKED after a deprep
+  // has just reset it, or Returned→De-prepped can never complete (gearflow#797).
+  if (units.some((u) => u.prepStatus === "PACKED" && u.status !== "RETURNED" && u.status !== "CANCELLED")) return "PACKED";
   return currentPrepStatus;
 }
 

--- a/src/lib/line-item-units.test.ts
+++ b/src/lib/line-item-units.test.ts
@@ -158,6 +158,28 @@ describe("deriveOrderLinePrepStatus", () => {
       ]),
     ).toBe("FLAGGED_TT_OVERDUE");
   });
+
+  it("gearflow#797: a RETURNED unit's stale PACKED prepStatus does not re-promote the line", () => {
+    // Return never clears a unit's prepStatus (kept as history), so after
+    // deprep resets the line to PENDING, the still-PACKED RETURNED unit must
+    // not immediately flip it back to PACKED — else the item never leaves
+    // the Return tab for De-prepped.
+    const units = [unit({ status: "RETURNED", prepStatus: "PACKED" })];
+    expect(deriveOrderLinePrepStatus("PENDING", units)).toBe("PENDING");
+  });
+
+  it("gearflow#797: a CANCELLED unit's stale PACKED prepStatus does not re-promote the line", () => {
+    const units = [unit({ status: "CANCELLED", prepStatus: "PACKED" })];
+    expect(deriveOrderLinePrepStatus("PENDING", units)).toBe("PENDING");
+  });
+
+  it("gearflow#797: a live PACKED unit still promotes the line even alongside a returned one", () => {
+    const units = [
+      unit({ status: "RETURNED", prepStatus: "PACKED" }),
+      unit({ status: "CONFIRMED", prepStatus: "PACKED" }),
+    ];
+    expect(deriveOrderLinePrepStatus("PENDING", units)).toBe("PACKED");
+  });
 });
 
 describe("nextOrdinal", () => {

--- a/src/lib/line-item-units.ts
+++ b/src/lib/line-item-units.ts
@@ -125,9 +125,14 @@ export function deriveOrderLineStatus(
  *   - Manual flags (`FLAGGED_FAULTY`, `FLAGGED_TT_OVERDUE`) survive —
  *     they're operator overrides set by `completeCheckAndFlag` and
  *     must not be wiped by a later unit-rollup.
- *   - Any unit with `prepStatus === "PACKED"` ⇒ line is `PACKED`
+ *   - Any *live* unit with `prepStatus === "PACKED"` ⇒ line is `PACKED`
  *     (the deploy tab needs to see it; quantity-aware deploy UX
  *     handles partial states separately via the rollup counters).
+ *     RETURNED/CANCELLED units are excluded from this check: returning a
+ *     unit never clears its `prepStatus` (kept as return-time history), so
+ *     counting it here would re-promote the line back to PACKED the moment
+ *     deprep resets it to PENDING — the exact bug where a returned item
+ *     never leaves the Return tab for De-prepped (gearflow#797).
  *   - Otherwise, the existing `line.prepStatus` survives — preserves
  *     PULLED while the operator is still scanning, and `PENDING` on
  *     fresh lines.
@@ -142,7 +147,16 @@ export function deriveOrderLinePrepStatus(
   ) {
     return currentPrepStatus;
   }
-  if (units.some((u) => u.prepStatus === "PACKED")) return "PACKED";
+  if (
+    units.some(
+      (u) =>
+        u.prepStatus === "PACKED" &&
+        u.status !== "RETURNED" &&
+        u.status !== "CANCELLED",
+    )
+  ) {
+    return "PACKED";
+  }
   return currentPrepStatus;
 }
 


### PR DESCRIPTION
## Summary

Fixes #797 — returned items sometimes get stuck on the Return tab and never progress to De-prepped, even though the deprep action reports success ("Removed N from prep").

**Root cause:** returning a unit (`returnLineUnits` in `convex/lib/fulfillment.ts`) intentionally leaves its `prepStatus` untouched (kept as return-time history — still `"PACKED"` from prep). For a returned line whose equipment model has **no check items configured**, deprep takes the "direct" path (`deprepItemInner` in `convex/checkRecordOps.ts`), which correctly resets the line's `prepStatus` to `PENDING` — then immediately calls `syncLineItemRollup`, which re-derives `prepStatus` from the unit rows via `deriveOrderLinePrepStatus`. That helper promoted the line back to `PACKED` the instant **any** unit had `prepStatus === "PACKED"`, including the just-returned unit's stale value — silently reverting the deprep inside the same mutation, before it returns. No error is thrown, hence the misleading success toast. The tab filter then still sees `status === "RETURNED" && prepStatus === "PACKED"` and keeps the item on the Return tab.

This reproduces **deterministically**, not randomly: 100% of the time for any returned line whose model has zero check items configured. Models with check items configured route through `completeCheckAndDeprepLineCore` instead, which never calls the rollup, so they're unaffected — that's why the bug looked "random across jobs" while actually being tied to which equipment model was involved.

**Fix:** exclude `RETURNED`/`CANCELLED` units from `deriveOrderLinePrepStatus`'s "any unit PACKED ⇒ line PACKED" rule, in both copies of this pure helper (`convex/lib/lineItemUnits.ts` and its documented source-of-truth twin `src/lib/line-item-units.ts`).

## Testing

- `src/lib/line-item-units.test.ts` — 3 new unit tests: a stale-RETURNED-unit case, a stale-CANCELLED-unit case, and confirming a genuinely live PACKED unit still promotes the line correctly (no regression to the existing promote-to-PACKED behavior).
- `convex/checkRecordOps.test.ts` (new) — end-to-end Convex integration test seeding a deployed item, returning it via `checkinItems`, then deprepping via the same batch `deprepItems` mutation the warehouse page's "Deprep Selected" button calls. Reproduces the bug pre-fix; asserts the line reads `prepStatus: PENDING` (not `PACKED`) and the RETURNED unit survives (deprep must not delete return history) post-fix.
- Ran the full affected test suite (`checkRecordOps`, `checkRecordWrites`, `kitPerUnit`, `warehousePageBatch`, `warehouseList`, `warehouseCloseWrites`, `line-item-units`) — all pass, no regressions.
- `pnpm exec eslint` on all changed/new files — clean.
- Updated `FEATUREDOCS/12-warehouse.md` with a footgun note documenting the fixed invariant (RETURNED unit `prepStatus` is stale history, not live state) for future readers of the return/deprep pipeline.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhVBuo8AcaqpWthBopcZfG)_