### PR TITLE
Fix Xero account-override defaulting bug; category visibility + advanced disclosure

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -197,8 +197,12 @@ wires an actual sale line type.
 
 Every level of the cascade above has a write path + form field:
 
-- **Category default** — `categories.xeroAccountCode`, one field on the
-  category create/edit dialog (`src/components/assets/category-manager.tsx`).
+- **Category default** — `categories.xeroAccountCode`, a labelled "Xero
+  coding" section (border-separated, not just a bare field) on the category
+  create/edit dialog (`src/components/assets/category-manager.tsx`) — this
+  dialog has no `SmartFormSection`-style layout the way model/kit forms do,
+  so the field needs its own visual heading to not blend into the plain
+  field list around it.
 - **Model defaults** — `models.xeroRentalAccountCode`/`xeroSaleAccountCode`,
   a "Xero coding" `SmartFormSection` on `src/components/assets/model-form.tsx`
   (rental and sale are independent — a kit-parent line reads `kits.xeroAccountCode`
@@ -212,9 +216,13 @@ Every level of the cascade above has a write path + form field:
   landed — what was missing was the client never sending them
   (`buildLineItemSetClear` in `src/hooks/use-line-item-writes.ts`) and no
   length bound (`assertLineItemFields` in `convex/lineItemWrites.ts`), both
-  now added (R-8.6.2 — defense-in-depth on a blocklist mutation).
+  now added (R-8.6.2 — defense-in-depth on a blocklist mutation). Tucked
+  behind a collapsed-by-default "Advanced: Xero coding" `Accordion` — this
+  dialog is on the everyday line-editing path, unlike category/model/kit
+  forms, so the override stays reachable without cluttering the common case.
 - **Service override** — `projectServices.xeroAccountCode`/`xeroTaxType`, on
-  the `ServiceDialog` in `src/components/projects/services-panel.tsx`.
+  the `ServiceDialog` in `src/components/projects/services-panel.tsx` — same
+  collapsed-by-default `Accordion` treatment, same reasoning.
 
 All five write paths mirror `categorySchema`/`modelSchema`/etc.'s new
 `.max(50)` bound server-side (`assertCategoryFields`/`assertModelFields`/
@@ -231,6 +239,19 @@ coding" section on category/model/kit is itself conditionally rendered on
 `useXeroLinked()` too — a titled section with self-gating-to-null fields
 inside would otherwise show an empty section with no content, which reads as
 broken.
+
+**Codeless accounts are excluded from the picker, not just displayed oddly.**
+`useXeroCodingOptions()` filters `cachedAccounts` down to `!!a.Code` before
+mapping to `ComboboxPicker` options — Xero's Invoices API `AccountCode` field
+takes the short account CODE, never the internal `AccountID` GUID, so an
+account with no code was never a valid selection regardless. This also fixed
+a real bug: the old fallback `a.Code ?? a.AccountID` only triggers on
+null/undefined, not on `Code: ""` (which Xero returns for some accounts with
+no code assigned) — that account's option `value` silently collapsed to
+`""`, the exact sentinel every picker here uses for "nothing selected."
+Every UNSET override field then matched that account by coincidence and
+rendered it as if selected, which read as "every override defaults to the
+first account in the list, and clearing never actually clears."
 
 ### Linked gate
 

--- a/src/components/assets/category-manager.tsx
+++ b/src/components/assets/category-manager.tsx
@@ -203,19 +203,22 @@ export function CategoryManager() {
                 <Label htmlFor="cat-sort">Sort order</Label>
                 <Input id="cat-sort" type="number" {...form.register("sortOrder")} className="w-24" />
               </div>
-              <Controller
-                name="xeroAccountCode"
-                control={form.control}
-                render={({ field }) => (
-                  <XeroAccountCodeField
-                    value={field.value}
-                    onChange={field.onChange}
-                    label="Xero account"
-                    placeholder="Inherit org default"
-                    helpText="Applied to every model/kit under this category unless overridden."
-                  />
-                )}
-              />
+              <div className="space-y-2 border-t border-line pt-4">
+                <Label className="text-ui-text font-medium text-ink">Xero coding</Label>
+                <Controller
+                  name="xeroAccountCode"
+                  control={form.control}
+                  render={({ field }) => (
+                    <XeroAccountCodeField
+                      value={field.value}
+                      onChange={field.onChange}
+                      label="Account"
+                      placeholder="Inherit org default"
+                      helpText="Applied to every model/kit under this category unless overridden."
+                    />
+                  )}
+                />
+              </div>
               {parentId && (
                 <p className="text-caption text-muted">
                   Subcategory of: {categories.find((c) => c.id === parentId)?.name}

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -42,6 +42,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { checkAvailability } from "@/server/line-items";
 import { lineItemSchema, type LineItemFormValues } from "@/lib/validations/line-item";
 import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { PlacementFields } from "./placement-fields";
 import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
@@ -343,22 +344,31 @@ function EditLineItemDialogBody({
         </section>
 
         {xeroLinked && (
-          <section className="space-y-4 border-t border-line pt-5">
-            <SectionTitle title="Xero coding" hint="Overrides the model/kit/category default for this line only." />
-            <Controller
-              control={form.control}
-              name="xeroAccountCode"
-              render={({ field }) => (
-                <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
-              )}
-            />
-            <Controller
-              control={form.control}
-              name="xeroTaxType"
-              render={({ field }) => (
-                <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
-              )}
-            />
+          <section className="border-t border-line pt-5">
+            <Accordion type="single" collapsible>
+              <AccordionItem value="xero-coding" className="border-line">
+                <AccordionTrigger>Advanced: Xero coding</AccordionTrigger>
+                <AccordionContent>
+                  <div className="space-y-4 pt-1">
+                    <p className="text-caption text-muted">Overrides the model/kit/category default for this line only.</p>
+                    <Controller
+                      control={form.control}
+                      name="xeroAccountCode"
+                      render={({ field }) => (
+                        <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
+                      )}
+                    />
+                    <Controller
+                      control={form.control}
+                      name="xeroTaxType"
+                      render={({ field }) => (
+                        <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
+                      )}
+                    />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           </section>
         )}
 

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -71,6 +71,7 @@ import { FadeIn, StaggerList, StaggerItem } from "@/components/ui/motion";
 import { ComboboxPicker, MultiComboboxPicker } from "@/components/ui/combobox-picker";
 import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -2133,25 +2134,29 @@ function ServiceDialog({
           </div>
 
           {xeroLinked && (
-            <div className="space-y-3 rounded-[var(--r)] border border-line p-3">
-              <div className="t-overline text-muted">Xero coding</div>
-              <div className="grid grid-cols-2 gap-3">
-                <Controller
-                  control={form.control}
-                  name="xeroAccountCode"
-                  render={({ field }) => (
-                    <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
-                  )}
-                />
-                <Controller
-                  control={form.control}
-                  name="xeroTaxType"
-                  render={({ field }) => (
-                    <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
-                  )}
-                />
-              </div>
-            </div>
+            <Accordion type="single" collapsible className="rounded-[var(--r)] border border-line">
+              <AccordionItem value="xero-coding" className="border-none px-3">
+                <AccordionTrigger>Advanced: Xero coding</AccordionTrigger>
+                <AccordionContent>
+                  <div className="grid grid-cols-2 gap-3 pt-1">
+                    <Controller
+                      control={form.control}
+                      name="xeroAccountCode"
+                      render={({ field }) => (
+                        <XeroAccountCodeField value={field.value} onChange={field.onChange} label="Account" placeholder="Inherit default" />
+                      )}
+                    />
+                    <Controller
+                      control={form.control}
+                      name="xeroTaxType"
+                      render={({ field }) => (
+                        <XeroTaxTypeField value={field.value} onChange={field.onChange} label="Tax type" placeholder="Use org default" />
+                      )}
+                    />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           )}
 
           {/* Notes */}

--- a/src/components/settings/xero-coding-fields.tsx
+++ b/src/components/settings/xero-coding-fields.tsx
@@ -29,21 +29,36 @@ interface XeroTaxRateOption {
 }
 
 /** Exported so Settings -> Xero's org-default pickers share this exact
- *  mapping instead of a second hand-maintained copy (R-3.1). */
+ *  mapping instead of a second hand-maintained copy (R-3.1).
+ *
+ *  Filters out accounts with no `Code`: Xero's Invoices API `AccountCode`
+ *  field takes the short account CODE, never the internal `AccountID` GUID,
+ *  so a codeless account is never a valid selection here regardless. This
+ *  also fixes a real bug — `a.Code ?? a.AccountID` (the old fallback) only
+ *  triggers on null/undefined, not on `Code: ""` (which Xero returns for
+ *  accounts with no code assigned), so that account's `value` silently
+ *  collapsed to `""` — the exact sentinel `ComboboxPicker` treats as
+ *  "nothing selected." Every UNSET field then matched that account by
+ *  coincidence and rendered it as if selected ("defaults to the first
+ *  account" — whichever codeless account happened to be in the list). */
 export function useXeroCodingOptions() {
   const integration = useXeroIntegration();
   const accounts = (integration?.cachedAccounts as XeroAccountOption[] | undefined) ?? [];
   const taxRates = (integration?.cachedTaxRates as XeroTaxRateOption[] | undefined) ?? [];
-  const accountOptions = accounts.map((a) => ({
-    value: a.Code ?? a.AccountID,
-    label: a.Name,
-    description: a.Code || undefined,
-  }));
-  const taxRateOptions = taxRates.map((t) => ({
-    value: t.TaxType,
-    label: t.Name,
-    description: t.TaxType,
-  }));
+  const accountOptions = accounts
+    .filter((a) => !!a.Code)
+    .map((a) => ({
+      value: a.Code as string,
+      label: a.Name,
+      description: a.Code,
+    }));
+  const taxRateOptions = taxRates
+    .filter((t) => !!t.TaxType)
+    .map((t) => ({
+      value: t.TaxType,
+      label: t.Name,
+      description: t.TaxType,
+    }));
   return { accountOptions, taxRateOptions };
 }
 


### PR DESCRIPTION
## Summary

Three fixes from user feedback on the account-coding override UI (#993):

**1. "Inherit" doesn't actually clear — defaults to the first account.**
Root cause: `useXeroCodingOptions()` built each account option's `value` as `a.Code ?? a.AccountID`. `??` only falls through on null/undefined, not on `Code: ""` — which Xero returns for accounts with no code assigned. That account's option `value` silently collapsed to `""`, the exact sentinel every picker uses for "nothing selected." Every unset override field then matched that account by coincidence and rendered it as if selected — which is why it looked like every override defaulted to one particular account, and clearing never actually cleared. Fixed by filtering codeless accounts out of the picker entirely: Xero's Invoices API `AccountCode` field takes the short code, never the internal `AccountID` GUID, so a codeless account was never a valid selection to begin with. This is the shared `useXeroCodingOptions()` hook, so the fix applies to every picker at once (Settings → Xero, category/model/kit defaults, line/service overrides).

**2. Category field wasn't visible.**
`category-manager.tsx` has no `SmartFormSection`-style layout the way the model/kit forms do — the field was a bare label sandwiched between unrelated fields with no visual separator, easy to miss entirely. Now a bordered "Xero coding" section with its own heading, matching how model/kit forms already present it.

**3. Line-item/service overrides shouldn't be inline all the time.**
These are advanced, rarely-used overrides sitting on the everyday line-editing path. Moved both behind a collapsed-by-default "Advanced: Xero coding" `Accordion` (the same primitive model/kit forms already use for their own "More details" sections). Category/model/kit stay plain visible fields — those are admin/config screens, not everyday editing surfaces, so hiding it there would just add friction to the ask in point 2.

`FEATUREDOCS/66` updated with all three.

## Testing

- `pnpm exec vitest run` — 243 tests passing across the relevant suites (xero-client, xero server, categories/models/kits/line-items/services writes, cascade resolver, push-in-context, combobox-picker smoke).
- `pnpm exec tsc --noEmit` — zero errors in touched files.
- `pnpm exec eslint` — no new warnings/errors.
- Not manually exercised in a live browser (no connected Xero org with an account catalog in this sandbox) — the root-cause fix (filtering codeless accounts) is confirmed by code inspection of `xero-client.ts`'s account schema and how `Code`/`AccountID` are used downstream in `xeroPush.ts`, not by reproducing the bug live.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HoeQabDo6GQpTgSKQfxdqa)_