### PR TITLE
Quick wins: scan audio feedback, my-tasks + dashboard overhaul, defaultDiscount wiring

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,8 @@
   - Generic SaaS dashboard language ("Manage your X directory")
   - Personality copy, mascots, or Kalam font in alert/compliance/overdue/conflict contexts
   - Full-row background tints on table hover (use left-edge indicator)
-  - 7-column stat card grids (use inline metrics strip)
+  - 7-column stat card grids (use a bounded bento grid of individually-bordered tiles,
+    max 4 per row on desktop — see "Dashboard Layout" below)
   - Floating-card-in-space login (use split-panel with brand mark)
   - Centered-everything layouts
   - Placeholder emoji or purely decorative icons
@@ -311,8 +312,24 @@ All detail pages (project, asset, model, kit, client, crew, supplier, maintenanc
 ### Dashboard Layout
 - Dynamic greeting (Good morning/afternoon/evening) + date
 - Alert badges (red/amber) only when problems exist
-- Inline metrics strip (single surface, vertical dividers) instead of stat card grid
-- Activity feed with staggered entrance
+- **Bento grid of hard-offset-shadow tiles** (`TILE`/`TILE_LINK` in `dashboard/page.tsx`), NOT an
+  inline metrics strip with vertical dividers — that was an earlier draft that never shipped;
+  stat tiles are individually-bordered cards (§2 hard offset shadows), each linking to its
+  detail page.
+- **Three fixed zones, in this order (no widget boards — the zones are the layout, not a
+  drag-and-drop grid a user can rearrange):**
+  1. **My work** — `MyWorkSection` (renamed header "My work"): the "On the floor now" live-jobs
+     tile, a tasks-due block (top 5 open tasks assigned to the user, "N more →" to `/my-tasks`),
+     and the user's managed projects with per-project blocker badges + latest-blocker snippet.
+  2. **Org risk** — the "Needs attention" chip tray (overdue returns, maintenance due, crew
+     offers pending, blockers). Chips only render when a problem exists (no permanent zero-chip
+     UI). Carries a code-comment extension point for sibling-feature org-risk board chips —
+     never a stub or a dead link ahead of that work landing.
+  3. **Demoted** — stat tiles, upcoming projects, recent activity feed (staggered entrance).
+  Blockers surface in exactly two places — the My work zone's per-project badges, and the Org
+  risk needs-attention chip — never in a separate standalone blockers panel.
+- FadeIn delays are derived from section render order (`nextSectionDelay()` in `dashboard/page.tsx`),
+  not hand-numbered literals — inserting a section never requires renumbering the ones after it.
 
 ### Breadcrumb Navigation
 ```
@@ -488,7 +505,7 @@ Archivo is loaded via `next/font/google` with weights 400–900. Always referenc
   - Warehouse (check-out/in, scanning)
   - Crew (schedule, roster)
   - Assets (gear, kits)
-- Sidebar-only (desktop + overflow): Settings, Admin, Clients, Suppliers, Test & Tag, Maintenance, Reports
+- Sidebar-only (desktop + overflow): Settings, Admin, Clients, Suppliers, Test & Tag, Maintenance, Reports, My tasks (personal-scope cross-project task list — the task *count* already surfaces on the Dashboard, so it doesn't need a bottom-nav slot too)
 - Settings accessible via avatar menu on mobile
 
 ### Deep Navigation on Mobile

--- a/FEATUREDOCS/03-database-schema.md
+++ b/FEATUREDOCS/03-database-schema.md
@@ -69,7 +69,9 @@ Grouped by area (table names are the Convex identifiers, e.g. `assets`,
   `projectCategories`, `categorySlots`, `projectGroups`, `projectManagers`,
   `projectModelRevenues`, `groupTemplates` + `groupTemplateItems`,
   `projectTasks`, `projectNumberSequences`.
-- **Clients** — `clients`.
+- **Clients** — `clients`. `defaultDiscount` snapshots onto `Project.discountPercent`
+  at project-create time only (server-side in `projectWrites.createNative`, plus the
+  WooCommerce order-assembly path) — see FEATUREDOCS/10 "Discount default cascade".
 - **Crew** — `crewMembers`, `crewRoles`, `crewSkills`, `crewAssignments`,
   `crewShifts`, `crewAvailabilities`, `crewTimeEntries`.
 - **Project services** — `projectServices`, `serviceTemplates`.

--- a/FEATUREDOCS/06-pages-layouts.md
+++ b/FEATUREDOCS/06-pages-layouts.md
@@ -57,6 +57,7 @@ already-pending or already-active tab is always a no-op. Regression test:
 | Path | Page |
 |------|------|
 | `/dashboard` | Overview, stats, recent activity, upcoming projects |
+| `/my-tasks` | This user's open tasks (direct + crew assignment) across every project, grouped Overdue/Today/This week/Later |
 | `/assets/registry` | Serialized + bulk asset list |
 | `/assets/registry/new` | Create asset(s) |
 | `/assets/registry/[id]` | Asset detail (tabs: info, history, maintenance, media) |

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -1,6 +1,6 @@
 # Project & Rental Management
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-23 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-26 (review quarterly — POLICY.md R-5.5)_
 
 ## Projects List Views (`ProjectTable`, `ProjectBoard`)
 `ProjectTable` (`src/components/projects/project-table.tsx`) is server-side
@@ -50,9 +50,14 @@ retired). Routes:
 - `defaultValues` are pre-filled from the project across all steps; stored dates
   are normalised to the form's `yyyy-MM-dd` shape via `normalizeDate`, times stay
   `HH:mm`. Existing project managers seed `managerIds`.
-- Two edit-only fields appear that create mode hides: **Status** (basics step) and
-  the **Financial** block — discount %, deposit %, deposit paid, invoiced total
-  (site step). These carry the parity that the old flat edit form had.
+- One edit-only field appears that create mode hides: **Status** (basics step).
+  The **Financial** block (site step, `isEditing`-gated) still holds deposit %,
+  deposit paid, invoiced total — these carry the parity that the old flat edit
+  form had, and are currently hand-typed inputs applied nowhere server-side
+  (RESERVED for #940 / WS1, see the schema.ts + wizard reservation comments; do
+  not wire deposit math without that issue). **Discount (%)** moved out of that
+  block (QW-4 / #953) to the basics step, always visible in both create and edit
+  mode, right after the Client picker — see "Discount default cascade" below.
 - Submit calls `updateProject(id, data)` and **reconciles managers** by diffing
   the initial set vs the selected set (`addProjectManager`/`removeProjectManager`
   on the delta only — no dupes, no accidental removals), then routes to
@@ -82,6 +87,39 @@ retired). Routes:
   edit). Per-moment dates + times live in an optional "Load-in, show & load-out
   times" accordion so the common case is "tap a preset, done". All ten underlying
   fields are preserved for `createProject()`.
+
+### Discount default cascade (QW-4 / #953)
+
+`Client.defaultDiscount` (`convex/schema.ts`) is a per-client default discount
+percentage, set on the client record (`client-form.tsx`, `src/lib/client-fields.ts`).
+It snapshots onto `Project.discountPercent` **at project-create time only**:
+
+- **Server-authoritative (R-9.3).** `projectWrites.createNative` resolves it
+  in-mutation: when the caller doesn't pass an explicit `discountPercent` AND the
+  project has a `clientId`, it org-checked-reads the client row and stamps
+  `client.defaultDiscount` (when set) onto the new project. `== null` (not a
+  truthy/falsy check) decides "not provided" — an explicit `0`% discount from the
+  caller always wins over the client default, never gets silently overwritten by
+  it (see the `== null` auto-pricing comment in `convex/lineItemWrites.ts` for the
+  same lesson applied elsewhere). This is the only place the cascade fires;
+  `updateNative` has no equivalent — reassigning a project's client later does
+  **not** retroactively recompute its discount.
+- **WooCommerce order assembly** builds projects directly (not through
+  `createNative` — see FEATUREDOCS/35 §"Order Processing" step 5), so it seeds the
+  same cascade independently via `resolveWooDiscountPercent` (canonical copy in
+  `src/lib/woocommerce-utils.ts`, a verbatim-copied twin in
+  `convex/wooCommerceActions.ts` since Convex functions can't import from `src/`).
+- **Wizard UX** (`project-wizard.tsx`, Basics step, next to the Client picker) is a
+  convenience layer only — the server snapshot above is authoritative regardless
+  of what the browser sends. Selecting a client prefills Discount (%) from
+  `client.defaultDiscount` with a "from client default" hint; the field stays
+  freely editable. Switching clients before submitting re-prefills, but **only**
+  while the user hasn't touched the field themselves (`discountTouchedRef`) —
+  once they type a value (including an explicit `0`), their choice sticks through
+  further client changes. Opening an existing project for edit never re-prefills
+  from the client's *current* default over whatever discount was actually saved
+  (`prefilledDiscountForClientId` seeds from the project's original `clientId`, so
+  the effect only fires on an actual client *change*, not on mount).
 
 ## Project Managers
 - **Manager picker permissions (#727).** The wizard's "Project manager(s)" field

--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -225,6 +225,38 @@ silently with their parent). `src/server/bulk-checkin.ts`, its int test, and the
 - `quickAddAndCheckOut()` adds items to project and **preps** them (sets `status: "CONFIRMED"`, `prepStatus: "PACKED"`) — does NOT deploy directly
 - `lookupAssetForScan()` treats scanned serialized assets as serialized (not bulk) even if the matching line item has qty > 1
 
+#### Scan Feedback (Audio)
+The three scan mutations on `warehouse/[projectId]/page.tsx` — `scanMutation` (Pick/Prep),
+`deployScanMutation` (Deploy tab), `returnScanMutation` (Return tab) — play an audio tone
+on every resolve result via the shared **`useScanFeedback`** hook (`@/hooks/use-scan-feedback`,
+backed by `src/lib/scan-feedback.ts`; see FEATUREDOCS/14 §"Audio / Scan Feedback" for the
+underlying implementation and the legacy `playBeep` defects it replaced). A
+`<ScanAudioToggle>` icon button (`@/components/scan-audio-toggle`) sits in the page header,
+next to the Documents/pick-list actions, controlling all three scanners at once.
+
+Each resolve branch maps to one of the 4 tone kinds:
+- **`success`** — every `toast.success(...)` branch: kit/item prepped, deployed, returned,
+  or a kit-member scan verified.
+- **`error`** — hard failures that block the scan outright: not on project, already
+  deployed, not prepped yet, TT-blocked, asset unavailable, wrong-kit member scans, etc.
+- **`exception`** — resolved but needs the operator's attention rather than a clean
+  success or a hard stop. Three specific branches, shared across all three mutations:
+  1. `reason === "already_returned"` (all units are already back — nothing to do, but
+     it's not an error).
+  2. The final `else` fallback when `lookupAssetForScan` doesn't recognise the tag at all
+     ("Asset not found" — unknown tag).
+  3. `result.type === "asset_child"` (scanned an accessory instead of its parent — the
+     UI redirects with "scan the parent"; disambiguation, not failure).
+  The Pick/Prep mutation's "asset found but not on this project, want to add it?" prompt
+  (`setAddPromptData` / `setAddPromptOpen`) also plays `exception` for the same reason —
+  it's a decision point, not a verdict.
+- **`info`** — not currently wired to a warehouse call site; reserved for neutral
+  heads-up moments (see FEATUREDOCS/14). Available to future consumers of the hook, e.g.
+  the WS5 returns station.
+
+A mutation's own `onError` (the server call itself failing — network, permission, etc.,
+distinct from a resolved-but-rejected scan result) always plays `error`.
+
 ### Kit/Prep-Kit Flows
 - Kit checkout: `checkOutKit()` — atomic transaction updating kit + all member assets + grandchildren
 - Kit checkin: `checkInKit()` — same pattern, handles grandchildren and prep-kit assets

--- a/FEATUREDOCS/14-test-and-tag.md
+++ b/FEATUREDOCS/14-test-and-tag.md
@@ -77,9 +77,34 @@ Multi-outlet/phase devices (power boards, RCD power boards, three-phase) require
 
 ### Session Features
 - **Session tester**: Defaults to logged-in user, selectable from org members. Persists across tests in session.
-- **Audio feedback**: Beep on save (success/fail tones), toggleable.
+- **Audio feedback**: Success/error tone on save, toggleable — via the shared `useScanFeedback` hook (`@/hooks/use-scan-feedback`), not a page-local implementation. See "Audio / Scan Feedback" below.
 - **Session log**: Desktop sidebar / mobile bottom bar showing tested items + results.
 - **Keyboard shortcuts**: Ctrl+Enter save, Escape reset to scan.
+
+## Audio / Scan Feedback
+
+The quick-test wizard was the **original** (and until #951/QW-1, only) audio call site in
+the repo — a page-local `playBeep(success: boolean)` in
+`src/app/(app)/test-and-tag/quick-test/page.tsx` that built a brand-new `AudioContext` per
+beep and never closed it (Chrome caps ~6 concurrent contexts, so head-down scanning
+sessions eventually went silent), never called `ctx.resume()` (autoplay policy can
+silently suspend a context created outside a user gesture), stopped the oscillator with
+a hard `osc.stop()` (audible click), and swallowed every failure with a bare `catch {}`.
+
+That logic has been extracted into the shared **`src/lib/scan-feedback.ts`** +
+**`src/hooks/use-scan-feedback.ts`** pair (FEATUREDOCS/12 §"Scan Feedback" has the full
+architecture — this section covers only what's specific to the quick-test wizard):
+
+- `saveMutation`'s `onSuccess` plays `success` when `overallResult === "PASS"`, `error`
+  otherwise (byte-identical to the legacy pass/fail tones: 800 Hz/150 ms vs 300 Hz/400 ms).
+  `onError` (the save itself failing, e.g. a network/validation error) always plays `error`.
+- The old page-local `audioEnabled` `useState` (default `true`, **not persisted** — reset
+  every mount) is gone. The header's `Volume2`/`VolumeX` icon button is now the shared
+  `<ScanAudioToggle enabled={scanFeedback.enabled} onToggle={scanFeedback.toggle} />`
+  component (`@/components/scan-audio-toggle`), backed by `useScanFeedback`'s
+  localStorage-persisted (`rvlt.scanAudio`) toggle. Default is still ON and the toggle is
+  visually/behaviourally identical — only the persistence and the underlying audio
+  implementation changed.
 
 ### Failure Workflow
 When overall result is FAIL, a dialog prompts with options:

--- a/FEATUREDOCS/29-integration-checklist.md
+++ b/FEATUREDOCS/29-integration-checklist.md
@@ -8,7 +8,7 @@ When implementing a new feature, ensure it integrates with ALL existing systems.
 |--------|-----------|
 | **Convex write** | New domain entity → Convex table in `convex/schema.ts` + `<domain>Writes.ts` mutations, NOT a Prisma model or server action. Every public mutation: `assertWritesEnabled` → `enforceBrowserWriteLimit` → `requireOrgPermission` → `resolveActor`. See FEATUREDOCS/28 and FEATUREDOCS/54. |
 | **Permissions** | Add resource to `src/lib/permissions.ts` (RBAC map used by both `requirePermission()` server-action carve-outs and Convex's `requireOrgPermission`). |
-| **Sidebar** | Add nav item to `src/components/layout/app-sidebar.tsx` with `resource` for gating. |
+| **Sidebar** | Add nav item to `src/components/layout/app-sidebar.tsx` with `resource` for gating. Exception: a **personal-scope** page (the user's own data, not an org resource — e.g. `/my-tasks`) omits `resource` entirely rather than gating on an unrelated resource; that avoids the fail-open gating flash and keeps the item visible to every role regardless of their org-resource permissions. Sidebar-only items are NOT automatically mirrored into `mobile-nav.tsx` — that file is deliberately capped at the 5 daily-operator workflows (DESIGN.md §16); check DESIGN.md before adding anything there. |
 | **Top bar** | Add segment label to `segmentLabels` in `src/components/layout/top-bar.tsx`. |
 | **Search** | Add entity search to `convex/globalSearch.ts`. Add to both `typeMap` objects and `typeIcons`/`typeLabels`/`pageIcons` in `src/components/layout/command-search.tsx`. |
 | **Page commands** | Add to `PAGE_COMMANDS` in `src/lib/page-commands.ts` for @ navigation. |

--- a/FEATUREDOCS/35-woocommerce-integration.md
+++ b/FEATUREDOCS/35-woocommerce-integration.md
@@ -1,6 +1,6 @@
 # WooCommerce Integration
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-23 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-26 (review quarterly — POLICY.md R-5.5)_
 
 Automatically creates RVLT Flow projects from WooCommerce orders via webhook.
 
@@ -51,7 +51,14 @@ behavior); only the fields this integration actually reads are modeled.
    - `custom_field` — Meta field value → Model.id
    - `name` — Product name → Model.name (case-insensitive contains)
 4. **Resolve location** — Meta key → fuzzy match existing locations (name + address, substring, bigram), auto-creates VENUE if no match
-5. **Create project** — With client, dates, location, line items (EQUIPMENT for matched, MISC for unmatched)
+5. **Create project** — With client, dates, location, line items (EQUIPMENT for matched, MISC for unmatched). Also
+   seeds `discountPercent` from the matched/created client's `Client.defaultDiscount` when set (QW-4 / #953) — this
+   path builds the project directly (`api.projects.createWithUniqueNumber` / `wooCommerceInternal.
+   createProjectWithUniqueNumber`, both plain inserts) rather than through `projectWrites.createNative`, so it
+   doesn't get that mutation's in-mutation discount cascade for free; `resolveWooDiscountPercent`
+   (`src/lib/woocommerce-utils.ts`, verbatim-copied into `convex/wooCommerceActions.ts` — Convex can't import from
+   `src/`) is the shared one-liner both copies call. A snapshot, not a live link — see the Project Wizard section
+   in FEATUREDOCS/10 for the same semantics on the manual-create path.
 6. **Recalculate totals**, log activity, notify configured users
 
 ### Client Matching Strategy
@@ -88,7 +95,7 @@ Location meta key configured?
 | `convex/schema.ts` | `wooCommerceIntegrations`, `wooCommerceOrderLogs` tables, `Model.sku` field (moved here from Prisma in the Convex-native domain migration; only a vestigial `WooOrderLogStatus` enum remains in `prisma/schema.prisma`) |
 | `convex/wooCommerceIntegrations.ts`, `convex/wooCommerceOrderLogs.ts`, `convex/wooCommerceActions.ts`, `convex/wooCommerceInternal.ts` | Convex queries/mutations/actions backing the integration + order log |
 | `src/server/woocommerce.ts` | Server actions (still `"use server"`, reading/writing via the Convex client above) + `processWooCommerceOrder` background processor |
-| `src/lib/woocommerce-utils.ts` | `verifyWebhookSignature` (HMAC-SHA256), `flexibleDateParse` (multi-format) |
+| `src/lib/woocommerce-utils.ts` | `verifyWebhookSignature` (HMAC-SHA256), `flexibleDateParse` (multi-format), `resolveWooDiscountPercent` (QW-4 discount seed) |
 | `src/lib/validations/woocommerce.ts` | Zod schema for settings form (`wooCommerceIntegrationSchema`) + the webhook trust-boundary schema (`wooOrderSchema`) that `WooOrder` is `z.infer`'d from |
 | `src/app/api/integrations/woocommerce/webhook/route.ts` | POST webhook endpoint (public, in middleware allowlist) |
 | `src/app/(app)/settings/woocommerce/page.tsx` | Settings UI (enable/disable, connection, matching, dates, location, defaults, setup guide, order log) |

--- a/FEATUREDOCS/37-check-items.md
+++ b/FEATUREDOCS/37-check-items.md
@@ -112,6 +112,11 @@ still server actions in `src/server/check-records.ts`. The five `completeCheckAn
 ### Ad-Hoc Check
 
 - **Route** (`/check/[assetTag]`): Standalone page to check any asset outside a project.
+- **Audio feedback**: Uses the shared `useScanFeedback` hook (`@/hooks/use-scan-feedback`,
+  see FEATUREDOCS/12 §"Scan Feedback (Audio)" and FEATUREDOCS/14 §"Audio / Scan Feedback")
+  with a `<ScanAudioToggle>` in the page header. `exception` plays once when the tag lookup
+  resolves and the asset isn't found (unknown tag); `submitMutation` plays `success` on save
+  and `error` on failure.
 
 ## Check Queue
 

--- a/FEATUREDOCS/50-project-tasks.md
+++ b/FEATUREDOCS/50-project-tasks.md
@@ -3,7 +3,8 @@
 > _Owner: Jayden Nawotka · Last reviewed: 2026-07-23 (review quarterly — POLICY.md R-5.5)_
 
 Per-project task lists so operators can track project work inside RVLT Flow instead of
-external tools (Asana, Slack threads). Each project gets a **Tasks** tab.
+external tools (Asana, Slack threads). Each project gets a **Tasks** tab, and every user gets
+a cross-project **`/my-tasks`** view of everything currently assigned to them (see below).
 
 ## Data model
 `ProjectTask` (`project_task`):
@@ -18,7 +19,9 @@ external tools (Asana, Slack threads). Each project gets a **Tasks** tab.
   user OR a crew member. Both FKs are `onDelete: SetNull` so deleting the person keeps the task.
 - `createdById?`, `completedAt?` (set when status enters `DONE`, cleared when it leaves)
 
-Indexes: `(organizationId, projectId)`, `(projectId, status)`, `(assigneeUserId, status)`.
+Indexes: `(organizationId, projectId)`, `(projectId, status)`, `(assigneeUserId, status)`,
+`(assigneeCrewId, status)` (added for `myOpenTasks`, below — mirrors the user-id index so a
+crew-assigned task's open status can be range-scanned the same way).
 Migration: `20260606000000_project_tasks`.
 
 ## Convex functions (formerly `src/server/project-tasks.ts`, now deleted)
@@ -41,9 +44,17 @@ Reads in [`convex/projectTasks.ts`](../convex/projectTasks.ts); browser-direct w
   its index, scoped to org (a foreign id can't be reordered in). Still `requireService`-gated
   (not yet browser-direct) and has no production caller — matches the "Drag-and-drop reordering"
   follow-up below; only exercised by `convex/review2Bulk.test.ts`.
-- ⚠️ `getMyOpenTasks(limit)` (cross-project "my tasks" read for a user-centric home screen) could
-  not be found anywhere in current code — it appears to have never shipped, or was removed.
-  Treat that line as aspirational/stale.
+- `myOpenTasks(orgId, now)` — cross-project "my tasks" read (#952 / QW-3), backing both
+  `/my-tasks` and the dashboard's tasks-due block (see [FEATUREDOCS/06](./06-pages-layouts.md)
+  and the dashboard section of `DESIGN.md`). `requireOrgRead` + a user token (mirrors
+  `dashboardLists.blocking`'s auth shape rather than inventing a new one). Union of this user's
+  directly-assigned OPEN tasks (`by_assigneeUserId_status`) and their crew-assigned OPEN tasks
+  (`by_assigneeCrewId_status`, crew ids resolved via `crewMembers.by_userId`), de-duped by task
+  id. Both source indexes are GLOBAL (span every org) — every row is re-checked against `orgId`
+  in-handler before use. Sorted overdue → due asc (undated last) → priority, bounded to 100.
+  `now` is client-passed and minute-bucketed (dashboard convention — Convex queries can't read
+  the clock); dates come back epoch-ms, not the ISO strings `listByProjectWithRelations` returns.
+  Tests: `convex/projectTasks.myOpenTasks.test.ts`.
 
 Every mutation writes its own audit row via `writeActivityLog` (Convex's `logActivity` counterpart)
 with `entityType: "ProjectTask"` and the `projectId`.
@@ -55,6 +66,22 @@ in-progress dot → done check), priority dot, due-date badge (red when overdue 
 checklist progress (`n/m`), and assignee avatar. A row dropdown edits, advances status, or deletes.
 The edit dialog covers title, description, status, priority, due date, assignee (ComboboxPicker
 of users + crew), and an inline checklist editor.
+
+## My tasks (`src/app/(app)/my-tasks/page.tsx`)
+A cross-project, personal-scope view: every open task assigned to the current user (directly
+or via their crew record), backed by `myOpenTasks` above. Bespoke card list (mobile-first, one
+column — not a `DataTable`), grouped by due bucket in this order: **Overdue / Today / This week
+/ Later** (undated tasks fall into Later). Each row shows a status-cycle icon (TODO → IN_PROGRESS
+→ DONE, same cycle as `tasks-panel.tsx`), priority dot, due badge (red when overdue), and a link
+through to the task's project. The status-cycle button is only interactive when
+`useCanDo("project", "update")` is true — viewer/warehouse roles get a static (non-clickable)
+icon instead, consistent with the read-only treatment elsewhere. Zero open tasks renders a
+`FlowMascot` all-clear empty state (personality allowed there — it's a true zero-state — but
+never inside the Overdue group itself, per DESIGN.md §9's ban on personality in overdue/alert
+copy). Registered in the sidebar RAIL (directly under Dashboard, no resource gate — personal
+scope, not an org resource) and in `PAGE_COMMANDS` (`searchable: false`). **Sidebar-only** — not
+in the mobile bottom nav, which stays the 5 daily-operator workflows (DESIGN.md §16).
+Test: `src/app/(app)/my-tasks/__tests__/page.smoke.test.tsx`.
 
 ## Follow-ups (deferred)
 - **Notifications on assignment / due date.** The notification system exists

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -115,6 +115,7 @@ import type * as lib_recalc from "../lib/recalc.js";
 import type * as lib_reservationConflicts from "../lib/reservationConflicts.js";
 import type * as lib_sanitizeSet from "../lib/sanitizeSet.js";
 import type * as lib_searchScore from "../lib/searchScore.js";
+import type * as lib_serviceCost from "../lib/serviceCost.js";
 import type * as lib_shardedCounter from "../lib/shardedCounter.js";
 import type * as lib_subHireLineGen from "../lib/subHireLineGen.js";
 import type * as lib_subHireOrderCounter from "../lib/subHireOrderCounter.js";
@@ -330,6 +331,7 @@ declare const fullApi: ApiFromModules<{
   "lib/reservationConflicts": typeof lib_reservationConflicts;
   "lib/sanitizeSet": typeof lib_sanitizeSet;
   "lib/searchScore": typeof lib_searchScore;
+  "lib/serviceCost": typeof lib_serviceCost;
   "lib/shardedCounter": typeof lib_shardedCounter;
   "lib/subHireLineGen": typeof lib_subHireLineGen;
   "lib/subHireOrderCounter": typeof lib_subHireOrderCounter;

--- a/convex/projectTasks.myOpenTasks.test.ts
+++ b/convex/projectTasks.myOpenTasks.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+//
+// convex/projectTasks.myOpenTasks — cross-project "my tasks" read (#952 / QW-3).
+// Verifies: union of user-assigned + crew-assigned OPEN tasks, de-dup, org
+// isolation (global-index cross-tenant guard), bound + sort (overdue → due asc
+// → undated last → priority), and minute-bucketed `now` driving the overdue flag.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER_ORG = "org_2";
+const USER = "user_1";
+const asUser = (orgId: string) => ({ subject: USER, orgId });
+const NOW = 1_700_000_000_000;
+const DAY = 86_400_000;
+
+async function baseSeed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role: "manager" });
+    await ctx.db.insert("users", { id: USER, name: "Alice", email: "a@x.com" });
+    await ctx.db.insert("projects", { id: "P1", organizationId: ORG, projectNumber: "P1", name: "Gig One", status: "CONFIRMED", isTemplate: false });
+    await ctx.db.insert("projects", { id: "P2", organizationId: ORG, projectNumber: "P2", name: "Gig Two", status: "CONFIRMED", isTemplate: false });
+  });
+}
+
+describe("projectTasks.myOpenTasks", () => {
+  test("returns the user's directly-assigned open tasks, excludes DONE and other users", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectTasks", { id: "t1", organizationId: ORG, projectId: "P1", title: "My todo", status: "TODO", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "t2", organizationId: ORG, projectId: "P1", title: "My in progress", status: "IN_PROGRESS", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "t3", organizationId: ORG, projectId: "P1", title: "My done", status: "DONE", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "t4", organizationId: ORG, projectId: "P1", title: "Someone else's", status: "TODO", assigneeUserId: "user_9" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW });
+    expect(res.map((r) => r.id).sort()).toEqual(["t1", "t2"]);
+    expect(res.every((r) => r.status !== "DONE")).toBe(true);
+  });
+
+  test("unions in crew-assigned open tasks for a user who is also a crew member", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("crewMembers", { id: "crew_1", organizationId: ORG, firstName: "Alice", lastName: "Crew", userId: USER, status: "ACTIVE" });
+      await ctx.db.insert("projectTasks", { id: "t1", organizationId: ORG, projectId: "P1", title: "Directly assigned", status: "TODO", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "t2", organizationId: ORG, projectId: "P2", title: "Crew assigned", status: "IN_PROGRESS", assigneeCrewId: "crew_1" });
+      // A different crew member's task must not leak in.
+      await ctx.db.insert("crewMembers", { id: "crew_2", organizationId: ORG, firstName: "Other", lastName: "Crew", status: "ACTIVE" });
+      await ctx.db.insert("projectTasks", { id: "t3", organizationId: ORG, projectId: "P2", title: "Other crew", status: "TODO", assigneeCrewId: "crew_2" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW });
+    expect(res.map((r) => r.id).sort()).toEqual(["t1", "t2"]);
+    const crewTask = res.find((r) => r.id === "t2")!;
+    expect(crewTask.projectName).toBe("Gig Two");
+    expect(crewTask.projectNumber).toBe("P2");
+  });
+
+  test("a user linked to multiple crew records never surfaces a duplicate task id", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      // Two crew records resolve to the same user (e.g. re-hired under a new
+      // crew row) — the union walks both, so the de-dup Map must still land on
+      // exactly one row per task id, with no duplicates in the final list.
+      await ctx.db.insert("crewMembers", { id: "crew_1", organizationId: ORG, firstName: "Alice", lastName: "Crew", userId: USER, status: "ACTIVE" });
+      await ctx.db.insert("crewMembers", { id: "crew_2", organizationId: ORG, firstName: "Alice2", lastName: "Crew2", userId: USER, status: "ACTIVE" });
+      await ctx.db.insert("projectTasks", { id: "t1", organizationId: ORG, projectId: "P1", title: "Directly assigned", status: "TODO", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "t2", organizationId: ORG, projectId: "P1", title: "Crew 1 task", status: "TODO", assigneeCrewId: "crew_1" });
+      await ctx.db.insert("projectTasks", { id: "t3", organizationId: ORG, projectId: "P1", title: "Crew 2 task", status: "IN_PROGRESS", assigneeCrewId: "crew_2" });
+    });
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW });
+    const ids = res.map((r) => r.id);
+    expect(ids.sort()).toEqual(["t1", "t2", "t3"]);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicates
+  });
+
+  test("org isolation: a same-id assignee in another org never leaks across the global index", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("members", { id: "m2", organizationId: OTHER_ORG, userId: USER, role: "manager" });
+      await ctx.db.insert("projects", { id: "P9", organizationId: OTHER_ORG, projectNumber: "P9", name: "Foreign gig", status: "CONFIRMED", isTemplate: false });
+      await ctx.db.insert("projectTasks", { id: "t1", organizationId: ORG, projectId: "P1", title: "In org", status: "TODO", assigneeUserId: USER });
+      await ctx.db.insert("projectTasks", { id: "tForeign", organizationId: OTHER_ORG, projectId: "P9", title: "Foreign", status: "TODO", assigneeUserId: USER });
+    });
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW });
+    expect(res.map((r) => r.id)).toEqual(["t1"]);
+
+    const resOther = await t.withIdentity(asUser(OTHER_ORG)).query(api.projectTasks.myOpenTasks, { orgId: OTHER_ORG, now: NOW });
+    expect(resOther.map((r) => r.id)).toEqual(["tForeign"]);
+  });
+
+  test("rejects an org mismatch between the caller's token and the requested orgId", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await expect(
+      t.withIdentity(asUser(OTHER_ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW }),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  test("bounds to 100 and sorts overdue → due asc → undated last → priority", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      // Undated, normal priority.
+      await ctx.db.insert("projectTasks", { id: "undated", organizationId: ORG, projectId: "P1", title: "Undated", status: "TODO", assigneeUserId: USER });
+      // Due in the future, two tasks same day — HIGH before NORMAL.
+      await ctx.db.insert("projectTasks", { id: "future-normal", organizationId: ORG, projectId: "P1", title: "Future normal", status: "TODO", assigneeUserId: USER, dueDate: NOW + 3 * DAY, priority: "NORMAL" });
+      await ctx.db.insert("projectTasks", { id: "future-high", organizationId: ORG, projectId: "P1", title: "Future high", status: "TODO", assigneeUserId: USER, dueDate: NOW + 3 * DAY, priority: "HIGH" });
+      // Overdue.
+      await ctx.db.insert("projectTasks", { id: "overdue", organizationId: ORG, projectId: "P1", title: "Overdue", status: "TODO", assigneeUserId: USER, dueDate: NOW - DAY });
+      // 100 filler tasks to exercise the bound.
+      for (let i = 0; i < 100; i++) {
+        await ctx.db.insert("projectTasks", { id: `filler-${i}`, organizationId: ORG, projectId: "P1", title: `Filler ${i}`, status: "TODO", assigneeUserId: USER, dueDate: NOW + (10 + i) * DAY });
+      }
+    });
+    const res = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW });
+    expect(res).toHaveLength(100); // bounded — 104 candidates exist
+    expect(res[0].id).toBe("overdue");
+    expect(res[0].overdue).toBe(true);
+    expect(res[1].id).toBe("future-high"); // same due date as future-normal, HIGH sorts first
+    expect(res[2].id).toBe("future-normal");
+    // Undated tasks sort last; with 104 candidates bounded to 100, the undated
+    // filler-heavy tail means "undated" itself may be trimmed — assert the
+    // ordering invariant instead of its literal presence.
+    const dueDates = res.map((r) => r.dueDate).filter((d): d is number => d != null);
+    expect(dueDates).toEqual([...dueDates].sort((a, b) => a - b));
+  });
+
+  test("computes overdue against the client-passed `now`, not server time", async () => {
+    const t = convexTest(schema, modules);
+    await baseSeed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectTasks", { id: "t1", organizationId: ORG, projectId: "P1", title: "Borderline", status: "TODO", assigneeUserId: USER, dueDate: NOW });
+    });
+    const before = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW - 1 });
+    expect(before[0].overdue).toBe(false); // dueDate (NOW) is not < now (NOW - 1)
+    const after = await t.withIdentity(asUser(ORG)).query(api.projectTasks.myOpenTasks, { orgId: ORG, now: NOW + 1 });
+    expect(after[0].overdue).toBe(true); // dueDate (NOW) < now (NOW + 1)
+  });
+});

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -155,6 +155,94 @@ async function resolveCrewIdsForUser(ctx: QueryCtx, userId: string, orgId: strin
   return crewLinks.filter((c) => c.organizationId === orgId).map((c) => c.id);
 }
 
+/**
+ * Union across both assignee shapes × both open statuses, de-duped by id (a
+ * task is assigned to a user XOR a crew record, never both, but the union
+ * itself needs the guard since it's built from several disjoint scans).
+ */
+async function collectMyOpenTasks(
+  ctx: QueryCtx,
+  userId: string,
+  crewIds: string[],
+  orgId: string,
+): Promise<Map<string, MyOpenTaskDoc>> {
+  const byId = new Map<string, MyOpenTaskDoc>();
+  const keep = (r: MyOpenTaskDoc) => {
+    if (r.organizationId !== orgId) return; // global index — org re-check
+    byId.set(r.id, r);
+  };
+  for (const status of OPEN_TASK_STATUSES) {
+    const userRows = await ctx.db
+      .query("projectTasks")
+      .withIndex("by_assigneeUserId_status", (q) => q.eq("assigneeUserId", userId).eq("status", status))
+      .collect();
+    for (const r of userRows) keep(r as unknown as MyOpenTaskDoc);
+
+    for (const crewId of crewIds) {
+      const crewRows = await ctx.db
+        .query("projectTasks")
+        .withIndex("by_assigneeCrewId_status", (q) => q.eq("assigneeCrewId", crewId).eq("status", status))
+        .collect();
+      for (const r of crewRows) keep(r as unknown as MyOpenTaskDoc);
+    }
+  }
+  return byId;
+}
+
+/**
+ * Sort: overdue → due asc (undated last) → priority. A single ascending sort
+ * on dueDate (undated = +Infinity) already puts overdue tasks first (their
+ * due date is the smallest, being in the past) and undated tasks last;
+ * priority breaks ties within the same due date.
+ */
+function sortMyOpenTasks(tasks: MyOpenTaskDoc[]): MyOpenTaskDoc[] {
+  return [...tasks].sort((a, b) => {
+    const aDue = a.dueDate ?? Infinity;
+    const bDue = b.dueDate ?? Infinity;
+    if (aDue !== bDue) return aDue - bDue;
+    const aPri = PRIORITY_SORT_WEIGHT[a.priority ?? "NORMAL"] ?? 1;
+    const bPri = PRIORITY_SORT_WEIGHT[b.priority ?? "NORMAL"] ?? 1;
+    return aPri - bPri;
+  });
+}
+
+/** Per-task project join {projectName, projectNumber} via point-reads. */
+async function resolveProjectsFor(
+  ctx: QueryCtx,
+  tasks: MyOpenTaskDoc[],
+): Promise<Map<string, { name: string; projectNumber: string }>> {
+  const projectIds = [...new Set(tasks.map((t) => t.projectId))];
+  const projects = new Map<string, { name: string; projectNumber: string }>();
+  await Promise.all(
+    projectIds.map(async (pid) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique();
+      if (p) projects.set(pid, { name: p.name, projectNumber: p.projectNumber });
+    }),
+  );
+  return projects;
+}
+
+function serializeMyOpenTask(
+  t: MyOpenTaskDoc,
+  projects: Map<string, { name: string; projectNumber: string }>,
+  now: number,
+) {
+  const project = projects.get(t.projectId) ?? { name: "", projectNumber: "" };
+  return {
+    id: t.id,
+    title: t.title,
+    status: t.status ?? "TODO",
+    priority: t.priority ?? "NORMAL",
+    dueDate: t.dueDate ?? null,
+    overdue: t.dueDate != null && t.dueDate < now,
+    projectId: t.projectId,
+    projectName: project.name,
+    projectNumber: project.projectNumber,
+    assigneeUserId: t.assigneeUserId ?? null,
+    assigneeCrewId: t.assigneeCrewId ?? null,
+  };
+}
+
 export const myOpenTasks = query({
   args: { orgId: v.string(), now: v.number() },
   handler: async (ctx, { orgId, now }) => {
@@ -164,75 +252,11 @@ export const myOpenTasks = query({
     const userId = auth.userId;
 
     const crewIds = await resolveCrewIdsForUser(ctx, userId, orgId);
+    const byId = await collectMyOpenTasks(ctx, userId, crewIds, orgId);
+    const bounded = sortMyOpenTasks([...byId.values()]).slice(0, MY_OPEN_TASKS_LIMIT);
+    const projects = await resolveProjectsFor(ctx, bounded);
 
-    // Union across both assignee shapes × both open statuses, de-duped by id
-    // (a task is assigned to a user XOR a crew record, never both, but the
-    // union itself needs the guard since it's built from several disjoint scans).
-    const byId = new Map<string, MyOpenTaskDoc>();
-    for (const status of OPEN_TASK_STATUSES) {
-      const userRows = await ctx.db
-        .query("projectTasks")
-        .withIndex("by_assigneeUserId_status", (q) => q.eq("assigneeUserId", userId).eq("status", status))
-        .collect();
-      for (const r of userRows) {
-        const row = r as unknown as MyOpenTaskDoc;
-        if (row.organizationId !== orgId) continue; // global index — org re-check
-        byId.set(row.id, row);
-      }
-      for (const crewId of crewIds) {
-        const crewRows = await ctx.db
-          .query("projectTasks")
-          .withIndex("by_assigneeCrewId_status", (q) => q.eq("assigneeCrewId", crewId).eq("status", status))
-          .collect();
-        for (const r of crewRows) {
-          const row = r as unknown as MyOpenTaskDoc;
-          if (row.organizationId !== orgId) continue; // global index — org re-check
-          byId.set(row.id, row);
-        }
-      }
-    }
-
-    // Sort: overdue → due asc (undated last) → priority. A single ascending
-    // sort on dueDate (undated = +Infinity) already puts overdue tasks first
-    // (their due date is the smallest, being in the past) and undated tasks
-    // last; priority breaks ties within the same due date.
-    const tasks = [...byId.values()];
-    tasks.sort((a, b) => {
-      const aDue = a.dueDate ?? Infinity;
-      const bDue = b.dueDate ?? Infinity;
-      if (aDue !== bDue) return aDue - bDue;
-      const aPri = PRIORITY_SORT_WEIGHT[a.priority ?? "NORMAL"] ?? 1;
-      const bPri = PRIORITY_SORT_WEIGHT[b.priority ?? "NORMAL"] ?? 1;
-      return aPri - bPri;
-    });
-    const bounded = tasks.slice(0, MY_OPEN_TASKS_LIMIT);
-
-    // Per-task project join {projectName, projectNumber} via point-reads.
-    const projectIds = [...new Set(bounded.map((t) => t.projectId))];
-    const projects = new Map<string, { name: string; projectNumber: string }>();
-    await Promise.all(
-      projectIds.map(async (pid) => {
-        const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique();
-        if (p) projects.set(pid, { name: p.name, projectNumber: p.projectNumber });
-      }),
-    );
-
-    return bounded.map((t) => {
-      const project = projects.get(t.projectId);
-      return {
-        id: t.id,
-        title: t.title,
-        status: t.status ?? "TODO",
-        priority: t.priority ?? "NORMAL",
-        dueDate: t.dueDate ?? null,
-        overdue: t.dueDate != null && t.dueDate < now,
-        projectId: t.projectId,
-        projectName: project?.name ?? "",
-        projectNumber: project?.projectNumber ?? "",
-        assigneeUserId: t.assigneeUserId ?? null,
-        assigneeCrewId: t.assigneeCrewId ?? null,
-      };
-    });
+    return bounded.map((t) => serializeMyOpenTask(t, projects, now));
   },
 });
 

--- a/convex/projectTasks.ts
+++ b/convex/projectTasks.ts
@@ -1,6 +1,7 @@
 import { v, ConvexError } from "convex/values";
 import { query, mutation } from "./_generated/server";
-import { requireOrgRead, requireOrgReadDoc, requireService } from "./lib/auth";
+import type { QueryCtx } from "./_generated/server";
+import { requireOrgRead, requireOrgReadDoc, requireService, getAuthContext } from "./lib/auth";
 import * as enums from "./lib/validators";
 
 /**
@@ -116,6 +117,122 @@ export const listByProjectWithRelations = query({
       });
     }
     return out;
+  },
+});
+
+// ─── myOpenTasks — cross-project "my tasks" read (#952 / QW-3) ────────────
+// Union of this user's directly-assigned OPEN tasks (by_assigneeUserId_status)
+// and their crew-assigned OPEN tasks (by_assigneeCrewId_status, resolved via
+// crewMembers.by_userId), de-duped, org-filtered, sorted, and bounded. Mirrors
+// dashboardLists.blocking's auth shape (requireOrgRead + getAuthContext user
+// token) rather than inventing a new one. `by_assigneeUserId_status` and
+// `by_assigneeCrewId_status` are GLOBAL indexes (span every org), so every row
+// pulled through them is re-checked against `orgId` before use — the
+// cross-tenant-read footgun called out in CLAUDE.md.
+const OPEN_TASK_STATUSES = ["TODO", "IN_PROGRESS"] as const;
+const PRIORITY_SORT_WEIGHT: Record<string, number> = { HIGH: 0, NORMAL: 1, LOW: 2 };
+const MY_OPEN_TASKS_LIMIT = 100;
+
+type MyOpenTaskDoc = {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  title: string;
+  status?: string;
+  priority?: string;
+  dueDate?: number;
+  assigneeUserId?: string;
+  assigneeCrewId?: string;
+};
+
+async function resolveCrewIdsForUser(ctx: QueryCtx, userId: string, orgId: string): Promise<string[]> {
+  // by_userId is global — a person can hold crew records in more than one org
+  // (or none), so filter to the caller's org before trusting any id.
+  const crewLinks = await ctx.db
+    .query("crewMembers")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+  return crewLinks.filter((c) => c.organizationId === orgId).map((c) => c.id);
+}
+
+export const myOpenTasks = query({
+  args: { orgId: v.string(), now: v.number() },
+  handler: async (ctx, { orgId, now }) => {
+    await requireOrgRead(ctx, orgId);
+    const auth = await getAuthContext(ctx);
+    if (!auth || auth.kind !== "user") throw new ConvexError("Unauthorized: user token required.");
+    const userId = auth.userId;
+
+    const crewIds = await resolveCrewIdsForUser(ctx, userId, orgId);
+
+    // Union across both assignee shapes × both open statuses, de-duped by id
+    // (a task is assigned to a user XOR a crew record, never both, but the
+    // union itself needs the guard since it's built from several disjoint scans).
+    const byId = new Map<string, MyOpenTaskDoc>();
+    for (const status of OPEN_TASK_STATUSES) {
+      const userRows = await ctx.db
+        .query("projectTasks")
+        .withIndex("by_assigneeUserId_status", (q) => q.eq("assigneeUserId", userId).eq("status", status))
+        .collect();
+      for (const r of userRows) {
+        const row = r as unknown as MyOpenTaskDoc;
+        if (row.organizationId !== orgId) continue; // global index — org re-check
+        byId.set(row.id, row);
+      }
+      for (const crewId of crewIds) {
+        const crewRows = await ctx.db
+          .query("projectTasks")
+          .withIndex("by_assigneeCrewId_status", (q) => q.eq("assigneeCrewId", crewId).eq("status", status))
+          .collect();
+        for (const r of crewRows) {
+          const row = r as unknown as MyOpenTaskDoc;
+          if (row.organizationId !== orgId) continue; // global index — org re-check
+          byId.set(row.id, row);
+        }
+      }
+    }
+
+    // Sort: overdue → due asc (undated last) → priority. A single ascending
+    // sort on dueDate (undated = +Infinity) already puts overdue tasks first
+    // (their due date is the smallest, being in the past) and undated tasks
+    // last; priority breaks ties within the same due date.
+    const tasks = [...byId.values()];
+    tasks.sort((a, b) => {
+      const aDue = a.dueDate ?? Infinity;
+      const bDue = b.dueDate ?? Infinity;
+      if (aDue !== bDue) return aDue - bDue;
+      const aPri = PRIORITY_SORT_WEIGHT[a.priority ?? "NORMAL"] ?? 1;
+      const bPri = PRIORITY_SORT_WEIGHT[b.priority ?? "NORMAL"] ?? 1;
+      return aPri - bPri;
+    });
+    const bounded = tasks.slice(0, MY_OPEN_TASKS_LIMIT);
+
+    // Per-task project join {projectName, projectNumber} via point-reads.
+    const projectIds = [...new Set(bounded.map((t) => t.projectId))];
+    const projects = new Map<string, { name: string; projectNumber: string }>();
+    await Promise.all(
+      projectIds.map(async (pid) => {
+        const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", pid)).unique();
+        if (p) projects.set(pid, { name: p.name, projectNumber: p.projectNumber });
+      }),
+    );
+
+    return bounded.map((t) => {
+      const project = projects.get(t.projectId);
+      return {
+        id: t.id,
+        title: t.title,
+        status: t.status ?? "TODO",
+        priority: t.priority ?? "NORMAL",
+        dueDate: t.dueDate ?? null,
+        overdue: t.dueDate != null && t.dueDate < now,
+        projectId: t.projectId,
+        projectName: project?.name ?? "",
+        projectNumber: project?.projectNumber ?? "",
+        assigneeUserId: t.assigneeUserId ?? null,
+        assigneeCrewId: t.assigneeCrewId ?? null,
+      };
+    });
   },
 });
 

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -411,6 +411,63 @@ describe("projectWrites.createNative", () => {
       t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, clientId: "foreign-client" } as typeof cargs),
     ).rejects.toThrow(/not found in your organization/i);
   });
+
+  // QW-4 (#953) — discount cascade: a new project with a client and no explicit
+  // discountPercent snapshots the client's defaultDiscount at create time.
+  describe("discount cascade (client.defaultDiscount)", () => {
+    async function seedClient(t: ReturnType<typeof convexTest>, id: string, defaultDiscount?: number) {
+      await t.run(async (ctx) => {
+        await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" });
+        await ctx.db.insert("clients", { id, organizationId: ORG, name: "Acme Co", defaultDiscount, createdAt: NOW, updatedAt: NOW });
+      });
+    }
+
+    test("default applied: no discountPercent supplied → stamps the client's defaultDiscount", async () => {
+      const t = makeT();
+      await seedClient(t, "c1", 15);
+      await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, clientId: "c1" } as typeof cargs);
+      const p = await t.run((ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first());
+      expect(p?.discountPercent).toBe(15);
+    });
+
+    test("explicit value wins: caller's discountPercent overrides the client default", async () => {
+      const t = makeT();
+      await seedClient(t, "c1", 15);
+      await t.withIdentity(asUser(ORG)).mutation(
+        api.projectWrites.createNative,
+        { ...cargs, clientId: "c1", discountPercent: 5 } as typeof cargs,
+      );
+      const p = await t.run((ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first());
+      expect(p?.discountPercent).toBe(5);
+    });
+
+    test("explicit 0 wins: an explicit 0% discount is NOT overwritten by the client default (no truthiness bug)", async () => {
+      const t = makeT();
+      await seedClient(t, "c1", 15);
+      await t.withIdentity(asUser(ORG)).mutation(
+        api.projectWrites.createNative,
+        { ...cargs, clientId: "c1", discountPercent: 0 } as typeof cargs,
+      );
+      const p = await t.run((ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first());
+      expect(p?.discountPercent).toBe(0);
+    });
+
+    test("no client → no default applied (discountPercent stays unset)", async () => {
+      const t = makeT();
+      await t.run(async (ctx) => { await ctx.db.insert("members", { id: "m", organizationId: ORG, userId: USER, role: "member" }); });
+      await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, cargs);
+      const p = await t.run((ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first());
+      expect(p?.discountPercent).toBeUndefined();
+    });
+
+    test("client with no defaultDiscount set → discountPercent stays unset", async () => {
+      const t = makeT();
+      await seedClient(t, "c1", undefined);
+      await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.createNative, { ...cargs, clientId: "c1" } as typeof cargs);
+      const p = await t.run((ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "np1")).first());
+      expect(p?.discountPercent).toBeUndefined();
+    });
+  });
 });
 
 describe("projectWrites.deleteNative", () => {

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -479,6 +479,24 @@ export const createNative = mutation({
       await assertRefInOrg(ctx, "locations", fields.locationId, fields.organizationId);
     }
 
+    // Discount cascade (#953 / QW-4): when the caller doesn't pass an explicit
+    // discountPercent, snapshot the client's `defaultDiscount` onto the project
+    // AT CREATE TIME (server-authoritative, R-9.3 — never trust a client-computed
+    // discount). `== null` (not falsy) is deliberate: an explicit 0% discount is a
+    // real caller choice and must win over the client default, never be silently
+    // overwritten by it (the lineItemWrites.ts `unitPrice == null` lesson — see the
+    // auto-pricing comment there for the truthiness bug this avoids). This is a
+    // ONE-TIME snapshot: reassigning the project's client later does NOT
+    // retroactively recompute discountPercent — updateNative has no equivalent
+    // cascade, by design.
+    let discountPercent = fields.discountPercent;
+    if (discountPercent == null && fields.clientId) {
+      const client = await ctx.db.query("clients").withIndex("by_cuid", (q) => q.eq("id", fields.clientId!)).first();
+      if (client && client.organizationId === fields.organizationId && client.defaultDiscount != null) {
+        discountPercent = client.defaultDiscount;
+      }
+    }
+
     // Dup-guard the client-minted cuid first (applies to both number paths). The
     // projectNumber clash-guard below is org-scoped and doesn't catch a cross-org
     // cuid collision. THROW (not the `{created:false}` number-clash signal, which
@@ -538,7 +556,7 @@ export const createNative = mutation({
     // mint a project with forged financials (projectWriteFields exposes them as args).
     // Non-breaking: createProject never sends these. (bumpProjectCounters keys off
     // status/isTemplate, not money, so it's unaffected by the strip.)
-    const insertFields = { ...fields, projectNumber };
+    const insertFields = { ...fields, projectNumber, discountPercent };
     for (const k of PROJECT_MONEY_ANCHORS) delete (insertFields as Record<string, unknown>)[k];
 
     await ctx.db.insert("projects", insertFields);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -854,6 +854,10 @@ export default defineSchema({
     discountAmount: v.optional(v.number()),
     taxAmount: v.optional(v.number()),
     total: v.optional(v.number()),
+    // RESERVED for #940 (WS1 — deposit/invoicing workflow). Hand-typed wizard inputs
+    // today (project-wizard.tsx), applied nowhere server-side — do NOT wire deposit
+    // math or delete these as dead fields in a hygiene pass; #940 owns them. See
+    // issue #953 (QW-4) re-review, which scoped `defaultDiscount` wiring separately.
     depositPercent: v.optional(v.number()),
     depositPaid: v.optional(v.number()),
     invoicedTotal: v.optional(v.number()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2143,7 +2143,8 @@ export default defineSchema({
     .index("by_createdById", ["createdById"])
     .index("by_organizationId_projectId", ["organizationId", "projectId"])
     .index("by_projectId_status", ["projectId", "status"])
-    .index("by_assigneeUserId_status", ["assigneeUserId", "status"]),
+    .index("by_assigneeUserId_status", ["assigneeUserId", "status"])
+    .index("by_assigneeCrewId_status", ["assigneeCrewId", "status"]),
 
   // SavedTableView
   savedTableViews: defineTable({

--- a/convex/wooCommerceActions.ts
+++ b/convex/wooCommerceActions.ts
@@ -140,6 +140,15 @@ function diceCoefficient(a: Set<string>, b: Set<string>): number {
 }
 
 /**
+ * QW-4 (#953) discount seed — copied verbatim from src/lib/woocommerce-utils.ts
+ * (`resolveWooDiscountPercent`). Convex files can't import from src/. Keep both
+ * copies byte-identical on change; see that file's comment for the full rationale.
+ */
+function resolveWooDiscountPercent(client: { defaultDiscount?: number | null }): number | undefined {
+  return client.defaultDiscount != null ? client.defaultDiscount : undefined;
+}
+
+/**
  * Flexible date parse — copied verbatim from src/lib/woocommerce-utils.ts
  * (`flexibleDateParse`). Convex files can't import from src/.
  */
@@ -287,6 +296,10 @@ type ClientDoc = {
   type?: string;
   contactEmail?: string;
   isActive?: boolean;
+  // QW-4 (#953): needed to seed a new Woo-order project's discountPercent (see
+  // buildProjectArgs below) — this path creates projects directly, bypassing
+  // projectWrites.createNative's own defaultDiscount cascade.
+  defaultDiscount?: number;
 };
 
 /**
@@ -668,6 +681,12 @@ export const processOrder = internalAction({
         : `${order.billing.first_name} ${order.billing.last_name} — Website Order #${order.number || order.id}`;
       const clientNotes = extractNotes(order, integration);
       const projectCreatedAt = Date.now();
+      // QW-4 (#953): seed the discount cascade here too — this path creates the
+      // project via createProjectWithUniqueNumber (a plain insert), which does
+      // NOT run projectWrites.createNative's in-mutation defaultDiscount lookup.
+      // A snapshot, not a live link (see the "no retroactive change" note on
+      // createNative).
+      const wooDiscountPercent = resolveWooDiscountPercent(client);
       const buildProjectArgs = (num: string) => ({
         id: projectId,
         organizationId: orgId,
@@ -681,6 +700,7 @@ export const processOrder = internalAction({
         ...(dates.rentalEnd ? { rentalEndDate: dates.rentalEnd.getTime() } : {}),
         ...(dates.eventStart ? { eventStartDate: dates.eventStart.getTime() } : {}),
         ...(clientNotes ? { clientNotes } : {}),
+        ...(wooDiscountPercent != null ? { discountPercent: wooDiscountPercent } : {}),
         tags: ["website-order"],
         createdAt: projectCreatedAt,
         updatedAt: projectCreatedAt,

--- a/src/app/(app)/check/[assetTag]/page.tsx
+++ b/src/app/(app)/check/[assetTag]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 // use-client: interactive — React state/effects (client-only) (R-8.1.1)
 
-import { use, useState, useRef } from "react";
+import { use, useState, useRef, useEffect } from "react";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useServerQuery } from "@/hooks/use-server-query";
 import {
@@ -16,6 +16,8 @@ import { useRouter } from "next/navigation";
 
 import { lookupAssetForAdHocCheck } from "@/server/check-records";
 import { useCheckRecordWrites } from "@/hooks/use-check-record-writes";
+import { useScanFeedback } from "@/hooks/use-scan-feedback";
+import { ScanAudioToggle } from "@/components/scan-audio-toggle";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { focusRing } from "@/lib/utils";
 import { RequirePermission } from "@/components/auth/require-permission";
@@ -39,6 +41,7 @@ export default function AdHocCheckPage({
 
   const [completed, setCompleted] = useState(false);
   const checkRecordWrites = useCheckRecordWrites();
+  const scanFeedback = useScanFeedback();
 
   const { data: result, isLoading } = useServerQuery({
     queryKey: ["ad-hoc-lookup", orgId, decodedTag],
@@ -57,6 +60,15 @@ export default function AdHocCheckPage({
     } | null;
   } | undefined;
 
+  // Unknown tag — resolved (we know it's not in the system) but needs the
+  // operator's attention, not a hard error. Fires once per tag lookup.
+  useEffect(() => {
+    if (!isLoading && lookup && !lookup.found) {
+      scanFeedback.play("exception");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, lookup?.found, decodedTag]);
+
   const submitMutation = useServerMutation({
     mutationFn: (checks: Array<{
       checkItemId: string;
@@ -70,21 +82,28 @@ export default function AdHocCheckPage({
         checks,
       }),
     onSuccess: () => {
+      scanFeedback.play("success");
       setCompleted(true);
       toast.success("Ad-hoc check saved");
     },
-    onError: (e) => toast.error(e.message),
+    onError: (e) => {
+      scanFeedback.play("error");
+      toast.error(e.message);
+    },
   });
 
   return (
     <RequirePermission resource="warehouse" action="scan">
       <PageMeta title="Ad-Hoc Check" />
       <div className="mx-auto max-w-xl space-y-6">
-        <div>
-          <h1 className="t-title text-ink">Ad-hoc check</h1>
-          <p className="text-ui-text text-muted mt-1">
-            Perform a quality check on an asset outside of a project.
-          </p>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h1 className="t-title text-ink">Ad-hoc check</h1>
+            <p className="text-ui-text text-muted mt-1">
+              Perform a quality check on an asset outside of a project.
+            </p>
+          </div>
+          <ScanAudioToggle enabled={scanFeedback.enabled} onToggle={scanFeedback.toggle} />
         </div>
 
         {/* Scanner for navigating to different tags */}

--- a/src/app/(app)/dashboard/__tests__/dashboard-reorder.smoke.test.tsx
+++ b/src/app/(app)/dashboard/__tests__/dashboard-reorder.smoke.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// Dashboard reorder (#952 / QW-3): the page now renders three fixed zones in
+// order — My work (On the floor now + MyWorkSection, which owns the tasks-due
+// block and per-project blocker badges), Org risk (needs-attention chips),
+// Demoted (stat tiles / upcoming / activity). The standalone "Blockers needing
+// you" panel that used to sit between the bento board and MyWorkSection is
+// gone — blockers now render in exactly two places (MyWorkSection + the
+// needs-attention chip), not three.
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: { id: "org1" } }),
+}));
+
+const STATS = {
+  totalAssets: 40,
+  checkedOutAssets: 10,
+  activeProjects: 3,
+  activeCrew: 2,
+  pendingCrewOffers: 0,
+  maintenanceDue: 0,
+  overdueReturns: 0,
+  countersReady: true,
+};
+
+const MY_PROJECT = {
+  id: "p1",
+  name: "Live Gig",
+  projectNumber: "260701",
+  status: "CHECKED_OUT",
+  rentalStartDate: "2026-07-01T00:00:00.000Z",
+  rentalEndDate: "2026-07-30T00:00:00.000Z",
+  client: { name: "Acme" },
+  _count: { lineItems: 2 },
+};
+
+const BLOCKER = {
+  threadId: "t1",
+  projectId: "p1",
+  projectName: "Live Gig",
+  projectNumber: "260701",
+  snippet: "Need sign-off",
+  reason: "pm",
+  createdByName: "Jay",
+  createdAt: 1,
+};
+
+const TASK = {
+  id: "task1",
+  title: "Confirm crew call times",
+  status: "TODO",
+  priority: "NORMAL",
+  dueDate: null,
+  overdue: false,
+  projectId: "p1",
+  projectName: "Live Gig",
+  projectNumber: "260701",
+};
+
+vi.mock("@/hooks/use-native-dashboard", () => ({
+  useNativeDashboardStats: () => ({ data: STATS, isLoading: false }),
+  useNativeSubHireStats: () => ({ activeSubHires: 0, monthlySubHireCost: 0, overdueReturns: 0 }),
+  useNativeUpcoming: () => [],
+  useNativeHome: () => ({ userName: "Jayden", userId: "user1", myProjects: [MY_PROJECT] }),
+  useNativeBlocking: () => [BLOCKER],
+  useNativeActivity: () => ({ logs: [], testRecords: [], maintenanceRecords: [] }),
+  useNativeMyOpenTasks: () => [TASK],
+}));
+
+import DashboardPage from "../page";
+
+describe("DashboardPage reorder (smoke)", () => {
+  it("renders zone 1 (My work) before zone 2 (Org risk) before zone 3 (stat tiles)", () => {
+    const { container } = render(<DashboardPage />);
+    const text = container.textContent ?? "";
+    const floorIdx = text.indexOf("On the floor now");
+    const myWorkIdx = text.indexOf("My work");
+    const riskIdx = text.indexOf("Needs attention");
+    const statIdx = text.indexOf("Active jobs");
+
+    expect(floorIdx).toBeGreaterThan(-1);
+    expect(myWorkIdx).toBeGreaterThan(-1);
+    expect(riskIdx).toBeGreaterThan(-1);
+    expect(statIdx).toBeGreaterThan(-1);
+
+    expect(floorIdx).toBeLessThan(myWorkIdx);
+    expect(myWorkIdx).toBeLessThan(riskIdx);
+    expect(riskIdx).toBeLessThan(statIdx);
+  });
+
+  it("does not render a standalone 'Blockers needing you' panel — MyWorkSection owns it now", () => {
+    render(<DashboardPage />);
+    expect(screen.queryByText("Blockers needing you")).toBeNull();
+  });
+
+  it("surfaces the blocker exactly once via MyWorkSection's per-project badge, plus the needs-attention chip", () => {
+    render(<DashboardPage />);
+    // The needs-attention chip.
+    expect(screen.getByText(/blocker.*need you/)).toBeDefined();
+    // MyWorkSection's per-project blocker count badge.
+    expect(screen.getByText("1 blocker")).toBeDefined();
+  });
+
+  it("passes myOpenTasks through to MyWorkSection's tasks-due block", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("Confirm crew call times")).toBeDefined();
+  });
+
+  it("renders the org-risk zone with the needs-attention chips", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("Needs attention")).toBeDefined();
+  });
+});

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import {
   useNativeHome,
   useNativeBlocking,
   useNativeActivity,
+  useNativeMyOpenTasks,
 } from "@/hooks/use-native-dashboard";
 import { useActiveOrganization } from "@/lib/auth-client";
 import {
@@ -17,7 +18,6 @@ import {
   Wrench,
   ArrowRight,
   ShieldAlert,
-  AtSign,
   AlertTriangle,
   UserCheck,
   Plus,
@@ -75,6 +75,15 @@ export default function DashboardPage() {
   const myHome = useNativeHome(orgId) as any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const myBlockers = useNativeBlocking(orgId) as any;
+  const myTasks = useNativeMyOpenTasks(orgId);
+
+  // Delay ladder derived from section index instead of hand-numbered literals
+  // (§ "Dashboard reorder" — the old 0.04/0.05/0.08/0.1/0.12/0.14/0.16 chain
+  // meant inserting a section required renumbering every one after it).
+  // `nextSectionDelay()` is called once per top-level FadeIn'd section below,
+  // in render order, top to bottom.
+  let sectionIndex = 0;
+  const nextSectionDelay = () => 0.04 + 0.04 * sectionIndex++;
 
   const now = new Date();
   const hour = now.getHours();
@@ -121,11 +130,15 @@ export default function DashboardPage() {
         />
       </FadeIn>
 
-      {/* ── Bento board ── */}
-      <div className="grid auto-rows-[minmax(0,auto)] grid-cols-2 gap-3 lg:grid-cols-4">
-        {/* On the floor now — hero tile */}
-        <FadeIn delay={0.04} className="col-span-2 lg:row-span-2">
-          <div className={`${TILE} flex h-full flex-col p-5`}>
+      {/* ══ Zone 1: My work ══
+          "On the floor now" + MyWorkSection (which now owns the tasks-due
+          block and the per-project blocker badges/snippets — the standalone
+          blockers panel that used to sit between the bento board and
+          MyWorkSection is gone; blockers now render in exactly two places:
+          here, and the "needs attention" chip in zone 2 below). */}
+      <div className="space-y-3">
+        <FadeIn delay={nextSectionDelay()}>
+          <div className={`${TILE} flex flex-col p-5`}>
             <div className="mb-3 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 {liveJobs.length > 0 && <LivePulse />}
@@ -136,35 +149,50 @@ export default function DashboardPage() {
             {!myHome ? (
               <div className="space-y-2"><Skeleton className="h-16 w-full rounded-[var(--r)]" /><Skeleton className="h-16 w-full rounded-[var(--r)]" /></div>
             ) : liveJobs.length === 0 ? (
-              <div className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center">
+              <div className="flex flex-col items-center justify-center gap-2 py-6 text-center">
                 <FlowMascot className="h-10 w-10" eyeColor="var(--ok)" />
                 <p className="text-[14px] font-medium text-ink">Nothing out right now</p>
                 <p className="t-micro text-muted">The warehouse is full and calm. Enjoy it.</p>
               </div>
             ) : (
-              <StaggerList className="flex flex-col gap-2">
+              <StaggerList className="flex flex-col gap-2 sm:grid sm:grid-cols-2">
                 {liveJobs.slice(0, 4).map((p) => (<StaggerItem key={p.id as string}><LiveJobRow project={p} now={now} /></StaggerItem>))}
               </StaggerList>
             )}
           </div>
         </FadeIn>
 
+        <FadeIn delay={nextSectionDelay()}>
+          <MyWorkSection
+            projects={myProjects}
+            blockers={(myBlockers ?? []) as Record<string, unknown>[]}
+            tasks={(myTasks ?? []) as unknown as Record<string, unknown>[]}
+          />
+        </FadeIn>
+      </div>
+
+      {/* ══ Zone 2: Org risk ══ */}
+      <FadeIn delay={nextSectionDelay()}>
+        <div className={`${TILE} p-5`}>
+          <h2 className="t-overline mb-3 text-muted">Needs attention</h2>
+          <NeedsAttention stats={stats} loading={statsLoading} blockers={myBlockers ?? []} subHireOverdue={subHireStats?.overdueReturns ?? 0} />
+          {/* Extension point: sibling issue's org-risk board chips (fleet/
+              maintenance/sub-hire exposure boards) slot in here alongside the
+              needs-attention chips above — owned by another team, not stubbed
+              ahead of that work. */}
+        </div>
+      </FadeIn>
+
+      {/* ══ Zone 3: Demoted (stats, upcoming, activity) ══ */}
+      <div className="grid auto-rows-[minmax(0,auto)] grid-cols-2 gap-3 lg:grid-cols-4">
         {/* Stat tiles */}
         <StatTile label="Active jobs" value={stats?.activeProjects} loading={statsLoading} hue="blue" sub="in flight" href="/projects" />
         <StatTile label="Overdue returns" value={overdue} loading={statsLoading} hue="red" sub={overdue > 0 ? "chase them" : "all back"} href="/projects" problem={overdue > 0} />
         <DeployTile deployed={deployed} total={total} util={util} loading={statsLoading} />
         <StatTile label="Crew booked" value={stats?.activeCrew} loading={statsLoading} hue="purple" sub="on the books" href="/crew" />
 
-        {/* Needs attention */}
-        <FadeIn delay={0.08} className="col-span-2">
-          <div className={`${TILE} h-full p-5`}>
-            <h2 className="t-overline mb-3 text-muted">Needs attention</h2>
-            <NeedsAttention stats={stats} loading={statsLoading} blockers={myBlockers ?? []} subHireOverdue={subHireStats?.overdueReturns ?? 0} />
-          </div>
-        </FadeIn>
-
         {/* Upcoming */}
-        <FadeIn delay={0.1} className="col-span-2">
+        <FadeIn delay={nextSectionDelay()} className="col-span-2">
           <div className={`${TILE} h-full p-5`}>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="t-overline text-muted">Upcoming</h2>
@@ -202,7 +230,7 @@ export default function DashboardPage() {
         </FadeIn>
 
         {/* Recent activity — full width */}
-        <FadeIn delay={0.12} className="col-span-2 lg:col-span-4">
+        <FadeIn delay={nextSectionDelay()} className="col-span-2 lg:col-span-4">
           <div className={`${TILE} p-5`}>
             <h2 className="t-overline mb-4 text-muted">Recent activity</h2>
             {!activity ? (
@@ -217,41 +245,6 @@ export default function DashboardPage() {
           </div>
         </FadeIn>
       </div>
-
-      {/* ── Blockers (alert context — plain, no personality) ── */}
-      {myBlockers && myBlockers.length > 0 && (
-        <FadeIn delay={0.14}>
-          <div className="rounded-[var(--r-lg)] border border-line border-l-[3px] border-l-t-out bg-card p-5 shadow-[var(--sh-card)] sm:p-6">
-            <div className="mb-3 flex items-center gap-2">
-              <ShieldAlert className="h-4 w-4 text-t-out" />
-              <h2 className="text-card-title font-semibold text-ink">Blockers needing you</h2>
-              <span className="rounded-full bg-out-soft px-1.5 py-0.5 text-[11px] font-medium text-t-out">{myBlockers.length}</span>
-            </div>
-            <StaggerList className="space-y-1">
-              {myBlockers.map((b: Record<string, unknown>) => (
-                <StaggerItem key={b.threadId as string}>
-                  <Link href={`/projects/${b.projectId}`} className={cn("group block rounded-[var(--r)] px-3 py-2.5 transition-colors hover:bg-out-soft", focusRing)}>
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-[11px] text-muted">{b.projectNumber as string}</span>
-                          <span className="truncate text-[14px] font-medium text-ink">{b.projectName as string}</span>
-                          {b.reason === "mention" && (<span className="inline-flex shrink-0 items-center gap-0.5 rounded-full bg-out-soft px-1.5 py-0.5 text-[11px] text-t-out"><AtSign className="h-2.5 w-2.5" /> mentioned</span>)}
-                        </div>
-                        {b.snippet ? <p className="mt-0.5 truncate text-[12px] text-muted">&ldquo;{b.snippet as string}&rdquo;</p> : null}
-                      </div>
-                      <span className="shrink-0 text-[11px] text-muted">{b.createdByName as string} &middot; {formatDistanceToNow(new Date(b.createdAt as number), { addSuffix: true })}</span>
-                    </div>
-                  </Link>
-                </StaggerItem>
-              ))}
-            </StaggerList>
-          </div>
-        </FadeIn>
-      )}
-
-      {/* ── Your jobs ── */}
-      <FadeIn delay={0.16}><MyWorkSection projects={myProjects} blockers={(myBlockers ?? []) as Record<string, unknown>[]} /></FadeIn>
     </div>
   );
 }

--- a/src/app/(app)/my-tasks/__tests__/page.smoke.test.tsx
+++ b/src/app/(app)/my-tasks/__tests__/page.smoke.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// /my-tasks (#952 / QW-3): renders grouped rows off useNativeMyOpenTasks, shows
+// the FlowMascot all-clear empty state when there's nothing open, and gates the
+// inline status-cycle button behind useCanDo("project", "update") — a read-only
+// role (viewer/warehouse) gets a static icon instead of a clickable one.
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: { id: "org1" } }),
+}));
+
+let canDo = true;
+vi.mock("@/lib/use-permissions", () => ({
+  useCanDo: () => canDo,
+}));
+
+let mockTasks: unknown[] | undefined = [];
+vi.mock("@/hooks/use-native-dashboard", () => ({
+  useNativeMyOpenTasks: () => mockTasks,
+}));
+
+const updateSpy = vi.fn(async () => undefined);
+vi.mock("@/hooks/use-project-tasks-writes", () => ({
+  useProjectTaskWrites: () => ({ update: updateSpy }),
+}));
+
+import MyTasksPage from "../page";
+
+const NOW = Date.now();
+const DAY = 86_400_000;
+
+function task(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "t1",
+    title: "Confirm crew call times",
+    status: "TODO",
+    priority: "NORMAL",
+    dueDate: null,
+    overdue: false,
+    projectId: "p1",
+    projectName: "Big Gig",
+    projectNumber: "260701",
+    assigneeUserId: "user1",
+    assigneeCrewId: null,
+    ...overrides,
+  };
+}
+
+describe("MyTasksPage (smoke)", () => {
+  beforeEach(() => {
+    canDo = true;
+    mockTasks = [];
+    updateSpy.mockClear();
+  });
+
+  it("renders the FlowMascot all-clear empty state when there are no open tasks", () => {
+    mockTasks = [];
+    render(<MyTasksPage />);
+    expect(screen.getAllByText(/All clear/i).length).toBeGreaterThan(0);
+  });
+
+  it("groups tasks into Overdue / Today / This week / Later buckets", () => {
+    mockTasks = [
+      task({ id: "overdue1", title: "Overdue task", dueDate: NOW - DAY, overdue: true }),
+      task({ id: "today1", title: "Today task", dueDate: NOW }),
+      task({ id: "week1", title: "This week task", dueDate: NOW + 3 * DAY }),
+      task({ id: "later1", title: "Undated task", dueDate: null }),
+    ];
+    render(<MyTasksPage />);
+    expect(screen.getAllByText("Overdue").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Today").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("This week").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Later").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Overdue task").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Today task").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("This week task").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Undated task").length).toBeGreaterThan(0);
+  });
+
+  it("clicking the status icon cycles the task forward when the user can edit", () => {
+    mockTasks = [task({ id: "t1", status: "TODO" })];
+    render(<MyTasksPage />);
+    const button = screen.getByTitle("Move to next status");
+    fireEvent.click(button);
+    expect(updateSpy).toHaveBeenCalledWith("t1", { status: "IN_PROGRESS" });
+  });
+
+  it("renders a read-only (non-interactive) status icon for a permission-gated role", () => {
+    canDo = false;
+    mockTasks = [task({ id: "t1", status: "TODO" })];
+    render(<MyTasksPage />);
+    expect(screen.queryByTitle("Move to next status")).toBeNull();
+    fireEvent.click(screen.getByText("Confirm crew call times"));
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("links each row through to its project", () => {
+    mockTasks = [task({ id: "t1", projectId: "p42", projectNumber: "260742", projectName: "Warehouse fit-out" })];
+    render(<MyTasksPage />);
+    const link = screen.getByText("Warehouse fit-out").closest("a");
+    expect(link?.getAttribute("href")).toBe("/projects/p42");
+  });
+});

--- a/src/app/(app)/my-tasks/page.tsx
+++ b/src/app/(app)/my-tasks/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+// use-client: interactive — status-cycle writes + client-only "now" (R-8.1.1)
+
+import Link from "next/link";
+import { Circle, CircleDot, CheckCircle2, CalendarClock, ListChecks } from "lucide-react";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useNativeMyOpenTasks, type NativeMyOpenTask } from "@/hooks/use-native-dashboard";
+import { useProjectTaskWrites } from "@/hooks/use-project-tasks-writes";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { useCanDo } from "@/lib/use-permissions";
+import { PageHeader } from "@/components/layout/page-header";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FlowMascot } from "@/components/ui/flow-mascot";
+import { StaggerList, StaggerItem, FadeIn } from "@/components/ui/motion";
+import { cn, focusRing } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  TASK_PRIORITY_LABELS,
+  type ProjectTaskStatus,
+  type ProjectTaskPriority,
+} from "@/lib/project-tasks";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+type Bucket = "Overdue" | "Today" | "This week" | "Later";
+const BUCKET_ORDER: Bucket[] = ["Overdue", "Today", "This week", "Later"];
+
+function startOfDay(d: Date) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+/** Overdue / Today / This week / Later, mirroring the dashboard's due-bucket convention. */
+function bucketFor(task: NativeMyOpenTask, now: Date): Bucket {
+  if (task.dueDate == null) return "Later";
+  if (task.overdue) return "Overdue";
+  const startToday = startOfDay(now).getTime();
+  if (task.dueDate < startToday + DAY) return "Today";
+  if (task.dueDate < startToday + 7 * DAY) return "This week";
+  return "Later";
+}
+
+function dueLabel(task: NativeMyOpenTask): string | null {
+  if (task.dueDate == null) return null;
+  return new Date(task.dueDate).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+const PRIORITY_DOT: Record<ProjectTaskPriority, string> = {
+  LOW: "bg-faint",
+  NORMAL: "bg-blue",
+  HIGH: "bg-t-out",
+};
+
+export default function MyTasksPage() {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const tasks = useNativeMyOpenTasks(orgId);
+  const canEdit = useCanDo("project", "update");
+  const writes = useProjectTaskWrites();
+  const now = new Date();
+
+  const cycleMut = useServerMutation({
+    mutationFn: (vars: { id: string; next: ProjectTaskStatus }) => writes.update(vars.id, { status: vars.next }),
+    onError: (e: Error) => toast.error(e.message || "Could not update task"),
+  });
+
+  function cycleStatus(task: NativeMyOpenTask) {
+    const next: ProjectTaskStatus = task.status === "TODO" ? "IN_PROGRESS" : "DONE";
+    cycleMut.mutate({ id: task.id, next });
+  }
+
+  const isLoading = !!orgId && tasks === undefined;
+  const grouped = new Map<Bucket, NativeMyOpenTask[]>();
+  if (tasks) {
+    for (const b of BUCKET_ORDER) grouped.set(b, []);
+    for (const t of tasks) grouped.get(bucketFor(t, now))!.push(t);
+  }
+
+  return (
+    <div className="space-y-6">
+      <FadeIn>
+        <PageHeader
+          title="My tasks"
+          description="Open tasks assigned to you, across every project."
+        />
+      </FadeIn>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 rounded-[var(--r)] border border-line px-3 py-2.5">
+              <Skeleton className="size-4 rounded-full" />
+              <Skeleton className="h-3.5 flex-1" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+          ))}
+        </div>
+      ) : !tasks || tasks.length === 0 ? (
+        <FadeIn delay={0.04}>
+          <div className="flex flex-col items-center gap-2 rounded-[var(--r-lg)] border-2 border-dashed border-line-2 py-14 text-center">
+            <FlowMascot className="h-11 w-11" eyeColor="var(--ok)" />
+            <p className="text-[14px] font-medium text-ink">All clear — nothing open on you</p>
+            <p className="t-micro text-muted">Tasks assigned to you (or your crew record) land here.</p>
+          </div>
+        </FadeIn>
+      ) : (
+        <div className="space-y-5">
+          {BUCKET_ORDER.map((bucket, i) => {
+            const list = grouped.get(bucket) ?? [];
+            if (list.length === 0) return null;
+            const overdueBucket = bucket === "Overdue";
+            return (
+              <FadeIn key={bucket} delay={0.04 + i * 0.04} className="space-y-1.5">
+                <h2
+                  className={cn(
+                    "flex items-center gap-2 t-overline",
+                    overdueBucket ? "text-t-out" : "text-muted",
+                  )}
+                >
+                  {bucket}
+                  <span className="text-faint">{list.length}</span>
+                </h2>
+                <StaggerList className="space-y-2">
+                  {list.map((task) => (
+                    <StaggerItem key={task.id}>
+                      <TaskRow task={task} canEdit={canEdit} onCycle={() => cycleStatus(task)} />
+                    </StaggerItem>
+                  ))}
+                </StaggerList>
+              </FadeIn>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TaskRow({
+  task,
+  canEdit,
+  onCycle,
+}: {
+  task: NativeMyOpenTask;
+  canEdit: boolean;
+  onCycle: () => void;
+}) {
+  const due = dueLabel(task);
+  const isDone = task.status === "DONE";
+  const statusIcon = isDone ? (
+    <CheckCircle2 className="h-[18px] w-[18px] text-primary" />
+  ) : task.status === "IN_PROGRESS" ? (
+    <CircleDot className="h-[18px] w-[18px] text-blue" />
+  ) : (
+    <Circle className="h-[18px] w-[18px]" />
+  );
+
+  return (
+    <div className="flex items-start gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-2.5 shadow-[var(--sh-card)]">
+      {canEdit ? (
+        <button
+          type="button"
+          title="Move to next status"
+          onClick={onCycle}
+          className={cn("mt-0.5 shrink-0 rounded-full text-muted hover:text-primary", focusRing)}
+        >
+          {statusIcon}
+        </button>
+      ) : (
+        <span className="mt-0.5 shrink-0 text-muted" aria-hidden>
+          {statusIcon}
+        </span>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn("h-1.5 w-1.5 shrink-0 rounded-full", PRIORITY_DOT[task.priority])}
+            aria-label={`${TASK_PRIORITY_LABELS[task.priority]} priority`}
+            title={`${TASK_PRIORITY_LABELS[task.priority]} priority`}
+          />
+          <span className="truncate text-table-cell text-ink-2">{task.title}</span>
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          {due && (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-badge font-medium",
+                task.overdue ? "bg-out-soft text-t-out" : "bg-paper-2 text-muted",
+              )}
+            >
+              <CalendarClock className="h-3 w-3" />
+              {due}
+            </span>
+          )}
+          <Link
+            href={`/projects/${task.projectId}`}
+            className={cn(
+              "inline-flex items-center gap-1 truncate text-caption text-muted hover:text-ink hover:underline",
+              focusRing,
+            )}
+          >
+            <ListChecks className="h-3 w-3 shrink-0" />
+            <span className="font-mono">{task.projectNumber}</span>
+            <span className="truncate">{task.projectName}</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/my-tasks/page.tsx
+++ b/src/app/(app)/my-tasks/page.tsx
@@ -46,6 +46,13 @@ function dueLabel(task: NativeMyOpenTask): string | null {
   return new Date(task.dueDate).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+function groupByBucket(tasks: NativeMyOpenTask[], now: Date): Map<Bucket, NativeMyOpenTask[]> {
+  const grouped = new Map<Bucket, NativeMyOpenTask[]>();
+  for (const b of BUCKET_ORDER) grouped.set(b, []);
+  for (const t of tasks) grouped.get(bucketFor(t, now))!.push(t);
+  return grouped;
+}
+
 const PRIORITY_DOT: Record<ProjectTaskPriority, string> = {
   LOW: "bg-faint",
   NORMAL: "bg-blue",
@@ -71,69 +78,112 @@ export default function MyTasksPage() {
   }
 
   const isLoading = !!orgId && tasks === undefined;
-  const grouped = new Map<Bucket, NativeMyOpenTask[]>();
-  if (tasks) {
-    for (const b of BUCKET_ORDER) grouped.set(b, []);
-    for (const t of tasks) grouped.get(bucketFor(t, now))!.push(t);
-  }
+  const grouped = tasks ? groupByBucket(tasks, now) : null;
 
   return (
     <div className="space-y-6">
       <FadeIn>
-        <PageHeader
-          title="My tasks"
-          description="Open tasks assigned to you, across every project."
-        />
+        <PageHeader title="My tasks" description="Open tasks assigned to you, across every project." />
       </FadeIn>
 
       {isLoading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-3 rounded-[var(--r)] border border-line px-3 py-2.5">
-              <Skeleton className="size-4 rounded-full" />
-              <Skeleton className="h-3.5 flex-1" />
-              <Skeleton className="h-4 w-16" />
-            </div>
-          ))}
-        </div>
+        <TaskListSkeleton />
       ) : !tasks || tasks.length === 0 ? (
-        <FadeIn delay={0.04}>
-          <div className="flex flex-col items-center gap-2 rounded-[var(--r-lg)] border-2 border-dashed border-line-2 py-14 text-center">
-            <FlowMascot className="h-11 w-11" eyeColor="var(--ok)" />
-            <p className="text-[14px] font-medium text-ink">All clear — nothing open on you</p>
-            <p className="t-micro text-muted">Tasks assigned to you (or your crew record) land here.</p>
-          </div>
-        </FadeIn>
+        <AllClearEmptyState />
       ) : (
         <div className="space-y-5">
-          {BUCKET_ORDER.map((bucket, i) => {
-            const list = grouped.get(bucket) ?? [];
-            if (list.length === 0) return null;
-            const overdueBucket = bucket === "Overdue";
-            return (
-              <FadeIn key={bucket} delay={0.04 + i * 0.04} className="space-y-1.5">
-                <h2
-                  className={cn(
-                    "flex items-center gap-2 t-overline",
-                    overdueBucket ? "text-t-out" : "text-muted",
-                  )}
-                >
-                  {bucket}
-                  <span className="text-faint">{list.length}</span>
-                </h2>
-                <StaggerList className="space-y-2">
-                  {list.map((task) => (
-                    <StaggerItem key={task.id}>
-                      <TaskRow task={task} canEdit={canEdit} onCycle={() => cycleStatus(task)} />
-                    </StaggerItem>
-                  ))}
-                </StaggerList>
-              </FadeIn>
-            );
-          })}
+          {BUCKET_ORDER.map((bucket, i) => (
+            <TaskBucketSection
+              key={bucket}
+              bucket={bucket}
+              tasks={grouped!.get(bucket) ?? []}
+              index={i}
+              canEdit={canEdit}
+              onCycle={cycleStatus}
+            />
+          ))}
         </div>
       )}
     </div>
+  );
+}
+
+function TaskListSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 rounded-[var(--r)] border border-line px-3 py-2.5">
+          <Skeleton className="size-4 rounded-full" />
+          <Skeleton className="h-3.5 flex-1" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AllClearEmptyState() {
+  return (
+    <FadeIn delay={0.04}>
+      <div className="flex flex-col items-center gap-2 rounded-[var(--r-lg)] border-2 border-dashed border-line-2 py-14 text-center">
+        <FlowMascot className="h-11 w-11" eyeColor="var(--ok)" />
+        <p className="text-[14px] font-medium text-ink">All clear — nothing open on you</p>
+        <p className="t-micro text-muted">Tasks assigned to you (or your crew record) land here.</p>
+      </div>
+    </FadeIn>
+  );
+}
+
+function TaskBucketSection({
+  bucket,
+  tasks,
+  index,
+  canEdit,
+  onCycle,
+}: {
+  bucket: Bucket;
+  tasks: NativeMyOpenTask[];
+  index: number;
+  canEdit: boolean;
+  onCycle: (task: NativeMyOpenTask) => void;
+}) {
+  if (tasks.length === 0) return null;
+  return (
+    <FadeIn delay={0.04 + index * 0.04} className="space-y-1.5">
+      <h2 className={cn("flex items-center gap-2 t-overline", bucket === "Overdue" ? "text-t-out" : "text-muted")}>
+        {bucket}
+        <span className="text-faint">{tasks.length}</span>
+      </h2>
+      <StaggerList className="space-y-2">
+        {tasks.map((task) => (
+          <StaggerItem key={task.id}>
+            <TaskRow task={task} canEdit={canEdit} onCycle={() => onCycle(task)} />
+          </StaggerItem>
+        ))}
+      </StaggerList>
+    </FadeIn>
+  );
+}
+
+function TaskStatusIcon({ status }: { status: ProjectTaskStatus }) {
+  if (status === "DONE") return <CheckCircle2 className="h-[18px] w-[18px] text-primary" />;
+  if (status === "IN_PROGRESS") return <CircleDot className="h-[18px] w-[18px] text-blue" />;
+  return <Circle className="h-[18px] w-[18px]" />;
+}
+
+function TaskDueBadge({ task }: { task: NativeMyOpenTask }) {
+  const due = dueLabel(task);
+  if (!due) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-badge font-medium",
+        task.overdue ? "bg-out-soft text-t-out" : "bg-paper-2 text-muted",
+      )}
+    >
+      <CalendarClock className="h-3 w-3" />
+      {due}
+    </span>
   );
 }
 
@@ -146,16 +196,6 @@ function TaskRow({
   canEdit: boolean;
   onCycle: () => void;
 }) {
-  const due = dueLabel(task);
-  const isDone = task.status === "DONE";
-  const statusIcon = isDone ? (
-    <CheckCircle2 className="h-[18px] w-[18px] text-primary" />
-  ) : task.status === "IN_PROGRESS" ? (
-    <CircleDot className="h-[18px] w-[18px] text-blue" />
-  ) : (
-    <Circle className="h-[18px] w-[18px]" />
-  );
-
   return (
     <div className="flex items-start gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-2.5 shadow-[var(--sh-card)]">
       {canEdit ? (
@@ -165,11 +205,11 @@ function TaskRow({
           onClick={onCycle}
           className={cn("mt-0.5 shrink-0 rounded-full text-muted hover:text-primary", focusRing)}
         >
-          {statusIcon}
+          <TaskStatusIcon status={task.status} />
         </button>
       ) : (
         <span className="mt-0.5 shrink-0 text-muted" aria-hidden>
-          {statusIcon}
+          <TaskStatusIcon status={task.status} />
         </span>
       )}
 
@@ -183,17 +223,7 @@ function TaskRow({
           <span className="truncate text-table-cell text-ink-2">{task.title}</span>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-1.5">
-          {due && (
-            <span
-              className={cn(
-                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-badge font-medium",
-                task.overdue ? "bg-out-soft text-t-out" : "bg-paper-2 text-muted",
-              )}
-            >
-              <CalendarClock className="h-3 w-3" />
-              {due}
-            </span>
-          )}
+          <TaskDueBadge task={task} />
           <Link
             href={`/projects/${task.projectId}`}
             className={cn(

--- a/src/app/(app)/test-and-tag/quick-test/page.tsx
+++ b/src/app/(app)/test-and-tag/quick-test/page.tsx
@@ -8,9 +8,11 @@ import { useServerQuery } from "@/hooks/use-server-query";
 
 import { toast } from "sonner";
 import Link from "next/link";
-import { ArrowLeft, Volume2, VolumeX, ChevronDown, ChevronUp } from "lucide-react";
+import { ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
 
 import { useTestTagWrites } from "@/hooks/use-test-tag-writes";
+import { useScanFeedback } from "@/hooks/use-scan-feedback";
+import { ScanAudioToggle } from "@/components/scan-audio-toggle";
 import { useConvex } from "convex/react";
 import { api } from "../../../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -34,24 +36,6 @@ import { ElectricalStep } from "./components/electrical-step";
 import { SubTestStep } from "./components/sub-test-step";
 import { ResultStep } from "./components/result-step";
 
-// ─── Audio ──────────────────────────────────────────────────────────────────
-
-function playBeep(success: boolean) {
-  try {
-    const ctx = new AudioContext();
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.frequency.value = success ? 800 : 300;
-    gain.gain.value = 0.1;
-    osc.start();
-    osc.stop(ctx.currentTime + (success ? 0.15 : 0.4));
-  } catch {
-    /* ignore if audio not available */
-  }
-}
-
 // ─── Step Labels ────────────────────────────────────────────────────────────
 
 const STEP_CONFIG: { key: WizardStep; label: string }[] = [
@@ -70,7 +54,7 @@ function QuickTestContent() {
   const orgId = activeOrg?.id;
   const convex = useConvex();
   const ttWrites = useTestTagWrites();
-  const [audioEnabled, setAudioEnabled] = useState(true);
+  const scanFeedback = useScanFeedback();
   const [sessionLogExpanded, setSessionLogExpanded] = useState(false);
 
   const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
@@ -208,7 +192,7 @@ function QuickTestContent() {
       });
     },
     onSuccess: () => {
-      if (audioEnabled) playBeep(state.overallResult === "PASS");
+      scanFeedback.play(state.overallResult === "PASS" ? "success" : "error");
       toast.success(`${state.overallResult} — ${state.asset?.testTagId}`);
       dispatch({
         type: "RECORD_SAVED",
@@ -221,7 +205,7 @@ function QuickTestContent() {
       });
     },
     onError: (e) => {
-      if (audioEnabled) playBeep(false);
+      scanFeedback.play("error");
       toast.error(e.message);
       dispatch({ type: "SET_SAVING", isSaving: false });
     },
@@ -289,15 +273,7 @@ function QuickTestContent() {
             </Select>
 
             {/* Audio toggle */}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setAudioEnabled(!audioEnabled)}
-              title={audioEnabled ? "Disable audio" : "Enable audio"}
-              aria-label={audioEnabled ? "Disable audio" : "Enable audio"}
-            >
-              {audioEnabled ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
-            </Button>
+            <ScanAudioToggle enabled={scanFeedback.enabled} onToggle={scanFeedback.toggle} />
           </div>
         </div>
 

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -33,6 +33,8 @@ import {
   getAvailableAssetsForModels,
 } from "@/server/warehouse";
 import { useWarehouseWrites } from "@/hooks/use-warehouse-writes";
+import { useScanFeedback } from "@/hooks/use-scan-feedback";
+import { ScanAudioToggle } from "@/components/scan-audio-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { StatusIndicator } from "@/components/ui/status-indicator";
@@ -686,6 +688,8 @@ function WarehouseProjectPage({
   const isManagerTier = currentRole === "owner" || currentRole === "admin" || currentRole === "manager";
   // Browser-direct check-record writes (deprep/pack/flag/store + kit/child/adhoc).
   const checkRecordWrites = useCheckRecordWrites();
+  // Scan-verdict audio feedback (success/error/exception tones) — see FEATUREDOCS/12.
+  const scanFeedback = useScanFeedback();
 
   // Post-write refresh is now a no-op: the native subscription pushes every
   // warehouseOps change live over the WebSocket, so an explicit refetch is
@@ -949,10 +953,14 @@ function WarehouseProjectPage({
               // No checks — mark kit children as prepped
               prepKitChildren(projectId, kitLi.id)
                 .then(() => {
+                  scanFeedback.play("success");
                   toast.success(`Kit prepped: ${kitResult.assetName}`);
                   invalidate();
                 })
-                .catch((e) => showError(e, { fallbackTitle: "Failed to prep kit" }));
+                .catch((e) => {
+                  scanFeedback.play("error");
+                  showError(e, { fallbackTitle: "Failed to prep kit" });
+                });
               setScanValue("");
               scanInputRef.current?.focus();
             }
@@ -962,6 +970,7 @@ function WarehouseProjectPage({
             not_on_project: "Kit not assigned to this project",
             already_checked_out: "Kit already deployed",
           };
+          scanFeedback.play("error");
           toast.error(messages[kitResult.reason as string] || "Cannot prep this kit");
           setScanValue("");
           scanInputRef.current?.focus();
@@ -990,8 +999,10 @@ function WarehouseProjectPage({
             next.add(kitGroupKey);
             return next;
           });
+          scanFeedback.play("success");
           toast.success(`Verified: ${memberResult.assetName}`);
         } else {
+          scanFeedback.play("error");
           toast.error(`This asset is in a kit${memberResult.kitAssetTag ? ` (${memberResult.kitAssetTag})` : ""} not on this project.`);
         }
         setScanValue("");
@@ -1001,6 +1012,9 @@ function WarehouseProjectPage({
 
       if (result.found && result.type === "asset_child") {
         const r = result as { assetName: string; parentAssetTag: string | null };
+        // Disambiguation needed — scanned an accessory, not its parent. Resolved
+        // but needs attention, not a hard failure.
+        scanFeedback.play("exception");
         toast.info(`${r.assetName} is an accessory${r.parentAssetTag ? ` of ${r.parentAssetTag}` : ""} — scan the parent; accessories move with it.`);
         setScanValue("");
         scanInputRef.current?.focus();
@@ -1034,15 +1048,22 @@ function WarehouseProjectPage({
           // No check items — prep directly (set prepStatus=PACKED, no deploy)
           prepItemDirect(projectId, result.lineItemId, result.assetId || undefined, undefined, selectedContainer || null)
             .then(() => {
+              scanFeedback.play("success");
               toast.success(`Prepped: ${result.assetName || "Asset"}`);
               setScanValue("");
               scanInputRef.current?.focus();
               invalidate();
             })
-            .catch((e) => showError(e));
+            .catch((e) => {
+              scanFeedback.play("error");
+              showError(e);
+            });
         }
       } else if (result.found && !result.lineItemId) {
         if (result.reason === "not_on_project" && "modelId" in result && result.modelId) {
+          // Asset found but not on this project — resolved but needs a decision
+          // (add it?), not a hard failure.
+          scanFeedback.play("exception");
           // Prompt user to add asset to the project
           setAddPromptData({
             assetName: result.assetName || "Unknown asset",
@@ -1071,16 +1092,24 @@ function WarehouseProjectPage({
           asset_unavailable: `Asset is ${assetStatus.replace("_", " ").toLowerCase()} and cannot be deployed`,
           tt_blocked: `Test & Tag ${ttStatus.toLowerCase()}${ttNextDue ? ` — next test due ${ttNextDue}` : ""}. Cannot deploy until tested.`,
         };
+        // "already_returned" is resolved but needs attention (all units are back
+        // already) rather than a hard failure — every other reason here blocks
+        // the scan outright.
+        scanFeedback.play(result.reason === "already_returned" ? "exception" : "error");
         toast.error(messages[result.reason as string] || "Cannot deploy this asset");
         setScanValue("");
         scanInputRef.current?.focus();
       } else {
+        // Unknown tag — resolved (we know it's not in the system) but needs the
+        // operator's attention, not a hard error.
+        scanFeedback.play("exception");
         toast.error("Asset not found");
         setScanValue("");
         scanInputRef.current?.focus();
       }
     },
     onError: (e) => {
+      scanFeedback.play("error");
       showError(e);
       setScanValue("");
       scanInputRef.current?.focus();
@@ -1097,11 +1126,16 @@ function WarehouseProjectPage({
         if (kitLi && kitLi.prepStatus === "PACKED") {
           kitCheckOutMutation
             .mutateAsync(kitResult.kitId)
-            .then(() => toast.success(`Deployed kit: ${kitResult.assetName}`))
-            .catch(() => {});
+            .then(() => {
+              scanFeedback.play("success");
+              toast.success(`Deployed kit: ${kitResult.assetName}`);
+            })
+            .catch(() => scanFeedback.play("error"));
         } else if (kitResult.reason === "already_checked_out") {
+          scanFeedback.play("error");
           toast.error("Kit already deployed");
         } else {
+          scanFeedback.play("error");
           toast.error("Kit is not prepped yet — prep it first in Pick/Prep");
         }
         setDeployScanValue("");
@@ -1111,6 +1145,7 @@ function WarehouseProjectPage({
 
       if (result.found && result.type === "kit_member") {
         const memberResult = result as { kitId: string | null; kitAssetTag: string | null; assetName: string };
+        scanFeedback.play("error");
         toast.error(`This asset is in a kit${memberResult.kitAssetTag ? ` (${memberResult.kitAssetTag})` : ""} — scan the kit barcode to deploy`);
         setDeployScanValue("");
         deployScanInputRef.current?.focus();
@@ -1119,6 +1154,8 @@ function WarehouseProjectPage({
 
       if (result.found && result.type === "asset_child") {
         const r = result as { assetName: string; parentAssetTag: string | null };
+        // Disambiguation needed — scanned an accessory, not its parent.
+        scanFeedback.play("exception");
         toast.error(`${r.assetName} is an accessory${r.parentAssetTag ? ` of ${r.parentAssetTag}` : ""} — scan the parent to deploy; it moves with the parent.`);
         setDeployScanValue("");
         deployScanInputRef.current?.focus();
@@ -1130,22 +1167,31 @@ function WarehouseProjectPage({
         if (matchedLi?.prepStatus === "PACKED" && matchedLi.status !== "CHECKED_OUT") {
           checkOutMutation
             .mutateAsync({ items: [{ lineItemId: result.lineItemId, assetId: result.assetId || undefined }] })
-            .then(() => toast.success(`Deployed: ${result.assetName || "Item"}`))
-            .catch(() => {});
+            .then(() => {
+              scanFeedback.play("success");
+              toast.success(`Deployed: ${result.assetName || "Item"}`);
+            })
+            .catch(() => scanFeedback.play("error"));
         } else if (matchedLi?.status === "CHECKED_OUT") {
+          scanFeedback.play("error");
           toast.error("Item already deployed");
         } else {
+          scanFeedback.play("error");
           toast.error("Item is not prepped yet — prep it first in Pick/Prep");
         }
       } else if (result.found && !result.lineItemId) {
+        scanFeedback.play("error");
         toast.error(result.reason === "not_on_project" ? "Asset not on this project" : "Cannot deploy this item");
       } else {
+        // Unknown tag.
+        scanFeedback.play("exception");
         toast.error("Asset not found");
       }
       setDeployScanValue("");
       deployScanInputRef.current?.focus();
     },
     onError: (e) => {
+      scanFeedback.play("error");
       showError(e);
       setDeployScanValue("");
       deployScanInputRef.current?.focus();
@@ -1183,12 +1229,13 @@ function WarehouseProjectPage({
               kitCheckInMutation
                 .mutateAsync({ kitId: kitResult.kitId, returnCondition: returnCondition as "GOOD" | "DAMAGED" | "MISSING" })
                 .then(() => {
+                  scanFeedback.play("success");
                   toast.success(`Kit returned: ${kitResult.assetName}`);
                   setReturnScanValue("");
                   setReturnNotes("");
                   returnScanInputRef.current?.focus();
                 })
-                .catch(() => {});
+                .catch(() => scanFeedback.play("error"));
             }
           }
         } else {
@@ -1196,6 +1243,7 @@ function WarehouseProjectPage({
             not_on_project: "Kit not assigned to this project",
             not_checked_out: "Kit is not deployed",
           };
+          scanFeedback.play("error");
           toast.error(messages[kitResult.reason as string] || "Cannot return this kit");
           setReturnScanValue("");
           returnScanInputRef.current?.focus();
@@ -1224,8 +1272,10 @@ function WarehouseProjectPage({
             next.add(kitGroupKey);
             return next;
           });
+          scanFeedback.play("success");
           toast.success(`Verified: ${memberResult.assetName}`);
         } else {
+          scanFeedback.play("error");
           toast.error(`This asset is in a kit${memberResult.kitAssetTag ? ` (${memberResult.kitAssetTag})` : ""} not on this project.`);
         }
         setReturnScanValue("");
@@ -1235,6 +1285,8 @@ function WarehouseProjectPage({
 
       if (result.found && result.type === "asset_child") {
         const r = result as { assetName: string; parentAssetTag: string | null };
+        // Disambiguation needed — scanned an accessory, not its parent.
+        scanFeedback.play("exception");
         toast.info(`${r.assetName} is an accessory${r.parentAssetTag ? ` of ${r.parentAssetTag}` : ""} — scan the parent to return; it comes back with the parent.`);
         setReturnScanValue("");
         returnScanInputRef.current?.focus();
@@ -1278,12 +1330,13 @@ function WarehouseProjectPage({
               }],
             })
             .then(() => {
+              scanFeedback.play("success");
               toast.success(`Returned: ${result.assetName || "Asset"}`);
               setReturnScanValue("");
               setReturnNotes("");
               returnScanInputRef.current?.focus();
             })
-            .catch(() => {});
+            .catch(() => scanFeedback.play("error"));
         }
       } else if (result.found && !result.lineItemId) {
         const messages: Record<string, string> = {
@@ -1292,16 +1345,22 @@ function WarehouseProjectPage({
           already_returned: "All units already returned",
           already_checked_out: "Already deployed",
         };
+        // "already_returned" is resolved but needs attention (nothing left to
+        // return), not a hard failure — every other reason here blocks the scan.
+        scanFeedback.play(result.reason === "already_returned" ? "exception" : "error");
         toast.error(messages[result.reason as string] || "Cannot return this asset");
         setReturnScanValue("");
         returnScanInputRef.current?.focus();
       } else {
+        // Unknown tag.
+        scanFeedback.play("exception");
         toast.error("Asset not found");
         setReturnScanValue("");
         returnScanInputRef.current?.focus();
       }
     },
     onError: (e) => {
+      scanFeedback.play("error");
       showError(e);
       setReturnScanValue("");
       returnScanInputRef.current?.focus();
@@ -2543,6 +2602,8 @@ function WarehouseProjectPage({
           {project.client && <p className="text-muted">{project.client.name}</p>}
         </div>
         <div className="flex gap-2">
+          {/* Scan audio toggle — shared across prep/deploy/return scan verdicts */}
+          <ScanAudioToggle enabled={scanFeedback.enabled} onToggle={scanFeedback.toggle} />
           {/* Mobile: Pick List button shown prominently */}
           <Button variant="line" className="sm:hidden" onClick={() => setPickListOpen(true)}>
             <ClipboardList className="mr-2 h-4 w-4" />

--- a/src/components/__tests__/scan-audio-toggle.smoke.test.tsx
+++ b/src/components/__tests__/scan-audio-toggle.smoke.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ScanAudioToggle } from "@/components/scan-audio-toggle";
+import { useScanFeedback } from "@/hooks/use-scan-feedback";
+
+/**
+ * Regression target: the old T&T `playBeep` swallowed every Web Audio failure
+ * with a bare `catch {}`, so nothing verified it actually survived running
+ * without a real Web Audio API (jsdom has none). This renders the real
+ * `useScanFeedback` + `ScanAudioToggle` pair end-to-end — no mocked
+ * AudioContext factory — and drives an actual scan-feedback play through the
+ * toggle's consumer, confirming the missing-API path never throws or breaks
+ * the render tree.
+ */
+function ScanFeedbackConsumer() {
+  const scanFeedback = useScanFeedback();
+  return (
+    <div>
+      <ScanAudioToggle enabled={scanFeedback.enabled} onToggle={scanFeedback.toggle} />
+      <button onClick={() => scanFeedback.play("success")}>Simulate scan</button>
+    </div>
+  );
+}
+
+describe("ScanAudioToggle + useScanFeedback smoke", () => {
+  it("renders enabled by default with the Volume2 (on) affordance", () => {
+    render(<ScanFeedbackConsumer />);
+    expect(screen.getByLabelText("Disable audio")).toBeTruthy();
+  });
+
+  it("toggling flips the icon/label and playing a tone never throws, even with no real Web Audio API", () => {
+    render(<ScanFeedbackConsumer />);
+
+    // Simulate a scan verdict with audio still enabled — jsdom has no
+    // AudioContext, so this exercises the real "swallow and continue" path.
+    expect(() => fireEvent.click(screen.getByText("Simulate scan"))).not.toThrow();
+
+    fireEvent.click(screen.getByLabelText("Disable audio"));
+    expect(screen.getByLabelText("Enable audio")).toBeTruthy();
+
+    // Disabled: play() should short-circuit before ever touching audio.
+    expect(() => fireEvent.click(screen.getByText("Simulate scan"))).not.toThrow();
+  });
+});

--- a/src/components/dashboard/__tests__/my-work-section.smoke.test.tsx
+++ b/src/components/dashboard/__tests__/my-work-section.smoke.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MyWorkSection } from "@/components/dashboard/my-work-section";
 
 const base = {
@@ -37,5 +37,33 @@ describe("MyWorkSection smoke", () => {
 
   it("renders empty + all-clear without throwing", () => {
     expect(() => render(<MyWorkSection projects={[]} />)).not.toThrow();
+  });
+
+  it("renders the tasks-due block with a 'N more' link when tasks exceed the shown count", () => {
+    const projects = [{ ...base, id: "a", status: "CONFIRMED", rentalStartDate: null, rentalEndDate: null }];
+    const tasks = Array.from({ length: 7 }, (_, i) => ({
+      id: `t${i}`,
+      title: `Task ${i}`,
+      status: i === 0 ? "IN_PROGRESS" : "TODO",
+      priority: "NORMAL",
+      dueDate: i === 0 ? Date.now() - 86_400_000 : null,
+      overdue: i === 0,
+      projectId: "a",
+      projectName: "Gig",
+      projectNumber: "260601",
+    }));
+    render(<MyWorkSection projects={projects} tasks={tasks} />);
+    // Only the first 5 are shown as rows...
+    expect(screen.getByText("Task 0")).toBeDefined();
+    expect(screen.getByText("Task 4")).toBeDefined();
+    expect(screen.queryByText("Task 5")).toBeNull();
+    // ...and the remaining 2 surface as a "more" link to /my-tasks.
+    const moreLink = screen.getByText(/2 more/);
+    expect(moreLink.closest("a")?.getAttribute("href")).toBe("/my-tasks");
+  });
+
+  it("omits the tasks-due block entirely when there are no open tasks", () => {
+    render(<MyWorkSection projects={[]} tasks={[]} />);
+    expect(screen.queryByText("Tasks due")).toBeNull();
   });
 });

--- a/src/components/dashboard/my-work-section.tsx
+++ b/src/components/dashboard/my-work-section.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { format } from "date-fns";
-import { ArrowRight, Boxes, CalendarClock, ShieldAlert, AtSign, CheckCircle2, FolderOpen } from "lucide-react";
+import { ArrowRight, Boxes, CalendarClock, ShieldAlert, AtSign, CheckCircle2, FolderOpen, Circle, CircleDot } from "lucide-react";
 import { cn, focusRing } from "@/lib/utils";
 import { StaggerList, StaggerItem } from "@/components/ui/motion";
 import { SectionHeader } from "@/components/layout/page-layouts";
@@ -16,6 +16,19 @@ const projectStatusLabels: Record<string, string> = {
 
 type Project = Record<string, unknown>;
 type Blocker = Record<string, unknown>;
+type TaskDue = Record<string, unknown>;
+
+const TASKS_DUE_SHOWN = 5;
+
+/** Compact due-date label for the tasks-due block (no "d MMM" year clutter). */
+function taskDueLabel(task: TaskDue): { text: string; overdue: boolean } | null {
+  const due = task.dueDate as number | null | undefined;
+  if (due == null) return null;
+  return {
+    text: new Date(due).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    overdue: !!task.overdue,
+  };
+}
 
 const DAY = 24 * 60 * 60 * 1000;
 function startOfDay(d: Date) { const x = new Date(d); x.setHours(0, 0, 0, 0); return x; }
@@ -47,7 +60,16 @@ function projectDateLine(p: Project): { text: string; tone: "error" | "warning" 
 
 const toneText = { error: "text-t-out", warning: "text-warn", muted: "text-muted" } as const;
 
-export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]; blockers?: Blocker[] }) {
+export function MyWorkSection({
+  projects,
+  blockers = [],
+  tasks = [],
+}: {
+  projects: Project[];
+  blockers?: Blocker[];
+  /** Top N of projectTasks.myOpenTasks (already sorted overdue → due asc → priority). */
+  tasks?: TaskDue[];
+}) {
   // Group blockers by project so each card can flag its own issues.
   const blockersByProject = new Map<string, Blocker[]>();
   for (const b of blockers) {
@@ -58,11 +80,14 @@ export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]
     blockersByProject.set(pid, arr);
   }
 
+  const shownTasks = tasks.slice(0, TASKS_DUE_SHOWN);
+  const moreTasks = tasks.length - shownTasks.length;
+
   return (
     <section className="space-y-4 rounded-[var(--r-lg)] border border-line bg-card p-5 shadow-[var(--sh-card)] sm:p-6">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <SectionHeader label="Your projects" />
+          <SectionHeader label="My work" />
           {projects.length > 0 && (
             <p className="t-micro mt-0.5 text-muted">
               {projects.length} you manage{blockers.length > 0 ? <> · <span className="text-t-out">{blockers.length} need a decision</span></> : null}
@@ -73,6 +98,8 @@ export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]
           All projects <ArrowRight className="h-3.5 w-3.5" />
         </Link>
       </div>
+
+      {shownTasks.length > 0 && <TasksDueBlock tasks={shownTasks} moreCount={moreTasks} />}
 
       {projects.length === 0 ? (
         <div className="rounded-[var(--r-lg)] border border-dashed border-line py-8 text-center">
@@ -152,5 +179,66 @@ export function MyWorkSection({ projects, blockers = [] }: { projects: Project[]
         </StaggerList>
       )}
     </section>
+  );
+}
+
+// ─── Tasks-due block ────────────────────────────────────────────
+
+const TASK_STATUS_ICON: Record<string, typeof Circle> = {
+  DONE: CheckCircle2,
+  IN_PROGRESS: CircleDot,
+  TODO: Circle,
+};
+const TASK_STATUS_ICON_TEXT: Record<string, string> = {
+  DONE: "text-primary",
+  IN_PROGRESS: "text-blue",
+  TODO: "text-muted",
+};
+
+function TasksDueBlock({ tasks, moreCount }: { tasks: TaskDue[]; moreCount: number }) {
+  return (
+    <div className="space-y-1.5 border-b border-line pb-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="t-overline text-muted">Tasks due</span>
+        {moreCount > 0 && (
+          <Link
+            href="/my-tasks"
+            className={cn("inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-red hover:underline", focusRing)}
+          >
+            {moreCount} more <ArrowRight className="h-3 w-3" />
+          </Link>
+        )}
+      </div>
+      <div className="space-y-0.5">
+        {tasks.map((t) => (
+          <TaskDueRow key={t.id as string} task={t} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskDueRow({ task }: { task: TaskDue }) {
+  const due = taskDueLabel(task);
+  const status = task.status as string;
+  const StatusIcon = TASK_STATUS_ICON[status] ?? Circle;
+  return (
+    <Link
+      href={`/projects/${task.projectId as string}`}
+      className={cn(
+        "group flex items-center justify-between gap-2 rounded-[var(--r)] px-2 py-1.5 transition-colors hover:bg-elev",
+        focusRing,
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <StatusIcon className={cn("h-3.5 w-3.5 shrink-0", TASK_STATUS_ICON_TEXT[status] ?? "text-muted")} />
+        <span className="truncate text-[13px] text-ink-2">{task.title as string}</span>
+      </span>
+      {due && (
+        <span className={cn("shrink-0 text-[11px] font-medium", due.overdue ? "text-t-out" : "text-muted")}>
+          {due.text}
+        </span>
+      )}
+    </Link>
   );
 }

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
   LayoutDashboard,
+  ListTodo,
   Package,
   Boxes,
   FolderOpen,
@@ -90,6 +91,13 @@ interface RailItem {
 // Primary modules. Hues per DESIGN.md §3.7/§15.5.
 const RAIL: RailItem[] = [
   { title: "Dashboard", url: "/dashboard", icon: LayoutDashboard, hue: "blue" },
+  // No `resource` gate — personal scope (this user's own assignments), not an
+  // org resource. A resource gate here would fail-open-flash on load like every
+  // other gated item; skipping it entirely (rather than gating on "project")
+  // means viewer/warehouse roles keep their own task list even without
+  // project:read. Sidebar-only per DESIGN.md §16 — NOT in the mobile bottom nav
+  // (that's the 5 daily-operator workflows; see mobile-nav.tsx).
+  { title: "My tasks", url: "/my-tasks", icon: ListTodo, hue: "blue" },
   {
     title: "Projects", url: "/projects", icon: FolderOpen, hue: "blue", resource: "project",
     subs: [{ title: "Templates", url: "/projects/templates", icon: BookTemplate, resource: "project" }],

--- a/src/components/layout/command-search.tsx
+++ b/src/components/layout/command-search.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRight,
   X,
   LayoutDashboard,
+  ListTodo,
   Warehouse,
   ShieldCheck,
   BarChart3,
@@ -108,7 +109,7 @@ const typeLabels: Record<SearchResultType, string> = {
 };
 
 const pageIcons: Record<string, React.ComponentType<{ className?: string }>> = {
-  LayoutDashboard, Package, Boxes, Box, CalendarRange, Container,
+  LayoutDashboard, ListTodo, Package, Boxes, Box, CalendarRange, Container,
   FolderOpen, BookTemplate, Warehouse, Users, MapPin, Wrench,
   ShieldCheck, BarChart3, Settings, UserCircle, PackageCheck, PackageX,
   CreditCard, Palette, Truck, FileText, ClipboardList, Pencil, Copy,

--- a/src/components/projects/project-wizard.tsx
+++ b/src/components/projects/project-wizard.tsx
@@ -206,8 +206,35 @@ export function ProjectWizard({
   });
 
   const v = form.watch();
-  // Resolve the selected client's label directly (it may not be in the current search page).
-  const selectedClientName = useClient(v.clientId || undefined)?.name;
+  // Resolve the selected client directly (it may not be in the current search page) —
+  // used for the display label AND the discount-default prefill below.
+  const selectedClient = useClient(v.clientId || undefined);
+  const selectedClientName = selectedClient?.name;
+
+  // QW-4 (#953): prefill Discount from the selected client's `defaultDiscount` — a
+  // UX convenience only; the server-authoritative snapshot happens in
+  // `projectWrites.createNative` (R-9.3) regardless of what the wizard sends. Re-
+  // prefills each time the client changes, but ONLY while the user hasn't touched
+  // the field themselves — once they type a value (including an explicit 0), their
+  // choice wins and further client changes leave it alone. Never fires on initial
+  // load of an existing project (editing doesn't retroactively re-apply the
+  // client's CURRENT default over whatever discount was actually saved).
+  const discountTouchedRef = useRef(false);
+  const prefilledDiscountForClientId = useRef(project?.clientId ?? "");
+  useEffect(() => {
+    const currentClientId = v.clientId || "";
+    if (!currentClientId) return;
+    if (discountTouchedRef.current) return;
+    if (prefilledDiscountForClientId.current === currentClientId) return;
+    if (selectedClient === undefined || selectedClient?.id !== currentClientId) return; // still loading / stale
+    prefilledDiscountForClientId.current = currentClientId;
+    form.setValue(
+      "discountPercent",
+      selectedClient?.defaultDiscount != null ? Number(selectedClient.defaultDiscount) : undefined,
+      { shouldDirty: false },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [v.clientId, selectedClient]);
 
   // Pre-fill the project code from the org's next sequence so the (now required)
   // field is populated by default — the user accepts it or types their own.
@@ -354,6 +381,19 @@ export function ProjectWizard({
                     onCreateNew={() => setQuickClient(true)} createNewLabel="New client" emptyMessage="No clients found." />
                 )} />
               </Field>
+              <Field
+                label="Discount (%)"
+                hint={
+                  selectedClient?.defaultDiscount != null
+                    ? "From client default — edit anytime. Won't retroactively change if you switch clients again after saving."
+                    : undefined
+                }
+              >
+                <Input
+                  type="number" step="0.01" min="0" max="100" placeholder="0"
+                  {...form.register("discountPercent", { onChange: () => { discountTouchedRef.current = true; } })}
+                />
+              </Field>
               <Field label="Project manager(s)" error={membersError ? "Couldn't load org members — you may not have permission to view them." : undefined}>
                 <ComboboxPicker value="" onChange={(id) => { if (id && !managerIds.includes(id)) setManagerIds((p) => [...p, id]); }}
                   options={memberOptions.filter((m) => !managerIds.includes(m.value))} placeholder="Add manager…" searchPlaceholder="Search members…" emptyMessage="No members found." />
@@ -425,7 +465,12 @@ export function ProjectWizard({
                   <div className="space-y-3 border-t border-line pt-4 sm:col-span-2">
                     <p className="t-overline text-faint">Financial</p>
                   </div>
-                  <Field label="Discount (%)"><Input type="number" step="0.01" min="0" max="100" {...form.register("discountPercent")} placeholder="0" /></Field>
+                  {/* RESERVED for #940 (WS1 — deposit/invoicing workflow). These are
+                      hand-typed inputs with no server-side math behind them yet (see
+                      the schema.ts reservation comment on depositPercent/depositPaid/
+                      invoicedTotal) — #940 owns wiring them up. Discount (%) moved to
+                      the Basics step (QW-4 / #953) since it's now applied at project
+                      creation and needed visible + editable there, not edit-only. */}
                   <Field label="Deposit (%)"><Input type="number" step="0.01" min="0" max="100" {...form.register("depositPercent")} placeholder="0" /></Field>
                   <Field label="Deposit paid ($)"><Input type="number" step="0.01" min="0" {...form.register("depositPaid")} placeholder="0.00" /></Field>
                   <Field label="Invoiced total ($)"><Input type="number" step="0.01" min="0" {...form.register("invoicedTotal")} placeholder="0.00" /></Field>

--- a/src/components/scan-audio-toggle.tsx
+++ b/src/components/scan-audio-toggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Volume2, VolumeX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Shared scan-audio toggle button — ghost icon button, Volume2/VolumeX, matching
+ * the original T&T quick-test toggle. Every scan-verdict surface (Warehouse
+ * prep/deploy/return, T&T quick-test, `/check/[assetTag]`) renders this so the
+ * on/off control is visually and behaviourally identical everywhere.
+ *
+ * See `useScanFeedback` (`@/hooks/use-scan-feedback`) for the underlying
+ * localStorage-persisted toggle state, and FEATUREDOCS/12 / FEATUREDOCS/14 for
+ * the architecture.
+ */
+export function ScanAudioToggle({
+  enabled,
+  onToggle,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onToggle}
+      title={enabled ? "Disable audio" : "Enable audio"}
+      aria-label={enabled ? "Disable audio" : "Enable audio"}
+    >
+      {enabled ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
+    </Button>
+  );
+}

--- a/src/hooks/__tests__/use-scan-feedback.test.tsx
+++ b/src/hooks/__tests__/use-scan-feedback.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const playScanFeedbackMock = vi.fn();
+vi.mock("@/lib/scan-feedback", () => ({
+  playScanFeedback: (...args: unknown[]) => playScanFeedbackMock(...args),
+}));
+
+import { useScanFeedback } from "@/hooks/use-scan-feedback";
+
+describe("useScanFeedback", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    playScanFeedbackMock.mockClear();
+  });
+
+  it("defaults to enabled when nothing is persisted", () => {
+    const { result } = renderHook(() => useScanFeedback());
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it("persists the toggle under the rvlt.scanAudio key, per-device (not user-scoped)", () => {
+    const { result } = renderHook(() => useScanFeedback());
+    act(() => result.current.toggle());
+    expect(result.current.enabled).toBe(false);
+    expect(localStorage.getItem("rvlt.scanAudio")).toBe("false");
+
+    act(() => result.current.toggle());
+    expect(result.current.enabled).toBe(true);
+    expect(localStorage.getItem("rvlt.scanAudio")).toBe("true");
+  });
+
+  it("a fresh mount reads the persisted value back", () => {
+    const first = renderHook(() => useScanFeedback());
+    act(() => first.result.current.toggle()); // -> disabled
+
+    const second = renderHook(() => useScanFeedback());
+    expect(second.result.current.enabled).toBe(false);
+  });
+
+  it("play() calls playScanFeedback only when enabled", () => {
+    const { result } = renderHook(() => useScanFeedback());
+
+    act(() => result.current.play("success"));
+    expect(playScanFeedbackMock).toHaveBeenCalledWith("success");
+
+    playScanFeedbackMock.mockClear();
+    act(() => result.current.toggle()); // -> disabled
+    act(() => result.current.play("error"));
+    expect(playScanFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it("survives malformed storage without throwing", () => {
+    localStorage.setItem("rvlt.scanAudio", "{not json");
+    const { result } = renderHook(() => useScanFeedback());
+    expect(result.current.enabled).toBe(true);
+  });
+});

--- a/src/hooks/use-native-dashboard.ts
+++ b/src/hooks/use-native-dashboard.ts
@@ -106,6 +106,36 @@ export function useNativeActivity(orgId: string | undefined) {
   return useAuthedQuery(api.dashboardActivity.bundle, enabled ? { orgId: orgId! } : "skip");
 }
 
+export interface NativeMyOpenTask {
+  id: string;
+  title: string;
+  status: "TODO" | "IN_PROGRESS" | "DONE";
+  priority: "LOW" | "NORMAL" | "HIGH";
+  dueDate: number | null;
+  overdue: boolean;
+  projectId: string;
+  projectName: string;
+  projectNumber: string;
+  assigneeUserId: string | null;
+  assigneeCrewId: string | null;
+}
+
+/**
+ * projectTasks.myOpenTasks: this user's open tasks across every project
+ * (direct + crew assignment), sorted overdue → due asc → undated last →
+ * priority, bounded to 100. Backs both the `/my-tasks` page and the
+ * dashboard's My work tasks-due block. Minute-bucketed `now`, same
+ * convention as the rest of this file (queries can't read the clock).
+ */
+export function useNativeMyOpenTasks(orgId: string | undefined) {
+  const enabled = !!orgId;
+  const nowBucket = enabled ? Math.floor(Date.now() / MINUTE) * MINUTE : 0;
+  return useAuthedQuery(
+    api.projectTasks.myOpenTasks,
+    enabled ? { orgId: orgId!, now: nowBucket } : "skip",
+  ) as NativeMyOpenTask[] | undefined;
+}
+
 export interface NativeSubHireStats {
   activeSubHires: number;
   monthlySubHireCost: number;

--- a/src/hooks/use-scan-feedback.ts
+++ b/src/hooks/use-scan-feedback.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { playScanFeedback, type ScanFeedbackKind } from "@/lib/scan-feedback";
+
+/**
+ * localStorage key for the scan-audio toggle. Deliberately **not** scoped to the
+ * signed-in user (unlike `usePersistentPref`) — warehouse terminals are shared
+ * devices, and the "audio on/off" preference belongs to the terminal, not the
+ * operator currently signed in on it.
+ */
+const STORAGE_KEY = "rvlt.scanAudio";
+const DEFAULT_ENABLED = true;
+
+function readEnabled(): boolean {
+  if (typeof window === "undefined") return DEFAULT_ENABLED;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_ENABLED;
+    return JSON.parse(raw) === true;
+  } catch {
+    return DEFAULT_ENABLED;
+  }
+}
+
+/**
+ * Shared scan-feedback hook: a per-device, localStorage-persisted audio toggle
+ * plus a `play(kind)` helper wired to `playScanFeedback`. Used by every scan
+ * verdict call site (Warehouse prep/deploy/return, T&T quick-test, the
+ * `/check/[assetTag]` ad-hoc station, and future consumers like the WS5 returns
+ * station) so the toggle and tone vocabulary stay in one place.
+ *
+ * See FEATUREDOCS/12 (Scan Feedback) and FEATUREDOCS/14 (Audio note).
+ */
+export function useScanFeedback(): {
+  enabled: boolean;
+  toggle: () => void;
+  play: (kind: ScanFeedbackKind) => void;
+} {
+  // Initialise to the default so server and first client render agree — reading
+  // localStorage in the initializer would diverge from SSR and throw a hydration
+  // mismatch. The effect below syncs the persisted value in right after mount.
+  const [enabled, setEnabled] = useState(DEFAULT_ENABLED);
+
+  useEffect(() => {
+    setEnabled(readEnabled());
+  }, []);
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+          // ignore quota / unavailable storage
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const play = useCallback(
+    (kind: ScanFeedbackKind) => {
+      if (!enabled) return;
+      playScanFeedback(kind);
+    },
+    [enabled],
+  );
+
+  return { enabled, toggle, play };
+}

--- a/src/lib/page-commands.ts
+++ b/src/lib/page-commands.ts
@@ -39,6 +39,14 @@ export const PAGE_COMMANDS: PageCommand[] = [
     description: "Overview and recent activity",
   },
   {
+    label: "My tasks",
+    href: "/my-tasks",
+    aliases: ["mytasks", "tasks", "todo", "mytodo"],
+    icon: "ListTodo",
+    description: "Open tasks assigned to you, across every project",
+    searchable: false,
+  },
+  {
     label: "Assets",
     href: "/assets/registry",
     aliases: ["assets", "registry", "assetregistry", "inventory"],

--- a/src/lib/scan-feedback.test.ts
+++ b/src/lib/scan-feedback.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  playScanFeedback,
+  setScanFeedbackContextFactory,
+  SCAN_FEEDBACK_TONES,
+  type AudioContextFactory,
+} from "@/lib/scan-feedback";
+
+/**
+ * jsdom has no Web Audio API, so every test here injects a fake `AudioContext`
+ * via `setScanFeedbackContextFactory` — the exact seam the spec calls for
+ * ("injectable context factory for tests ... no more blind catch").
+ */
+
+interface FakeOscillator {
+  frequency: { value: number };
+  connect: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+}
+
+interface FakeGain {
+  gain: {
+    setValueAtTime: ReturnType<typeof vi.fn>;
+    linearRampToValueAtTime: ReturnType<typeof vi.fn>;
+  };
+  connect: ReturnType<typeof vi.fn>;
+}
+
+function createFakeAudioContext() {
+  const oscillators: FakeOscillator[] = [];
+  const gains: FakeGain[] = [];
+  const resume = vi.fn().mockResolvedValue(undefined);
+
+  const ctx = {
+    state: "suspended" as AudioContextState,
+    currentTime: 0,
+    destination: {},
+    resume,
+    createOscillator: vi.fn((): FakeOscillator => {
+      const osc: FakeOscillator = {
+        frequency: { value: 0 },
+        connect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+      };
+      oscillators.push(osc);
+      return osc;
+    }),
+    createGain: vi.fn((): FakeGain => {
+      const gain: FakeGain = {
+        gain: {
+          setValueAtTime: vi.fn(),
+          linearRampToValueAtTime: vi.fn(),
+        },
+        connect: vi.fn(),
+      };
+      gains.push(gain);
+      return gain;
+    }),
+  };
+
+  return { ctx: ctx as unknown as AudioContext, oscillators, gains, resume };
+}
+
+describe("playScanFeedback", () => {
+  afterEach(() => {
+    setScanFeedbackContextFactory(null);
+  });
+
+  it("lazily creates a single shared AudioContext reused across N plays", () => {
+    const fake = createFakeAudioContext();
+    let calls = 0;
+    const factory: AudioContextFactory = () => {
+      calls += 1;
+      return fake.ctx;
+    };
+    setScanFeedbackContextFactory(factory);
+
+    playScanFeedback("success");
+    playScanFeedback("error");
+    playScanFeedback("success");
+
+    expect(calls).toBe(1);
+  });
+
+  it("calls resume() before every play", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("success");
+    playScanFeedback("success");
+    playScanFeedback("info");
+
+    expect(fake.resume).toHaveBeenCalledTimes(3);
+  });
+
+  it("plays success at 800Hz / 150ms — byte-identical to the legacy T&T beep", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("success");
+
+    expect(fake.oscillators).toHaveLength(1);
+    expect(fake.oscillators[0].frequency.value).toBe(800);
+    expect(fake.oscillators[0].stop).toHaveBeenCalledWith(0.15);
+    expect(SCAN_FEEDBACK_TONES.success).toEqual({ frequency: 800, durationMs: 150 });
+  });
+
+  it("plays error at 300Hz / 400ms — byte-identical to the legacy T&T beep", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("error");
+
+    expect(fake.oscillators).toHaveLength(1);
+    expect(fake.oscillators[0].frequency.value).toBe(300);
+    expect(fake.oscillators[0].stop).toHaveBeenCalledWith(0.4);
+    expect(SCAN_FEEDBACK_TONES.error).toEqual({ frequency: 300, durationMs: 400 });
+  });
+
+  it("plays info at 600Hz / 80ms as a single blip", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("info");
+
+    expect(fake.oscillators).toHaveLength(1);
+    expect(fake.oscillators[0].frequency.value).toBe(600);
+    expect(fake.oscillators[0].stop).toHaveBeenCalledWith(0.08);
+  });
+
+  it("plays exception as a 500Hz double-blip, second blip after the first ends", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("exception");
+
+    expect(fake.oscillators).toHaveLength(2);
+    expect(fake.oscillators[0].frequency.value).toBe(500);
+    expect(fake.oscillators[1].frequency.value).toBe(500);
+
+    const firstStart = fake.oscillators[0].start.mock.calls[0][0] as number;
+    const firstStop = fake.oscillators[0].stop.mock.calls[0][0] as number;
+    const secondStart = fake.oscillators[1].start.mock.calls[0][0] as number;
+
+    expect(firstStart).toBe(0);
+    expect(firstStop).toBeCloseTo(0.12, 5);
+    // Second blip starts strictly after the first ends (gap, not overlap).
+    expect(secondStart).toBeGreaterThan(firstStop);
+    expect(secondStart).toBeCloseTo(firstStop + 0.09, 5);
+  });
+
+  it("ramps gain out instead of a hard stop (no click)", () => {
+    const fake = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    playScanFeedback("success");
+
+    const gain = fake.gains[0].gain;
+    expect(gain.setValueAtTime).toHaveBeenCalled();
+    expect(gain.linearRampToValueAtTime).toHaveBeenCalledWith(0, 0.15);
+  });
+
+  it("swallows AudioContext construction failures instead of throwing", () => {
+    setScanFeedbackContextFactory(() => {
+      throw new Error("Web Audio unavailable");
+    });
+
+    expect(() => playScanFeedback("success")).not.toThrow();
+  });
+
+  it("swallows failures from a context that throws mid-play", () => {
+    const fake = createFakeAudioContext();
+    fake.ctx.createOscillator = vi.fn(() => {
+      throw new Error("boom");
+    });
+    setScanFeedbackContextFactory(() => fake.ctx);
+
+    expect(() => playScanFeedback("success")).not.toThrow();
+  });
+
+  it("re-creates the context if the shared one was closed", () => {
+    const fakeA = createFakeAudioContext();
+    (fakeA.ctx as unknown as { state: AudioContextState }).state = "closed";
+    let created = 0;
+    const fakeB = createFakeAudioContext();
+    setScanFeedbackContextFactory(() => {
+      created += 1;
+      return created === 1 ? fakeA.ctx : fakeB.ctx;
+    });
+
+    playScanFeedback("success");
+    playScanFeedback("success");
+
+    expect(created).toBe(2);
+  });
+});

--- a/src/lib/scan-feedback.ts
+++ b/src/lib/scan-feedback.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure, client-only audio feedback for scan verdicts — barcode/tag scanning
+ * across Warehouse prep/deploy/return, the T&T quick-test wizard, and the
+ * `/check/[assetTag]` ad-hoc station. See FEATUREDOCS/12 (Scan Feedback) and
+ * FEATUREDOCS/14 (Audio note).
+ *
+ * Replaces the old per-call-site `playBeep` (T&T quick-test) which created a
+ * brand-new `AudioContext` on every beep and never closed it — Chrome caps
+ * concurrent contexts at ~6, so head-down scanning eventually went silent.
+ * This module keeps a single **lazy, module-level shared `AudioContext`**,
+ * calls `resume()` before every play (browsers auto-suspend contexts created
+ * outside a user gesture — the old code never resumed, so beeps could be
+ * silently dropped), and ramps gain out instead of hard-stopping (no click).
+ */
+
+export type ScanFeedbackKind = "success" | "error" | "exception" | "info";
+
+interface TonePlan {
+  /** Oscillator frequency in Hz. */
+  frequency: number;
+  /** Blip duration in ms. */
+  durationMs: number;
+  /** Gap before a second blip, in ms. Omitted = single blip. */
+  secondBlipGapMs?: number;
+}
+
+/**
+ * Tone vocabulary (spec decision, 4 kinds):
+ * - `success`   — clean scan resolved as expected (800 Hz / 150 ms — byte-identical
+ *                 to the old T&T "pass" beep).
+ * - `error`     — hard failure, scan rejected (300 Hz / 400 ms — byte-identical to
+ *                 the old T&T "fail" beep).
+ * - `exception` — resolved but needs attention: not a clean success, not a hard
+ *                 error (e.g. already-returned asset, unknown tag, disambiguation
+ *                 needed — "scan the parent instead"). 500 Hz double-blip.
+ * - `info`      — neutral heads-up, e.g. a quantity prompt opening (600 Hz / 80 ms).
+ */
+export const SCAN_FEEDBACK_TONES: Record<ScanFeedbackKind, TonePlan> = {
+  success: { frequency: 800, durationMs: 150 },
+  error: { frequency: 300, durationMs: 400 },
+  exception: { frequency: 500, durationMs: 120, secondBlipGapMs: 90 },
+  info: { frequency: 600, durationMs: 80 },
+};
+
+const GAIN = 0.1;
+/** Ramp-out window at the tail of each blip, so the stop doesn't click. */
+const RAMP_OUT_MS = 15;
+
+export type AudioContextFactory = () => AudioContext;
+
+function defaultAudioContextFactory(): AudioContext {
+  const Ctor =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) throw new Error("Web Audio API unavailable");
+  return new Ctor();
+}
+
+let contextFactory: AudioContextFactory = defaultAudioContextFactory;
+let sharedContext: AudioContext | null = null;
+
+/**
+ * Inject a fake `AudioContext` factory for tests (jsdom has no Web Audio API).
+ * Pass `null` to restore the real browser factory. Also used by the T&T page's
+ * legacy tests if they construct their own fake — see `scan-feedback.test.ts`.
+ */
+export function setScanFeedbackContextFactory(factory: AudioContextFactory | null): void {
+  contextFactory = factory ?? defaultAudioContextFactory;
+  sharedContext = null;
+}
+
+function getSharedContext(): AudioContext | null {
+  try {
+    if (!sharedContext || sharedContext.state === "closed") {
+      sharedContext = contextFactory();
+    }
+    return sharedContext;
+  } catch {
+    return null;
+  }
+}
+
+function playBlip(ctx: AudioContext, plan: TonePlan, startAt: number): number {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.frequency.value = plan.frequency;
+
+  const durationS = plan.durationMs / 1000;
+  const rampOutS = Math.min(RAMP_OUT_MS / 1000, durationS / 2);
+  const rampStart = startAt + durationS - rampOutS;
+
+  gain.gain.setValueAtTime(GAIN, startAt);
+  gain.gain.setValueAtTime(GAIN, rampStart);
+  gain.gain.linearRampToValueAtTime(0, startAt + durationS);
+
+  osc.start(startAt);
+  osc.stop(startAt + durationS);
+
+  return startAt + durationS;
+}
+
+/**
+ * Play a scan feedback tone. Safe to call unconditionally — any Web Audio
+ * failure (autoplay policy, missing API, closed context) is swallowed so
+ * callers never need their own try/catch.
+ */
+export function playScanFeedback(kind: ScanFeedbackKind): void {
+  const ctx = getSharedContext();
+  if (!ctx) return;
+  try {
+    void ctx.resume();
+    const plan = SCAN_FEEDBACK_TONES[kind];
+    const firstBlipEnd = playBlip(ctx, plan, ctx.currentTime);
+    if (plan.secondBlipGapMs != null) {
+      playBlip(ctx, plan, firstBlipEnd + plan.secondBlipGapMs / 1000);
+    }
+  } catch {
+    // Audio is a non-critical enhancement — never let it break a scan flow.
+  }
+}

--- a/src/lib/woocommerce-utils.test.ts
+++ b/src/lib/woocommerce-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "vitest";
+import { resolveWooDiscountPercent } from "./woocommerce-utils";
+
+// QW-4 (#953) — the discount seed for WooCommerce-assembled projects (both the
+// Convex `processOrder` action and the legacy `src/server/woocommerce.ts` path
+// call this canonical definition; `convex/wooCommerceActions.ts` carries a
+// verbatim copy since Convex can't import from src/ — keep them in sync).
+describe("resolveWooDiscountPercent", () => {
+  test("returns the client's defaultDiscount when set", () => {
+    expect(resolveWooDiscountPercent({ defaultDiscount: 15 })).toBe(15);
+  });
+
+  test("returns an explicit 0% default (not falsy-coerced to undefined)", () => {
+    expect(resolveWooDiscountPercent({ defaultDiscount: 0 })).toBe(0);
+  });
+
+  test("returns undefined when the client has no defaultDiscount set", () => {
+    expect(resolveWooDiscountPercent({})).toBeUndefined();
+    expect(resolveWooDiscountPercent({ defaultDiscount: undefined })).toBeUndefined();
+  });
+
+  test("returns undefined when defaultDiscount is explicitly null", () => {
+    expect(resolveWooDiscountPercent({ defaultDiscount: null })).toBeUndefined();
+  });
+});

--- a/src/lib/woocommerce-utils.ts
+++ b/src/lib/woocommerce-utils.ts
@@ -42,3 +42,21 @@ export function flexibleDateParse(value: string, preferredFormat: string = "auto
 
   return null;
 }
+
+/**
+ * QW-4 (#953): the project-assembly discount seed for a WooCommerce order.
+ *
+ * Both Woo assembly paths (`convex/wooCommerceActions.ts`'s `processOrder` action
+ * and this file's caller, `src/server/woocommerce.ts`'s legacy twin) build a new
+ * project directly — neither goes through `projectWrites.createNative`, so
+ * neither gets its in-mutation `defaultDiscount` cascade for free. This is the
+ * canonical definition (R-3.1 single source of truth); `convex/wooCommerceActions.ts`
+ * carries a verbatim copy (same pattern as `flexibleDateParse` in that file —
+ * Convex's function bundler can't reach into `src/`, see its comment). Keep both
+ * copies byte-identical on change. Woo orders never carry an explicit discount of
+ * their own, so there's no "explicit value wins" case here (unlike `createNative`,
+ * which also has to arbitrate a caller-supplied discount).
+ */
+export function resolveWooDiscountPercent(client: { defaultDiscount?: number | null }): number | undefined {
+  return client.defaultDiscount != null ? client.defaultDiscount : undefined;
+}

--- a/src/server/woocommerce.ts
+++ b/src/server/woocommerce.ts
@@ -12,7 +12,7 @@ import { requirePermission } from "@/lib/org-context";
 import { serialize } from "@/lib/serialize";
 import { logActivity } from "@/lib/activity-log";
 import { recalculateProjectTotals } from "@/server/line-items";
-import { flexibleDateParse } from "@/lib/woocommerce-utils";
+import { flexibleDateParse, resolveWooDiscountPercent } from "@/lib/woocommerce-utils";
 import {
   getWooCommerceOrderLogsPage,
   getFailedOrderLogById,
@@ -321,6 +321,12 @@ export async function processWooCommerceOrder(
       : `${order.billing.first_name} ${order.billing.last_name} — Website Order #${order.number || order.id}`;
     const clientNotes = extractNotes(order, integration);
     const projectCreatedAt = Date.now();
+    // QW-4 (#953): seed the discount cascade here too — this path creates the
+    // project via api.projects.createWithUniqueNumber (a plain insert), which
+    // does NOT run projectWrites.createNative's in-mutation defaultDiscount
+    // lookup. A snapshot, not a live link (see the "no retroactive change" note
+    // on createNative).
+    const wooDiscountPercent = resolveWooDiscountPercent(client);
     const buildProjectArgs = (num: string) => ({
       id: projectId,
       organizationId: orgId,
@@ -334,6 +340,7 @@ export async function processWooCommerceOrder(
       ...(dates.rentalEnd ? { rentalEndDate: dates.rentalEnd.getTime() } : {}),
       ...(dates.eventStart ? { eventStartDate: dates.eventStart.getTime() } : {}),
       ...(clientNotes ? { clientNotes } : {}),
+      ...(wooDiscountPercent != null ? { discountPercent: wooDiscountPercent } : {}),
       tags: ["website-order"],
       createdAt: projectCreatedAt,
       updatedAt: projectCreatedAt,


### PR DESCRIPTION
## Summary

Implements all three sub-issues of the #937 quick-wins tracking issue:

- **QW-1 (#951) — Shared scan audio feedback.** Extracts the old T&T-only `playBeep` into `src/lib/scan-feedback.ts`, fixing the per-beep `AudioContext` leak (now a lazy shared context with `resume()` before each play), and adds a 4-tone vocabulary (`success`/`error`/`exception`/`info`). `useScanFeedback` hook persists an on/off toggle per-device in `localStorage`. Wired into the T&T quick-test wizard (byte-identical behaviour, now persisted), warehouse prep/deploy/return scanning, and the `/check/[assetTag]` ad-hoc station.
- **QW-3 (#952) — "My tasks" rollup + dashboard overhaul.** New `convex/projectTasks.myOpenTasks` query (cross-project, union of user- and crew-assigned open tasks, org-isolated, sorted overdue → due-asc → priority). New `/my-tasks` page with a sidebar entry. Dashboard reordered into three zones: **My work** (promoted to top — my tasks due, blockers/mentions, my projects), **Org risk** (needs-attention chips, with an extension-point comment for a sibling issue's board chips), and **Demoted** (org counters + activity feed, below the fold).
- **QW-4 (#953) — Wire `Client.defaultDiscount`.** `projectWrites.createNative` now stamps a project's `discountPercent` from the client's `defaultDiscount` when the caller doesn't explicitly provide one (explicit `0` always wins — no truthiness bug). Same behaviour seeded into both WooCommerce project-assembly paths. Project wizard prefills the discount field from the selected client, editable, with untouched-only re-prefill on client change. `depositPercent`/`depositPaid`/`invoicedTotal` are left dormant and marked reserved for #940 (WS1) per the tracking issue's re-review.

Closes #951, closes #952, closes #953, closes #937.

FEATUREDOCS/06, 10, 12, 14, 29, 35, 50 and DESIGN.md updated in this PR per R-5.2/5.3.

## Size rationale (R-2.8 / T-2)

This PR is ~2100 LOC, over the ≤400 LOC SHOULD-level target. It bundles three independent quick-wins rather than three separate PRs because all three were scoped to land together as sub-issues of a single tracking issue (#937) on one designated branch. Each quick-win is its own self-contained, atomically-committed unit (5 commits for QW-4, 6 for QW-1, 5 for QW-3 — see commit history) and could be reverted or reviewed independently by commit range if needed. Splitting into separate PRs now would mean re-branching after the fact with no correctness benefit, so keeping them as one PR was the pragmatic call here rather than a default choice for future work.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — 313 files / 3978 tests passing (includes new unit tests for `scan-feedback.ts`, `useScanFeedback`, `myOpenTasks` union/de-dup/org-isolation/sort, `/my-tasks` and dashboard-reorder jsdom smoke tests, and `projectWrites.createNative` discount-default cases)
- `pnpm lint` — 0 errors; pre-existing warning count (1444) unchanged, no new warnings introduced
- Convex: schema/functions bundle and type-check cleanly via `convex dev --once` against an anonymous local deployment (no `CONVEX_DEPLOY_KEY` available in this environment) — the real shared dev deployment push still needs to run with a valid key outside this environment.

## Checklist

- [x] New dependency? — No new dependencies added.