### PR TITLE
fix(projects): surface manager-picker load errors instead of swallowing them (#727)

### DIFF
--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -84,6 +84,15 @@ retired). Routes:
   fields are preserved for `createProject()`.
 
 ## Project Managers
+- **Manager picker permissions (#727).** The wizard's "Project manager(s)" field
+  (basics step) loads options via `getOrgMembers()`, which requires
+  `orgMembers:read` — the `member` role was granted this (`fix(rbac): grant
+  member role read-only access to orgMembers`) so it no longer 403s for
+  `member`-role users creating projects. `useServerQuery`'s `error` is destructured
+  and surfaced through `Field`'s `error` prop (not just `data`), so any future
+  permission regression (or a real network failure) renders a visible "Couldn't
+  load org members" message instead of silently resolving to an empty picker
+  indistinguishable from "this org has no other members".
 - Multi-PM support via `ProjectManager` join table (replaces old single `projectManagerId`)
 - Managed on the project detail page sidebar via `ProjectManagersPanel`
 - Add/remove PMs via browser-direct mutations `addNative` / `removeNative` in

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -158,7 +158,7 @@ export function ProjectWizard({
   const locNameById = new Map(rawLocations.map((l) => [l.id, l.name]));
   const locationOptions = rawLocations.map((l) => ({ value: l.id, label: l.parentId ? `${locNameById.get(l.parentId) ?? ""} → ${l.name}` : l.name, description: l.address || undefined }));
   const orgTags = useOrgTags(orgId);
-  const { data: membersData } = useServerQuery({ queryKey: ["org-members", orgId], queryFn: () => getOrgMembers({ pageSize: 200 }) });
+  const { data: membersData, error: membersError } = useServerQuery({ queryKey: ["org-members", orgId], queryFn: () => getOrgMembers({ pageSize: 200 }) });
   const memberOptions = (membersData?.members || []).map((m) => ({ value: m.user.id, label: m.user.name || m.user.email, description: m.user.name ? m.user.email : undefined }));
 
   const form = useForm<ProjectFormValues>({
@@ -354,7 +354,7 @@ export function ProjectWizard({
                     onCreateNew={() => setQuickClient(true)} createNewLabel="New client" emptyMessage="No clients found." />
                 )} />
               </Field>
-              <Field label="Project manager(s)">
+              <Field label="Project manager(s)" error={membersError ? "Couldn't load org members — you may not have permission to view them." : undefined}>
                 <ComboboxPicker value="" onChange={(id) => { if (id && !managerIds.includes(id)) setManagerIds((p) => [...p, id]); }}
                   options={memberOptions.filter((m) => !managerIds.includes(m.value))} placeholder="Add manager…" searchPlaceholder="Search members…" emptyMessage="No members found." />
                 {managerIds.length > 0 && (


### PR DESCRIPTION
## Summary

- Closes #727 (the remaining part of it — see below).
- `ProjectWizard`'s "Project manager(s)" picker (`src/components/projects/project-wizard.tsx`) called `useServerQuery` but only destructured `data`, so any `getOrgMembers` failure — a permission denial or otherwise — silently resolved `memberOptions` to `[]`. The empty picker was indistinguishable from "this org has no other members."
- Now destructures `error` from `useServerQuery` and surfaces it through the existing `Field` component's `error` prop, so a real failure renders a visible "Couldn't load org members — you may not have permission to view them." message instead of failing silently.
- Updated `FEATUREDOCS/10-projects.md` (Project Managers section) to document this behavior per project convention.

**Note on scope:** the underlying RBAC gap the issue diagnosed (`member` role lacking `orgMembers:read`, causing this to actually 403 for `member`-role users) was already fixed on `main` in `a9d21cb` (`fix(rbac): grant member role read-only access to orgMembers`, 2026-07-25) — prior to this branch being created. This PR addresses the remaining defensive-UX gap the issue also called out: the wizard shouldn't swallow query errors regardless of their cause, so a future permission regression (or a transient network failure) doesn't masquerade as "no data."

## Testing

- `pnpm exec vitest run src/components/projects/__tests__/project-wizard-focus.smoke.test.tsx` — 2 passed
- `pnpm exec tsc --noEmit` — no new errors introduced (3 pre-existing implicit-`any` warnings on unrelated lines in this file, confirmed present before this change via `git stash`)
- `pnpm exec eslint src/components/projects/project-wizard.tsx` — 0 errors, only pre-existing warnings (complexity/line-count on the wizard function)

## Checklist

- [x] No new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4C9CrhHf932oWpjQRRboB)_