### PR TITLE
Fix invalid_scope on Xero connect: use granular accounting.invoices scope

### DIFF
--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -73,7 +73,7 @@ describe("exchangeXeroAuthCode / refreshXeroAccessToken", () => {
     refresh_token: "refresh-xyz",
     token_type: "Bearer",
     expires_in: 1800,
-    scope: "openid profile email offline_access accounting.transactions",
+    scope: "openid profile email offline_access accounting.invoices",
   };
 
   it("exchanges an authorization code for a token pair with Basic auth", async () => {

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -23,14 +23,26 @@ const IDENTITY_BASE = "https://identity.xero.com";
 const API_BASE = "https://api.xero.com";
 const AUTHORIZE_BASE = "https://login.xero.com/identity/connect/authorize";
 
-/** Scopes requested at connect time — read-only reference data + invoice/contact
- *  write, plus offline_access for the refresh token. */
+/**
+ * Scopes requested at connect time — read-only reference data + invoice/contact
+ * write, plus offline_access for the refresh token.
+ *
+ * `accounting.invoices` (NOT the broad `accounting.transactions`): Xero split
+ * `accounting.transactions` into granular scopes on 4 March 2026, and any Xero
+ * app created after that date is issued ONLY the granular set — the broad
+ * scope isn't available to request at all, so asking for it throws
+ * `invalid_scope` at the /authorize step for every new app. `accounting.invoices`
+ * is the granular replacement covering invoices/credit notes/quotes, which is
+ * all this integration pushes (createXeroDraftInvoice). Pre-March-2026 apps can
+ * still use the broad scope through September 2027, but there's no reason to —
+ * the granular scope works for both old and new apps.
+ */
 export const XERO_OAUTH_SCOPES = [
   "openid",
   "profile",
   "email",
   "offline_access",
-  "accounting.transactions",
+  "accounting.invoices",
   "accounting.contacts",
   "accounting.settings.read",
 ] as const;


### PR DESCRIPTION
## Summary

- Follow-up to #982, which fixed a scope-encoding issue but didn't resolve the live `invalid_scope` error the user was still seeing after deploying it.
- Root cause: Xero split the broad `accounting.transactions` scope into granular scopes on 4 March 2026. Any Xero developer app created after that date is issued **only** the granular scope set — `accounting.transactions` isn't available to request at all for a new app, so asking for it makes `/authorize` reject the whole request with `invalid_scope`. Confirmed against Xero's own changelog and granular-scopes FAQ.
- `accounting.invoices` is the granular replacement covering invoices/credit notes/quotes — everything this integration actually pushes (`createXeroDraftInvoice`). It works for both new and pre-existing apps, so there's no reason to keep the deprecated broad scope.
- `accounting.contacts` and `accounting.settings.read` were already granular scopes, unaffected by the split — no change needed there.

## Testing

- `pnpm exec vitest run src/lib/xero-client.test.ts src/server/xero.test.ts` — 23 passing (updated a token-response fixture's `scope` field to match).
- `pnpm exec tsc --noEmit` clean on touched files.
- Not verified against a live Xero connect flow from this sandbox — the user will confirm on next deploy.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HoeQabDo6GQpTgSKQfxdqa)_