### PR TITLE
PDF: global document settings — footer, T&Cs, quote validity (#790 Phase 3)

### DIFF
--- a/src/app/(app)/settings/branding/page.tsx
+++ b/src/app/(app)/settings/branding/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { BrandingSettings } from "@/components/settings/branding-settings";
+import { DocumentSettings } from "@/components/settings/document-settings";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useOrganization } from "@/hooks/use-organization";
@@ -28,20 +29,37 @@ export default function BrandingSettingsPage() {
 
   return (
     <FadeIn>
-    <SettingsCard>
-      <FormSection
-        title="Branding & Colors"
-        description="Customize your organization's colors across the UI and PDF documents."
-      >
-        <div className="sm:col-span-2">
-          <BrandingSettings
-            orgName={name}
-            settings={settings}
-            onBrandingChange={(branding) => setSettings((prev) => ({ ...prev, branding }))}
-          />
-        </div>
-      </FormSection>
-    </SettingsCard>
+    <div className="space-y-6">
+      <SettingsCard>
+        <FormSection
+          title="Branding & Colors"
+          description="Customize your organization's colors across the UI and PDF documents."
+        >
+          <div className="sm:col-span-2">
+            <BrandingSettings
+              orgName={name}
+              settings={settings}
+              onBrandingChange={(branding) => setSettings((prev) => ({ ...prev, branding }))}
+            />
+          </div>
+        </FormSection>
+      </SettingsCard>
+
+      <SettingsCard>
+        <FormSection
+          title="Documents"
+          description="Footer text and quote terms shown on generated PDF documents."
+        >
+          <div className="sm:col-span-2">
+            <DocumentSettings
+              orgName={name}
+              settings={settings}
+              onDocumentsChange={(documents) => setSettings((prev) => ({ ...prev, documents }))}
+            />
+          </div>
+        </FormSection>
+      </SettingsCard>
+    </div>
     </FadeIn>
   );
 }

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -60,7 +60,7 @@ const settingsNav: SettingsNavSection[] = [
     items: [
       { title: "General", href: "/settings", icon: Building2, permission: "orgSettings" },
       { title: "Billing", href: "/settings/billing", icon: CreditCard, permission: "orgSettings" },
-      { title: "Branding", href: "/settings/branding", icon: Palette, permission: "orgSettings" },
+      { title: "Branding & documents", href: "/settings/branding", icon: Palette, permission: "orgSettings" },
       { title: "Team", href: "/settings/team", icon: Users, permission: "orgMembers" },
       { title: "Single Sign-On", href: "/settings/sso", icon: Shield, permission: "orgSettings" },
     ],

--- a/src/components/settings/document-settings.tsx
+++ b/src/components/settings/document-settings.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { refreshOrganization } from "@/hooks/use-organization";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { updateOrganization } from "@/server/settings";
+import type { OrgSettings, OrgDocumentSettings } from "@/lib/org-settings-types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+
+interface DocumentSettingsProps {
+  orgName: string;
+  settings: OrgSettings;
+  onDocumentsChange?: (documents: OrgDocumentSettings | undefined) => void;
+}
+
+const DEFAULT_QUOTE_VALIDITY_DAYS = 30;
+
+export function DocumentSettings({ orgName, settings, onDocumentsChange }: DocumentSettingsProps) {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const documents = settings.documents || {};
+
+  const [footerText, setFooterText] = useState(documents.footerText || "");
+  const [footerSecondLine, setFooterSecondLine] = useState(documents.footerSecondLine || "");
+  const [termsAndConditions, setTermsAndConditions] = useState(documents.termsAndConditions || "");
+  const [quoteValidityDays, setQuoteValidityDays] = useState(documents.quoteValidityDays ?? DEFAULT_QUOTE_VALIDITY_DAYS);
+
+  // Sync from server when settings change
+  useEffect(() => {
+    const d = settings.documents || {};
+    setFooterText(d.footerText || ""); // eslint-disable-line react-hooks/set-state-in-effect
+    setFooterSecondLine(d.footerSecondLine || ""); // eslint-disable-line react-hooks/set-state-in-effect
+    setTermsAndConditions(d.termsAndConditions || ""); // eslint-disable-line react-hooks/set-state-in-effect
+    setQuoteValidityDays(d.quoteValidityDays ?? DEFAULT_QUOTE_VALIDITY_DAYS); // eslint-disable-line react-hooks/set-state-in-effect
+  }, [settings.documents]);
+
+  function buildDocuments(): OrgDocumentSettings | undefined {
+    const next: OrgDocumentSettings = {
+      footerText: footerText.trim() || undefined,
+      footerSecondLine: footerSecondLine.trim() || undefined,
+      termsAndConditions: termsAndConditions.trim() || undefined,
+      quoteValidityDays: quoteValidityDays !== DEFAULT_QUOTE_VALIDITY_DAYS ? quoteValidityDays : undefined,
+    };
+    const hasAny =
+      !!next.footerText || !!next.footerSecondLine || !!next.termsAndConditions || next.quoteValidityDays !== undefined;
+    return hasAny ? next : undefined;
+  }
+
+  const mutation = useServerMutation({
+    mutationFn: () =>
+      updateOrganization({
+        name: orgName,
+        settings: { ...settings, documents: buildDocuments() },
+      }),
+    onSuccess: () => {
+      onDocumentsChange?.(buildDocuments());
+      refreshOrganization(orgId);
+      toast.success("Document settings saved");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const hasChanges =
+    footerText !== (documents.footerText || "") ||
+    footerSecondLine !== (documents.footerSecondLine || "") ||
+    termsAndConditions !== (documents.termsAndConditions || "") ||
+    quoteValidityDays !== (documents.quoteValidityDays ?? DEFAULT_QUOTE_VALIDITY_DAYS);
+
+  const validityOutOfRange = !Number.isFinite(quoteValidityDays) || quoteValidityDays < 1 || quoteValidityDays > 365;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="footerText">Footer text</Label>
+        <Input
+          id="footerText"
+          value={footerText}
+          onChange={(e) => setFooterText(e.target.value)}
+          placeholder={`${orgName || "Your org"} | your@email.com | 0400 000 000`}
+          maxLength={200}
+        />
+        <p className="text-xs text-fg-3">
+          Shown at the bottom of every page. Leave blank to auto-generate from your org name, email, and phone.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="footerSecondLine">Footer second line</Label>
+        <Input
+          id="footerSecondLine"
+          value={footerSecondLine}
+          onChange={(e) => setFooterSecondLine(e.target.value)}
+          placeholder="Optional second line"
+          maxLength={200}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="termsAndConditions">Terms &amp; conditions</Label>
+        <Textarea
+          id="termsAndConditions"
+          value={termsAndConditions}
+          onChange={(e) => setTermsAndConditions(e.target.value)}
+          placeholder="Shown as a block on quotes. Plain text — no tokens."
+          maxLength={4000}
+          rows={5}
+        />
+        <p className="text-xs text-fg-3">Shown on quotes only.</p>
+      </div>
+
+      <div className="space-y-2 sm:max-w-xs">
+        <Label htmlFor="quoteValidityDays">Quote validity (days)</Label>
+        <Input
+          id="quoteValidityDays"
+          type="number"
+          min={1}
+          max={365}
+          value={quoteValidityDays}
+          onChange={(e) => setQuoteValidityDays(e.target.valueAsNumber)}
+          aria-invalid={validityOutOfRange}
+        />
+        <p className="text-xs text-fg-3">
+          Quotes show &ldquo;Valid until&rdquo; computed from the generation date plus this many days.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending || !hasChanges || validityOutOfRange}
+        >
+          {mutation.isPending ? "Saving..." : "Save Document Settings"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/org-settings-types.ts
+++ b/src/lib/org-settings-types.ts
@@ -22,6 +22,16 @@ export interface OrgBranding {
   showOrgNameOnDocuments?: boolean;
 }
 
+/** Global document settings — footer text, T&Cs, quote validity. Applies to
+ *  all 5 project doc types (footer) or just the quote (T&Cs, validity). */
+export interface OrgDocumentSettings {
+  footerText?: string;
+  footerSecondLine?: string;
+  termsAndConditions?: string;
+  /** Days a quote stays valid from its generation date. Default 30. */
+  quoteValidityDays?: number;
+}
+
 export interface TestTagSettings {
   prefix?: string;
   digits?: number;
@@ -55,6 +65,7 @@ export interface OrgSettings {
   /** Zero-pad width for the project-number increment. Default 2. */
   projectNumberIncrementPadding?: number;
   branding?: OrgBranding;
+  documents?: OrgDocumentSettings;
   testTag?: TestTagSettings;
   icalToken?: string;
   icalEnabled?: boolean;

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -31,6 +31,7 @@ import {
   type SubHireGroupForStructuring,
 } from "./structure-line-items";
 import type { DocumentData, DocumentLineItem, CrewEntry, CallSheetDayData, DocumentType } from "./types";
+import type { OrgDocumentSettings } from "@/lib/org-settings-types";
 
 const DEFAULT_DOC_COLOR = "#0d4f4f";
 
@@ -103,6 +104,7 @@ export async function buildDocumentData(
     documentLogoMode?: "logo" | "icon" | "none";
     showOrgNameOnDocuments?: boolean;
   } | undefined;
+  const documentSettings = orgSettings.documents as OrgDocumentSettings | undefined;
 
   // Load logo/icon as base64
   const [logoData, iconData] = await Promise.all([
@@ -634,6 +636,9 @@ export async function buildDocumentData(
 
   const totalNum = Number(serialized.total) || 0;
   const depositNum = Number(serialized.depositPaid) || 0;
+  const now = new Date();
+  const quoteValidityDays = documentSettings?.quoteValidityDays ?? 30;
+  const quoteValidUntil = new Date(now.getTime() + quoteValidityDays * 24 * 60 * 60 * 1000);
 
   return {
     // Org
@@ -695,7 +700,11 @@ export async function buildDocumentData(
     internal_notes: serialized.internalNotes || "",
 
     // Metadata
-    document_date: formatDate(new Date().toISOString()),
+    document_date: formatDate(now),
+    document_footer_text: documentSettings?.footerText || "",
+    document_footer_second_line: documentSettings?.footerSecondLine || "",
+    quote_terms_and_conditions: documentSettings?.termsAndConditions || "",
+    quote_valid_until: formatDate(quoteValidUntil),
 
     // PM
     pm_name: pmName,

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -59,6 +59,10 @@ function makeData(overrides: Partial<DocumentData> = {}): DocumentData {
     crew_notes: "",
     internal_notes: "",
     document_date: "2026-07-26",
+    document_footer_text: "",
+    document_footer_second_line: "",
+    quote_terms_and_conditions: "",
+    quote_valid_until: "2026-08-25",
     line_items: [],
     pm_name: "",
     pm_phone: "",
@@ -269,5 +273,45 @@ describe("composeDocument — layout invariants", () => {
   it("only quote and invoice show a totals block", () => {
     const withTotals = PROJECT_DOC_TYPES.filter((t) => DOCUMENT_LAYOUTS[t].blocks.some((b) => b.kind === "totals"));
     expect(withTotals.sort()).toEqual(["invoice", "quote"]);
+  });
+});
+
+describe("composeDocument — org document settings (footer, T&Cs, quote validity)", () => {
+  const soloData = (overrides: Partial<DocumentData> = {}) =>
+    makeData({
+      line_items: [makeLineItem({ id: "only-item", status: "CHECKED_OUT", checkedOutQuantity: 1, model: { name: "Solo Item" } })],
+      ...overrides,
+    });
+
+  it("uses the org's footer text when set, falling back to org contact details otherwise", () => {
+    const withFooter = composeDocument("quote", soloData({ document_footer_text: "Custom footer", document_footer_second_line: "Second line" }), "#0d4f4f");
+    const footerSchema = withFooter.template.schemas[0].find((s) => s.type === "gearflowPageFooter")!;
+    const footerConfig = JSON.parse(withFooter.inputs[0][footerSchema.name as string]);
+    expect(footerConfig.text).toBe("Custom footer");
+    expect(footerConfig.secondLine).toBe("Second line");
+
+    const withoutFooter = composeDocument("quote", soloData({ document_footer_text: "" }), "#0d4f4f");
+    const footerSchema2 = withoutFooter.template.schemas[0].find((s) => s.type === "gearflowPageFooter")!;
+    const footerConfig2 = JSON.parse(withoutFooter.inputs[0][footerSchema2.name as string]);
+    expect(footerConfig2.text).toBe("Test Org | org@test.com | 0400 000 000");
+  });
+
+  it("omits the T&Cs block entirely when the org hasn't set any terms", () => {
+    const result = composeDocument("quote", soloData({ quote_terms_and_conditions: "" }), "#0d4f4f");
+    const hasTermsSchema = result.template.schemas[0].some((s) => String(s.name).startsWith("termsAndConditions"));
+    expect(hasTermsSchema).toBe(false);
+  });
+
+  it("renders the T&Cs block when the org has set terms", () => {
+    const result = composeDocument("quote", soloData({ quote_terms_and_conditions: "All sales final." }), "#0d4f4f");
+    const termsSchema = result.template.schemas[0].find((s) => String(s.name).startsWith("termsAndConditions"))!;
+    expect(termsSchema).toBeDefined();
+    expect(result.inputs[0][termsSchema.name as string]).toBe("All sales final.");
+  });
+
+  it("renders the quote validity note using the real computed date, not static copy", () => {
+    const result = composeDocument("quote", soloData({ quote_valid_until: "2026-09-15" }), "#0d4f4f");
+    const validitySchema = result.template.schemas[0].find((s) => String(s.name).startsWith("quoteValidityNote"))!;
+    expect(result.inputs[0][validitySchema.name as string]).toBe("This quote is valid until 2026-09-15.");
   });
 });

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -292,6 +292,14 @@ function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: Layout
     case "quoteValidityNote":
       return 8;
 
+    case "termsAndConditions": {
+      // Optional — collapses to zero height (and is skipped entirely by the
+      // page-layout walk) when the org hasn't set any T&Cs text.
+      if (!data.quote_terms_and_conditions) return 0;
+      const lines = data.quote_terms_and_conditions.split("\n").length;
+      return Math.max(lines * 4 + 4, 8);
+    }
+
     case "signature":
       return 20;
   }
@@ -556,6 +564,9 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
 
   for (const block of bodyBlocks) {
     const height = estimateBlockHeight(block, data, ctx);
+    // Optional content blocks (e.g. termsAndConditions with no text set)
+    // collapse to zero height and are omitted entirely — no schema, no gap.
+    if (height <= 0) continue;
 
     if (currentY + height > maxY && currentPage.entries.length > 0) {
       if (block.kind === "table") {
@@ -782,7 +793,24 @@ function buildEntryFields(
             fontSize: 9,
             fontColor: "#333333",
           },
-          input: "This quote is valid for 30 days from the date of issue.",
+          input: `This quote is valid until ${data.quote_valid_until}.`,
+        },
+      ];
+
+    case "termsAndConditions":
+      return [
+        {
+          schema: {
+            name,
+            type: "text",
+            content: "",
+            position: { x: MARGIN, y },
+            width: CONTENT_WIDTH,
+            height,
+            fontSize: 8,
+            fontColor: "#666666",
+          },
+          input: data.quote_terms_and_conditions,
         },
       ];
 
@@ -808,23 +836,20 @@ export interface ComposeResult {
 
 /**
  * Compose a fixed-layout document into a multi-page pdfme Template + inputs.
- * This is the sole entry point for the 5 project document types.
+ * This is the sole entry point for the 5 project document types. Footer text
+ * comes from `data.document_footer_text`/`document_footer_second_line` (org
+ * "documents" settings — see org-settings-types.ts); empty falls back to an
+ * auto-generated "{org} | {email} | {phone}" line.
  */
-export function composeDocument(
-  docType: ProjectDocumentType,
-  data: DocumentData,
-  docColor: string,
-  footerText?: string,
-  footerSecondLine?: string,
-): ComposeResult {
+export function composeDocument(docType: ProjectDocumentType, data: DocumentData, docColor: string): ComposeResult {
   const layout = getDocumentLayout(docType);
   const pages = computePages(layout, data, docType);
 
   const allSchemas: (Schema & Record<string, unknown>)[][] = [];
   const mergedInputs: Record<string, string> = {};
   const footerConfig: FooterConfig = {
-    text: footerText || `${data.org_name} | ${data.org_email} | ${data.org_phone}`,
-    secondLine: footerSecondLine || "",
+    text: data.document_footer_text || `${data.org_name} | ${data.org_email} | ${data.org_phone}`,
+    secondLine: data.document_footer_second_line || "",
   };
 
   for (let pageIdx = 0; pageIdx < pages.length; pageIdx++) {

--- a/src/lib/pdfme/document-layouts.ts
+++ b/src/lib/pdfme/document-layouts.ts
@@ -60,6 +60,7 @@ export type LayoutBlock =
   | { kind: "clientNotes" }
   | { kind: "totalItemsNote" }
   | { kind: "quoteValidityNote" }
+  | { kind: "termsAndConditions" }
   | { kind: "signature"; columns: number; labels: string[] };
 
 export interface DocumentLayout {
@@ -130,6 +131,7 @@ export const DOCUMENT_LAYOUTS: Record<ProjectDocumentType, DocumentLayout> = {
       { kind: "table", config: defaultTable },
       { kind: "totals", config: defaultTotals },
       { kind: "clientNotes" },
+      { kind: "termsAndConditions" },
       { kind: "quoteValidityNote" },
     ],
   },

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -202,6 +202,15 @@ export interface DocumentData {
 
   // Metadata
   document_date: string;
+  /** Org-level document settings (src/lib/org-settings-types.ts `documents`).
+   *  footer_text/footer_second_line: empty string = composer auto-generates
+   *  from org_name/org_email/org_phone. */
+  document_footer_text: string;
+  document_footer_second_line: string;
+  /** Quote-only: plain-text T&Cs block and a real computed "valid until" date
+   *  (generatedAt + org's quoteValidityDays, default 30). */
+  quote_terms_and_conditions: string;
+  quote_valid_until: string;
 
   // PM
   pm_name: string;

--- a/src/lib/validations/org-settings.test.ts
+++ b/src/lib/validations/org-settings.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { orgDocumentSettingsSchema } from "./org-settings";
+
+describe("orgDocumentSettingsSchema", () => {
+  it("accepts an empty object (all fields optional)", () => {
+    expect(orgDocumentSettingsSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts valid values", () => {
+    const result = orgDocumentSettingsSchema.safeParse({
+      footerText: "RVLT Flow | hello@rvlt.app | 0400 000 000",
+      footerSecondLine: "ABN 12 345 678 901",
+      termsAndConditions: "All sales final.",
+      quoteValidityDays: 14,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects quoteValidityDays outside 1-365", () => {
+    expect(orgDocumentSettingsSchema.safeParse({ quoteValidityDays: 0 }).success).toBe(false);
+    expect(orgDocumentSettingsSchema.safeParse({ quoteValidityDays: 366 }).success).toBe(false);
+    expect(orgDocumentSettingsSchema.safeParse({ quoteValidityDays: 1 }).success).toBe(true);
+    expect(orgDocumentSettingsSchema.safeParse({ quoteValidityDays: 365 }).success).toBe(true);
+  });
+
+  it("rejects non-integer quoteValidityDays", () => {
+    expect(orgDocumentSettingsSchema.safeParse({ quoteValidityDays: 30.5 }).success).toBe(false);
+  });
+
+  it("rejects footer/T&Cs text over the length caps", () => {
+    expect(orgDocumentSettingsSchema.safeParse({ footerText: "a".repeat(201) }).success).toBe(false);
+    expect(orgDocumentSettingsSchema.safeParse({ footerSecondLine: "a".repeat(201) }).success).toBe(false);
+    expect(orgDocumentSettingsSchema.safeParse({ termsAndConditions: "a".repeat(4001) }).success).toBe(false);
+  });
+
+  it("accepts text right at the length caps", () => {
+    expect(orgDocumentSettingsSchema.safeParse({ footerText: "a".repeat(200) }).success).toBe(true);
+    expect(orgDocumentSettingsSchema.safeParse({ termsAndConditions: "a".repeat(4000) }).success).toBe(true);
+  });
+});

--- a/src/lib/validations/org-settings.ts
+++ b/src/lib/validations/org-settings.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/**
+ * Global document settings (footer text, terms & conditions, quote
+ * validity) — org-level, part of the `orgSettings` Convex blob
+ * (`OrgSettings.documents`, see `src/lib/org-settings-types.ts`). Bounds
+ * mirrored server-side per R-8.6.2; the only write path is
+ * `updateOrganization` (`src/server/settings.ts`).
+ */
+export const orgDocumentSettingsSchema = z.object({
+  footerText: z.string().max(200).optional(),
+  footerSecondLine: z.string().max(200).optional(),
+  termsAndConditions: z.string().max(4000).optional(),
+  /** Days a quote stays valid from its generation date. Default 30. */
+  quoteValidityDays: z.coerce.number().int().min(1).max(365).optional(),
+});
+
+export type OrgDocumentSettingsValues = z.input<typeof orgDocumentSettingsSchema>;

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/org-settings-read";
 import { env } from "@/env";
 import { validateProjectNumberFormat } from "@/lib/project-number";
+import { orgDocumentSettingsSchema } from "@/lib/validations/org-settings";
 import type { OrgSettings, TestTagSettings } from "@/lib/org-settings-types";
 
 export async function getOrganization() {
@@ -48,6 +49,13 @@ export async function updateOrganization(data: {
   if (pnFormat) {
     const err = validateProjectNumberFormat(pnFormat);
     if (err) throw new Error(`Project number format: ${err}`);
+  }
+
+  if (data.settings.documents) {
+    const parsed = orgDocumentSettingsSchema.safeParse(data.settings.documents);
+    if (!parsed.success) {
+      throw new Error(`Document settings: ${parsed.error.issues[0]?.message ?? "invalid"}`);
+    }
   }
 
   // Identity (name) stays on the Better Auth org row; business settings + tax


### PR DESCRIPTION
## Summary

Phase 3 of #790, stacked on #938 (Phase 0-2 — the new pipeline this depends on). **Do not merge before #938** — this branches from it and will show only its own diff once #938 lands and this retargets to `main`.

- Adds `documents.{footerText, footerSecondLine, termsAndConditions, quoteValidityDays}` to the existing `orgSettings` blob (`OrgSettings.documents`) — no new tables, additive JSON.
- New `src/lib/validations/org-settings.ts` validates the group server-side (string length caps, `quoteValidityDays` 1-365 per R-8.6.2), wired into the single write path (`updateOrganization()`).
- New "Documents" card on `/settings/branding` (page title becomes "Branding & documents").
- `build-document-data.ts` computes 4 new `DocumentData` fields from the org's settings: `document_footer_text`/`document_footer_second_line` (footer on every doc — empty falls back to auto-generated `{org} | {email} | {phone}`), `quote_terms_and_conditions`, and `quote_valid_until` — a **real computed date** (`generatedAt + quoteValidityDays`, default 30), replacing the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry.
- `document-composer.ts`: quote layout gains a `termsAndConditions` block that collapses to zero height and is omitted entirely when the org hasn't set any T&Cs (no empty box on every quote by default).

## Testing

- `pnpm test` — 3899/3899 passing, incl. new tests for: org-settings Zod bounds, footer text override/fallback, T&Cs block presence/absence, and the quote validity note using the real computed date instead of static copy.
- `pnpm lint` — 0 errors.
- `npx tsc --noEmit` — clean.

## Checklist

- [x] No new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_014R1LcPyFnLd3BjRDFPb1X9)_