### PR TITLE
fix: bulk assets showing 0 available (mislabeled models + unmaintained availableQuantity)

### DIFF
--- a/FEATUREDOCS/08-assets.md
+++ b/FEATUREDOCS/08-assets.md
@@ -7,21 +7,33 @@
 2. **Bulk** (`BulkAsset`): Quantity-tracked, `totalQuantity`/`availableQuantity`
 3. **Kit** (`Kit`): Container of serialized + bulk assets (see [kits.md](./09-kits.md))
 
-### ⚠️ Stock-type resolution — `model.assetType` may be absent on the Convex mirror
+### ⚠️ Stock-type resolution — `model.assetType` may be absent OR a stale label
 `Model.assetType` is `v.optional` in the Convex schema, so older / backfilled model
 docs read back `undefined`. Every stock/availability computation used to coerce it
 with `assetType ?? "SERIALIZED"` — which sent a genuine BULK model down the
 serialized branch of `computeStockBreakdown` (`totalStock = assets.length = 0`, since
 a bulk model has no serialized assets), so **every bulk line showed "0 available"**
-and was spuriously overbooked. Use **`resolveModelAssetType(assetType, hasBulkAssets)`**
-(`src/lib/overbooking-core.ts`) instead of the `?? "SERIALIZED"` default at every
-stock site: it returns a present value unchanged and falls back to `BULK` only when
-the model has active bulk assets. Applied at all five computation sites —
+and was spuriously overbooked. Use **`resolveModelAssetType(assetType, hasBulkAssets,
+hasAssets)`** (`src/lib/overbooking-core.ts`) instead of the `?? "SERIALIZED"` default
+at every stock site: it returns a present value unchanged and falls back to `BULK`
+only when the model has active bulk assets. Applied at all five computation sites —
 `overbooking-core.ts` (`reconstructOverbookedStatus`), `line-items.ts` (`addLineItem`
 / `updateLineItem` / `checkAvailability`), and `server/availability.ts` (calendar
 stock). Regression: `overbooking-core.test.ts`. Follow-up (durable, needs a prod
 backfill): always-write `assetType` on the model mirror so no consumer has to guess —
 `models-read.ts` mapping a lone doc still can't resolve without the bulk-asset signal.
+
+**gearflow#801:** the undefined-only fallback above never fires for a *new* model,
+because `model-form.tsx`'s create form defaults `assetType` to an EXPLICIT
+`"SERIALIZED"` (there's a Serialized/Bulk selector, but Serialized is what you get
+unless you deliberately switch it) — so a model stocked exclusively with bulk assets
+and never switched away from the default reads back `assetType: "SERIALIZED"`,
+present not absent, and stayed stuck at `available: 0` forever. `hasAssets` (the
+model's active serialized-asset count) closes that gap: an explicit `"SERIALIZED"`
+label is only overridden to `"BULK"` when the model has real bulk stock AND zero
+actual serialized assets — the one case where the label can't possibly be right,
+since a model with genuine serialized assets keeps its explicit label untouched.
+Regression: `overbooking-core.test.ts` / `convex/availabilityCore.test.ts`.
 
 ## Auto-Incrementing Tags
 Stored in `Organization.metadata` JSON:

--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -51,13 +51,13 @@ performs the action that advances gear to the next stage:
 Every stage's primary button advances gear one step; each stage past Pick also has a
 **secondary "Move to …" button** that reverses one step, so an operator can correct a
 misclick without a workaround. The reverses mirror their forward mutation exactly —
-flipping unit + asset status (and kit bulk-availability, opposite sign) back:
+flipping unit + asset status (and kit/standalone bulk-availability, opposite sign) back:
 
 | Reverse | Server action → Convex mutation | Effect |
 | --- | --- | --- |
 | Prepped → Pick | `deprepItem` / `deprepKit` | remove packed units, `prepStatus` → PENDING |
-| Deployed → Prepped | `undeployItems` / `undeployKit` → `warehouseOps.undeployItems`/`.undeployKit` | units CHECKED_OUT → prepped, assets → AVAILABLE @ default location, kit bulk availability +1 |
-| Returned → Deployed | `unreturnItems` / `unreturnKit` → `.unreturnItems`/`.unreturnKit` | units RETURNED → CHECKED_OUT, assets → CHECKED_OUT @ project location, kit bulk availability −1 |
+| Deployed → Prepped | `undeployItems` / `undeployKit` → `warehouseOps.undeployItems`/`.undeployKit` | units CHECKED_OUT → prepped, assets → AVAILABLE @ default location, bulk availability +1 (kit AND standalone) |
+| Returned → Deployed | `unreturnItems` / `unreturnKit` → `.unreturnItems`/`.unreturnKit` | units RETURNED → CHECKED_OUT, assets → CHECKED_OUT @ project location, bulk availability −1 (kit AND standalone) |
 | De-prepped → Returned | `undeprepLine` → `.undeprepLine` | line `prepStatus` → PACKED (status stays RETURNED) |
 
 Selection is parsed by the shared `moveBackSelection` helper (same bulk `id:idx` / line-id /
@@ -147,6 +147,41 @@ a time (return had to be clicked 16×). Fixes:
 - `returnLineUnits`' bulk branch defaults `quantity` to the **full remaining**
   checked-out quantity (was `?? 1`), so one return action brings back all 16; an
   explicit `quantity` is still honoured for partial returns.
+
+#### ⚠️ Standalone bulk checkout/checkin now maintains `bulkAssets.availableQuantity` (gearflow#801)
+`bulkAssets.availableQuantity` — the registry's "Available" column
+(`asset-table.tsx`) — was only ever adjusted by kit checkout/checkin
+(`collectKitBulkAdjustments`) and DEDICATED-mode accessory attach/detach
+(`assetAccessoriesWrites.ts`). A bulk asset added **directly** to a project line
+(not inside a kit) went through `checkOutBulkItem` (`warehouseOps.ts`) and
+`returnLineUnits` (`convex/lib/fulfillment.ts`), neither of which touched
+`availableQuantity` — so for any bulk stock only ever deployed standalone, the
+registry's live "Available" number just sat wherever creation/kit activity last
+left it, permanently drifting from real usage.
+
+Fixed by having both the forward path and its move-back reverse call
+`adjustBulkAvailability` (`convex/lib/inventory.ts`) for **standalone** (top-level,
+non-kit-child) bulk lines:
+- **Checkout** (`checkOutBulkItem`) deducts the DELTA over what the line already
+  had checked out — so a repeat/idempotent checkout call for the same total
+  quantity doesn't double-consume stock.
+- **Checkin** (`returnLineUnits`' bulk branch) restores the actually-returned
+  quantity, unconditionally regardless of `returnCondition` — a bulk asset has no
+  per-unit condition bucket to route DAMAGED/MISSING into (unlike serialized
+  assets going to `IN_MAINTENANCE`/`LOST`), matching kit checkin's existing
+  unconditional restore.
+- **Move-back** (`undeployItems` / `unreturnItems`) mirrors the forward
+  adjustment in the opposite direction via `flipLineUnits`' new `bulkFlips`
+  report + the shared `applyBulkFlipAvailability` helper, so a misclick
+  correction doesn't leak or double-consume shelf stock.
+
+The gate is `!lineItem.isKitChild` — kit members are the kit's own responsibility
+(`collectKitBulkAdjustments` off `kitBulkItems`, a different table entirely, never
+touched by these code paths), and accessory children also set `isKitChild: true`
+so they're out of scope here too (see [FEATUREDOCS/48](./48-child-assets-accessories.md)'s
+SHIPS_WITH/DEDICATED split — SHIPS_WITH accessory bulk children still have this
+same gap, tracked as a follow-up, not fixed by this change). Regression:
+`convex/bulk-fulfillment-quantity.test.ts`.
 - Regression: `convex/bulk-fulfillment-quantity.test.ts` drives prep → return through
   the real `prepUnit`/`returnLineUnits` with a `convex-test` harness.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -110,6 +110,25 @@ the file list below before picking this back up.
 **Estimate:** human ~1 week / CC ~30 min
 **Priority:** P2
 
+### SHIPS_WITH Accessory Bulk Children Don't Adjust `bulkAssets.availableQuantity`
+**What:** `FEATUREDOCS/48-child-assets-accessories.md` documents that SHIPS_WITH
+accessory bulk children are "drawn from the live pool at prep/checkout (a normal
+booking)", implying `bulkAssets.availableQuantity` should decrement/restore as they
+deploy/return with their parent. In code, `checkoutAccessoryChildren` /
+`checkinAccessoryChildren` (`warehouseOps.ts` / `convex/lib/fulfillment.ts`) only
+flip unit status directly — neither calls `adjustBulkAvailability`. So a SHIPS_WITH
+bulk accessory (e.g. "2 clamps ship with every light") never touches the registry's
+"Available" column, same class of bug as gearflow#801 #2 but for accessory children
+specifically.
+**Why not fixed alongside #801:** #801's acceptance criteria scoped to "a bulk-only
+model added standalone (no kit) to a project" — the #801 fix deliberately gates on
+`!lineItem.isKitChild`, which also (correctly, for now) excludes accessory children
+from the new standalone adjustment, to avoid conflicting with DEDICATED-mode
+accessories' existing attach/detach-based accounting (`assetAccessoriesWrites.ts`).
+Distinguishing SHIPS_WITH from DEDICATED at checkout/checkin time (the child line
+doesn't currently carry `allocationMode`) is a separate, scoped piece of work.
+**Priority:** P2
+
 ## Call Sheet
 
 ### ~~Template Editor Settings for New Section Types~~ ✅ SHIPPED

--- a/convex/availabilityCore.test.ts
+++ b/convex/availabilityCore.test.ts
@@ -25,7 +25,9 @@ describe("availabilityCore stock math == overbooking-core (byte-for-byte pin)", 
   test("resolveModelAssetType matches the original over every combo", () => {
     for (const assetType of [undefined, null, "SERIALIZED", "BULK", "OTHER", ""]) {
       for (const hasBulk of [true, false]) {
-        expect(coreType(assetType, hasBulk)).toBe(origType(assetType, hasBulk));
+        for (const hasAssets of [true, false]) {
+          expect(coreType(assetType, hasBulk, hasAssets)).toBe(origType(assetType, hasBulk, hasAssets));
+        }
       }
     }
   });
@@ -127,6 +129,25 @@ describe("computeModelAvailability", () => {
     });
     const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "thisP" });
     expect(r).toMatchObject({ totalStock: 14, effectiveStock: 14, unavailable: 0, booked: 3, available: 11, assetType: "BULK" });
+  });
+
+  // Regression: issue #801 — a model created via model-form.tsx keeps the
+  // create form's explicit "SERIALIZED" default unless someone deliberately
+  // switches the Asset type selector to Bulk, even when it's stocked
+  // exclusively with bulk assets. Before the fix, `assetType: "SERIALIZED"`
+  // was PRESENT (not absent), so the undefined-only fallback in
+  // resolveModelAssetType never kicked in, and this bulk-only model showed
+  // `available: 0` no matter how much real bulk stock existed.
+  test("BULK-only model mislabeled SERIALIZED (model-form.tsx default) still reports real bulk availability", () => {
+    const b = mkBundle({
+      assetType: "SERIALIZED", // the model-form.tsx create default — never switched to Bulk
+      assets: [], // zero serialized assets — this model only ever held bulk stock
+      bulks: [{ totalQuantity: 10 }],
+      lines: [{ projectId: "thisP", quantity: 3 }],
+      projects: [{ id: "thisP", rentalStartDate: START, rentalEndDate: END, status: "CONFIRMED" }],
+    });
+    const r = computeModelAvailability(b, { rentalStart: START, rentalEnd: END, excludeProjectId: "thisP" });
+    expect(r).toMatchObject({ totalStock: 10, effectiveStock: 10, unavailable: 0, booked: 3, available: 7, assetType: "BULK" });
   });
 
   test("dated: CANCELLED lines + sub-hire lines are excluded from booked", () => {

--- a/convex/bulk-fulfillment-quantity.test.ts
+++ b/convex/bulk-fulfillment-quantity.test.ts
@@ -16,20 +16,27 @@ const NOW = 1_700_000_000_000;
  * checked-out quantity (not 1, which forced "click return 16 times").
  */
 
-async function seedBulkLine(t: T, opts: { orderedQuantity: number }) {
+async function seedBulkLine(t: T, opts: { orderedQuantity: number; availableQuantity?: number; isKitChild?: boolean }) {
   await t.run(async (ctx) => {
     await ctx.db.insert("projects", {
       id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig",
       status: "PREPPING", isTemplate: false, createdAt: NOW, updatedAt: NOW,
     });
+    await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "Cable", assetType: "BULK", createdAt: NOW, updatedAt: NOW });
+    await ctx.db.insert("bulkAssets", {
+      id: "ba1", organizationId: ORG, assetTag: "CABLE", modelId: "m1", availableQuantity: opts.availableQuantity ?? 20,
+    });
     await ctx.db.insert("projectLineItems", {
       id: "bl", organizationId: ORG, projectId: "p1", type: "EQUIPMENT",
-      status: "CONFIRMED", isKitChild: false, isOptional: false,
+      status: "CONFIRMED", isKitChild: opts.isKitChild ?? false, isOptional: false,
       bulkAssetId: "ba1", quantity: opts.orderedQuantity, sortOrder: 0,
       createdAt: NOW, updatedAt: NOW,
     });
   });
 }
+
+const readBulkAvailable = (t: T) =>
+  t.run(async (ctx) => (await ctx.db.query("bulkAssets").withIndex("by_cuid", (q) => q.eq("id", "ba1")).unique())?.availableQuantity);
 
 const readBulkUnit = (t: T) =>
   t.run(async (ctx) =>
@@ -116,5 +123,172 @@ describe("bulk fulfillment quantity", () => {
     const unit = await readBulkUnit(t);
     expect(unit?.returnedQuantity).toBe(5);
     expect(unit?.status).toBe("CHECKED_OUT"); // not fully returned
+  });
+});
+
+/**
+ * Regression for issue #801 (#2): a bulk asset checked out/returned STANDALONE
+ * (not inside a kit) never touched `bulkAssets.availableQuantity` — only the kit
+ * checkout/checkin path (`collectKitBulkAdjustments`) and DEDICATED-mode
+ * accessory attach/detach did. So the registry's "Available" column drifted
+ * arbitrarily out of sync with real deployment for any bulk stock only ever
+ * used standalone.
+ */
+describe("standalone bulk checkout/checkin maintains bulkAssets.availableQuantity", () => {
+  test("checkOutBulkItem (via checkoutItemsCore) decrements available stock", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 20 });
+    const { checkoutItemsCore } = await import("./warehouseOps");
+    await t.run((ctx) =>
+      checkoutItemsCore(ctx, {
+        organizationId: ORG, projectId: "p1", userId: "user_1",
+        items: [{ lineItemId: "bl", quantity: 6 }], includeAccessories: false, now: NOW,
+      }),
+    );
+    expect(await readBulkAvailable(t)).toBe(14);
+    const unit = await readBulkUnit(t);
+    expect(unit?.status).toBe("CHECKED_OUT");
+    expect(unit?.quantity).toBe(6);
+  });
+
+  test("a repeat checkout call for the same total quantity does not double-consume stock", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 20 });
+    const { checkoutItemsCore } = await import("./warehouseOps");
+    const doCheckout = () =>
+      t.run((ctx) =>
+        checkoutItemsCore(ctx, {
+          organizationId: ORG, projectId: "p1", userId: "user_1",
+          items: [{ lineItemId: "bl", quantity: 6 }], includeAccessories: false, now: NOW,
+        }),
+      );
+    await doCheckout();
+    await doCheckout();
+    expect(await readBulkAvailable(t)).toBe(14);
+  });
+
+  test("returnLineUnits (standalone bulk check-in) restores available stock", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 16, availableQuantity: 4 });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 16, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    await t.run((ctx) =>
+      returnLineUnits(ctx, {
+        organizationId: ORG, projectId: "p1", lineItemId: "bl", bulkAssetId: "ba1",
+        returnCondition: "GOOD", userId: "user_1", defaultLocationId: null, quantity: 10,
+      }),
+    );
+    expect(await readBulkAvailable(t)).toBe(14);
+  });
+
+  test("a full standalone checkout-then-return round trip leaves availableQuantity unchanged", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 8, availableQuantity: 20 });
+    const { checkoutItemsCore } = await import("./warehouseOps");
+    await t.run((ctx) =>
+      checkoutItemsCore(ctx, {
+        organizationId: ORG, projectId: "p1", userId: "user_1",
+        items: [{ lineItemId: "bl", quantity: 8 }], includeAccessories: false, now: NOW,
+      }),
+    );
+    expect(await readBulkAvailable(t)).toBe(12);
+    await t.run((ctx) =>
+      returnLineUnits(ctx, {
+        organizationId: ORG, projectId: "p1", lineItemId: "bl", bulkAssetId: "ba1",
+        returnCondition: "GOOD", userId: "user_1", defaultLocationId: null,
+      }),
+    );
+    expect(await readBulkAvailable(t)).toBe(20);
+  });
+
+  test("kit-child bulk lines are NOT double-adjusted by the standalone path (kits own their own adjustment)", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 20, isKitChild: true });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 6, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    await t.run((ctx) =>
+      returnLineUnits(ctx, {
+        organizationId: ORG, projectId: "p1", lineItemId: "bl", bulkAssetId: "ba1",
+        returnCondition: "GOOD", userId: "user_1", defaultLocationId: null,
+      }),
+    );
+    // isKitChild lines are the kit's own bulk-adjustment responsibility
+    // (collectKitBulkAdjustments off kitBulkItems) — the standalone path must
+    // stay out of the way, or a kit checkin would double-release stock.
+    expect(await readBulkAvailable(t)).toBe(20);
+  });
+});
+
+/**
+ * Move-back parity for issue #801 (#2): the forward checkout/checkin mutations
+ * now maintain `bulkAssets.availableQuantity` for standalone lines, so their
+ * "Move to …" reverses (undeployItems / unreturnItems) must mirror kit
+ * move-back's documented "+1"/"-1" (FEATUREDOCS/12-warehouse.md) — otherwise a
+ * misclick-correction workflow would leak or double-consume shelf stock.
+ */
+describe("standalone bulk move-back maintains bulkAssets.availableQuantity", () => {
+  test("undeployItems (Deployed → Prepped) releases stock back to the shelf", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 14 }); // 6 already deployed
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 6, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    const { undeployItemsCore } = await import("./warehouseOps");
+    await t.run((ctx) =>
+      undeployItemsCore(ctx, { organizationId: ORG, projectId: "p1", userId: "user_1", items: [{ lineItemId: "bl" }], now: NOW }),
+    );
+    expect(await readBulkAvailable(t)).toBe(20);
+    const unit = await readBulkUnit(t);
+    expect(unit?.status).toBe("CONFIRMED");
+  });
+
+  test("unreturnItems (Returned → Deployed) re-consumes stock from the shelf", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 20 }); // fully returned already
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 6, returnedQuantity: 6, status: "RETURNED",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    const { unreturnItemsCore } = await import("./warehouseOps");
+    await t.run((ctx) =>
+      unreturnItemsCore(ctx, { organizationId: ORG, projectId: "p1", userId: "user_1", items: [{ lineItemId: "bl" }], now: NOW }),
+    );
+    expect(await readBulkAvailable(t)).toBe(14);
+    const unit = await readBulkUnit(t);
+    expect(unit?.status).toBe("CHECKED_OUT");
+  });
+
+  test("kit-child bulk lines are NOT double-adjusted by undeployItems move-back", async () => {
+    const t = convexTest(schema, modules);
+    await seedBulkLine(t, { orderedQuantity: 6, availableQuantity: 20, isKitChild: true });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "u1", organizationId: ORG, lineItemId: "bl", ordinal: 1,
+        bulkAssetId: "ba1", quantity: 6, returnedQuantity: 0, status: "CHECKED_OUT",
+        createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    const { undeployItemsCore } = await import("./warehouseOps");
+    await t.run((ctx) =>
+      undeployItemsCore(ctx, { organizationId: ORG, projectId: "p1", userId: "user_1", items: [{ lineItemId: "bl" }], now: NOW }),
+    );
+    expect(await readBulkAvailable(t)).toBe(20);
   });
 });

--- a/convex/lib/availabilityCore.ts
+++ b/convex/lib/availabilityCore.ts
@@ -3,7 +3,7 @@
  * (`convex/lineItemWrites.ts` addNative / patchNative).
  *
  * The two pure stock-math helpers (`resolveModelAssetType`, `computeStockBreakdown`)
- * are copied BYTE-FOR-BYTE from `src/lib/overbooking-core.ts:46-74` — the Convex
+ * are copied BYTE-FOR-BYTE from `src/lib/overbooking-core.ts:57-87` — the Convex
  * bundler can't resolve the `@/` alias, so they're duplicated here (same pattern as
  * `convex/lib/reservationConflicts.ts`) and PINNED against the originals by a
  * cross-import equality test in `convex/availabilityCore.test.ts`.
@@ -25,8 +25,10 @@ import type { Doc } from "../_generated/dataModel";
 export function resolveModelAssetType(
   assetType: string | null | undefined,
   hasBulkAssets: boolean,
+  hasAssets: boolean,
 ): "SERIALIZED" | "BULK" {
-  if (assetType === "BULK" || assetType === "SERIALIZED") return assetType;
+  if (assetType === "BULK") return "BULK";
+  if (assetType === "SERIALIZED") return hasBulkAssets && !hasAssets ? "BULK" : "SERIALIZED";
   return hasBulkAssets ? "BULK" : "SERIALIZED";
 }
 
@@ -139,7 +141,7 @@ export function computeModelAvailability(
   const { rentalStart, rentalEnd, excludeProjectId } = opts;
   const hasDates = rentalStart != null && rentalEnd != null;
 
-  const assetType = resolveModelAssetType(model?.assetType, activeBulkAssets.length > 0);
+  const assetType = resolveModelAssetType(model?.assetType, activeBulkAssets.length > 0, activeAssets.length > 0);
   const modelForBreakdown = {
     assetType,
     assets: activeAssets.map((a) => ({ status: a.status ?? "AVAILABLE" })),

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -14,6 +14,7 @@
 import { ConvexError } from "convex/values";
 import { createId } from "@paralleldrive/cuid2";
 import type { MutationCtx } from "../_generated/server";
+import { adjustBulkAvailability } from "./inventory";
 import {
   computeRollupCounters,
   deriveOrderLineStatus,
@@ -271,6 +272,19 @@ export async function returnLineUnits(
         updatedAt: now,
       });
       remaining -= canReturn;
+    }
+    // Standalone (non-kit-child) bulk lines release back to the shared shelf
+    // pool directly (issue #801 #2), mirroring collectKitBulkAdjustments'
+    // unconditional restore on kit check-in — a bulk asset has no per-unit
+    // condition bucket to route DAMAGED/MISSING returns into, so (like kits)
+    // the full actually-returned quantity always goes back regardless of
+    // `returnCondition`. Kit members never reach this branch through their own
+    // checkin (patchKitMemberUnits, not returnLineUnits); accessory children are
+    // out of scope here (see FEATUREDOCS/48's SHIPS_WITH/DEDICATED split) —
+    // both set isKitChild, so this single flag is the right gate.
+    const actuallyReturned = returnQty - remaining;
+    if (!lineItem.isKitChild && actuallyReturned > 0) {
+      await adjustBulkAvailability(ctx, args.organizationId, [{ bulkAssetId: targetBulkId, delta: actuallyReturned }]);
     }
     return { unitsFlipped: bulkUnits.length, assetsTouched: [] };
   }

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -79,12 +79,27 @@ async function checkOutSerializedItem(
 
 async function checkOutBulkItem(
   ctx: Ctx,
-  p: { organizationId: string; lineItemId: string; lineItemQuantity: number; bulkAssetId: string; checkoutQty: number; userId: string; projectId: string; notes?: string; now: number },
+  p: { organizationId: string; lineItemId: string; lineItemQuantity: number; bulkAssetId: string; checkoutQty: number; userId: string; projectId: string; notes?: string; now: number; isKitChild: boolean },
 ): Promise<void> {
+  const priorUnits = await lineUnits(ctx, p.lineItemId);
+  const priorCheckedOutQty = priorUnits.find((u) => u.bulkAssetId === p.bulkAssetId && u.status === "CHECKED_OUT")?.quantity ?? 0;
   const { id: unitId } = await ensureBulkUnit(ctx, { organizationId: p.organizationId, lineItemId: p.lineItemId, bulkAssetId: p.bulkAssetId, quantity: p.checkoutQty });
   const unit = await unitByCuid(ctx, unitId);
   if (unit) {
     await ctx.db.patch(unit._id, { status: "CHECKED_OUT", quantity: p.checkoutQty, checkedOutAt: p.now, checkedOutById: p.userId, updatedAt: p.now });
+  }
+  // Standalone (non-kit-child) bulk lines consume the shared shelf pool directly
+  // (issue #801 #2) — kit members instead go through the kit's own
+  // collectKitBulkAdjustments off `kitBulkItems`, and accessory children are
+  // out of scope here (see FEATUREDOCS/48's SHIPS_WITH/DEDICATED split); both
+  // set isKitChild, so this single flag is the right gate. Deduct only the
+  // DELTA over what this line already had checked out, so a repeat/idempotent
+  // checkout call for the same total quantity doesn't double-consume stock.
+  if (!p.isKitChild) {
+    const delta = p.checkoutQty - priorCheckedOutQty;
+    if (delta !== 0) {
+      await adjustBulkAvailability(ctx, p.organizationId, [{ bulkAssetId: p.bulkAssetId, delta: -delta }]);
+    }
   }
   await scanLog(ctx, { organizationId: p.organizationId, bulkAssetId: p.bulkAssetId, projectId: p.projectId, action: "CHECK_OUT", scannedById: p.userId, scannedAt: p.now, notes: p.notes || `Checked out ${p.checkoutQty} of ${p.lineItemQuantity}` });
 }
@@ -288,7 +303,7 @@ export async function checkoutItemsCore(ctx: Ctx, a: CheckoutItemsArgs): Promise
         await checkOutBulkItem(ctx, {
           organizationId: a.organizationId, lineItemId: lineItem.id, lineItemQuantity: lineItem.quantity ?? 0,
           bulkAssetId: lineItem.bulkAssetId, checkoutQty: item.quantity || lineItem.quantity || 0, userId: a.userId,
-          projectId: a.projectId, notes: item.notes, now: a.now,
+          projectId: a.projectId, notes: item.notes, now: a.now, isKitChild: !!lineItem.isKitChild,
         });
       } else {
         // No serialised asset, no bulk asset. Prefer deploying the prepped
@@ -851,7 +866,11 @@ export const checkinItems = mutation({
 // bulk pool. Kits go through their own reverse (like checkoutKit / checkinKit).
 
 /** Flip a line's units from one status to another (whole units, up to `want`),
- *  restoring each serialised unit's asset status + location. */
+ *  restoring each serialised unit's asset status + location. Also reports the
+ *  bulk units flipped (`bulkFlips`) — PURE reporting only, no availability side
+ *  effect here; callers that own a top-level (non-kit-child) line decide
+ *  whether to apply it via `adjustBulkAvailability` (issue #801 #2 move-back
+ *  parity — see undeployItemsCore / unreturnItemsCore). */
 async function flipLineUnits(
   ctx: Ctx,
   p: {
@@ -861,12 +880,13 @@ async function flipLineUnits(
     assetStatus: string; locationId: string | null; clearLoc: boolean;
     want?: number; now: number;
   },
-): Promise<{ flipped: number; assetIds: string[] }> {
+): Promise<{ flipped: number; assetIds: string[]; bulkFlips: Array<{ bulkAssetId: string; quantity: number }> }> {
   const units = (await lineUnits(ctx, p.lineItemId))
     .filter((u) => u.status === p.fromStatus)
     .sort((a, b) => a.ordinal - b.ordinal);
   const toFlip = p.want != null ? units.slice(0, Math.max(0, Math.min(p.want, units.length))) : units;
   const assetIds: string[] = [];
+  const bulkFlips: Array<{ bulkAssetId: string; quantity: number }> = [];
   for (const u of toFlip) {
     await ctx.db.patch(u._id, {
       status: p.toStatus,
@@ -875,9 +895,28 @@ async function flipLineUnits(
       updatedAt: p.now,
     });
     if (u.assetId) assetIds.push(u.assetId);
+    if (u.bulkAssetId) bulkFlips.push({ bulkAssetId: u.bulkAssetId, quantity: u.quantity ?? 0 });
   }
   if (assetIds.length > 0) await setAssetsStatus(ctx, assetIds, p.assetStatus, p.locationId, p.clearLoc, p.now);
-  return { flipped: toFlip.length, assetIds };
+  return { flipped: toFlip.length, assetIds, bulkFlips };
+}
+
+/** Apply issue #801 #2 standalone-bulk availability adjustments for a set of
+ *  flipped bulk units, honoring the isKitChild gate (kit members own their own
+ *  adjustment via collectKitBulkAdjustments off `kitBulkItems`, not per-unit
+ *  flips). `sign` is +1 to release stock back to the shelf (undeploy) or -1 to
+ *  re-consume it (unreturn) — mirrors kit move-back's documented "+1"/"-1". */
+async function applyBulkFlipAvailability(
+  ctx: Ctx,
+  organizationId: string,
+  isKitChild: boolean | undefined,
+  bulkFlips: Array<{ bulkAssetId: string; quantity: number }>,
+  sign: 1 | -1,
+): Promise<void> {
+  if (isKitChild) return;
+  for (const bf of bulkFlips) {
+    if (bf.quantity > 0) await adjustBulkAvailability(ctx, organizationId, [{ bulkAssetId: bf.bulkAssetId, delta: sign * bf.quantity }]);
+  }
 }
 
 /** Cascade a line's ACCESSORY children back with their parent (whole units). */
@@ -915,7 +954,7 @@ export async function undeployItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<
   for (const item of a.items) {
     const line = await lineByCuid(ctx, item.lineItemId);
     if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
-    const { flipped } = await flipLineUnits(ctx, {
+    const { flipped, bulkFlips } = await flipLineUnits(ctx, {
       organizationId: a.organizationId, lineItemId: line.id, fromStatus: "CHECKED_OUT",
       toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE",
       locationId: defLoc, clearLoc: true, want: item.quantity, now: a.now,
@@ -925,6 +964,7 @@ export async function undeployItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<
       // Legacy unit-less line — set counters directly; a rollup would zero them.
       await ctx.db.patch(line._id, { status: "CONFIRMED", prepStatus: "PACKED", checkedOutQuantity: 0, updatedAt: a.now });
     }
+    await applyBulkFlipAvailability(ctx, a.organizationId, line.isKitChild, bulkFlips, 1);
     await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "CHECKED_OUT", toStatus: "CONFIRMED", toPrepStatus: "PACKED", assetStatus: "AVAILABLE", locationId: defLoc, clearLoc: true, now: a.now });
     if (!wholeLine) await syncLineItemRollup(ctx, line.id);
     await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_IN", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Prepped (un-deploy)" });
@@ -951,7 +991,7 @@ export async function unreturnItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<
   for (const item of a.items) {
     const line = await lineByCuid(ctx, item.lineItemId);
     if (!line || line.projectId !== a.projectId || line.organizationId !== a.organizationId) throw new ConvexError(`Line item ${item.lineItemId} not found in project`);
-    const { flipped } = await flipLineUnits(ctx, {
+    const { flipped, bulkFlips } = await flipLineUnits(ctx, {
       organizationId: a.organizationId, lineItemId: line.id, fromStatus: "RETURNED",
       toStatus: "CHECKED_OUT", resetReturnedQty: true, assetStatus: "CHECKED_OUT",
       locationId: projLoc, clearLoc: false, want: item.quantity, now: a.now,
@@ -962,6 +1002,7 @@ export async function unreturnItemsCore(ctx: Ctx, a: ReverseItemsArgs): Promise<
       // would zero checkedOutQuantity (no units to recompute from).
       await ctx.db.patch(line._id, { status: "CHECKED_OUT", returnedQuantity: 0, checkedOutQuantity: line.quantity ?? 0, checkedOutAt: a.now, checkedOutById: a.userId, updatedAt: a.now });
     }
+    await applyBulkFlipAvailability(ctx, a.organizationId, line.isKitChild, bulkFlips, -1);
     await reverseAccessoryChildren(ctx, { organizationId: a.organizationId, parentLineItemId: line.id, fromStatus: "RETURNED", toStatus: "CHECKED_OUT", assetStatus: "CHECKED_OUT", locationId: projLoc, clearLoc: false, now: a.now });
     if (!wholeLine) await syncLineItemRollup(ctx, line.id);
     await scanLog(ctx, { organizationId: a.organizationId, projectId: a.projectId, action: "CHECK_OUT", scannedById: a.userId, scannedAt: a.now, notes: "Moved back to Deployed (un-return)" });

--- a/src/lib/overbooking-core.test.ts
+++ b/src/lib/overbooking-core.test.ts
@@ -246,15 +246,29 @@ describe("reconstructOverbookedStatus", () => {
 });
 
 describe("resolveModelAssetType", () => {
-  it("returns a present value unchanged", () => {
-    expect(resolveModelAssetType("SERIALIZED", true)).toBe("SERIALIZED");
-    expect(resolveModelAssetType("BULK", false)).toBe("BULK");
+  it("returns a present value unchanged when the model actually has serialized assets", () => {
+    expect(resolveModelAssetType("SERIALIZED", true, true)).toBe("SERIALIZED");
+    expect(resolveModelAssetType("BULK", false, true)).toBe("BULK");
   });
   it("falls back to BULK when assetType is absent but bulk assets exist", () => {
-    expect(resolveModelAssetType(undefined, true)).toBe("BULK");
-    expect(resolveModelAssetType(null, true)).toBe("BULK");
+    expect(resolveModelAssetType(undefined, true, false)).toBe("BULK");
+    expect(resolveModelAssetType(null, true, false)).toBe("BULK");
   });
   it("falls back to SERIALIZED when assetType is absent and there are no bulk assets", () => {
-    expect(resolveModelAssetType(undefined, false)).toBe("SERIALIZED");
+    expect(resolveModelAssetType(undefined, false, false)).toBe("SERIALIZED");
+  });
+  // Regression: issue #801 — a bulk-only model created via model-form.tsx keeps
+  // its explicit "SERIALIZED" form default (not absent) unless someone
+  // deliberately switches it to Bulk, so the undefined-only fallback above never
+  // fires. `computeStockBreakdown` then took the SERIALIZED branch forever
+  // (totalStock = assets.length = 0) even though the model held real bulk stock.
+  it("overrides an explicit SERIALIZED label when the model has bulk stock and zero serialized assets", () => {
+    expect(resolveModelAssetType("SERIALIZED", true, false)).toBe("BULK");
+  });
+  it("keeps an explicit SERIALIZED label when the model genuinely has serialized assets, even alongside stray bulk rows", () => {
+    expect(resolveModelAssetType("SERIALIZED", true, true)).toBe("SERIALIZED");
+  });
+  it("keeps an explicit SERIALIZED label when there are no bulk assets either", () => {
+    expect(resolveModelAssetType("SERIALIZED", false, false)).toBe("SERIALIZED");
   });
 });

--- a/src/lib/overbooking-core.ts
+++ b/src/lib/overbooking-core.ts
@@ -42,12 +42,25 @@ import { mapLineItemDoc } from "@/lib/project-equipment-reconstruct";
  * every bulk line showed "0 available". Fall back to `"BULK"` when the model has
  * any active bulk asset. A present value is returned unchanged, so this is a
  * strictly-safe replacement for `assetType ?? "SERIALIZED"` at every stock site.
+ *
+ * The undefined-only fallback above never fires for a NEW model, though: the
+ * model-form.tsx create form defaults `assetType` to an EXPLICIT `"SERIALIZED"`
+ * (there's a Serialized/Bulk selector, but Serialized is what you get unless you
+ * deliberately switch it), so a model stocked exclusively with bulk assets and
+ * never switched away from the default reads back `assetType: "SERIALIZED"` —
+ * present, not absent — and stays stuck on the zero-stock branch forever
+ * (issue #801). `hasAssets` closes that gap: a model with real bulk stock and
+ * ZERO actual serialized assets can never have any serialized stock to report
+ * under any interpretation, so an explicit-but-label-only `"SERIALIZED"` is
+ * trusted less than the data in that one unambiguous case.
  */
 export function resolveModelAssetType(
   assetType: string | null | undefined,
   hasBulkAssets: boolean,
+  hasAssets: boolean,
 ): "SERIALIZED" | "BULK" {
-  if (assetType === "BULK" || assetType === "SERIALIZED") return assetType;
+  if (assetType === "BULK") return "BULK";
+  if (assetType === "SERIALIZED") return hasBulkAssets && !hasAssets ? "BULK" : "SERIALIZED";
   return hasBulkAssets ? "BULK" : "SERIALIZED";
 }
 
@@ -270,7 +283,7 @@ export function reconstructOverbookedStatus(
     const m = convexModelMap.get(modelId);
     if (!m) continue;
     const modelForBreakdown = {
-      assetType: resolveModelAssetType(m.assetType, (bulkMap.get(modelId)?.length ?? 0) > 0),
+      assetType: resolveModelAssetType(m.assetType, (bulkMap.get(modelId)?.length ?? 0) > 0, (assetMap.get(modelId)?.length ?? 0) > 0),
       assets: (assetMap.get(modelId) ?? []).map((a) => ({ status: a.status ?? "AVAILABLE" })),
       bulkAssets: (bulkMap.get(modelId) ?? []).map((ba) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
     };

--- a/src/server/line-items.ts
+++ b/src/server/line-items.ts
@@ -45,7 +45,7 @@ export async function checkAvailability(
   }
 
   const modelForBreakdown = {
-    assetType: resolveModelAssetType(model.assetType, activeBulkAssets.length > 0),
+    assetType: resolveModelAssetType(model.assetType, activeBulkAssets.length > 0, activeAssets.length > 0),
     assets: activeAssets.map((a: ConvexAsset) => ({ status: a.status ?? "AVAILABLE" })),
     bulkAssets: activeBulkAssets.map((ba: ConvexBulkAsset) => ({ totalQuantity: ba.totalQuantity ?? 0 })),
   };


### PR DESCRIPTION
## Summary

Fixes #801 — bulk assets showing "0 available" even when stock exists. Two independent root causes, both fixed:

1. **`resolveModelAssetType` mislabeling.** `model-form.tsx`'s create form defaults a new model's `assetType` to an explicit `"SERIALIZED"` unless someone deliberately switches the Asset type selector to Bulk. `resolveModelAssetType`'s undefined-only fallback to `BULK` never fires for that case (the value is present, not absent), so a model stocked exclusively with bulk assets stayed on the zero-stock `SERIALIZED` branch of `computeStockBreakdown` forever — `available: 0` no matter how much real bulk stock existed. `resolveModelAssetType` now also takes `hasAssets` and overrides an explicit `"SERIALIZED"` label to `"BULK"` only when the model has real bulk stock **and** zero actual serialized assets — the one case an explicit-but-label-only `SERIALIZED` can't possibly be right.

2. **`bulkAssets.availableQuantity` never maintained for standalone bulk lines.** That field (the registry's "Available" column) was only ever adjusted by kit checkout/checkin and DEDICATED-mode accessory attach/detach. A bulk asset added directly to a project line (not inside a kit) went through `checkOutBulkItem`/`returnLineUnits`, neither of which called `adjustBulkAvailability` — so the registry's live number drifted arbitrarily out of sync with real deployment. Fixed for checkout, checkin, and their move-back reverses (`undeployItems`/`unreturnItems`), gated on `!lineItem.isKitChild` so kit members and accessory children aren't double-adjusted.

A related but distinct gap (SHIPS_WITH accessory bulk children have the same missing-adjustment issue) was identified but is out of scope per the issue's acceptance criteria — tracked as a follow-up in `TODOS.md`.

## Testing

- `convex/availabilityCore.test.ts` / `src/lib/overbooking-core.test.ts` — extended the `resolveModelAssetType` byte-for-byte pinning test + added regression tests for the mislabeled-SERIALIZED-bulk-only-model case, including a full `computeModelAvailability` pipeline fixture.
- `convex/bulk-fulfillment-quantity.test.ts` — new regression tests: standalone checkout deducts `availableQuantity`, checkin restores it, a full round-trip nets to zero, kit-child lines are *not* double-adjusted, and the same coverage for the `undeployItems`/`unreturnItems` move-back reverses.
- `pnpm exec tsc --noEmit` — no new errors (pre-existing unrelated errors are all missing-generated-Prisma-client in this sandbox, no `DATABASE_URL`).
- `pnpm exec eslint` on all touched files — 0 errors (pre-existing complexity warnings only, no new ones after extracting a shared `applyBulkFlipAvailability` helper).
- `pnpm exec vitest run convex/ src/lib/overbooking-core.test.ts` — 1244 tests pass (only pre-existing environment-only failures from the missing Prisma client, unrelated to this change).

Docs updated in the same PR: `FEATUREDOCS/08-assets.md`, `FEATUREDOCS/12-warehouse.md`, `TODOS.md`.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JxjQYT1cdLaugGs65SgiPv)_