### PR TITLE
fix(pdf): page numbers, drop redundant Days column, fix asset-tag overflow

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -39,6 +39,21 @@ delivery-docket):
 - Header repeats on every continuation page; footer on every page.
 - Totals/signature/notes blocks are kept whole (pushed to the next page if
   they don't fit, never split).
+- Every page's footer carries "Page X of Y" (omitted on single-page
+  documents) — `pageNumber` is computed once in `composeDocument` per page
+  index against the final page count and rendered right-aligned by
+  `gearflowPageFooter`.
+
+**Quote/invoice table simplification (2026-07-26):** the quote/invoice table
+dropped its separate "Days" column — it duplicated the per-line `duration`
+value next to the rate/total columns without adding information the reader
+needed, and produced confusing/misleading output on lines whose duration
+didn't match the project's overall rental span. `duration` is still a real
+per-line DB field (`project-line-item-read.ts`); it's just no longer
+rendered as its own column. `getAssetTag()` (`gearflow-table.ts`) also
+dedupes unit tags before applying the "+N more" truncation — a bulk line's
+units all share one `bulkAsset` tag, so without dedup a 10-unit bulk line
+rendered as `"TTP00099, TTP00099 +8"` instead of the single tag.
 
 Call sheets don't go through this pipeline — they use their own service-based
 builder (`templates/call-sheet-services.ts`, queries `ProjectService`/
@@ -86,7 +101,7 @@ of importing `@pdfme/generator` directly. `no-restricted-imports` in
 | `gearflowTable` | Equipment table — grouping (by `groupName` or `prepContainer`), kit children (3 levels), badges, checkboxes, conditions, per-unit expansion. Container line items (`isContainerLineItem`) are excluded. |
 | `gearflowFinancialSummary` | Subtotal/discount/tax/total block with optional deposit/balance |
 | `gearflowPageHeader` | Three modes: logo, icon, none — org info + doc title |
-| `gearflowPageFooter` | Centered footer with top border |
+| `gearflowPageFooter` | Centered footer with top border; right-aligned "Page X of Y" when the document has more than one page (`FooterConfig.pageNumber`, computed per-page in `composeDocument`) |
 | `gearflowCheckbox` | Empty/checked checkbox square |
 | `gearflowSignatureLine` | Signature blocks with configurable columns |
 | `gearflowCrewTable` | Crew table for call sheets — sorted by call time then role |

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -316,6 +316,37 @@ describe("composeDocument — org document settings (footer, T&Cs, quote validit
   });
 });
 
+describe("composeDocument — footer page numbers", () => {
+  function footerConfigsFor(result: ComposeResult) {
+    return result.template.schemas.map((pageSchemas, pageIdx) => {
+      const footer = pageSchemas.find((s) => s.type === "gearflowPageFooter")!;
+      return JSON.parse(result.inputs[0][footer.name as string]) as { pageNumber?: string };
+    });
+  }
+
+  it("omits the page number on a single-page document", () => {
+    const data = makeData({ line_items: [makeLineItem({ id: "only-item", status: "CHECKED_OUT", checkedOutQuantity: 1, model: { name: "Solo Item" } })] });
+    const result = composeDocument("quote", data, "#0d4f4f");
+    expect(result.template.schemas.length).toBe(1);
+
+    const [footerConfig] = footerConfigsFor(result);
+    expect(footerConfig.pageNumber).toBeUndefined();
+  });
+
+  it("renders 'Page X of Y' on every page of a multi-page document", () => {
+    const lineItems = makeLongLineItemList(120);
+    const data = makeData({ line_items: lineItems, total_items: lineItems.length });
+    const result = composeDocument("quote", data, "#0d4f4f");
+    const total = result.template.schemas.length;
+    expect(total).toBeGreaterThan(1);
+
+    const footerConfigs = footerConfigsFor(result);
+    footerConfigs.forEach((config, pageIdx) => {
+      expect(config.pageNumber).toBe(`Page ${pageIdx + 1} of ${total}`);
+    });
+  });
+});
+
 describe("composeDocument — quote content audit (#790 Phase 4)", () => {
   function tableItemsAndConfig(result: ComposeResult): { items: DocumentLineItem[]; config: TablePluginConfig } {
     const tableSchema = result.template.schemas[0].find((s) => s.type === "gearflowTable")!;

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -874,7 +874,10 @@ export function composeDocument(docType: ProjectDocumentType, data: DocumentData
       width: CONTENT_WIDTH,
       height: FOOTER_HEIGHT,
     });
-    mergedInputs[footerName] = JSON.stringify(footerConfig);
+    mergedInputs[footerName] = JSON.stringify({
+      ...footerConfig,
+      pageNumber: pages.length > 1 ? `Page ${pageIdx + 1} of ${pages.length}` : undefined,
+    } satisfies FooterConfig);
 
     allSchemas.push(pageSchemas);
   }

--- a/src/lib/pdfme/plugins/gearflow-page-footer.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-page-footer.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { PDFDocument } from "@pdfme/pdf-lib";
+import * as pdfLib from "@pdfme/pdf-lib";
+import gearflowPageFooter from "./gearflow-page-footer";
+import type { FooterConfig } from "../types";
+
+interface DrawTextCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+async function runFooterPlugin(config: FooterConfig): Promise<DrawTextCall[]> {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([595, 842]);
+
+  const drawText: DrawTextCall[] = [];
+  page.drawText = ((text: string, opts: Record<string, unknown>) => {
+    drawText.push({ text, x: opts.x as number, y: opts.y as number });
+  }) as typeof page.drawText;
+  page.drawLine = (() => {}) as typeof page.drawLine;
+
+  const schema = {
+    name: "footer",
+    type: "gearflowPageFooter" as const,
+    position: { x: 0, y: 0 },
+    width: 170,
+    height: 10,
+  };
+
+  await gearflowPageFooter.pdf({
+    schema,
+    page,
+    pdfLib,
+    pdfDoc,
+    value: JSON.stringify(config),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _cache: new Map<string | number, unknown>(),
+    options: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+  return drawText;
+}
+
+describe("gearflowPageFooter — page number", () => {
+  it("does not draw a page number when config.pageNumber is absent", async () => {
+    const calls = await runFooterPlugin({ text: "RVLT Flow | hello@rvlt.app" });
+    expect(calls.some((c) => c.text.startsWith("Page "))).toBe(false);
+  });
+
+  it("draws 'Page X of Y' right-aligned when config.pageNumber is present", async () => {
+    const calls = await runFooterPlugin({
+      text: "RVLT Flow | hello@rvlt.app",
+      pageNumber: "Page 2 of 4",
+    });
+    const pageNumCall = calls.find((c) => c.text === "Page 2 of 4");
+    expect(pageNumCall).toBeDefined();
+    // Right-aligned: drawn further right than the centered main text call.
+    const mainCall = calls.find((c) => c.text === "RVLT Flow | hello@rvlt.app");
+    expect(mainCall).toBeDefined();
+    expect(pageNumCall!.x).toBeGreaterThan(mainCall!.x);
+  });
+});

--- a/src/lib/pdfme/plugins/gearflow-page-footer.ts
+++ b/src/lib/pdfme/plugins/gearflow-page-footer.ts
@@ -56,6 +56,18 @@ async function pdfRender(arg: PDFRenderProps<FooterSchema>) {
       color: textColor,
     });
   }
+
+  // Page number (right-aligned)
+  if (config.pageNumber) {
+    const pageNumWidth = fonts.regular.widthOfTextAtSize(config.pageNumber, fontSize);
+    page.drawText(config.pageNumber, {
+      x: x + width - pageNumWidth,
+      y: y + height - 12,
+      size: fontSize,
+      font: fonts.regular,
+      color: textColor,
+    });
+  }
 }
 
 const gearflowPageFooter: Plugin<FooterSchema> = {

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -138,9 +138,11 @@ function getItemName(item: DocumentLineItem, isKit: boolean): string {
  * Get asset tag display for a line. Preference order:
  *   1. Kit row → the kit's own tag
  *   2. Units present (post-cutover, multi-quantity deployed line) →
- *      join up to 2 unit tags, then "+N more" if there are extras.
- *      One unit collapses to its single tag so single-asset lines
- *      look identical to the pre-cutover output.
+ *      dedupe tags first (bulk assets share one tag across many units,
+ *      so a 10-unit bulk line has 10 identical unit tags, not 10 distinct
+ *      ones), then join up to 2 distinct tags, "+N more" for extras. One
+ *      distinct tag collapses to itself so single-asset lines and bulk
+ *      lines both render one clean tag instead of duplicating it.
  *   3. Legacy line.asset (kit children, un-migrated splits)
  *   4. Bulk asset tag
  *   5. "-"
@@ -153,9 +155,11 @@ export function getAssetTag(item: DocumentLineItem, isKit: boolean): string {
   if (isKit) {
     return item.kit?.assetTag || "-";
   }
-  const unitTags = (item.units ?? [])
-    .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
-    .filter((t): t is string => !!t);
+  const unitTags = [...new Set(
+    (item.units ?? [])
+      .map((u) => u.asset?.assetTag ?? u.bulkAsset?.assetTag)
+      .filter((t): t is string => !!t)
+  )];
   if (unitTags.length > 0) {
     if (unitTags.length === 1) return unitTags[0];
     if (unitTags.length === 2) return unitTags.join(", ");

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -65,7 +65,6 @@ function getColumnsForDocType(config: TablePluginConfig, totalWidth: number): Co
         { key: "description", label: "Description", width: 0, flex: 3, align: "left" },
         { key: "qty", label: "Qty", width: 30, align: "center" },
         { key: "unitPrice", label: config.documentType === "invoice" ? "Rate" : "Unit Price", width: 60, align: "right" },
-        { key: "days", label: "Days", width: 30, align: "center" },
         { key: "total", label: config.documentType === "invoice" ? "Amount" : "Total", width: 60, align: "right" },
       ], totalWidth);
 
@@ -521,19 +520,6 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
             break;
           }
 
-          case "days": {
-            const dayStr = String(item.duration);
-            const dayWidth = fonts.regular.widthOfTextAtSize(dayStr, fontSize);
-            page.drawText(dayStr, {
-              x: cellX + (col.width - dayWidth) / 2 - cellPadding,
-              y: textY,
-              size: fontSize,
-              font: fonts.regular,
-              color: textColor,
-            });
-            break;
-          }
-
           case "total": {
             if (!config.showPricing) break;
             const totalStr = isItemized ? "-" : formatCurrency(item.lineTotal);
@@ -768,19 +754,6 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
                 break;
               }
 
-              case "days": {
-                const dayStr = String(child.duration);
-                const dayWidth = fonts.regular.widthOfTextAtSize(dayStr, childFontSize);
-                page.drawText(dayStr, {
-                  x: childCellX + (col.width - dayWidth) / 2 - cellPadding,
-                  y: childTextY,
-                  size: childFontSize,
-                  font: fonts.regular,
-                  color: childTextColor,
-                });
-                break;
-              }
-
               case "total": {
                 if (!config.showPricing) break;
                 const totalStr = formatCurrency(child.lineTotal);
@@ -940,19 +913,6 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
                     const pW = fonts.regular.widthOfTextAtSize(pStr, grandchildFontSize);
                     page.drawText(pStr, {
                       x: colEndX - pW - cellPadding,
-                      y: nestedTextY,
-                      size: grandchildFontSize,
-                      font: fonts.regular,
-                      color: grandchildTextColor,
-                    });
-                    break;
-                  }
-
-                  case "days": {
-                    const dStr = String(nested.duration);
-                    const dW = fonts.regular.widthOfTextAtSize(dStr, grandchildFontSize);
-                    page.drawText(dStr, {
-                      x: nestedCellX + (col.width - dW) / 2 - cellPadding,
                       y: nestedTextY,
                       size: grandchildFontSize,
                       font: fonts.regular,

--- a/src/lib/pdfme/plugins/get-asset-tag.test.ts
+++ b/src/lib/pdfme/plugins/get-asset-tag.test.ts
@@ -138,4 +138,33 @@ describe("getAssetTag", () => {
     });
     expect(getAssetTag(li, false)).toBe("BULK-XLR");
   });
+
+  it("bulk line with many units sharing one tag → the tag alone, not duplicated + overflow", () => {
+    // Bulk assets aren't individually serialized: every unit on a bulk line
+    // carries the SAME bulkAsset tag. Naive first-2-plus-N logic on the raw
+    // (non-deduped) list renders "TTP00099, TTP00099 +8" — dedupe first.
+    const li = lineItem({
+      quantity: 10,
+      units: Array.from({ length: 10 }, (_, i) => ({
+        id: `u${i}`,
+        asset: null,
+        bulkAsset: { assetTag: "TTP00099" },
+        status: "CHECKED_OUT",
+      })),
+    });
+    expect(getAssetTag(li, false)).toBe("TTP00099");
+  });
+
+  it("mixed units where some share a tag → dedupes before the '+N' count", () => {
+    const li = lineItem({
+      quantity: 4,
+      units: [
+        { id: "u0", asset: { assetTag: "TAG-A" }, bulkAsset: null, status: "CHECKED_OUT" },
+        { id: "u1", asset: { assetTag: "TAG-A" }, bulkAsset: null, status: "CHECKED_OUT" },
+        { id: "u2", asset: { assetTag: "TAG-B" }, bulkAsset: null, status: "CHECKED_OUT" },
+        { id: "u3", asset: { assetTag: "TAG-C" }, bulkAsset: null, status: "CHECKED_OUT" },
+      ],
+    });
+    expect(getAssetTag(li, false)).toBe("TAG-A, TAG-B +1");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #790 based on real generated PDF output (invoice, longer invoice, return sheet) — three concrete quality defects the prior unit-level testing didn't catch:

- **No page numbers anywhere.** `FooterConfig.pageNumber` was already declared in the type but never read by the footer plugin. `composeDocument` now computes `Page X of Y` per page (omitted on single-page documents) and `gearflowPageFooter` renders it right-aligned.
- **Redundant "Days" column on quote/invoice.** The Rate column already carries a "/day" suffix, so a separate Days column next to it just duplicated information and looked confusing. Removed the column and the three now-dead `case "days"` render branches (top-level/child/grandchild). `duration` is still a real per-line DB field — only the standalone column display is gone.
- **Asset tag overflow on bulk lines.** `getAssetTag()`'s "+N more" truncation ran on the raw per-unit tag list. Bulk assets aren't individually serialized, so every unit on a bulk line shares one tag — a 10-unit bulk line rendered `"TTP00099, TTP00099 +8"` instead of the single tag. Now dedupes tags before truncating; genuinely distinct per-unit tags still list and truncate exactly as before.

FEATUREDOCS/13-pdfs.md updated to document both the page-number behavior and the table simplification.

## Testing

- `pnpm exec vitest run src/lib/pdfme` — 113/113 passing (new tests: `gearflow-page-footer.test.ts`, page-number cases in `document-composer.test.ts`, bulk-dedup cases in `get-asset-tag.test.ts`)
- `pnpm exec vitest run` (full suite) — all passing
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — no new warnings/errors (complexity-ratchet and knip-ratchet both improved vs. baseline)

## Checklist

- [x] No new dependencies


---
_Generated by [Claude Code](https://claude.ai/code/session_014R1LcPyFnLd3BjRDFPb1X9)_