### PR TITLE
PDF: quote content fixes — no /day suffix, audited discount/notes (#790 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **#790** — Org-level document settings (footer text, terms & conditions, quote
+  validity days) on a new "Documents" card at `/settings/branding`. Quotes now show
+  a T&Cs block (omitted when unset) and a real computed "valid until" date instead
+  of a static "valid for 30 days" blurb.
+
 ### Fixed
+
+- **#790** — The quote layout no longer shows a "/day" (or other rental-period)
+  suffix next to prices. Audited discount/item-notes/group-notes rendering on the
+  quote end-to-end and confirmed they already flow correctly through the new
+  pipeline (regression-tested in `document-composer.test.ts`).
 
 - **#790** — Project documents (quote, invoice, pull slip, delivery docket, return sheet)
   longer than one page silently dropped their tail: since no stored `DocumentTemplate` could

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -143,7 +143,7 @@ removed (dual pipelines, ~8,300 dead LOC, and the pagination bug it caused).
 
 | Type | Blocks | `expandProjectGroups` | Status filter |
 |------|--------|------------------------|----------------|
-| `quote` | header, client+project details, table, totals, client notes, quote-validity note | false (collapse groups) | none |
+| `quote` | header, client+project details, table (no "/day" price suffix), totals, client notes, T&Cs (omitted if unset), quote-validity note (real computed date) | false (collapse groups) | none |
 | `invoice` | header, client+project details (+ tax ID, payment terms), table (no badges), totals (+ deposit/balance), client notes | false | none |
 | `packing-list` | header, client+project details, table (checkboxes, per-unit, asset tags, categories), total-items note | true (expand groups) | none |
 | `return-sheet` | header, client+project details, table (checkboxes, condition columns, per-unit, asset tags), signature (3 cols) | true | `CHECKED_OUT`, `RETURNED` |
@@ -152,6 +152,61 @@ removed (dual pipelines, ~8,300 dead LOC, and the pagination bug it caused).
 Call sheets are a 6th `DocumentType` value but are **not** in
 `DOCUMENT_LAYOUTS` — they render via `templates/call-sheet-services.ts`
 instead (`ProjectDocumentType = Exclude<DocumentType, "call-sheet">`).
+
+## Global Document Settings
+
+Org-level, stored in the existing `orgSettings` Convex blob (`OrgSettings.documents`,
+`src/lib/org-settings-types.ts`) — no new tables. Validated server-side by
+`src/lib/validations/org-settings.ts` (string length caps, `quoteValidityDays` 1-365,
+R-8.6.2), the only write path being `updateOrganization()`. Edited on a "Documents"
+card at `/settings/branding` ("Branding & documents").
+
+| Setting | Effect |
+|---|---|
+| `footerText` / `footerSecondLine` | Rendered on every page of every doc type. Empty falls back to an auto-generated `{org name} \| {org email} \| {org phone}` line. |
+| `termsAndConditions` | Plain text (no token system) rendered as a block on the quote only. Omitted entirely (zero height, no schema) when unset — no empty box by default. |
+| `quoteValidityDays` (default 30) | Feeds a **real computed date** — `document_date + quoteValidityDays` — into the quote's "This quote is valid until {date}" line. Replaces the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry. |
+
+`build-document-data.ts` computes 4 `DocumentData` fields from these settings each
+time a document is built: `document_footer_text`, `document_footer_second_line`,
+`quote_terms_and_conditions`, `quote_valid_until`.
+
+### Quote-specific fixes (#790 Phase 4)
+
+- **No "/day" (or other period) price suffix on the quote.** `TablePluginConfig.hidePricingPeriodSuffix`
+  (only the quote's `document-layouts.ts` entry sets it `true`) suppresses the
+  `PRICING_LABELS` lookup in `gearflow-table.ts`'s top-level price cell. Other doc
+  types are unaffected (kit/group child rows never showed the suffix anyway — only
+  the top-level unitPrice cell did).
+- **Discount, item notes, group notes**: audited end-to-end
+  (`document-composer.test.ts`) and confirmed already flowing correctly through the
+  new pipeline — `data.discount_amount`/`discount_percent` are unconditional from the
+  Convex `projects.discountAmount`/`discountPercent` fields, gated only by the
+  quote's `totals.showDiscount` (default `true`); `item.notes` (incl. a Project
+  Group's `notes: group.description`) already reaches the table plugin whenever
+  `table.showNotes` is `true` (default for quote). No code change was needed here —
+  just proof, since these were the class of bug (height/render consumers drifting
+  out of sync) this whole redesign targets.
+- **Terms & conditions block, real computed quote expiry**: see Global Document
+  Settings above.
+- **Crewing/services billable-to-client section — deferred, not in this PR.** The
+  design doc's Phase 4 checklist calls for a quote section built from billable
+  `CrewAssignment`/`ProjectService` rows gated by `billableToClient`. That field
+  exists on the Convex `projectServices` schema but has **no UI to set it anywhere
+  in the app** (confirmed by grep — the one place it's read,
+  `project-service-read.ts`, defaults it to `false` when absent). Gating the
+  existing quote services injection (`build-document-data.ts`'s `showOnDocuments`
+  filter, already live) by `billableToClient` today would silently hide every
+  existing org's services from every quote, since no org has ever been able to set
+  the field `true`. Shipping the gate without the UI control would recreate exactly
+  the "feature nobody can reach" anti-pattern this redesign removed. Needs a
+  `billableToClient` toggle added to the project-services edit UI first — tracked
+  as a follow-up, not silently dropped.
+- **General tidiness pass per DESIGN.md**: DESIGN.md §6 explicitly defers PDF
+  branding/visual changes ("Do not apply RVLT design system colors or fonts to PDF
+  templates in this redesign") — so no visual re-skin was done here. The block
+  ordering (header → details → table → totals → notes → T&Cs → validity) matches
+  the pre-redesign section defaults.
 
 ## Child Rendering (Kits, Prep-Kits, Accessories)
 All document templates use a unified line item hierarchy with up to 3 levels:

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -9,8 +9,8 @@
 import { describe, it, expect } from "vitest";
 import { composeDocument, type ComposeResult } from "./document-composer";
 import { DOCUMENT_LAYOUTS, type ProjectDocumentType } from "./document-layouts";
-import { makeLineItem } from "./plugins/test-utils";
-import type { DocumentData, DocumentLineItem } from "./types";
+import { makeLineItem, runTablePlugin } from "./plugins/test-utils";
+import type { DocumentData, DocumentLineItem, TablePluginConfig } from "./types";
 
 function makeData(overrides: Partial<DocumentData> = {}): DocumentData {
   return {
@@ -313,5 +313,68 @@ describe("composeDocument — org document settings (footer, T&Cs, quote validit
     const result = composeDocument("quote", soloData({ quote_valid_until: "2026-09-15" }), "#0d4f4f");
     const validitySchema = result.template.schemas[0].find((s) => String(s.name).startsWith("quoteValidityNote"))!;
     expect(result.inputs[0][validitySchema.name as string]).toBe("This quote is valid until 2026-09-15.");
+  });
+});
+
+describe("composeDocument — quote content audit (#790 Phase 4)", () => {
+  function tableItemsAndConfig(result: ComposeResult): { items: DocumentLineItem[]; config: TablePluginConfig } {
+    const tableSchema = result.template.schemas[0].find((s) => s.type === "gearflowTable")!;
+    return JSON.parse(result.inputs[0][tableSchema.name as string]) as { items: DocumentLineItem[]; config: TablePluginConfig };
+  }
+
+  function totalsConfig(result: ComposeResult): { discountAmount: number; discountPercent: number } {
+    const totalsSchema = result.template.schemas[0].find((s) => s.type === "gearflowFinancialSummary")!;
+    return JSON.parse(result.inputs[0][totalsSchema.name as string]);
+  }
+
+  it("quote table hides the '/day' (or other period) price suffix; other doc types are unaffected", () => {
+    const { config: quoteConfig } = tableItemsAndConfig(composeDocument("quote", makeData({ line_items: [] }), "#0d4f4f"));
+    expect(quoteConfig.hidePricingPeriodSuffix).toBe(true);
+
+    const { config: invoiceConfig } = tableItemsAndConfig(composeDocument("invoice", makeData({ line_items: [] }), "#0d4f4f"));
+    expect(invoiceConfig.hidePricingPeriodSuffix).toBe(false);
+  });
+
+  it("the price suffix is actually suppressed at render time on the quote", async () => {
+    const item = makeLineItem({ id: "priced", status: "CONFIRMED", unitPrice: 100, pricingType: "PER_DAY", model: { name: "Priced Item" } });
+    const { items, config } = tableItemsAndConfig(composeDocument("quote", makeData({ line_items: [item] }), "#0d4f4f"));
+    const calls = await runTablePlugin(items, config);
+    const text = calls.drawText.map((c) => c.text).join("\n");
+    expect(text).not.toContain("/day");
+  });
+
+  it("discount renders on the quote totals block when set", () => {
+    const config = totalsConfig(composeDocument("quote", makeData({ discount_percent: 10, discount_amount: 50 }), "#0d4f4f"));
+    expect(config.discountAmount).toBe(50);
+    expect(config.discountPercent).toBe(10);
+  });
+
+  it("discount is zero (not rendered) when the project has none", () => {
+    const config = totalsConfig(composeDocument("quote", makeData({ discount_percent: 0, discount_amount: 0 }), "#0d4f4f"));
+    expect(config.discountAmount).toBe(0);
+  });
+
+  it("item notes reach the rendered quote table", async () => {
+    const item = makeLineItem({ id: "noted-item", status: "CONFIRMED", notes: "Fragile — handle with care", model: { name: "Glass Case" } });
+    const { items, config } = tableItemsAndConfig(composeDocument("quote", makeData({ line_items: [item] }), "#0d4f4f"));
+    const calls = await runTablePlugin(items, config);
+    const text = calls.drawText.map((c) => c.text).join("\n");
+    expect(text).toContain("Fragile");
+  });
+
+  it("Project Group descriptions (carried as .notes) reach the rendered quote table", async () => {
+    const group = makeLineItem({
+      id: "group-1",
+      isGroupRow: true,
+      groupName: "Lighting Package",
+      notes: "Includes rigging and truss",
+      model: { name: "Lighting Package" },
+      quantity: 1,
+      status: "CONFIRMED",
+    });
+    const { items, config } = tableItemsAndConfig(composeDocument("quote", makeData({ line_items: [group] }), "#0d4f4f"));
+    const calls = await runTablePlugin(items, config);
+    const text = calls.drawText.map((c) => c.text).join("\n");
+    expect(text).toContain("Includes rigging and truss");
   });
 });

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -712,6 +712,7 @@ function buildEntryFields(
           showRowNumbers: block.config.showRowNumbers,
           filterOptional: false,
           filterByStatus,
+          hidePricingPeriodSuffix: block.config.hidePricingPeriodSuffix ?? false,
         },
       };
       if (entry.tableStartIndex) tableValue.startIndex = entry.tableStartIndex;

--- a/src/lib/pdfme/document-layouts.ts
+++ b/src/lib/pdfme/document-layouts.ts
@@ -128,7 +128,7 @@ export const DOCUMENT_LAYOUTS: Record<ProjectDocumentType, DocumentLayout> = {
     blocks: [
       { kind: "header", title: "QUOTE" },
       { kind: "detailsRow", client: defaultClientDetails, project: defaultProjectDetails },
-      { kind: "table", config: defaultTable },
+      { kind: "table", config: { ...defaultTable, hidePricingPeriodSuffix: true } },
       { kind: "totals", config: defaultTotals },
       { kind: "clientNotes" },
       { kind: "termsAndConditions" },

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -508,7 +508,7 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
             if (!config.showPricing) break;
             const priceStr = isItemized ? "-"
               : item.unitPrice != null
-                ? `${formatCurrency(item.unitPrice)}${PRICING_LABELS[item.pricingType] || ""}`
+                ? `${formatCurrency(item.unitPrice)}${config.hidePricingPeriodSuffix ? "" : PRICING_LABELS[item.pricingType] || ""}`
                 : "-";
             const priceWidth = fonts.regular.widthOfTextAtSize(priceStr, fontSize);
             page.drawText(priceStr, {

--- a/src/lib/pdfme/plugins/test-utils.ts
+++ b/src/lib/pdfme/plugins/test-utils.ts
@@ -60,6 +60,7 @@ const DEFAULT_CONFIG: TablePluginConfig = {
   showRowNumbers: false,
   filterOptional: false,
   filterByStatus: null,
+  hidePricingPeriodSuffix: false,
 };
 
 /**

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -249,6 +249,8 @@ export interface TablePluginConfig {
   showRowNumbers: boolean;
   filterOptional: boolean;
   filterByStatus: string[] | null;
+  /** Suppress the "/day" (or other period) price suffix — quote layout only (#790 Phase 4). */
+  hidePricingPeriodSuffix: boolean;
 }
 
 /** Config for financial summary plugin */


### PR DESCRIPTION
## Summary

Phase 4 of #790 (the issue's original quote-cleanup scope), stacked on #939 (Phase 3) and #938 (Phase 0-2). **Do not merge before #939/#938** — this branches from #939 and will show only its own diff once the stack lands and this retargets to `main`.

- **No "/day" (or other rental-period) price suffix on the quote.** New `TablePluginConfig.hidePricingPeriodSuffix`; only the quote's `document-layouts.ts` entry sets it `true` — other doc types unaffected.
- **Audited discount, item notes, and group notes/descriptions end-to-end** and confirmed they already flow correctly through the new pipeline — no code change was needed for these, `document-composer.test.ts` now proves it instead of leaving it as an assumption.
- Terms & conditions block and real computed quote-expiry date were already landed in #939 (Phase 3), since that's where the underlying settings live.

**Deliberately deferred, not silently dropped**: the billable-to-client crewing/services section. `billableToClient` exists on the Convex `projectServices` schema but has no UI to set it anywhere in the app — gating the existing services-on-quote injection by it today would silently hide every org's services from every quote, since no org has ever been able to set the field `true`. This needs a `billableToClient` toggle added to the project-services edit UI first, which is bigger than a PDF-pipeline change. Documented in FEATUREDOCS/13 as a tracked follow-up.

**On DESIGN.md tidiness**: DESIGN.md §6 explicitly defers PDF branding/visual changes for this redesign round ("Do not apply RVLT design system colors or fonts to PDF templates"), so no visual re-skin was done — block ordering already matches the pre-redesign section defaults.

## Testing

- `pnpm test` — 3905/3905 passing, incl. new tests: price-suffix suppression (config value + actual rendered text), discount presence/absence on totals, item notes reaching the rendered table, and Project Group descriptions reaching the rendered table.
- `pnpm lint` — 0 errors.
- `npx tsc --noEmit` — clean.

## Checklist

- [x] No new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_014R1LcPyFnLd3BjRDFPb1X9)_