### PR TITLE
Remove "Show on quote / invoice" checkbox from service edit form

### DIFF
--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -1586,18 +1586,6 @@ function ServiceDialog({
                   />
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="showOnDocuments"
-                  checked={form.watch("showOnDocuments")}
-                  onCheckedChange={(checked) =>
-                    form.setValue("showOnDocuments", !!checked)
-                  }
-                />
-                <Label htmlFor="showOnDocuments" className="text-ui-text font-normal cursor-pointer">
-                  Show on quote / invoice
-                </Label>
-              </div>
             </div>
 
             {/* Cost to Business */}


### PR DESCRIPTION
## Summary

- Removes the "Show on quote / invoice" checkbox/label pair from the "Charge to Client" block of the service edit form (`src/components/projects/services-panel.tsx`).
- `showOnDocuments` is **not** dropped from the schema/data model: it's still actively read by the PDF pipeline (`src/lib/pdfme/build-document-data.ts`), the equipment tab's document filter (`equipment-tab.tsx`), the service-card "· On quote" badge, and the service-template default toggle (`settings/services/page.tsx`). Removing it entirely would silently change what appears on client-facing quotes/invoices, so per the issue's own guidance this was scoped to removing the redundant per-instance override control only — the template-level default remains the single place this is configured going forward.

## Testing

- `pnpm exec tsc --noEmit` — no new errors in the touched file
- `pnpm exec eslint src/components/projects/services-panel.tsx` — only pre-existing warnings (file/function length, complexity), no errors introduced
- No existing test file covers this component's UI, and no test references the removed checkbox

## Checklist

- [x] New dependency? N/A — no new dependency added

Closes #795


---
_Generated by [Claude Code](https://claude.ai/code/session_0117FKUUtPrnbmpmUKcfmgB7)_