### PR TITLE
Hotfix: unbreak prod Convex deploy (projects.depositPercent schema break)

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -86,7 +86,14 @@ through this engine.
 - `clients.paymentProfile` (`FULL_UPFRONT | DEPOSIT_BALANCE`, absent =
   `FULL_UPFRONT`) + `clients.profileDepositPercent` (default 25) — the
   client payment profile now owns "how much deposit". `projects.depositPercent`
-  no longer exists (removed from the schema entirely).
+  is retired at the application layer (no reader/writer anywhere), but is
+  **still declared `v.optional` in the schema** — the original hard removal
+  broke the prod Convex deploy, because real pre-#940 wizard values were still
+  stored on live project documents and strict schema validation rejects a push
+  where an existing document has a field the validator no longer declares.
+  `backfillStripProjectDepositPercent.ts` strips it from every project; once a
+  run confirms zero remaining, the field can be fully deleted from the
+  validator in a follow-up PR.
 - `projects.depositPaid`/`invoicedTotal` — moved from "hand-typed wizard
   input, applied nowhere server-side" to recalc-OWNED
   `PROJECT_MONEY_ANCHORS` (same treatment as `equipmentRevenue`/`total`/

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as backfillClientContacts from "../backfillClientContacts.js";
 import type * as backfillKitUnits from "../backfillKitUnits.js";
 import type * as backfillMaintenanceSchedules from "../backfillMaintenanceSchedules.js";
 import type * as backfillProjectWindow from "../backfillProjectWindow.js";
+import type * as backfillStripProjectDepositPercent from "../backfillStripProjectDepositPercent.js";
 import type * as bulkAssets from "../bulkAssets.js";
 import type * as bulkAssetsWrites from "../bulkAssetsWrites.js";
 import type * as categories from "../categories.js";
@@ -285,6 +286,7 @@ declare const fullApi: ApiFromModules<{
   backfillKitUnits: typeof backfillKitUnits;
   backfillMaintenanceSchedules: typeof backfillMaintenanceSchedules;
   backfillProjectWindow: typeof backfillProjectWindow;
+  backfillStripProjectDepositPercent: typeof backfillStripProjectDepositPercent;
   bulkAssets: typeof bulkAssets;
   bulkAssetsWrites: typeof bulkAssetsWrites;
   categories: typeof categories;

--- a/convex/backfillStripProjectDepositPercent.test.ts
+++ b/convex/backfillStripProjectDepositPercent.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// Hotfix for #940 (WS1 — finance model): strips the deprecated
+// `projects.depositPercent` field so it can eventually be fully removed from
+// the schema validator. See convex/backfillStripProjectDepositPercent.ts.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+
+function project(id: string, extra: Record<string, unknown> = {}) {
+  return {
+    id, organizationId: ORG, projectNumber: `P-${id}`, name: "Gig", status: "CONFIRMED" as const,
+    createdAt: NOW, updatedAt: NOW, ...extra,
+  };
+}
+
+async function runBackfill(t: T, apply = true) {
+  let cursor: string | null = null;
+  let scanned = 0;
+  let updated = 0;
+  for (;;) {
+    const r: { scanned: number; updated: number; isDone: boolean; continueCursor: string } =
+      await t.withIdentity(SERVICE).mutation(
+        api.backfillStripProjectDepositPercent.backfillStripProjectDepositPercentPage,
+        { cursor, apply },
+      );
+    scanned += r.scanned;
+    updated += r.updated;
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+  return { scanned, updated };
+}
+const projById = (t: T, id: string) => t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first());
+
+describe("backfillStripProjectDepositPercent — removes the deprecated field", () => {
+  test("strips depositPercent from a project that has it", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", project("p1", { depositPercent: 0 }));
+    });
+    const { scanned, updated } = await runBackfill(t);
+    expect(scanned).toBe(1);
+    expect(updated).toBe(1);
+    const p = await projById(t, "p1");
+    expect(p?.depositPercent).toBeUndefined();
+  });
+
+  test("a project without depositPercent is skipped", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", project("p1"));
+    });
+    const { scanned, updated } = await runBackfill(t);
+    expect(scanned).toBe(0);
+    expect(updated).toBe(0);
+  });
+
+  test("re-running the backfill strips nothing new", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("projects", project("p1", { depositPercent: 25 })); });
+    expect((await runBackfill(t)).updated).toBe(1);
+    expect((await runBackfill(t)).updated).toBe(0);
+  });
+
+  test("dry-run scans but writes nothing", async () => {
+    const t = makeT();
+    await t.run(async (ctx) => { await ctx.db.insert("projects", project("p1", { depositPercent: 10 })); });
+    const { scanned, updated } = await runBackfill(t, false);
+    expect(scanned).toBe(1);
+    expect(updated).toBe(0);
+    const p = await projById(t, "p1");
+    expect(p?.depositPercent).toBe(10);
+  });
+});

--- a/convex/backfillStripProjectDepositPercent.ts
+++ b/convex/backfillStripProjectDepositPercent.ts
@@ -1,0 +1,42 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+
+/**
+ * Hotfix for #940 (WS1 — finance model): #940 removed `projects.depositPercent`
+ * from the schema validator (deposit % moved to the client payment profile), but
+ * never stripped the field from existing project documents — it was a real,
+ * hand-typed wizard input pre-#940, not a dead/unused field. That broke the prod
+ * Convex deploy: schema validation rejects a push where a live document has a
+ * field the validator no longer declares. `convex/schema.ts` re-added the field
+ * as `v.optional` (harmless round-trip, nothing reads/writes it) to unblock
+ * deploys; this migration strips it so the field can be fully deleted from the
+ * validator in a follow-up once every project has been paged.
+ *
+ * Same paginated-mutation + apply-flag shape as `backfillProjectWindow.ts`.
+ * Idempotent — a project with no `depositPercent` is skipped. SERVICE-only.
+ *
+ * Driver: scripts/convex-backfill-strip-project-deposit-percent.ts.
+ */
+export const backfillStripProjectDepositPercentPage = mutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    apply: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, { cursor, apply, numItems }) => {
+    await requireService(ctx);
+    const res = await ctx.db.query("projects").paginate({ cursor, numItems: numItems ?? 300 });
+
+    let scanned = 0;
+    let updated = 0;
+    for (const project of res.page) {
+      if (project.depositPercent === undefined) continue;
+      scanned++;
+      if (!apply) continue;
+      await ctx.db.patch(project._id, { depositPercent: undefined });
+      updated++;
+    }
+    return { scanned, updated, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1037,6 +1037,16 @@ export default defineSchema({
     // deriveInvoiceTotals) — summed from this project's non-VOID invoices, same as
     // equipmentRevenue/subtotal/total above. Never client-writable (stripped in
     // projectWrites.ts's PROJECT_MONEY_ANCHORS the same way the others are).
+    //
+    // DEPRECATED, kept for one rollout cycle (same pattern as loadInDate/eventStartDate
+    // above): #940's original removal of this field from the validator broke the prod
+    // deploy — real hand-typed wizard values (project-wizard.tsx, pre-#940) are still
+    // stored on live project documents, and Convex schema validation rejects a push
+    // where an existing document has a field the validator no longer declares. Re-added
+    // as optional so it round-trips harmlessly; nothing reads or writes it anymore.
+    // `backfillStripProjectDepositPercent.ts` strips it from every project so this can
+    // be fully deleted from the validator in a follow-up once that's run and confirmed.
+    depositPercent: v.optional(v.number()),
     depositPaid: v.optional(v.number()),
     invoicedTotal: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),

--- a/scripts/convex-backfill-strip-project-deposit-percent.ts
+++ b/scripts/convex-backfill-strip-project-deposit-percent.ts
@@ -1,0 +1,59 @@
+/**
+ * Hotfix for #940 (WS1 — finance model) driver.
+ * See convex/backfillStripProjectDepositPercent.ts for the full rationale.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-strip-project-deposit-percent.ts          # dry-run
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-strip-project-deposit-percent.ts --apply  # writes
+ *
+ * Pages the `projects` table via
+ * api.backfillStripProjectDepositPercent.backfillStripProjectDepositPercentPage
+ * until done, removing the deprecated `depositPercent` field from every project
+ * that still has it. Idempotent — safe to re-run. Once a full run reports
+ * `updated === scanned` and a re-run reports 0/0, `depositPercent` can be fully
+ * deleted from `convex/schema.ts`'s `projects` validator.
+ *
+ * A fresh Convex client is fetched per page so the short-lived service token
+ * can't expire mid-run. No ANALYZE — Convex.
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  console.log("Strip projects.depositPercent (#940 hotfix) backfill");
+  console.log("─".repeat(60));
+  console.log(`Mode: ${apply ? "APPLY (will remove depositPercent)" : "dry-run"}`);
+  console.log();
+
+  let cursor: string | null = null;
+  let scanned = 0;
+  let updated = 0;
+  let page = 0;
+  for (;;) {
+    // Fresh client per page — the service token is short-lived.
+    const convex = await getConvexClient();
+    const r: { scanned: number; updated: number; isDone: boolean; continueCursor: string } =
+      await convex.mutation(api.backfillStripProjectDepositPercent.backfillStripProjectDepositPercentPage, { cursor, apply });
+    scanned += r.scanned;
+    updated += r.updated;
+    page++;
+    if (r.scanned > 0) {
+      console.log(`  page ${page}: ${apply ? `stripped ${r.updated}` : `would strip ${r.scanned}`} project(s)`);
+    }
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+
+  console.log();
+  console.log(`${scanned} project(s) with a stray depositPercent found across ${page} page(s).`);
+  if (apply) console.log(`✓ Stripped ${updated} project(s).`);
+  else console.log(`(Dry run — re-run with --apply to strip ${scanned} project(s).)`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("\nBackfill failed:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

The `main` deploy workflow has been failing at "Deploy Convex functions"
since PR #973 (WS1, #940) merged. Root cause: #940 removed
`projects.depositPercent` from the Convex schema validator entirely (deposit
% moved to the client payment profile), but never checked for or stripped it
from live data. The field was a real, hand-typed wizard input pre-#940 — the
comment #940 deleted even warned *"do NOT wire deposit math or delete these
as dead fields in a hygiene pass; #940 owns them"* — and at least one
production `projects` document still has `depositPercent: 0`. Convex's
strict schema validation rejects a push where an existing document carries a
field the validator no longer declares, so every push to `main` since the
WS1 merge has failed the same way. The site itself is fine (the old image
keeps serving), but no further deploy can land until this is fixed.

## What changed

- `convex/schema.ts` — re-added `depositPercent: v.optional(v.number())` to
  the `projects` table, using the same "deprecated, kept for one rollout
  cycle" pattern already established in this exact file for
  `loadInDate`/`eventStartDate` etc. Nothing reads or writes it anymore — it
  round-trips harmlessly until every live document has been cleaned up.
- `convex/backfillStripProjectDepositPercent.ts` (new) — a paginated mutation
  that strips `depositPercent` from every project that still has it, mirroring
  `backfillProjectWindow.ts`'s shape exactly (idempotent, `apply`-flag
  dry-run, SERVICE-only). + `backfillStripProjectDepositPercent.test.ts` (4
  tests: strips when present, skips when absent, idempotent re-run, dry-run
  writes nothing).
- `scripts/convex-backfill-strip-project-deposit-percent.ts` (new) — driver
  script mirroring `convex-backfill-project-window.ts`.
- `convex/_generated/api.d.ts` — hand-added the new module's entry (alphabetical,
  matching the generator's own ordering). Could not run `pnpm exec convex
  codegen` in this sandbox (no `CONVEX_DEPLOYMENT` configured); the addition
  is a mechanical two-line diff following the existing `backfillProjectWindow`
  entry exactly.
- `FEATUREDOCS/66-finance-quotes-invoices-xero.md` — updated the "Derive,
  don't hand-type" section to reflect that `depositPercent` is deprecated but
  still schema-present, and why.

## Follow-up (not in this PR)

Once someone with real prod Convex credentials runs
`scripts/convex-backfill-strip-project-deposit-percent.ts --apply` against
prod and a re-run confirms `0 scanned`, a small follow-up PR can delete
`depositPercent` from the `projects` validator for good.

## Testing

```
pnpm exec tsc --noEmit   # clean
pnpm lint                # 0 errors (warnings only, pre-existing baseline)
pnpm exec vitest run     # 4575/4575 passed, 369 files (+4 new tests)
pnpm build                # succeeds, all routes
pnpm run any-ratchet       # OK, 137 == baseline
pnpm run collect-ratchet   # OK, 730 == baseline
pnpm run knip-ratchet      # OK, 418 == baseline
pnpm run complexity-ratchet # OK, 686 == baseline
```

Not run: `pnpm exec convex dev --once` / `codegen` against a real deployment
— no `CONVEX_DEPLOY_KEY`/`CONVEX_DEPLOYMENT` in this sandbox (same
limitation noted in #972/#973). The actual fix here is exactly the schema
validator change the failing prod deploy log surfaced, so this should
resolve on the next push to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhk2JYhAbZpTLkGzFFXumE)_