### PR TITLE
perf: cache JWKS responses + public login-page org/SSO lookup (#802 #803 #804)

### DIFF
--- a/FEATUREDOCS/33-enterprise-sso.md
+++ b/FEATUREDOCS/33-enterprise-sso.md
@@ -113,6 +113,16 @@ Six card sections:
 | `patchProviderOidcConfig(id, patch)` | `requirePermission("orgSettings", "update")` | Direct DB patch for ID token mode |
 | `getOrgLoginInfo(orgSlug)` | None (public) | Org info for login page |
 
+**`getOrgLoginInfo` is cached (#804):** it is a public, pre-auth action hit on every
+login-page visit (human or bot), and its `SsoProvider.findMany` + Convex org-settings
+read was the T-9 `slow_query` p95 incident driver. It now serves through a 60s
+in-process TTL cache (`src/lib/org-login-info-cache.ts` — bounded map, null results
+cached, stale-on-error). `updateSSOSettings` / `deleteSSOProvider` /
+`updateSSOProviderMeta` / `patchProviderOidcConfig` invalidate it explicitly so admin
+edits show immediately; provider CRUD through Better Auth's own API (e.g.
+`authClient.sso.register()`) is covered by the TTL alone — a just-registered provider
+can take up to 60s to appear on the login page.
+
 ## Provider Registration
 SSO provider CRUD uses Better Auth's built-in API endpoints from the client (`authClient.sso.register()`), not server actions. SP Metadata (ACS URL, Metadata URL, OIDC Redirect) is displayed in the provider form for IdP configuration.
 

--- a/FEATUREDOCS/54-convex-data-layer.md
+++ b/FEATUREDOCS/54-convex-data-layer.md
@@ -44,6 +44,18 @@ domain entity means adding a Convex table + `*Writes.ts` mutations, not a Prisma
   exists because `auth.ts`'s hooks mirror data into Convex (which needs the service
   token, which would need `auth.ts`) — importing the full instance from the signer
   would be circular (POLICY.md R-3.5).
+- **The JWKS endpoint Convex verifies those tokens against is cached (#803).**
+  Convex's customJwt provider fetches `CONVEX_AUTH_JWKS_URL`
+  (`/api/auth/jwks`, served by Better Auth) to verify the ES256 token attached
+  to every function call. Better Auth's own handler reads the `jwks` table on
+  every request and sets no cache headers, so each fetch was a full dynamic
+  origin round trip (measured 0.9–5.6s TTFB from us-east, where Convex Cloud
+  runs) — a fixed per-call overhead shared by every Convex op, the uniform-slowdown
+  signature behind the T-P6 `convex_op_latency` incident. `src/lib/jwks-route-cache.ts`
+  now memoizes the JWKS response in-process (5 min TTL, stale-on-error — the key
+  set only ever changes at bootstrap; no rotation is configured) and serves it
+  with `Cache-Control: public, max-age=300, s-maxage=300, stale-while-revalidate=86400`
+  from the `[...all]` auth route. All other auth routes pass through untouched.
 - **Cross-domain joins that need two `*-read.ts` modules both ways** (e.g. a model
   needs its category, AND a category's counts need the org's models) live in a
   dedicated `*-join.ts` module (`model-category-join.ts`), not in either domain's

--- a/FEATUREDOCS/61-observability.md
+++ b/FEATUREDOCS/61-observability.md
@@ -130,6 +130,16 @@ to the originating Next.js request (POLICY.md R-8.9.6). A true W3C `traceparent`
 the Convex function body itself would need threading a trace id through every query/mutation's
 args across all ~43 `*Writes.ts` domain modules — out of scope here.
 
+**2026-07-26 follow-up (#802/#803/#804):** all three latency alerts were still breaching after
+the round-3 fixes. Two shared-root-cause remediations landed: (1) the JWKS endpoint Convex
+verifies every function-call token against (`/api/auth/jwks`) was an uncached per-request DB
+read measuring 0.9–5.6s TTFB from us-east — now memoized in-process + served with
+`Cache-Control` (`src/lib/jwks-route-cache.ts`, see FEATUREDOCS/54); (2) the public login
+page's `getOrgLoginInfo` — whose `SsoProvider.findMany` was the sole T-9 `slow_query` p95
+incident driver — is now behind a 60s in-process cache (`src/lib/org-login-info-cache.ts`,
+see FEATUREDOCS/33). LCP (T-7, #802) is expected to recover downstream of the Convex-leg
+fix per #802's own triage; re-check all three alerts after a few days of traffic.
+
 ## Vendor cost budget tracking (T-P4, R-9.12/#764, #831)
 
 The README.md R-0.4 budget registry registers a $15/mo ceiling each for Resend and Google

--- a/docs/convex-observability-runbook.md
+++ b/docs/convex-observability-runbook.md
@@ -115,6 +115,22 @@ another slot or upgrading the plan.
 See `docs/exceptions.md` (R-8.9.3 row) for the dated exception covering the residual baseline
 latency / SSR-streaming follow-up that didn't fit this cycle.
 
+**2026-07-26 update (#802/#803/#804):** the round-3 "residual ~500ms infra baseline" has a
+now-tested candidate root cause: `GET /api/auth/jwks` — which Convex's customJwt provider
+fetches to verify the token on every function call — was an uncached, per-request DB read
+measuring 0.9–5.6s TTFB from us-east (probed 2026-07-26; a bare `/` redirect on the same
+origin is ~0.7s, so the endpoint adds work on top of an already-long origin RTT). Two fixes
+landed: the JWKS response is memoized in-process + served with `Cache-Control`
+(`src/lib/jwks-route-cache.ts`), and the public login page's `getOrgLoginInfo` (whose
+`SsoProvider.findMany` was the only query over the T-9 incident line) is behind a 60s
+in-process cache (`src/lib/org-login-info-cache.ts`). Re-check all three alerts (LCP p75,
+`convex_op_latency` p95, `slow_query` p95) after a few days of traffic; if `convex_op_latency`
+p95 is still >1s, the residual is genuine app↔Convex network distance and belongs to the
+R-8.9.3 exception's SSR/streaming follow-up, plus an ops-side option: add a CDN cache rule
+for `/api/auth/jwks` (Cloudflare does not edge-cache extensionless JSON by default even with
+`Cache-Control`; a Cache Rule honoring the served `s-maxage=300` would let Convex's fetches
+hit the us-east edge instead of the origin).
+
 ## Remaining ops steps (not code)
 
 Optionally wire the Convex dashboard **log stream → PostHog/Slack** for full

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,12 @@
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
+import { withJwksResponseCache } from "@/lib/jwks-route-cache";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const handlers = toNextJsHandler(auth);
+
+// GET /api/auth/jwks is memoized in-process + served with Cache-Control (#803):
+// Convex fetches it to verify the token on every function call, and Better
+// Auth's own handler is an uncached DB read per request. All other auth routes
+// pass through untouched. See src/lib/jwks-route-cache.ts for the full policy.
+export const GET = withJwksResponseCache(handlers.GET);
+export const POST = handlers.POST;

--- a/src/lib/jwks-route-cache.test.ts
+++ b/src/lib/jwks-route-cache.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  withJwksResponseCache,
+  resetJwksResponseCache,
+  JWKS_ROUTE_PATH,
+  JWKS_TTL_MS,
+  JWKS_CACHE_CONTROL,
+} from "./jwks-route-cache";
+
+const JWKS_URL = `https://flow.example.com${JWKS_ROUTE_PATH}`;
+const KEYS_BODY = JSON.stringify({ keys: [{ kid: "k1", kty: "EC", alg: "ES256" }] });
+
+function jwksRequest(url = JWKS_URL): Request {
+  return new Request(url, { method: "GET" });
+}
+
+describe("withJwksResponseCache", () => {
+  beforeEach(() => {
+    resetJwksResponseCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("serves the JWKS from the wrapped handler with cache headers on first fetch", async () => {
+    const handler = vi.fn(async () => new Response(KEYS_BODY, { status: 200 }));
+    const wrapped = withJwksResponseCache(handler);
+
+    const res = await wrapped(jwksRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(KEYS_BODY);
+    expect(res.headers.get("Cache-Control")).toBe(JWKS_CACHE_CONTROL);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves repeat requests from the memo without re-invoking the handler", async () => {
+    const handler = vi.fn(async () => new Response(KEYS_BODY, { status: 200 }));
+    const wrapped = withJwksResponseCache(handler);
+
+    await wrapped(jwksRequest());
+    const res2 = await wrapped(jwksRequest());
+    const res3 = await wrapped(jwksRequest());
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(await res2.text()).toBe(KEYS_BODY);
+    expect(await res3.text()).toBe(KEYS_BODY);
+    expect(res2.headers.get("Cache-Control")).toBe(JWKS_CACHE_CONTROL);
+  });
+
+  it("re-fetches after the TTL expires", async () => {
+    const handler = vi.fn(async () => new Response(KEYS_BODY, { status: 200 }));
+    const wrapped = withJwksResponseCache(handler);
+
+    await wrapped(jwksRequest());
+    vi.advanceTimersByTime(JWKS_TTL_MS + 1);
+    await wrapped(jwksRequest());
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes non-jwks auth routes through untouched", async () => {
+    const passthrough = new Response("session", { status: 200 });
+    const handler = vi.fn(async () => passthrough);
+    const wrapped = withJwksResponseCache(handler);
+
+    const res = await wrapped(jwksRequest("https://flow.example.com/api/auth/get-session"));
+
+    expect(res).toBe(passthrough);
+    expect(res.headers.get("Cache-Control")).toBeNull();
+    // Passthrough must never be memoized: a second jwks request still hits the handler.
+    await wrapped(jwksRequest());
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves the last-known-good key set when the handler starts failing", async () => {
+    let fail = false;
+    const handler = vi.fn(async () => {
+      if (fail) throw new Error("db down");
+      return new Response(KEYS_BODY, { status: 200 });
+    });
+    const wrapped = withJwksResponseCache(handler);
+
+    await wrapped(jwksRequest());
+    fail = true;
+    vi.advanceTimersByTime(JWKS_TTL_MS + 1);
+
+    const res = await wrapped(jwksRequest());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(KEYS_BODY);
+  });
+
+  it("serves stale on a non-ok downstream response", async () => {
+    let status = 200;
+    const handler = vi.fn(async () =>
+      status === 200
+        ? new Response(KEYS_BODY, { status: 200 })
+        : new Response("boom", { status: 500 }),
+    );
+    const wrapped = withJwksResponseCache(handler);
+
+    await wrapped(jwksRequest());
+    status = 500;
+    vi.advanceTimersByTime(JWKS_TTL_MS + 1);
+
+    const res = await wrapped(jwksRequest());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(KEYS_BODY);
+  });
+
+  it("propagates the failure when there is no cached key set yet", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("db down");
+    });
+    const wrapped = withJwksResponseCache(handler);
+
+    await expect(wrapped(jwksRequest())).rejects.toThrow("db down");
+  });
+
+  it("returns the downstream error response when there is no cached key set yet", async () => {
+    const handler = vi.fn(async () => new Response("boom", { status: 500 }));
+    const wrapped = withJwksResponseCache(handler);
+
+    const res = await wrapped(jwksRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/lib/jwks-route-cache.ts
+++ b/src/lib/jwks-route-cache.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+/**
+ * In-process response cache + HTTP cache headers for `GET /api/auth/jwks` (#803).
+ *
+ * Better Auth's jwt-plugin JWKS endpoint reads the `Jwks` table on EVERY request
+ * and sets no `Cache-Control` header, so every fetch is a full dynamic origin
+ * round trip (measured 0.9–5.6s TTFB from us-east, where Convex Cloud runs).
+ * Convex's customJwt provider fetches this URL (`CONVEX_AUTH_JWKS_URL`) to
+ * verify the ES256 token attached to every single Convex function call — an
+ * uncached, slow JWKS endpoint is the one fixed per-call cost shared by ALL
+ * Convex ops, which is exactly the uniform ~1s p95 signature #803 diagnosed.
+ *
+ * Cache policy (R-9.9): the signing key set effectively never changes — Better
+ * Auth creates one ES256 key at bootstrap and no rotation is configured. Two
+ * layers, both bounded at 5 minutes:
+ *   • In-process memo — removes the per-fetch DB read + handler work, so the
+ *     origin answers from memory (and stops competing for DB pool connections
+ *     with real queries — the pool-contention shape #804 observed).
+ *   • `Cache-Control: public, max-age=300, s-maxage=300, stale-while-revalidate`
+ *     — lets standards-respecting JWKS fetchers (jose's createRemoteJWKSet,
+ *     CDNs with a cache rule) reuse the response instead of re-fetching.
+ * Worst-case staleness if a NEW key ever appears (bootstrap-only today) is
+ * memo TTL + client max-age = 10 minutes; verifiers that see an unknown `kid`
+ * re-fetch on their own. JWKS bodies are public signing keys — public caching
+ * is safe by construction (private keys never leave the `Jwks` table).
+ *
+ * Failure posture matches `single-org.ts`: on a downstream error, serve the
+ * last-known-good key set (keys this stable are better stale than absent —
+ * a 500 here takes down auth for every Convex call) and let the next request
+ * retry.
+ */
+
+export const JWKS_ROUTE_PATH = "/api/auth/jwks";
+export const JWKS_TTL_MS = 5 * 60 * 1000;
+export const JWKS_CACHE_CONTROL =
+  "public, max-age=300, s-maxage=300, stale-while-revalidate=86400";
+
+type RouteHandler = (request: Request) => Promise<Response>;
+
+let cached: { body: string; at: number } | null = null;
+
+/** Test/teardown hook — drop the memoized response so the next call re-fetches. */
+export function resetJwksResponseCache(): void {
+  cached = null;
+}
+
+function jwksResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": JWKS_CACHE_CONTROL,
+    },
+  });
+}
+
+/**
+ * Wrap the Better Auth catch-all GET handler: requests to `/api/auth/jwks` are
+ * served from the in-process memo (with cache headers); every other auth route
+ * passes through untouched.
+ */
+export function withJwksResponseCache(handler: RouteHandler): RouteHandler {
+  return async (request: Request): Promise<Response> => {
+    let pathname: string;
+    try {
+      pathname = new URL(request.url).pathname;
+    } catch {
+      return handler(request);
+    }
+    if (pathname !== JWKS_ROUTE_PATH) return handler(request);
+
+    const now = Date.now();
+    if (cached && now - cached.at < JWKS_TTL_MS) return jwksResponse(cached.body);
+
+    try {
+      const response = await handler(request);
+      if (!response.ok) {
+        // Serve stale on a downstream failure; surface the error only if we
+        // have never successfully loaded the key set.
+        return cached ? jwksResponse(cached.body) : response;
+      }
+      const body = await response.text();
+      cached = { body, at: now };
+      return jwksResponse(body);
+    } catch (error) {
+      if (cached) return jwksResponse(cached.body);
+      throw error;
+    }
+  };
+}

--- a/src/lib/org-login-info-cache.test.ts
+++ b/src/lib/org-login-info-cache.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  withOrgLoginInfoCache,
+  invalidateOrgLoginInfoCache,
+  ORG_LOGIN_INFO_TTL_MS,
+  ORG_LOGIN_INFO_MAX_ENTRIES,
+  type OrgLoginInfo,
+} from "./org-login-info-cache";
+
+function info(slug: string): OrgLoginInfo {
+  return {
+    orgId: `org_${slug}`,
+    orgName: `Org ${slug}`,
+    orgSlug: slug,
+    orgLogo: null,
+    hasSSO: true,
+    ssoEnabled: true,
+    enforceSSO: false,
+    allowPasswordLogin: true,
+    providers: [
+      {
+        providerId: "sso-1",
+        issuer: "https://idp.example.com",
+        domain: "example.com",
+        type: "oidc",
+        displayName: "Example IdP",
+        icon: "key",
+      },
+    ],
+  };
+}
+
+describe("withOrgLoginInfoCache", () => {
+  beforeEach(() => {
+    invalidateOrgLoginInfoCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads once and serves repeat lookups from the cache", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    const first = await withOrgLoginInfoCache("acme", load);
+    const second = await withOrgLoginInfoCache("acme", load);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(info("acme"));
+    expect(second).toBe(first);
+  });
+
+  it("caches null results for unknown slugs", async () => {
+    const load = vi.fn(async () => null);
+
+    expect(await withOrgLoginInfoCache("nope", load)).toBeNull();
+    expect(await withOrgLoginInfoCache("nope", load)).toBeNull();
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the cache per slug", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    await withOrgLoginInfoCache("a", load);
+    await withOrgLoginInfoCache("b", load);
+
+    expect(load).toHaveBeenCalledTimes(2);
+    expect((await withOrgLoginInfoCache("a", load))?.orgSlug).toBe("a");
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads after the TTL expires", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    await withOrgLoginInfoCache("acme", load);
+    vi.advanceTimersByTime(ORG_LOGIN_INFO_TTL_MS + 1);
+    await withOrgLoginInfoCache("acme", load);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads after explicit invalidation", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    await withOrgLoginInfoCache("acme", load);
+    invalidateOrgLoginInfoCache();
+    await withOrgLoginInfoCache("acme", load);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates a single slug without dropping others", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    await withOrgLoginInfoCache("a", load);
+    await withOrgLoginInfoCache("b", load);
+    invalidateOrgLoginInfoCache("a");
+    await withOrgLoginInfoCache("a", load);
+    await withOrgLoginInfoCache("b", load);
+
+    expect(load).toHaveBeenCalledTimes(3);
+  });
+
+  it("serves the stale value when the loader fails", async () => {
+    let fail = false;
+    const load = vi.fn(async (slug: string) => {
+      if (fail) throw new Error("db down");
+      return info(slug);
+    });
+
+    await withOrgLoginInfoCache("acme", load);
+    fail = true;
+    vi.advanceTimersByTime(ORG_LOGIN_INFO_TTL_MS + 1);
+
+    const res = await withOrgLoginInfoCache("acme", load);
+    expect(res?.orgSlug).toBe("acme");
+  });
+
+  it("rethrows a loader failure when nothing is cached for the slug", async () => {
+    const load = vi.fn(async () => {
+      throw new Error("db down");
+    });
+
+    await expect(withOrgLoginInfoCache("acme", load)).rejects.toThrow("db down");
+  });
+
+  it("evicts oldest entries past the size cap so arbitrary slugs cannot grow memory", async () => {
+    const load = vi.fn(async (slug: string) => info(slug));
+
+    for (let i = 0; i < ORG_LOGIN_INFO_MAX_ENTRIES + 5; i++) {
+      await withOrgLoginInfoCache(`slug-${i}`, load);
+    }
+    expect(load).toHaveBeenCalledTimes(ORG_LOGIN_INFO_MAX_ENTRIES + 5);
+
+    // slug-0 was evicted → reloads. The newest entry is still cached.
+    await withOrgLoginInfoCache("slug-0", load);
+    expect(load).toHaveBeenCalledTimes(ORG_LOGIN_INFO_MAX_ENTRIES + 6);
+    await withOrgLoginInfoCache(`slug-${ORG_LOGIN_INFO_MAX_ENTRIES + 4}`, load);
+    expect(load).toHaveBeenCalledTimes(ORG_LOGIN_INFO_MAX_ENTRIES + 6);
+  });
+});

--- a/src/lib/org-login-info-cache.ts
+++ b/src/lib/org-login-info-cache.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+/**
+ * In-process TTL cache for the public login page's org/SSO lookup (#804).
+ *
+ * `getOrgLoginInfo` (src/server/sso.ts) is a PUBLIC, pre-auth server action:
+ * every login-page visit — human or bot — runs `Organization.findUnique` +
+ * `SsoProvider.findMany` (Prisma) + `orgSettings:getByOrg` (a Convex round
+ * trip) with no caching. `SsoProvider.findMany` from this path is the single
+ * query breaching the T-9 slow_query p95 incident line, and its multi-second
+ * tail on a tiny indexed table is pool-contention-shaped — repeated public
+ * hits holding pooled connections amplify exactly that.
+ *
+ * Cache policy (R-9.9): org branding + SSO provider config change on the
+ * order of "an admin edited settings", so a short 60s TTL removes nearly all
+ * of the repeated load while keeping the login page at most a minute stale.
+ * The SSO settings/provider mutations in src/server/sso.ts additionally
+ * invalidate explicitly, so the common admin path (edit → check login page)
+ * is fresh immediately; provider CRUD that goes through Better Auth's own API
+ * (e.g. `registerSSOProvider`) is covered by the TTL alone.
+ *
+ * The map is bounded because the slug is CALLER-SUPPLIED on a public action:
+ * unknown slugs (null results) are cached too — so bots probing the login
+ * endpoint can't force a DB read per request — but evicted oldest-first past
+ * MAX_ENTRIES so arbitrary slugs can't grow memory. Single-org app: the real
+ * working set is 1 entry.
+ *
+ * Failure posture matches `single-org.ts`: on a loader error, serve the
+ * last-known value for the slug if there is one (the login page staying up
+ * beats strict freshness); rethrow only when there is nothing to serve.
+ *
+ * The types live here (a plain lib module), NOT in src/server/sso.ts — a
+ * `"use server"` file must only export async functions, and re-exporting
+ * types from one crashes SSR (see CLAUDE.md "Server Actions").
+ */
+
+export interface OrgLoginProviderInfo {
+  providerId: string;
+  issuer: string;
+  domain: string;
+  type: "saml" | "oidc";
+  displayName: string;
+  icon: string;
+}
+
+export interface OrgLoginInfo {
+  orgId: string;
+  orgName: string;
+  orgSlug: string;
+  orgLogo: string | null;
+  hasSSO: boolean;
+  ssoEnabled: boolean;
+  enforceSSO: boolean;
+  allowPasswordLogin: boolean;
+  providers: OrgLoginProviderInfo[];
+}
+
+export const ORG_LOGIN_INFO_TTL_MS = 60 * 1000;
+export const ORG_LOGIN_INFO_MAX_ENTRIES = 20;
+
+const cache = new Map<string, { value: OrgLoginInfo | null; at: number }>();
+
+/**
+ * Serve `load(slug)` through the cache. Null results (unknown slug) are
+ * cached like real ones.
+ */
+export async function withOrgLoginInfoCache(
+  slug: string,
+  load: (slug: string) => Promise<OrgLoginInfo | null>,
+): Promise<OrgLoginInfo | null> {
+  const now = Date.now();
+  const hit = cache.get(slug);
+  if (hit && now - hit.at < ORG_LOGIN_INFO_TTL_MS) return hit.value;
+
+  let value: OrgLoginInfo | null;
+  try {
+    value = await load(slug);
+  } catch (error) {
+    if (hit) return hit.value; // stale-on-error
+    throw error;
+  }
+
+  // Re-insert so Map iteration order doubles as oldest-first eviction order.
+  cache.delete(slug);
+  cache.set(slug, { value, at: now });
+  while (cache.size > ORG_LOGIN_INFO_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  return value;
+}
+
+/** Invalidate one slug's entry, or the whole cache when no slug is given. */
+export function invalidateOrgLoginInfoCache(slug?: string): void {
+  if (slug === undefined) cache.clear();
+  else cache.delete(slug);
+}

--- a/src/server/sso.ts
+++ b/src/server/sso.ts
@@ -20,6 +20,11 @@ import { env } from "@/env";
 import { readOrgSettingsBlob, saveOrgSettings } from "@/lib/org-settings-read";
 import type { OrgSettings } from "@/lib/org-settings-types";
 import { DANGEROUS_OBJECT_KEYS } from "@/lib/safe-object-key";
+import {
+  withOrgLoginInfoCache,
+  invalidateOrgLoginInfoCache,
+  type OrgLoginInfo,
+} from "@/lib/org-login-info-cache";
 
 // ─── Read helpers ────────────────────────────────────────────────────────────
 
@@ -60,6 +65,8 @@ export async function updateSSOSettings(data: Partial<OrgSSOSettings>) {
   const updatedSSO = { ...currentSSO, ...data };
   settings.sso = updatedSSO;
   await saveOrgSettings(organizationId, settings);
+  // Login-page cache reads enabled/enforceSSO/allowPasswordLogin from this blob.
+  invalidateOrgLoginInfoCache();
 
   await logActivity({
     organizationId,
@@ -144,6 +151,7 @@ export async function deleteSSOProvider(providerId: string) {
   if (!provider) throw new Error("SSO provider not found");
 
   await prisma.ssoProvider.delete({ where: { id: provider.id } });
+  invalidateOrgLoginInfoCache();
 
   await logActivity({
     organizationId,
@@ -206,6 +214,7 @@ export async function patchProviderOidcConfig(
     where: { id: provider.id },
     data: { oidcConfig: JSON.stringify(config) },
   });
+  invalidateOrgLoginInfoCache();
 
   return { success: true };
 }
@@ -231,6 +240,8 @@ export async function updateSSOProviderMeta(
   };
   settings.sso = sso;
   await saveOrgSettings(organizationId, settings);
+  // Login-page cache renders provider displayName/icon from providerMeta.
+  invalidateOrgLoginInfoCache();
 
   return { success: true };
 }
@@ -420,8 +431,18 @@ export async function rejectSSOUser(approvalId: string, note?: string) {
 /**
  * Get org info for the org-specific login page.
  * This is public — called from the login page before authentication.
+ *
+ * Served through a 60s in-process cache (#804): this pre-auth path ran
+ * `SsoProvider.findMany` + a Convex org-settings read on every login-page
+ * visit, and that findMany was the T-9 slow_query p95 incident driver. The
+ * SSO mutations above invalidate the cache so admin edits show immediately;
+ * see src/lib/org-login-info-cache.ts for the full policy.
  */
 export async function getOrgLoginInfo(orgSlug: string) {
+  return withOrgLoginInfoCache(orgSlug, loadOrgLoginInfo);
+}
+
+async function loadOrgLoginInfo(orgSlug: string): Promise<OrgLoginInfo | null> {
   const org = await prisma.organization.findUnique({
     where: { slug: orgSlug },
     select: { id: true, name: true, slug: true, logo: true },


### PR DESCRIPTION
## Summary

All three 2026-07-23 perf incidents (#802 LCP p75, #803 `convex_op_latency` p95, #804 `slow_query` p95) verified **still breaching** as of today via PostHog SQL (convex p95 1,367ms today; `SsoProvider.findMany` p95 1,830ms over the last 2 days; LCP p75 2.7–4.9s). This PR lands the two repo-side remediations the issues themselves identified:

**1. `/api/auth/jwks` caching (#803, likely #802 downstream).** Convex's customJwt provider fetches this endpoint to verify the ES256 token attached to every Convex function call. Better Auth's handler does an uncached `Jwks` table read per request with no `Cache-Control` header — probed today at **0.9–5.6s TTFB from us-east** (where Convex Cloud runs), a fixed per-call overhead matching the uniform ~1s slowdown across ~20 otherwise-trivial functions. New `src/lib/jwks-route-cache.ts` memoizes the response in-process (5 min TTL, stale-on-error — the key set only changes at bootstrap, no rotation configured) and serves `Cache-Control: public, max-age=300, s-maxage=300, stale-while-revalidate=86400`. Other auth routes pass through untouched.

**2. `getOrgLoginInfo` caching (#804).** This public, pre-auth server action runs `SsoProvider.findMany` + a Convex org-settings round trip on every login-page visit; that `findMany` was the *only* query breaching the T-9 incident line. New `src/lib/org-login-info-cache.ts` serves it through a 60s in-process TTL cache (bounded map for the caller-supplied slug, null results cached, stale-on-error), with explicit invalidation from the SSO settings/provider mutations.

**#802 (LCP)** is expected to recover downstream of the Convex-leg fix per its own triage ("this should close as a consequence of that fix, not a separate one"); the client-rendered-dashboard residual is already covered by the dated R-8.9.3 exception from #862.

Docs updated in the same PR: FEATUREDOCS/33, /54, /61 + `docs/convex-observability-runbook.md` (including re-check criteria and a CDN cache-rule ops option if the residual persists).

**Size rationale (R-2.8/T-2):** 540 changed LOC, of which ~280 are the two new unit-test suites and ~90 are the R-5.2-mandated same-PR docs updates — the production-code delta is ~170 LOC across two small, self-contained cache modules plus wiring. Splitting the two caches into separate PRs would separate two remediations for a shared incident cluster (#802–#804 cross-reference each other as one root-cause investigation) without reducing review surface per file.

## Testing

- New unit suites: `src/lib/jwks-route-cache.test.ts` (8 tests: memo, TTL, passthrough, stale-on-error/non-ok, no-cache failure propagation) and `src/lib/org-login-info-cache.test.ts` (9 tests: per-slug caching, null caching, TTL, invalidation, stale-on-error, bounded eviction).
- Full unit suite: 304 files / 3,906 tests passed.
- `tsc --noEmit` clean; ESLint clean on touched files (one pre-existing warning in an untouched function).
- Live probes of `https://flow.rvlt.app/api/auth/jwks` (0.9–5.6s TTFB, `cf-cache-status: DYNAMIC`, no cache headers) documented the before-state.

## Checklist

- [x] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3) — **no new dependencies**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wf18EiDaRVqU31nunC3qnL