### PR TITLE
Remove DateRangeBar mini timeline bars app-wide

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -312,7 +312,6 @@ All detail pages (project, asset, model, kit, client, crew, supplier, maintenanc
 - Dynamic greeting (Good morning/afternoon/evening) + date
 - Alert badges (red/amber) only when problems exist
 - Inline metrics strip (single surface, vertical dividers) instead of stat card grid
-- Projects with `DateRangeBar` for visual rental period
 - Activity feed with staggered entrance
 
 ### Breadcrumb Navigation
@@ -370,7 +369,9 @@ All status → color intent mappings live in `src/lib/status-colors.ts`. **Never
 Inline charts from `@/components/ui/sparkline`:
 - **`Sparkline`** — tiny line chart, red stroke on espresso
 - **`UtilizationBar`** — thin progress bar (red for active, amber for at-risk, green for available)
-- **`DateRangeBar`** — rental period visualization
+
+(`DateRangeBar` — the unlabeled mini timeline bar under rental dates — was removed
+app-wide in 2026-07: with no legend or axis it read as decoration, not data.)
 
 ## §6 PDF Pipeline (separate from app UI)
 PDF generation (`src/lib/pdfme/`) uses Helvetica (pdfme constraint — no Unicode, no web fonts). PDF branding updates are **deferred** to a follow-up PR. Do not apply RVLT design system colors or fonts to PDF templates in this redesign. See `docs/designs/ux-ui-redesign.md` T3 decision.

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -267,7 +267,7 @@ HERO CARD (rounded-[--r-lg] border-2 bg-card, full width):
 
 ┌─── LEFT (~63%) ──────────────────────┐ ┌─── RIGHT (~37%, 340px sticky) ───┐
 │  TABS: [Equipment] [Labour &          │ │  ── Schedule ──                   │
-│   logistics] [Financials] [Tasks]     │ │  DateRangeBar + date rows         │
+│   logistics] [Financials] [Tasks]     │ │  date rows                        │
 │   [Notes] [Files]                     │ │  ── Location ──                   │
 │                                       │ │  venue + site contact             │
 │  Financials tab = FinancialSummary    │ │  ── Team ──                       │

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -68,7 +68,6 @@ import { useOptimisticProjectNotes, useNativeProjectStatus, useProjectWrites } f
 import { CanDo } from "@/components/auth/permission-gate";
 import { RequirePermission } from "@/components/auth/require-permission";
 import { FadeIn } from "@/components/ui/motion";
-import { DateRangeBar } from "@/components/ui/sparkline";
 import { DetailLayout, DetailMain, DetailSidebar, SidebarSection } from "@/components/layout/page-layouts";
 import { ProjectLifecycle } from "@/components/projects/project-lifecycle";
 import { useCanDo } from "@/lib/use-permissions";
@@ -218,18 +217,11 @@ export default function ProjectDetailPage({
     );
   }
 
-  // Compute date range bar reference window (1 week before start to 1 week after end)
   const rentalStart = project.rentalStartDate
     ? new Date(project.rentalStartDate as unknown as string)
     : null;
   const rentalEnd = project.rentalEndDate
     ? new Date(project.rentalEndDate as unknown as string)
-    : null;
-  const rangeStart = rentalStart
-    ? new Date(rentalStart.getTime() - 7 * 24 * 60 * 60 * 1000)
-    : null;
-  const rangeEnd = rentalEnd
-    ? new Date(rentalEnd.getTime() + 7 * 24 * 60 * 60 * 1000)
     : null;
 
   return (
@@ -619,15 +611,6 @@ export default function ProjectDetailPage({
                 {/* Schedule */}
                 {!project.isTemplate && (
                   <SidebarSection title="Schedule">
-                    {rentalStart && rentalEnd && rangeStart && rangeEnd && (
-                      <DateRangeBar
-                        start={rentalStart}
-                        end={rentalEnd}
-                        rangeStart={rangeStart}
-                        rangeEnd={rangeEnd}
-                        className="mb-2"
-                      />
-                    )}
                     <div className="space-y-1 text-ui-text">
                       <div className="flex justify-between gap-2">
                         <span className="text-muted flex items-center gap-1">

--- a/src/components/dashboard/my-work-section.tsx
+++ b/src/components/dashboard/my-work-section.tsx
@@ -6,7 +6,6 @@ import { ArrowRight, Boxes, CalendarClock, ShieldAlert, AtSign, CheckCircle2, Fo
 import { cn, focusRing } from "@/lib/utils";
 import { StaggerList, StaggerItem } from "@/components/ui/motion";
 import { SectionHeader } from "@/components/layout/page-layouts";
-import { DateRangeBar } from "@/components/ui/sparkline";
 import { getStatusColor } from "@/lib/status-colors";
 
 const projectStatusLabels: Record<string, string> = {
@@ -49,10 +48,6 @@ function projectDateLine(p: Project): { text: string; tone: "error" | "warning" 
 const toneText = { error: "text-t-out", warning: "text-warn", muted: "text-muted" } as const;
 
 export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]; blockers?: Blocker[] }) {
-  const now = new Date();
-  const rangeStart = new Date(now); rangeStart.setDate(rangeStart.getDate() - 7);
-  const rangeEnd = new Date(now); rangeEnd.setDate(rangeEnd.getDate() + 53);
-
   // Group blockers by project so each card can flag its own issues.
   const blockersByProject = new Map<string, Blocker[]>();
   for (const b of blockers) {
@@ -93,8 +88,6 @@ export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]
             const client = p.client as { name?: string } | null;
             const equip = (p._count as { lineItems?: number } | undefined)?.lineItems ?? 0;
             const dateLine = projectDateLine(p);
-            const start = p.rentalStartDate ? new Date(p.rentalStartDate as string) : null;
-            const end = p.rentalEndDate ? new Date(p.rentalEndDate as string) : null;
             const pBlockers = blockersByProject.get(p.id as string) ?? [];
             const latest = pBlockers[0];
             return (
@@ -126,10 +119,6 @@ export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]
                     {client?.name ? <> · {client.name}</> : null}
                   </p>
 
-                  {/* date range */}
-                  {start && end && (
-                    <div className="mt-2.5"><DateRangeBar start={start} end={end} rangeStart={rangeStart} rangeEnd={rangeEnd} /></div>
-                  )}
 
                   {/* footer: gear + blockers */}
                   <div className="mt-auto flex items-center justify-between gap-2 pt-3">

--- a/src/components/projects/project-table.tsx
+++ b/src/components/projects/project-table.tsx
@@ -21,20 +21,9 @@ import { useTablePreferences } from "@/lib/use-table-preferences";
 import { Button } from "@/components/ui/button";
 import { CanDo } from "@/components/auth/permission-gate";
 import { StatusIndicator } from "@/components/ui/status-indicator";
-import { DateRangeBar } from "@/components/ui/sparkline";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { projectStatusLabels } from "@/lib/status-labels";
 import { getStatusColor } from "@/lib/status-colors";
-
-/** 60-day window for the date range bar: today -7d to today +53d */
-function getDateRangeWindow() {
-  const now = new Date();
-  const rangeStart = new Date(now);
-  rangeStart.setDate(rangeStart.getDate() - 7);
-  const rangeEnd = new Date(now);
-  rangeEnd.setDate(rangeEnd.getDate() + 53);
-  return { rangeStart, rangeEnd };
-}
 
 const typeLabels: Record<string, string> = {
   DRY_HIRE: "Dry hire",
@@ -198,26 +187,11 @@ const projectColumns: ColumnDef<AnyProject>[] = [
     header: "Dates",
     sortKey: "rentalStartDate",
     mobile: "meta",
-    cell: (row) => {
-      const start = row.rentalStartDate as number | null;
-      const end = row.rentalEndDate as number | null;
-      const { rangeStart, rangeEnd } = getDateRangeWindow();
-      return (
-        <div className="flex flex-col gap-1 min-w-[120px]">
-          <span className="text-muted text-sm">
-            {formatDateRange(start, end)}
-          </span>
-          {start && end && (
-            <DateRangeBar
-              start={new Date(start)}
-              end={new Date(end)}
-              rangeStart={rangeStart}
-              rangeEnd={rangeEnd}
-            />
-          )}
-        </div>
-      );
-    },
+    cell: (row) => (
+      <span className="text-muted text-sm min-w-[120px]">
+        {formatDateRange(row.rentalStartDate as number | null, row.rentalEndDate as number | null)}
+      </span>
+    ),
   },
   {
     id: "total",

--- a/src/components/ui/sparkline.test.ts
+++ b/src/components/ui/sparkline.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Sparkline, UtilizationBar, and DateRangeBar pure logic.
+ * Tests for Sparkline and UtilizationBar pure logic.
  *
  * These components render SVG — we test the math and edge cases
  * by extracting the logic or calling the components and checking
@@ -123,84 +123,5 @@ describe("UtilizationBar math", () => {
     expect(computeBarProps(80).barColor).toBe("var(--warning)");
     expect(computeBarProps(51).barColor).toBe("var(--warning)");
     expect(computeBarProps(50).barColor).toBe("var(--primary)");
-  });
-});
-
-// ─── DateRangeBar math ───────────────────────────────────────────────
-
-function computeDateBarProps(
-  start: Date,
-  end: Date,
-  rangeStart: Date,
-  rangeEnd: Date,
-) {
-  const totalMs = rangeEnd.getTime() - rangeStart.getTime();
-  if (totalMs <= 0) return null;
-
-  const leftPct = Math.max(
-    0,
-    ((start.getTime() - rangeStart.getTime()) / totalMs) * 100,
-  );
-  const widthPct = Math.min(
-    100 - leftPct,
-    ((end.getTime() - start.getTime()) / totalMs) * 100,
-  );
-  return { leftPct, widthPct: Math.max(widthPct, 2) };
-}
-
-describe("DateRangeBar math", () => {
-  const jan1 = new Date("2026-01-01");
-  const jan15 = new Date("2026-01-15");
-  const jan31 = new Date("2026-01-31");
-  const feb1 = new Date("2026-02-01");
-
-  it("returns null when range end <= range start", () => {
-    expect(computeDateBarProps(jan1, jan15, jan31, jan1)).toBeNull();
-  });
-
-  it("returns null when range is zero (same start and end)", () => {
-    expect(computeDateBarProps(jan1, jan15, jan1, jan1)).toBeNull();
-  });
-
-  it("computes correct position for rental in middle of range", () => {
-    const result = computeDateBarProps(jan15, jan31, jan1, feb1);
-    expect(result).not.toBeNull();
-    // Jan 15 is about 45% through January
-    expect(result!.leftPct).toBeGreaterThan(40);
-    expect(result!.leftPct).toBeLessThan(50);
-    // 16 days out of 31 is about 52%
-    expect(result!.widthPct).toBeGreaterThan(45);
-    expect(result!.widthPct).toBeLessThan(55);
-  });
-
-  it("clamps left to 0 when rental starts before range", () => {
-    const beforeRange = new Date("2025-12-15");
-    const result = computeDateBarProps(beforeRange, jan15, jan1, jan31);
-    expect(result).not.toBeNull();
-    expect(result!.leftPct).toBe(0);
-  });
-
-  it("enforces minimum 2% width for very short rentals", () => {
-    // 1 hour rental in a 31-day range
-    const start = new Date("2026-01-15T10:00:00");
-    const end = new Date("2026-01-15T11:00:00");
-    const result = computeDateBarProps(start, end, jan1, jan31);
-    expect(result).not.toBeNull();
-    expect(result!.widthPct).toBe(2);
-  });
-
-  it("clamps width when rental extends beyond range", () => {
-    const farEnd = new Date("2026-06-01");
-    const result = computeDateBarProps(jan15, farEnd, jan1, jan31);
-    expect(result).not.toBeNull();
-    // Width should be clamped to 100 - leftPct
-    expect(result!.leftPct + result!.widthPct).toBeLessThanOrEqual(100);
-  });
-
-  it("full range rental spans 100%", () => {
-    const result = computeDateBarProps(jan1, jan31, jan1, jan31);
-    expect(result).not.toBeNull();
-    expect(result!.leftPct).toBe(0);
-    expect(result!.widthPct).toBe(100);
   });
 });

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -88,39 +88,3 @@ export function UtilizationBar({ value, color, className }: UtilizationBarProps)
     </div>
   );
 }
-
-/** Mini date range bar for showing rental periods inline */
-interface DateRangeBarProps {
-  /** Start date */
-  start: Date;
-  /** End date */
-  end: Date;
-  /** Reference range start (e.g., start of month) */
-  rangeStart: Date;
-  /** Reference range end (e.g., end of month) */
-  rangeEnd: Date;
-  color?: string;
-  className?: string;
-}
-
-export function DateRangeBar({ start, end, rangeStart, rangeEnd, color = "var(--primary)", className }: DateRangeBarProps) {
-  const totalMs = rangeEnd.getTime() - rangeStart.getTime();
-  if (totalMs <= 0) return null;
-
-  const leftPct = Math.max(0, ((start.getTime() - rangeStart.getTime()) / totalMs) * 100);
-  const widthPct = Math.min(100 - leftPct, ((end.getTime() - start.getTime()) / totalMs) * 100);
-
-  return (
-    <div className={cn("relative h-1.5 w-full rounded-full bg-bg-inset", className)}>
-      <div
-        className="absolute h-full rounded-full"
-        style={{
-          left: `${leftPct}%`,
-          width: `${Math.max(widthPct, 2)}%`,
-          backgroundColor: color,
-          opacity: 0.7,
-        }}
-      />
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary

Removes the `DateRangeBar` component — the unlabeled 1.5px mini timeline bar rendered under rental dates — from the whole app. With no legend, axis, or tooltip it read as unexplained decoration rather than data (see #958).

- Removed all three render sites: projects table "Dates" column (`project-table.tsx`), project detail "Schedule" sidebar (`projects/[id]/page.tsx`), and dashboard "My Work" cards (`my-work-section.tsx`), along with their now-dead reference-window derivations (`getDateRangeWindow()`, `rangeStart`/`rangeEnd`).
- Deleted the `DateRangeBar` component from `src/components/ui/sparkline.tsx` and its "DateRangeBar math" test block; `Sparkline` and `UtilizationBar` are untouched.
- Updated `DESIGN.md` (§5 Data Visualization, Dashboard Layout) and `FEATUREDOCS/10-projects.md` to match.

The formatted date text itself is unchanged — only the bars are gone.

Closes #958

## Testing

- `pnpm test src/components/ui/sparkline.test.ts src/components/projects/__tests__/project-table.smoke.test.tsx` — 16 tests passed.
- `pnpm exec tsc --noEmit` — identical error count (97, all pre-existing local-env Prisma-type noise) before and after the change; no new errors.
- `pnpm exec eslint` on the five touched files — 0 errors (only pre-existing max-lines/complexity warnings).
- Repo-wide grep confirms no remaining `DateRangeBar` references outside historical CHANGELOG entries.

## Checklist

- [x] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3) — no new dependencies (removal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162pc6RfvBiLMjHFKp5TnKf

---
_Generated by [Claude Code](https://claude.ai/code/session_0162pc6RfvBiLMjHFKp5TnKf)_