### PR TITLE
Clean up the service dialog crew rate table

### DIFF
--- a/FEATUREDOCS/31-crew-management.md
+++ b/FEATUREDOCS/31-crew-management.md
@@ -241,6 +241,15 @@ on the page (issue #796 — "put all crew management on the services"):
   service's "Cost to Business" total becomes a read-only auto-calculated sum of that
   table once any crew is assigned (see "Service ↔ Crew Cost Linkage" above); a
   crew-less service keeps the old manually-typed cost field.
+  `CrewRateTable` renders as a real `Table`/`TableRow`/`TableCell` (from
+  `@/components/ui/table`) instead of stacked flex rows — column labels ("Crew",
+  "Rate", "Cost") live once in the header instead of being repeated per row per
+  field, and the Rate cell joins the override amount + rate-type select into one
+  bordered control. The Hours column only renders at all when at least one
+  assigned row is hourly-rated. The crew-member picker's selected-chip row
+  (`MultiComboboxPicker`'s default "X selected" chips under the trigger) is
+  suppressed here (`showSelectedTags={false}`) since the rate table immediately
+  below lists the same members — showing both was duplicate information.
 - **`CrewPanel`** (`src/components/projects/crew-panel.tsx`) is rendered FROM
   INSIDE `ServicesPanel` (not mounted separately by the page) as a "Project crew"
   section below the service list — every crew member across every service on the

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -96,6 +96,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -1104,6 +1113,7 @@ function CrewMemberSelect({
         placeholder="Search and select crew..."
         searchPlaceholder="Search crew members..."
         emptyMessage="No crew members available"
+        showSelectedTags={false}
       />
     </div>
   );
@@ -1159,24 +1169,51 @@ function CrewRateTable({
   onRemoveRow: (crewMemberId: string) => void;
   total: number;
 }) {
+  // Hours only applies to hourly-rated rows — the column is dropped entirely
+  // (not just blanked per-row) when nothing on the service is hourly, so the
+  // common daily/flat case stays a tight 4-column table.
+  const showHours = rows.some((row) => (row.rateType || previewCost(row).rateType) === "HOURLY");
+  const labelColSpan = showHours ? 3 : 2;
+
   return (
     <div className="space-y-1.5">
       <Label>Crew rates</Label>
-      <div className="space-y-2 rounded-[var(--r)] border border-line p-2">
-        {rows.map((row) => (
-          <CrewRateTableRow
-            key={row.crewMemberId}
-            row={row}
-            member={crewMemberById.get(row.crewMemberId)}
-            previewCost={previewCost}
-            onChangeRow={onChangeRow}
-            onRemoveRow={onRemoveRow}
-          />
-        ))}
-        <div className="flex items-center justify-between border-t border-line pt-2 text-ui-text">
-          <span className="font-medium text-ink-2">Total labour cost</span>
-          <span className="font-semibold tabular-nums text-ink">{formatCurrency(total)}</span>
-        </div>
+      <div className="rounded-[var(--r)] border border-line overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead>Crew</TableHead>
+              <TableHead>Rate</TableHead>
+              {showHours && <TableHead className="text-right">Hours</TableHead>}
+              <TableHead className="text-right">Cost</TableHead>
+              <TableHead className="w-8" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <CrewRateTableRow
+                key={row.crewMemberId}
+                row={row}
+                member={crewMemberById.get(row.crewMemberId)}
+                previewCost={previewCost}
+                onChangeRow={onChangeRow}
+                onRemoveRow={onRemoveRow}
+                showHours={showHours}
+              />
+            ))}
+          </TableBody>
+          <TableFooter>
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={labelColSpan} className="font-medium text-ink-2">
+                Total labour cost
+              </TableCell>
+              <TableCell className="text-right font-semibold tabular-nums text-ink">
+                {formatCurrency(total)}
+              </TableCell>
+              <TableCell />
+            </TableRow>
+          </TableFooter>
+        </Table>
       </div>
     </div>
   );
@@ -1188,86 +1225,89 @@ function CrewRateTableRow({
   previewCost,
   onChangeRow,
   onRemoveRow,
+  showHours,
 }: {
   row: ServiceCrewTableRow;
   member: CrewRateTableMember | undefined;
   previewCost: (row: ServiceCrewTableRow) => { rate: number; rateType: string; cost: number };
   onChangeRow: (crewMemberId: string, patch: Partial<ServiceCrewTableRow>) => void;
   onRemoveRow: (crewMemberId: string) => void;
+  /** Whether the table is rendering the Hours column at all (see CrewRateTable). */
+  showHours: boolean;
 }) {
   const { rate, rateType, cost } = previewCost(row);
   const effectiveRateType = row.rateType || rateType;
-  const isOverridden = row.rateOverride != null && row.rateOverride > 0;
 
   return (
-    <div className="flex flex-wrap items-end gap-2 rounded-[var(--r)] bg-paper-2/60 p-2">
-      <div className="flex min-w-0 flex-1 items-center gap-2 basis-full sm:basis-auto">
-        <PersonAvatar name={memberDisplayName(member, "?")} src={member?.image ?? undefined} className="size-6 shrink-0" />
-        <span className="truncate text-ui-text font-medium text-ink-2">{memberDisplayName(member, "Unknown")}</span>
-      </div>
-      <div className="w-24 space-y-0.5">
-        <Label className="text-[10px] text-faint">Rate override</Label>
-        <Input
-          type="number"
-          step="0.01"
-          min={0}
-          value={row.rateOverride ?? ""}
-          onChange={(e) => onChangeRow(row.crewMemberId, { rateOverride: parseOptionalNumber(e.target.value) })}
-          placeholder={formatCurrency(rate)}
-          className="h-8 text-caption"
-        />
-      </div>
-      <div className="w-24 space-y-0.5">
-        <Label className="text-[10px] text-faint">Rate type</Label>
-        <Select
-          value={effectiveRateType}
-          onValueChange={(v) => onChangeRow(row.crewMemberId, { rateType: v as ServiceCrewTableRow["rateType"] })}
-        >
-          <SelectTrigger className="h-8 text-caption">
-            <SelectValue>{crewRateTypeLabels[effectiveRateType]}</SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="DAILY">Daily</SelectItem>
-            <SelectItem value="HOURLY">Hourly</SelectItem>
-            <SelectItem value="FLAT">Flat</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      {effectiveRateType === "HOURLY" && (
-        <div className="w-20 space-y-0.5">
-          <Label className="text-[10px] text-faint">Hours</Label>
+    <TableRow>
+      <TableCell>
+        <div className="flex min-w-0 items-center gap-2">
+          <PersonAvatar name={memberDisplayName(member, "?")} src={member?.image ?? undefined} className="size-6 shrink-0" />
+          <span className="truncate font-medium text-ink-2">{memberDisplayName(member, "Unknown")}</span>
+        </div>
+      </TableCell>
+      <TableCell>
+        {/* Amount + unit rendered as one joined control (shared border) so the
+            row reads as a single "Rate" field despite being two inputs. */}
+        <div className="flex w-fit">
           <Input
             type="number"
-            step="0.5"
+            step="0.01"
             min={0}
-            value={row.estimatedHours ?? ""}
-            onChange={(e) => onChangeRow(row.crewMemberId, { estimatedHours: parseOptionalNumber(e.target.value) })}
-            className="h-8 text-caption"
+            value={row.rateOverride ?? ""}
+            onChange={(e) => onChangeRow(row.crewMemberId, { rateOverride: parseOptionalNumber(e.target.value) })}
+            placeholder={formatCurrency(rate)}
+            aria-label="Rate override"
+            className="h-7 w-[72px] rounded-r-none border-r-0 text-caption"
           />
+          <Select
+            value={effectiveRateType}
+            onValueChange={(v) => onChangeRow(row.crewMemberId, { rateType: v as ServiceCrewTableRow["rateType"] })}
+          >
+            <SelectTrigger aria-label="Rate type" className="h-7 w-[72px] rounded-l-none text-caption">
+              <SelectValue>{crewRateTypeLabels[effectiveRateType]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DAILY">Daily</SelectItem>
+              <SelectItem value="HOURLY">Hourly</SelectItem>
+              <SelectItem value="FLAT">Flat</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
+      </TableCell>
+      {showHours && (
+        <TableCell className="text-right">
+          {effectiveRateType === "HOURLY" ? (
+            <Input
+              type="number"
+              step="0.5"
+              min={0}
+              value={row.estimatedHours ?? ""}
+              onChange={(e) => onChangeRow(row.crewMemberId, { estimatedHours: parseOptionalNumber(e.target.value) })}
+              aria-label="Estimated hours"
+              className="ml-auto h-7 w-16 text-right text-caption"
+            />
+          ) : (
+            <span className="text-faint">—</span>
+          )}
+        </TableCell>
       )}
-      <div className="w-20 space-y-0.5 text-right">
-        <Label className="text-[10px] text-faint">Cost</Label>
-        <div className="flex h-8 items-center justify-end text-caption font-medium tabular-nums text-ink">
-          {formatCurrency(cost)}
-        </div>
-      </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="touch-target size-8 shrink-0"
-        onClick={() => onRemoveRow(row.crewMemberId)}
-        aria-label={`Remove ${memberDisplayName(member, "crew member")}`}
-      >
-        <X className="h-3.5 w-3.5 text-muted" />
-      </Button>
-      {!isOverridden && (
-        <p className="w-full text-[10px] text-faint">
-          Using default rate — {formatCurrency(rate)}/{rateType.toLowerCase()}
-        </p>
-      )}
-    </div>
+      <TableCell className="text-right font-medium tabular-nums text-ink whitespace-nowrap">
+        {formatCurrency(cost)}
+      </TableCell>
+      <TableCell>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="touch-target size-7 shrink-0"
+          onClick={() => onRemoveRow(row.crewMemberId)}
+          aria-label={`Remove ${memberDisplayName(member, "crew member")}`}
+        >
+          <X className="h-3.5 w-3.5 text-muted" />
+        </Button>
+      </TableCell>
+    </TableRow>
   );
 }
 

--- a/src/components/ui/combobox-picker.tsx
+++ b/src/components/ui/combobox-picker.tsx
@@ -337,10 +337,6 @@ function MultiComboboxPicker({
     )
   }, [options, search])
 
-  const selectedLabels = values
-    .map((v) => options.find((o) => o.value === v)?.label)
-    .filter(Boolean)
-
   function handleToggle(optionValue: string) {
     if (values.includes(optionValue)) {
       onChange(values.filter((v) => v !== optionValue))
@@ -443,30 +439,49 @@ function MultiComboboxPicker({
         </PopoverPrimitive.Portal>
       </PopoverPrimitive.Root>
 
-      {showSelectedTags && selectedLabels.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {values.map((v) => {
-            const opt = options.find((o) => o.value === v)
-            if (!opt) return null
-            return (
-              <span
-                key={v}
-                className="inline-flex items-center gap-1 rounded-md bg-accent/50 px-1.5 py-0.5 text-xs"
-              >
-                {opt.icon && <span className="shrink-0">{opt.icon}</span>}
-                {opt.label}
-                <button
-                  type="button"
-                  onClick={() => handleRemove(v)}
-                  className="ml-0.5 text-fg-3 hover:text-fg"
-                >
-                  <XIcon className="size-3" />
-                </button>
-              </span>
-            )
-          })}
-        </div>
-      )}
+      <SelectedTagsRow show={showSelectedTags} values={values} options={options} onRemove={handleRemove} />
+    </div>
+  )
+}
+
+/** The removable-chip row under a MultiComboboxPicker's trigger — split out so
+ *  its `show`/empty-selection checks don't add branches to the (already large)
+ *  MultiComboboxPicker function itself (R-3.6 complexity ratchet). */
+function SelectedTagsRow({
+  show,
+  values,
+  options,
+  onRemove,
+}: {
+  show: boolean
+  values: string[]
+  options: ComboboxPickerOption[]
+  onRemove: (value: string) => void
+}) {
+  if (!show) return null
+  const selected = values
+    .map((v) => ({ value: v, option: options.find((o) => o.value === v) }))
+    .filter((entry): entry is { value: string; option: ComboboxPickerOption } => !!entry.option)
+  if (selected.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {selected.map(({ value: v, option }) => (
+        <span
+          key={v}
+          className="inline-flex items-center gap-1 rounded-md bg-accent/50 px-1.5 py-0.5 text-xs"
+        >
+          {option.icon && <span className="shrink-0">{option.icon}</span>}
+          {option.label}
+          <button
+            type="button"
+            onClick={() => onRemove(v)}
+            className="ml-0.5 text-fg-3 hover:text-fg"
+          >
+            <XIcon className="size-3" />
+          </button>
+        </span>
+      ))}
     </div>
   )
 }

--- a/src/components/ui/combobox-picker.tsx
+++ b/src/components/ui/combobox-picker.tsx
@@ -303,6 +303,12 @@ interface MultiComboboxPickerProps {
   emptyMessage?: string
   className?: string
   disabled?: boolean
+  /**
+   * Render the selected-items chip row below the trigger. Defaults to true.
+   * Set false when the caller already renders the selection elsewhere (e.g.
+   * a table listing the same items) — showing both is duplicate information.
+   */
+  showSelectedTags?: boolean
 }
 
 function MultiComboboxPicker({
@@ -314,6 +320,7 @@ function MultiComboboxPicker({
   emptyMessage = "No results found.",
   className,
   disabled = false,
+  showSelectedTags = true,
 }: MultiComboboxPickerProps) {
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState("")
@@ -436,7 +443,7 @@ function MultiComboboxPicker({
         </PopoverPrimitive.Portal>
       </PopoverPrimitive.Root>
 
-      {selectedLabels.length > 0 && (
+      {showSelectedTags && selectedLabels.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {values.map((v) => {
             const opt = options.find((o) => o.value === v)


### PR DESCRIPTION
## Summary

- The service edit dialog's Crew section showed every assigned crew member's name twice: once as removable chips under the "Assign crew members" picker, and again as a row in the Crew rates section below. Each rate row also repeated its own "Rate override" / "Rate type" / "Hours" / "Cost" field labels, making the section look cluttered.
- `CrewRateTable` now renders as a real `Table`/`TableRow`/`TableCell` (the same primitives used by the equipment and sub-hire tables elsewhere in the app) with column labels ("Crew", "Rate", "Cost") living once in the header instead of per-row-per-field. The rate-override input and rate-type select are joined into a single bordered "Rate" control, and the Hours column is only rendered at all when at least one assigned crew member is hourly-rated.
- Added a `showSelectedTags` prop to `MultiComboboxPicker` (`combobox-picker.tsx`) so a caller can suppress its own selected-item chip row when the selection is already rendered elsewhere — used here to drop the duplicate name chips under the crew picker.
- Dropped the "Using default rate — $X/daily" footnote per row since the rate input's placeholder already communicates the same thing.
- Updated `FEATUREDOCS/31-crew-management.md` to describe the new table shape.

Researched compact rate-table patterns on Mobbin before implementing (Fresha's team pay-run summary modal was the clearest reference: header labels once, single-line rows, right-aligned numbers).

## Testing

- `pnpm exec eslint` on the touched files — no new errors (pre-existing complexity/line-count warnings only).
- `pnpm exec tsc --noEmit` — no new type errors (remaining errors are pre-existing, from a missing generated Prisma client in this container, unrelated to this change).
- `pnpm exec vitest run src/components/ui/__tests__/combobox-picker.smoke.test.tsx` — 7/7 passing.
- Not verified in a running browser: this container has no `.env`/DB/Convex credentials, so `pnpm dev` can't start here. Worth a quick manual look at the service dialog's Crew section once on a machine with the dev server working.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_014nzeqPtEp69VQ8T78ymZuv)_