### PR TITLE
Xero integration: fix invalid_scope, gate settings on deployment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,15 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 # ── Cron (optional) ────────────────────────────────────────────────────────────
 # CRON_SECRET=
 
+# ── Xero integration (optional — WS1 #940) ────────────────────────────────────
+# Unset = the "Connect Xero" action throws a clear error at click-time rather
+# than gating app boot; no org connecting Xero is a valid steady state.
+# From your Xero developer app (developer.xero.com/app/manage):
+# XERO_CLIENT_ID=
+# XERO_CLIENT_SECRET=
+# Defaults to `${NEXT_PUBLIC_APP_URL}/api/integrations/xero/callback` when unset.
+# XERO_REDIRECT_URI=
+
 # ── Analytics + error tracking (PostHog, optional) ────────────────────────────
 # Public write-only ingestion key (phc_…) — safe to expose; browser needs the
 # NEXT_PUBLIC_ copy (inlined at build). Analytics + client/server exception

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -188,6 +188,18 @@ unlinked, every coding field (category/model/kit/line/service forms, the
 client's Xero contact card, the Settings → Xero page) is hidden but the
 stored value is retained, inert.
 
+### Deployment gate
+
+A second, deployment-level gate sits above the org-level linked gate:
+`src/server/xero.ts` `isXeroConfigured()` reports whether `XERO_CLIENT_ID`/
+`XERO_CLIENT_SECRET` are set at all (unauthenticated — it reveals nothing but
+a boolean). When unset, the "Xero" item never renders in the Settings nav
+(`src/app/(app)/settings/layout.tsx`, `useServerQuery` — one-shot, never
+invalidated, a deployment's env config doesn't change mid-session) and a
+direct visit to `/settings/xero` shows a "not configured" message instead of
+a "Connect Xero" button that would otherwise throw at click-time
+(`requireXeroAppCredentials()` in `src/server/xero.ts`).
+
 ### Client contact mapping
 
 Client detail page (Xero-linked only) — search Xero contacts by name, or

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -25,6 +25,8 @@ import {
 import { cn } from "@/lib/utils";
 import { useCanDo } from "@/lib/use-permissions";
 import { useActiveOrganization } from "@/lib/auth-client";
+import { useServerQuery } from "@/hooks/use-server-query";
+import { isXeroConfigured } from "@/server/xero";
 import {
   Select,
   SelectContent,
@@ -109,6 +111,15 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
   const canManageLineItems = useCanDo("project", "manage_line_items");
   const canManageXero = useCanDo("invoice", "xero_manage");
   const { data: activeOrg } = useActiveOrganization();
+  // Deployment-level gate (XERO_CLIENT_ID/SECRET) on top of the org-level
+  // xero_manage permission — no Xero developer app means the page is dead
+  // weight, not just permission-gated. Defaults to hidden while loading so
+  // the nav never flashes a link that's about to disappear.
+  const { data: xeroConfig } = useServerQuery({
+    queryKey: ["xero-configured"],
+    queryFn: () => isXeroConfigured(),
+  });
+  const xeroConfigured = xeroConfig?.configured === true;
 
   if (!canReadSettings && !canReadMembers) {
     return (
@@ -126,7 +137,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
     if (permission === "orgMembers") return canReadMembers;
     if (permission === "checkItem") return canReadCheckItems;
     if (permission === "project") return canManageLineItems;
-    if (permission === "invoice") return canManageXero;
+    if (permission === "invoice") return canManageXero && xeroConfigured;
     return true;
   };
 

--- a/src/app/(app)/settings/xero/page.tsx
+++ b/src/app/(app)/settings/xero/page.tsx
@@ -12,9 +12,11 @@ import {
   disconnectXero,
   refreshXeroReferenceData,
   updateXeroCodingSettings,
+  isXeroConfigured,
   type XeroCodingSettingsInput,
 } from "@/server/xero";
 import { useServerMutation } from "@/hooks/use-server-mutation";
+import { useServerQuery } from "@/hooks/use-server-query";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -43,6 +45,10 @@ const SERVICE_TYPES = [
 export default function XeroSettingsPage() {
   const integration = useXeroIntegration();
   const searchParams = useSearchParams();
+  const { data: xeroConfig, isLoading: xeroConfigLoading } = useServerQuery({
+    queryKey: ["xero-configured"],
+    queryFn: () => isXeroConfigured(),
+  });
 
   useEffect(() => {
     if (searchParams.get("xero_connected")) toast.success("Xero connected");
@@ -90,6 +96,25 @@ export default function XeroSettingsPage() {
     onSuccess: () => toast.success("Xero coding defaults saved"),
     onError: (e) => toast.error(e.message),
   });
+
+  // Deployment-level gate — settings nav already hides this page's link when
+  // unconfigured, but a direct URL visit should get a clear message instead
+  // of a "Connect Xero" button that would just throw at click-time.
+  if (!xeroConfigLoading && xeroConfig?.configured !== true) {
+    return (
+      <FormSection title="Xero" description="Connect Xero to push draft invoices and resolve account coding.">
+        <SettingsCard>
+          <p className="t-body text-fg-3">
+            Xero isn&apos;t configured on this deployment yet — an admin needs to set
+            <code className="mx-1 rounded bg-paper-2 px-1 py-0.5 t-micro">XERO_CLIENT_ID</code>
+            and
+            <code className="mx-1 rounded bg-paper-2 px-1 py-0.5 t-micro">XERO_CLIENT_SECRET</code>
+            before any organisation can connect.
+          </p>
+        </SettingsCard>
+      </FormSection>
+    );
+  }
 
   return (
     <div className="space-y-8">

--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -49,6 +49,22 @@ describe("buildXeroAuthorizeUrl", () => {
     // between the documented XERO_OAUTH_SCOPES list and what's requested.
     expect(parsed.searchParams.get("scope")).toBe(XERO_OAUTH_SCOPES.join(" "));
   });
+
+  it("percent-encodes the scope's spaces as %20, not +", () => {
+    // Regression test: `new URLSearchParams(...).toString()` encodes spaces
+    // as `+` (application/x-www-form-urlencoded), which round-trips fine
+    // through URLSearchParams.get() in a test (masking the bug) but Xero's
+    // /authorize endpoint parses the query string strictly and never decodes
+    // `+` back to a space — it saw one unrecognized scope blob and rejected
+    // the whole authorize request with `invalid_scope`.
+    const url = buildXeroAuthorizeUrl({
+      clientId: "client-123",
+      redirectUri: "https://flow.rvlt.app/api/integrations/xero/callback",
+      state: "signed-state-token",
+    });
+    expect(url).toContain("scope=openid%20profile%20email");
+    expect(url).not.toContain("+");
+  });
 });
 
 describe("exchangeXeroAuthCode / refreshXeroAccessToken", () => {

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -65,14 +65,24 @@ export function buildXeroAuthorizeUrl(opts: {
   redirectUri: string;
   state: string;
 }): string {
-  const params = new URLSearchParams({
+  // NOT URLSearchParams: its application/x-www-form-urlencoded encoding turns
+  // the space-separated `scope` list into `+`-joined tokens
+  // (openid+profile+email+...). Xero's /authorize endpoint parses the query
+  // string strictly and never decodes `+` back to a space, so it sees one
+  // unrecognized scope blob and rejects the whole request with
+  // `invalid_scope`. encodeURIComponent percent-encodes a space as `%20`,
+  // which Xero decodes correctly.
+  const params: Record<string, string> = {
     response_type: "code",
     client_id: opts.clientId,
     redirect_uri: opts.redirectUri,
     scope: XERO_OAUTH_SCOPES.join(" "),
     state: opts.state,
-  });
-  return `${AUTHORIZE_BASE}?${params.toString()}`;
+  };
+  const query = Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+  return `${AUTHORIZE_BASE}?${query}`;
 }
 
 const tokenResponseSchema = z.object({

--- a/src/server/xero.ts
+++ b/src/server/xero.ts
@@ -59,6 +59,19 @@ function requireXeroAppCredentials(): { clientId: string; clientSecret: string }
 // instead of a server-action round trip, per FEATUREDOCS/54's "browser
 // components subscribe to native reactive queries" default.
 
+/**
+ * Whether this DEPLOYMENT has a Xero developer app configured
+ * (XERO_CLIENT_ID/XERO_CLIENT_SECRET) — distinct from whether any particular
+ * org has connected (that's `xeroIntegrations.isConnected`, read via
+ * `useXeroLinked()`). No permission gate: it reveals nothing but a boolean,
+ * and the settings nav needs it before a user's org context justifies
+ * `xero_manage`. Consumed via `useServerQuery` (never invalidated — a
+ * deployment's env config doesn't change mid-session, see use-server-query.ts).
+ */
+export async function isXeroConfigured() {
+  return serialize({ configured: Boolean(env.XERO_CLIENT_ID && env.XERO_CLIENT_SECRET) });
+}
+
 /** Build the Xero authorize URL for the "Connect Xero" button. Requires
  *  xero_manage (org admin+) — connecting/disconnecting the integration is a
  *  more sensitive action than everyday invoice pushing. */


### PR DESCRIPTION
## Summary

- Fixes the `invalid_scope` error Xero returned on "Connect Xero": `buildXeroAuthorizeUrl` built the query string with `URLSearchParams`, which encodes the space-separated `scope` list as `+`-joined tokens (form-urlencoded convention). Xero's `/authorize` endpoint parses the query string strictly and never decodes `+` back to a space, so it saw one unrecognized scope blob and rejected the whole request. Now built manually with `encodeURIComponent`, which produces `%20`.
- Gates the Xero settings UI on deployment-level config: adds `isXeroConfigured()` (unauthenticated, boolean-only server action) and hides the "Xero" item in the Settings nav — plus shows a clear "not configured" message instead of a "Connect Xero" button on a direct `/settings/xero` visit — when `XERO_CLIENT_ID`/`XERO_CLIENT_SECRET` aren't set on the deployment.
- Adds the missing `XERO_CLIENT_ID`/`XERO_CLIENT_SECRET`/`XERO_REDIRECT_URI` block to `.env.example` (documented in `src/env.ts` and `CLAUDE.md` but never added to the example file).
- Updates `FEATUREDOCS/66-finance-quotes-invoices-xero.md` with the new deployment gate.

## Testing

- `pnpm exec vitest run src/lib/xero-client.test.ts src/server/xero.test.ts` — all passing, including a new regression test asserting the raw authorize URL contains `%20` (not `+`) in the scope param. The prior test round-tripped through `URLSearchParams.get()`, which silently decodes `+` back to a space — that's why it didn't catch the bug.
- `pnpm exec tsc --noEmit` clean on all touched files.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HoeQabDo6GQpTgSKQfxdqa)_