### PR TITLE
Xero client mapping in Settings + per-entity account-coding override UI

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -193,6 +193,45 @@ nothing else). Every equipment line resolves via the RENTAL branch of the
 cascade today; the SALE branch is unit-tested but unreachable until #950
 wires an actual sale line type.
 
+### Per-entity coding override UI
+
+Every level of the cascade above has a write path + form field:
+
+- **Category default** — `categories.xeroAccountCode`, one field on the
+  category create/edit dialog (`src/components/assets/category-manager.tsx`).
+- **Model defaults** — `models.xeroRentalAccountCode`/`xeroSaleAccountCode`,
+  a "Xero coding" `SmartFormSection` on `src/components/assets/model-form.tsx`
+  (rental and sale are independent — a kit-parent line reads `kits.xeroAccountCode`
+  instead, since a kit isn't a model).
+- **Kit default** — `kits.xeroAccountCode`, same pattern on
+  `src/components/kits/kit-form.tsx`.
+- **Line override** — `projectLineItems.xeroAccountCode`/`xeroTaxType`, on
+  `src/components/projects/edit-line-item-dialog.tsx`. Note `lineItemWrites.patchNative`
+  is a BLOCKLIST model (`LINE_IMMUTABLE_ON_PATCH`), not an allowlist, so these
+  two fields technically already passed through server-side before this UI
+  landed — what was missing was the client never sending them
+  (`buildLineItemSetClear` in `src/hooks/use-line-item-writes.ts`) and no
+  length bound (`assertLineItemFields` in `convex/lineItemWrites.ts`), both
+  now added (R-8.6.2 — defense-in-depth on a blocklist mutation).
+- **Service override** — `projectServices.xeroAccountCode`/`xeroTaxType`, on
+  the `ServiceDialog` in `src/components/projects/services-panel.tsx`.
+
+All five write paths mirror `categorySchema`/`modelSchema`/etc.'s new
+`.max(50)` bound server-side (`assertCategoryFields`/`assertModelFields`/
+`assertKitFields`/`assertLineItemFields`/`assertServiceFields` — R-8.6.2,
+a browser-direct caller bypassing the client Zod parse can't skip the bound).
+
+**Shared UI**: `src/components/settings/xero-coding-fields.tsx` —
+`XeroAccountCodeField`/`XeroTaxTypeField`, both self-gating on `useXeroLinked()`
+(render `null` when unlinked, matching every other Xero-linked-only surface)
+and sourced from the same `useXeroCodingOptions()` hook Settings → Xero's own
+org-default pickers use (R-3.1 — one mapping from `xeroIntegrations.cachedAccounts`/
+`cachedTaxRates` to `ComboboxPicker` options, not five copies). Every "Xero
+coding" section on category/model/kit is itself conditionally rendered on
+`useXeroLinked()` too — a titled section with self-gating-to-null fields
+inside would otherwise show an empty section with no content, which reads as
+broken.
+
 ### Linked gate
 
 `convex/lib/xeroGate.ts` `isXeroLinked(ctx, orgId)` (server) and
@@ -283,6 +322,7 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 | `src/components/settings/xero-client-mapping.tsx` | Searchable client list + per-row `XeroContactCard` (Settings → Xero) |
 | `src/components/clients/xero-contact-card.tsx` | The actual per-client search/link/unlink UI, embedded by the above |
 | `src/components/ui/combobox-picker.tsx` | Searchable, scrollable account/tax-type pickers on Settings → Xero |
+| `src/components/settings/xero-coding-fields.tsx` | `XeroAccountCodeField`/`XeroTaxTypeField` — shared, self-gating cascade override fields used on category/model/kit/line/service forms |
 
 ## Testing
 
@@ -311,22 +351,15 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
   is the pattern to follow when this lands.
 - **Project financial tab "invoiced/paid/outstanding" summary** beyond what
   `financial-summary.tsx`'s new Invoicing block already shows.
-- **Live Xero verification.** No Xero developer app credentials exist in
-  this sandbox — the OAuth round trip and a real invoice push have only been
-  exercised against fixture responses, never Xero's live servers.
-- **Per-entity Xero coding override UI (category/model/kit/line/service).**
-  The schema fields, the cascade resolver (all 4 levels, unit-tested), and
-  the push-time resolution (`convex/xeroPush.ts`) are ALL built and fully
-  functional — what's NOT built is the collapsed "Xero coding" form section
-  the spec calls for on the category/model/kit forms and the project line/
-  kit/service dialogs. Until that UI lands, every equipment/service line
-  resolves straight through to whichever of the org default account
-  (Settings → Xero) applies — levels 1-3 of the cascade (per-line override,
-  model/kit, category) have no write path yet, so they're currently always
-  absent. This mirrors the `billableToClient` precedent already documented
-  in FEATUREDOCS/13 ("a field with no UI has no live behaviour") — tracked
-  as the immediate next follow-up, not silently dropped. What IS wired:
-  client Xero contact mapping (client detail page) and the org-level
-  defaults (Settings → Xero: default account, per-service-type defaults,
-  default tax type) — enough for Xero-linked orgs to push correctly-coded
-  invoices today, just without per-line overrides.
+- **Live Xero verification — partial.** The OAuth connect/callback round trip
+  HAS since been exercised against Xero's live servers (a real developer app,
+  post-deploy) and works end to end. A real invoice push has still only been
+  exercised against fixture responses (`src/lib/xero-client.test.ts`), never
+  a live Xero org's Accounting API.
+  Two live-only gotchas discovered so far, both fixed: (1) Xero split the
+  broad `accounting.transactions` OAuth scope into granular scopes on 4 March
+  2026 — any app created after that date is issued ONLY the granular set, so
+  `XERO_OAUTH_SCOPES` (`src/lib/xero-client.ts`) requests `accounting.invoices`,
+  not the deprecated broad scope. (2) the OAuth callback route's post-exchange
+  redirect must be built from `env.NEXT_PUBLIC_APP_URL`, never `request.url`
+  — see "Connection (OAuth2)" above.

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -230,15 +230,23 @@ without a separate clear control.
 
 ### Client contact mapping
 
-Client detail page (Xero-linked only) — search Xero contacts by name, or
-push an unmapped client's invoice and the push flow auto-creates the
-contact. **Duplicate protection:** auto-create first tries an exact-email
-match against Xero (`findXeroContactByEmail`) and LINKS instead of creating
-when found — verified by `src/server/xero.test.ts`'s mocked-boundary tests.
-`convex/clientXeroWrites.ts` is deliberately separate from the general
-`clientWrites.ts` browser-direct mutations — `xeroContactId`/`xeroContactName`
-can only change through a real Xero search/create/link round trip, never a
-plain client-form save.
+Lives on **Settings → Xero → "Client mapping"** (`src/components/settings/xero-client-mapping.tsx`),
+not the client detail page — moved there so mapping doesn't require opening
+each client individually: one searchable box (`useClientSearch`, the
+indexed `api.search.clients` query, not a whole-org JS filter) lists every
+client with its current mapping status, and expanding a row reveals the
+actual search/link/unlink UI. That per-client UI itself is unchanged —
+`XeroContactCard` (`src/components/clients/xero-contact-card.tsx`) is reused
+as-is, just embedded per-row instead of standalone on the client page, so
+there's one definition of "how to map a client," not two. Search Xero
+contacts by name, or push an unmapped client's invoice and the push flow
+auto-creates the contact. **Duplicate protection:** auto-create first tries
+an exact-email match against Xero (`findXeroContactByEmail`) and LINKS
+instead of creating when found — verified by `src/server/xero.test.ts`'s
+mocked-boundary tests. `convex/clientXeroWrites.ts` is deliberately separate
+from the general `clientWrites.ts` browser-direct mutations —
+`xeroContactId`/`xeroContactName` can only change through a real Xero
+search/create/link round trip, never a plain client-form save.
 
 ### Reference data cache
 
@@ -272,6 +280,9 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 | `src/lib/invoices-read.ts` | Service-token read — latest issued invoice number (PDF `invoice_number` token) |
 | `src/hooks/use-xero-linked.ts` | Client-side linked gate |
 | `src/app/api/integrations/xero/callback/route.ts` | Public OAuth callback route |
+| `src/components/settings/xero-client-mapping.tsx` | Searchable client list + per-row `XeroContactCard` (Settings → Xero) |
+| `src/components/clients/xero-contact-card.tsx` | The actual per-client search/link/unlink UI, embedded by the above |
+| `src/components/ui/combobox-picker.tsx` | Searchable, scrollable account/tax-type pickers on Settings → Xero |
 
 ## Testing
 

--- a/convex/categoriesWrites.ts
+++ b/convex/categoriesWrites.ts
@@ -25,6 +25,7 @@ export const categoryFields = {
   icon: v.optional(v.string()),
   sortOrder: v.optional(v.number()),
   tags: v.optional(v.array(v.string())),
+  xeroAccountCode: v.optional(v.string()),
 };
 
 /**
@@ -35,11 +36,12 @@ export const categoryFields = {
  * (src/hooks/use-category-writes.ts) runs `categorySchema.parse()` client-side and
  * calls createNative/updateNative directly.
  */
-function assertCategoryFields(f: { name: string; description?: string; icon?: string; sortOrder?: number }): void {
+function assertCategoryFields(f: { name: string; description?: string; icon?: string; sortOrder?: number; xeroAccountCode?: string }): void {
   assertStrLen(f.name, "name", { min: 1, max: 100 });
   assertStrLen(f.description, "description", { max: 500 });
   assertStrLen(f.icon, "icon", { max: 10 });
   assertNumRange(f.sortOrder, "sortOrder", { min: 0, integer: true });
+  assertStrLen(f.xeroAccountCode, "xeroAccountCode", { max: 50 });
 }
 
 async function logCategory(
@@ -93,6 +95,7 @@ export const createNative = mutation({
       icon: a.icon || undefined,
       sortOrder: a.sortOrder ?? 0,
       tags: a.tags ?? [],
+      xeroAccountCode: a.xeroAccountCode || undefined,
       suggestedCrewRoles: [],
       createdAt: a.now,
       updatedAt: a.now,
@@ -133,6 +136,7 @@ export const updateNative = mutation({
       icon: a.icon || undefined,
       sortOrder: a.sortOrder ?? 0,
       tags: a.tags ?? [],
+      xeroAccountCode: a.xeroAccountCode || undefined,
       updatedAt: a.now,
     });
     await logCategory(ctx, { orgId: a.orgId, actor, auditId: a.auditId, now: a.now, action: "UPDATE", id: a.id, name: a.name, summary: `Updated category ${a.name}` });

--- a/convex/kitWrites.ts
+++ b/convex/kitWrites.ts
@@ -44,6 +44,7 @@ function assertKitFields(f: {
   notes?: string;
   weight?: number;
   purchasePrice?: number;
+  xeroAccountCode?: string;
 }): void {
   if (f.name != null) assertStrLen(f.name, "name", { min: 1, max: 200 });
   if (f.assetTag != null) assertStrLen(f.assetTag, "assetTag", { min: 1, max: 50 });
@@ -53,6 +54,7 @@ function assertKitFields(f: {
   assertStrLen(f.notes, "notes", { max: 2000 });
   assertNumRange(f.weight, "weight", { min: 0 });
   assertNumRange(f.purchasePrice, "purchasePrice", { min: 0 });
+  assertStrLen(f.xeroAccountCode, "xeroAccountCode", { max: 50 });
 }
 
 const kitPatch = v.object({
@@ -79,6 +81,7 @@ const kitPatch = v.object({
   checkMode: v.optional(enums.KitCheckMode),
   isPrep: v.optional(v.boolean()),
   isActive: v.optional(v.boolean()),
+  xeroAccountCode: v.optional(v.string()),
   createdAt: v.optional(v.number()),
   updatedAt: v.optional(v.number()),
 });
@@ -109,6 +112,7 @@ export const createNative = mutation({
     tags: v.optional(v.array(v.string())),
     checkMode: v.optional(enums.KitCheckMode),
     isActive: v.optional(v.boolean()),
+    xeroAccountCode: v.optional(v.string()),
     createdAt: v.optional(v.number()),
     updatedAt: v.optional(v.number()),
     actor: actorValidator,

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -250,9 +250,11 @@ const actorValidator = v.object({ userId: v.string(), userName: v.string() });
  * `customLineItemSchema`'s DIFFERENT bounds (description min 1/max 200, notes max 500)
  * are enforced separately in `addCustomNative` — the two schemas diverge here.
  */
-function assertLineItemFields(f: { description?: string | null; subhireOrderNumber?: string | null }): void {
+function assertLineItemFields(f: { description?: string | null; subhireOrderNumber?: string | null; xeroAccountCode?: string | null; xeroTaxType?: string | null }): void {
   assertStrLen(f.description, "description", { max: 500 });
   assertStrLen(f.subhireOrderNumber, "subhireOrderNumber", { max: 100 });
+  assertStrLen(f.xeroAccountCode, "xeroAccountCode", { max: 50 });
+  assertStrLen(f.xeroTaxType, "xeroTaxType", { max: 50 });
 }
 
 /** Bound `accessoryPlan.excluded`/`.added` (R-8.6.2) — a browser-direct caller
@@ -610,7 +612,7 @@ export const patchNative = mutation({
     assertLineMoneyFields(setObj as {
       quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
     });
-    assertLineItemFields(setObj as { description?: string; subhireOrderNumber?: string }); // R-8.6.2
+    assertLineItemFields(setObj as { description?: string; subhireOrderNumber?: string; xeroAccountCode?: string; xeroTaxType?: string }); // R-8.6.2
 
     // lineTotal is a DERIVED value — assertLineMoneyFields only bounds it, it never
     // verifies it matches unitPrice×quantity×duration−discount. The legit client

--- a/convex/modelWrites.ts
+++ b/convex/modelWrites.ts
@@ -68,6 +68,8 @@ export const modelFields = {
   barcodeLabelTemplate: v.optional(v.string()),
   tags: v.optional(v.array(v.string())),
   isActive: v.optional(v.boolean()),
+  xeroRentalAccountCode: v.optional(v.string()),
+  xeroSaleAccountCode: v.optional(v.string()),
 };
 
 type ModelArgs = {
@@ -82,6 +84,7 @@ type ModelArgs = {
   defaultEquipmentClass?: string; defaultApplianceType?: string; defaultTestProfileId?: string;
   maintenanceIntervalDays?: number; assetType?: string; barcodeLabelTemplate?: string;
   tags?: string[]; isActive?: boolean;
+  xeroRentalAccountCode?: string; xeroSaleAccountCode?: string;
 };
 
 /**
@@ -100,6 +103,8 @@ function assertModelFields(a: ModelArgs) {
   assertStrLen(a.modelNumber, "modelNumber", { max: 100 });
   assertStrLen(a.sku, "sku", { max: 100 });
   assertStrLen(a.description, "description", { max: 2000 });
+  assertStrLen(a.xeroRentalAccountCode, "xeroRentalAccountCode", { max: 50 });
+  assertStrLen(a.xeroSaleAccountCode, "xeroSaleAccountCode", { max: 50 });
 
   if (a.dailyRate != null && (!Number.isFinite(a.dailyRate) || a.dailyRate < 0)) {
     throw new ConvexError("Daily rate must be zero or positive");
@@ -156,6 +161,8 @@ function toDoc(a: ModelArgs) {
     barcodeLabelTemplate: a.barcodeLabelTemplate ?? undefined,
     isActive: a.isActive ?? true,
     tags: a.tags ?? [],
+    xeroRentalAccountCode: a.xeroRentalAccountCode || undefined,
+    xeroSaleAccountCode: a.xeroSaleAccountCode || undefined,
   };
 }
 

--- a/convex/projectServicesWrites.ts
+++ b/convex/projectServicesWrites.ts
@@ -7,7 +7,7 @@ import { requireOrgPermission, resolveActor, type Actor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { assertFinite } from "./lib/moneyGuards";
-import { assertNumRange } from "./lib/fieldGuards";
+import { assertNumRange, assertStrLen } from "./lib/fieldGuards";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals, orgDefaultTaxRate } from "./lib/recalc";
 import { recalcServiceCostFromCrew, recalcServiceChargeFromCrew } from "./lib/serviceCost";
@@ -132,6 +132,8 @@ const serviceInputArgs = {
   numberOfTrips: v.optional(v.number()),
   crewCountRequired: v.optional(v.number()),
   crewRoleId: v.optional(v.string()),
+  xeroAccountCode: v.optional(v.string()),
+  xeroTaxType: v.optional(v.string()),
 };
 
 type ServiceInput = {
@@ -161,6 +163,8 @@ type ServiceInput = {
   numberOfTrips?: number;
   crewCountRequired?: number;
   crewRoleId?: string;
+  xeroAccountCode?: string;
+  xeroTaxType?: string;
 };
 
 /**
@@ -171,8 +175,10 @@ type ServiceInput = {
  * bounds (`unitPrice`/`discount`/`costTotal` non-negative + finite) are already
  * enforced just below. `quantity` was the one bound neither path re-checked.
  */
-function assertServiceFields(f: { quantity?: number }): void {
+function assertServiceFields(f: { quantity?: number; xeroAccountCode?: string; xeroTaxType?: string }): void {
   assertNumRange(f.quantity, "quantity", { min: 1 });
+  assertStrLen(f.xeroAccountCode, "xeroAccountCode", { max: 50 });
+  assertStrLen(f.xeroTaxType, "xeroTaxType", { max: 50 });
 }
 
 /** Port of buildServiceData — clamps endDate by type, computes lineTotal, and returns
@@ -185,7 +191,7 @@ function buildServiceFields(a: ServiceInput) {
   assertFinite(a.discount, "discount");
   assertFinite(a.costTotal, "costTotal");
   assertFinite(a.chargeRateOverride, "chargeRateOverride");
-  assertServiceFields({ quantity: a.quantity });
+  assertServiceFields({ quantity: a.quantity, xeroAccountCode: a.xeroAccountCode, xeroTaxType: a.xeroTaxType });
   // Bound money NON-NEGATIVE (browser-direct bypasses the server Zod min(0)). A negative
   // discount would INFLATE the customer-facing service line total (max(0, unitPrice - disc)
   // → serviceRevenue → project total); a negative costTotal would INFLATE project margin
@@ -233,6 +239,8 @@ function buildServiceFields(a: ServiceInput) {
     numberOfTrips: a.numberOfTrips || null,
     crewCountRequired: a.crewCountRequired || null,
     crewRoleId: a.crewRoleId || null,
+    xeroAccountCode: a.xeroAccountCode || null,
+    xeroTaxType: a.xeroTaxType || null,
   };
   return { fields, serviceDate, serviceEndDate, lineTotal };
 }
@@ -505,6 +513,8 @@ export const createServiceNative = mutation({
       ...(fields.numberOfTrips != null ? { numberOfTrips: fields.numberOfTrips } : {}),
       ...(fields.crewCountRequired != null ? { crewCountRequired: fields.crewCountRequired } : {}),
       ...(fields.crewRoleId != null ? { crewRoleId: fields.crewRoleId } : {}),
+      ...(fields.xeroAccountCode != null ? { xeroAccountCode: fields.xeroAccountCode } : {}),
+      ...(fields.xeroTaxType != null ? { xeroTaxType: fields.xeroTaxType } : {}),
       sortOrder,
       createdAt: a.now,
       updatedAt: a.now,
@@ -642,6 +652,8 @@ export const updateServiceNative = mutation({
     setOrClear("numberOfTrips", fields.numberOfTrips);
     setOrClear("crewCountRequired", fields.crewCountRequired);
     setOrClear("crewRoleId", fields.crewRoleId);
+    setOrClear("xeroAccountCode", fields.xeroAccountCode);
+    setOrClear("xeroTaxType", fields.xeroTaxType);
 
     // Validate the default crew role even when no crew reconcile happens (it's patched
     // onto the service above regardless of the crew block below).

--- a/src/app/(app)/assets/models/[id]/edit/page.tsx
+++ b/src/app/(app)/assets/models/[id]/edit/page.tsx
@@ -82,6 +82,8 @@ function EditModelContent({ params }: { params: Promise<{ id: string }> }) {
     barcodeLabelTemplate: model.barcodeLabelTemplate || "",
     isActive: model.isActive,
     tags: model.tags ?? [],
+    xeroRentalAccountCode: model.xeroRentalAccountCode || undefined,
+    xeroSaleAccountCode: model.xeroSaleAccountCode || undefined,
   };
 
   return (

--- a/src/app/(app)/clients/[id]/page.tsx
+++ b/src/app/(app)/clients/[id]/page.tsx
@@ -22,8 +22,6 @@ import { toast } from "sonner";
 import { api } from "../../../../../convex/_generated/api";
 import { useClientWrites } from "@/hooks/use-native-client-writes";
 import { ClientContactsManager, ReadOnlyContactsList } from "@/components/clients/client-contacts-manager";
-import { XeroContactCard } from "@/components/clients/xero-contact-card";
-import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { getPrimaryContact } from "@/lib/client-contact-helpers";
 import { projectStatusLabels, clientTypeLabels, formatLabel } from "@/lib/status-labels";
 import { formatCurrency } from "@/lib/formatters";
@@ -82,7 +80,6 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
   // subscription auto-updates — no manual refetch needed.
   const client = useAuthedQuery(api.clients.detail, orgId ? { orgId, id } : "skip");
   const isLoading = client === undefined;
-  const xeroLinked = useXeroLinked();
 
   const clientWrites = useClientWrites();
   const media = useMediaWrites("client");
@@ -422,23 +419,6 @@ function ClientDetailContent({ params }: { params: Promise<{ id: string }> }) {
                     <ClientContactsManager clientId={id} contacts={contacts} />
                   </CanDo>
                 </SidebarSection>
-
-                {/* WS1 (#940) — Xero contact mapping. Gated at the SECTION
-                    level (not just inside the card) so an unlinked org or a
-                    caller without xero_manage never even sees the "Xero"
-                    heading — an empty section with no content reads as
-                    broken, not as "nothing to see here". */}
-                {xeroLinked && (
-                  <SidebarSection title="Xero">
-                    <CanDo resource="invoice" action="xero_manage">
-                      <XeroContactCard
-                        clientId={id}
-                        xeroContactId={client.xeroContactId as string | null | undefined}
-                        xeroContactName={client.xeroContactName as string | null | undefined}
-                      />
-                    </CanDo>
-                  </SidebarSection>
-                )}
 
                 {/* Address & billing — merged: addresses + payment terms */}
                 <SidebarSection title="Address & billing">

--- a/src/app/(app)/kits/[id]/edit/page.tsx
+++ b/src/app/(app)/kits/[id]/edit/page.tsx
@@ -67,6 +67,7 @@ function EditKitContent({ params }: { params: Promise<{ id: string }> }) {
             images: kit.images || [],
             isActive: kit.isActive,
             tags: kit.tags ?? [],
+            xeroAccountCode: kit.xeroAccountCode || undefined,
           }}
         />
       </div>

--- a/src/app/(app)/settings/xero/page.tsx
+++ b/src/app/(app)/settings/xero/page.tsx
@@ -22,6 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { XeroClientMapping } from "@/components/settings/xero-client-mapping";
 import { RequirePermission } from "@/components/auth/require-permission";
 
 interface XeroAccount {
@@ -247,6 +248,14 @@ export default function XeroSettingsPage() {
               </RequirePermission>
             </SettingsCard>
           </FormSection>
+
+          <RequirePermission resource="invoice" action="xero_manage">
+            <FormSection title="Client mapping" description="Map each client to a Xero contact. Search for a client, then search/link/unlink its Xero contact.">
+              <SettingsCard>
+                <XeroClientMapping />
+              </SettingsCard>
+            </FormSection>
+          </RequirePermission>
 
           <FormSection title="Invoice numbering" description="Configured on Settings -> General (same format engine as project numbers, namespaced separately). Default: INV-%YYYY-%SEQ, yearly reset, 4 digits.">
             <SettingsCard>

--- a/src/app/(app)/settings/xero/page.tsx
+++ b/src/app/(app)/settings/xero/page.tsx
@@ -23,17 +23,8 @@ import { Badge } from "@/components/ui/badge";
 import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { XeroClientMapping } from "@/components/settings/xero-client-mapping";
+import { useXeroCodingOptions } from "@/components/settings/xero-coding-fields";
 import { RequirePermission } from "@/components/auth/require-permission";
-
-interface XeroAccount {
-  AccountID: string;
-  Code?: string;
-  Name: string;
-}
-interface XeroTaxRate {
-  Name: string;
-  TaxType: string;
-}
 
 const SERVICE_TYPES = [
   { key: "LABOUR", label: "Labour" },
@@ -74,18 +65,7 @@ export default function XeroSettingsPage() {
   });
 
   const isConnected = integration?.isConnected === true;
-  const accounts = (integration?.cachedAccounts as XeroAccount[] | undefined) ?? [];
-  const taxRates = (integration?.cachedTaxRates as XeroTaxRate[] | undefined) ?? [];
-  const accountOptions = accounts.map((a) => ({
-    value: a.Code ?? a.AccountID,
-    label: a.Name,
-    description: a.Code || undefined,
-  }));
-  const taxRateOptions = taxRates.map((t) => ({
-    value: t.TaxType,
-    label: t.Name,
-    description: t.TaxType,
-  }));
+  const { accountOptions, taxRateOptions } = useXeroCodingOptions();
 
   const [defaultAccountCode, setDefaultAccountCode] = useState(integration?.defaultAccountCode ?? "");
   const [defaultTaxType, setDefaultTaxType] = useState(integration?.defaultTaxType ?? "");
@@ -164,7 +144,7 @@ export default function XeroSettingsPage() {
             <SettingsCard>
               <div className="flex items-center justify-between gap-4">
                 <div className="t-micro text-fg-3">
-                  {accounts.length} accounts, {taxRates.length} tax rates
+                  {accountOptions.length} accounts, {taxRateOptions.length} tax rates
                   {integration?.cacheRefreshedAt ? ` — refreshed ${new Date(integration.cacheRefreshedAt).toLocaleString()}` : " — never refreshed"}
                   {integration?.cacheError && <span className="block text-destructive">Last refresh failed: {integration.cacheError}</span>}
                 </div>

--- a/src/components/assets/category-manager.tsx
+++ b/src/components/assets/category-manager.tsx
@@ -14,6 +14,7 @@ import { useCategories } from "@/hooks/use-categories";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { useOrgTags } from "@/hooks/use-org-tags";
 import { TagInput } from "@/components/ui/tag-input";
+import { XeroAccountCodeField } from "@/components/settings/xero-coding-fields";
 import { Button } from "@/components/ui/button";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
 import { Input } from "@/components/ui/input";
@@ -124,6 +125,7 @@ export function CategoryManager() {
       icon: cat.icon || "",
       sortOrder: cat.sortOrder ?? 0,
       tags: cat.tags ?? [],
+      xeroAccountCode: cat.xeroAccountCode || "",
     });
     setDialogOpen(true);
   }
@@ -201,6 +203,19 @@ export function CategoryManager() {
                 <Label htmlFor="cat-sort">Sort order</Label>
                 <Input id="cat-sort" type="number" {...form.register("sortOrder")} className="w-24" />
               </div>
+              <Controller
+                name="xeroAccountCode"
+                control={form.control}
+                render={({ field }) => (
+                  <XeroAccountCodeField
+                    value={field.value}
+                    onChange={field.onChange}
+                    label="Xero account"
+                    placeholder="Inherit org default"
+                    helpText="Applied to every model/kit under this category unless overridden."
+                  />
+                )}
+              />
               {parentId && (
                 <p className="text-caption text-muted">
                   Subcategory of: {categories.find((c) => c.id === parentId)?.name}

--- a/src/components/assets/model-form.tsx
+++ b/src/components/assets/model-form.tsx
@@ -30,6 +30,8 @@ import {
   Accordion, AccordionContent, AccordionItem, AccordionTrigger,
 } from "@/components/ui/accordion";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { XeroAccountCodeField } from "@/components/settings/xero-coding-fields";
+import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { QuickCreateCategory } from "./quick-create-category";
 import { SpecificationsEditor } from "./specifications-editor";
 import {
@@ -58,6 +60,7 @@ export function ModelForm({ initialData }: ModelFormProps) {
   const categories = useCategoriesWithParent(orgId) ?? [];
 
   const orgTags = useOrgTags(orgId);
+  const xeroLinked = useXeroLinked();
 
   // Reactive: testProfiles subscribes to Convex (Convex list returns all; filter
   // isActive client-side to match the old getTestProfiles default).
@@ -287,6 +290,37 @@ export function ModelForm({ initialData }: ModelFormProps) {
             </div>
           </div>
         </SmartFormSection>
+
+        {xeroLinked && (
+          <SmartFormSection title="Xero coding" hint="Overrides the category default for lines using this model — leave blank to inherit.">
+            <div className="grid gap-5 sm:grid-cols-2">
+              <Controller
+                name="xeroRentalAccountCode"
+                control={form.control}
+                render={({ field }) => (
+                  <XeroAccountCodeField
+                    value={field.value}
+                    onChange={field.onChange}
+                    label="Rental account"
+                    placeholder="Inherit category default"
+                  />
+                )}
+              />
+              <Controller
+                name="xeroSaleAccountCode"
+                control={form.control}
+                render={({ field }) => (
+                  <XeroAccountCodeField
+                    value={field.value}
+                    onChange={field.onChange}
+                    label="Sale account"
+                    placeholder="Inherit category default"
+                  />
+                )}
+              />
+            </div>
+          </SmartFormSection>
+        )}
 
         {/* Compliance & technical */}
         <SmartFormSection title="Compliance & technical" hint="Test & tag and physical specs — optional.">

--- a/src/components/kits/kit-form.tsx
+++ b/src/components/kits/kit-form.tsx
@@ -22,6 +22,8 @@ import { Input } from "@/components/ui/input";
 import { AssetTagInput } from "@/components/ui/asset-tag-input";
 import { Textarea } from "@/components/ui/textarea";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { XeroAccountCodeField } from "@/components/settings/xero-coding-fields";
+import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
@@ -66,6 +68,7 @@ export function KitForm({ initialData }: KitFormProps) {
   }));
 
   const orgTags = useOrgTags(orgId);
+  const xeroLinked = useXeroLinked();
 
   const form = useForm<KitFormValues>({
     resolver: zodResolver(kitSchema),
@@ -311,6 +314,23 @@ export function KitForm({ initialData }: KitFormProps) {
             </SmartFormField>
           </div>
         </SmartFormSection>
+
+        {xeroLinked && (
+          <SmartFormSection title="Xero coding" hint="Overrides the category default for lines using this kit — leave blank to inherit.">
+            <Controller
+              name="xeroAccountCode"
+              control={form.control}
+              render={({ field }) => (
+                <XeroAccountCodeField
+                  value={field.value}
+                  onChange={field.onChange}
+                  label="Kit account"
+                  placeholder="Inherit category default"
+                />
+              )}
+            />
+          </SmartFormSection>
+        )}
 
         {/* More details — progressive disclosure */}
         <section className="border-t border-line pt-6">

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -41,6 +41,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { checkAvailability } from "@/server/line-items";
 import { lineItemSchema, type LineItemFormValues } from "@/lib/validations/line-item";
+import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
+import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { PlacementFields } from "./placement-fields";
 import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
 import type { LineItemData, CategoryData } from "./equipment-rows";
@@ -55,6 +57,8 @@ export interface EditLineItemPayload {
   discount?: number;
   notes?: string;
   isOptional: boolean;
+  xeroAccountCode?: string;
+  xeroTaxType?: string;
 }
 
 export interface EditLineItemPlacement {
@@ -131,6 +135,7 @@ function EditLineItemDialogBody({
 
   // Disable the whole form when another user holds an active lock
   const formDisabled = isLocked;
+  const xeroLinked = useXeroLinked();
 
   const form = useForm<LineItemFormValues>({
     resolver: zodResolver(lineItemSchema),
@@ -144,6 +149,8 @@ function EditLineItemDialogBody({
       discount: item.discount != null && Number(item.discount) > 0 ? Number(item.discount) : undefined,
       notes: item.notes ?? "",
       isOptional: item.isOptional ?? false,
+      xeroAccountCode: item.xeroAccountCode ?? "",
+      xeroTaxType: item.xeroTaxType ?? "",
     },
   });
   const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
@@ -215,6 +222,8 @@ function EditLineItemDialogBody({
         discount: disc,
         notes: data.notes || undefined,
         isOptional: data.isOptional ?? false,
+        xeroAccountCode: data.xeroAccountCode || undefined,
+        xeroTaxType: data.xeroTaxType || undefined,
       },
       overbookConfirmed,
       baseUpdatedAt,
@@ -332,6 +341,26 @@ function EditLineItemDialogBody({
             )}
           />
         </section>
+
+        {xeroLinked && (
+          <section className="space-y-4 border-t border-line pt-5">
+            <SectionTitle title="Xero coding" hint="Overrides the model/kit/category default for this line only." />
+            <Controller
+              control={form.control}
+              name="xeroAccountCode"
+              render={({ field }) => (
+                <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
+              )}
+            />
+            <Controller
+              control={form.control}
+              name="xeroTaxType"
+              render={({ field }) => (
+                <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
+              )}
+            />
+          </section>
+        )}
 
         {/* Placement & options */}
         <section className="space-y-4 border-t border-line pt-5">

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -54,6 +54,10 @@ export interface LineItemData {
   }>;
   kit?: { name?: string } | null;
   childLineItems?: LineItemData[];
+  /** Per-line Xero coding override (WS1 #940 cascade) — first non-null level
+   *  wins over model/kit/category/org defaults. See convex/lib/xeroAccountCascade.ts. */
+  xeroAccountCode?: string | null;
+  xeroTaxType?: string | null;
   /** Optimistic-concurrency baseline — Prisma `updatedAt` (serialised). Sent
    *  back on save so the server can reject stale writes (collaboration). */
   updatedAt?: string | Date | number | null;

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -8,7 +8,7 @@ import { useServiceTemplates } from "@/hooks/use-service-templates";
 import { refreshProjectCrew } from "@/hooks/use-project-crew";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { isFilledAssignmentStatus } from "@/lib/crew-assignment-status";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Plus,
@@ -69,6 +69,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FadeIn, StaggerList, StaggerItem } from "@/components/ui/motion";
 import { ComboboxPicker, MultiComboboxPicker } from "@/components/ui/combobox-picker";
+import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
+import { useXeroLinked } from "@/hooks/use-xero-linked";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -1441,6 +1443,7 @@ function ServiceDialog({
   const isEditing = !!editingService;
   const isManagerPlus = useIsManagerPlus();
   const svcWrites = useProjectServiceWrites();
+  const xeroLinked = useXeroLinked();
 
   const matchingTemplate = preselectedType
     ? templates.find((t) => t.type === preselectedType && t.isActive)
@@ -1496,6 +1499,8 @@ function ServiceDialog({
         numberOfTrips: (editingService.numberOfTrips as number) || undefined,
         crewCountRequired: (editingService.crewCountRequired as number) || undefined,
         crewRoleId: (editingService.crewRoleId as string) || "",
+        xeroAccountCode: (editingService.xeroAccountCode as string) || undefined,
+        xeroTaxType: (editingService.xeroTaxType as string) || undefined,
         crew: editingService.crewAssignments
           ? (editingService.crewAssignments as ServiceRow["crewAssignments"])
               .filter((a): a is typeof a & { crewMember: NonNullable<typeof a.crewMember> } => !!a.crewMember)
@@ -2126,6 +2131,28 @@ function ServiceDialog({
               </div>
             )}
           </div>
+
+          {xeroLinked && (
+            <div className="space-y-3 rounded-[var(--r)] border border-line p-3">
+              <div className="t-overline text-muted">Xero coding</div>
+              <div className="grid grid-cols-2 gap-3">
+                <Controller
+                  control={form.control}
+                  name="xeroAccountCode"
+                  render={({ field }) => (
+                    <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="xeroTaxType"
+                  render={({ field }) => (
+                    <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
+                  )}
+                />
+              </div>
+            </div>
+          )}
 
           {/* Notes */}
           <div className="space-y-1.5">

--- a/src/components/settings/xero-client-mapping.tsx
+++ b/src/components/settings/xero-client-mapping.tsx
@@ -1,0 +1,79 @@
+"use client";
+// use-client: interactive search + expandable per-client mapping (R-8.1.1)
+
+import { useState } from "react";
+import { Search, Link2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useClientSearch } from "@/hooks/use-clients";
+import { XeroContactCard } from "@/components/clients/xero-contact-card";
+
+/**
+ * WS1 (#940) — centralized client<->Xero contact mapping, replacing the old
+ * per-client-detail-page card (moved here per user request: one searchable
+ * list instead of visiting each client individually). Reuses
+ * `XeroContactCard` unchanged for the actual search/link/unlink UI — only
+ * the list-and-search shell around it is new, so there's one definition of
+ * "how to map a client to a Xero contact," not two.
+ */
+export function XeroClientMapping() {
+  const { data: activeOrg } = useActiveOrganization();
+  const [query, setQuery] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const clients = useClientSearch(activeOrg?.id, query);
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-3" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search clients…"
+          className="pl-8"
+        />
+      </div>
+      <div className="max-h-96 divide-y divide-line overflow-y-auto rounded-[var(--r)] border border-line">
+        {clients === undefined ? (
+          <p className="p-3 text-table-cell text-fg-3">Loading…</p>
+        ) : clients.length === 0 ? (
+          <p className="p-3 text-table-cell text-fg-3">No clients found.</p>
+        ) : (
+          clients.map((c) => {
+            const xeroContactId = c.xeroContactId as string | null | undefined;
+            const xeroContactName = c.xeroContactName as string | null | undefined;
+            const isExpanded = expandedId === c.id;
+            return (
+              <div key={c.id} className="p-3">
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isExpanded ? null : c.id)}
+                  className="flex w-full items-center justify-between gap-2 text-left"
+                >
+                  <span className="min-w-0 truncate font-medium text-fg">{c.name}</span>
+                  {xeroContactId ? (
+                    <Badge status="ok">
+                      <Link2 className="h-3 w-3" /> {xeroContactName ?? "Linked"}
+                    </Badge>
+                  ) : (
+                    <Badge status="neutral">Not linked</Badge>
+                  )}
+                </button>
+                {isExpanded && (
+                  <div className="mt-3">
+                    <XeroContactCard
+                      clientId={c.id}
+                      xeroContactId={xeroContactId}
+                      xeroContactName={xeroContactName}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/xero-coding-fields.tsx
+++ b/src/components/settings/xero-coding-fields.tsx
@@ -1,0 +1,125 @@
+"use client";
+// use-client: interactive picker fields (R-8.1.1)
+
+import { Label } from "@/components/ui/label";
+import { ComboboxPicker } from "@/components/ui/combobox-picker";
+import { useXeroLinked, useXeroIntegration } from "@/hooks/use-xero-linked";
+
+/**
+ * Shared Xero account-code / tax-type picker fields for the coding cascade
+ * (WS1 #940 follow-up) — org default (Settings -> Xero) -> category default
+ * -> model/kit default -> line/service override. `convex/lib/xeroAccountCascade.ts`
+ * is the resolver; these components are the write side for the 3 levels
+ * that had no UI (category/model/kit defaults, line/service overrides).
+ *
+ * Self-gating on `useXeroLinked()` (return null when unlinked) so every call
+ * site gets "hidden but retained, inert" for free — matches every other
+ * Xero-linked-only surface (FEATUREDOCS/66 "Linked gate"), not a per-caller
+ * decision that could drift.
+ */
+
+interface XeroAccountOption {
+  AccountID: string;
+  Code?: string;
+  Name: string;
+}
+interface XeroTaxRateOption {
+  Name: string;
+  TaxType: string;
+}
+
+/** Exported so Settings -> Xero's org-default pickers share this exact
+ *  mapping instead of a second hand-maintained copy (R-3.1). */
+export function useXeroCodingOptions() {
+  const integration = useXeroIntegration();
+  const accounts = (integration?.cachedAccounts as XeroAccountOption[] | undefined) ?? [];
+  const taxRates = (integration?.cachedTaxRates as XeroTaxRateOption[] | undefined) ?? [];
+  const accountOptions = accounts.map((a) => ({
+    value: a.Code ?? a.AccountID,
+    label: a.Name,
+    description: a.Code || undefined,
+  }));
+  const taxRateOptions = taxRates.map((t) => ({
+    value: t.TaxType,
+    label: t.Name,
+    description: t.TaxType,
+  }));
+  return { accountOptions, taxRateOptions };
+}
+
+interface XeroAccountCodeFieldProps {
+  value: string | null | undefined;
+  onChange: (value: string) => void;
+  label?: string;
+  placeholder?: string;
+  helpText?: string;
+}
+
+/** A single "Xero account" picker — used once on category/kit forms, twice
+ *  (rental + sale) on the model form, and once as a per-line/service override. */
+export function XeroAccountCodeField({
+  value,
+  onChange,
+  label = "Xero account",
+  placeholder = "Inherit from default",
+  helpText,
+}: XeroAccountCodeFieldProps) {
+  const linked = useXeroLinked();
+  const { accountOptions } = useXeroCodingOptions();
+  if (!linked) return null;
+  return (
+    <div className="space-y-1.5">
+      <Label className="t-micro text-fg-3">{label}</Label>
+      <ComboboxPicker
+        value={value ?? ""}
+        onChange={onChange}
+        options={accountOptions}
+        placeholder={placeholder}
+        searchPlaceholder="Search accounts…"
+        emptyMessage="No accounts found."
+        allowClear
+        className="w-full"
+      />
+      {helpText && <p className="t-micro text-fg-3">{helpText}</p>}
+    </div>
+  );
+}
+
+interface XeroTaxTypeFieldProps {
+  value: string | null | undefined;
+  onChange: (value: string) => void;
+  label?: string;
+  placeholder?: string;
+  helpText?: string;
+}
+
+/** A single "Xero GST tax type" picker — the tax-type cascade is only 2
+ *  levels (line/service override -> org default), so this has no
+ *  category/model/kit equivalent. */
+export function XeroTaxTypeField({
+  value,
+  onChange,
+  label = "Xero tax type",
+  placeholder = "Use org default",
+  helpText,
+}: XeroTaxTypeFieldProps) {
+  const linked = useXeroLinked();
+  const { taxRateOptions } = useXeroCodingOptions();
+  if (!linked) return null;
+  return (
+    <div className="space-y-1.5">
+      <Label className="t-micro text-fg-3">{label}</Label>
+      <ComboboxPicker
+        value={value ?? ""}
+        onChange={onChange}
+        options={taxRateOptions}
+        placeholder={placeholder}
+        searchPlaceholder="Search tax types…"
+        emptyMessage="No tax types found."
+        allowClear
+        className="w-full"
+      />
+      {helpText && <p className="t-micro text-fg-3">{helpText}</p>}
+    </div>
+  );
+}

--- a/src/hooks/use-category-writes.ts
+++ b/src/hooks/use-category-writes.ts
@@ -34,6 +34,7 @@ export function useCategoryWrites() {
     icon: parsed.icon || undefined,
     sortOrder: parsed.sortOrder ?? 0,
     tags: parsed.tags ?? [],
+    xeroAccountCode: parsed.xeroAccountCode || undefined,
   });
 
   return {

--- a/src/hooks/use-kit-writes.ts
+++ b/src/hooks/use-kit-writes.ts
@@ -49,6 +49,7 @@ export function useKitWrites() {
         notes: p.notes || undefined, purchaseDate: p.purchaseDate ? new Date(p.purchaseDate).getTime() : undefined,
         purchasePrice: p.purchasePrice ?? undefined, image: p.image || undefined, images: p.images ?? undefined,
         barcode: p.assetTag, qrCode: p.assetTag, isActive: p.isActive, tags: p.tags ?? undefined, checkMode: p.checkMode,
+        xeroAccountCode: p.xeroAccountCode || undefined,
         createdAt: now, updatedAt: now, actor: actor(), auditId: createId(),
       });
       return { id };
@@ -63,7 +64,7 @@ export function useKitWrites() {
           caseType: p.caseType || undefined, caseDimensions: p.caseDimensions || undefined, notes: p.notes || undefined,
           purchaseDate: p.purchaseDate ? new Date(p.purchaseDate).getTime() : undefined, purchasePrice: p.purchasePrice ?? undefined,
           image: p.image || undefined, images: p.images ?? undefined, isActive: p.isActive, tags: p.tags ?? undefined,
-          checkMode: p.checkMode, updatedAt: Date.now(),
+          checkMode: p.checkMode, xeroAccountCode: p.xeroAccountCode || undefined, updatedAt: Date.now(),
         },
         actor: actor(), auditId: createId(), now: Date.now(),
       });

--- a/src/hooks/use-line-item-writes.ts
+++ b/src/hooks/use-line-item-writes.ts
@@ -135,6 +135,8 @@ export function buildLineItemSetClear(parsed: ParsedLineItem): {
   setStr("groupName", parsed.groupName);
   setStr("notes", parsed.notes);
   setStr("subhireOrderNumber", parsed.subhireOrderNumber);
+  setStr("xeroAccountCode", parsed.xeroAccountCode);
+  setStr("xeroTaxType", parsed.xeroTaxType);
 
   if (parsed.modelId !== undefined) setStr("modelId", parsed.modelId);
   if (parsed.assetId !== undefined) setStr("assetId", parsed.assetId);

--- a/src/hooks/use-project-service-writes.ts
+++ b/src/hooks/use-project-service-writes.ts
@@ -76,6 +76,8 @@ export function useProjectServiceWrites() {
         numberOfTrips: p.numberOfTrips,
         crewCountRequired: p.crewCountRequired,
         crewRoleId: p.crewRoleId,
+        xeroAccountCode: p.xeroAccountCode || undefined,
+        xeroTaxType: p.xeroTaxType || undefined,
       },
       crew: (p.crew ?? []).map((c) => ({
         id: createId(),

--- a/src/lib/validations/category.ts
+++ b/src/lib/validations/category.ts
@@ -7,6 +7,7 @@ export const categorySchema = z.object({
   icon: z.string().max(10).optional(),
   sortOrder: z.coerce.number().int().min(0).default(0),
   tags: z.array(z.string()).default([]),
+  xeroAccountCode: z.string().max(50).optional(),
 });
 
 export type CategoryFormValues = z.input<typeof categorySchema>;

--- a/src/lib/validations/kit.ts
+++ b/src/lib/validations/kit.ts
@@ -19,6 +19,7 @@ export const kitSchema = z.object({
   checkMode: z.enum(["KIT_LEVEL", "PER_ITEM"]).default("KIT_LEVEL"),
   isActive: z.boolean().default(true),
   tags: z.array(z.string()).default([]),
+  xeroAccountCode: z.string().max(50).optional(),
 });
 
 export type KitFormValues = z.input<typeof kitSchema>;

--- a/src/lib/validations/line-item.ts
+++ b/src/lib/validations/line-item.ts
@@ -46,6 +46,8 @@ export const lineItemSchema = z.object({
   showSubhireOnDocs: z.boolean().default(false),
   supplierId: z.string().optional(),
   subhireOrderNumber: z.string().max(100).optional(),
+  xeroAccountCode: z.string().max(50).optional(),
+  xeroTaxType: z.string().max(50).optional(),
 });
 
 export type LineItemFormValues = z.input<typeof lineItemSchema>;

--- a/src/lib/validations/model.ts
+++ b/src/lib/validations/model.ts
@@ -36,6 +36,8 @@ export const modelSchema = z.object({
   barcodeLabelTemplate: z.string().optional(),
   isActive: z.boolean().default(true),
   tags: z.array(z.string()).default([]),
+  xeroRentalAccountCode: z.string().max(50).optional(),
+  xeroSaleAccountCode: z.string().max(50).optional(),
 });
 
 export type ModelFormValues = z.input<typeof modelSchema>;

--- a/src/lib/validations/project-service.ts
+++ b/src/lib/validations/project-service.ts
@@ -55,6 +55,9 @@ export const projectServiceSchema = z.object({
   crewCountRequired: z.coerce.number().optional(),
   crewRoleId: z.string().optional(),
   crew: z.array(serviceCrewMemberSchema).optional(),
+
+  xeroAccountCode: z.string().max(50).optional(),
+  xeroTaxType: z.string().max(50).optional(),
 });
 
 export type ProjectServiceFormValues = z.input<typeof projectServiceSchema>;


### PR DESCRIPTION
## Summary

**Part 1 — Client mapping relocation:**
- Moves Xero client&lt;-&gt;contact mapping off the per-client detail page and onto a single "Client mapping" section on Settings → Xero, per user request ("change the Xero client mapping to be in the client setting instead, and should have a box that lists them all, with the search option").
- New `src/components/settings/xero-client-mapping.tsx`: a searchable box (`useClientSearch`, the existing indexed `api.search.clients` query) listing every client with its current mapping status; expanding a row reveals the mapping UI.
- `XeroContactCard` (`src/components/clients/xero-contact-card.tsx`) reused completely unchanged, just embedded per-row instead of standalone on the client page.

**Part 2 — Per-entity Xero account-coding override UI:**
The cascade resolver (`convex/lib/xeroAccountCascade.ts`, 4 levels, unit-tested) and push-time resolution (`convex/xeroPush.ts`) already existed with zero UI at 3 of its 4 levels. This wires the write path + form field at every level:

- **Shared component** — `XeroAccountCodeField`/`XeroTaxTypeField` (`src/components/settings/xero-coding-fields.tsx`), self-gating on `useXeroLinked()`, sourced from one shared `useXeroCodingOptions()` mapping (also now used by Settings → Xero's own org-default pickers, replacing a duplicate inline copy).
- **Category default** — `categories.xeroAccountCode`, field on the category dialog.
- **Model defaults** — `models.xeroRentalAccountCode`/`xeroSaleAccountCode`, a "Xero coding" section on the model form.
- **Kit default** — `kits.xeroAccountCode`, same pattern on the kit form.
- **Line override** — `projectLineItems.xeroAccountCode`/`xeroTaxType` on the line-item edit dialog. `lineItemWrites.patchNative` is a blocklist mutation, not an allowlist, so these fields already passed through server-side — added the missing client send path (`buildLineItemSetClear`) and a length bound (`assertLineItemFields`, R-8.6.2 defense-in-depth).
- **Service override** — `projectServices.xeroAccountCode`/`xeroTaxType` on the service create/edit dialog.

All 5 write paths mirror their Zod schema's new `.max(50)` bound server-side (R-8.6.2 — a browser-direct caller bypassing the client Zod parse can't skip it).

Also updates `FEATUREDOCS/66`: moves the coding-override UI out of "Deferred," and corrects live-Xero-verification status (OAuth connect/callback since confirmed working against Xero's live servers post-deploy, including the granular-scope and localhost-redirect fixes from earlier in this branch's history).

## Size rationale (R-2.8 / T-2, 551 LOC)

Over the 200-400 LOC target. Not split further because it's one cohesive
unit: every level of a single cascade (`xeroAccountCascade.ts`'s org →
category → model/kit → line/service precedence), reviewed together so the
cascade's consistency is checkable in one pass rather than across 5
isolated PRs that each show one field addition with no shared context. It
IS split internally into 6 atomic, independently-revertable commits (one
per cascade level + the shared component + the earlier client-mapping
move), each buildable/testable on its own.

## Testing

- `pnpm exec vitest run` on the 9 relevant suites (categories/models/kits/line-items/services writes, cascade resolver, push-in-context, xero-client, xero server) — 233 passing.
- `pnpm exec tsc --noEmit` — zero errors in any touched file (79 pre-existing errors elsewhere, all confirmed present without this diff via `git stash`).
- `pnpm exec eslint` on every touched file — no new warnings/errors; confirmed via before/after diff that counts are unchanged or only marginally higher on already-over-threshold functions.
- Not manually exercised in a live browser (no connected Xero org with client/category/model/kit data in this sandbox) — worth a pass on Settings → Xero, a category/model/kit form, and a line-item/service edit dialog after deploy.

## Checklist

- [x] New dependency? N/A — no new dependencies added.
