### PR TITLE
fix(warehouse): sync line.returnCondition from units so close-out sees real returns

### DIFF
--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -18,6 +18,7 @@ import {
   computeRollupCounters,
   deriveOrderLineStatus,
   deriveOrderLinePrepStatus,
+  deriveOrderLineReturnCondition,
   nextOrdinal,
   type UnitLike,
 } from "./lineItemUnits";
@@ -56,6 +57,7 @@ export async function syncLineItemRollup(ctx: Ctx, lineItemId: string): Promise<
     ...computeRollupCounters(unitLikes),
     status: deriveOrderLineStatus(line.status ?? "CONFIRMED", unitLikes) as typeof line.status,
     prepStatus: (deriveOrderLinePrepStatus(line.prepStatus, unitLikes) ?? undefined) as typeof line.prepStatus,
+    returnCondition: (deriveOrderLineReturnCondition(line.returnCondition, unitLikes) ?? undefined) as typeof line.returnCondition,
     updatedAt: Date.now(),
   });
 }

--- a/convex/lib/lineItemUnits.ts
+++ b/convex/lib/lineItemUnits.ts
@@ -86,8 +86,8 @@ export function deriveOrderLinePrepStatus(
  *  writes `returnCondition` onto the unit row, never the line, so without this
  *  the line's own field stays permanently null for any per-unit-tracked item
  *  and downstream readers (close-out summary/tally) can't see it. "Worst
- *  condition wins" across units with a recorded condition: any DAMAGED beats
- *  any MISSING beats GOOD, so a single damaged unit on a multi-unit line still
+ *  condition wins" across units that have a recorded condition — DAMAGED beats
+ *  MISSING beats GOOD, so a single damaged unit on a multi-unit line still
  *  surfaces as an exception. Units not yet returned (no recorded condition)
  *  are ignored, not treated as missing data. */
 export function deriveOrderLineReturnCondition(

--- a/convex/lib/lineItemUnits.ts
+++ b/convex/lib/lineItemUnits.ts
@@ -82,6 +82,25 @@ export function deriveOrderLinePrepStatus(
   return currentPrepStatus;
 }
 
+/** Derive the order line's `returnCondition` from its units — return only ever
+ *  writes `returnCondition` onto the unit row, never the line, so without this
+ *  the line's own field stays permanently null for any per-unit-tracked item
+ *  and downstream readers (close-out summary/tally) can't see it. "Worst
+ *  condition wins" across units with a recorded condition: any DAMAGED beats
+ *  any MISSING beats GOOD, so a single damaged unit on a multi-unit line still
+ *  surfaces as an exception. Units not yet returned (no recorded condition)
+ *  are ignored, not treated as missing data. */
+export function deriveOrderLineReturnCondition(
+  currentReturnCondition: string | null | undefined,
+  units: readonly UnitLike[],
+): string | null | undefined {
+  const withCondition = units.filter((u) => u.returnCondition != null);
+  if (withCondition.length === 0) return currentReturnCondition;
+  if (withCondition.some((u) => u.returnCondition === "DAMAGED")) return "DAMAGED";
+  if (withCondition.some((u) => u.returnCondition === "MISSING")) return "MISSING";
+  return "GOOD";
+}
+
 /** Next free `ordinal` for a new unit on an order line (1..N, never reuses gaps). */
 export function nextOrdinal(units: readonly { ordinal: number }[]): number {
   if (units.length === 0) return 1;

--- a/convex/warehouseCloseWrites.test.ts
+++ b/convex/warehouseCloseWrites.test.ts
@@ -309,3 +309,78 @@ describe("warehouseCloses.closeOutSummary (browser-direct read)", () => {
     ).rejects.toThrow();
   });
 });
+
+// ─── gearflow#797 follow-up: per-unit-tracked returns and close-out ──────────
+// returnLineUnits (convex/lib/fulfillment.ts) only ever patches a UNIT's
+// returnCondition, never the LINE's — so for any modern per-unit-tracked item,
+// line.returnCondition stayed permanently null. closeOutSummary read that null
+// as "still pending" (blocking the close-out tab) while closeOutCore defaulted
+// the same null to "GOOD"/stored — a silent audit-trail miscount for anything
+// actually returned DAMAGED/MISSING. Fixed by having syncLineItemRollup derive
+// the line's returnCondition from its units (deriveOrderLineReturnCondition).
+describe("gearflow#797 — per-unit return syncs line.returnCondition", () => {
+  const SERVICE = { subject: "gearflow-service", svc: true };
+
+  async function seedDeployedItem(t: ReturnType<typeof convexTest>, id: string) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "manager" });
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Test", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("models", { id: "mdl1", organizationId: ORG, name: "Drum Shield", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("assets", { id, organizationId: ORG, modelId: "mdl1", assetTag: id.toUpperCase(), status: "CHECKED_OUT", isActive: true, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", {
+        id: `L_${id}`, organizationId: ORG, projectId: "p1", type: "EQUIPMENT", modelId: "mdl1", assetId: id,
+        quantity: 1, status: "CHECKED_OUT", prepStatus: "PACKED", createdAt: NOW, updatedAt: NOW,
+      });
+      await ctx.db.insert("projectLineItemUnits", {
+        id: `u_${id}`, organizationId: ORG, lineItemId: `L_${id}`, ordinal: 1, assetId: id,
+        quantity: 1, returnedQuantity: 0, status: "CHECKED_OUT", prepStatus: "PACKED", createdAt: NOW, updatedAt: NOW,
+      });
+    });
+  }
+
+  test("a GOOD return is not flagged pending and counts as stored", async () => {
+    const t = makeT();
+    await seedDeployedItem(t, "as1");
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.checkinItems, {
+      organizationId: ORG, projectId: "p1", userId: USER,
+      items: [{ lineItemId: "L_as1", assetId: "as1", returnCondition: "GOOD" }],
+      now: NOW,
+    });
+
+    const s = await t.withIdentity(asUser(ORG)).query(api.warehouseCloses.closeOutSummary, { orgId: ORG, projectId: "p1" });
+    expect(s.pendingCount).toBe(0);
+    expect(s.storedCount).toBe(1);
+    expect(s.canClose).toBe(true);
+
+    // The actual close-out mutation must also tally it as stored, not miscount it.
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, {
+      id: "wc1", orgId: ORG, projectId: "p1", now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    expect(res.storedCount).toBe(1);
+    expect(res.damagedCount).toBe(0);
+  });
+
+  test("a DAMAGED return surfaces as an exception, not a silent stored count", async () => {
+    const t = makeT();
+    await seedDeployedItem(t, "as2");
+    await t.withIdentity(SERVICE).mutation(api.warehouseOps.checkinItems, {
+      organizationId: ORG, projectId: "p1", userId: USER,
+      items: [{ lineItemId: "L_as2", assetId: "as2", returnCondition: "DAMAGED" }],
+      now: NOW,
+    });
+
+    const s = await t.withIdentity(asUser(ORG)).query(api.warehouseCloses.closeOutSummary, { orgId: ORG, projectId: "p1" });
+    expect(s.pendingCount).toBe(0);
+    expect(s.damagedCount).toBe(1);
+    expect(s.storedCount).toBe(0);
+    expect(s.exceptions).toHaveLength(1);
+
+    // Regression: before the fix this silently landed in storedCount (line.returnCondition
+    // was null, and closeOutCore's `!li.returnCondition || "GOOD"` default treated null as GOOD).
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseCloseWrites.closeOutNative, {
+      id: "wc1", orgId: ORG, projectId: "p1", now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    expect(res.damagedCount).toBe(1);
+    expect(res.storedCount).toBe(0);
+  });
+});

--- a/src/lib/line-item-units.test.ts
+++ b/src/lib/line-item-units.test.ts
@@ -3,6 +3,7 @@ import {
   computeRollupCounters,
   deriveOrderLineStatus,
   deriveOrderLinePrepStatus,
+  deriveOrderLineReturnCondition,
   nextOrdinal,
   isFullyAssigned,
   type UnitLike,
@@ -179,6 +180,48 @@ describe("deriveOrderLinePrepStatus", () => {
       unit({ status: "CONFIRMED", prepStatus: "PACKED" }),
     ];
     expect(deriveOrderLinePrepStatus("PENDING", units)).toBe("PACKED");
+  });
+});
+
+describe("deriveOrderLineReturnCondition", () => {
+  it("returns the current value when no unit has a recorded condition", () => {
+    expect(deriveOrderLineReturnCondition(null, [unit()])).toBeNull();
+    expect(deriveOrderLineReturnCondition("GOOD", [unit({ status: "CHECKED_OUT" })])).toBe(
+      "GOOD",
+    );
+  });
+
+  it("gearflow#797 follow-up: a returned unit's condition promotes the line, which return itself never does", () => {
+    // Regression: returnLineUnits only ever patches the UNIT's returnCondition,
+    // never the line's — so the close-out summary (which reads the line field)
+    // saw every per-unit-tracked return as null and flagged it "still pending"
+    // even though the item was correctly returned GOOD.
+    const units = [unit({ status: "RETURNED", returnCondition: "GOOD" })];
+    expect(deriveOrderLineReturnCondition(null, units)).toBe("GOOD");
+  });
+
+  it("worst condition wins: DAMAGED beats MISSING beats GOOD", () => {
+    expect(
+      deriveOrderLineReturnCondition(null, [
+        unit({ status: "RETURNED", returnCondition: "GOOD" }),
+        unit({ status: "RETURNED", returnCondition: "DAMAGED" }),
+        unit({ status: "RETURNED", returnCondition: "MISSING" }),
+      ]),
+    ).toBe("DAMAGED");
+    expect(
+      deriveOrderLineReturnCondition(null, [
+        unit({ status: "RETURNED", returnCondition: "GOOD" }),
+        unit({ status: "RETURNED", returnCondition: "MISSING" }),
+      ]),
+    ).toBe("MISSING");
+  });
+
+  it("ignores units that haven't been returned yet (no recorded condition)", () => {
+    const units = [
+      unit({ status: "RETURNED", returnCondition: "GOOD" }),
+      unit({ status: "CHECKED_OUT", returnCondition: null }),
+    ];
+    expect(deriveOrderLineReturnCondition(null, units)).toBe("GOOD");
   });
 });
 

--- a/src/lib/line-item-units.ts
+++ b/src/lib/line-item-units.ts
@@ -161,6 +161,30 @@ export function deriveOrderLinePrepStatus(
 }
 
 /**
+ * Derive the order line's `returnCondition` from its units.
+ *
+ * Return only ever writes `returnCondition` onto the unit row, never the
+ * line, so without this the line's own field stays permanently null for any
+ * per-unit-tracked item — and downstream readers (close-out summary/tally)
+ * that check `line.returnCondition` can never see it.
+ *
+ * "Worst condition wins" across units with a recorded condition: any
+ * DAMAGED beats any MISSING beats GOOD, so a single damaged unit on a
+ * multi-unit line still surfaces as an exception. Units not yet returned
+ * (no recorded condition) are ignored, not treated as missing data.
+ */
+export function deriveOrderLineReturnCondition(
+  currentReturnCondition: ReturnCondition | null,
+  units: readonly UnitLike[],
+): ReturnCondition | null {
+  const withCondition = units.filter((u) => u.returnCondition != null);
+  if (withCondition.length === 0) return currentReturnCondition;
+  if (withCondition.some((u) => u.returnCondition === "DAMAGED")) return "DAMAGED";
+  if (withCondition.some((u) => u.returnCondition === "MISSING")) return "MISSING";
+  return "GOOD";
+}
+
+/**
  * Next free `ordinal` for a new unit on an order line. Ordinals are a stable
  * 1..N identity within the line; they never reuse a gap, so a unit keeps its
  * number even after siblings are removed.

--- a/src/lib/line-item-units.ts
+++ b/src/lib/line-item-units.ts
@@ -168,8 +168,8 @@ export function deriveOrderLinePrepStatus(
  * per-unit-tracked item — and downstream readers (close-out summary/tally)
  * that check `line.returnCondition` can never see it.
  *
- * "Worst condition wins" across units with a recorded condition: any
- * DAMAGED beats any MISSING beats GOOD, so a single damaged unit on a
+ * "Worst condition wins" across units that have a recorded condition —
+ * DAMAGED beats MISSING beats GOOD, so a single damaged unit on a
  * multi-unit line still surfaces as an exception. Units not yet returned
  * (no recorded condition) are ignored, not treated as missing data.
  */


### PR DESCRIPTION
## Summary

Follow-up to #797 (merged in #917) — found while verifying that fix live: depreping now works correctly, but the close-out tab showed **"1 item still pending"** for an item that had already been fully returned and deprepped.

**Root cause:** `returnLineUnits` (`convex/lib/fulfillment.ts`) only ever writes `returnCondition` onto the **unit** row, never onto the **line's** own `returnCondition` field. For any per-unit-tracked item (the modern fulfillment model — i.e. most items today), the line's `returnCondition` therefore stays permanently `null`.

Two different consumers read that stale `null` two different (wrong) ways:
- `closeOutSummary` (`convex/warehouseCloses.ts`, powers the close-out tab banner) treated `null` on a returned item as ambiguous → **pending**, blocking the tab even for a normal GOOD return.
- `closeOutCore` (`convex/warehouseCloseWrites.ts`, the mutation that actually performs the close-out) defaulted the same `null` to **"GOOD"/stored** — meaning an item genuinely returned **DAMAGED or MISSING** could get silently miscounted as stored in the close-out audit record. This is a real data-integrity issue, not just a UI annoyance.

**Fix:** rather than patch either read site (which would leave the two consumers divergent), fixed it at the source — `syncLineItemRollup` now derives the line's `returnCondition` from its units via a new `deriveOrderLineReturnCondition` helper (mirrored in both `convex/lib/lineItemUnits.ts` and its `src/lib/line-item-units.ts` source-of-truth twin), the same pattern already used for `status`/`prepStatus`. "Worst condition wins" — any DAMAGED unit beats any MISSING beats GOOD, so a single damaged unit on a multi-unit line still surfaces as a close-out exception. Both consumers now read correct data with zero changes needed on the read side.

## Testing

- `src/lib/line-item-units.test.ts` — 4 new unit tests for `deriveOrderLineReturnCondition`: no-condition passthrough, the exact stale-null regression, worst-condition-wins ordering, and ignoring not-yet-returned units.
- `convex/warehouseCloseWrites.test.ts` — 2 new end-to-end Convex integration tests seeding a real deployed item, returning it via `warehouseOps.checkinItems` (the real per-unit return path), then asserting both `closeOutSummary` (the read the tab uses) *and* `closeOutNative` (the actual close-out mutation) agree on the outcome — one for a GOOD return (not pending, counted stored) and one for a DAMAGED return (surfaces as an exception, not silently counted stored).
- Ran the full affected suite (`checkRecordOps`, `checkRecordWrites`, `warehouseCloseWrites`, `kitPerUnit`, `warehousePageBatch`, `warehouseList`, `bulk-fulfillment-quantity`, `line-item-units`) — all pass, no regressions.
- `pnpm exec eslint` on all changed files — clean (pre-existing warnings elsewhere in `fulfillment.ts` are unrelated to this diff).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhVBuo8AcaqpWthBopcZfG)_