### PR TITLE
docs: finance as a first-class, version-controlled workflow — architecture + UI/UX plan (#985)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -258,11 +258,17 @@ Registry `StatusIndicator` (when deployed) offers `dot` / `glow` / `inline` vari
 - **Never:** Plain colored rectangles, badges without semantic mapping
 
 ### Tables
-- **Headers:** `t-overline` (10px/700/uppercase), `fg-3`, no background
+- **Headers:** `t-overline` (11px/600, **sentence case**), `muted`, no background
 - **Rows:** 1px `border-top` separator, 10–12px cell padding
 - **Hover:** Left-edge 2px red bar (opacity 0→1) + subtle `bg-elevated` tint
-- **IDs/tags:** `t-mono` (JetBrains Mono), `fg-3`
+- **IDs/tags:** `t-mono` (Geist Mono), `muted`
 - **Values:** Right-aligned, `tabular-nums`, 500 weight
+
+> _Corrected 2026-07-28 (#985 design review): this section previously read
+> "`t-overline` (10px/700/uppercase)" and "`t-mono` (JetBrains Mono)" — both stale.
+> 10px breaks the absolute 11px floor, uppercase is banned by §5.2, and the mono stack
+> is Geist Mono (see Type Stack). The Type Scale and §5.2 are authoritative; this
+> section now matches them._
 
 ### Forms
 - **Layout:** Flat sections separated by `border-top`. No card wrapping per section.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,17 @@ docs. Recommend shipping **read-only v1 first** (a much smaller, lower-risk
 surface) and adding write endpoints once the read API has real users. API
 reference docs belong with the user guide (see Continuous tracks).
 
+### 3.3 — Finance as a first-class, version-controlled workflow
+**Effort:** L · **Tracking:** [#985](https://github.com/TwoToned/gearflow/issues/985)
+(sub-issues #986–#990)
+WS1 (#940) shipped the finance *entities* and #957 shipped the lock *enforcement*;
+neither built the workflow or the UX. This program adds quote revisions on a single
+shared `projects.revision` counter (project v2 == quote v2), immutable stored PDF
+artifacts so a sent quote is actually reproducible, a top-level Finance tab that owns
+send / new-version / accept / invoice, and lock UI that is visible before you try
+rather than a toast after you've tried. Design:
+[`docs/designs/finance-first-class-version-control.md`](./designs/finance-first-class-version-control.md).
+
 ---
 
 ## Phase 4 — Experience pass

--- a/docs/designs/finance-first-class-version-control.md
+++ b/docs/designs/finance-first-class-version-control.md
@@ -113,6 +113,35 @@ spine, and this doc builds that spine once.
    artifact for a sent revision / issued invoice, plus an explicitly watermarked **DRAFT
    PREVIEW** before sending.
 
+Refined 2026-07-28 (second pass):
+
+5. **No quote numbering engine.** A quote is identified by its project number + version —
+   `RVLT-2026-0087 v2`. No `QTE:` counter, no new org settings, no second numbering surface
+   to keep in sync. The project number is already the shared reference with the client.
+6. **Invoices get full parity** with the quote workflow: a real issue dialog with invoice
+   date, due date and notes. This also fixes a live bug — `dueDate` is plumbed all the way
+   through `issueNative` (`convex/invoicesWrites.ts` L214-242) but the UI's `issueInvoice(id)`
+   never passes it, so **every invoice issued today has no due date at all**.
+7. **"Send" means freeze + generate, not email.** Flow records that you sent it (date,
+   recipient, version), freezes pricing and produces the PDF; you attach it to your own
+   email. This holds the #934 "no client-facing emails" decision. The button still reads
+   "Send quote" because that's the real-world act, but the dialog says plainly that Flow
+   doesn't email the client.
+8. **Rental dates stay editable after a send, but drift is flagged loudly.** Gigs move;
+   locking dates would fight operational reality. Instead the Finance tab and lock strip
+   surface "this project has changed since quote v2 was sent", with what changed (§6.5).
+9. **Finance gets an org-level home** — a `/finance` section, not only a per-project tab
+   (Phase F, §6.6). Today finance is visible one project at a time, so nothing is chaseable.
+10. **Quotes do not push to Xero.** Flow owns the quote end to end; Xero only ever sees the
+    invoice. Two systems holding divergent quote versions is the exact failure this program
+    exists to remove.
+11. **Send/accept = manager+ (`invoice:publish`); recall = admin/owner or the project's PM.**
+    Un-sending a document the client may already hold is trust-sensitive, so it reuses
+    #792's narrower `isHardLockOverrideAllowed` audience rather than the general permission.
+12. **Production has effectively no live quote/invoice data** (confirmed by Jayden) — the
+    #940 features shipped recently and haven't been used in anger. The backfill is therefore
+    a simple forward migration, not a defensive one (§8).
+
 ---
 
 ## 3. Target model — the quote revision is the unit of version control
@@ -128,6 +157,11 @@ projects.revision : number         ← the authority (starts at 1 on create)
 `projects.revision` is **recalc-adjacent but not recalc-owned**: it is written only by the
 two revision mutations below, stripped from every generic client patch the same way
 `PROJECT_MONEY_ANCHORS` already are (`convex/projectWrites.ts`). Never client-supplied.
+
+**Identity.** A quote has no document number of its own (decision 5). It is referred to
+everywhere — UI, PDF header, filename, audit log — as `<projectNumber> v<version>`, e.g.
+`RVLT-2026-0087 v2`. `src/lib/project-number.ts`'s engine is untouched by this program;
+only invoices keep their `INV:`-namespaced counter.
 
 **Invariants (server-enforced, tested):**
 - Exactly one quote row per `(projectId, revision)`. The existing
@@ -183,6 +217,18 @@ All five: the standard 4-guard browser-direct shape (FEATUREDOCS/54) — `assert
 `enforceBrowserWriteLimit`, `requireOrgPermission`, `resolveActor` — plus `assertRefInOrg`,
 plus `writeActivityLog`. `sendNative` keeps `assertLifecycleGuard(…, { kind: "financial" })`
 so a hard-locked project can't emit a new quote out of band.
+
+**Permissions (decision 11).** Send, new-version, accept and decline check
+`invoice:publish` — owner/admin/manager, the existing audience. **Recall additionally
+requires `isHardLockOverrideAllowed`** (org admin/owner, or a member of the project's
+`projectManagers` set — `convex/lib/projectLocks.ts`), because un-sending a document the
+client may already be holding is a trust-sensitive act. No new permission resource is
+introduced; both checks already exist.
+
+**"Send" does not email anyone (decision 7).** Flow stamps the revision as sent, freezes
+pricing, and produces the PDF. The dialog states this outright so nobody assumes the client
+was contacted — which is the failure mode of naming a button "Send" in a product that
+doesn't deliver mail (#934: "no client-facing emails — PDFs sent manually / by Xero").
 
 **Money still never originates from the client** (R-9.3). The send dialog's only inputs are
 `quoteDate`, `validityDays`, `recipientContactId`, `notes`. Every figure comes from
@@ -315,6 +361,9 @@ existing `financials` tab is retired, not duplicated. Templates keep hiding it, 
 │  Lock strip:  🔒 Pricing locked — Quote v2 sent 26 Jul                  │
 │               [ Create quote v3 ]  [ Recall v2 ]                       │
 ├────────────────────────────────────────────────────────────────────────┤
+│  ⚠ Changed since v2 was sent: 3 lines added, rental window +2 days      │
+│                                            [ See what changed ]        │
+├────────────────────────────────────────────────────────────────────────┤
 │  Totals:  Subtotal · Discount · GST · Total · Margin                   │
 │           Deposit invoiced · Invoiced to date · Outstanding            │
 ├────────────────────────────────────────────────────────────────────────┤
@@ -331,10 +380,11 @@ existing `financials` tab is retired, not duplicated. Templates keep hiding it, 
 
 Each revision row: version, state chip (`status-colors.ts` intents — never hardcoded per
 DESIGN.md §3), quote date, valid-until (amber when within 3 days, red when expired), total,
-who sent it, and its actions. Clicking a row opens the read-only "as of v N" view — which is
-`project-versions-panel.tsx`'s existing snapshot summary + `project-snapshot-diff.ts`'s
-existing diff, now reachable from the workflow instead of a ⋯ menu. The ⋯ "Versions" entry
-stays as a deep link; the panel is not duplicated.
+who sent it, and its actions. There is no quote document number (decision 5) — the row reads
+`v2` and the PDF header reads `Quote — RVLT-2026-0087 v2`. Clicking a row opens the read-only
+"as of v N" view — which is `project-versions-panel.tsx`'s existing snapshot summary +
+`project-snapshot-diff.ts`'s existing diff, now reachable from the workflow instead of a ⋯
+menu. The ⋯ "Versions" entry stays as a deep link; the panel is not duplicated.
 
 ### 6.3 Send dialog
 
@@ -352,13 +402,68 @@ The one place a quote leaves the building. Radix `Dialog` (no `AlertDialog`), fi
   _"Sending freezes pricing at v N. To change prices afterwards, create v N+1."_
 - **[ Preview draft PDF ]** (watermarked) and **[ Send quote v N ]**.
 
-No monetary input anywhere in this dialog.
+No monetary input anywhere in this dialog. The footer states plainly: _"Flow doesn't email
+clients — this generates the PDF for you to send."_ (decision 7).
 
-### 6.4 Documents dropdown
+### 6.4 Invoice issue dialog (decision 6)
+
+Invoices get the same treatment, because "or an invoice willy nilly" was half the original
+complaint. Radix `Dialog` on **issue** (not on draft creation, which stays one click):
+
+- **Invoice date** — user-set, defaults to today
+- **Due date** — defaults to invoice date + `OrgDocumentSettings.paymentTermsDays` (**new
+  setting**, default 14). Today `dueDate` is fully plumbed through `issueNative`
+  (`convex/invoicesWrites.ts` L214-242) but `issueInvoice(id)` never passes it, so **every
+  invoice issued today carries no due date** — an outright bug this closes.
+- **Notes** and a **read-only amount summary** (server-computed; the deposit % and balance
+  math are unchanged)
+- **[ Preview ]** (watermarked) and **[ Issue INV-… ]** — the number is still assigned
+  server-side at issue, the one numbering moment (FEATUREDOCS/66)
+
+The existing "advance the project to INVOICED?" chain moves into this dialog's success path
+as a proper `Dialog`, replacing `window.confirm`.
+
+### 6.5 Drift indicator — "changed since v2 was sent" (decision 8)
+
+Rental dates and gear stay editable after a send; the drift is made loud instead
+(§2 decision 8). **This costs almost nothing to build**, because the pieces already exist:
+`sendNative` captures a snapshot for the revision, `collectCurrentEntries` reads current
+state through the identical shape, and `diffSnapshotEntries` already compares them. Drift is
+just that diff, rendered as a summary line.
+
+- Shows when a `SENT`/`ACCEPTED` revision exists and its snapshot differs from current
+- Summarises by kind — lines added/removed, prices changed, rental window moved, services
+  or crew changed — and "See what changed" opens the full existing diff view
+- Appears on the Finance tab and in the lock strip, so it's visible from any tab
+- Distinct from `StalePricingBanner`, which answers a different question ("stored prices no
+  longer match what current dates would derive" → offers Recalculate). Drift answers "the
+  job no longer matches the document the client is holding" → offers "Create quote v3".
+  Both can be true at once; they are not merged.
+
+### 6.6 Documents dropdown
 
 Loses "Quote / proposal" and "Invoice". Keeps Pull slip, Delivery docket, Return sheet, Call
 sheet, Project timeline. The `typeMap` entries for `quote`/`invoice` in
 `src/app/api/documents/[projectId]/route.tsx` survive only behind `preview=1` + permission.
+
+### 6.7 Org-level Finance section (decision 9 — Phase F)
+
+Per-project finance can't be chased. A `/finance` nav section answers the questions nobody
+can currently ask without opening projects one at a time:
+
+- **Quotes out** — sent, awaiting acceptance, sorted by age
+- **Expiring** — `validUntil` inside 7 days, and already-expired
+- **Never sent** — draft revisions sitting on active projects
+- **Confirmed but uninvoiced** — accepted/confirmed jobs with no issued invoice
+- **Deposit due** — `DEPOSIT_BALANCE` clients whose deposit invoice hasn't issued
+  (the existing derived nudge, lifted to org scope)
+- **Outstanding** — issued invoices unpaid, once the Xero payment poll lands (FEATUREDOCS/66
+  phase 2); until then the section renders issued-and-unreconciled
+
+**Performance constraint, learned the hard way:** this must be a **date-ranged aggregation
+query, not a per-project loop**. #942 records that unbounded overbooking reads once
+accounted for 77% of org DB I/O. Indexes to add: `quotes.by_organizationId_status`,
+`invoices.by_organizationId_status` (exists), and a bounded default horizon.
 
 ---
 
@@ -440,33 +545,50 @@ snapshotId: v.optional(v.string()),           // the projectSnapshots row for th
 
 // invoices
 pdfFileId: v.optional(v.string()),            // stored artifact, written at issueNative
+invoiceDate: v.optional(v.number()),          // user-set at issue (decision 6)
 
 // projectSnapshots
 reason: … | v.literal("QUOTE_SENT"),
 revision: v.optional(v.number()),
+
+// OrgDocumentSettings (src/lib/org-settings-types.ts)
+paymentTermsDays?: number;                    // default 14 — due-date default at issue
 ```
 
-New index: `quotes.by_projectId_status`. `by_projectId_version` becomes the uniqueness guard.
+New indexes: `quotes.by_projectId_status`, `quotes.by_organizationId_status` (Phase F).
+`by_projectId_version` becomes the uniqueness guard.
+
+**No quote numbering fields** (decision 5) — no `quoteNumber`, no `QTE:` scope key, no new
+`OrgSettings` numbering entries. `src/lib/project-number.ts` and `src/lib/invoice-number.ts`
+are untouched by this program.
 
 **Schema discipline:** `convex/schema.ts` is hand-maintained — never regenerate
 (CLAUDE.md). Every new field is `v.optional` on arrival; nothing is removed from a validator
 while live documents may still carry it (the `depositPercent` prod-deploy incident recorded in
 FEATUREDOCS/66 is the standing precedent).
 
-**Backfill** (`convex/backfill*.ts`, the established pattern):
+**Backfill** (`convex/backfill*.ts`, the established pattern). Production has effectively no
+live quote/invoice data (decision 12 — the #940 features shipped days ago and haven't been
+used in anger), so this is a **simple forward migration**, not a defensive one. The
+originally-planned lazy-draft-on-first-load path is dropped as unnecessary complexity:
+
 1. `projects.revision` ← `max(quotes.version)` for the project, else 1.
 2. `quotes.status: "PUBLISHED"` → `"SENT"`; `publishedAt/ById` → `sentAt/ById`.
 3. `quotes.quoteDate` ← `sentAt`; `validUntil` ← `sentAt + quoteValidityDays`.
-4. Existing sent quotes get **no** artifact — their rows render "no stored document
-   (pre-versioning)" rather than a regenerated fake. Retro-rendering a historical quote from
-   today's project state would manufacture a document that was never sent, which is the exact
-   defect this program exists to remove.
-5. Projects with no quote row get a `DRAFT` v1 lazily on first Finance-tab load, not a bulk
-   insert.
+4. Every project without a quote row gets a `DRAFT` v1 inserted directly — a bulk insert is
+   fine at this data volume, and it means every project has a coherent revision from day one
+   with no lazy-creation race to reason about.
+5. Any pre-existing sent quote gets **no** artifact — its row renders "no stored document
+   (pre-versioning)". Retro-rendering a historical quote from today's project state would
+   manufacture a document that was never sent, which is the exact defect this program removes.
+
+**Still run a count first.** "Effectively none" is a reasonable basis for choosing the simple
+path, not a licence to skip verification — the migration logs the row counts it touched, and
+a mismatch against expectation halts rather than proceeds.
 
 ---
 
-## 9. Rollout — five phases, five issues under one tracker
+## 9. Rollout — six phases, six issues under one tracker
 
 Tracking issue: [#985](https://github.com/TwoToned/gearflow/issues/985).
 Sequenced so each phase is independently shippable and nothing half-lands.
@@ -476,10 +598,11 @@ Sequenced so each phase is independently shippable and nothing half-lands.
 | **A** | Revision model + state machine | [#986](https://github.com/TwoToned/gearflow/issues/986) | `projects.revision`, quote schema + enum, the five verbs, acceptance gate on CONFIRMED, backfill, server tests | M |
 | **B** | Immutable artifacts | [#987](https://github.com/TwoToned/gearflow/issues/987) | Render-and-store at send/issue, `pdfFileId` wiring, artifact routes, watermarked draft preview, Documents-menu removal | M |
 | **C** | Unified lock state | [#988](https://github.com/TwoToned/gearflow/issues/988) | `resolveLockTier` (status × quote), `reason` plumbing, close the deferred gate sites, parity tests | S |
-| **D** | Finance tab | [#989](https://github.com/TwoToned/gearflow/issues/989) | Tab promotion, quote rail + version history + diff entry, send dialog, invoice rail, retire `window.confirm` | M |
+| **D** | Finance tab | [#989](https://github.com/TwoToned/gearflow/issues/989) | Tab promotion, quote rail + version history + diff entry, send dialog, **invoice issue dialog + due dates**, **drift indicator**, retire `window.confirm` | M |
 | **E** | Lock UX | [#990](https://github.com/TwoToned/gearflow/issues/990) | Lock strip, header chip, `<LockedField>`, `aria-disabled` action pattern, `useJustifiedMutation` wiring, `UnpricedBadge` mounting, list/board glyphs, session diff-before-commit | M |
+| **F** | Org-level Finance section | [#992](https://github.com/TwoToned/gearflow/issues/992) | `/finance` nav section — quotes out, expiring, never sent, confirmed-uninvoiced, deposit due, outstanding; aggregation query (not a per-project loop) | M |
 
-**Dependencies:** A → B, A → C, (A,B,C) → D, C → E. D and E are parallelisable.
+**Dependencies:** A → B, A → C, (A,B,C) → D, C → E, (A,B,D) → F. D and E are parallelisable.
 
 ---
 
@@ -500,10 +623,27 @@ Sequenced so each phase is independently shippable and nothing half-lands.
   `TooltipProvider` / Radix-in-modal footguns from CLAUDE.md); locked state renders read-only
   fields and the tooltip explains; `aria-disabled` actions are reachable by keyboard.
 - **a11y** — lock states announced, not colour-only (DESIGN.md); `docs/a11y-manual-checklist.md`.
+- **Drift** — `diffSnapshotEntries(sentRevisionSnapshot, currentEntries)` produces the
+  expected summary for each change kind (line added/removed, price changed, dates moved),
+  and produces *nothing* on an untouched project (zero-noise, mirroring
+  `ProjectConflictsBanner`).
+- **Org finance query (Phase F)** — asserted to be a single aggregation, not an N-project
+  loop; a fixture org with many projects bounds the read count.
 
 ---
 
-## 11. Open questions
+## 11. Resolved questions
+
+- **Quote numbering?** No — project number + version (`RVLT-2026-0087 v2`). Decision 5.
+- **Do quotes push to Xero as Xero Quotes?** No — Flow owns the quote end to end; Xero only
+  sees the invoice. Two systems holding divergent quote versions is the failure this program
+  exists to remove. Decision 10.
+- **Does "Send" email the client?** No — it freezes and generates; you send it yourself. The
+  dialog says so explicitly. Decision 7.
+- **Do rental dates lock after a send?** No — they stay editable and drift is flagged loudly
+  (§6.5). Decision 8.
+
+## 12. Open questions
 
 - **Multiple concurrent draft revisions?** Ruled out for v1 (one draft, always at
   `projects.revision`). Comparing two speculative options is a real workflow ("with and
@@ -519,9 +659,13 @@ Sequenced so each phase is independently shippable and nothing half-lands.
   not `window.confirm`.
 - **CANCELLED remains ungated** — inherited open question from #957, unchanged here.
 
+- **Duplicated projects / templates** — a duplicate starts at `revision: 1` with a fresh
+  `DRAFT` v1 and copies no quote history; a template carries no revision at all. Assumed,
+  not asked — say so if that's wrong.
+
 ---
 
-## 12. POLICY.md compliance notes (BUILD mode)
+## 13. POLICY.md compliance notes (BUILD mode)
 
 - **R-3.1 / single source of truth** — one revision counter; one lock-tier resolver; the send
   dialog's validity math resolves through the same `quoteValidityDays` setting the PDF reads.

--- a/docs/designs/finance-first-class-version-control.md
+++ b/docs/designs/finance-first-class-version-control.md
@@ -1,0 +1,541 @@
+# Finance as a first-class, version-controlled workflow
+
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-28 (review quarterly — POLICY.md R-5.5)_
+
+**Created:** 2026-07-28
+**Driver:** Jayden — _"I want to make the finance (quoting, invoicing stuff) a first-class
+citizen and streamlined workflow, compliant with version control and such."_ Three concrete
+asks: (1) real quote versioning wired into the quoting workflow, (2) a structured Finance
+menu on projects that owns quote send/versioning/dates/PDF instead of "rogue pressing the
+documents button", (3) project locking that is **visible** rather than a toast that fires
+after you've already tried something.
+**Supersedes/extends:** WS1 (#940, FEATUREDOCS/66) shipped the finance *entities*;
+#957/#791/#792/#793 (FEATUREDOCS/62) shipped the lock *enforcement*. This doc is the
+workflow and UX layer neither of them built.
+**Tracking:** [#985](https://github.com/TwoToned/gearflow/issues/985) (sub-issues #986–#990).
+**Owning docs to update:** [FEATUREDOCS/66](../../FEATUREDOCS/66-finance-quotes-invoices-xero.md),
+[FEATUREDOCS/62](../../FEATUREDOCS/62-project-lifecycle-locks.md),
+[FEATUREDOCS/13](../../FEATUREDOCS/13-pdfs.md),
+[FEATUREDOCS/10](../../FEATUREDOCS/10-projects.md).
+
+---
+
+## 1. Problem — what's actually in the repo today
+
+Verified against the codebase on 2026-07-28, not from the docs.
+
+### 1.1 There are three unrelated "version" mechanisms, and none is the one we want
+
+| Mechanism | What it is | Why it isn't versioning |
+|---|---|---|
+| `projectSnapshots` + `projectSnapshotEntries` | Whole-project entity snapshots | Captured **automatically** at CONFIRMED / COMPLETED / UNLOCK only (`crossesIntoSnapshotStatus`). Not user-driven, unnamed, unnumbered, invisible outside a ⋯-menu panel. |
+| `quotes.version` | A number bumped inside `publishNative` | Derived at publish time by scanning existing rows (`convex/quotesWrites.ts` L60-72). Never surfaced as a workflow. No draft state, no send, no dates, no recall. |
+| The PDF | `generatePdf(projectId, orgId, "quote")` | Reads **live project state** (`src/lib/pdfme/build-document-data.ts`). Reads the `quotes` table **not at all**. |
+
+### 1.2 The central defect: a sent quote is not reproducible
+
+`/api/documents/[projectId]?type=quote` renders from whatever the project looks like **right
+now**. Two clicks a week apart produce two different documents under the same name, and the
+document the client is holding exists nowhere in the system. `quotes.snapshot` freezes
+money — but the PDF never consults it, and the snapshot doesn't carry the line
+descriptions, client block, dates, terms or notes needed to re-render the page anyway.
+`quotes.pdfFileId` is declared in `convex/schema.ts` (L2089) and has **zero readers and zero
+writers** — a placeholder nobody wired.
+
+The same is true of invoices: `invoices` are documented as "immutable once ISSUED", and the
+row genuinely is — but the **artifact** is still live-rendered from the project on every
+click, so the immutability guarantee stops at the database boundary.
+
+### 1.3 Finance has no home in the UI
+
+`ProjectFinancePanel` (306 lines) is mounted at the **bottom of the Financials tab**, below
+the billing summary, the unlock banner, the financial summary, a divider, the costs panel and
+another divider. Publishing a quote is a bare button with no dialog — no quote date, no
+valid-until, no recipient, no preview, no confirmation. Meanwhile the header's **Documents ▾**
+dropdown offers "Quote / proposal" and "Invoice" as one-click live PDFs, entirely outside the
+finance workflow. That dropdown is the "rogue" path.
+
+Also in that panel: a `window.confirm()` for the advance-to-INVOICED prompt
+(`project-finance-panel.tsx` L109) — against CLAUDE.md's "no `AlertDialog` — use `Dialog`"
+convention and DESIGN.md.
+
+### 1.4 The locks are real on the server and nearly invisible on the client
+
+The server side is genuinely good: one `assertLifecycleGuard`, one tier table, stable
+`ConvexError` codes, ~25 gate sites. The client side is one mount:
+
+```
+src/app/(app)/projects/[id]/page.tsx:155   const lockStatus = useProjectLockStatus(id, orgId)
+src/app/(app)/projects/[id]/page.tsx:570   <UnlockSessionBanner …>   ← inside the Financials tab
+```
+
+That's the **entire** consumption surface. Which means, verified by grep:
+
+- **No lock indication in the project header**, on the lifecycle stepper, or anywhere outside
+  the Financials tab. A locked project looks identical to an open one.
+- **The Equipment tab is fully interactive on a locked project** — every price input, every
+  add/remove control is enabled. You find out it's locked from a red toast, after the fact.
+- **`useJustifiedMutation` has zero call sites.** It is built, smoke-tested, exported and
+  wired into nothing (FEATUREDOCS/62 admits this under "Wiring status"). Every ON_SITE+
+  structural edit therefore fails with a `JUSTIFICATION_REQUIRED` toast and no way to
+  supply the justification.
+- **`UnpricedBadge` has zero call sites.** New items silently default to $0 with no visual
+  marker, which is precisely the case the badge exists for.
+- **No lock indicator on the project list, board, or cards** — you can't tell before opening.
+- **The deferred gate sites are still open** (FEATUREDOCS/62 "Deliberately deferred"):
+  `bulkDeleteServicesNative`, `bulkUpdateServiceStatusNative`, `generateServicesNative`,
+  `cloneServicesNative`, `convertLineItemToServiceNative`, `reorderNative`,
+  `bulkDeleteNative`, `bulkStatusNative`, `generateShiftsNative`. Any UI that claims "locked"
+  while these write is lying.
+
+### 1.5 Consequence
+
+The three asks are one problem. Quote versioning without immutable artifacts is theatre;
+a Finance menu without a lock is a suggestion; a lock without UI is a trap. They share one
+spine, and this doc builds that spine once.
+
+---
+
+## 2. Locked decisions (Jayden, 2026-07-28)
+
+1. **One shared revision number.** `projects.revision` is the single counter. Project v2 ==
+   Quote v2 == the snapshot taken at v2. A new project is v1 with a draft Quote v1. There is
+   no second counter anywhere.
+2. **Sending a quote locks pricing; cutting a new version is the unlock.** Structural adds
+   stay possible on a sent revision but land at $0 (the existing `defaultToZero` behaviour).
+   A **Recall** action un-sends for pre-client typo fixes, audited.
+3. **Acceptance is required to confirm, admin-overridable.** A revision must be `ACCEPTED`
+   before the project advances to `CONFIRMED`; org admins/owners and the project's PMs can
+   override with a bounded justification, reusing the existing hard-lock-override audience
+   and justification plumbing.
+4. **Quote and Invoice leave the Documents dropdown.** Documents keeps warehouse artifacts
+   only. Client-facing finance documents come from the Finance tab: the stored immutable
+   artifact for a sent revision / issued invoice, plus an explicitly watermarked **DRAFT
+   PREVIEW** before sending.
+
+---
+
+## 3. Target model — the quote revision is the unit of version control
+
+### 3.1 One number, three tables
+
+```
+projects.revision : number         ← the authority (starts at 1 on create)
+  quotes.version  = revision it was cut from   (exactly one quote row per revision)
+  projectSnapshots.revision                    (the frozen entity state for that revision)
+```
+
+`projects.revision` is **recalc-adjacent but not recalc-owned**: it is written only by the
+two revision mutations below, stripped from every generic client patch the same way
+`PROJECT_MONEY_ANCHORS` already are (`convex/projectWrites.ts`). Never client-supplied.
+
+**Invariants (server-enforced, tested):**
+- Exactly one quote row per `(projectId, revision)`. The existing
+  `by_projectId_version` index becomes the uniqueness check.
+- At most one `DRAFT` quote per project, and it is always at `projects.revision`.
+- At most one `SENT` quote per project (the one the client is holding).
+- `projects.revision` is monotonic. Never decremented, never reused — a recalled-then-
+  re-sent revision keeps its number, a superseded one is never reissued.
+
+### 3.2 Revision lifecycle
+
+```
+        project created
+              │
+              ▼
+        v1  DRAFT ──── send ────▶ v1  SENT ──── accept ────▶ v1  ACCEPTED ──▶ project may CONFIRM
+              ▲                     │  │  │
+              │                     │  │  └── decline ─────▶ v1  DECLINED
+              └──── recall ─────────┘  │
+                                       └── new version ────▶ v2  DRAFT   (v1 → SUPERSEDED on v2's send)
+                                                                  │
+                                                    valid-until passes
+                                                                  ▼
+                                                            v1  EXPIRED
+```
+
+`QuoteStatus` (`convex/lib/validators.ts` L449) goes from
+`DRAFT | PUBLISHED | SUPERSEDED` to
+`DRAFT | SENT | ACCEPTED | DECLINED | SUPERSEDED | EXPIRED`.
+`PUBLISHED` is renamed to `SENT` (backfill in §7) — "published" was never accurate; nothing
+was published anywhere.
+
+**Supersede timing:** v1 stays `SENT` while v2 is a draft. It only flips to `SUPERSEDED` when
+v2 is actually sent. There is always exactly one document that represents "what the client
+currently has", and cutting a draft never invalidates it. This is the difference between a
+version-control system and a delete button.
+
+**EXPIRED** is derived-on-read, not a cron — `validUntil < now && status === "SENT"` renders
+as expired and blocks acceptance without an explicit re-send. No scheduled job, no clock
+skew, no stale row. (Consistent with FEATUREDOCS/66's "readiness is derived" precedent.)
+
+### 3.3 The five verbs
+
+| Verb | Mutation | What it does |
+|---|---|---|
+| **Send** | `quotesWrites.sendNative` | Freezes the revision: captures the finance snapshot (`buildFinanceLines`, unchanged) **and** a `revision` snapshot via `captureProjectSnapshot`, stamps the user-chosen `quoteDate` + computed `validUntil` + recipient contact, schedules artifact render (§4), sets `SENT`, supersedes the previous `SENT` row, raises the project's lock state (§5), offers to advance `ENQUIRY/QUOTING → QUOTED`. |
+| **Recall** | `quotesWrites.recallNative` | `SENT → DRAFT` on the current revision. Marks the stored artifact `recalled` (retained for audit — never deleted; the client may already have it). Requires `invoice:publish` + a bounded reason. Drops the lock back. |
+| **New version** | `quotesWrites.newVersionNative` | Increments `projects.revision`, inserts a `DRAFT` quote at the new number, releases the pricing lock. The previous `SENT` row is untouched until the new one sends. |
+| **Accept** | `quotesWrites.markAcceptedNative` | `SENT → ACCEPTED` with an acceptance date + optional reference (PO number, email subject). Unblocks `CONFIRMED`. |
+| **Decline** | `quotesWrites.markDeclinedNative` | `SENT → DECLINED` with a bounded reason. Offers `CANCELLED`, never forces it. |
+
+All five: the standard 4-guard browser-direct shape (FEATUREDOCS/54) — `assertWritesEnabled`,
+`enforceBrowserWriteLimit`, `requireOrgPermission`, `resolveActor` — plus `assertRefInOrg`,
+plus `writeActivityLog`. `sendNative` keeps `assertLifecycleGuard(…, { kind: "financial" })`
+so a hard-locked project can't emit a new quote out of band.
+
+**Money still never originates from the client** (R-9.3). The send dialog's only inputs are
+`quoteDate`, `validityDays`, `recipientContactId`, `notes`. Every figure comes from
+`buildFinanceLines` + the project's recalc-owned totals, exactly as `publishNative` does today.
+
+### 3.4 Acceptance gate on CONFIRMED
+
+`projectWrites.updateStatusNative` gains one check on transitions landing on `CONFIRMED`:
+
+```ts
+if (to === "CONFIRMED" && !(await hasAcceptedQuote(ctx, project))) {
+  await requireHardLockOverrideAllowed(ctx, orgId, projectId, actor.userId);  // reuse #792's audience
+  assertStrLen(justification, "justification", { min: 10, max: 1000 });       // reuse #793's bounds
+}
+```
+
+Reuses the existing override audience and justification bounds — no new permission, no new
+dialog primitive, no second copy of the bounds (R-3.1). The client pre-checks and shows the
+override dialog rather than letting the server 
+throw first, using the same `useJustifiedMutation` pattern.
+
+---
+
+## 4. Immutable artifacts — the PDF becomes the record
+
+### 4.1 Render-and-store at the freeze moment
+
+The moment a quote is sent (or an invoice issued), the PDF is rendered **once** and the bytes
+stored, then never regenerated:
+
+```
+send/issue ──▶ Next.js server action (pdfme runs in Node, not Convex)
+                 └─▶ generatePdf(...)  ──▶ uploadToS3()  [= Convex _storage, src/lib/storage.ts]
+                       └─▶ storageId ──▶ quotes.pdfFileId / invoices.pdfFileId
+```
+
+Chosen over "reconstruct the document from the snapshot at render time" because it is the only
+option that is *actually* immutable: a reconstruction path re-executes ~1,400 lines of
+`build-document-data.ts` + the composer against a snapshot that would need to grow to carry
+every token, and any future change to that code silently changes historical documents. Storing
+bytes makes the guarantee structural rather than disciplinary — the same reasoning as
+`withValidatedBody` in CLAUDE.md.
+
+`src/lib/storage.ts` already routes to Convex `_storage`, and `storedFiles` already carries
+the org row the `/api/files/{storageId}` proxy authorises against — so this is a new caller of
+an existing, org-checked path, not new infrastructure.
+
+**Failure handling.** Render failure must not silently produce a `SENT` quote with no
+document. `sendNative` writes the row inside the Convex transaction; the artifact render runs
+immediately after in the server action and patches `pdfFileId`. A quote in `SENT` with a null
+`pdfFileId` renders a "Document still generating / failed — retry" state in the Finance tab
+with a `regenerateArtifactNative`-style retry that is only callable while `pdfFileId` is null.
+Never a silent gap, never a second render path for a quote that already has one.
+
+### 4.2 Draft preview
+
+`GET /api/documents/[projectId]?type=quote&preview=1` stays, but:
+- requires `invoice:read`,
+- renders a **DRAFT PREVIEW — NOT SENT** watermark block (new `LayoutBlock` kind in
+  `document-layouts.ts`; layouts are plain TS per the #790 redesign, so this is a block, not a
+  template),
+- is reachable **only** from the Finance tab's send dialog and the draft revision row.
+
+### 4.3 Artifact retrieval
+
+`GET /api/finance/quote/[quoteId]/pdf` and `/api/finance/invoice/[invoiceId]/pdf` — org-checked,
+stream the stored bytes, `Content-Disposition` naming the revision
+(`RVLT-<projectNumber>-quote-v2.pdf`). No regeneration path. A recalled or superseded
+revision's artifact stays downloadable, badged with its state.
+
+### 4.4 PDF data-shape audit (CLAUDE.md standing rule)
+
+The new watermark block is a **new `LayoutBlock` kind**, not a `DocumentLineItem` shape
+change — so the three-consumer audit (`gearflow-table.ts` render,
+`document-composer.ts` `calculateItemHeight`, `getFilteredParentItems`) applies only to the
+composer's block-height switch, which must reserve height for the watermark block. That
+reservation gets a `document-composer.test.ts` case. No line-item shape changes anywhere in
+this program — confirmed by walking the send path: it consumes `buildFinanceLines`, which is
+the *data-model* snapshot builder and explicitly not the PDF's line structuring
+(FEATUREDOCS/66 §"Money is never hand-typed").
+
+---
+
+## 5. Unified lock state — one precedence table, two inputs
+
+**The risk here is a second lock mechanism**, which would be an R-3.1 defect on the most
+safety-critical code in the app. So the quote-send lock is not new machinery: it becomes a
+second *input* to the existing one.
+
+`convex/lib/projectLocks.ts` `lockTierForStatus(status)` → `resolveLockTier({ status, quoteState })`:
+
+| Status tier | Current quote state | Effective tier | Unlock affordance offered |
+|---|---|---|---|
+| OPEN (`ENQUIRY`/`QUOTING`/`QUOTED`) | none, or `DRAFT` | **OPEN** | — |
+| OPEN | `SENT` or `ACCEPTED` | **FINANCE_LOCKED** | **"Create quote v(N+1)"** (primary) · "Recall quote" (secondary) |
+| FINANCE_LOCKED (`CONFIRMED`+) | any | **FINANCE_LOCKED** | Unlock session (existing) |
+| JUSTIFY (`ON_SITE`/`RETURNED`) | any | **JUSTIFY** | Unlock session / per-edit justify (existing) |
+| HARD_LOCKED (`COMPLETED`/`INVOICED`) | any | **HARD_LOCKED** | Full unlock session (existing) |
+
+Properties that make this safe:
+- **Monotonic.** A quote state can only *raise* the tier, never lower it. A sent quote on a
+  COMPLETED project doesn't soften anything.
+- **One function.** Every one of the ~25 existing gate sites keeps calling
+  `assertLifecycleGuard` unchanged; only the guard's internal tier resolution learns about
+  quotes. Zero new gate sites, zero new call-site edits.
+- **The reason is carried.** `LifecycleGuardResult` gains `reason: "STATUS" | "QUOTE_SENT"` so
+  the UI can say _why_ and offer the right unlock. `LockTier` values are unchanged, so
+  `FINANCIALS_LOCKED` / `PROJECT_LOCKED` codes and their toast mappings still apply.
+- **`defaultToZero` is unchanged** — a quote-sent project defaults new adds to $0 exactly like
+  a CONFIRMED one, which is precisely the desired behaviour for "gear added after the quote
+  went out".
+
+`projectLocksRead.status` returns the new `reason` + the current quote revision/state so the
+client renders one coherent banner from one query.
+
+---
+
+## 6. The Finance tab
+
+### 6.1 Promotion
+
+`Finance` becomes a **top-level project tab** (Equipment · Labour & logistics · **Finance** ·
+Tasks · Notes · Files). The money-summary content currently on "Financials" moves in; the
+existing `financials` tab is retired, not duplicated. Templates keep hiding it, as today.
+
+### 6.2 Layout
+
+```
+┌─ Finance ─────────────────────────────────────────────────────────────┐
+│  Lock strip:  🔒 Pricing locked — Quote v2 sent 26 Jul                  │
+│               [ Create quote v3 ]  [ Recall v2 ]                       │
+├────────────────────────────────────────────────────────────────────────┤
+│  Totals:  Subtotal · Discount · GST · Total · Margin                   │
+│           Deposit invoiced · Invoiced to date · Outstanding            │
+├────────────────────────────────────────────────────────────────────────┤
+│  QUOTES                                          [ Send quote v3 ▸ ]   │
+│   ○ v3  Draft      —            $18,400   [Preview draft]              │
+│   ● v2  Sent       26 Jul 26    $18,120   [PDF] [Diff v1→v2] [Accept]  │
+│   ○ v1  Superseded 19 Jul 26    $16,900   [PDF] [Diff]                 │
+├────────────────────────────────────────────────────────────────────────┤
+│  INVOICES                              [ Deposit ] [ Balance ] [ Full ]│
+│   ● INV-2026-0043  Deposit  Issued  25 Jul  $4,530  [PDF] [Xero ✓]     │
+│   ○ (draft)        Balance  —               $13,590 [Issue] [Delete]   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+Each revision row: version, state chip (`status-colors.ts` intents — never hardcoded per
+DESIGN.md §3), quote date, valid-until (amber when within 3 days, red when expired), total,
+who sent it, and its actions. Clicking a row opens the read-only "as of v N" view — which is
+`project-versions-panel.tsx`'s existing snapshot summary + `project-snapshot-diff.ts`'s
+existing diff, now reachable from the workflow instead of a ⋯ menu. The ⋯ "Versions" entry
+stays as a deep link; the panel is not duplicated.
+
+### 6.3 Send dialog
+
+The one place a quote leaves the building. Radix `Dialog` (no `AlertDialog`), fields:
+
+- **Quote date** — user-set, defaults to today; this is the date printed on the PDF and the
+  anchor for validity. (Today: hardcoded `now` in `build-document-data.ts` L743.)
+- **Valid for** — days, defaults to `OrgDocumentSettings.quoteValidityDays` (30). Shows the
+  resolved date. (Today: computed from `now` at render time, so a re-render silently *extends*
+  a quote's validity — a real correctness bug this fixes.)
+- **Recipient** — client contact picker (`resolveClientContactDisplay` exists), stamped onto
+  the revision so "who was this sent to" is answerable.
+- **Notes to client** — the existing `quotes.notes`.
+- **Read-only summary** — line count, subtotal, GST, total, and an explicit
+  _"Sending freezes pricing at v N. To change prices afterwards, create v N+1."_
+- **[ Preview draft PDF ]** (watermarked) and **[ Send quote v N ]**.
+
+No monetary input anywhere in this dialog.
+
+### 6.4 Documents dropdown
+
+Loses "Quote / proposal" and "Invoice". Keeps Pull slip, Delivery docket, Return sheet, Call
+sheet, Project timeline. The `typeMap` entries for `quote`/`invoice` in
+`src/app/api/documents/[projectId]/route.tsx` survive only behind `preview=1` + permission.
+
+---
+
+## 7. Lock UX — making the lock legible
+
+Design principle: **a lock must be visible before you try, explain itself, and offer the
+exit.** Today it is invisible, unexplained, and exits only through a tab you weren't on.
+
+### 7.1 Six surfaces
+
+1. **Header chip** — next to the project status, always mounted:
+   `🔒 Pricing locked` / `🔒 Locked` / `🔓 Unlocked by Jayden · 12m`. Click scrolls to the
+   lock strip. Uses `status-colors.ts` intents.
+2. **Lock strip** — one shared `<ProjectLockStrip>` rendered at the top of the project
+   detail (not inside a tab), replacing the Financials-tab-only banner. States: locked (with
+   reason + exit CTA), session open (with "Save & relock" / "Discard" + who + why), hard
+   locked (with the restricted audience explained). One component, one `useProjectLockStatus`
+   subscription, mounted once.
+3. **Field level** — a shared `<LockedField>` wrapper renders money inputs read-only with a
+   lock glyph and a tooltip naming the reason and the exit. Wrapping, not per-form `disabled`
+   props, so there is one implementation to keep honest. Applies to: `price-edit-dialog`,
+   `edit-line-item-dialog`, `line-item-form-fields`, `edit-group-dialog`, `add-service-dialog`,
+   `crew-panel` rate fields, `bulk-edit-line-items-dialog`, and the project edit form's tax/
+   discount inputs.
+4. **Action level** — gated buttons render `aria-disabled` (**not** `disabled`, which would
+   kill the tooltip) inside a `TooltipProvider` — remember there is no global provider — with
+   a no-op handler and copy that names the exit. Per DESIGN.md §9.1 every interactive element
+   needs its states declared, and "silently dead" is not one of them.
+5. **Justify tier** — `useJustifiedMutation` + `JustificationDialog` threaded through every
+   equipment / group / service / crew call site. The affected actions carry a small
+   "needs a reason" hint at ON_SITE+ so the dialog isn't a surprise.
+6. **List / board / cards** — a lock glyph on `project-table`, `project-board` and dashboard
+   cards, so the state is knowable before opening. Sourced from status + quote state
+   (both already on the row) — no extra query.
+
+Plus: **`UnpricedBadge` finally gets mounted** on every $0-defaulted line and group, which is
+the visual half of `defaultToZero` that was never wired.
+
+### 7.2 Unlock session UX
+
+- The strip shows elapsed time, who opened it, and the justification.
+- **"Save & relock" shows the diff first** — `project-snapshot-diff.ts` already diffs the
+  UNLOCK snapshot against current, and `collectCurrentEntries` already reads through the same
+  code path. Committing blind is the one thing that turns an audit trail into noise.
+- **"Discard"** shows the same diff plus the documented conflict caveat (warehouse-backed
+  entities aren't force-restored — `isWarehouseBacked`).
+- Sessions **auto-commit on status change** already (`autoCommitOpenSession`); the strip now
+  says so before you transition.
+
+### 7.3 Server parity (non-negotiable)
+
+Every mutation the new UI presents as locked **must** actually be gated, or the UI is a lie.
+The deferred gate sites from FEATUREDOCS/62 close as part of this program:
+`bulkDeleteServicesNative`, `bulkUpdateServiceStatusNative`, `generateServicesNative`,
+`cloneServicesNative`, `convertLineItemToServiceNative`, `lineItemWrites.reorderNative`,
+`crewAssignmentsWrites.bulkDeleteNative` / `bulkStatusNative` / `generateShiftsNative`.
+
+---
+
+## 8. Data model changes
+
+```ts
+// projects
+revision: v.optional(v.number()),            // authority; absent ⇒ 1 (read-time coalesce, backfilled)
+
+// quotes — extended, not replaced
+version: v.number(),                          // == the projects.revision it was cut from
+status: QuoteStatus,                          // DRAFT | SENT | ACCEPTED | DECLINED | SUPERSEDED | EXPIRED
+quoteDate: v.optional(v.number()),            // user-set, printed on the PDF
+validUntil: v.optional(v.number()),           // derived at send from quoteDate + validityDays
+sentAt / sentById: v.optional(...),           // replaces publishedAt/publishedById (backfilled)
+recipientContactId: v.optional(v.string()),
+acceptedAt / acceptedById / acceptanceRef: v.optional(...),
+declinedAt / declinedById / declineReason: v.optional(...),
+recalledAt / recalledById / recallReason: v.optional(...),
+supersededByQuoteId: v.optional(v.string()),
+pdfFileId: v.optional(v.string()),            // ← finally written
+snapshotId: v.optional(v.string()),           // the projectSnapshots row for this revision
+
+// invoices
+pdfFileId: v.optional(v.string()),            // stored artifact, written at issueNative
+
+// projectSnapshots
+reason: … | v.literal("QUOTE_SENT"),
+revision: v.optional(v.number()),
+```
+
+New index: `quotes.by_projectId_status`. `by_projectId_version` becomes the uniqueness guard.
+
+**Schema discipline:** `convex/schema.ts` is hand-maintained — never regenerate
+(CLAUDE.md). Every new field is `v.optional` on arrival; nothing is removed from a validator
+while live documents may still carry it (the `depositPercent` prod-deploy incident recorded in
+FEATUREDOCS/66 is the standing precedent).
+
+**Backfill** (`convex/backfill*.ts`, the established pattern):
+1. `projects.revision` ← `max(quotes.version)` for the project, else 1.
+2. `quotes.status: "PUBLISHED"` → `"SENT"`; `publishedAt/ById` → `sentAt/ById`.
+3. `quotes.quoteDate` ← `sentAt`; `validUntil` ← `sentAt + quoteValidityDays`.
+4. Existing sent quotes get **no** artifact — their rows render "no stored document
+   (pre-versioning)" rather than a regenerated fake. Retro-rendering a historical quote from
+   today's project state would manufacture a document that was never sent, which is the exact
+   defect this program exists to remove.
+5. Projects with no quote row get a `DRAFT` v1 lazily on first Finance-tab load, not a bulk
+   insert.
+
+---
+
+## 9. Rollout — five phases, five issues under one tracker
+
+Tracking issue: [#985](https://github.com/TwoToned/gearflow/issues/985).
+Sequenced so each phase is independently shippable and nothing half-lands.
+
+| # | Phase | Issue | Scope | Effort |
+|---|---|---|---|---|
+| **A** | Revision model + state machine | [#986](https://github.com/TwoToned/gearflow/issues/986) | `projects.revision`, quote schema + enum, the five verbs, acceptance gate on CONFIRMED, backfill, server tests | M |
+| **B** | Immutable artifacts | [#987](https://github.com/TwoToned/gearflow/issues/987) | Render-and-store at send/issue, `pdfFileId` wiring, artifact routes, watermarked draft preview, Documents-menu removal | M |
+| **C** | Unified lock state | [#988](https://github.com/TwoToned/gearflow/issues/988) | `resolveLockTier` (status × quote), `reason` plumbing, close the deferred gate sites, parity tests | S |
+| **D** | Finance tab | [#989](https://github.com/TwoToned/gearflow/issues/989) | Tab promotion, quote rail + version history + diff entry, send dialog, invoice rail, retire `window.confirm` | M |
+| **E** | Lock UX | [#990](https://github.com/TwoToned/gearflow/issues/990) | Lock strip, header chip, `<LockedField>`, `aria-disabled` action pattern, `useJustifiedMutation` wiring, `UnpricedBadge` mounting, list/board glyphs, session diff-before-commit | M |
+
+**Dependencies:** A → B, A → C, (A,B,C) → D, C → E. D and E are parallelisable.
+
+---
+
+## 10. Test plan
+
+- **Server (Convex, `convex-test`)** — revision monotonicity; one-draft/one-sent invariants;
+  supersede-on-send-not-on-draft; recall round trip; acceptance gate incl. the admin override
+  path; cross-org IDOR on every new mutation and both artifact routes (R-8.4.3); RBAC per
+  role; `resolveLockTier` truth table across status × quote state (the whole matrix, since
+  this is the safety-critical function); every newly-gated bulk mutation rejecting when locked.
+- **Pure units** — expiry derivation across DST and timezone boundaries (`datePartsInTimezone`
+  already exists); `validUntil` computation; the revision-diff selectors.
+- **PDF** — `document-composer.test.ts` gains a watermark-block height case; an integration
+  test asserting a sent revision's stored artifact bytes are byte-identical on repeat
+  download while the live project changes underneath it. That test is the whole point of the
+  program and should be named so.
+- **jsdom smoke** — Finance tab renders and its overlays actually **open** (the standing
+  `TooltipProvider` / Radix-in-modal footguns from CLAUDE.md); locked state renders read-only
+  fields and the tooltip explains; `aria-disabled` actions are reachable by keyboard.
+- **a11y** — lock states announced, not colour-only (DESIGN.md); `docs/a11y-manual-checklist.md`.
+
+---
+
+## 11. Open questions
+
+- **Multiple concurrent draft revisions?** Ruled out for v1 (one draft, always at
+  `projects.revision`). Comparing two speculative options is a real workflow ("with and
+  without the LED wall") but it is a *variant* feature, not a version-control one, and it
+  would break the shared-counter model. Revisit separately.
+- **Does a recalled quote's artifact stay downloadable?** Proposed yes (retained, badged
+  `Recalled`) — the client may hold it, so deleting our copy makes the record worse.
+- **Do invoices get revisions too?** No. An issued invoice corrects via VOID + reissue or a
+  CREDIT note (FEATUREDOCS/66); that is the accounting-correct model and versioning it would
+  compete with it.
+- **Should `QUOTED` become automatic on send?** Proposed: offered, not forced (matches the
+  existing "issuing offers to advance to INVOICED" UI-chain precedent) — but as a **Dialog**,
+  not `window.confirm`.
+- **CANCELLED remains ungated** — inherited open question from #957, unchanged here.
+
+---
+
+## 12. POLICY.md compliance notes (BUILD mode)
+
+- **R-3.1 / single source of truth** — one revision counter; one lock-tier resolver; the send
+  dialog's validity math resolves through the same `quoteValidityDays` setting the PDF reads.
+- **R-9.3 / server authority** — no monetary amount originates in the client; the send dialog
+  accepts only dates, a contact and free text; artifact bytes are rendered server-side from
+  server-computed data.
+- **R-8.4.3 / cross-tenant reads** — `quotes.by_cuid` and `by_projectId` are global Convex
+  indexes; every read of a quote, artifact or snapshot re-checks `organizationId`. The two new
+  artifact routes are the highest-risk new surface and are IDOR-tested explicitly.
+- **R-8.2.3 / R-8.6.2 / R-8.6.4** — send/accept/decline/recall forms get Zod schemas in
+  `src/lib/validations/quote.ts` derived with `.omit()`/`.extend()` from one base, never
+  re-declared; the artifact routes take no JSON body, so `withValidatedBody` doesn't apply,
+  but any that gains one must use it.
+- **Browser-direct write bar (FEATUREDOCS/54)** — every `*Native` mutation mirrors its Zod
+  bounds server-side via `convex/lib/fieldGuards.ts`. Client validation is UX only.
+- **R-5.2 / R-5.3 / R-5.8** — FEATUREDOCS 66, 62, 13, 10 and this doc update in the same PRs
+  as the behaviour.

--- a/docs/designs/finance-first-class-version-control.md
+++ b/docs/designs/finance-first-class-version-control.md
@@ -12,7 +12,10 @@ after you've already tried something.
 **Supersedes/extends:** WS1 (#940, FEATUREDOCS/66) shipped the finance *entities*;
 #957/#791/#792/#793 (FEATUREDOCS/62) shipped the lock *enforcement*. This doc is the
 workflow and UX layer neither of them built.
-**Tracking:** [#985](https://github.com/TwoToned/gearflow/issues/985) (sub-issues #986–#990).
+**Tracking:** [#985](https://github.com/TwoToned/gearflow/issues/985) (sub-issues #986–#990, #992).
+**UI/UX spec:** [`finance-workflow-ux.md`](./finance-workflow-ux.md) — authoritative for
+anything visual (layout, states, copy, tokens, the action matrix). Reviewed via
+`/plan-design-review` 2026-07-28.
 **Owning docs to update:** [FEATUREDOCS/66](../../FEATUREDOCS/66-finance-quotes-invoices-xero.md),
 [FEATUREDOCS/62](../../FEATUREDOCS/62-project-lifecycle-locks.md),
 [FEATUREDOCS/13](../../FEATUREDOCS/13-pdfs.md),
@@ -367,20 +370,22 @@ existing `financials` tab is retired, not duplicated. Templates keep hiding it, 
 │  Totals:  Subtotal · Discount · GST · Total · Margin                   │
 │           Deposit invoiced · Invoiced to date · Outstanding            │
 ├────────────────────────────────────────────────────────────────────────┤
-│  QUOTES                                          [ Send quote v3 ▸ ]   │
+│  Quote                                         [ Create quote v3 ▸ ]   │
 │   ○ v3  Draft      —            $18,400   [Preview draft]              │
-│   ● v2  Sent       26 Jul 26    $18,120   [PDF] [Diff v1→v2] [Accept]  │
-│   ○ v1  Superseded 19 Jul 26    $16,900   [PDF] [Diff]                 │
+│   ● v2  Sent       26 Jul 26    $18,120   [Mark accepted]          ⋯   │
+│   ○ v1  Superseded 19 Jul 26    $16,900   [PDF]                    ⋯   │
 ├────────────────────────────────────────────────────────────────────────┤
-│  INVOICES                              [ Deposit ] [ Balance ] [ Full ]│
+│  Invoices                                        [ New invoice ▾ ]     │
 │   ● INV-2026-0043  Deposit  Issued  25 Jul  $4,530  [PDF] [Xero ✓]     │
 │   ○ (draft)        Balance  —               $13,590 [Issue] [Delete]   │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
 Each revision row: version, state chip (`status-colors.ts` intents — never hardcoded per
-DESIGN.md §3), quote date, valid-until (amber when within 3 days, red when expired), total,
-who sent it, and its actions. There is no quote document number (decision 5) — the row reads
+DESIGN.md §3), quote date, valid-until, total, who sent it, and **one** primary action.
+Full visual spec, state→intent mapping, validity thresholds and the state × role × tier action
+matrix live in [`finance-workflow-ux.md`](./finance-workflow-ux.md) — that doc is authoritative
+for anything visual, so the constants aren't duplicated here (R-3.1). There is no quote document number (decision 5) — the row reads
 `v2` and the PDF header reads `Quote — RVLT-2026-0087 v2`. Clicking a row opens the read-only
 "as of v N" view — which is `project-versions-panel.tsx`'s existing snapshot summary +
 `project-snapshot-diff.ts`'s existing diff, now reachable from the workflow instead of a ⋯

--- a/docs/designs/finance-workflow-ux.md
+++ b/docs/designs/finance-workflow-ux.md
@@ -1,0 +1,628 @@
+# Finance workflow — UI/UX design
+
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-28 (review quarterly — POLICY.md R-5.5)_
+
+**Created:** 2026-07-28
+**Companion to:** [`finance-first-class-version-control.md`](./finance-first-class-version-control.md)
+(architecture + data model). That doc says *what* the system does; this one says what it looks
+like and how it behaves. **Tracking:** #985, phases D (#989), E (#990), F (#992).
+**Binding constraint:** [`DESIGN.md`](../../DESIGN.md) — RVLT design language.
+**Review status:** reviewed 2026-07-28 via `/plan-design-review` (7 passes + an independent
+design agent). Decisions D1–D6 recorded inline. Initial 6/10 → 9/10.
+
+---
+
+## 1. Research — patterns studied, taken, rejected
+
+Surveyed on Mobbin (web): finance document records, version history, locked-state UI.
+
+### 1.1 Finance document records
+
+| Source | Pattern | Verdict |
+|---|---|---|
+| [Copilot](https://mobbin.com/screens/c42703a2-226d-4957-93ad-e41a1fbef3dc) | Status pill beside the title; key facts as a definition list; history timeline in a right rail | **Take** the definition list; **reject** the timeline (we already have one — §11 F2) |
+| [Midday](https://mobbin.com/screens/db7ce37b-95a1-4c40-b909-d3f83c79a2b0) | Big amount, one action row, facts, collapsible activity; stat tiles above the list | **Take** for Phase F |
+| [Remote](https://mobbin.com/screens/963a1de6-005a-4133-9523-786ba8503d58) | **PDF preview pane beside the record** | **Take** — the send dialog previews the document beside the fields (§4) |
+| [Harvest](https://mobbin.com/screens/65d0fed3-d247-4d1a-91c6-32be8f8f9ab3) | A literal "SENT" stamp across the document | **Take** — validates the DRAFT watermark |
+| [Mercury](https://mobbin.com/screens/beaecf88-fff5-4787-b565-2555c2ed9e6a) | Timeline names the *negative*: "created but not sent" | **Take** the copy instinct |
+
+### 1.2 Version history
+
+[Notion](https://mobbin.com/screens/3647446f-f959-4e58-baba-ef7e4f9ab6b0),
+[Linear](https://mobbin.com/screens/6c14e085-9ff5-4e61-9a21-b04f1b0a3433),
+[Fibery](https://mobbin.com/screens/714aa790-1b39-4ef7-ab48-9402ebeb7aea),
+[Substack](https://mobbin.com/screens/d1d0d099-5452-4842-bbb7-681486136291),
+[Dropbox Paper](https://mobbin.com/screens/bcfd5f3a-f097-400a-8349-4d64134ac578) all converge:
+**large overlay, content left, version rail right, selected row highlighted, restore pinned in
+a footer.** Adopt the anatomy. Take Linear's **`‹ 1 of 3 ›` change stepper**; take Dropbox
+Paper's quantified header voice ("5 changes since 6 days ago").
+
+**Deliberate divergence — no "Restore".** Every reference offers it; we must not. A sent quote
+is an immutable record of what a client was given. Our equivalent is forward-only:
+**"Start v(N+1) from this version"**.
+
+### 1.3 Locked states
+
+[IKEA](https://mobbin.com/screens/1b45d6bf-22b8-4965-b04a-a2b26c7a215a) gets the copy shape
+right in one line: _"Locked for safekeeping — this design can't be saved. Create a copy to
+modify it."_ **State → consequence → the exit.** That is our lock-copy formula (§7.1).
+[Adobe Express](https://mobbin.com/screens/afe97676-f21f-4b7b-bd69-f64d7b4eae13) shows the
+field-level version. **Rejected:**
+[Whop](https://mobbin.com/screens/0c058329-261f-4b41-b8a9-90048a268f69)'s full-page permission
+wall — DESIGN.md §8 bans full-page replacement for recoverable states.
+
+---
+
+## 2. Banner soup — the problem to solve before adding anything
+
+Five notices already compete for the top of a project page: reservation conflicts, stale
+pricing, an open unlock session, and now lock state and quote drift. They co-occur: a locked
+project with a drifted quote and stale pricing is an ordinary Tuesday. Five stacked notices is
+not a design.
+
+### 2.1 One rail, action-ordered
+
+`<ProjectAlertRail>` — a single bordered container under the project hero. Rows use DESIGN.md
+Notices: **left-edge 3px accent bar + surface background**, never a full-background tint.
+Container carries `--sh-card`.
+
+**Sort is two-key: CTA-bearing first, then severity.** Severity alone buries the only row you
+can act on. On the ordinary-Tuesday case, severity-only ordering pushes "quote drift" — the
+single row with a forward action — to position 5.
+
+| Rank | Condition | Intent | CTA |
+|---|---|---|---|
+| 1 | Pricing locked (status or quote-sent) | warning | **Create quote v(N+1)** / Unlock financials |
+| 2 | Job changed since quote vN | warning | **Create quote v(N+1)** |
+| 3 | Reservation conflicts | error | Resolve |
+| 4 | Unlock session open | primary | Save & relock · Discard |
+| 5 | Hard locked (COMPLETED/INVOICED) | **neutral** | Open full unlock (permitted roles) |
+
+**Hard lock is `neutral`, not `error`.** A completed, invoiced job is the product's happy
+ending. DESIGN.md reserves `--t-out`/error for PROBLEM / OVERDUE / FAILED. Painting every
+finished job overdue-red trains staff to ignore red, which corrodes the conflict and overdue
+signals that actually need it.
+
+**Drift and stale pricing merge into one row.** From the user's seat they are the same
+complaint — "this job no longer matches its numbers" — with two remedies. One row, two
+actions: `Create quote v3` and `Recalculate pricing`. This also deletes the `2 more notices`
+collapse, its `sessionStorage` key, that key's invalidation bug (a rail collapsed yesterday
+would hide a hard lock that arrived today), and the announced-but-hidden a11y problem. **Four
+notices, all visible, no collapse mechanism.**
+
+**Row anatomy** (specified so it isn't invented five times): 3px left accent · 16px lucide
+icon in the intent colour · `t-body` copy in the §7.1 `[state] — [consequence].` form · CTA as
+a `line`-variant button, inline right, one per row (a second action becomes a `⋯`). One line at
+≥768px, wraps to two below.
+
+**Not sticky**, and — corrected from an earlier draft — **the project hero is not sticky
+either**. Only the global top bar (`top-bar.tsx:88`) and `DetailSidebar`
+(`page-layouts.tsx:129`, `lg:sticky lg:top-4`) are. So the always-visible lock anchor is the
+**sidebar** (§3.2), not a hero chip.
+
+**Subscription ownership.** The rail mounts at project level but three of its notices need
+finance data. It must read lock + drift through the **existing** `useProjectLockStatus`
+subscription plus one derived drift field on it — never a second quote/invoice subscription for
+every user on every tab. Users without `invoice:read` get lock rows only; finance rows are
+omitted, not empty.
+
+---
+
+## 3. The Finance tab
+
+### 3.1 Position
+
+Top-level project tab: `Equipment · Labour & logistics · Finance · Tasks · Notes · Files`. The
+old `Financials` tab is retired, its content absorbed. Hidden on templates.
+
+**Auth-gated:** without `invoice:read` the tab is **present but shows a permission notice** —
+not hidden. Hiding it reflows the tab bar between roles and breaks `?tab=finance` deep links
+(DESIGN.md §8 requires an auth-gated state; a broken link is not one).
+
+### 3.2 Layout and the sticky rail
+
+The tab keeps the standard **63/37 detail split** (D2). Two consequences, both deliberate:
+rows stay lean enough for 63%, and anything wide gets its own overlay (§8).
+
+**The sticky sidebar becomes the finance rail on this tab** — swapping Schedule/Location/Team
+for what the job actually is while you are doing money. This is the only always-visible surface
+in the layout, so lock state lives here:
+
+```
+Lock                        ← always mounted, always positive (§7.2)
+  Pricing locked · v2 with client
+  [ Create quote v3 ]
+
+Value                       ← SectionHeader
+  Current project value
+  $18,400   +$280 vs quote v2      ← t-data, 38px hero figure on the first line
+  Invoiced      $4,530
+  Outstanding  $13,590
+```
+
+**Two adjacent unlabelled totals is the tab's worst failure mode** — the draft's value
+(`$18,400`) and the sent quote's value (`$18,120`) are different numbers with different
+meanings. Every currency figure here is labelled by provenance, and the delta against the
+client-held revision is explicit. `Discount −0` and any other zero row does not render.
+
+**The Money block is cut entirely.** `ProjectSummaryStrip` (`page.tsx:477`) already renders
+totals across the top of every project page and `ProjectCostsPanel` (`:636`) sits below — a
+third summary in the same viewport was noise the original banner-soup audit missed.
+
+### 3.3 Section order follows the lifecycle (D4)
+
+| Phase | Order |
+|---|---|
+| Pre-acceptance (ENQUIRY → QUOTED) | **Quote** → Invoices → Costs |
+| Post-acceptance (CONFIRMED +) | **Invoices** → Quote *(collapsed to one line: `v2 · Accepted 26 Jul · $18,120 · PDF · History`)* → Costs |
+
+Same components, one switch on lifecycle. A project spends most of its life post-acceptance; a
+fixed order leaves an archive permanently above live work.
+
+```
+┌─ Quote ────────────────────────── [ Create quote v3 ] ─┐   ← header button, see §3.4
+│  v3  Draft        $18,400   Preview            ⋯       │
+│      Not sent yet · 3 changes since v2                 │
+│  v2  Sent 26 Jul  $18,120   Mark accepted      ⋯       │
+│      To Sarah Chen · Valid until 25 Aug (28 days)      │
+│  v1  Superseded   $16,900   PDF                ⋯       │
+│      Sent 19 Jul by Jayden                             │
+│  Show 4 earlier revisions                              │
+├─ Invoices ─────────────────────── [ New invoice ▾ ] ───┤
+│  INV-2026-0043  Deposit  Issued 25 Jul  $4,530  ⋯      │
+│  —              Balance  Draft          $13,590 Issue…  │
+└─ Costs / P&L  (ProjectCostsPanel) ─────────────────────┘
+```
+
+Sections separated by 32px and a `SectionHeader`; **no card chrome on rows**.
+`ProjectCostsPanel` carries its own card — it renders last, where the idiom change reads as a
+boundary rather than an inconsistency.
+
+`New invoice ▾` replaces three equally-weighted `Deposit`/`Balance`/`Full` buttons for a
+decision made once per project.
+
+**Revision list is bounded and sorted.** Descending by version, always. Show the draft (if
+any) + the current SENT/ACCEPTED + `Show N earlier revisions`. A haggled job reaches v7; six
+dead rows would push invoices below the fold.
+
+### 3.4 The `Create quote v(N+1)` button — one owner
+
+**The Quote block header button is the sole owner** of this action, whenever the current
+revision is SENT or ACCEPTED. When the current revision is a DRAFT the same slot reads
+`Send quote v3`. The alert rail may *echo* it; it may not own it. In the reviewed draft this
+action existed only in a rail row that collapsed by default — the primary forward action in the
+entire workflow had no designed home.
+
+### 3.5 Revision row
+
+Two lines, no card chrome. Table-like list per DESIGN.md Tables (1px `border-top`, left-edge
+2px red bar on hover, no full-row tint).
+
+- **Line 1:** `v3` in `t-mono` **at 13.5px** (`t-mono` defaults to 12px; the row's primary
+  identifier must not be its smallest element) · state pill · total right-aligned
+  `tabular-nums` · **one** primary action · `⋯`
+- **Line 2:** `t-micro text-muted` — recipient, validity, sender, or drift count
+
+**State → intent** — new `quoteStatusIntent()` in `src/lib/status-colors.ts`, alongside
+`assetStatusIntent`; rendered with `Badge`, never `StatusIndicator` (both exist and differ):
+
+| State | Intent | Note |
+|---|---|---|
+| Draft | neutral | |
+| **Sent** | **info** (`bg-blue-soft text-blue`) | |
+| **Accepted** | **primary** (`bg-red text-white`) | |
+| Declined | error | |
+| Expired | warning | |
+| Recalled | warning | |
+| Superseded | **no pill** — plain `text-muted` text | a dead revision doesn't earn a filled shape |
+
+> **Corrected during review.** An earlier draft assigned solid red to *Sent* and green to
+> *Accepted*. DESIGN.md:154 and :255 both define solid `--red` as LIVE / ACTIVE / IN-USE and
+> name its members: "CHECKED_OUT, ON_SITE, **ACCEPTED**". The draft inverted the design
+> system's own worked example, and put a solid-red pill on the busiest row of the busiest tab
+> beside red hover bars and the red primary button.
+
+**Validity urgency**, colour **and** words: `Valid until 25 Aug (28 days)` `text-muted` →
+**≤7 days** `text-warn` + `(3 days left)` → past `text-t-out` + `Expired 2 days ago`.
+(The companion doc's "within 3 days" was a second copy of this constant; **7 days is
+authoritative**, R-3.1.)
+
+**Formatting rules, stated once:** currency always `formatCurrency` with symbol and 2dp
+(`$18,120.00`); zero rows suppressed entirely; every figure `tabular-nums`. All day-boundary
+maths (validity, expiry, "sent 26 Jul") resolves through `datePartsInTimezone` in the **org's**
+timezone, never the browser's — a quote must not expire a day early for a PM in another state.
+
+### 3.6 The action matrix
+
+The single largest specificity gap in the reviewed draft was the word "actions". Written out so
+`QuoteRevisionRow` and the revision viewer cannot disagree:
+
+| State | Primary (inline) | In `⋯` | Gated |
+|---|---|---|---|
+| Draft | `Preview` | Delete draft | Delete: `invoice:publish` |
+| Sent | `Mark accepted` | PDF · Compare · Mark declined · **Recall** | Recall: admin/owner **or** project PM |
+| Sent + expired | `Re-send` | PDF · Compare · Mark declined | `Mark accepted` is present but gated, tooltip: *"Quote v2 expired on 25 Aug. Re-send it, or make v3."* |
+| Sent + no artifact yet | `Generating…` (spinner) | Compare | after 30s → `Generation failed · Retry` |
+| Accepted | `PDF` | Compare · Start v(N+1) | |
+| Declined / Superseded / Expired / Recalled | `PDF` | Compare · Start v(N+1) | |
+
+**Permission rule:** a user without `invoice:publish` sees every row and every artifact, and
+every mutating action rendered per §7.4 (visible, explained, unavailable) — never hidden.
+**Lock rule:** HARD_LOCKED gates `Create v(N+1)`, `Recall` and `Mark accepted` behind the
+full-unlock session, with the §7.1 copy.
+
+**Recall confirmation** (a `Dialog`, since recall is the one destructive-feeling verb):
+> **Recall quote v2?** — Sarah Chen may already have this PDF; recalling doesn't unsend their
+> copy. v2 returns to draft and its document stays in the history, marked Recalled.
+> Reason (required) · `[ Cancel ] [ Recall v2 ]`
+
+**Decline capture:** `Mark declined` opens a small `Dialog` — reason (optional, 500 max) and
+an offer, not a forcing: *"Cancel this project too?"* as an unchecked checkbox.
+
+**Acceptance capture:** `Mark accepted` opens a `Dialog`, not a bare click — it captures the
+acceptance date and an optional reference (PO number, email subject) that an accountant will
+later need. A one-click accept would silently drop that field.
+
+### 3.7 Empty states
+
+- **No client:** 56px `documents` spot illustration (`text-primary/60`) in its container,
+  `t-heading` "No client on this project", `t-micro` "Quotes and invoices need a client to
+  bill.", primary `Assign client`. No Kalam — it neighbours money.
+- **No invoices yet:** this is the state of *every* project until deposit time and the
+  reviewed draft claimed it couldn't happen. `t-micro text-muted` inline: "No invoices yet." +
+  the `New invoice ▾` button already in the header. No illustration — an expected state doesn't
+  earn a hero empty state.
+- **No quotes at all:** should be impossible post-Phase A, but the migration halts on a count
+  mismatch, which produces exactly this. Renders `Create quote v1` rather than a blank block.
+
+---
+
+## 4. Send quote dialog
+
+Radix `Dialog`, `--r-lg` (20px), `--sh-card`, max-width 880px.
+
+```
+┌─ Send quote v3 ──────────────────────────────────── ✕ ─┐
+│ ┌────────────────────────┐ ┌─────────────────────────┐ │
+│ │ Quote date [28 Jul 26] │ │   ┌─────────────────┐   │ │
+│ │ Valid for  [30] days   │ │   │ DRAFT PREVIEW   │   │ │
+│ │            → 27 Aug 26 │ │   │  — NOT SENT —   │   │ │
+│ │ Send to    [Sarah Chen]│ │   └─────────────────┘   │ │
+│ │ Notes      [         ] │ │  Download draft PDF     │ │
+│ │ ── Summary ──          │ └─────────────────────────┘ │
+│ │ 42 lines · 3 services  │                             │
+│ │ Total       18,120.00  │                             │
+│ └────────────────────────┘                             │
+│  Sending freezes pricing at v3. To change prices, v4.  │
+│  Flow doesn't email clients — this makes the PDF.      │
+│                          [ Cancel ]   [ Send v3 ]      │
+└────────────────────────────────────────────────────────┘
+```
+
+**Why a preview pane.** "What am I about to send" is the actual question and a form can't
+answer it. Renders lazily behind a `<Skeleton>` (solid `--elev`, no gradient), never blocks the
+dialog opening, and degrades to `Preview unavailable — you can still send`. **Never a gate.**
+Page 1 only, with `Download draft PDF` — no in-dialog pagination; we are not building a
+document viewer.
+
+**Fields.** Quote date (defaults today, max +1 day — *"A quote can't be dated more than a day
+ahead."*). Valid for (days + resolved date, from `quoteValidityDays`). Send to — client-contact
+combobox, **must** be the Radix `combobox-picker.tsx`, since a Base UI popup inside a Radix
+modal inherits the body `pointer-events: none` lock and swallows every click (CLAUDE.md; this
+has broken pickers here before). Empty contact list → `No contacts on this client` +
+`Add contact`, and sending stays possible (the PDF is still valid). Notes, 2000 max, counter
+past 1800, over → *"Notes are limited to 2,000 characters."* **No monetary input** (R-9.3).
+
+### 4.1 Submit — and the terminal state that hands over the PDF (D3)
+
+Submit → spinner, label `Sending…`, fields disabled → then `Generating document…`. The dialog
+**waits for the artifact, up to 8 seconds**; past that it closes anyway and the row shows
+`Generating…`. The quote is sent either way.
+
+**The dialog does not close on success. It becomes the handover:**
+
+> **Quote v3 sent** — pricing is now locked at v3.
+> `[ Download PDF ]`  `[ Copy summary for email ]`  `[ Done ]`
+> *This job is at Quoting. Move it to Quoted?* `[ Move ]`
+
+The user's next act is to open their mail client and attach the PDF. The reviewed draft closed
+the dialog, fired a toast, and then asked *the system's* question ("Advance to Quoted?") —
+giving them a modal instead of a file and three clicks back to the thing they came for. The
+status prompt becomes a passive offer **inside** this state, never a second modal.
+
+**On error:** inline notice above the footer, **fields stay filled and editable**, focus moves
+to the notice. Re-typing four fields after a network hiccup depletes goodwill fast.
+**Dirty-close:** `Esc` with changes → inline confirm bar within the same dialog
+(*"Discard this send? [Keep editing] [Discard]"*) — **not** a nested Dialog, which is a known
+footgun here and would need the banned `AlertDialog` shape.
+
+---
+
+## 5. Invoice issue dialog
+
+Same skeleton, 640px, no preview pane (the content is the quote's, already seen). Invoice date;
+**due date** defaulting to invoice date + `paymentTermsDays` and labelled `Net 14`; notes;
+read-only server-computed amounts. Same loading / error / dirty-close behaviour as §4.
+
+Footer: *"Issuing assigns INV-2026-0044 and locks this invoice. Corrections need a credit
+note."* Success is a terminal state with `Download PDF`, matching §4.1.
+
+**Xero states on the row** (the reviewed draft showed only `Xero ✓`): not connected → nothing
+renders · pending → `Pushing…` · pushed → `Xero ✓` `text-ok` · failed → `Xero failed` `text-warn`
++ `Retry` in `⋯`. Never a bare tick with three invisible siblings.
+
+**Already-issued deposit:** the `New invoice ▾` menu keeps the Deposit item visible and gated
+per §7.4 — *"A deposit invoice was already issued (INV-2026-0043)."*
+
+---
+
+## 6. Interaction state matrix
+
+DESIGN.md §8 requires every applicable state. What the **user sees**, not backend behaviour.
+
+| Surface | Loading | Empty | Error | Success | Partial |
+|---|---|---|---|---|---|
+| **Finance tab** | Skeletons matching revision-row shape; solid `--elev`, min 200ms | §3.7 | Left-edge red notice + `Retry`; shell stays, never a blank page | — | Quotes loaded, invoices still loading → independent skeletons |
+| Finance tab (authz) | — | — | — | — | No `invoice:read` → permission notice in place of content; tab stays mounted |
+| **Revision row** | — | — | Sent, no artifact → `Generating…`; after 30s `Generation failed · Retry` (retry only callable while the artifact is absent) | New row fades in, 150ms | — |
+| **Send dialog** | `Sending…` → `Generating document…`, 8s ceiling | — | Inline notice, fields preserved, focus moved | Terminal handover state (§4.1) | Mutation OK + render failed → **still the success state**, `Download PDF` replaced by `Document generating — we'll have it shortly` |
+| **Preview pane** | Skeleton page + `Rendering preview…` | — | `Preview unavailable` + `Try again`; never blocks Send | Page 1 + `Download draft PDF` | — |
+| **Issue dialog** | As send | — | As send; number collisions retry server-side, user sees only the spinner | Terminal state + `Download PDF` | — |
+| **Revision viewer** | Content skeleton left, rail skeleton right | Single revision → compare control disabled, tooltip *"v1 is the first version — nothing to compare yet"* | Snapshot unreadable → *"This version's detail couldn't be loaded"* **and the PDF stays downloadable** | — | No differences → stepper reads `No changes`; diff too large → first 50 + `50 of 214 changes shown` |
+| Revision viewer | — | Pre-versioning quote (no snapshot, by design) → *"Sent before version history — the PDF is the record"* + download | — | — | — |
+| **Alert rail** | Nothing — never skeleton a notice | Renders nothing | Lock status unreadable → **fail closed**: *"Lock state unknown — refresh before editing"*, actions gated | — | Some conditions resolved → render those, omit rest silently |
+| **LockedField** | Lock status `undefined` on first paint → renders **locked**, then relaxes | — | — | — | — |
+| **Org Finance (§9)** | Section skeletons, tiles last | Groups omitted; whole-page zero state | Notice + `Retry`; tiles keep last values greyed | — | One section failed → inline retry there, others render |
+
+**Four rules this encodes:**
+
+1. **Fail closed on lock state.** Unknown lock → gate and say so. Assuming unlocked lets
+   someone edit a hard-locked job because a query blipped. The same applies to
+   `<LockedField>`'s first paint: render locked and relax, never editable-then-snap — which
+   would be both a layout shift and a correctness flicker.
+2. **Never lose typed input on error.**
+3. **The artifact outranks the record.** If the snapshot won't load but the PDF exists, offer
+   the PDF. The client is holding that document.
+4. **A successful send is a success even if the render failed.** The quote *is* sent; the UI
+   must not imply otherwise.
+
+---
+
+## 7. Lock UX
+
+### 7.1 The copy formula
+
+**`[state] — [consequence]. [the exit].`** One `lock-copy.ts` module so six surfaces can't
+drift (R-3.1).
+
+| Situation | Copy |
+|---|---|
+| Quote sent | **Pricing locked** — quote v2 is with the client. Make v3 to change prices. |
+| Confirmed+ | **Pricing locked** — this job is confirmed. Unlock financials to edit money. |
+| On site | **Changes need a reason** — this job is on site. You'll be asked why. |
+| Hard locked | **Locked** — this job is completed. Admins and its PM can open a full unlock. |
+| Session open | **Unlocked by Jayden · 12m** — "client added two movers". Save & relock, or discard. |
+| Drift + stale | **This job no longer matches its numbers** — 2 lines added, rental window +2 days. |
+| Can't confirm | **Quote v2 hasn't been accepted** — mark it accepted, or confirm anyway with a reason. |
+
+No personality, no Kalam, no mascot (DESIGN.md bans them in lock/compliance contexts).
+Sentence case throughout.
+
+### 7.2 Lock indicator — sticky sidebar, always positive
+
+Lives in the **sticky sidebar** (§3.2), the only always-visible surface. Always mounted, always
+stating something:
+
+- `Editing v3 (draft)` — neutral
+- `Pricing locked · v2 with client` — `bg-warn-soft text-warn`
+- `Locked` — `bg-rep-soft text-rep` (neutral; a completed job is not a problem)
+- `Unlocked by Jayden · 12m` — `bg-red text-white`, live
+
+**Absence is not a state.** After creating v3 the reviewed draft communicated "you are now
+editing a draft" by *removing* a badge — the whole mental model this program sells,
+communicated by a disappearance.
+
+Timer: `12m` → `1h 4m` → `3h+` above three hours; a session open overnight reads
+`since yesterday 18:40`. `aria-live="off"` — announcing every minute would be hostile.
+
+Icons are lucide `Lock` / `LockOpen` at 12px in the intent colour — **never `🔒`/`🔓` emoji**,
+which DESIGN.md bans and which render as colour glyphs against a single-red-accent system.
+
+### 7.3 Field level — `<LockedField>`
+
+A wrapper, so there is one implementation. Renders the value as static text **in the input's
+exact metrics** — same border width, padding, line-height, and 44px mobile min-height — so
+there is no reflow between states. `bg-paper-2`, `border-line`, `text-ink-2`, 12px lock glyph
+inset right. Tooltip carries the §7.1 copy plus the exit as a link. `aria-readonly` +
+`aria-describedby` → the reason, so screen readers get the explanation that glyph-plus-colour
+alone would not deliver.
+
+Applies to: `price-edit-dialog`, `edit-line-item-dialog`, `line-item-form-fields`,
+`edit-group-dialog`, `add-service-dialog`, `crew-panel` rates, `bulk-edit-line-items-dialog`,
+and the project edit form's tax/discount inputs.
+
+### 7.4 Action level — the `disabled` trap
+
+A `disabled` button fires no pointer events, so its tooltip never opens: a dead control and
+*no explanation*, which is worse than today's toast. Gated actions therefore use
+`aria-disabled="true"` + `opacity-45` + `cursor-not-allowed` + a no-op handler + a real tooltip
+(inside its own `TooltipProvider` — there is no global one) + keyboard focusable.
+
+Gated menu items show the lock glyph and the reason as a `t-micro` second line rather than
+vanishing. Disappearing controls teach nothing.
+
+### 7.5 The CONFIRMED acceptance gate
+
+Undesigned in the reviewed draft, and it fires at the most emotionally loaded moment in the
+workflow — the client just said yes and the PM wants the job green. A raw `ConvexError` toast
+here reads as a broken product.
+
+Advancing to CONFIRMED without an accepted quote opens a `Dialog`:
+
+> **Quote v2 hasn't been accepted**
+> Mark it accepted first, or confirm anyway and say why.
+> `[ Mark v2 accepted ]` (primary) · reason field (10–1000 chars) · `[ Confirm anyway ]`
+
+`Confirm anyway` is gated per §7.4 for anyone outside the override audience (admin/owner or the
+project's PM), tooltip: *"Only admins and this job's PM can confirm without an accepted quote."*
+The primary path is the *correct* one, one click away.
+
+### 7.6 Unpriced badge, and the composite on-site state
+
+`UnpricedBadge` (built, mounted nowhere) goes on every `$0`-defaulted line and group:
+*"Added while pricing was locked — set a price in the next quote version."*
+
+**The composite ON_SITE state** — JUSTIFY tier + `$0` lines + drift against an accepted quote,
+all at once — is the *normal* state of a live job and must render coherently: the rail shows
+**one** row (drift, CTA `Create quote v3`), the sidebar shows `Changes need a reason`, and
+unpriced lines carry badges. It is legitimate to create v3 for a running job; that is how
+on-site additions get billed.
+
+### 7.7 List, board and card glyphs
+
+12px lucide `Lock` beside the project status on `project-table`, `project-board` and dashboard
+cards, `text-muted`, tooltip carrying the §7.1 state line. Derived from row data already
+present — no extra query. This is what makes the lock knowable *before* you open the project.
+
+---
+
+## 8. Revision viewer & compare
+
+Full overlay `Dialog`, `--r-lg`, `--sh-card`, 90vw × 85vh. Content left, revision rail right.
+
+```
+┌─ Quote v2 · RVLT-2026-0087 ───────────────────── ✕ ─┐
+│ ┌───────────────────────────┐ ┌──────────────────┐  │
+│ │ (read-only "as of v2")    │ │ v3 Draft  Current│  │
+│ │  Lighting                 │ │ v2 Sent 26 Jul ● │  │
+│ │  6× Source Four 1,200 →1,320│ │ v1 Superseded   │  │
+│ │  + 1× Followspot      480 │ │ ──────────────── │  │
+│ │  Total   16,900 → 18,120  │ │ [vs previous]    │  │
+│ └───────────────────────────┘ │ [vs the job now] │  │
+│  ‹  Change 1 of 3  ›          └──────────────────┘  │
+│  [ Download PDF ]      [ Start v4 from this version ]│
+└──────────────────────────────────────────────────────┘
+```
+
+**Trimmed per D5.** Highlighting is **always on** — a toggle that turns off the reason you
+opened compare view isn't a feature. The `‹ 1 of 3 ›` stepper stays; at 120 lines a diff list
+is unusable. The any-version picker is replaced by a **two-item segmented control**:
+`vs previous` and `vs the job now` — the only two comparisons anyone actually makes, and half
+the empty/error surface.
+
+Changed rows are marked with `--select` (`rgba(224,54,61,.20)`) held while stepped to, then
+faded — an in-system token, not an invented "pulse". No second activity timeline here:
+`ProjectActivityFeed` already reads the same `activityLog` from the sticky sidebar.
+
+Primary action is **`Start v4 from this version`**, never `Restore` (§1.2), and only when no
+draft exists, preserving the one-draft invariant.
+
+**The artifact never changes.** A superseded revision's PDF downloads byte-identical to the day
+it was sent — no retroactive "SUPERSEDED" stamp, because the client's copy doesn't have one.
+The UI carries the state; the bytes stay honest. This is the deliberate divergence from
+Harvest's live-stamped document, and it is the whole point of Phase B.
+
+---
+
+## 9. Org-level Finance section (Phase F)
+
+**Nav:** directly below `Projects` — Finance is project-derived and adjacency says so. Module
+hue **teal**, unused by the current nav set; red is never a module hue. Uses `NavLink`, never a
+plain `<Link>` (DOM crash risk).
+
+**Layout** — `ListPageLayout`: `PageHeader` ("Finance", no "Manage your…" boilerplate) → up to
+4 individually-bordered `--sh-card` stat tiles, each linking to its section (never an inline
+metrics strip with dividers) → filters → sections.
+
+Tiles: `Quotes out` · `Expiring ≤7d` · `Uninvoiced` · `Outstanding`.
+
+**Sections** are one list with sticky group headers, not six tables — six tables is six empty
+states and six scroll contexts. Groups with zero rows are **omitted**, not shown empty. Rows:
+project number + name, client, the section-relevant date, amount, one deep link into that
+project's Finance tab.
+
+**Whole-page zero state** (a quiet week, not an error): `documents` illustration at 56px,
+"Nothing needs chasing", "No quotes awaiting a reply and no invoices outstanding." This is the
+one place in the finance surface where a Kalam annotation is permitted — it is a *good* state.
+
+**Deliberate omission:** no charts. This is a worklist, not a report. `DateRangeBar` was removed
+app-wide in 2026-07 for exactly this reason.
+
+---
+
+## 10. Responsive (DESIGN.md §15)
+
+- **Finance tab:** rows collapse to one line (`v2 · Sent · $18,120`). **Full-row tap opens a
+  revision sheet — no inline icon buttons and no `⋯` in mobile card mode** (DESIGN.md §15;
+  the reviewed draft contradicted this). Actions live inside the sheet.
+- **Sticky finance rail** stacks above the tab content on mobile, not below — lock state and
+  value are the first things you need.
+- **Send dialog** goes full-screen below 768px; the preview pane is replaced by
+  `Download draft PDF` (a 3-page PDF in a 375px column is not a preview). Footer sticks.
+- **Revision viewer:** view a revision and download its PDF. **Compare and the change stepper
+  are desktop-only.** Comparing a 120-line money document is a desk task; a stepper over a
+  six-column table at 375px is worse than "open it on a laptop".
+- **Alert rail:** rows wrap to two lines; no collapse (there are only four).
+- Touch targets ≥44px. Safe areas via inline `style` with `env()`, not Tailwind arbitraries.
+
+## 11. Accessibility
+
+- Every state is **colour + text**, never colour alone. Expiry says "3 days left"; locks say why.
+- `<LockedField>`: `aria-readonly` + `aria-describedby` → the reason.
+- Gated actions: `aria-disabled`, focusable, tooltip keyboard-reachable.
+- **Alert rail:** `aria-live` **off on first paint** — a polite region that mounts *with*
+  content announces all of it on every project load and every client navigation. Enabled only
+  for notices that arrive post-mount (the lock landing after a send). A hard-lock row uses
+  `role="alert"`, not polite.
+- Change stepper: `Previous change` / `Next change`, position announced.
+- Dialogs: focus trapped, returned to the invoking control; `Esc` confirms only when dirty.
+- Session timer `aria-live="off"`.
+- Verified against `docs/a11y-manual-checklist.md`.
+
+## 12. Component inventory
+
+**New:** `ProjectAlertRail` (+ row primitive), `FinanceSidebarRail`, `LockedField`,
+`GatedAction`, `QuoteRevisionRow`, `SendQuoteDialog`, `IssueInvoiceDialog`,
+`RecallQuoteDialog`, `AcceptQuoteDialog`, `DeclineQuoteDialog`, `ConfirmWithoutAcceptedQuoteDialog`,
+`RevisionViewerDialog`, `ChangeStepper`, `lock-copy.ts`, `quoteStatusIntent()` in
+`status-colors.ts`.
+
+**Reused unchanged:** `Dialog`, `Tooltip` (+ own provider), `Badge`, `Skeleton`,
+`SectionHeader`, `FadeIn`, `combobox-picker`, `PersonAvatar`, `UnpricedBadge`,
+`JustificationDialog`, `project-snapshot-diff.ts`, `ProjectCostsPanel`, `ProjectActivityFeed`.
+
+**Migrated into the rail** — and **restyled**, not moved as-is: `ProjectConflictsBanner`,
+`StalePricingBanner`, `UnlockSessionBanner`. `StalePricingBanner` currently uses
+`bg-amber-500/5` (a full-background tint, banned by DESIGN.md Notices) and hardcoded
+`text-amber-600 dark:text-amber-400` instead of `text-warn`. Every migrated row re-renders
+through the rail's row primitive with `intentStyles` tokens and a left-edge 3px accent.
+
+**Cut:** the Money block (duplicate of `ProjectSummaryStrip` + `ProjectCostsPanel`); the
+viewer's second timeline; the highlight toggle; the any-version compare picker; in-dialog PDF
+pagination; the three-button invoice-kind row; the `2 more notices` collapse; mobile compare.
+
+**Retired:** the `Financials` tab shell; `window.confirm` in the finance path.
+
+## 13. Testing (design-specific)
+
+- jsdom smoke tests that **open** every overlay — the standing `TooltipProvider` /
+  Base-UI-in-Radix-modal regression class (`model-roi-tab.smoke.test.tsx` is the precedent)
+- Alert rail: CTA-first sort, all four conditions, all-clear renders nothing, merged
+  drift+stale row renders both actions
+- `LockedField`: no layout shift between states; renders locked while status is `undefined`
+- `GatedAction`: tooltip keyboard-reachable, control focusable
+- Every revision state renders a distinct, labelled treatment (incl. Superseded's no-pill)
+- Send dialog: terminal success state exposes `Download PDF`; error preserves all four fields
+- Lifecycle reorder: pre- and post-acceptance section order
+
+## 14. Open scope question
+
+**`Start v(N+1) from this version`** — seeding a new draft from an older revision's pricing.
+Not in any phase's scope. It emerged from the version-control framing: users who can compare
+revisions will want to walk one back, and every reference pattern trains them to expect it.
+Mechanically close to `restoreProjectSnapshot`'s FINANCIAL scope, which exists.
+
+Recommended: **build it in Phase D**, since §8 already draws it as the viewer's primary footer
+action and without it the viewer is a read-only cul-de-sac that shows you a problem and offers
+no way to act. **Needs a decision before Phase D starts** — if it goes the other way, the
+viewer ships with an empty primary slot.

--- a/docs/designs/finance-workflow-ux.md
+++ b/docs/designs/finance-workflow-ux.md
@@ -500,7 +500,7 @@ Full overlay `Dialog`, `--r-lg`, `--sh-card`, 90vw × 85vh. Content left, revisi
 │ │  Total   16,900 → 18,120  │ │ [vs previous]    │  │
 │ └───────────────────────────┘ │ [vs the job now] │  │
 │  ‹  Change 1 of 3  ›          └──────────────────┘  │
-│  [ Download PDF ]      [ Start v4 from this version ]│
+│  [ Download PDF ]        [ Use v2's pricing for v4 ]│
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -514,8 +514,39 @@ Changed rows are marked with `--select` (`rgba(224,54,61,.20)`) held while stepp
 faded — an in-system token, not an invented "pulse". No second activity timeline here:
 `ProjectActivityFeed` already reads the same `activityLog` from the sticky sidebar.
 
-Primary action is **`Start v4 from this version`**, never `Restore` (§1.2), and only when no
+### 8.1 Reprice-from-revision — the forward-only undo (decided, Phase D)
+
+Primary action is **`Use v2's pricing for v4`**, never `Restore` (§1.2). Shown only when no
 draft exists, preserving the one-draft invariant.
+
+**What it does:** creates the next draft revision and resets the project's **money fields** to
+that revision's values. Structure is untouched — same gear, same quantities, same dates. It is
+the forward-only equivalent of the Restore every reference pattern offers, and it exists
+because a user who can compare two versions will reach for the undo; that is what comparing is
+for.
+
+**The label is deliberately narrow.** An earlier draft read "Start v4 from this version", which
+reads as restoring the whole job, gear included. It doesn't, and an undo people misread is an
+undo people stop trusting.
+
+**Mechanically it is small:** `restoreProjectSnapshot` with `scope: "FINANCIAL"`
+(`convex/lib/projectSnapshots.ts:198`) already patches only `LOCKED_PROJECT_FIELDS` /
+`LOCKED_GROUP_FIELDS` / `LOCKED_LINE_ITEM_FIELDS` from a snapshot, and clears prices to unset
+(rather than deleting rows) for anything added since (`:233`). That is exactly this behaviour.
+The mutation composes `newVersionNative` + that call in one transaction, through
+`assertLifecycleGuard`, writing **one** audit entry for the whole operation — not one per line.
+
+**Confirm dialog — it must disclose both surprises before it runs:**
+
+> **Use v2's pricing for v4?**
+> v4 will be created with the prices from quote v2. Gear, quantities and dates are unchanged.
+> · **3 items added since v2 have no price in it** — they'll be unpriced and need one.
+> · The rental window has changed since v2, so these prices were worked out over a different
+>   duration. *(shown only when the window actually moved)*
+> `[ Cancel ]` `[ Create v4 with v2's pricing ]`
+
+Silent `$0` lines on a quote are exactly the failure this program exists to prevent, so the
+unpriced count is stated up front, not discovered afterwards via badges.
 
 **The artifact never changes.** A superseded revision's PDF downloads byte-identical to the day
 it was sent — no retroactive "SUPERSEDED" stamp, because the client's copy doesn't have one.
@@ -584,8 +615,8 @@ app-wide in 2026-07 for exactly this reason.
 **New:** `ProjectAlertRail` (+ row primitive), `FinanceSidebarRail`, `LockedField`,
 `GatedAction`, `QuoteRevisionRow`, `SendQuoteDialog`, `IssueInvoiceDialog`,
 `RecallQuoteDialog`, `AcceptQuoteDialog`, `DeclineQuoteDialog`, `ConfirmWithoutAcceptedQuoteDialog`,
-`RevisionViewerDialog`, `ChangeStepper`, `lock-copy.ts`, `quoteStatusIntent()` in
-`status-colors.ts`.
+`RevisionViewerDialog`, `ChangeStepper`, `RepriceFromRevisionDialog` (§8.1), `lock-copy.ts`,
+`quoteStatusIntent()` in `status-colors.ts`.
 
 **Reused unchanged:** `Dialog`, `Tooltip` (+ own provider), `Badge`, `Skeleton`,
 `SectionHeader`, `FadeIn`, `combobox-picker`, `PersonAvatar`, `UnpricedBadge`,
@@ -614,15 +645,20 @@ pagination; the three-button invoice-kind row; the `2 more notices` collapse; mo
 - Every revision state renders a distinct, labelled treatment (incl. Superseded's no-pill)
 - Send dialog: terminal success state exposes `Download PDF`; error preserves all four fields
 - Lifecycle reorder: pre- and post-acceptance section order
+- Reprice-from-revision (§8.1): the confirm dialog states the unpriced-item count before
+  running; the warning about a moved rental window appears only when the window actually
+  moved; structure is provably unchanged after the operation; one audit entry, not N
 
-## 14. Open scope question
+## 14. Resolved scope question
 
-**`Start v(N+1) from this version`** — seeding a new draft from an older revision's pricing.
-Not in any phase's scope. It emerged from the version-control framing: users who can compare
-revisions will want to walk one back, and every reference pattern trains them to expect it.
-Mechanically close to `restoreProjectSnapshot`'s FINANCIAL scope, which exists.
+**Reprice-from-revision — decided 2026-07-28: build it in Phase D.** Full spec at §8.1.
 
-Recommended: **build it in Phase D**, since §8 already draws it as the viewer's primary footer
-action and without it the viewer is a read-only cul-de-sac that shows you a problem and offers
-no way to act. **Needs a decision before Phase D starts** — if it goes the other way, the
-viewer ships with an empty primary slot.
+It was surfaced by this review as out-of-scope work that the design implied but no issue
+covered. Resolved in favour of building because the mechanic already exists and is tested
+(`restoreProjectSnapshot` FINANCIAL scope), the expectation is universal across every version
+-history pattern studied, and without it the revision viewer is a read-only cul-de-sac that
+shows you a problem and offers no way to act on it.
+
+Scope added to Phase D (#989): one mutation, one confirm dialog, the viewer footer action,
+tests. Renamed from "Start v(N+1) from this version" to **"Use vN's pricing for v(N+1)"** so
+the label can't be read as restoring structure.


### PR DESCRIPTION
## Summary

Planning docs for #985 — making quoting/invoicing a first-class, streamlined, version-controlled workflow instead of a panel at the bottom of a tab plus an ad-hoc PDF button. **Docs only; no code changes.** Implementation is phased across #986–#990 and #992.

### What's here

| File | What |
|---|---|
| `docs/designs/finance-first-class-version-control.md` | **New** — architecture: quote revisions on one shared counter, the state machine, immutable PDF artifacts, unified lock state, data model, backfill, rollout, test plan |
| `docs/designs/finance-workflow-ux.md` | **New** — UI/UX: layout, the full interaction-state matrix, the state × role × lock-tier action matrix, lock copy deck, responsive, a11y, component inventory |
| `docs/ROADMAP.md` | Indexes the program as item 3.3 |
| `DESIGN.md` | Corrects a self-contradictory Tables section the review uncovered (below) |

### The problem, verified in-repo

**Three unrelated "version" mechanisms exist and none is the one we want.** `projectSnapshots` fire automatically at CONFIRMED/COMPLETED/UNLOCK and are invisible outside a `⋯` menu. `quotes.version` is bumped implicitly inside `publishNative` with no draft, send, dates or recall. And the PDF — the thing the client actually receives — reads **live project state** (`src/lib/pdfme/build-document-data.ts`) and consults the `quotes` table not at all.

So **a sent quote is not reproducible**. Two clicks a week apart produce two different documents under the same name. `quotes.pdfFileId` is declared in `convex/schema.ts` (L2089) with zero readers and zero writers. Invoices have the same hole: the row is immutable once ISSUED, but the artifact is live-rendered on every click, so the guarantee stops at the DB boundary.

Two live bugs fall out of the same root cause: `quoteValidUntil` is computed from `now` at render time (`build-document-data.ts` L672-673), so re-opening a quote silently extends how long it's valid; and `dueDate` is plumbed through `issueNative` but never passed by the UI, so **every invoice issued today has no due date**.

Separately, the #957 locks are strong on the server and nearly invisible on the client — `useProjectLockStatus` has exactly one mount, inside the Financials tab. `useJustifiedMutation` and `UnpricedBadge` are both built, tested and wired to nothing, which means ON_SITE+ structural edits fail with `JUSTIFICATION_REQUIRED` and no way to supply one.

### The model

```
projects.revision : number         ← the authority (starts at 1 on create)
  quotes.version  = the revision it was cut from   (one quote row per revision)
  projectSnapshots.revision                        (frozen entity state for that revision)

  v1 DRAFT ─ send ─▶ v1 SENT ─ accept ─▶ v1 ACCEPTED ─▶ project may CONFIRM
       ▲               │ │ │
       └─ recall ──────┘ │ └─ decline ─▶ v1 DECLINED
                         └─ new version ─▶ v2 DRAFT   (v1 → SUPERSEDED on v2's send)
```

Supersede fires on **send**, not on draft — so there is always exactly one document representing what the client currently has, and cutting a draft never invalidates it. Expiry is derived on read, so no cron and no stale rows.

The quote-send lock is **not new machinery**: `lockTierForStatus(status)` becomes `resolveLockTier({ status, quoteState })`. A quote state can only ever *raise* the tier, and all ~25 existing gate sites keep calling `assertLifecycleGuard` unchanged. A second lock mechanism on the most safety-critical function in the app would have been an R-3.1 defect.

### Design review

Ran `/plan-design-review` (7 passes) plus an independent design agent that read the source rather than the docs. Scored 6/10 → 9/10. It caught three real errors:

- **Status colours were inverted.** DESIGN.md:154 and :255 both define solid red as LIVE/ACTIVE and name `ACCEPTED` as a member; the draft gave solid red to *Sent* and green to *Accepted*. Now `Sent` → info, `Accepted` → primary.
- **The "always-visible" lock anchor didn't exist.** Only `top-bar.tsx:88` and `DetailSidebar` (`page-layouts.tsx:129`) are sticky — the project hero isn't, so scrolling into the Equipment tab loses every lock signal at once. Lock state moved to the sticky sidebar.
- **A third money summary.** The proposed Money block duplicated `ProjectSummaryStrip` (`page.tsx:477`) and `ProjectCostsPanel` (`:636`) in the same viewport. Cut.

It also found that `Create quote v(N+1)` — the most common action after sending — had no designed home, and that the send flow ended by asking the system's question ("Advance to Quoted?") while never handing over the PDF the user opened their mail client to attach. Both fixed.

### DESIGN.md correction (please sanity-check)

The Tables section specified `t-overline (10px/700/uppercase)` and `t-mono (JetBrains Mono)` — contradicting the same document's absolute 11px floor, its §5.2 no-uppercase ban, and its Geist Mono type stack. Corrected in place to 11px/600 sentence case + Geist Mono, with a dated note explaining why. CLAUDE.md says to flag conflicts rather than silently diverge, and every future table would have hit the same trap.

## PR size rationale (R-2.8 / T-2)

The size bot flags 1375 changed LOC against the ≤ 400 SHOULD-level target. Accurate — R-0.5 excludes generated code, vendored code, lockfiles, migrations and test fixtures, and **documentation is not on that list**, so this genuinely counts.

**Splitting was considered and rejected as impractical:** the natural seam is architecture doc (~700) / UX doc (~675), and neither half lands under 400, so a split buys no compliance. It also breaks the docs — the architecture doc explicitly defers to the UX doc as authoritative for anything visual (an R-3.1 measure to stop visual constants being defined twice), so shipping them separately means one lands on `main` referencing a file that isn't there yet.

**Why the underlying intent is still met:** T-2 derives from the SmartBear/Cisco review-rate study, and R-2.8 states the actual constraint as "reviewers should not sustain > ~500 LOC/hour; sessions ≤ 60–90 min." That rate is calibrated on code. 1375 lines of prose is a 30–45 minute read, inside R-2.8's own session guidance — the reviewer-fatigue risk the threshold exists to prevent doesn't bite the same way here.

**One piece is genuinely separable if you'd prefer it split:** the `DESIGN.md` correction (10 LOC) is unrelated to the finance program and could land on its own. Say the word and I'll pull it out.

## Testing

No code changed, so there is nothing to execute. Verification was:

- **Every factual claim checked against source** before it went in a doc — file and line references throughout both docs are real. The three review findings above were each verified with grep before being acted on.
- **Relative links resolve** — checked every `./` and `../` link in both new docs and in the ROADMAP entry (this repo runs `link-check.yml`).
- **CI** will run lint / typecheck / tests as usual; a docs-only diff shouldn't move them.

Not verified: nothing here has been built, so the design is unproven against real rendering. The state matrix and action matrix are specifications, not observations.

## Checklist

- [x] New dependency? **No** — no dependencies added or changed; this diff is four markdown files.

---

Closes nothing on its own. Tracking: #985 · phases #986 (revision model) · #987 (immutable artifacts) · #988 (unified lock state) · #989 (Finance tab) · #990 (lock UX) · #992 (org-level Finance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfAao521DoJhPrTYoZLaMg