### PR TITLE
Phase A — quote revision model + state machine (#986)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,21 @@ Related: `by_cuid` and `by_modelId` are **global** Convex indexes, and `requireO
 authorises the *caller's* org, not the *row's*. Any doc fetched by cuid or modelId must
 be checked against `organizationId`, or you have a cross-tenant read.
 
+### ⚠️ Quote status is DERIVED — never branch on the stored column
+A quote's `status` column is not the whole answer. `EXPIRED` is computed on read
+(`validUntil < now && status === "SENT"`) and never stored, and the deprecated
+`PUBLISHED` still appears on any row the #986 backfill hasn't reached. Always go
+through `effectiveQuoteStatus()` / the `effectiveStatus` field the `convex/quotes.ts`
+queries return (`convex/lib/quoteState.ts`) — a `q.status === "SENT"` test silently
+treats expired quotes as live and pre-#986 rows as neither. Same reason `quotes` reads
+go through `listProjectQuotes`/`requireQuoteInOrg`: `by_projectId` is global, so the
+org check has to happen in the loader, not at the call site.
+
+`projects.revision` is the one version counter (project v2 == quote v2 == the snapshot
+taken at v2). It is server-owned — written only by `createNative` and
+`quotesWrites.newVersionNative`, and stripped from client patches the same way
+`PROJECT_MONEY_ANCHORS` are. See FEATUREDOCS/66.
+
 ### Prisma v7
 - Import from `@/generated/prisma/client` (NOT `@/generated/prisma`)
 - After schema changes: `pnpm exec prisma migrate dev` → `pnpm exec prisma generate` → restart dev

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -1,6 +1,6 @@
 # Project & Rental Management
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-27 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-28 (review quarterly — POLICY.md R-5.5)_
 
 ## Projects List Views (`ProjectTable`, `ProjectBoard`)
 `ProjectTable` (`src/components/projects/project-table.tsx`) is server-side
@@ -35,6 +35,53 @@ Each status maps to one of four lock tiers, resolved by `lockTierForStatus()`
 | `ON_SITE` / `RETURNED` | **JUSTIFY** | Above, plus structural mutations need a confirm + written justification |
 | `COMPLETED` / `INVOICED` | **HARD_LOCKED** | Everything — no per-edit path, only a FULL unlock session |
 | `CANCELLED` | OPEN | Ungated (open question — see FEATUREDOCS/62) |
+
+Phase C (#988) makes the resolver take the project's quote state as a second
+input (`resolveLockTier({ status, quoteState })`), so a sent quote raises the
+tier without any gate site changing. Not built yet.
+
+### Acceptance gate on CONFIRMED (#986 — see FEATUREDOCS/66)
+
+A project may not advance to `CONFIRMED` until one of its quote revisions is
+`ACCEPTED`. Confirming a job whose price the client never agreed to is the
+failure the revision model exists to prevent.
+
+Org admins/owners and the project's assigned PMs override with a bounded
+justification (≥10 chars, ≤1000 — `requireJustification` in
+`convex/lib/projectLocks.ts`, the same audience and bounds as #792's hard-lock
+revert). The justification lands on the `STATUS_CHANGE` audit row's `metadata`.
+
+Only an actual transition INTO `CONFIRMED` is gated — re-saving an
+already-confirmed project never re-prompts. A **re-crossing** (revert to
+`PREPPING`, then back) IS gated again, matching `crossesIntoSnapshotStatus`'s
+own re-crossing rule: pricing may have moved while the project was reverted.
+
+## Project revisions (`projects.revision`)
+
+The single version counter shared by the project, its quote and its snapshot
+(#986 — full model in [FEATUREDOCS/66](./66-finance-quotes-invoices-xero.md)):
+
+```
+projects.revision : number         ← the authority (starts at 1 on create)
+  quotes.version  = the revision it was cut from   (one quote row per revision)
+  projectSnapshots.revision                        (frozen entity state for that revision)
+```
+
+Project v2 == Quote v2 == the snapshot taken at v2. There is deliberately no
+second counter (R-3.1).
+
+**Server-owned.** Written ONLY by `createNative` (seeded to 1 — and by both
+service-token create paths, including the WooCommerce order → project flow) and
+`quotesWrites.newVersionNative`. It is stripped from every generic client patch
+alongside `PROJECT_MONEY_ANCHORS` (`PROJECT_SERVER_OWNED` in
+`convex/projectWrites.ts`) and can't be cleared: a client-settable revision
+would let a browser caller renumber, skip or rewind versions, orphaning the
+quote rows keyed to those numbers.
+
+**Templates carry no revision** — they are never quoted, and a project created
+from one starts its own count at 1 rather than inheriting a number. Absent reads
+as 1 via `projectRevision()` (`convex/lib/quoteState.ts`), so pre-#986 documents
+and any row the backfill hasn't reached behave as v1.
 
 ## Project Hierarchy
 ```
@@ -484,8 +531,14 @@ HERO CARD (rounded-[--r-lg] border-2 bg-card, full width):
 ### Financials Tab
 Moved out of the sidebar into its own non-template main-content tab (after
 "Labour & logistics") to declutter the right rail. Contains `FinancialSummary`
-+ `ProjectCostsPanel`. The allGroups/pricing computation that feeds
-`FinancialSummary` lives in the tab now (same logic as before).
++ `ProjectCostsPanel` + `ProjectFinancePanel`. The allGroups/pricing computation
+that feeds `FinancialSummary` lives in the tab now (same logic as before).
+
+`ProjectFinancePanel`'s quote half is the `<ProjectQuoteRail>` revision rail
+(#986): one row per revision with send / recall / new-version / accept / decline.
+Phase D (#989) promotes finance to its own top-level tab and retires this one —
+until then the rail is the minimum surface for exercising the model, not the
+designed layout.
 - Total with margin bar (green > 40%, amber 20-40%, red < 20%)
 - Equipment revenue, discount, tax breakdown
 - Services + Labour costs section

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -1,6 +1,6 @@
 # Finance — Quotes, Invoices, Client Payment Profiles, Xero Integration
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-26 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-28 (review quarterly — POLICY.md R-5.5)_
 
 WS1 of #934 (#940) — the finance model. **RVLT Flow owns quote + invoice
 generation; Xero owns the ledger, payment collection, and reconciliation.**
@@ -13,16 +13,14 @@ reporting, or email documents to clients — those stay Xero's job.
 ## Architecture
 
 ```
-Project (recalc-owned pricing) → Quote (snapshot, versioned) → PDF
+Project (recalc-owned pricing) → Quote revision (snapshot, versioned) → PDF
                                 → Invoice (Flow-numbered) → InvoiceLine (resolved Xero coding)
                                      → Xero draft invoice (push)
 ```
 
-- **Quote** (`quotes` table) — snapshot-on-publish, versioned. Publishing
-  freezes the project's CURRENT server-computed pricing (never trusts
-  client-supplied money — R-9.3) into an immutable row; republishing
-  supersedes the previous `PUBLISHED` quote (status → `SUPERSEDED`, never
-  overwritten in place) and bumps `version`.
+- **Quote revision** (`quotes` table) — see "Quote revisions (#986)" below.
+  Sending freezes the project's CURRENT server-computed pricing (never trusts
+  client-supplied money — R-9.3) into an immutable row.
 - **Invoice** (`invoices` table) — `kind`: `FULL | DEPOSIT | BALANCE |
   CREDIT`. Created as `DRAFT`; `invoiceNumber` is assigned only at `issueNative`
   (the ONE numbering moment — drafts stay unnumbered). Immutable once
@@ -64,6 +62,160 @@ unchanged) — that pipeline stays presentation-only.
 `depositPaid`/`invoicedTotal` on the **project** are DERIVED in
 `recalcProjectTotals` (summed from this project's `ISSUED` invoices — see
 "Derive, don't hand-type" below), not the invoice-level fields above.
+
+## Quote revisions (#986 — Phase A of #985)
+
+WS1 shipped `quotes.version` as a number bumped inside `publishNative` by
+scanning existing rows: no draft state, no send, no dates, no recall, and a
+`DRAFT` literal nothing ever wrote. #986 replaced that with a real revision
+model. The program-level design is
+[`docs/designs/finance-first-class-version-control.md`](../docs/designs/finance-first-class-version-control.md).
+
+### One counter, three tables
+
+```
+projects.revision : number         ← the authority (starts at 1 on create)
+  quotes.version  = the revision it was cut from   (exactly one quote row per revision)
+  projectSnapshots.revision                        (the frozen entity state for that revision)
+```
+
+Project v2 == Quote v2 == the snapshot taken at v2. There is deliberately **no
+second counter** (R-3.1) and **no quote document number** — a quote is referred
+to everywhere as `<projectNumber> v<version>` (`RVLT-2026-0087 v2`), because the
+project number is already the shared reference with the client.
+`src/lib/project-number.ts` and `src/lib/invoice-number.ts` are untouched.
+
+`projects.revision` is **server-owned**: written only by `createNative` (seeded
+to 1; templates carry none) and `quotesWrites.newVersionNative`, and stripped
+from every generic client patch alongside `PROJECT_MONEY_ANCHORS`
+(`PROJECT_SERVER_OWNED` in `convex/projectWrites.ts`). Absent reads as 1 via
+`projectRevision()` — one coalesce, not one per call site.
+
+### State machine
+
+```
+  v1 DRAFT ─ send ─▶ v1 SENT ─ accept ─▶ v1 ACCEPTED ─▶ project may CONFIRM
+       ▲               │ │ │
+       └─ recall ──────┘ │ └─ decline ─▶ v1 DECLINED
+                         └─ new version ─▶ v2 DRAFT   (v1 → SUPERSEDED on v2's send)
+```
+
+`QuoteStatus`: `DRAFT | SENT | ACCEPTED | DECLINED | SUPERSEDED | EXPIRED`.
+
+**Supersede fires on SEND, not on draft.** v1 stays `SENT` while v2 is a draft,
+so there is always exactly one row representing "what the client currently has",
+and cutting a draft never invalidates it. That is the difference between version
+control and a delete button. **Recall reverses it**: un-sending v2 restores the
+row it superseded to `SENT`, because v1 is then the last thing actually sent.
+
+**`EXPIRED` is derived on read**, never stored — `validUntil < now && SENT`
+(`convex/lib/quoteState.ts` `effectiveQuoteStatus`). No cron, no clock skew, no
+stale row, same precedent as the derived readiness chips below. Consumers MUST
+branch on `effectiveStatus`, not the raw `status` column.
+
+**`PUBLISHED` is deprecated** and normalises to `SENT` on read, so behaviour is
+identical before, during and after the migration. It stays declared in the
+validator until a backfill run confirms zero live rows carry it — strict Convex
+schema validation rejects a push where an existing document has a value the
+validator no longer declares (the `depositPercent` incident below is the
+standing precedent).
+
+### Server-enforced invariants (each has a test)
+
+- Exactly one quote row per `(projectId, revision)` — `by_projectId_version` is
+  the uniqueness guard.
+- At most one `DRAFT`, always at `projects.revision`. Cutting v2 while v1 is
+  still a draft is refused; edit the draft instead.
+- At most one live (`SENT`/`ACCEPTED`) row — the document the client is holding.
+- `projects.revision` is monotonic. Never decremented, never reused — a
+  recalled-then-re-sent revision keeps its number.
+
+### The five verbs (`convex/quotesWrites.ts`)
+
+| Verb | Behaviour |
+|---|---|
+| **Send** (`sendNative`) | Freezes the revision: `buildFinanceLines` money snapshot + a `QUOTE_SENT` `captureProjectSnapshot` at the same revision, stamps `quoteDate`/`validUntil`/recipient, sets `SENT`, supersedes the previous live row, offers `ENQUIRY/QUOTING → QUOTED`. Creates the `DRAFT` row when the revision has none yet. |
+| **Recall** (`recallNative`) | `SENT`/`EXPIRED` → `DRAFT` on the same revision, with a bounded reason. The artifact is marked recalled and **retained, never deleted** — the client may already hold it. Restores the row this send superseded. |
+| **New version** (`newVersionNative`) | Increments `projects.revision` and inserts a `DRAFT` at the new number. The previous live row is untouched until the new one sends. A draft carries `snapshot: null` — its figures are the project's live totals until it is sent. |
+| **Accept** (`markAcceptedNative`) | `SENT → ACCEPTED` + acceptance date + optional reference (PO number, email subject). An `EXPIRED` revision cannot be accepted without an explicit re-send. Unblocks `CONFIRMED`. |
+| **Decline** (`markDeclinedNative`) | `SENT`/`EXPIRED` → `DECLINED` + bounded reason. Offers `CANCELLED`, never forces it. |
+
+All five take the standard 4-guard browser-direct shape (FEATUREDOCS/54) plus
+org-checked reference loads and `writeActivityLog`. `sendNative` and
+`newVersionNative` keep `assertLifecycleGuard(…, { kind: "financial" })`, so a
+hard-locked project can't emit a quote out of band.
+
+**"Send" does not email anyone.** Flow records the send, freezes pricing and
+(Phase B, #987) stores the PDF for the user to attach to their own mail. The UI
+says so outright — naming a button "Send" in a product that doesn't deliver mail
+is otherwise a trap. This holds the #934 "no client-facing emails" line.
+
+**Money never originates from the client** (R-9.3). `sendNative`'s only client
+inputs are `quoteDate`, `validityDays`, `recipientContactId` and `notes`.
+
+### Permissions (split)
+
+- **Send / new-version / accept / decline** → `invoice:publish`
+  (owner/admin/manager — the existing audience, unchanged).
+- **Recall** → additionally `isHardLockOverrideAllowed` (org admin/owner, or a
+  member of the project's `projectManagers` set). Un-sending a document the
+  client may already be holding is trust-sensitive in a way the other four verbs
+  are not.
+
+No new permission resource is introduced — both checks already existed.
+
+### Acceptance gate on CONFIRMED
+
+`projectWrites.updateStatusNative` refuses a transition landing on `CONFIRMED`
+unless a revision is `ACCEPTED`. Org admins/owners and the project's PMs
+override with a bounded justification, reusing #792's audience and #793's bounds
+(`requireJustification` in `convex/lib/projectLocks.ts` — the bounds were
+already duplicated inline there, so #986 collapsed them to one definition).
+
+Only an actual transition INTO `CONFIRMED` is gated, so re-saving an
+already-confirmed project never re-prompts. A re-crossing IS gated again,
+matching `crossesIntoSnapshotStatus`'s own re-crossing rule — pricing may have
+moved while the project was reverted.
+
+### Validity and expiry
+
+`src/lib/quote-validity.ts` is the SINGLE definition of the default (30 days),
+the bounds (1–365) and the day-boundary maths; `convex/lib/quoteDates.ts` mirrors
+it byte-for-byte (the Convex bundler can't resolve `@/`), pinned by
+`convex/quoteDates.test.ts`. Before #986 the default was hand-copied into
+`document-settings.tsx` and `build-document-data.ts` and the bounds into
+`org-settings.ts` — three copies of two constants.
+
+`validUntil` is the **end of its calendar day in the ORG's timezone**, resolved
+two-pass so it survives DST in both hemispheres and half/quarter-hour offsets. A
+quote must not expire a day early for a PM in another state. It is stamped ONCE,
+at send, and only read back — the pre-#986 PDF computed validity from `now` at
+render time, so re-opening a quote silently extended how long it was valid.
+
+### Backfill
+
+`convex/backfillQuoteRevisions.ts` + `scripts/convex-backfill-quote-revisions.ts`.
+Production has effectively no live quote data, so this is a simple forward
+migration: `revision ← max(quotes.version)` else 1; `PUBLISHED → SENT`;
+`publishedAt/ById → sentAt/ById`; `quoteDate`/`validUntil` derived on the org's
+calendar day; and a `DRAFT` v1 inserted for every project with no quote row.
+
+Pre-existing sent quotes get **no artifact** — retro-rendering one from today's
+project state would manufacture a document that was never sent, which is the
+exact defect this program removes.
+
+"Effectively none" is a basis for choosing the simple path, not a licence to skip
+verification. The driver counts first, **halts** on a mismatch against
+`--expect-quotes` before writing anything, and fails the run unless
+`verifyQuoteRevisions` reads zero un-migrated rows afterwards.
+
+### Not in Phase A
+
+Immutable stored artifacts and `pdfFileId` wiring (#987), the unified
+status × quote-state lock tier (#988), the real Finance tab with its send and
+invoice-issue dialogs and drift indicator (#989), lock UX (#990), and the
+org-level Finance section (#992). The current UI surface is
+`<ProjectQuoteRail>` — enough to exercise the five verbs, not the designed tab.
 
 ## Numbering (zero engine change)
 
@@ -110,10 +262,13 @@ through this engine.
 
 ## Lifecycle locks
 
-Quote publish and invoice create/issue/void go through the shared
+Quote send/new-version and invoice create/issue/void go through the shared
 `assertLifecycleGuard(ctx, project, { kind: "financial" })` (FEATUREDOCS/62)
-— same FINANCE_LOCKED+ gate every other money-touching mutation uses. No new
-project status was added for "ready to invoice" — readiness is derived
+— same FINANCE_LOCKED+ gate every other money-touching mutation uses. Phase C
+(#988) folds quote state into the tier resolution itself (`resolveLockTier`),
+so a sent revision raises the tier and "cut the next revision" becomes the
+sanctioned exit; the gate sites don't change. No new project status was added
+for "ready to invoice" — readiness is derived
 (the payment-profile-driven "deposit not yet invoiced" nudge chips on the
 project's Finance tab), and issuing a BALANCE/FULL invoice offers a UI-chain
 prompt to advance the project to `INVOICED` (the EXISTING project status
@@ -258,7 +413,12 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 | File | Purpose |
 |------|---------|
 | `convex/schema.ts` | `quotes`, `invoices`, `invoiceLines`, `xeroIntegrations`, `xeroSyncLogs` tables; Xero coding fields on `categories`/`models`/`kits`/`projectLineItems`/`projectServices`; `clients.paymentProfile`/`profileDepositPercent`/`xeroContactId`/`xeroContactName` |
-| `convex/quotesWrites.ts` | `publishNative` |
+| `convex/quotesWrites.ts` | The five quote verbs: `sendNative`/`recallNative`/`newVersionNative`/`markAcceptedNative`/`markDeclinedNative` |
+| `convex/quotes.ts` | `listForProject` (with derived `effectiveStatus`) / `revisionStateForProject` |
+| `convex/lib/quoteState.ts` | Derived `EXPIRED`, `PUBLISHED`→`SENT` normalisation, `hasAcceptedQuote`, org-checked quote/project loaders |
+| `convex/lib/quoteDates.ts` / `src/lib/quote-validity.ts` | Validity default + bounds + timezone-correct `validUntil`/expiry (mirrored pair) |
+| `convex/backfillQuoteRevisions.ts` | Forward migration + `verifyQuoteRevisions` |
+| `src/hooks/use-quote-writes.ts` / `src/components/projects/project-quote-rail.tsx` | Client wiring for the five verbs |
 | `convex/invoicesWrites.ts` | `createNative`/`issueNative`/`voidNative`/`deleteDraftNative`/`createCreditNative` |
 | `convex/lib/financeSnapshot.ts` | `buildFinanceLines` — the shared quote/invoice line-breakdown builder |
 | `convex/lib/xeroAccountCascade.ts` | Pure cascade resolver functions |
@@ -285,9 +445,23 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 - `src/server/xero.test.ts` — 4 mocked-boundary tests on `pushInvoiceToXero`
   (auto-create-contact idempotency, the failure path).
 - `convex/lib/xeroGate.test.ts` — 4 tests, the linked gate + org-scoping.
-- `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 18 tests,
+- `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 40 tests,
   server-computed money, gapless/namespaced numbering, cross-org IDOR guards,
-  RBAC, lifecycle-lock gating.
+  RBAC, lifecycle-lock gating. #986 added the four revision invariants,
+  supersede-on-send-not-on-draft, the recall round trip (including restoring
+  the superseded predecessor), derived-`EXPIRED` blocking acceptance, and the
+  manager-can-send-but-not-recall / PM-can-recall RBAC split.
+- `convex/quoteDates.test.ts` — pins the `convex/lib` ↔ `src/lib` mirror over a
+  timezone × instant × validity matrix, and asserts `validUntil` lands on the
+  last local instant of its calendar day across DST in both hemispheres, at
+  half/quarter-hour offsets, and over month/year/leap boundaries.
+- `convex/backfillQuoteRevisions.test.ts` — dry-run/apply split, every migration
+  step, idempotency, template exclusion, monotonicity, SERVICE-only access, and
+  zero un-migrated rows afterwards.
+- `convex/projectWrites.test.ts` — the acceptance gate on `CONFIRMED`: blocked
+  without an accepted revision, satisfied by one, unsatisfied by a merely-SENT
+  one or another org's (IDOR), the admin/PM override with its audited
+  justification, and `revision` being un-forgeable and un-clearable.
 - `convex/recalc.test.ts` — 4 new tests for the derived `depositPaid`/
   `invoicedTotal` fields.
 

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -108,6 +108,14 @@ and cutting a draft never invalidates it. That is the difference between version
 control and a delete button. **Recall reverses it**: un-sending v2 restores the
 row it superseded to `SENT`, because v1 is then the last thing actually sent.
 
+Supersede applies to an `ACCEPTED` revision as well, which has a consequence
+worth stating outright: **acceptance does not survive a re-quote.** Accept v1,
+then send v2, and `hasAcceptedQuote` goes false — the client agreed to v1's
+price, not v2's, so the project needs v2 accepted (or an admin override) before
+it can advance to `CONFIRMED` again. Cutting the v2 *draft* changes nothing; only
+sending it does. A project that is ALREADY `CONFIRMED` stays confirmed — the gate
+fires on transitions, not continuously.
+
 **`EXPIRED` is derived on read**, never stored — `validUntil < now && SENT`
 (`convex/lib/quoteState.ts` `effectiveQuoteStatus`). No cron, no clock skew, no
 stale row, same precedent as the derived readiness chips below. Consumers MUST

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as backfillClientContacts from "../backfillClientContacts.js";
 import type * as backfillKitUnits from "../backfillKitUnits.js";
 import type * as backfillMaintenanceSchedules from "../backfillMaintenanceSchedules.js";
 import type * as backfillProjectWindow from "../backfillProjectWindow.js";
+import type * as backfillQuoteRevisions from "../backfillQuoteRevisions.js";
 import type * as backfillStripProjectDepositPercent from "../backfillStripProjectDepositPercent.js";
 import type * as bulkAssets from "../bulkAssets.js";
 import type * as bulkAssetsWrites from "../bulkAssetsWrites.js";
@@ -286,6 +287,7 @@ declare const fullApi: ApiFromModules<{
   backfillKitUnits: typeof backfillKitUnits;
   backfillMaintenanceSchedules: typeof backfillMaintenanceSchedules;
   backfillProjectWindow: typeof backfillProjectWindow;
+  backfillQuoteRevisions: typeof backfillQuoteRevisions;
   backfillStripProjectDepositPercent: typeof backfillStripProjectDepositPercent;
   bulkAssets: typeof bulkAssets;
   bulkAssetsWrites: typeof bulkAssetsWrites;

--- a/convex/backfillQuoteRevisions.test.ts
+++ b/convex/backfillQuoteRevisions.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment node
+//
+// convex/backfillQuoteRevisions.ts — the #986 forward migration. Verifies the
+// dry-run/apply split, every migration step, idempotency, template exclusion,
+// SERVICE-only access, and that `verifyQuoteRevisions` reads ZERO un-migrated
+// rows afterwards (the "verification query proving zero un-migrated rows" the
+// acceptance criteria ask for).
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import { assertExpectedQuoteRows } from "./backfillQuoteRevisions";
+import { computeValidUntil, startOfDayInTimezone } from "./lib/quoteDates";
+
+const modules = import.meta.glob("./**/*.ts");
+/** `convexTest(schema, …)` is what makes `ctx.db` schema-aware inside `t.run`. */
+const makeT = () => convexTest(schema, modules);
+type T = ReturnType<typeof makeT>;
+const ORG = "org_1";
+const NOW = 1_700_000_000_000;
+const SERVICE = { subject: "gearflow-service", svc: true };
+
+const run = (t: T, apply: boolean) =>
+  t.withIdentity(SERVICE).mutation(api.backfillQuoteRevisions.backfillQuoteRevisionsPage, { cursor: null, apply });
+const verify = (t: T) =>
+  t.withIdentity(SERVICE).query(api.backfillQuoteRevisions.verifyQuoteRevisions, { cursor: null });
+
+/** A pre-#986 world: one project with a PUBLISHED quote, one with none, one
+ *  template. No `projects.revision` anywhere. */
+async function seedLegacy(t: T) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("orgSettings", {
+      organizationId: ORG,
+      settings: JSON.stringify({ timezone: "Australia/Sydney", documents: { quoteValidityDays: 14 } }),
+    });
+    await ctx.db.insert("projects", {
+      id: "p1", organizationId: ORG, projectNumber: "P1", name: "Quoted gig",
+      status: "QUOTED", isTemplate: false, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("quotes", {
+      id: "q1", organizationId: ORG, projectId: "p1", version: 2, status: "PUBLISHED",
+      snapshot: { total: 110 }, publishedAt: NOW, publishedById: "user_1", createdAt: NOW,
+    });
+    await ctx.db.insert("quotes", {
+      id: "q0", organizationId: ORG, projectId: "p1", version: 1, status: "SUPERSEDED",
+      snapshot: { total: 100 }, publishedAt: NOW - 1000, publishedById: "user_1", createdAt: NOW - 1000,
+    });
+    await ctx.db.insert("projects", {
+      id: "p2", organizationId: ORG, projectNumber: "P2", name: "Never quoted",
+      status: "ENQUIRY", isTemplate: false, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("projects", {
+      id: "tpl", organizationId: ORG, projectNumber: "TPL", name: "Template",
+      status: "ENQUIRY", isTemplate: true, createdAt: NOW, updatedAt: NOW,
+    });
+  });
+}
+
+const quotesFor = (t: T, projectId: string) =>
+  t.run(async (ctx) => ctx.db.query("quotes").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect());
+const projectById = (t: T, id: string) =>
+  t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", id)).first());
+
+describe("backfillQuoteRevisions", () => {
+  test("counts before it migrates — a dry run writes nothing", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+
+    const before = await verify(t);
+    expect(before.nonTemplateProjects).toBe(2);
+    expect(before.liveQuoteRows).toBe(2);
+    expect(before.projectsMissingRevision).toBe(2);
+    expect(before.projectsWithNoQuote).toBe(1);
+    expect(before.quotesStillPublished).toBe(1);
+
+    const dry = await run(t, false);
+    expect(dry.scanned).toBe(2);
+    expect(dry.projectsStamped).toBe(2);
+    // BOTH legacy rows carry `publishedAt` — the superseded v1 gets its dates
+    // migrated too, so its history reads in the new vocabulary as well.
+    expect(dry.quotesMigrated).toBe(2);
+    expect(dry.draftsInserted).toBe(1);
+    // …and nothing changed on disk.
+    expect((await projectById(t, "p1"))?.revision).toBeUndefined();
+    expect((await quotesFor(t, "p1")).find((q) => q.id === "q1")?.status).toBe("PUBLISHED");
+  });
+
+  test("apply: stamps revision, renames PUBLISHED → SENT and derives the quote dates", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    const applied = await run(t, true);
+    expect(applied.projectsStamped).toBe(2);
+    expect(applied.quotesMigrated).toBe(2);
+    expect(applied.draftsInserted).toBe(1);
+
+    // 1. revision ← max(quotes.version)
+    expect((await projectById(t, "p1"))?.revision).toBe(2);
+    // …else 1 for a project that has never been quoted.
+    expect((await projectById(t, "p2"))?.revision).toBe(1);
+
+    // 2 + 3. PUBLISHED → SENT, published* → sent*, dates derived in the org's timezone.
+    const migrated = (await quotesFor(t, "p1")).find((q) => q.id === "q1");
+    expect(migrated?.status).toBe("SENT");
+    expect(migrated?.sentAt).toBe(NOW);
+    expect(migrated?.sentById).toBe("user_1");
+    expect(migrated?.publishedAt).toBeUndefined();
+    expect(migrated?.publishedById).toBeUndefined();
+    const expectedQuoteDate = startOfDayInTimezone(NOW, "Australia/Sydney");
+    expect(migrated?.quoteDate).toBe(expectedQuoteDate);
+    expect(migrated?.validUntil).toBe(computeValidUntil(expectedQuoteDate, 14, "Australia/Sydney"));
+    expect(migrated?.validityDays).toBe(14);
+
+    // 5. No artifact is fabricated for a pre-existing sent quote.
+    expect(migrated?.pdfFileId).toBeUndefined();
+    expect(migrated?.snapshotId).toBeUndefined();
+
+  });
+
+  test("apply: an already-SUPERSEDED row moves off the deprecated columns too", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await run(t, true);
+    // Nothing is left for the schema validator to have to keep declaring — the
+    // `depositPercent` lesson (FEATUREDOCS/66).
+    const superseded = (await quotesFor(t, "p1")).find((q) => q.id === "q0");
+    expect(superseded?.status).toBe("SUPERSEDED");
+    expect(superseded?.sentAt).toBe(NOW - 1000);
+    expect(superseded?.publishedAt).toBeUndefined();
+  });
+
+  test("apply: a project with no quote row gets a DRAFT v1 with no frozen money", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await run(t, true);
+
+    const drafts = await quotesFor(t, "p2");
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]?.status).toBe("DRAFT");
+    expect(drafts[0]?.version).toBe(1);
+    expect(drafts[0]?.snapshot).toBeNull();
+  });
+
+  test("templates are skipped entirely — they're never quoted", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await run(t, true);
+    expect((await projectById(t, "tpl"))?.revision).toBeUndefined();
+    expect(await quotesFor(t, "tpl")).toHaveLength(0);
+  });
+
+  test("verification reads zero un-migrated rows after a full run", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await run(t, true);
+
+    const after = await verify(t);
+    expect(after.projectsMissingRevision).toBe(0);
+    expect(after.projectsWithNoQuote).toBe(0);
+    expect(after.projectsWithRevisionBelowQuotes).toBe(0);
+    expect(after.quotesStillPublished).toBe(0);
+    expect(after.quotesMissingSentAt).toBe(0);
+    expect(after.quotesMissingValidUntil).toBe(0);
+    expect(after.duplicateRevisionRows).toBe(0);
+  });
+
+  test("is idempotent — a second run does nothing", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await run(t, true);
+    const second = await run(t, true);
+    expect(second).toMatchObject({ scanned: 0, projectsStamped: 0, quotesMigrated: 0, draftsInserted: 0 });
+  });
+
+  test("never lowers an already-higher revision (monotonic)", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      await ctx.db.patch(p!._id, { revision: 5 });
+    });
+    await run(t, true);
+    expect((await projectById(t, "p1"))?.revision).toBe(5);
+  });
+
+  test("is SERVICE-only", async () => {
+    const t = makeT();
+    await seedLegacy(t);
+    await expect(
+      t.withIdentity({ subject: "user_1", orgId: ORG }).mutation(api.backfillQuoteRevisions.backfillQuoteRevisionsPage, {
+        cursor: null, apply: true,
+      }),
+    ).rejects.toThrow();
+    await expect(
+      t.withIdentity({ subject: "user_1", orgId: ORG }).query(api.backfillQuoteRevisions.verifyQuoteRevisions, {
+        cursor: null,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("assertExpectedQuoteRows — the halt-on-mismatch guard", () => {
+  test("passes when the count matches, or when no expectation was given", () => {
+    expect(() => assertExpectedQuoteRows(3, 3)).not.toThrow();
+    expect(() => assertExpectedQuoteRows(999, undefined)).not.toThrow();
+  });
+
+  test("halts on a mismatch rather than migrating", () => {
+    expect(() => assertExpectedQuoteRows(41, 3)).toThrow(/expected 3 live quote row/i);
+  });
+});

--- a/convex/backfillQuoteRevisions.ts
+++ b/convex/backfillQuoteRevisions.ts
@@ -1,0 +1,262 @@
+import { v, ConvexError } from "convex/values";
+import { createId } from "@paralleldrive/cuid2";
+import { mutation, query } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import { requireService } from "./lib/auth";
+import { resolveOrgQuoteConfig } from "./lib/orgSettings";
+import { computeValidUntil, startOfDayInTimezone } from "./lib/quoteDates";
+import { listProjectQuotes } from "./lib/quoteState";
+
+/**
+ * #986 forward migration — bring every project and quote onto the revision model.
+ *
+ * Production has effectively no live quote data (the #940 finance features
+ * shipped days ago and haven't been used in anger — decision 12), so this is a
+ * SIMPLE forward migration, not a defensive one: no lazy-creation path, no
+ * dual-read window, no reconstruction of history that never happened.
+ *
+ * Per project (paginated, `apply`-gated, idempotent — same shape as
+ * `backfillProjectWindow.ts` / `backfillStripProjectDepositPercent.ts`):
+ *
+ * 1. `projects.revision` ← `max(quotes.version)`, else 1. Only ever SET when
+ *    absent or lower than the quote rows demand — never lowered (monotonic).
+ * 2. `quotes.status: "PUBLISHED"` → `"SENT"`; `publishedAt/ById` → `sentAt/ById`.
+ * 3. `quoteDate` ← `sentAt`; `validUntil` ← `quoteDate + org quoteValidityDays`,
+ *    both resolved on the ORG's calendar day, same as `sendNative` stamps them.
+ * 4. A project with NO quote row gets a `DRAFT` v1 inserted directly, so every
+ *    project has a coherent revision from day one.
+ * 5. Pre-existing sent quotes get **no artifact**. Retro-rendering one from
+ *    today's project state would manufacture a document that was never sent —
+ *    the exact defect this program removes. Their rows render "no stored
+ *    document (pre-versioning)" in the Finance tab.
+ *
+ * Templates are skipped entirely: they're never quoted and carry no revision.
+ *
+ * `verifyQuoteRevisions` is the companion verification query — the driver runs it
+ * BEFORE applying (so the operator sees the counts and halts on a mismatch
+ * against expectation) and AFTER (to prove zero un-migrated rows remain).
+ *
+ * Driver: `scripts/convex-backfill-quote-revisions.ts`. SERVICE-only.
+ */
+
+/** Cached per page so a 300-project page doesn't re-read the same org settings
+ *  row 300 times (the org set on one page is small). */
+type QuoteConfig = { quoteValidityDays: number; timezone: string | undefined };
+
+/** What one project still needs. `null` ⇒ already migrated (the idempotent
+ *  no-op case, which is every project on a re-run). */
+interface ProjectWork {
+  maxVersion: number;
+  needsRevision: boolean;
+  staleQuotes: Doc<"quotes">[];
+  needsDraft: boolean;
+}
+
+/** Read-only inspection, shared by the dry run and the apply pass so the two can
+ *  never disagree about what work exists. */
+async function planProjectWork(ctx: MutationCtx, project: Doc<"projects">): Promise<ProjectWork | null> {
+  // `listProjectQuotes` re-checks org — `by_projectId` is a GLOBAL index (R-8.4.3),
+  // and that holds even inside a service-token migration.
+  const quotes = await listProjectQuotes(ctx, project.organizationId, project.id);
+
+  const maxVersion = quotes.reduce((max, q) => Math.max(max, q.version ?? 1), 1);
+  const needsRevision = project.revision == null || project.revision < maxVersion;
+  const staleQuotes = quotes.filter((q) => q.status === "PUBLISHED" || (q.publishedAt != null && q.sentAt == null));
+  const needsDraft = quotes.length === 0;
+
+  if (!needsRevision && staleQuotes.length === 0 && !needsDraft) return null;
+  return { maxVersion, needsRevision, staleQuotes, needsDraft };
+}
+
+/** Steps 2 + 3: PUBLISHED → SENT, published* → sent*, and the derived dates. */
+async function migrateQuoteRow(ctx: MutationCtx, quote: Doc<"quotes">, config: QuoteConfig): Promise<void> {
+  const sentAt = quote.sentAt ?? quote.publishedAt ?? quote.createdAt ?? quote._creationTime;
+  const quoteDate = quote.quoteDate ?? startOfDayInTimezone(sentAt, config.timezone);
+  await ctx.db.patch(quote._id, {
+    status: quote.status === "PUBLISHED" ? "SENT" : quote.status,
+    sentAt: quote.sentAt ?? sentAt,
+    sentById: quote.sentById ?? quote.publishedById,
+    quoteDate,
+    validUntil: quote.validUntil ?? computeValidUntil(quoteDate, config.quoteValidityDays, config.timezone),
+    validityDays: quote.validityDays ?? config.quoteValidityDays,
+    // The deprecated columns are cleared once their values have moved, so the
+    // validator can drop them in a follow-up (the `depositPercent` lesson: a
+    // field can only leave the schema once no live row still carries it).
+    publishedAt: undefined,
+    publishedById: undefined,
+  });
+}
+
+/** Step 4: every project without a quote row gets a DRAFT at its revision. */
+async function insertDraftRevision(ctx: MutationCtx, project: Doc<"projects">, version: number): Promise<void> {
+  await ctx.db.insert("quotes", {
+    id: createId(),
+    organizationId: project.organizationId,
+    projectId: project.id,
+    version,
+    status: "DRAFT",
+    // A draft carries no frozen money — its figures are the project's live totals
+    // until it is sent (parity with `newVersionNative`).
+    snapshot: null,
+    createdAt: project.createdAt ?? project._creationTime,
+    updatedAt: project.updatedAt ?? project._creationTime,
+  });
+}
+
+/** The write half, split from the handler so the page loop stays a plain
+ *  plan → tally → apply sequence (R-3.6). */
+async function applyProjectWork(
+  ctx: MutationCtx,
+  project: Doc<"projects">,
+  work: ProjectWork,
+  configFor: (orgId: string) => Promise<QuoteConfig>,
+): Promise<void> {
+  if (work.needsRevision) await ctx.db.patch(project._id, { revision: work.maxVersion });
+  if (work.staleQuotes.length > 0) {
+    const config = await configFor(project.organizationId);
+    for (const quote of work.staleQuotes) await migrateQuoteRow(ctx, quote, config);
+  }
+  if (work.needsDraft) await insertDraftRevision(ctx, project, project.revision ?? work.maxVersion);
+}
+
+export const backfillQuoteRevisionsPage = mutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    apply: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    projectsStamped: v.number(),
+    quotesMigrated: v.number(),
+    draftsInserted: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, { cursor, apply, numItems }) => {
+    await requireService(ctx);
+    const res = await ctx.db.query("projects").paginate({ cursor, numItems: numItems ?? 300 });
+
+    const configCache = new Map<string, QuoteConfig>();
+    const configFor = async (orgId: string): Promise<QuoteConfig> => {
+      const hit = configCache.get(orgId);
+      if (hit) return hit;
+      const config = await resolveOrgQuoteConfig(ctx, orgId);
+      configCache.set(orgId, config);
+      return config;
+    };
+
+    const tally = { scanned: 0, projectsStamped: 0, quotesMigrated: 0, draftsInserted: 0 };
+
+    for (const project of res.page) {
+      if (project.isTemplate) continue; // templates are never quoted
+      const work = await planProjectWork(ctx, project);
+      if (!work) continue;
+
+      tally.scanned++;
+      if (work.needsRevision) tally.projectsStamped++;
+      tally.quotesMigrated += work.staleQuotes.length;
+      if (work.needsDraft) tally.draftsInserted++;
+      if (apply) await applyProjectWork(ctx, project, work, configFor);
+    }
+
+    return { ...tally, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});
+
+/**
+ * Verification — the "prove zero un-migrated rows" query the acceptance criteria
+ * ask for. Every number must read 0 after a full apply run; `liveQuoteRows` and
+ * `nonTemplateProjects` are the totals the operator compares against expectation
+ * BEFORE applying (decision 12: "effectively none" is a basis for choosing the
+ * simple path, not a licence to skip counting).
+ *
+ * Paginated like the migration itself so it can't blow the read limit on a large
+ * org — the driver accumulates across pages.
+ */
+/** The un-migrated conditions, counted per project so the query handler stays a
+ *  plain accumulation loop. Every field must read 0 after a full apply run. */
+const EMPTY_COUNTS = {
+  nonTemplateProjects: 0,
+  liveQuoteRows: 0,
+  projectsMissingRevision: 0,
+  projectsWithNoQuote: 0,
+  projectsWithRevisionBelowQuotes: 0,
+  quotesStillPublished: 0,
+  quotesMissingSentAt: 0,
+  quotesMissingValidUntil: 0,
+  duplicateRevisionRows: 0,
+};
+type VerifyCounts = typeof EMPTY_COUNTS;
+
+async function inspectProject(ctx: QueryCtx, project: Doc<"projects">): Promise<VerifyCounts> {
+  const counts = { ...EMPTY_COUNTS, nonTemplateProjects: 1 };
+  const quotes = await listProjectQuotes(ctx, project.organizationId, project.id);
+  counts.liveQuoteRows = quotes.length;
+
+  if (project.revision == null) counts.projectsMissingRevision = 1;
+  if (quotes.length === 0) counts.projectsWithNoQuote = 1;
+
+  const maxVersion = quotes.reduce((max, q) => Math.max(max, q.version ?? 1), 1);
+  if (project.revision != null && project.revision < maxVersion) counts.projectsWithRevisionBelowQuotes = 1;
+
+  countQuoteIssues(quotes, counts);
+  return counts;
+}
+
+/** The per-row un-migrated conditions, accumulated into `counts` in place. */
+function countQuoteIssues(quotes: Doc<"quotes">[], counts: VerifyCounts): void {
+  const seenVersions = new Set<number>();
+  for (const quote of quotes) {
+    if (seenVersions.has(quote.version)) counts.duplicateRevisionRows++;
+    seenVersions.add(quote.version);
+    if (quote.status === "PUBLISHED") counts.quotesStillPublished++;
+    if (quote.publishedAt != null && quote.sentAt == null) counts.quotesMissingSentAt++;
+    if (quote.status === "SENT" && quote.validUntil == null) counts.quotesMissingValidUntil++;
+  }
+}
+
+export const verifyQuoteRevisions = query({
+  args: { cursor: v.union(v.string(), v.null()), numItems: v.optional(v.number()) },
+  returns: v.object({
+    nonTemplateProjects: v.number(),
+    liveQuoteRows: v.number(),
+    projectsMissingRevision: v.number(),
+    projectsWithNoQuote: v.number(),
+    projectsWithRevisionBelowQuotes: v.number(),
+    quotesStillPublished: v.number(),
+    quotesMissingSentAt: v.number(),
+    quotesMissingValidUntil: v.number(),
+    duplicateRevisionRows: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, { cursor, numItems }) => {
+    await requireService(ctx);
+    const res = await ctx.db.query("projects").paginate({ cursor, numItems: numItems ?? 300 });
+
+    const totals = { ...EMPTY_COUNTS };
+    for (const project of res.page) {
+      if (project.isTemplate) continue;
+      const counts = await inspectProject(ctx, project);
+      for (const key of Object.keys(totals) as (keyof VerifyCounts)[]) totals[key] += counts[key];
+    }
+
+    return { ...totals, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});
+
+/** Guard used by the driver so a mismatch between the counted live rows and the
+ *  operator's `--expect-quotes` halts BEFORE anything is written. Exported (and
+ *  unit-tested) rather than inlined in the script so the halt condition is
+ *  itself covered. */
+export function assertExpectedQuoteRows(counted: number, expected: number | undefined): void {
+  if (expected === undefined) return;
+  if (counted !== expected) {
+    throw new ConvexError(
+      `Refusing to migrate: expected ${expected} live quote row(s), found ${counted}. ` +
+        "Re-run the dry run and confirm the figure before applying.",
+    );
+  }
+}

--- a/convex/lib/orgSettings.ts
+++ b/convex/lib/orgSettings.ts
@@ -1,4 +1,5 @@
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { resolveQuoteValidityDays } from "./quoteDates";
 
 /** Org default tax rate from the Convex orgSettings mirror (source of truth; the
  *  Postgres column is deprecated). null when unset. Resolved IN-mutation so browser
@@ -9,4 +10,31 @@ export async function resolveOrgDefaultTaxRate(ctx: MutationCtx | QueryCtx, orgI
     .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
     .first();
   return row?.defaultTaxRate ?? null;
+}
+
+/** The org's document settings that quote sending depends on, resolved IN-mutation
+ *  so a browser caller can't spoof them (#986). `settings` is the JSON string of
+ *  the `OrgSettings` TS shape (src/lib/org-settings-types.ts); an unparseable
+ *  blob degrades to the documented defaults rather than failing the send. */
+export async function resolveOrgQuoteConfig(
+  ctx: MutationCtx | QueryCtx,
+  orgId: string,
+): Promise<{ quoteValidityDays: number; timezone: string | undefined }> {
+  const row = await ctx.db
+    .query("orgSettings")
+    .withIndex("by_organizationId", (q) => q.eq("organizationId", orgId))
+    .first();
+  let parsed: { timezone?: unknown; documents?: { quoteValidityDays?: unknown } } = {};
+  if (row?.settings) {
+    try {
+      parsed = JSON.parse(row.settings) as typeof parsed;
+    } catch {
+      parsed = {};
+    }
+  }
+  const configured = parsed.documents?.quoteValidityDays;
+  return {
+    quoteValidityDays: resolveQuoteValidityDays(typeof configured === "number" ? configured : null),
+    timezone: typeof parsed.timezone === "string" && parsed.timezone ? parsed.timezone : undefined,
+  };
 }

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -153,7 +153,25 @@ export interface LifecycleGuardResult {
   defaultToZero: boolean;
 }
 
-const JUSTIFICATION_BOUNDS = { min: 10, max: 1000 } as const;
+/** #793's bounds for every "explain why you're overriding this" free-text field.
+ *  EXPORTED so the hard-lock-revert gate and #986's acceptance-gate override read
+ *  the same two numbers instead of hand-copying them (R-3.1) — they were already
+ *  duplicated inline in `projectWrites.updateStatusNative` before #986. */
+export const JUSTIFICATION_BOUNDS = { min: 10, max: 1000 } as const;
+
+/**
+ * Require a bounded justification, throwing `JUSTIFICATION_REQUIRED` with a
+ * caller-supplied explanation of what is being justified. Returns the trimmed
+ * text so the caller can persist exactly what was validated.
+ */
+export function requireJustification(justification: string | null | undefined, message: string): string {
+  const trimmed = justification?.trim();
+  if (!trimmed || trimmed.length < JUSTIFICATION_BOUNDS.min) {
+    throw new ConvexError({ code: "JUSTIFICATION_REQUIRED", message });
+  }
+  assertStrLen(trimmed, "justification", JUSTIFICATION_BOUNDS);
+  return trimmed;
+}
 
 /**
  * The one call every gate site makes (#793's "one shared guard helper... so

--- a/convex/lib/projectSnapshots.ts
+++ b/convex/lib/projectSnapshots.ts
@@ -12,7 +12,9 @@ import { LOCKED_GROUP_FIELDS, LOCKED_LINE_ITEM_FIELDS, LOCKED_PROJECT_FIELDS, LO
  * queryable join instead of a client-side JSON walk.
  */
 
-export type SnapshotReason = "CONFIRMED" | "COMPLETED" | "UNLOCK";
+/** #986 added QUOTE_SENT — the frozen entity state for a quote revision, taken by
+ *  `quotesWrites.sendNative`. It is the only reason that carries a `revision`. */
+export type SnapshotReason = "CONFIRMED" | "COMPLETED" | "UNLOCK" | "QUOTE_SENT";
 export type SnapshotEntityType = "project" | "category" | "group" | "lineItem" | "service" | "crewAssignment";
 export type UnlockScope = "FINANCIAL" | "FULL";
 
@@ -71,6 +73,10 @@ export interface CaptureSnapshotArgs {
   orgId: string;
   project: Doc<"projects">;
   reason: SnapshotReason;
+  /** The `projects.revision` this snapshot freezes. Set for QUOTE_SENT so the
+   *  quote row and its snapshot share one number; omitted for the status-driven
+   *  reasons, which aren't revision-scoped. */
+  revision?: number;
   statusFrom?: string;
   statusTo?: string;
   actor: { userId: string; userName: string };
@@ -81,7 +87,7 @@ export interface CaptureSnapshotArgs {
  *  assignments as one versioned snapshot. Returns the new snapshotId. Never
  *  overwrites a prior snapshot — every capture is a new row (versioned list). */
 export async function captureProjectSnapshot(ctx: MutationCtx, args: CaptureSnapshotArgs): Promise<string> {
-  const { orgId, project, reason, statusFrom, statusTo, actor, now } = args;
+  const { orgId, project, reason, revision, statusFrom, statusTo, actor, now } = args;
   const snapshotId = createId();
 
   await ctx.db.insert("projectSnapshots", {
@@ -89,6 +95,7 @@ export async function captureProjectSnapshot(ctx: MutationCtx, args: CaptureSnap
     organizationId: orgId,
     projectId: project.id,
     reason,
+    revision,
     takenAt: now,
     takenBy: actor.userId,
     takenByName: actor.userName,

--- a/convex/lib/quoteDates.ts
+++ b/convex/lib/quoteDates.ts
@@ -1,0 +1,149 @@
+import { datePartsInTimezone, type ProjectNumberDateParts } from "./projectNumber";
+
+/**
+ * Quote validity + expiry maths (#986) — the SINGLE definition of "how long is a
+ * quote valid" and "has it expired", shared by the send mutation
+ * (`convex/quotesWrites.ts`), the Finance tab and the PDF. Before #986 the
+ * default `30` was hand-copied into `document-settings.tsx` and
+ * `build-document-data.ts`, and validity was computed from `now` **at render
+ * time** — so re-opening a quote silently extended how long it was valid
+ * (`build-document-data.ts` L672-673). `validUntil` is now stamped once, at
+ * send, and only ever read back.
+ *
+ * Every day-boundary calculation resolves in the ORG's timezone, never the
+ * browser's or the server's — a quote must not expire a day early for a PM in
+ * another state (`docs/designs/finance-workflow-ux.md` §3.5).
+ *
+ * ⚠️ This file is a byte-for-byte MIRROR of `src/lib/quote-validity.ts` (only the
+ * `datePartsInTimezone` import path differs — the Convex bundler can't resolve
+ * `@/`). PINNED by a cross-import equality test in `convex/quoteDates.test.ts`,
+ * same pattern as `convex/lib/projectNumber.ts`. Do NOT diverge from the src/lib
+ * copy — change both or neither.
+ */
+
+/** Days a quote stays valid from its quote date when the org hasn't set one. */
+export const DEFAULT_QUOTE_VALIDITY_DAYS = 30;
+
+/** Bounds on `OrgDocumentSettings.quoteValidityDays` and the send dialog's
+ *  "valid for" input. Mirrored server-side via `assertNumRange` (R-8.6.2) and by
+ *  `orgDocumentSettingsSchema` — one definition, both ends. */
+export const QUOTE_VALIDITY_BOUNDS = { min: 1, max: 365 } as const;
+
+/** A sent quote inside this many days of `validUntil` reads as "expiring soon"
+ *  (warning intent). Authoritative for BOTH the per-project Finance tab and the
+ *  org-level Finance section's "Expiring" bucket — R-3.1. */
+export const QUOTE_EXPIRING_SOON_DAYS = 7;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The UTC-instant offset of `timezone` at a given instant, in ms
+ * (`local - UTC`; e.g. +10h for Australia/Sydney in winter). Returns 0 for an
+ * unresolvable timezone, matching `datePartsInTimezone`'s fallback posture —
+ * a bad timezone string degrades to UTC rather than throwing inside a mutation.
+ */
+function timezoneOffsetMs(instantMs: number, timezone?: string): number {
+  if (!timezone) return 0;
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(new Date(instantMs));
+    const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+    const year = get("year");
+    const month = get("month");
+    const day = get("day");
+    // Some ICU versions emit hour "24" for midnight under hour12:false.
+    const hour = get("hour") % 24;
+    const minute = get("minute");
+    const second = get("second");
+    if (![year, month, day, hour, minute, second].every((n) => Number.isFinite(n))) return 0;
+    const asUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+    // instantMs may carry sub-second precision the formatter dropped — floor to
+    // the second on both sides so the offset lands on a whole minute.
+    return asUtc - Math.floor(instantMs / 1000) * 1000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The UTC instant for a wall-clock time on a calendar date IN `timezone`.
+ * Two-pass: the first pass guesses with the offset in force at the naive UTC
+ * instant, the second re-resolves the offset at that guess — which is what makes
+ * it correct across a DST boundary (the offset that applies is the one at the
+ * *result*, not at the naive input).
+ */
+function zonedWallClockToUtc(
+  parts: ProjectNumberDateParts,
+  time: { hour: number; minute: number; second: number; ms: number },
+  timezone?: string,
+): number {
+  const naive = Date.UTC(parts.year, parts.month - 1, parts.day, time.hour, time.minute, time.second, time.ms);
+  const firstPass = naive - timezoneOffsetMs(naive, timezone);
+  return naive - timezoneOffsetMs(firstPass, timezone);
+}
+
+/** Add `days` calendar days to a Y/M/D triple. Pure UTC arithmetic — UTC has no
+ *  DST, so "add a day" can't land on a phantom or doubled local hour here; the
+ *  timezone only re-enters when the result is converted back to an instant. */
+export function addCalendarDays(parts: ProjectNumberDateParts, days: number): ProjectNumberDateParts {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day) + days * MS_PER_DAY);
+  return { year: shifted.getUTCFullYear(), month: shifted.getUTCMonth() + 1, day: shifted.getUTCDate() };
+}
+
+/** First instant (00:00:00.000 local) of the calendar day `instantMs` falls on
+ *  in `timezone`. Used to normalise a user-picked `quoteDate` so the date printed
+ *  on the PDF doesn't shift with the submitting browser's clock. */
+export function startOfDayInTimezone(instantMs: number, timezone?: string): number {
+  const parts = datePartsInTimezone(new Date(instantMs), timezone);
+  return zonedWallClockToUtc(parts, { hour: 0, minute: 0, second: 0, ms: 0 }, timezone);
+}
+
+/** Last instant (23:59:59.999 local) of the calendar day `instantMs` falls on
+ *  in `timezone` — a quote stays valid through the whole of its final day. */
+export function endOfDayInTimezone(instantMs: number, timezone?: string): number {
+  const parts = datePartsInTimezone(new Date(instantMs), timezone);
+  return zonedWallClockToUtc(parts, { hour: 23, minute: 59, second: 59, ms: 999 }, timezone);
+}
+
+/**
+ * `validUntil` for a quote: the END of the calendar day `validityDays` after the
+ * quote date, in the org's timezone. A quote dated 26 Jul valid for 30 days runs
+ * through the end of 25 Aug.
+ */
+export function computeValidUntil(quoteDateMs: number, validityDays: number, timezone?: string): number {
+  const start = datePartsInTimezone(new Date(quoteDateMs), timezone);
+  const end = addCalendarDays(start, validityDays);
+  return zonedWallClockToUtc(end, { hour: 23, minute: 59, second: 59, ms: 999 }, timezone);
+}
+
+/** Whether a stamped `validUntil` has passed. Timezone-free by construction —
+ *  `validUntil` is already an absolute instant resolved in the org's timezone. */
+export function isPastValidUntil(validUntil: number | null | undefined, nowMs: number): boolean {
+  return validUntil != null && validUntil < nowMs;
+}
+
+/** Whole days remaining until `validUntil` (negative once past, 0 on the final
+ *  day). Drives the `≤7 days` warning copy in the Finance tab. */
+export function daysUntilValidUntil(validUntil: number | null | undefined, nowMs: number): number | null {
+  if (validUntil == null) return null;
+  return Math.floor((validUntil - nowMs) / MS_PER_DAY);
+}
+
+/** Resolve the org's configured quote validity, clamped to the supported bounds.
+ *  A stored value outside them (hand-edited settings blob) falls back to the
+ *  default rather than minting an absurd `validUntil`. */
+export function resolveQuoteValidityDays(configured: number | null | undefined): number {
+  if (configured == null || !Number.isInteger(configured)) return DEFAULT_QUOTE_VALIDITY_DAYS;
+  if (configured < QUOTE_VALIDITY_BOUNDS.min || configured > QUOTE_VALIDITY_BOUNDS.max) {
+    return DEFAULT_QUOTE_VALIDITY_DAYS;
+  }
+  return configured;
+}

--- a/convex/lib/quoteState.ts
+++ b/convex/lib/quoteState.ts
@@ -1,0 +1,179 @@
+import { ConvexError } from "convex/values";
+import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { isPastValidUntil } from "./quoteDates";
+
+/**
+ * Quote revision state — the shared read model behind the five verbs
+ * (`convex/quotesWrites.ts`), the acceptance gate on `CONFIRMED`
+ * (`convex/projectWrites.ts`) and the Finance tab queries (`convex/quotes.ts`).
+ * #986, Phase A of the finance version-control program.
+ *
+ * Two rules are encoded here once so nothing re-derives them:
+ *
+ * 1. **`EXPIRED` is derived on read**, never stored — `validUntil < now &&
+ *    status === "SENT"`. No cron, no clock skew, no stale row (same precedent as
+ *    FEATUREDOCS/66's derived readiness chips). Everything that branches on
+ *    "is this quote still live" MUST go through `effectiveQuoteStatus`.
+ * 2. **`PUBLISHED` reads as `SENT`.** It is the deprecated pre-#986 value;
+ *    `backfillQuoteRevisions.ts` rewrites it, but readers normalise on the way
+ *    out so behaviour is identical before, during and after the migration.
+ *
+ * ⚠️ R-8.4.3: `quotes.by_cuid` and `by_projectId` are GLOBAL Convex indexes and
+ * `requireOrgRead`/`requireOrgPermission` authorise the CALLER's org, not the
+ * ROW's. Every loader in this file re-checks `organizationId` — use them rather
+ * than querying the table directly.
+ */
+
+/** The vocabulary a reader ever sees. `PUBLISHED` is normalised away; `EXPIRED`
+ *  is only ever produced here, never persisted. */
+export type EffectiveQuoteStatus =
+  | "DRAFT"
+  | "SENT"
+  | "ACCEPTED"
+  | "DECLINED"
+  | "SUPERSEDED"
+  | "EXPIRED";
+
+/** Statuses that represent a document the client is currently holding — the ones
+ *  `sendNative` supersedes when the next revision goes out, and the ones that
+ *  block cutting a second draft. */
+const LIVE_STATUSES: ReadonlySet<EffectiveQuoteStatus> = new Set<EffectiveQuoteStatus>([
+  "SENT",
+  "ACCEPTED",
+  "EXPIRED",
+]);
+
+/** Map a STORED status onto the post-#986 vocabulary. Only `PUBLISHED` moves. */
+export function normalizeStoredQuoteStatus(status: string): EffectiveQuoteStatus {
+  return (status === "PUBLISHED" ? "SENT" : status) as EffectiveQuoteStatus;
+}
+
+/**
+ * The status a reader should act on: the stored one, normalised, with `SENT`
+ * rendered as `EXPIRED` once `validUntil` has passed. An expired revision blocks
+ * acceptance until it is explicitly re-sent — that's the whole point of stamping
+ * `validUntil` at send instead of recomputing it at render time.
+ */
+export function effectiveQuoteStatus(
+  quote: Pick<Doc<"quotes">, "status" | "validUntil">,
+  nowMs: number,
+): EffectiveQuoteStatus {
+  const status = normalizeStoredQuoteStatus(quote.status);
+  if (status === "SENT" && isPastValidUntil(quote.validUntil, nowMs)) return "EXPIRED";
+  return status;
+}
+
+/** True when this revision is the document the client currently holds (sent,
+ *  accepted, or sent-and-since-expired). */
+export function isLiveQuoteStatus(status: EffectiveQuoteStatus): boolean {
+  return LIVE_STATUSES.has(status);
+}
+
+/** A project's revision number. Absent ⇒ 1 — pre-#986 documents and any row the
+ *  backfill hasn't reached read as v1 rather than `undefined` leaking into
+ *  arithmetic (R-3.1: ONE coalesce, not one per call site). */
+export function projectRevision(project: Pick<Doc<"projects">, "revision">): number {
+  const revision = project.revision;
+  return typeof revision === "number" && Number.isFinite(revision) && revision >= 1
+    ? Math.floor(revision)
+    : 1;
+}
+
+/** Every quote row for a project, org-checked (`by_projectId` is global). */
+export async function listProjectQuotes(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  projectId: string,
+): Promise<Doc<"quotes">[]> {
+  const rows = await ctx.db
+    .query("quotes")
+    .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+    .collect();
+  return rows.filter((r) => r.organizationId === orgId);
+}
+
+/** The single quote row at `(projectId, revision)`, org-checked. The "exactly one
+ *  row per revision" invariant makes this unambiguous; a second row at the same
+ *  revision is a bug, and this returns the first deterministically rather than
+ *  throwing, so a corrupted project stays readable. The org check is pushed into
+ *  the query so the read stays a point lookup on `by_projectId_version` rather
+ *  than a `.collect()` of the (already tiny) range. */
+export async function findQuoteAtRevision(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  projectId: string,
+  revision: number,
+): Promise<Doc<"quotes"> | null> {
+  return await ctx.db
+    .query("quotes")
+    .withIndex("by_projectId_version", (q) => q.eq("projectId", projectId).eq("version", revision))
+    .filter((q) => q.eq(q.field("organizationId"), orgId))
+    .first();
+}
+
+/** The revision the client is currently holding — the one `SENT`/`ACCEPTED` (or
+ *  since-expired) row. Null when nothing has been sent yet. */
+export async function findLiveQuote(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  projectId: string,
+  nowMs: number,
+): Promise<Doc<"quotes"> | null> {
+  const quotes = await listProjectQuotes(ctx, orgId, projectId);
+  return quotes.find((q) => isLiveQuoteStatus(effectiveQuoteStatus(q, nowMs))) ?? null;
+}
+
+/**
+ * Whether this project has an accepted quote revision — the gate on advancing to
+ * `CONFIRMED` (decision 3). Only the CURRENT document counts: sending a new
+ * revision supersedes the accepted one, so a project whose pricing changed after
+ * acceptance has to get the new revision accepted (or be overridden) before it
+ * can confirm again.
+ */
+export async function hasAcceptedQuote(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  projectId: string,
+  nowMs: number,
+): Promise<boolean> {
+  const quotes = await listProjectQuotes(ctx, orgId, projectId);
+  return quotes.some((q) => effectiveQuoteStatus(q, nowMs) === "ACCEPTED");
+}
+
+/** Load a quote by its cuid and assert it belongs to `orgId` (R-8.4.3 — `by_cuid`
+ *  is global). Throws `NOT_FOUND` for both "missing" and "another org's", so a
+ *  cross-tenant probe can't distinguish the two. */
+export async function requireQuoteInOrg(
+  ctx: QueryCtx | MutationCtx,
+  quoteId: string,
+  orgId: string,
+): Promise<Doc<"quotes">> {
+  const quote = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", quoteId)).first();
+  if (!quote || quote.organizationId !== orgId) {
+    throw new ConvexError({ code: "NOT_FOUND", message: "Quote not found." });
+  }
+  return quote;
+}
+
+/** Load a project by its cuid and assert it belongs to `orgId` (`by_cuid` is
+ *  global). Shared by every quote mutation so the check can't be forgotten. */
+export async function requireProjectInOrg(
+  ctx: QueryCtx | MutationCtx,
+  projectId: string,
+  orgId: string,
+): Promise<Doc<"projects">> {
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
+  if (!project || project.organizationId !== orgId) {
+    throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+  }
+  return project;
+}
+
+/** Human label for a revision — `<projectNumber> v<version>`. There is
+ *  deliberately no quote number (decision 5): the project number is already the
+ *  shared reference with the client, and a second counter would be one more
+ *  surface to keep in sync. Used in audit summaries and, later, PDF headers. */
+export function quoteLabel(projectNumber: string, version: number): string {
+  return `${projectNumber} v${version}`;
+}

--- a/convex/lib/validators.ts
+++ b/convex/lib/validators.ts
@@ -446,10 +446,29 @@ export const ProjectTaskPriority = v.union(
 
 // ─── WS1 Finance (#940) — Quote/Invoice entities, client payment profiles, Xero ───
 
+/**
+ * Quote revision state (#986 — Phase A of the finance version-control program).
+ *
+ * `EXPIRED` is DERIVED ON READ (`validUntil < now && status === "SENT"`), never
+ * stored — see `convex/lib/quoteState.ts` `effectiveQuoteStatus`. It is declared
+ * here only so the vocabulary is complete in one place for the client-facing
+ * `EffectiveQuoteStatus` type; no mutation ever writes it.
+ *
+ * `PUBLISHED` is DEPRECATED (pre-#986 vocabulary — "published" was never accurate,
+ * nothing was published anywhere). `backfillQuoteRevisions.ts` rewrites every
+ * live row to `SENT`; the literal stays declared until a run confirms zero
+ * remaining, because strict Convex schema validation rejects a push where an
+ * existing document carries a value the validator no longer declares (the
+ * `projects.depositPercent` prod-deploy incident, FEATUREDOCS/66).
+ */
 export const QuoteStatus = v.union(
   v.literal("DRAFT"),
-  v.literal("PUBLISHED"),
+  v.literal("SENT"),
+  v.literal("ACCEPTED"),
+  v.literal("DECLINED"),
   v.literal("SUPERSEDED"),
+  v.literal("EXPIRED"),
+  v.literal("PUBLISHED"),
 );
 export const InvoiceKind = v.union(
   v.literal("FULL"),

--- a/convex/projectLifecycleLocks.test.ts
+++ b/convex/projectLifecycleLocks.test.ts
@@ -39,8 +39,22 @@ async function project(t: ReturnType<typeof convexTest>, status: string, extra: 
   await t.run(async (ctx) => {
     await ctx.db.insert("projects", {
       id: "p1", organizationId: ORG, projectNumber: "P-1", name: "Test Gig",
-      status, isTemplate: false, taxRate: 10, discountPercent: 0,
+      status, isTemplate: false, taxRate: 10, discountPercent: 0, revision: 1,
       createdAt: NOW, updatedAt: NOW, ...extra,
+    });
+  });
+}
+
+/** #986 — advancing to CONFIRMED now requires an ACCEPTED quote revision (or an
+ *  admin override with a justification). Tests below whose subject is snapshot
+ *  capture, not the acceptance gate, satisfy it directly rather than routing
+ *  through the whole send/accept flow. The gate itself is covered in
+ *  convex/projectWrites.test.ts. */
+async function acceptedQuote(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("quotes", {
+      id: "q1", organizationId: ORG, projectId: "p1", version: 1, status: "ACCEPTED",
+      snapshot: null, sentAt: NOW, acceptedAt: NOW,
     });
   });
 }
@@ -318,6 +332,7 @@ describe("#792 snapshot capture at CONFIRMED/COMPLETED", () => {
     const t = makeT();
     await member(t, "member");
     await project(t, "QUOTED");
+    await acceptedQuote(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Speaker", unitPrice: 100, quantity: 1 });
     });
@@ -339,6 +354,7 @@ describe("#792 snapshot capture at CONFIRMED/COMPLETED", () => {
     const t = makeT();
     await member(t, "member");
     await project(t, "QUOTED");
+    await acceptedQuote(t);
     await t.withIdentity(asUser()).mutation(api.projectWrites.updateStatusNative, {
       id: "p1", orgId: ORG, status: "CONFIRMED", actor: ACTOR, auditId: "log1", now: NOW,
     });

--- a/convex/projectLocksRead.ts
+++ b/convex/projectLocksRead.ts
@@ -83,7 +83,16 @@ export const listSnapshots = query({
   returns: v.array(
     v.object({
       id: v.string(),
-      reason: v.union(v.literal("CONFIRMED"), v.literal("COMPLETED"), v.literal("UNLOCK")),
+      // QUOTE_SENT (#986) — a snapshot taken when a quote revision was sent.
+      // These carry `revision`, which the Versions panel uses to label the row
+      // "as of quote v2" rather than by its status transition.
+      reason: v.union(
+        v.literal("CONFIRMED"),
+        v.literal("COMPLETED"),
+        v.literal("UNLOCK"),
+        v.literal("QUOTE_SENT"),
+      ),
+      revision: v.optional(v.number()),
       takenAt: v.number(),
       takenBy: v.string(),
       takenByName: v.optional(v.string()),
@@ -101,6 +110,7 @@ export const listSnapshots = query({
       .map((s) => ({
         id: s.id,
         reason: s.reason,
+        revision: s.revision,
         takenAt: s.takenAt,
         takenBy: s.takenBy,
         takenByName: s.takenByName,

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -140,6 +140,161 @@ describe("projectWrites.updateStatusNative", () => {
   });
 });
 
+// #986 (decision 3) — a project may not advance to CONFIRMED until a quote
+// revision has been ACCEPTED. Overridable by the SAME narrow audience that can
+// open a full unlock session (org admins/owners + this project's PMs) with the
+// SAME bounded justification as #792/#793 — no new permission, no second copy of
+// the bounds (R-3.1).
+describe("projectWrites.updateStatusNative — acceptance gate on CONFIRMED (#986)", () => {
+  const toConfirmed = { id: "p1", orgId: ORG, status: "CONFIRMED" as const, actor: ACTOR, auditId: "log1", now: NOW };
+
+  async function seedAcceptedQuote(t: ReturnType<typeof makeT>, status: "ACCEPTED" | "SENT" = "ACCEPTED") {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("quotes", {
+        id: "q1", organizationId: ORG, projectId: "p1", version: 1, status,
+        snapshot: null, sentAt: NOW, validUntil: NOW + 30 * 86_400_000,
+      });
+    });
+  }
+
+  test("blocks the move when no quote revision has been accepted", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "QUOTED");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, toConfirmed),
+    ).rejects.toThrow(/no accepted quote/i);
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("QUOTED");
+  });
+
+  test("allows the move once a revision is ACCEPTED — no justification needed", async () => {
+    const t = makeT();
+    await seedProject(t, "member", false, "QUOTED");
+    await seedAcceptedQuote(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, toConfirmed);
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("CONFIRMED");
+  });
+
+  test("a merely SENT (unaccepted) revision does not satisfy the gate", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "QUOTED");
+    await seedAcceptedQuote(t, "SENT");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, toConfirmed),
+    ).rejects.toThrow(/no accepted quote/i);
+  });
+
+  test("another org's accepted quote never satisfies the gate (IDOR guard)", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "QUOTED");
+    await t.run(async (ctx) => {
+      // Same projectId, different org — `by_projectId` is a GLOBAL index.
+      await ctx.db.insert("quotes", {
+        id: "q_foreign", organizationId: "org_2", projectId: "p1", version: 1, status: "ACCEPTED", snapshot: null,
+      });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, toConfirmed),
+    ).rejects.toThrow(/no accepted quote/i);
+  });
+
+  test("an admin/owner overrides with a bounded justification, which is audited", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "QUOTED");
+
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, { ...toConfirmed, justification: "too short" }),
+    ).rejects.toThrow(/no accepted quote/i);
+
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...toConfirmed,
+      justification: "Client confirmed verbally on site; PO to follow.",
+    });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.status).toBe("CONFIRMED");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.metadata).toEqual({ justification: "Client confirmed verbally on site; PO to follow." });
+    });
+  });
+
+  test("a non-PM member cannot override even with a justification", async () => {
+    const t = makeT();
+    await seedProject(t, "member", false, "QUOTED");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+        ...toConfirmed,
+        justification: "Client confirmed verbally on site; PO to follow.",
+      }),
+    ).rejects.toThrow(/admins.*owners.*PM/i);
+  });
+
+  test("the project's assigned PM can override", async () => {
+    const t = makeT();
+    await seedProject(t, "member", false, "QUOTED");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectManagers", { id: "pm1", organizationId: ORG, projectId: "p1", userId: USER });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...toConfirmed,
+      justification: "Client confirmed verbally on site; PO to follow.",
+    });
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("CONFIRMED");
+  });
+
+  test("moves that don't land on CONFIRMED are ungated, and a no-op re-assert never re-prompts", async () => {
+    const t = makeT();
+    // Seeded AT confirmed with no accepted quote — leaving CONFIRMED, and
+    // re-asserting the SAME status, must both pass ungated.
+    await seedProject(t, "member");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...toConfirmed, status: "PREPPING" as const,
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...toConfirmed, status: "PREPPING" as const, auditId: "log2",
+    });
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("PREPPING");
+  });
+
+  test("RE-crossing into CONFIRMED is gated again (parity with the snapshot re-crossing rule)", async () => {
+    const t = makeT();
+    await seedProject(t, "owner");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...toConfirmed, status: "PREPPING" as const,
+    });
+    // Coming back needs the gate — pricing may have moved while it was reverted.
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, { ...toConfirmed, auditId: "log2" }),
+    ).rejects.toThrow(/no accepted quote/i);
+  });
+});
+
+// #986 — `projects.revision` is the shared quote/project version counter and is
+// SERVER-OWNED: written only by createNative (seeded to 1) and
+// quotesWrites.newVersionNative, never by a client patch.
+describe("projectWrites — projects.revision is server-owned (#986)", () => {
+  test("updateNative strips a client-supplied revision and refuses to clear it", async () => {
+    const t = makeT();
+    await seedProject(t, "member");
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      await ctx.db.patch(p!._id, { revision: 3 });
+    });
+
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateNative, {
+      id: "p1", orgId: ORG, set: { name: "Renamed", revision: 99 }, clear: ["revision"],
+      actor: ACTOR, auditId: "log9", now: NOW,
+    });
+
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.name).toBe("Renamed");
+    expect(p?.revision).toBe(3); // neither forged nor cleared
+  });
+});
+
 describe("projectWrites.updateNotesNative", () => {
   test("patches a whitelisted notes field + audit; clears on null", async () => {
     const t = makeT();

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -22,8 +22,10 @@ import {
   lifecycleAuditMetadata,
   LOCKED_PROJECT_FIELDS,
   requireHardLockOverrideAllowed,
+  requireJustification,
 } from "./lib/projectLocks";
 import { captureProjectSnapshot } from "./lib/projectSnapshots";
+import { hasAcceptedQuote } from "./lib/quoteState";
 import { autoCommitOpenSession } from "./projectUnlockSessionsWrites";
 
 /** Forward status transitions that a project's open BLOCKING comments must gate
@@ -156,14 +158,27 @@ export const updateStatusNative = mutation({
     // revert (normal forward move, ungated here).
     if (from !== status && isRevertOutOfHardLock(from, status)) {
       await requireHardLockOverrideAllowed(ctx, orgId, id, actor.userId);
-      const trimmed = justification?.trim();
-      if (!trimmed || trimmed.length < 10) {
-        throw new ConvexError({
-          code: "JUSTIFICATION_REQUIRED",
-          message: "Reverting a completed project's status requires a justification (at least 10 characters).",
-        });
-      }
-      assertStrLen(trimmed, "justification", { max: 1000 });
+      requireJustification(
+        justification,
+        "Reverting a completed project's status requires a justification (at least 10 characters).",
+      );
+    }
+
+    // #986 (decision 3): a project may not advance to CONFIRMED until a quote
+    // revision has been ACCEPTED — confirming a job the client never agreed to
+    // price is the failure the whole revision model exists to prevent. Overridable
+    // by the SAME narrow audience that can open a full unlock session (org
+    // admins/owners + this project's PMs) with the SAME bounded justification, so
+    // there is no new permission and no second copy of the bounds (R-3.1).
+    // Deliberately only on an actual transition INTO CONFIRMED: re-saving a
+    // project that is already CONFIRMED never re-prompts, and a later revision
+    // superseding the accepted one doesn't retroactively invalidate the status.
+    if (from !== status && status === "CONFIRMED" && !(await hasAcceptedQuote(ctx, orgId, id, now))) {
+      await requireHardLockOverrideAllowed(ctx, orgId, id, actor.userId);
+      requireJustification(
+        justification,
+        "This project has no accepted quote. Confirming anyway requires a justification (at least 10 characters).",
+      );
     }
 
     await ctx.db.patch(project._id, { status, updatedAt: now });
@@ -338,10 +353,21 @@ const PROJECT_MONEY_ANCHORS = [
   "depositPaid", "invoicedTotal",
 ] as const;
 
-/** Immutable on a general `updateNative` patch: the money anchors + `isTemplate` (a project
- * is never flipped to a template in place — that's a saveAsTemplate copy). `projectNumber`
- * stays editable (a legit code edit). */
-const PROJECT_UPDATE_IMMUTABLE = [...PROJECT_MONEY_ANCHORS, "isTemplate"] as const;
+/**
+ * SERVER-OWNED project fields that no client patch may set, for the same reason
+ * as `PROJECT_MONEY_ANCHORS` but a different authority. `revision` (#986) is the
+ * shared quote/project version counter — written ONLY by `createNative` (seeded
+ * to 1) and `quotesWrites.newVersionNative`. A client-settable revision would let
+ * a browser caller renumber, skip or rewind versions, which breaks monotonicity
+ * and would silently orphan the quote rows keyed to those numbers.
+ */
+const PROJECT_SERVER_OWNED = ["revision"] as const;
+
+/** Immutable on a general `updateNative` patch: the money anchors + the
+ * server-owned fields + `isTemplate` (a project is never flipped to a template in
+ * place — that's a saveAsTemplate copy). `projectNumber` stays editable (a legit
+ * code edit). */
+const PROJECT_UPDATE_IMMUTABLE = [...PROJECT_MONEY_ANCHORS, ...PROJECT_SERVER_OWNED, "isTemplate"] as const;
 
 const PROJECT_NEVER_CLEAR = new Set<string>([
   "id", "organizationId", "projectNumber", ...PROJECT_UPDATE_IMMUTABLE,
@@ -426,8 +452,9 @@ export const updateNative = mutation({
     if (!project) throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
     if (project.organizationId !== orgId) throw new ConvexError("Forbidden: organization mismatch.");
 
-    // strip organizationId/id (no cross-tenant reassign) + the recalc-owned money anchors
-    // and isTemplate (no client-forged totals / in-place template flip).
+    // strip organizationId/id (no cross-tenant reassign) + the recalc-owned money anchors,
+    // the server-owned `revision` counter (#986) and isTemplate (no client-forged totals,
+    // no client-renumbered revisions, no in-place template flip).
     const setObj = sanitizeClientSet(set, PROJECT_UPDATE_IMMUTABLE);
 
     // #791/#792 finance soft-lock: setting or clearing a locked project field
@@ -700,6 +727,11 @@ export const createNative = mutation({
     // status/isTemplate, not money, so it's unaffected by the strip.)
     const insertFields = { ...fields, projectNumber, discountPercent };
     for (const k of PROJECT_MONEY_ANCHORS) delete (insertFields as Record<string, unknown>)[k];
+    for (const k of PROJECT_SERVER_OWNED) delete (insertFields as Record<string, unknown>)[k];
+    // #986 — every real project starts at revision 1 (its first quote is v1).
+    // Templates carry no revision at all: they're never quoted, and a duplicate
+    // made from one starts its own count at 1 rather than inheriting a number.
+    if (!fields.isTemplate) (insertFields as Record<string, unknown>).revision = 1;
 
     await ctx.db.insert("projects", insertFields);
     await bumpProjectCounters(ctx, fields.organizationId, null, insertFields);

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -460,7 +460,9 @@ export const createWithUniqueNumber = mutation({
       )
       .unique();
     if (clash) return { created: false, id: clash.id };
-    await ctx.db.insert("projects", args);
+    // #986 — a real project starts at revision 1 (its first quote is v1), same as
+    // projectWrites.createNative. Templates carry no revision at all.
+    await ctx.db.insert("projects", args.isTemplate ? args : { ...args, revision: 1 });
     await bumpCountersForTable(ctx, "projects", null, args);
     return { created: true, id: args.id };
   },

--- a/convex/quoteDates.test.ts
+++ b/convex/quoteDates.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment node
+//
+// convex/lib/quoteDates.ts — quote validity + expiry maths (#986).
+//
+// Two jobs:
+//  1. PIN the duplication. The Convex bundler can't resolve `@/`, so this module
+//     is a byte-for-byte mirror of src/lib/quote-validity.ts. This test imports
+//     BOTH copies and asserts identical output over a matrix (same pattern as
+//     convex/projectNumber.test.ts).
+//  2. Prove the day-boundary behaviour the whole feature rests on: `validUntil`
+//     is the END of its calendar day IN THE ORG'S TIMEZONE, resolved correctly
+//     across DST transitions in both directions and across the year boundary. A
+//     quote must not expire a day early for a PM in another state.
+import { describe, test, expect } from "vitest";
+import {
+  addCalendarDays as convexAddDays,
+  computeValidUntil as convexValidUntil,
+  daysUntilValidUntil as convexDaysUntil,
+  endOfDayInTimezone as convexEndOfDay,
+  isPastValidUntil as convexIsPast,
+  resolveQuoteValidityDays as convexResolveDays,
+  startOfDayInTimezone as convexStartOfDay,
+  DEFAULT_QUOTE_VALIDITY_DAYS as CONVEX_DEFAULT,
+  QUOTE_EXPIRING_SOON_DAYS as CONVEX_EXPIRING_SOON,
+  QUOTE_VALIDITY_BOUNDS as CONVEX_BOUNDS,
+} from "./lib/quoteDates";
+import {
+  addCalendarDays as srcAddDays,
+  computeValidUntil as srcValidUntil,
+  daysUntilValidUntil as srcDaysUntil,
+  endOfDayInTimezone as srcEndOfDay,
+  isPastValidUntil as srcIsPast,
+  resolveQuoteValidityDays as srcResolveDays,
+  startOfDayInTimezone as srcStartOfDay,
+  DEFAULT_QUOTE_VALIDITY_DAYS as SRC_DEFAULT,
+  QUOTE_EXPIRING_SOON_DAYS as SRC_EXPIRING_SOON,
+  QUOTE_VALIDITY_BOUNDS as SRC_BOUNDS,
+} from "@/lib/quote-validity";
+
+const DAY = 86_400_000;
+
+const TIMEZONES = [
+  undefined,
+  "UTC",
+  "Australia/Sydney", // DST, southern hemisphere, +10/+11
+  "Australia/Brisbane", // no DST, +10 — the "same state, different rules" case
+  "America/New_York", // DST, northern hemisphere, -5/-4
+  "Asia/Kolkata", // +5:30 — a half-hour offset
+  "Pacific/Chatham", // +12:45/+13:45 — a quarter-hour offset with DST
+  "Not/AZone", // unresolvable → falls back to UTC, never throws
+];
+
+const INSTANTS = [
+  Date.UTC(2026, 0, 1, 0, 0, 0), // year boundary
+  Date.UTC(2026, 3, 4, 15, 30, 0), // AU DST end weekend (5 Apr 2026, 3am → 2am)
+  Date.UTC(2026, 9, 3, 14, 0, 0), // AU DST start weekend (4 Oct 2026, 2am → 3am)
+  Date.UTC(2026, 2, 8, 6, 59, 0), // US DST start (8 Mar 2026)
+  Date.UTC(2026, 10, 1, 5, 59, 0), // US DST end (1 Nov 2026)
+  Date.UTC(2026, 1, 27, 23, 59, 0), // leap-adjacent (2026 is not a leap year)
+  Date.UTC(2024, 1, 28, 12, 0, 0), // leap year, day before 29 Feb
+  Date.UTC(2026, 6, 26, 4, 0, 0), // the design doc's worked example (26 Jul)
+];
+
+const VALIDITY_DAYS = [1, 7, 14, 30, 45, 365];
+
+describe("quoteDates — convex/lib == src/lib (byte-for-byte pin)", () => {
+  test("the shared constants are identical", () => {
+    expect(CONVEX_DEFAULT).toBe(SRC_DEFAULT);
+    expect(CONVEX_EXPIRING_SOON).toBe(SRC_EXPIRING_SOON);
+    expect(CONVEX_BOUNDS).toEqual(SRC_BOUNDS);
+  });
+
+  test("every function agrees across the timezone × instant × validity matrix", () => {
+    for (const tz of TIMEZONES) {
+      for (const instant of INSTANTS) {
+        expect(convexStartOfDay(instant, tz)).toBe(srcStartOfDay(instant, tz));
+        expect(convexEndOfDay(instant, tz)).toBe(srcEndOfDay(instant, tz));
+        for (const days of VALIDITY_DAYS) {
+          expect(convexValidUntil(instant, days, tz)).toBe(srcValidUntil(instant, days, tz));
+        }
+      }
+    }
+    for (const days of [-1, 0, 1, 31, 365, 400]) {
+      expect(convexAddDays({ year: 2026, month: 7, day: 26 }, days)).toEqual(
+        srcAddDays({ year: 2026, month: 7, day: 26 }, days),
+      );
+    }
+    for (const configured of [undefined, null, 0, 1, 30, 365, 366, 14.5]) {
+      expect(convexResolveDays(configured)).toBe(srcResolveDays(configured));
+    }
+    expect(convexIsPast(100, 200)).toBe(srcIsPast(100, 200));
+    expect(convexDaysUntil(100, 200)).toBe(srcDaysUntil(100, 200));
+  });
+});
+
+describe("computeValidUntil — the day-boundary contract", () => {
+  test("lands on the END of the Nth calendar day after the quote date", () => {
+    // The design doc's worked example: dated 26 Jul, valid 30 days → 25 Aug.
+    const quoteDate = Date.UTC(2026, 6, 26, 9, 15, 0);
+    const validUntil = computeIn("UTC", quoteDate, 30);
+    expect(new Date(validUntil).toISOString()).toBe("2026-08-25T23:59:59.999Z");
+  });
+
+  test("resolves in the ORG's timezone, not the server's", () => {
+    const quoteDate = Date.UTC(2026, 6, 26, 9, 15, 0); // 26 Jul UTC = 26 Jul 19:15 Sydney
+    const sydney = computeIn("Australia/Sydney", quoteDate, 7);
+    // 26 Jul 19:15 Sydney + 7 days = 2 Aug; end of 2 Aug at +10 = 2 Aug 13:59:59.999Z.
+    expect(new Date(sydney).toISOString()).toBe("2026-08-02T13:59:59.999Z");
+    expect(localPartsIn("Australia/Sydney", sydney)).toBe("2026-08-02 23:59:59");
+    // A UTC-resolved answer would have been 10 hours later — that gap is exactly
+    // the "expires a day early for a PM in another state" bug.
+    expect(sydney).toBeLessThan(computeIn("UTC", quoteDate, 7));
+  });
+
+  test("a quote spanning a DST START keeps a whole final day (the 23h day)", () => {
+    // Sydney springs forward 2am → 3am on 4 Oct 2026.
+    const quoteDate = Date.UTC(2026, 8, 27, 2, 0, 0); // 27 Sep 12:00 Sydney
+    const validUntil = computeIn("Australia/Sydney", quoteDate, 10); // → 7 Oct
+    // 7 Oct is post-transition (+11), so end-of-day is 12:59:59.999Z.
+    expect(new Date(validUntil).toISOString()).toBe("2026-10-07T12:59:59.999Z");
+    expect(localPartsIn("Australia/Sydney", validUntil)).toBe("2026-10-07 23:59:59");
+  });
+
+  test("a quote spanning a DST END keeps a whole final day (the 25h day)", () => {
+    // Sydney falls back 3am → 2am on 5 Apr 2026.
+    const quoteDate = Date.UTC(2026, 2, 28, 2, 0, 0); // 28 Mar 13:00 Sydney (+11)
+    const validUntil = computeIn("Australia/Sydney", quoteDate, 14); // → 11 Apr (+10)
+    expect(new Date(validUntil).toISOString()).toBe("2026-04-11T13:59:59.999Z");
+    expect(localPartsIn("Australia/Sydney", validUntil)).toBe("2026-04-11 23:59:59");
+  });
+
+  test("northern-hemisphere DST is handled the same way", () => {
+    const quoteDate = Date.UTC(2026, 2, 1, 17, 0, 0); // 1 Mar 12:00 New York (-5)
+    const validUntil = computeIn("America/New_York", quoteDate, 14); // → 15 Mar (-4)
+    expect(localPartsIn("America/New_York", validUntil)).toBe("2026-03-15 23:59:59");
+  });
+
+  test("half- and quarter-hour offsets land on the local day, not a rounded one", () => {
+    const quoteDate = Date.UTC(2026, 6, 26, 20, 0, 0); // 27 Jul 01:30 Kolkata
+    expect(localPartsIn("Asia/Kolkata", computeIn("Asia/Kolkata", quoteDate, 30))).toBe("2026-08-26 23:59:59");
+    expect(localPartsIn("Pacific/Chatham", computeIn("Pacific/Chatham", quoteDate, 30))).toBe("2026-08-26 23:59:59");
+  });
+
+  test("crosses month, year and leap-day boundaries", () => {
+    expect(localPartsIn("UTC", computeIn("UTC", Date.UTC(2026, 11, 20), 30))).toBe("2027-01-19 23:59:59");
+    expect(localPartsIn("UTC", computeIn("UTC", Date.UTC(2024, 1, 15), 30))).toBe("2024-03-16 23:59:59"); // via 29 Feb
+  });
+
+  test("an unresolvable timezone degrades to UTC instead of throwing", () => {
+    expect(computeIn("Not/AZone", Date.UTC(2026, 6, 26), 30)).toBe(computeIn("UTC", Date.UTC(2026, 6, 26), 30));
+  });
+});
+
+describe("expiry derivation", () => {
+  const quoteDate = Date.UTC(2026, 6, 26, 9, 0, 0);
+  const validUntil = computeIn("Australia/Sydney", quoteDate, 7);
+
+  test("is not expired at any point on the final local day, and is the instant after", () => {
+    expect(convexIsPast(validUntil, validUntil)).toBe(false);
+    expect(convexIsPast(validUntil, validUntil - 1)).toBe(false);
+    expect(convexIsPast(validUntil, validUntil + 1)).toBe(true);
+  });
+
+  test("never expires for an unstamped (draft) revision", () => {
+    expect(convexIsPast(undefined, Date.now())).toBe(false);
+    expect(convexIsPast(null, Date.now())).toBe(false);
+  });
+
+  test("daysUntilValidUntil counts down to 0 on the final day and goes negative after", () => {
+    expect(convexDaysUntil(validUntil, validUntil - 3 * DAY)).toBe(3);
+    expect(convexDaysUntil(validUntil, validUntil - 1)).toBe(0);
+    expect(convexDaysUntil(validUntil, validUntil + DAY)).toBe(-1);
+    expect(convexDaysUntil(null, 0)).toBeNull();
+  });
+});
+
+describe("resolveQuoteValidityDays", () => {
+  test("falls back to the default for unset, non-integer or out-of-range values", () => {
+    expect(convexResolveDays(undefined)).toBe(CONVEX_DEFAULT);
+    expect(convexResolveDays(null)).toBe(CONVEX_DEFAULT);
+    expect(convexResolveDays(0)).toBe(CONVEX_DEFAULT);
+    expect(convexResolveDays(366)).toBe(CONVEX_DEFAULT);
+    expect(convexResolveDays(14.5)).toBe(CONVEX_DEFAULT);
+  });
+
+  test("passes through anything inside the shared bounds", () => {
+    expect(convexResolveDays(CONVEX_BOUNDS.min)).toBe(CONVEX_BOUNDS.min);
+    expect(convexResolveDays(CONVEX_BOUNDS.max)).toBe(CONVEX_BOUNDS.max);
+    expect(convexResolveDays(7)).toBe(7);
+  });
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function computeIn(timezone: string, quoteDateMs: number, days: number): number {
+  return convexValidUntil(quoteDateMs, days, timezone);
+}
+
+/** "YYYY-MM-DD HH:mm:ss" as read in `timezone` — asserts the LOCAL wall clock,
+ *  which is the thing the feature actually promises. */
+function localPartsIn(timezone: string, instantMs: number): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(new Date(instantMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour") === "24" ? "00" : get("hour")}:${get("minute")}:${get("second")}`;
+}

--- a/convex/quotes.ts
+++ b/convex/quotes.ts
@@ -1,16 +1,77 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { requireOrgRead } from "./lib/auth";
+import {
+  effectiveQuoteStatus,
+  isLiveQuoteStatus,
+  listProjectQuotes,
+  projectRevision,
+  requireProjectInOrg,
+} from "./lib/quoteState";
 
-/** Read-only queries for the `quotes` table (WS1 #940). */
+/**
+ * Read-only queries for the `quotes` table (WS1 #940, reworked by #986).
+ *
+ * Every row is returned with a DERIVED `effectiveStatus`, because `EXPIRED` is
+ * never stored — `validUntil < now && SENT` is resolved on read (no cron, no
+ * clock skew, no stale row). Consumers MUST branch on `effectiveStatus`, not on
+ * the raw `status` column, which can still read `PUBLISHED` on any row the
+ * backfill hasn't reached.
+ *
+ * `now` is a client-supplied argument rather than `Date.now()` because a Convex
+ * query must be deterministic to stay reactively cacheable — the same reason
+ * every `*Native` mutation takes one. Omitting it yields the stored statuses
+ * with no expiry applied.
+ *
+ * The previous `listForProject` read `by_projectId` (a GLOBAL index) with no org
+ * re-check; `listProjectQuotes` filters by `organizationId` (R-8.4.3).
+ */
 
 export const listForProject = query({
-  args: { orgId: v.string(), projectId: v.string() },
-  handler: async (ctx, { orgId, projectId }) => {
+  args: { orgId: v.string(), projectId: v.string(), now: v.optional(v.number()) },
+  handler: async (ctx, { orgId, projectId, now }) => {
     await requireOrgRead(ctx, orgId);
-    return await ctx.db
-      .query("quotes")
-      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .collect();
+    const at = now ?? 0;
+    const quotes = await listProjectQuotes(ctx, orgId, projectId);
+    return quotes
+      .map((q) => ({ ...q, effectiveStatus: effectiveQuoteStatus(q, at) }))
+      .sort((a, b) => b.version - a.version);
+  },
+});
+
+/**
+ * The project's revision state in one round trip: the current revision number,
+ * the open draft (if any) and the revision the client is currently holding.
+ * Backs the Finance tab's lock strip and, in Phase C (#988), the quote input to
+ * `resolveLockTier`.
+ */
+export const revisionStateForProject = query({
+  args: { orgId: v.string(), projectId: v.string(), now: v.optional(v.number()) },
+  handler: async (ctx, { orgId, projectId, now }) => {
+    await requireOrgRead(ctx, orgId);
+    const at = now ?? 0;
+    const project = await requireProjectInOrg(ctx, projectId, orgId);
+    const revision = projectRevision(project);
+    const quotes = await listProjectQuotes(ctx, orgId, projectId);
+
+    const withStatus = quotes.map((q) => ({ quote: q, status: effectiveQuoteStatus(q, at) }));
+    const draft = withStatus.find((r) => r.status === "DRAFT" && r.quote.version === revision);
+    const live = withStatus.find((r) => isLiveQuoteStatus(r.status));
+
+    return {
+      revision,
+      hasAcceptedQuote: withStatus.some((r) => r.status === "ACCEPTED"),
+      draftQuoteId: draft?.quote.id ?? null,
+      liveQuote: live
+        ? {
+            id: live.quote.id,
+            version: live.quote.version,
+            status: live.status,
+            sentAt: live.quote.sentAt ?? live.quote.publishedAt ?? null,
+            validUntil: live.quote.validUntil ?? null,
+            snapshotId: live.quote.snapshotId ?? null,
+          }
+        : null,
+    };
   },
 });

--- a/convex/quotesWrites.test.ts
+++ b/convex/quotesWrites.test.ts
@@ -149,6 +149,36 @@ describe("quotesWrites.sendNative", () => {
     await expect(send(t, { recipientContactId: "ct1" })).rejects.toThrow(/client contact not found/i);
   });
 
+  test("supersedes an ACCEPTED revision too — acceptance doesn't survive a re-quote", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.markAcceptedNative, {
+      id: "q1", organizationId: ORG, actor, auditId: "a2", now: NOW + 1,
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a3", now: NOW + 2,
+    });
+    // v1 is STILL accepted while v2 is only a draft — cutting a draft never
+    // invalidates what the client agreed to.
+    let state = await t
+      .withIdentity(asUser(ORG))
+      .query(api.quotes.revisionStateForProject, { orgId: ORG, projectId: "p1", now: NOW + 2 });
+    expect(state.hasAcceptedQuote).toBe(true);
+
+    await send(t, { id: "ignored", auditId: "a4", now: NOW + 3 });
+
+    // …but once v2 actually goes out, v1 is no longer the deal. The project
+    // needs v2 accepted (or an admin override) before it can confirm again —
+    // the pricing the client agreed to has changed.
+    state = await t
+      .withIdentity(asUser(ORG))
+      .query(api.quotes.revisionStateForProject, { orgId: ORG, projectId: "p1", now: NOW + 3 });
+    expect(state.hasAcceptedQuote).toBe(false);
+    expect((await getQuotes(t)).find((q) => q.id === "q1")?.status).toBe("SUPERSEDED");
+  });
+
   test("rejects a cross-org projectId (IDOR guard)", async () => {
     const t = makeT();
     await seedMember(t);

--- a/convex/quotesWrites.test.ts
+++ b/convex/quotesWrites.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment node
 //
-// convex/quotesWrites.ts — quote publish/supersede. Verifies: server-computed
-// snapshot money (never client-supplied), versioning + supersede-on-republish,
-// the RBAC + lifecycle-lock guards, and cross-tenant IDOR protection on
-// projectId (R-8.4.3 — every doc fetched by global index must be org-checked).
+// convex/quotesWrites.ts — the five quote-revision verbs (#986). Verifies the
+// four server-enforced invariants (one row per revision, one draft, one live
+// document, monotonic revision), supersede-on-SEND-not-on-draft, the recall
+// round trip, derived-EXPIRED behaviour, server-computed snapshot money (never
+// client-supplied), RBAC per verb (incl. recall's narrower audience), and
+// cross-tenant IDOR protection on every mutation (R-8.4.3 — every doc fetched by
+// a global index must be org-checked).
 import { convexTest } from "convex-test";
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { describe, test, expect } from "vitest";
@@ -16,6 +19,7 @@ const ORG = "org_1";
 const OTHER = "org_2";
 const USER = "user_1";
 const NOW = 1_700_000_000_000;
+const DAY = 86_400_000;
 const actor = { userId: USER, userName: "Alice" };
 const asUser = (orgId: string) => ({ subject: USER, orgId });
 
@@ -25,17 +29,18 @@ function makeT() {
   return t;
 }
 
-async function seedMember(t: ReturnType<typeof makeT>, role = "owner") {
+async function seedMember(t: ReturnType<typeof makeT>, role = "owner", orgId = ORG, userId = USER) {
   await t.run(async (ctx) => {
-    await ctx.db.insert("members", { id: "m1", organizationId: ORG, userId: USER, role });
+    await ctx.db.insert("members", { id: `m_${userId}_${orgId}`, organizationId: orgId, userId, role });
   });
 }
 
 async function seedProject(t: ReturnType<typeof makeT>, orgId = ORG, status: Doc<"projects">["status"] = "QUOTING") {
   await t.run(async (ctx) => {
     await ctx.db.insert("projects", {
-      id: "p1", organizationId: orgId, projectNumber: "P1", name: "Gig",
-      status, isTemplate: false, subtotal: 100, discountAmount: 0, taxAmount: 10, total: 110, taxRate: 10,
+      id: "p1", organizationId: orgId, projectNumber: "RVLT-2026-0087", name: "Gig",
+      status, isTemplate: false, revision: 1,
+      subtotal: 100, discountAmount: 0, taxAmount: 10, total: 110, taxRate: 10,
       createdAt: NOW, updatedAt: NOW,
     });
     await ctx.db.insert("projectLineItems", {
@@ -45,45 +50,103 @@ async function seedProject(t: ReturnType<typeof makeT>, orgId = ORG, status: Doc
   });
 }
 
-const getQuotes = (t: ReturnType<typeof makeT>) => t.run(async (ctx) => ctx.db.query("quotes").withIndex("by_projectId", (q) => q.eq("projectId", "p1")).collect());
+const getQuotes = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => ctx.db.query("quotes").withIndex("by_projectId", (q) => q.eq("projectId", "p1")).collect());
+const getProject = (t: ReturnType<typeof makeT>) =>
+  t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
 
-describe("quotesWrites.publishNative", () => {
-  test("publishes v1 with a server-computed snapshot (never trusts client money)", async () => {
+const sendArgs = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: "q1", organizationId: ORG, projectId: "p1", quoteDate: NOW, actor, auditId: "a1", now: NOW, ...over,
+});
+
+/** Send the current revision, returning the created/updated quote id. */
+async function send(t: ReturnType<typeof makeT>, over: Partial<Record<string, unknown>> = {}) {
+  return await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.sendNative, sendArgs(over) as never);
+}
+
+describe("quotesWrites.sendNative", () => {
+  test("sends v1 with a server-computed snapshot (never trusts client money)", async () => {
     const t = makeT();
     await seedMember(t);
     await seedProject(t);
 
-    const result = await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-      id: "q1", organizationId: ORG, projectId: "p1", notes: "Valid 30 days", actor, auditId: "a1", now: NOW,
-    });
+    const result = await send(t, { notes: "Valid 30 days" });
     expect(result.version).toBe(1);
 
     const quotes = await getQuotes(t);
     expect(quotes).toHaveLength(1);
-    expect(quotes[0]?.status).toBe("PUBLISHED");
+    expect(quotes[0]?.status).toBe("SENT");
+    expect(quotes[0]?.sentById).toBe(USER);
     const snapshot = quotes[0]?.snapshot as { lines: { description: string; lineTotal: number }[]; total: number };
-    expect(snapshot.total).toBe(110); // from the project's OWN recalc-owned total, not client input
+    expect(snapshot.total).toBe(110); // the project's OWN recalc-owned total, not client input
     expect(snapshot.lines.some((l) => l.description === "PA System" && l.lineTotal === 100)).toBe(true);
   });
 
-  test("republishing supersedes the prior PUBLISHED quote and bumps the version", async () => {
+  test("stamps validUntil from quoteDate + validityDays and captures a QUOTE_SENT snapshot", async () => {
     const t = makeT();
     await seedMember(t);
     await seedProject(t);
 
-    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-      id: "q1", organizationId: ORG, projectId: "p1", actor, auditId: "a1", now: NOW,
-    });
-    const second = await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW + 1,
-    });
-    expect(second.version).toBe(2);
+    const result = await send(t, { validityDays: 14 });
+    // End of the 14th day after the quote date (UTC — no org timezone configured).
+    expect(result.validUntil).toBe(Date.UTC(2023, 10, 28, 23, 59, 59, 999));
+
+    const snapshots = await t.run(async (ctx) => ctx.db.query("projectSnapshots").collect());
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.reason).toBe("QUOTE_SENT");
+    expect(snapshots[0]?.revision).toBe(1);
 
     const quotes = await getQuotes(t);
-    const v1 = quotes.find((q) => q.id === "q1");
-    const v2 = quotes.find((q) => q.id === "q2");
-    expect(v1?.status).toBe("SUPERSEDED");
-    expect(v2?.status).toBe("PUBLISHED");
+    expect(quotes[0]?.snapshotId).toBe(snapshots[0]?.id);
+  });
+
+  test("falls back to the org's configured quoteValidityDays", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("orgSettings", {
+        organizationId: ORG,
+        settings: JSON.stringify({ documents: { quoteValidityDays: 7 } }),
+      });
+    });
+
+    const result = await send(t);
+    expect(result.validUntil).toBe(Date.UTC(2023, 10, 21, 23, 59, 59, 999));
+    const quotes = await getQuotes(t);
+    expect(quotes[0]?.validityDays).toBe(7);
+  });
+
+  test("offers QUOTED from ENQUIRY/QUOTING but never applies it itself", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t, ORG, "QUOTING");
+
+    const result = await send(t);
+    expect(result.offerStatusChange).toBe("QUOTED");
+    expect((await getProject(t))?.status).toBe("QUOTING"); // NOT forced
+  });
+
+  test("re-sending an already-sent revision is rejected — cut a new version instead", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    await expect(send(t, { id: "q2", auditId: "a2", now: NOW + 1 })).rejects.toThrow(/already been sent/i);
+  });
+
+  test("rejects a recipient contact belonging to another client", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      await ctx.db.patch(project!._id, { clientId: "c1" });
+      await ctx.db.insert("clientContacts", { id: "ct1", organizationId: ORG, clientId: "c_other", name: "Bob" });
+    });
+
+    await expect(send(t, { recipientContactId: "ct1" })).rejects.toThrow(/client contact not found/i);
   });
 
   test("rejects a cross-org projectId (IDOR guard)", async () => {
@@ -91,32 +154,326 @@ describe("quotesWrites.publishNative", () => {
     await seedMember(t);
     await seedProject(t, OTHER); // project belongs to a DIFFERENT org
 
-    await expect(
-      t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-        id: "q1", organizationId: ORG, projectId: "p1", actor, auditId: "a1", now: NOW,
-      }),
-    ).rejects.toThrow(/not found in your organization/i);
+    await expect(send(t)).rejects.toThrow(/not found in your organization/i);
   });
 
   test("a viewer is denied (invoice:publish)", async () => {
     const t = makeT();
     await seedMember(t, "viewer");
     await seedProject(t);
-    await expect(
-      t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-        id: "q1", organizationId: ORG, projectId: "p1", actor, auditId: "a1", now: NOW,
-      }),
-    ).rejects.toThrow(/insufficient permissions/i);
+    await expect(send(t)).rejects.toThrow(/insufficient permissions/i);
   });
 
   test("a FINANCE_LOCKED project (CONFIRMED+) without an open unlock session is rejected", async () => {
     const t = makeT();
     await seedMember(t, "manager");
     await seedProject(t, ORG, "CONFIRMED");
+    await expect(send(t)).rejects.toThrow(/financials.*locked/i);
+  });
+
+  test("mirrors its Zod bounds server-side (notes + validityDays)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+
+    await expect(send(t, { notes: "x".repeat(2001) })).rejects.toThrow(/at most 2000/i);
+    await expect(send(t, { validityDays: 0 })).rejects.toThrow(/at least 1/i);
+    await expect(send(t, { validityDays: 400 })).rejects.toThrow(/at most 365/i);
+    await expect(send(t, { validityDays: 1.5 })).rejects.toThrow(/whole number/i);
+  });
+});
+
+describe("quotesWrites.newVersionNative — monotonicity and the one-draft invariant", () => {
+  test("increments projects.revision and opens a DRAFT, leaving the sent revision alone", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    const result = await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW + 1,
+    });
+    expect(result.version).toBe(2);
+    expect((await getProject(t))?.revision).toBe(2);
+
+    const quotes = await getQuotes(t);
+    // SUPERSEDE FIRES ON SEND, NOT ON DRAFT — v1 is still the client's document.
+    expect(quotes.find((q) => q.id === "q1")?.status).toBe("SENT");
+    expect(quotes.find((q) => q.id === "q2")?.status).toBe("DRAFT");
+    expect(quotes.find((q) => q.id === "q2")?.snapshot).toBeNull();
+  });
+
+  test("v1 flips to SUPERSEDED only when v2 is actually sent", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW + 1,
+    });
+    await send(t, { id: "ignored", auditId: "a3", now: NOW + 2 });
+
+    const quotes = await getQuotes(t);
+    expect(quotes.find((q) => q.id === "q1")?.status).toBe("SUPERSEDED");
+    expect(quotes.find((q) => q.id === "q1")?.supersededByQuoteId).toBe("q2");
+    expect(quotes.find((q) => q.id === "q2")?.status).toBe("SENT");
+    // Exactly one row per revision — the send reused the existing v2 draft rather
+    // than inserting a second row at version 2.
+    expect(quotes.filter((q) => q.version === 2)).toHaveLength(1);
+  });
+
+  test("refuses to cut a second draft while one is open", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+
     await expect(
-      t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.publishNative, {
-        id: "q1", organizationId: ORG, projectId: "p1", actor, auditId: "a1", now: NOW,
+      t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+        id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW,
       }),
-    ).rejects.toThrow(/financials.*locked/i);
+    ).rejects.toThrow(/hasn't been sent yet/i);
+  });
+
+  test("revision is never decremented or reused — a recalled-then-re-sent revision keeps its number", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.recallNative, {
+      id: "q1", organizationId: ORG, reason: "Wrong rental window", actor, auditId: "a2", now: NOW + 1,
+    });
+    const resent = await send(t, { auditId: "a3", now: NOW + 2 });
+
+    expect(resent.version).toBe(1);
+    expect((await getProject(t))?.revision).toBe(1);
+    expect(await getQuotes(t)).toHaveLength(1);
+  });
+
+  test("rejects a cross-org projectId (IDOR guard)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t, OTHER);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+        id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW,
+      }),
+    ).rejects.toThrow(/not found in your organization/i);
+  });
+});
+
+describe("quotesWrites.recallNative", () => {
+  const recall = (t: ReturnType<typeof makeT>, over: Partial<Record<string, unknown>> = {}) =>
+    t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.recallNative, {
+      id: "q1", organizationId: ORG, reason: "Wrong rental window", actor, auditId: "a2", now: NOW + 1, ...over,
+    } as never);
+
+  test("round trip: SENT → DRAFT, keeping the row and its send history", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    await recall(t);
+    const quotes = await getQuotes(t);
+    expect(quotes[0]?.status).toBe("DRAFT");
+    expect(quotes[0]?.recallReason).toBe("Wrong rental window");
+    expect(quotes[0]?.recalledById).toBe(USER);
+    // Never deleted — the client may already be holding the document.
+    expect(quotes[0]?.sentAt).toBe(NOW);
+  });
+
+  test("restores the revision this send superseded", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW + 1,
+    });
+    await send(t, { id: "ignored", auditId: "a3", now: NOW + 2 });
+
+    const result = await recall(t, { id: "q2", auditId: "a4", now: NOW + 3 });
+    expect(result.restoredQuoteId).toBe("q1");
+
+    const quotes = await getQuotes(t);
+    expect(quotes.find((q) => q.id === "q1")?.status).toBe("SENT");
+    expect(quotes.find((q) => q.id === "q1")?.supersededByQuoteId).toBeUndefined();
+    expect(quotes.find((q) => q.id === "q2")?.status).toBe("DRAFT");
+  });
+
+  test("a manager can send but CANNOT recall; the project's PM can", async () => {
+    const t = makeT();
+    await seedMember(t, "manager");
+    await seedProject(t);
+    await send(t); // manager sends fine — invoice:publish
+
+    await expect(recall(t)).rejects.toThrow(/admins.*owners.*PM/i);
+
+    // Same manager, now an assigned PM on this project.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectManagers", { id: "pm1", organizationId: ORG, projectId: "p1", userId: USER });
+    });
+    await recall(t, { auditId: "a5" });
+    expect((await getQuotes(t))[0]?.status).toBe("DRAFT");
+  });
+
+  test("requires a bounded reason (reuses #793's 10-char floor)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    await expect(recall(t, { reason: "typo" })).rejects.toThrow(/at least 10/i);
+    await expect(recall(t, { reason: "x".repeat(1001) })).rejects.toThrow(/at most 1000/i);
+  });
+
+  test("cannot recall a draft or an accepted revision", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.markAcceptedNative, {
+      id: "q1", organizationId: ORG, actor, auditId: "a2", now: NOW + 1,
+    });
+
+    await expect(recall(t, { auditId: "a3" })).rejects.toThrow(/is accepted/i);
+  });
+
+  test("rejects another org's quote (IDOR guard)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedMember(t, "owner", OTHER, "user_2");
+    await seedProject(t, OTHER);
+    await t.withIdentity({ subject: "user_2", orgId: OTHER }).mutation(api.quotesWrites.sendNative, {
+      id: "q1", organizationId: OTHER, projectId: "p1", quoteDate: NOW,
+      actor: { userId: "user_2", userName: "Bob" }, auditId: "a1", now: NOW,
+    });
+
+    await expect(recall(t)).rejects.toThrow(/quote not found/i);
+  });
+});
+
+describe("quotesWrites.markAcceptedNative / markDeclinedNative", () => {
+  const accept = (t: ReturnType<typeof makeT>, over: Partial<Record<string, unknown>> = {}) =>
+    t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.markAcceptedNative, {
+      id: "q1", organizationId: ORG, actor, auditId: "a2", now: NOW + 1, ...over,
+    } as never);
+  const decline = (t: ReturnType<typeof makeT>, over: Partial<Record<string, unknown>> = {}) =>
+    t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.markDeclinedNative, {
+      id: "q1", organizationId: ORG, reason: "Too expensive", actor, auditId: "a2", now: NOW + 1, ...over,
+    } as never);
+
+  test("accept records the date + reference and offers CONFIRMED", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    const result = await accept(t, { acceptanceRef: "PO-4821" });
+    expect(result.offerStatusChange).toBe("CONFIRMED");
+    const quotes = await getQuotes(t);
+    expect(quotes[0]?.status).toBe("ACCEPTED");
+    expect(quotes[0]?.acceptanceRef).toBe("PO-4821");
+    expect(quotes[0]?.acceptedById).toBe(USER);
+  });
+
+  test("an EXPIRED revision cannot be accepted without a re-send", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t, { validityDays: 1 });
+
+    // Two days later the SENT row reads EXPIRED — derived, never stored.
+    await expect(accept(t, { now: NOW + 2 * DAY })).rejects.toThrow(/expired/i);
+    expect((await getQuotes(t))[0]?.status).toBe("SENT"); // still SENT on disk
+
+    // Re-sending reopens the window, and acceptance then succeeds.
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.recallNative, {
+      id: "q1", organizationId: ORG, reason: "Client asked for more time", actor, auditId: "a3", now: NOW + 2 * DAY,
+    });
+    await send(t, { quoteDate: NOW + 2 * DAY, auditId: "a4", now: NOW + 2 * DAY });
+    await accept(t, { auditId: "a5", now: NOW + 2 * DAY + 1 });
+    expect((await getQuotes(t))[0]?.status).toBe("ACCEPTED");
+  });
+
+  test("decline records a bounded reason and offers CANCELLED without forcing it", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+
+    const result = await decline(t);
+    expect(result.offerStatusChange).toBe("CANCELLED");
+    expect((await getQuotes(t))[0]?.status).toBe("DECLINED");
+    expect((await getProject(t))?.status).toBe("QUOTING"); // NOT forced
+    await expect(decline(t, { reason: "x" })).rejects.toThrow(/at least 3/i);
+  });
+
+  test("a viewer is denied both verbs", async () => {
+    const t = makeT();
+    await seedMember(t, "owner");
+    await seedProject(t);
+    await send(t);
+    await t.run(async (ctx) => {
+      const member = await ctx.db.query("members").first();
+      await ctx.db.patch(member!._id, { role: "viewer" });
+    });
+
+    await expect(accept(t)).rejects.toThrow(/insufficient permissions/i);
+    await expect(decline(t)).rejects.toThrow(/insufficient permissions/i);
+  });
+
+  test("reject another org's quote (IDOR guard)", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedMember(t, "owner", OTHER, "user_2");
+    await seedProject(t, OTHER);
+    await t.withIdentity({ subject: "user_2", orgId: OTHER }).mutation(api.quotesWrites.sendNative, {
+      id: "q1", organizationId: OTHER, projectId: "p1", quoteDate: NOW,
+      actor: { userId: "user_2", userName: "Bob" }, auditId: "a1", now: NOW,
+    });
+
+    await expect(accept(t)).rejects.toThrow(/quote not found/i);
+    await expect(decline(t)).rejects.toThrow(/quote not found/i);
+  });
+});
+
+describe("quotes read queries", () => {
+  test("listForProject derives EXPIRED and never leaks another org's rows", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t, { validityDays: 1 });
+    // A same-projectId row planted under another org — `by_projectId` is global.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("quotes", {
+        id: "foreign", organizationId: OTHER, projectId: "p1", version: 9, status: "SENT", snapshot: null,
+      });
+    });
+
+    const rows = await t
+      .withIdentity(asUser(ORG))
+      .query(api.quotes.listForProject, { orgId: ORG, projectId: "p1", now: NOW + 2 * DAY });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.effectiveStatus).toBe("EXPIRED");
+    expect(rows[0]?.status).toBe("SENT"); // stored value untouched
+  });
+
+  test("revisionStateForProject reports the revision, the draft and the live document", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor, auditId: "a2", now: NOW + 1,
+    });
+
+    const state = await t
+      .withIdentity(asUser(ORG))
+      .query(api.quotes.revisionStateForProject, { orgId: ORG, projectId: "p1", now: NOW + 1 });
+    expect(state.revision).toBe(2);
+    expect(state.draftQuoteId).toBe("q2");
+    expect(state.liveQuote?.id).toBe("q1");
+    expect(state.hasAcceptedQuote).toBe(false);
   });
 });

--- a/convex/quotesWrites.ts
+++ b/convex/quotesWrites.ts
@@ -1,116 +1,649 @@
 import { v, ConvexError } from "convex/values";
 import { mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { requireOrgPermission, resolveActor } from "./lib/auth";
 import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
-import { assertStrLen } from "./lib/fieldGuards";
-import { assertRefInOrg } from "./lib/orgRef";
-import { assertLifecycleGuard } from "./lib/projectLocks";
+import { assertNumRange, assertStrLen } from "./lib/fieldGuards";
+import { assertClientContactBelongsToClient, assertRefInOrg } from "./lib/orgRef";
+import { assertLifecycleGuard, requireHardLockOverrideAllowed } from "./lib/projectLocks";
+import { captureProjectSnapshot } from "./lib/projectSnapshots";
 import { buildFinanceLines } from "./lib/financeSnapshot";
+import { resolveOrgQuoteConfig } from "./lib/orgSettings";
+import { computeValidUntil, startOfDayInTimezone, QUOTE_VALIDITY_BOUNDS } from "./lib/quoteDates";
+import {
+  effectiveQuoteStatus,
+  findQuoteAtRevision,
+  isLiveQuoteStatus,
+  listProjectQuotes,
+  projectRevision,
+  quoteLabel,
+  requireProjectInOrg,
+  requireQuoteInOrg,
+  type EffectiveQuoteStatus,
+} from "./lib/quoteState";
 
 /**
- * Quote write mutations (WS1 #940) — browser-direct, the standard 4-guard
- * shape (FEATUREDOCS/54). Publish = SNAPSHOT the project's current pricing
- * into a new, versioned, immutable row; republish supersedes the previous
- * PUBLISHED quote (never overwritten in place — the client saw a real
- * document at version N, so it stays retrievable even after version N+1
- * exists). The snapshot money is built server-side from the project's own
- * recalc-owned totals + `buildFinanceLines` (R-9.3 — no client-supplied
- * amount is ever trusted).
+ * Quote revision mutations (#986 — Phase A of the finance version-control
+ * program). Five verbs over ONE shared counter, `projects.revision`:
+ *
+ * ```
+ *   v1 DRAFT ─ send ─▶ v1 SENT ─ accept ─▶ v1 ACCEPTED ─▶ project may CONFIRM
+ *        ▲               │ │ │
+ *        └─ recall ──────┘ │ └─ decline ─▶ v1 DECLINED
+ *                          └─ new version ─▶ v2 DRAFT  (v1 → SUPERSEDED on v2's send)
+ * ```
+ *
+ * Properties this file exists to guarantee, each with a test in
+ * `quotesWrites.test.ts`:
+ *
+ * - **Exactly one quote row per `(projectId, revision)`** — `by_projectId_version`
+ *   is the uniqueness guard.
+ * - **At most one `DRAFT`**, always at `projects.revision`.
+ * - **At most one live (`SENT`/`ACCEPTED`) row** — the document the client is
+ *   currently holding.
+ * - **`projects.revision` is monotonic** — never decremented, never reused. A
+ *   recalled-then-re-sent revision keeps its number.
+ * - **Supersede fires on SEND, not on draft.** v1 stays `SENT` while v2 is a
+ *   draft, so cutting a draft never invalidates the client's document. That is
+ *   the difference between version control and a delete button.
+ *
+ * Every mutation takes the standard 4-guard browser-direct shape
+ * (FEATUREDOCS/54): `assertWritesEnabled`, `enforceBrowserWriteLimit`,
+ * `requireOrgPermission`, `resolveActor` — plus org-checked reference loads
+ * (`by_cuid`/`by_projectId` are GLOBAL indexes, R-8.4.3) and `writeActivityLog`.
+ *
+ * **Money never originates from the client** (R-9.3). `sendNative`'s only client
+ * inputs are `quoteDate`, `validityDays`, `recipientContactId` and `notes`; every
+ * figure comes from `buildFinanceLines` plus the project's own recalc-owned
+ * totals, exactly as the superseded `publishNative` did.
+ *
+ * **Permissions (decision 11).** Send / new-version / accept / decline check
+ * `invoice:publish` (owner/admin/manager). **Recall additionally requires
+ * `isHardLockOverrideAllowed`** (org admin/owner, or one of the project's
+ * `projectManagers`) — un-sending a document the client may already be holding is
+ * trust-sensitive in a way the other four verbs are not. No new permission
+ * resource is introduced.
  */
 
 const actorValidator = v.object({ userId: v.string(), userName: v.string() });
 
-function assertQuoteFields(f: { notes?: string }): void {
-  assertStrLen(f.notes, "notes", { max: 2000 });
+/** Mirrors `quoteSchema`'s bounds in `src/lib/validations/quote.ts` — the client
+ *  Zod parse is UX only and is bypassable by any caller with a valid session
+ *  hitting the mutation directly (FEATUREDOCS/54 "the write security bar"). */
+const NOTES_BOUNDS = { max: 2000 } as const;
+/** Recall reuses #793's justification bounds rather than inventing a third copy. */
+const RECALL_REASON_BOUNDS = { min: 10, max: 1000 } as const;
+const DECLINE_REASON_BOUNDS = { min: 3, max: 1000 } as const;
+const ACCEPTANCE_REF_BOUNDS = { max: 200 } as const;
+/** Any date a client may stamp on a revision. Bounded so a typo'd year can't mint
+ *  a `validUntil` centuries out (or a negative instant). */
+const DATE_BOUNDS = { min: 0, max: 4_102_444_800_000 } as const; // ≤ 2100-01-01
+
+/** Project statuses a successful send offers to advance to `QUOTED` from. The
+ *  UI decides whether to take the offer — status is never forced by a quote verb
+ *  (same precedent as "issuing an invoice offers to advance to INVOICED"). */
+const SEND_OFFERS_QUOTED_FROM = new Set(["ENQUIRY", "QUOTING"]);
+/** Accepting offers to advance to CONFIRMED from any pre-confirmed status. */
+const ACCEPT_OFFERS_CONFIRMED_FROM = new Set(["ENQUIRY", "QUOTING", "QUOTED"]);
+
+const offerValidator = v.union(
+  v.literal("QUOTED"),
+  v.literal("CONFIRMED"),
+  v.literal("CANCELLED"),
+  v.null(),
+);
+
+/** The 4-guard preamble every verb shares. `invoice:publish` is the audience for
+ *  all five; recall layers `requireHardLockOverrideAllowed` on top. */
+async function guardQuoteWrite(
+  ctx: MutationCtx,
+  orgId: string,
+  suppliedActor: { userId: string; userName: string },
+): Promise<{ userId: string; userName: string }> {
+  await assertWritesEnabled(ctx, "quote");
+  await enforceBrowserWriteLimit(ctx);
+  await requireOrgPermission(ctx, orgId, "invoice", "publish");
+  return await resolveActor(ctx, suppliedActor);
 }
 
-export const publishNative = mutation({
-  returns: v.object({ id: v.string(), version: v.number() }),
+/** Load the quote + its project together, both org-checked, for the four verbs
+ *  that address a quote by id. */
+async function loadQuoteAndProject(
+  ctx: MutationCtx,
+  quoteId: string,
+  orgId: string,
+): Promise<{ quote: Doc<"quotes">; project: Doc<"projects"> }> {
+  const quote = await requireQuoteInOrg(ctx, quoteId, orgId);
+  const project = await requireProjectInOrg(ctx, quote.projectId, orgId);
+  return { quote, project };
+}
+
+/** Assert a quote is in one of the states a verb accepts, with a message that
+ *  names the actual state and the way out rather than a bare "invalid". */
+function assertQuoteStatusIs(
+  actual: EffectiveQuoteStatus,
+  allowed: readonly EffectiveQuoteStatus[],
+  label: string,
+  verb: string,
+): void {
+  if (allowed.includes(actual)) return;
+  const hint =
+    actual === "EXPIRED"
+      ? ` It expired — send it again to ${verb} it.`
+      : actual === "DRAFT"
+        ? " It hasn't been sent yet."
+        : actual === "SUPERSEDED"
+          ? " A newer revision has since been sent."
+          : "";
+  throw new ConvexError({
+    code: "QUOTE_STATE_INVALID",
+    message: `Can't ${verb} ${label} — it is ${actual.toLowerCase()}.${hint}`,
+  });
+}
+
+/** The money snapshot frozen onto a revision at send. Built entirely server-side
+ *  from `buildFinanceLines` + the project's recalc-owned totals (R-9.3). */
+async function buildQuoteSnapshot(
+  ctx: MutationCtx,
+  project: Doc<"projects">,
+  notes: string | undefined,
+): Promise<Record<string, unknown>> {
+  const lines = await buildFinanceLines(ctx, project.id);
+  return {
+    lines,
+    subtotal: Number(project.subtotal) || 0,
+    discountPercent: Number(project.discountPercent) || 0,
+    discountAmount: Number(project.discountAmount) || 0,
+    taxRate: project.taxRate != null ? Number(project.taxRate) : null,
+    taxAmount: Number(project.taxAmount) || 0,
+    total: Number(project.total) || 0,
+    notes: notes ?? null,
+  };
+}
+
+/**
+ * Everything `sendNative` must establish before it starts writing: the project is
+ * real, in-org, not a template, not hard-locked; the recipient (if any) belongs to
+ * this project's client; the current revision has an editable draft (or none yet);
+ * and the client-minted id isn't a duplicate. Split out of the handler so the
+ * write path reads as a straight line (R-3.6).
+ */
+async function prepareSend(
+  ctx: MutationCtx,
+  args: { organizationId: string; projectId: string; id: string; recipientContactId?: string; now: number },
+): Promise<{ project: Doc<"projects">; revision: number; label: string; existing: Doc<"quotes"> | null; quoteId: string }> {
+  const { organizationId, projectId, id, recipientContactId, now } = args;
+
+  await assertRefInOrg(ctx, "projects", projectId, organizationId);
+  const project = await requireProjectInOrg(ctx, projectId, organizationId);
+  if (project.isTemplate) {
+    throw new ConvexError({ code: "TEMPLATE_QUOTE", message: "Templates don't have quotes." });
+  }
+  // Same financial gate every money-touching mutation uses, so a hard-locked
+  // project can't emit a quote out of band. NOTE for #988 (Phase C): once
+  // `resolveLockTier` folds quote state in, a SENT quote itself raises the tier —
+  // this call site must then treat "cut and send the NEXT revision" as the
+  // sanctioned exit from the quote-derived lock, or sending v2 would be blocked
+  // by v1's own lock.
+  await assertLifecycleGuard(ctx, project, { kind: "financial" });
+
+  // The recipient must belong to THIS project's client — otherwise a caller could
+  // stamp another client's contact onto the revision and leak their PII onto the
+  // document (the same check the project's own contact picker makes).
+  if (recipientContactId) {
+    if (!project.clientId) {
+      throw new ConvexError({ code: "INVALID_FIELD", message: "Assign a client before choosing a recipient." });
+    }
+    await assertClientContactBelongsToClient(ctx, recipientContactId, project.clientId, organizationId);
+  }
+
+  const revision = projectRevision(project);
+  const label = quoteLabel(project.projectNumber, revision);
+  const existing = await findQuoteAtRevision(ctx, organizationId, projectId, revision);
+  if (existing) {
+    if (effectiveQuoteStatus(existing, now) !== "DRAFT") {
+      throw new ConvexError({
+        code: "QUOTE_ALREADY_SENT",
+        message: `${label} has already been sent. Create v${revision + 1} to change it.`,
+      });
+    }
+  } else {
+    // `by_cuid` is global and non-unique — dup-guard the client-minted id.
+    const dup = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dup) throw new ConvexError({ code: "DUPLICATE", message: "Quote already exists" });
+  }
+
+  return { project, revision, label, existing, quoteId: existing?.id ?? id };
+}
+
+/** Supersede-on-SEND (never on draft): whatever the client was holding stops
+ *  being the current document the moment a newer revision goes out. */
+async function supersedeLiveQuotes(
+  ctx: MutationCtx,
+  orgId: string,
+  projectId: string,
+  keepQuoteId: string,
+  now: number,
+): Promise<void> {
+  for (const other of await listProjectQuotes(ctx, orgId, projectId)) {
+    if (other.id === keepQuoteId) continue;
+    if (!isLiveQuoteStatus(effectiveQuoteStatus(other, now))) continue;
+    await ctx.db.patch(other._id, { status: "SUPERSEDED", supersededByQuoteId: keepQuoteId, updatedAt: now });
+  }
+}
+
+/**
+ * SEND — the freeze moment. Stamps the user-chosen `quoteDate`, the computed
+ * `validUntil`, the recipient and the money snapshot onto the current revision,
+ * captures a `QUOTE_SENT` project snapshot for the same revision, and supersedes
+ * whatever the client was previously holding.
+ *
+ * "Send" does NOT email anybody (decision 7) — Flow records the send, freezes
+ * pricing and (Phase B, #987) produces the PDF for the user to attach to their
+ * own mail. The dialog says so outright.
+ *
+ * The DRAFT row is created here when the revision has none yet, so a project that
+ * has never quoted doesn't need a separate "create draft" round trip. `id` is the
+ * client-minted cuid for that row and is ignored when a draft already exists.
+ */
+export const sendNative = mutation({
+  returns: v.object({
+    id: v.string(),
+    version: v.number(),
+    validUntil: v.number(),
+    offerStatusChange: offerValidator,
+  }),
   args: {
     id: v.string(),
     organizationId: v.string(),
     projectId: v.string(),
+    /** User-chosen date printed on the PDF and the anchor for validity. */
+    quoteDate: v.number(),
+    /** Defaults to the org's `documents.quoteValidityDays` when omitted. */
+    validityDays: v.optional(v.number()),
+    recipientContactId: v.optional(v.string()),
     notes: v.optional(v.string()),
     actor: actorValidator,
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, notes, actor: suppliedActor, auditId, now }) => {
-    await assertWritesEnabled(ctx, "quote");
-    await enforceBrowserWriteLimit(ctx);
-    await requireOrgPermission(ctx, organizationId, "invoice", "publish");
-    const actor = await resolveActor(ctx, suppliedActor);
-    assertQuoteFields({ notes });
+  handler: async (ctx, args) => {
+    const { id, organizationId, projectId, quoteDate, validityDays, recipientContactId, notes, auditId, now } = args;
+    const actor = await guardQuoteWrite(ctx, organizationId, args.actor);
+
+    assertStrLen(notes, "notes", NOTES_BOUNDS);
+    assertNumRange(quoteDate, "quoteDate", DATE_BOUNDS);
+    assertNumRange(validityDays, "validityDays", { ...QUOTE_VALIDITY_BOUNDS, integer: true });
+
+    const { project, revision, label, existing, quoteId } = await prepareSend(ctx, {
+      organizationId, projectId, id, recipientContactId, now,
+    });
+
+    const config = await resolveOrgQuoteConfig(ctx, organizationId);
+    const days = validityDays ?? config.quoteValidityDays;
+    // Normalise to the org's calendar day so the printed date (and the validity
+    // window derived from it) doesn't shift with the sender's browser clock.
+    const stampedQuoteDate = startOfDayInTimezone(quoteDate, config.timezone);
+    const validUntil = computeValidUntil(stampedQuoteDate, days, config.timezone);
+
+    const snapshot = await buildQuoteSnapshot(ctx, project, notes);
+    const snapshotId = await captureProjectSnapshot(ctx, {
+      orgId: organizationId, project, reason: "QUOTE_SENT", revision, actor, now,
+    });
+    await supersedeLiveQuotes(ctx, organizationId, projectId, quoteId, now);
+
+    const sendFields = {
+      status: "SENT" as const,
+      snapshot,
+      snapshotId,
+      quoteDate: stampedQuoteDate,
+      validUntil,
+      validityDays: days,
+      recipientContactId,
+      notes,
+      sentAt: now,
+      sentById: actor.userId,
+      // A re-send after a recall clears the recall marker on the row itself; the
+      // audit log keeps the history.
+      recalledAt: undefined,
+      recalledById: undefined,
+      recallReason: undefined,
+      updatedAt: now,
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, sendFields);
+    } else {
+      await ctx.db.insert("quotes", {
+        id: quoteId,
+        organizationId,
+        projectId,
+        version: revision,
+        createdById: actor.userId,
+        createdAt: now,
+        ...sendFields,
+      });
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "UPDATE",
+      entityType: "quote",
+      entityId: quoteId,
+      entityName: label,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Sent quote ${label}`,
+      details: { version: revision, quoteDate: stampedQuoteDate, validUntil, total: snapshot.total },
+      projectId,
+      createdAt: now,
+    });
+
+    return {
+      id: quoteId,
+      version: revision,
+      validUntil,
+      offerStatusChange: SEND_OFFERS_QUOTED_FROM.has(project.status ?? "") ? ("QUOTED" as const) : null,
+    };
+  },
+});
+
+/**
+ * RECALL — un-send, for the pre-client typo fix. `SENT → DRAFT` on the same
+ * revision (the number is never reused or skipped). The stored artifact is marked
+ * recalled and RETAINED, never deleted: the client may already be holding it, so
+ * destroying our copy would make the record worse, not better.
+ *
+ * Restores whatever this send superseded back to `SENT` — after recalling v2, the
+ * last thing actually sent is v1, and the model must say so.
+ *
+ * Narrower audience than the other verbs (decision 11): `invoice:publish` AND
+ * `isHardLockOverrideAllowed`.
+ */
+export const recallNative = mutation({
+  returns: v.object({ id: v.string(), version: v.number(), restoredQuoteId: v.union(v.string(), v.null()) }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    reason: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, reason, actor: suppliedActor, auditId, now }) => {
+    const actor = await guardQuoteWrite(ctx, organizationId, suppliedActor);
+    const { quote, project } = await loadQuoteAndProject(ctx, id, organizationId);
+    await requireHardLockOverrideAllowed(ctx, organizationId, project.id, actor.userId);
+
+    const trimmed = reason.trim();
+    assertStrLen(trimmed, "reason", RECALL_REASON_BOUNDS);
+
+    const label = quoteLabel(project.projectNumber, quote.version);
+    assertQuoteStatusIs(effectiveQuoteStatus(quote, now), ["SENT", "EXPIRED"], label, "recall");
+
+    await ctx.db.patch(quote._id, {
+      status: "DRAFT",
+      recalledAt: now,
+      recalledById: actor.userId,
+      recallReason: trimmed,
+      updatedAt: now,
+    });
+
+    // Un-supersede the revision this one displaced: with v2 recalled, v1 is once
+    // again the document the client is holding.
+    let restoredQuoteId: string | null = null;
+    for (const other of await listProjectQuotes(ctx, organizationId, project.id)) {
+      if (other.id === quote.id || other.supersededByQuoteId !== quote.id) continue;
+      if (effectiveQuoteStatus(other, now) !== "SUPERSEDED") continue;
+      await ctx.db.patch(other._id, { status: "SENT", supersededByQuoteId: undefined, updatedAt: now });
+      restoredQuoteId = other.id;
+    }
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "UPDATE",
+      entityType: "quote",
+      entityId: quote.id,
+      entityName: label,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Recalled quote ${label}`,
+      details: { version: quote.version, restoredQuoteId },
+      metadata: { reason: trimmed },
+      projectId: project.id,
+      createdAt: now,
+    });
+
+    return { id: quote.id, version: quote.version, restoredQuoteId };
+  },
+});
+
+/**
+ * NEW VERSION — the unlock. Increments `projects.revision` and opens a `DRAFT`
+ * quote at the new number. The previous `SENT`/`ACCEPTED` row is deliberately
+ * left alone: it stays the client's current document until the new revision is
+ * actually sent.
+ *
+ * Requires the current revision to have been sent (in any terminal state) —
+ * cutting v2 while v1 is still a draft would break "at most one DRAFT, always at
+ * `projects.revision`". Edit the draft instead.
+ */
+export const newVersionNative = mutation({
+  returns: v.object({ id: v.string(), version: v.number() }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    projectId: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, projectId, actor: suppliedActor, auditId, now }) => {
+    const actor = await guardQuoteWrite(ctx, organizationId, suppliedActor);
 
     await assertRefInOrg(ctx, "projects", projectId, organizationId);
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
-    if (!project) throw new ConvexError("Project not found: " + projectId);
+    const project = await requireProjectInOrg(ctx, projectId, organizationId);
+    if (project.isTemplate) {
+      throw new ConvexError({ code: "TEMPLATE_QUOTE", message: "Templates don't have quotes." });
+    }
     await assertLifecycleGuard(ctx, project, { kind: "financial" });
 
-    // Dup-guard the client-minted id (by_cuid is global + non-unique).
-    const dup = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", id)).first();
-    if (dup) throw new ConvexError("Quote already exists");
-
-    // Supersede the current PUBLISHED quote for this project, if any.
-    const existingPublished = await ctx.db
-      .query("quotes")
-      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
-      .filter((q) => q.eq(q.field("status"), "PUBLISHED"))
-      .collect();
-    let nextVersion = 1;
-    for (const q of existingPublished) {
-      nextVersion = Math.max(nextVersion, (q.version ?? 0) + 1);
-      await ctx.db.patch(q._id, { status: "SUPERSEDED", updatedAt: now });
+    const revision = projectRevision(project);
+    const current = await findQuoteAtRevision(ctx, organizationId, projectId, revision);
+    if (!current || effectiveQuoteStatus(current, now) === "DRAFT") {
+      throw new ConvexError({
+        code: "QUOTE_DRAFT_OPEN",
+        message: `Quote v${revision} hasn't been sent yet — edit that draft instead of creating v${revision + 1}.`,
+      });
     }
-    // Also account for any prior SUPERSEDED versions when computing the next
-    // number (a project republished 3x should reach version 4, not loop at 2).
-    const allForProject = await ctx.db.query("quotes").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect();
-    for (const q of allForProject) nextVersion = Math.max(nextVersion, (q.version ?? 0) + 1);
 
-    const lines = await buildFinanceLines(ctx, projectId);
-    const snapshot = {
-      lines,
-      subtotal: Number(project.subtotal) || 0,
-      discountPercent: Number(project.discountPercent) || 0,
-      discountAmount: Number(project.discountAmount) || 0,
-      taxRate: project.taxRate != null ? Number(project.taxRate) : null,
-      taxAmount: Number(project.taxAmount) || 0,
-      total: Number(project.total) || 0,
-      notes: notes ?? null,
-    };
+    const next = revision + 1;
+    // Monotonicity belt-and-braces: a row already sitting at the next number
+    // would mean `projects.revision` had drifted backwards. Never overwrite it.
+    if (await findQuoteAtRevision(ctx, organizationId, projectId, next)) {
+      throw new ConvexError({
+        code: "QUOTE_VERSION_CONFLICT",
+        message: `Quote v${next} already exists for this project.`,
+      });
+    }
+    const dup = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", id)).first();
+    if (dup) throw new ConvexError({ code: "DUPLICATE", message: "Quote already exists" });
 
+    await ctx.db.patch(project._id, { revision: next, updatedAt: now });
+    // A draft carries NO money snapshot — its figures are the project's live
+    // totals until the moment it is sent. Freezing them now would be a lie that
+    // drifts silently (`snapshot` is only ever written by `sendNative`).
     await ctx.db.insert("quotes", {
       id,
       organizationId,
       projectId,
-      version: nextVersion,
-      status: "PUBLISHED",
-      snapshot,
-      publishedAt: now,
-      publishedById: actor.userId,
+      version: next,
+      status: "DRAFT",
+      snapshot: null,
       createdById: actor.userId,
       createdAt: now,
       updatedAt: now,
     });
 
+    const label = quoteLabel(project.projectNumber, next);
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
       action: "CREATE",
       entityType: "quote",
       entityId: id,
-      entityName: `Quote v${nextVersion} — ${project.name}`,
+      entityName: label,
       userId: actor.userId,
       userName: actor.userName,
-      summary: `Published quote v${nextVersion} for ${project.name}`,
+      summary: `Started quote ${label}`,
+      details: { version: next, previousVersion: revision },
       projectId,
       createdAt: now,
     });
 
-    return { id, version: nextVersion };
+    return { id, version: next };
   },
 });
 
-export const quoteFields = { notes: v.optional(v.string()) };
+/**
+ * ACCEPT — `SENT → ACCEPTED`, the thing that unblocks `CONFIRMED`
+ * (`projectWrites.updateStatusNative`). An EXPIRED revision cannot be accepted:
+ * the client's window closed, and re-sending is the honest way to reopen it.
+ */
+export const markAcceptedNative = mutation({
+  returns: v.object({ id: v.string(), version: v.number(), offerStatusChange: offerValidator }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    /** Defaults to `now` when omitted; normalised to the org's calendar day. */
+    acceptedAt: v.optional(v.number()),
+    /** PO number, email subject, "verbal — call 26/7" … free text, bounded. */
+    acceptanceRef: v.optional(v.string()),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, acceptedAt, acceptanceRef, actor: suppliedActor, auditId, now }) => {
+    const actor = await guardQuoteWrite(ctx, organizationId, suppliedActor);
+    const { quote, project } = await loadQuoteAndProject(ctx, id, organizationId);
+
+    assertStrLen(acceptanceRef, "acceptanceRef", ACCEPTANCE_REF_BOUNDS);
+    assertNumRange(acceptedAt, "acceptedAt", DATE_BOUNDS);
+
+    const label = quoteLabel(project.projectNumber, quote.version);
+    assertQuoteStatusIs(effectiveQuoteStatus(quote, now), ["SENT"], label, "accept");
+
+    const config = await resolveOrgQuoteConfig(ctx, organizationId);
+    const stampedAcceptedAt = startOfDayInTimezone(acceptedAt ?? now, config.timezone);
+
+    await ctx.db.patch(quote._id, {
+      status: "ACCEPTED",
+      acceptedAt: stampedAcceptedAt,
+      acceptedById: actor.userId,
+      acceptanceRef: acceptanceRef?.trim() || undefined,
+      updatedAt: now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "UPDATE",
+      entityType: "quote",
+      entityId: quote.id,
+      entityName: label,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Marked quote ${label} accepted`,
+      details: { version: quote.version, acceptedAt: stampedAcceptedAt, acceptanceRef: acceptanceRef ?? null },
+      projectId: project.id,
+      createdAt: now,
+    });
+
+    return {
+      id: quote.id,
+      version: quote.version,
+      offerStatusChange: ACCEPT_OFFERS_CONFIRMED_FROM.has(project.status ?? "") ? ("CONFIRMED" as const) : null,
+    };
+  },
+});
+
+/**
+ * DECLINE — `SENT → DECLINED` with a bounded reason. Offers `CANCELLED` and never
+ * forces it: a declined quote often becomes a re-quote, not a dead job.
+ * An expired revision can still be declined — the client answering late is a real
+ * outcome and recording it beats leaving the row ambiguous.
+ */
+export const markDeclinedNative = mutation({
+  returns: v.object({ id: v.string(), version: v.number(), offerStatusChange: offerValidator }),
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    reason: v.string(),
+    actor: actorValidator,
+    auditId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, { id, organizationId, reason, actor: suppliedActor, auditId, now }) => {
+    const actor = await guardQuoteWrite(ctx, organizationId, suppliedActor);
+    const { quote, project } = await loadQuoteAndProject(ctx, id, organizationId);
+
+    const trimmed = reason.trim();
+    assertStrLen(trimmed, "reason", DECLINE_REASON_BOUNDS);
+
+    const label = quoteLabel(project.projectNumber, quote.version);
+    assertQuoteStatusIs(effectiveQuoteStatus(quote, now), ["SENT", "EXPIRED"], label, "decline");
+
+    await ctx.db.patch(quote._id, {
+      status: "DECLINED",
+      declinedAt: now,
+      declinedById: actor.userId,
+      declineReason: trimmed,
+      updatedAt: now,
+    });
+
+    await writeActivityLog(ctx, {
+      id: auditId,
+      organizationId,
+      action: "UPDATE",
+      entityType: "quote",
+      entityId: quote.id,
+      entityName: label,
+      userId: actor.userId,
+      userName: actor.userName,
+      summary: `Marked quote ${label} declined`,
+      details: { version: quote.version },
+      metadata: { reason: trimmed },
+      projectId: project.id,
+      createdAt: now,
+    });
+
+    return { id: quote.id, version: quote.version, offerStatusChange: "CANCELLED" as const };
+  },
+});
+
+/**
+ * The client-supplied field sets, exported for the Zod↔Convex parity test
+ * (`convex/validationDrift.test.ts`, R-8.6.1) — each one pairs with the
+ * correspondingly-named schema in `src/lib/validations/quote.ts`. Dates are
+ * `Date` client-side and ms timestamps over the wire; the field NAMES match,
+ * which is what parity checks.
+ *
+ * Note what is absent from all four — no monetary amount appears anywhere in a
+ * client-supplied quote payload (R-9.3).
+ */
+export const quoteSendFields = {
+  quoteDate: v.number(),
+  validityDays: v.optional(v.number()),
+  recipientContactId: v.optional(v.string()),
+  notes: v.optional(v.string()),
+};
+export const quoteRecallFields = { reason: v.string() };
+export const quoteAcceptFields = {
+  acceptedAt: v.optional(v.number()),
+  acceptanceRef: v.optional(v.string()),
+};
+export const quoteDeclineFields = { reason: v.string() };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1070,6 +1070,14 @@ export default defineSchema({
     depositPercent: v.optional(v.number()),
     depositPaid: v.optional(v.number()),
     invoicedTotal: v.optional(v.number()),
+    // #986 — THE revision counter for this project. Project v2 == Quote v2 ==
+    // the projectSnapshots row taken at v2; there is deliberately no second
+    // counter anywhere (R-3.1). SERVER-OWNED: written only by createNative
+    // (seeded to 1) and quotesWrites.newVersionNative, and stripped from every
+    // generic client patch the same way PROJECT_MONEY_ANCHORS are. Optional so
+    // pre-#986 documents validate; absent ⇒ 1 via `projectRevision()`
+    // (convex/lib/quoteState.ts), and `backfillQuoteRevisions.ts` stamps it.
+    revision: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
     isTemplate: v.optional(v.boolean()),
     createdAt: v.optional(v.number()),
@@ -2074,11 +2082,23 @@ export default defineSchema({
     // single-project scan; this is the org-wide equivalent R-9.8 needs.
     .index("by_organizationId_date", ["organizationId", "date"]),
 
-  // Quote (WS1 #940) — snapshot-on-publish, versioned. `snapshot` is a JSON blob
-  // (lines + totals) frozen at publish time; republishing bumps `version` and
-  // supersedes the previous PUBLISHED row (never overwritten in place — an audit
-  // trail of every quote a client was actually sent). `pdfFileId` links the
-  // generated PDF (Convex file storage) for re-download without regenerating.
+  // Quote revision (WS1 #940, reworked by #986). ONE row per
+  // `(projectId, projects.revision)` — `version` IS the revision the row was cut
+  // from, never an independent counter. `snapshot` is a JSON blob (lines +
+  // totals) frozen at SEND time; `snapshotId` points at the `projectSnapshots`
+  // row capturing the whole entity state for the same revision.
+  //
+  // State machine (convex/quotesWrites.ts): DRAFT ─send→ SENT ─accept→ ACCEPTED,
+  // ─decline→ DECLINED, ─recall→ DRAFT; the previous SENT/ACCEPTED row flips to
+  // SUPERSEDED only when the NEXT revision actually sends (never on draft), so
+  // there is always exactly one row representing "what the client currently
+  // has". EXPIRED is DERIVED on read (validUntil < now && SENT) — never stored,
+  // no cron, no clock skew (convex/lib/quoteState.ts).
+  //
+  // `publishedAt`/`publishedById` are the DEPRECATED pre-#986 names, kept
+  // declared until `backfillQuoteRevisions.ts` confirms zero remaining rows
+  // carry them (schema-validation precedent: FEATUREDOCS/66 `depositPercent`).
+  // `pdfFileId` links the stored immutable artifact — written in Phase B (#987).
   quotes: defineTable({
     id: v.string(),
     organizationId: v.string(),
@@ -2087,6 +2107,28 @@ export default defineSchema({
     status: enums.QuoteStatus,
     snapshot: v.any(),
     pdfFileId: v.optional(v.string()),
+    snapshotId: v.optional(v.string()),
+    // Send (the freeze moment)
+    quoteDate: v.optional(v.number()),
+    validUntil: v.optional(v.number()),
+    validityDays: v.optional(v.number()),
+    recipientContactId: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    sentAt: v.optional(v.number()),
+    sentById: v.optional(v.string()),
+    // Outcome
+    acceptedAt: v.optional(v.number()),
+    acceptedById: v.optional(v.string()),
+    acceptanceRef: v.optional(v.string()),
+    declinedAt: v.optional(v.number()),
+    declinedById: v.optional(v.string()),
+    declineReason: v.optional(v.string()),
+    // Recall (un-send; the artifact is retained, never deleted)
+    recalledAt: v.optional(v.number()),
+    recalledById: v.optional(v.string()),
+    recallReason: v.optional(v.string()),
+    supersededByQuoteId: v.optional(v.string()),
+    // DEPRECATED (pre-#986) — backfilled into sentAt/sentById.
     publishedAt: v.optional(v.number()),
     publishedById: v.optional(v.string()),
     createdById: v.optional(v.string()),
@@ -2096,7 +2138,9 @@ export default defineSchema({
     .index("by_cuid", ["id"])
     .index("by_organizationId", ["organizationId"])
     .index("by_projectId", ["projectId"])
+    // The uniqueness guard for "exactly one quote row per (projectId, revision)".
     .index("by_projectId_version", ["projectId", "version"])
+    .index("by_projectId_status", ["projectId", "status"])
     .index("by_organizationId_status", ["organizationId", "status"]),
 
   // Invoice (WS1 #940) — Flow owns generation + numbering, Xero owns the ledger.
@@ -2753,7 +2797,17 @@ export default defineSchema({
     id: v.string(),
     organizationId: v.string(),
     projectId: v.string(),
-    reason: v.union(v.literal("CONFIRMED"), v.literal("COMPLETED"), v.literal("UNLOCK")),
+    // QUOTE_SENT (#986) — the frozen entity state for a quote revision, captured
+    // by quotesWrites.sendNative. Unlike the status-driven reasons it carries
+    // `revision`, so "as of quote v2" and "the snapshot taken at v2" are the
+    // same row (one shared counter — projects.revision).
+    reason: v.union(
+      v.literal("CONFIRMED"),
+      v.literal("COMPLETED"),
+      v.literal("UNLOCK"),
+      v.literal("QUOTE_SENT"),
+    ),
+    revision: v.optional(v.number()),
     takenAt: v.number(),
     takenBy: v.string(),
     takenByName: v.optional(v.string()),

--- a/convex/validationDrift.test.ts
+++ b/convex/validationDrift.test.ts
@@ -31,7 +31,7 @@ import { subTestFields } from "./subTestRecords";
 import { projectWriteFields } from "./projects";
 import { updateFields as supplierOrderUpdateFields } from "./supplierOrdersWrites";
 import { itemFields as supplierOrderItemFields } from "./supplierOrderItemsWrites";
-import { quoteFields } from "./quotesWrites";
+import { quoteSendFields, quoteRecallFields, quoteAcceptFields, quoteDeclineFields } from "./quotesWrites";
 import { invoiceFields } from "./invoicesWrites";
 
 import { clientSchema } from "@/lib/validations/client";
@@ -46,7 +46,12 @@ import { modelSchema } from "@/lib/validations/model";
 import { supplierSchema } from "@/lib/validations/supplier";
 import { subTestRecordSchema } from "@/lib/validations/test-tag";
 import { supplierOrderUpdateSchema, supplierOrderItemSchema } from "@/lib/validations/supplier-order";
-import { quoteSchema } from "@/lib/validations/quote";
+import {
+  quoteSendSchema,
+  quoteRecallSchema,
+  quoteAcceptSchema,
+  quoteDeclineSchema,
+} from "@/lib/validations/quote";
 import { invoiceSchema } from "@/lib/validations/invoice";
 
 /** Unwrap a Zod schema (through .refine/.default/.optional wrappers) to its object shape keys. */
@@ -149,8 +154,12 @@ const PAIRS: Pair[] = [
   { name: "supplierOrderUpdate", zod: supplierOrderUpdateSchema, convex: supplierOrderUpdateFields },
   // WS7 #946 — supplierOrderItem CRUD (new browser path; previously had none).
   { name: "supplierOrderItem", zod: supplierOrderItemSchema, convex: supplierOrderItemFields },
-  // WS1 #940 — quote publish / invoice create (finance model).
-  { name: "quote", zod: quoteSchema, convex: quoteFields },
+  // WS1 #940 / #986 — the four quote verbs that take client input (new-version
+  // takes none) + invoice create (finance model).
+  { name: "quoteSend", zod: quoteSendSchema, convex: quoteSendFields },
+  { name: "quoteRecall", zod: quoteRecallSchema, convex: quoteRecallFields },
+  { name: "quoteAccept", zod: quoteAcceptSchema, convex: quoteAcceptFields },
+  { name: "quoteDecline", zod: quoteDeclineSchema, convex: quoteDeclineFields },
   {
     name: "invoice",
     zod: invoiceSchema,

--- a/convex/wooCommerceInternal.ts
+++ b/convex/wooCommerceInternal.ts
@@ -298,7 +298,9 @@ export const createProjectWithUniqueNumber = internalMutation({
       )
       .unique();
     if (clash) return { created: false, id: clash.id };
-    await ctx.db.insert("projects", args);
+    // #986 — a real project starts at revision 1 (its first quote is v1), same as
+    // projectWrites.createNative. Templates carry no revision at all.
+    await ctx.db.insert("projects", args.isTemplate ? args : { ...args, revision: 1 });
     await bumpCountersForTable(ctx, "projects", null, args);
     return { created: true, id: args.id };
   },

--- a/scripts/convex-backfill-quote-revisions.ts
+++ b/scripts/convex-backfill-quote-revisions.ts
@@ -1,0 +1,182 @@
+/**
+ * #986 (Phase A — quote revision model) backfill driver.
+ * See `convex/backfillQuoteRevisions.ts` for the full rationale.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts --apply
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts --apply --expect-quotes=3
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts --verify-only
+ *
+ * ALWAYS COUNTS FIRST. Production is expected to hold effectively no live quote
+ * data (decision 12), which is the basis for the simple forward migration — not
+ * a licence to skip verification. The run:
+ *
+ *   1. verifies (counts every project/quote and every un-migrated condition),
+ *   2. halts if `--expect-quotes` was supplied and doesn't match the count,
+ *   3. applies page by page,
+ *   4. re-verifies and FAILS THE RUN unless every un-migrated counter reads 0.
+ *
+ * Idempotent — safe to re-run; a second run reports 0 work. A fresh Convex client
+ * is fetched per page so the short-lived service token can't expire mid-run.
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../convex/_generated/api";
+import { assertExpectedQuoteRows } from "../convex/backfillQuoteRevisions";
+
+const apply = process.argv.includes("--apply");
+const verifyOnly = process.argv.includes("--verify-only");
+const expectFlag = process.argv.find((a) => a.startsWith("--expect-quotes="));
+const expectedQuotes = expectFlag ? Number(expectFlag.split("=")[1]) : undefined;
+
+/** Declared rather than inferred: `runVerification` accumulates into the same
+ *  shape it returns, so inferring from the call would be circular. */
+type VerifyPage = {
+  nonTemplateProjects: number;
+  liveQuoteRows: number;
+  projectsMissingRevision: number;
+  projectsWithNoQuote: number;
+  projectsWithRevisionBelowQuotes: number;
+  quotesStillPublished: number;
+  quotesMissingSentAt: number;
+  quotesMissingValidUntil: number;
+  duplicateRevisionRows: number;
+  isDone: boolean;
+  continueCursor: string;
+};
+type MigratePage = {
+  scanned: number;
+  projectsStamped: number;
+  quotesMigrated: number;
+  draftsInserted: number;
+  isDone: boolean;
+  continueCursor: string;
+};
+type Verification = Omit<VerifyPage, "isDone" | "continueCursor">;
+
+const UNMIGRATED_KEYS = [
+  "projectsMissingRevision",
+  "projectsWithNoQuote",
+  "projectsWithRevisionBelowQuotes",
+  "quotesStillPublished",
+  "quotesMissingSentAt",
+  "quotesMissingValidUntil",
+  "duplicateRevisionRows",
+] as const;
+
+async function runVerification(): Promise<Verification> {
+  const totals: Verification = {
+    nonTemplateProjects: 0,
+    liveQuoteRows: 0,
+    projectsMissingRevision: 0,
+    projectsWithNoQuote: 0,
+    projectsWithRevisionBelowQuotes: 0,
+    quotesStillPublished: 0,
+    quotesMissingSentAt: 0,
+    quotesMissingValidUntil: 0,
+    duplicateRevisionRows: 0,
+  };
+  let cursor: string | null = null;
+  for (;;) {
+    const convex = await getConvexClient();
+    const r: VerifyPage = await convex.query(api.backfillQuoteRevisions.verifyQuoteRevisions, { cursor });
+    for (const key of Object.keys(totals) as (keyof typeof totals)[]) totals[key] += r[key];
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+  return totals;
+}
+
+function printVerification(label: string, v: Verification) {
+  console.log(`${label}:`);
+  console.log(`  non-template projects .............. ${v.nonTemplateProjects}`);
+  console.log(`  live quote rows ................... ${v.liveQuoteRows}`);
+  for (const key of UNMIGRATED_KEYS) {
+    console.log(`  ${key.padEnd(33, ".")} ${v[key]}`);
+  }
+}
+
+function unmigratedTotal(v: Verification): number {
+  return UNMIGRATED_KEYS.reduce((sum, key) => sum + v[key], 0);
+}
+
+/** The paginated apply pass, split out so `main` stays a readable sequence. */
+async function runMigration(): Promise<void> {
+  let cursor: string | null = null;
+  let page = 0;
+  const applied = { scanned: 0, projectsStamped: 0, quotesMigrated: 0, draftsInserted: 0 };
+  for (;;) {
+    const convex = await getConvexClient();
+    const r: MigratePage = await convex.mutation(api.backfillQuoteRevisions.backfillQuoteRevisionsPage, {
+      cursor,
+      apply,
+    });
+    applied.scanned += r.scanned;
+    applied.projectsStamped += r.projectsStamped;
+    applied.quotesMigrated += r.quotesMigrated;
+    applied.draftsInserted += r.draftsInserted;
+    page++;
+    if (r.scanned > 0) {
+      console.log(
+        `  page ${page}: ${apply ? "migrated" : "would migrate"} ${r.scanned} project(s) — ` +
+          `${r.projectsStamped} revision stamp(s), ${r.quotesMigrated} quote(s), ${r.draftsInserted} draft(s)`,
+      );
+    }
+    if (r.isDone) break;
+    cursor = r.continueCursor;
+  }
+
+  console.log();
+  console.log(
+    `${applied.scanned} project(s) needing work across ${page} page(s): ` +
+      `${applied.projectsStamped} revision stamp(s), ${applied.quotesMigrated} quote row(s), ` +
+      `${applied.draftsInserted} draft v1 insert(s).`,
+  );
+}
+
+/** Fail the run unless every un-migrated counter reads 0. */
+function assertFullyMigrated(v: Verification): void {
+  const remaining = unmigratedTotal(v);
+  if (remaining > 0) {
+    console.error(`\n✗ ${remaining} un-migrated row(s) remain — investigate before shipping Phase B.`);
+    process.exit(1);
+  }
+  console.log("\n✓ Zero un-migrated rows.");
+}
+
+async function main() {
+  console.log("Quote revision model (#986) backfill");
+  console.log("─".repeat(60));
+  console.log(`Mode: ${verifyOnly ? "verify only" : apply ? "APPLY (will write)" : "dry-run"}`);
+  console.log();
+
+  const before = await runVerification();
+  printVerification("Before", before);
+  console.log();
+
+  if (verifyOnly) {
+    assertFullyMigrated(before);
+    return;
+  }
+
+  // Halt on a mismatch against expectation BEFORE writing anything.
+  assertExpectedQuoteRows(before.liveQuoteRows, expectedQuotes);
+
+  await runMigration();
+
+  if (!apply) {
+    console.log("(Dry run — re-run with --apply to write.)");
+    return;
+  }
+
+  console.log();
+  const after = await runVerification();
+  printVerification("After", after);
+  assertFullyMigrated(after);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("\nBackfill failed:", err);
+    process.exit(1);
+  });

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { FileText, Send, Ban, Trash2, UploadCloud, AlertCircle } from "lucide-react";
+import { Send, Ban, Trash2, UploadCloud, AlertCircle } from "lucide-react";
 
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { api } from "../../../convex/_generated/api";
-import { useQuoteWrites } from "@/hooks/use-quote-writes";
+import { ProjectQuoteRail } from "@/components/projects/project-quote-rail";
 import { useInvoiceWrites } from "@/hooks/use-invoice-writes";
 import { useNativeProjectStatus } from "@/hooks/use-native-project-writes";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
@@ -35,43 +35,43 @@ const INVOICE_STATUS_BADGE: Record<string, "ok" | "warn" | "neutral" | "overbook
 };
 
 /**
- * WS1 (#940) — the project's Quotes & Invoices workflow. Publish a quote
- * (snapshot the current pricing), create/issue/void invoices per the
- * client's payment profile, and (Xero-linked orgs) push an issued invoice
- * as a Xero draft. "Deposit not yet invoiced" nudge chips are DERIVED
- * (kind/status of existing invoices), not a stored flag — there is no new
- * READY_TO_INVOICE project status.
+ * WS1 (#940), reworked by #986 — the project's Quotes & Invoices workflow.
+ *
+ * The quote half is now a REVISION RAIL over `projects.revision`
+ * (`<ProjectQuoteRail>`): send the current revision (freezing its pricing and
+ * capturing a snapshot), recall it, cut the next version, or record the client's
+ * accept/decline. Sending does NOT email anyone — it records the send and
+ * freezes the numbers.
+ *
+ * Invoices are unchanged: create/issue/void per the client's payment profile,
+ * and (Xero-linked orgs) push an issued invoice as a Xero draft. "Deposit not
+ * yet invoiced" nudge chips are DERIVED (kind/status of existing invoices), not
+ * a stored flag — there is no READY_TO_INVOICE project status.
+ *
+ * The full Finance tab — send dialog, version history + diffs, invoice issue
+ * dialog with due dates, drift indicator — is Phase D (#989).
  */
 export function ProjectFinancePanel({ projectId, clientId, projectStatus }: ProjectFinancePanelProps) {
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
   const xeroLinked = useXeroLinked();
 
-  const quotes = useAuthedQuery(api.quotes.listForProject, orgId ? { orgId, projectId } : "skip");
   const invoices = useAuthedQuery(api.invoices.listForProject, orgId ? { orgId, projectId } : "skip");
   const client = useAuthedQuery(api.clients.getById, clientId ? { id: clientId } : "skip");
 
-  const quoteWrites = useQuoteWrites();
   const invoiceWrites = useInvoiceWrites();
   const { updateStatus } = useNativeProjectStatus(orgId);
 
   const [voidTarget, setVoidTarget] = useState<{ id: string; number: string } | null>(null);
   const [voidReason, setVoidReason] = useState("");
 
-  const publishQuoteMutation = useServerMutation({
-    mutationFn: () => quoteWrites.publish(projectId, {}),
-    onSuccess: (r) => toast.success(`Published quote v${r.version}`),
-    onError: (e) => toast.error(e.message),
-  });
-
   if (!clientId) {
     return <p className="t-micro text-fg-4">Assign a client to this project to generate quotes and invoices.</p>;
   }
-  if (quotes === undefined || invoices === undefined || client === undefined) {
+  if (invoices === undefined || client === undefined) {
     return <p className="t-micro text-fg-4">Loading…</p>;
   }
 
-  const publishedQuote = quotes.find((q) => q.status === "PUBLISHED");
   const paymentProfile = (client?.paymentProfile as string | undefined) ?? "FULL_UPFRONT";
   const depositPercent = (client?.profileDepositPercent as number | undefined) ?? 25;
 
@@ -129,22 +129,8 @@ export function ProjectFinancePanel({ projectId, clientId, projectStatus }: Proj
 
   return (
     <div className="space-y-6">
-      {/* Quote */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h3 className="t-overline text-fg-3">Quote</h3>
-          <CanDo resource="invoice" action="publish">
-            <Button type="button" variant="line" size="sm" loading={publishQuoteMutation.isPending} onClick={() => publishQuoteMutation.mutate(undefined)}>
-              <FileText className="h-3.5 w-3.5" /> {publishedQuote ? "Republish quote" : "Publish quote"}
-            </Button>
-          </CanDo>
-        </div>
-        {publishedQuote ? (
-          <p className="t-micro text-fg-4">v{publishedQuote.version} published {formatDate(new Date(publishedQuote.publishedAt ?? 0))}</p>
-        ) : (
-          <p className="t-micro text-fg-4">No quote published yet.</p>
-        )}
-      </div>
+      {/* Quote revisions (#986) */}
+      <ProjectQuoteRail projectId={projectId} orgId={orgId} />
 
       {/* Nudge chips */}
       {paymentProfile === "DEPOSIT_BALANCE" ? (

--- a/src/components/projects/project-quote-rail.tsx
+++ b/src/components/projects/project-quote-rail.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { CheckCircle2, FileText, Send, Undo2, XCircle } from "lucide-react";
+
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { api } from "../../../convex/_generated/api";
+import { useQuoteWrites } from "@/hooks/use-quote-writes";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { formatCurrency, formatDate } from "@/lib/formatters";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { CanDo } from "@/components/auth/permission-gate";
+
+/**
+ * The quote REVISION RAIL (#986, Phase A) — one row per revision over the
+ * project's single `revision` counter, with the five verbs wired up.
+ *
+ * This is the minimum viable surface for exercising the model. The real Finance
+ * tab — a send dialog with quote date / valid-until / recipient / watermarked
+ * preview, version history with diffs, and the drift indicator — is Phase D
+ * (#989). The state → intent mapping likewise lands there as
+ * `quoteStatusIntent()` in `status-colors.ts`; this uses the badge vocabulary
+ * the finance panel already had.
+ */
+
+/** Minimum reason length per verb — mirrors `quoteRecallSchema`/
+ *  `quoteDeclineSchema`, which the server mirrors again via `fieldGuards`. The
+ *  disabled button is UX; neither client check is the security boundary. */
+const REASON_MIN = { recall: 10, decline: 3 } as const;
+
+const QUOTE_STATUS_BADGE: Record<string, "ok" | "warn" | "neutral" | "overbooked"> = {
+  DRAFT: "neutral",
+  SENT: "ok",
+  ACCEPTED: "ok",
+  DECLINED: "overbooked",
+  EXPIRED: "warn",
+  SUPERSEDED: "neutral",
+};
+
+interface QuoteRevisionDoc {
+  id: string;
+  version: number;
+  /** DERIVED — `EXPIRED` is never stored (convex/lib/quoteState.ts). Always
+   *  branch on this, never on the raw `status` column, which can still read
+   *  `PUBLISHED` on a row the backfill hasn't reached. */
+  effectiveStatus: string;
+  sentAt?: number;
+  validUntil?: number;
+  snapshot?: unknown;
+}
+
+type ReasonVerb = "recall" | "decline";
+interface ReasonTarget {
+  id: string;
+  version: number;
+  verb: ReasonVerb;
+}
+
+export function ProjectQuoteRail({ projectId, orgId }: { projectId: string; orgId: string | undefined }) {
+  // Frozen at mount: `now` only drives the DERIVED expiry read, and a value that
+  // changed every render would re-subscribe the queries on every render. Phase D
+  // owns live-ticking validity copy.
+  const [now] = useState(() => Date.now());
+  const [reasonTarget, setReasonTarget] = useState<ReasonTarget | null>(null);
+
+  const quotes = useAuthedQuery(api.quotes.listForProject, orgId ? { orgId, projectId, now } : "skip");
+  const revisionState = useAuthedQuery(
+    api.quotes.revisionStateForProject,
+    orgId ? { orgId, projectId, now } : "skip",
+  );
+  const quoteWrites = useQuoteWrites();
+
+  const sendMutation = useServerMutation({
+    mutationFn: () => quoteWrites.send(projectId),
+    onSuccess: (r) => toast.success(`Sent quote v${r.version} — pricing is now frozen at this revision`),
+    onError: (e) => toast.error(e.message),
+  });
+  const newVersionMutation = useServerMutation({
+    mutationFn: () => quoteWrites.newVersion(projectId),
+    onSuccess: (r) => toast.success(`Started quote v${r.version}`),
+    onError: (e) => toast.error(e.message),
+  });
+
+  async function acceptQuote(quote: QuoteRevisionDoc) {
+    try {
+      await quoteWrites.markAccepted(quote.id);
+      toast.success(`Marked v${quote.version} accepted — this project can now be confirmed`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to mark accepted");
+    }
+  }
+
+  if (quotes === undefined || revisionState === undefined) {
+    return <p className="t-micro text-fg-4">Loading quotes…</p>;
+  }
+
+  const { revision, liveQuote, hasAcceptedQuote, draftQuoteId } = revisionState;
+
+  return (
+    <div className="space-y-2">
+      <RailHeader
+        revision={revision}
+        hasOpenDraft={draftQuoteId != null || quotes.length === 0}
+        sending={sendMutation.isPending}
+        creating={newVersionMutation.isPending}
+        onSend={() => sendMutation.mutate(undefined)}
+        onNewVersion={() => newVersionMutation.mutate(undefined)}
+      />
+
+      <p className="t-micro text-fg-4">
+        Sending freezes pricing at that revision — to change prices afterwards, create the next version.
+        Flow doesn&rsquo;t email clients; sending records the send and generates the document for you.
+      </p>
+
+      {quotes.length === 0 ? (
+        <p className="t-micro text-fg-4">No quote yet — sending creates v{revision}.</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {quotes.map((quote) => (
+            <QuoteRevisionRow
+              key={quote.id}
+              quote={quote}
+              onAccept={() => void acceptQuote(quote)}
+              onDecline={() => setReasonTarget({ id: quote.id, version: quote.version, verb: "decline" })}
+              onRecall={() => setReasonTarget({ id: quote.id, version: quote.version, verb: "recall" })}
+            />
+          ))}
+        </ul>
+      )}
+
+      {liveQuote && !hasAcceptedQuote && (
+        <p className="t-micro text-warn">
+          This project can&rsquo;t be confirmed until a quote revision is marked accepted (admins and the
+          project&rsquo;s PMs can override with a reason).
+        </p>
+      )}
+
+      <ReasonDialog target={reasonTarget} onClose={() => setReasonTarget(null)} />
+    </div>
+  );
+}
+
+function RailHeader({
+  revision,
+  hasOpenDraft,
+  sending,
+  creating,
+  onSend,
+  onNewVersion,
+}: {
+  revision: number;
+  hasOpenDraft: boolean;
+  sending: boolean;
+  creating: boolean;
+  onSend: () => void;
+  onNewVersion: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <h3 className="t-overline text-fg-3">Quote</h3>
+      <CanDo resource="invoice" action="publish">
+        {hasOpenDraft ? (
+          <Button type="button" variant="line" size="sm" loading={sending} onClick={onSend}>
+            <Send className="h-3.5 w-3.5" /> Send quote v{revision}
+          </Button>
+        ) : (
+          <Button type="button" variant="line" size="sm" loading={creating} onClick={onNewVersion}>
+            <FileText className="h-3.5 w-3.5" /> Create quote v{revision + 1}
+          </Button>
+        )}
+      </CanDo>
+    </div>
+  );
+}
+
+/**
+ * One revision in the rail. Identity is `v<version>` — a quote has no document
+ * number of its own (decision 5); it is referred to everywhere as
+ * `<projectNumber> v<version>`, and the project number is already on the page.
+ */
+function QuoteRevisionRow({
+  quote,
+  onAccept,
+  onDecline,
+  onRecall,
+}: {
+  quote: QuoteRevisionDoc;
+  onAccept: () => void;
+  onDecline: () => void;
+  onRecall: () => void;
+}) {
+  const isSent = quote.effectiveStatus === "SENT";
+  // A sent-or-expired revision is the one the client is holding: it can be
+  // recalled or declined. Only a still-valid one can be accepted.
+  const isHeldByClient = isSent || quote.effectiveStatus === "EXPIRED";
+
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
+      <RevisionMeta quote={quote} />
+      <CanDo resource="invoice" action="publish">
+        <div className="flex items-center gap-1.5">
+          {isSent && (
+            <Button type="button" variant="line" size="sm" onClick={onAccept}>
+              <CheckCircle2 className="h-3.5 w-3.5" /> Mark accepted
+            </Button>
+          )}
+          {isHeldByClient && (
+            <Button type="button" variant="line" size="sm" onClick={onDecline}>
+              <XCircle className="h-3.5 w-3.5" /> Declined
+            </Button>
+          )}
+          {isHeldByClient && (
+            <Button type="button" variant="line" size="sm" onClick={onRecall}>
+              <Undo2 className="h-3.5 w-3.5" /> Recall
+            </Button>
+          )}
+        </div>
+      </CanDo>
+    </li>
+  );
+}
+
+function RevisionMeta({ quote }: { quote: QuoteRevisionDoc }) {
+  // A DRAFT carries no frozen money — its figures are the project's live totals
+  // until it is sent, so the row deliberately shows no amount.
+  const total = (quote.snapshot as { total?: number } | null)?.total;
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <Badge status={QUOTE_STATUS_BADGE[quote.effectiveStatus] ?? "neutral"}>{quote.effectiveStatus}</Badge>
+      <span className="font-medium text-fg">v{quote.version}</span>
+      {total != null && <span className="tabular-nums text-fg-4">{formatCurrency(total)}</span>}
+      {quote.sentAt != null && <span className="text-fg-4">sent {formatDate(new Date(quote.sentAt))}</span>}
+      {quote.effectiveStatus === "SENT" && quote.validUntil != null && (
+        <span className="text-fg-4">valid until {formatDate(new Date(quote.validUntil))}</span>
+      )}
+    </div>
+  );
+}
+
+/** Recall and decline both take a bounded reason, so both route through ONE
+ *  Dialog rather than two near-identical ones. (Radix `Dialog` — there is no
+ *  `AlertDialog` in this codebase.) */
+function ReasonDialog({ target, onClose }: { target: ReasonTarget | null; onClose: () => void }) {
+  const [reason, setReason] = useState("");
+  const quoteWrites = useQuoteWrites();
+  const isRecall = target?.verb === "recall";
+
+  async function confirm() {
+    if (!target) return;
+    try {
+      if (target.verb === "recall") {
+        const result = await quoteWrites.recall(target.id, { reason });
+        toast.success(
+          result.restoredQuoteId
+            ? `Recalled v${target.version} — the previous revision is the client's current quote again`
+            : `Recalled v${target.version} — it's a draft again`,
+        );
+      } else {
+        await quoteWrites.markDeclined(target.id, { reason });
+        toast.success(`Marked v${target.version} declined`);
+      }
+      setReason("");
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed");
+    }
+  }
+
+  return (
+    <Dialog
+      open={!!target}
+      onOpenChange={(open) => {
+        if (!open) {
+          setReason("");
+          onClose();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isRecall ? "Recall" : "Decline"} quote v{target?.version}
+          </DialogTitle>
+        </DialogHeader>
+        <p className="t-micro text-fg-4">
+          {isRecall
+            ? "Un-sends this revision so you can edit it. The document you already sent is kept for the record — the client may still be holding it."
+            : "Records that the client declined this revision. The project's status is left alone."}
+        </p>
+        <Textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder={isRecall ? "Why is this being recalled?" : "Why did the client decline?"}
+          rows={3}
+        />
+        <DialogFooter>
+          <Button type="button" variant="line" onClick={onClose}>Cancel</Button>
+          <Button
+            type="button"
+            disabled={reason.trim().length < REASON_MIN[target?.verb ?? "decline"]}
+            onClick={() => void confirm()}
+          >
+            {isRecall ? "Recall quote" : "Mark declined"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/document-settings.tsx
+++ b/src/components/settings/document-settings.tsx
@@ -8,6 +8,7 @@ import { refreshOrganization } from "@/hooks/use-organization";
 import { useActiveOrganization } from "@/lib/auth-client";
 import { updateOrganization } from "@/server/settings";
 import type { OrgSettings, OrgDocumentSettings } from "@/lib/org-settings-types";
+import { DEFAULT_QUOTE_VALIDITY_DAYS, QUOTE_VALIDITY_BOUNDS } from "@/lib/quote-validity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -19,7 +20,6 @@ interface DocumentSettingsProps {
   onDocumentsChange?: (documents: OrgDocumentSettings | undefined) => void;
 }
 
-const DEFAULT_QUOTE_VALIDITY_DAYS = 30;
 
 export function DocumentSettings({ orgName, settings, onDocumentsChange }: DocumentSettingsProps) {
   const { data: activeOrg } = useActiveOrganization();
@@ -72,7 +72,10 @@ export function DocumentSettings({ orgName, settings, onDocumentsChange }: Docum
     termsAndConditions !== (documents.termsAndConditions || "") ||
     quoteValidityDays !== (documents.quoteValidityDays ?? DEFAULT_QUOTE_VALIDITY_DAYS);
 
-  const validityOutOfRange = !Number.isFinite(quoteValidityDays) || quoteValidityDays < 1 || quoteValidityDays > 365;
+  const validityOutOfRange =
+    !Number.isFinite(quoteValidityDays) ||
+    quoteValidityDays < QUOTE_VALIDITY_BOUNDS.min ||
+    quoteValidityDays > QUOTE_VALIDITY_BOUNDS.max;
 
   return (
     <div className="space-y-4">
@@ -119,14 +122,15 @@ export function DocumentSettings({ orgName, settings, onDocumentsChange }: Docum
         <Input
           id="quoteValidityDays"
           type="number"
-          min={1}
-          max={365}
+          min={QUOTE_VALIDITY_BOUNDS.min}
+          max={QUOTE_VALIDITY_BOUNDS.max}
           value={quoteValidityDays}
           onChange={(e) => setQuoteValidityDays(e.target.valueAsNumber)}
           aria-invalid={validityOutOfRange}
         />
         <p className="text-xs text-fg-3">
-          Quotes show &ldquo;Valid until&rdquo; computed from the generation date plus this many days.
+          Default &ldquo;valid for&rdquo; when sending a quote. The send dialog stamps the resulting
+          &ldquo;valid until&rdquo; date onto that revision, so it never shifts afterwards.
         </p>
       </div>
 

--- a/src/hooks/use-quote-writes.ts
+++ b/src/hooks/use-quote-writes.ts
@@ -4,15 +4,38 @@ import { useMutation } from "convex/react";
 import { createId } from "@paralleldrive/cuid2";
 import { useSession, useActiveOrganization } from "@/lib/auth-client";
 import { api } from "../../convex/_generated/api";
-import { quoteSchema, type QuoteFormValues } from "@/lib/validations/quote";
+import {
+  quoteAcceptSchema,
+  quoteDeclineSchema,
+  quoteRecallSchema,
+  quoteSendSchema,
+  type QuoteAcceptValues,
+  type QuoteDeclineValues,
+  type QuoteRecallValues,
+  type QuoteSendValues,
+} from "@/lib/validations/quote";
 
-/** Browser-direct QUOTE writes (WS1 #940) — mirrors use-native-client-writes.ts. */
+/**
+ * Browser-direct QUOTE REVISION writes (WS1 #940, reworked by #986) — the five
+ * verbs over one shared revision counter. Mirrors use-native-client-writes.ts.
+ *
+ * `offerStatusChange` on the send/accept/decline results is an OFFER for the
+ * caller to act on (advance to QUOTED / CONFIRMED / CANCELLED), never something
+ * the mutation applied itself — status is never forced by a quote verb, matching
+ * the existing "issuing an invoice offers to advance to INVOICED" precedent.
+ */
+export type QuoteStatusOffer = "QUOTED" | "CONFIRMED" | "CANCELLED" | null;
+
 export function useQuoteWrites() {
   const { data: session } = useSession();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
 
-  const publishM = useMutation(api.quotesWrites.publishNative);
+  const sendM = useMutation(api.quotesWrites.sendNative);
+  const recallM = useMutation(api.quotesWrites.recallNative);
+  const newVersionM = useMutation(api.quotesWrites.newVersionNative);
+  const acceptM = useMutation(api.quotesWrites.markAcceptedNative);
+  const declineM = useMutation(api.quotesWrites.markDeclinedNative);
 
   const actor = () => ({ userId: session?.user.id ?? "", userName: session?.user.name ?? "" });
   const requireOrg = (): string => {
@@ -21,14 +44,88 @@ export function useQuoteWrites() {
   };
 
   return {
-    publish: async (projectId: string, data: QuoteFormValues): Promise<{ id: string; version: number }> => {
+    /** Freeze the current revision and stamp it sent. Does NOT email the client
+     *  (decision 7) — it records the send and, from Phase B, stores the PDF. */
+    send: async (
+      projectId: string,
+      data: QuoteSendValues = {},
+    ): Promise<{ id: string; version: number; validUntil: number; offerStatusChange: QuoteStatusOffer }> => {
       const org = requireOrg();
-      const parsed = quoteSchema.parse(data);
-      return await publishM({
+      const parsed = quoteSendSchema.parse(data);
+      return await sendM({
         id: createId(),
         organizationId: org,
         projectId,
+        quoteDate: (parsed.quoteDate ?? new Date()).getTime(),
+        validityDays: parsed.validityDays,
+        recipientContactId: parsed.recipientContactId || undefined,
         notes: parsed.notes || undefined,
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+    },
+
+    /** Un-send a revision. Needs admin/owner or one of the project's PMs on top
+     *  of `invoice:publish` — enforced server-side either way. */
+    recall: async (
+      quoteId: string,
+      data: QuoteRecallValues,
+    ): Promise<{ id: string; version: number; restoredQuoteId: string | null }> => {
+      const org = requireOrg();
+      const parsed = quoteRecallSchema.parse(data);
+      return await recallM({
+        id: quoteId,
+        organizationId: org,
+        reason: parsed.reason,
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+    },
+
+    /** Cut the next revision — increments `projects.revision` and opens a draft.
+     *  The previous sent revision stays the client's current document until the
+     *  new one is actually sent. */
+    newVersion: async (projectId: string): Promise<{ id: string; version: number }> => {
+      const org = requireOrg();
+      return await newVersionM({
+        id: createId(),
+        organizationId: org,
+        projectId,
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+    },
+
+    markAccepted: async (
+      quoteId: string,
+      data: QuoteAcceptValues = {},
+    ): Promise<{ id: string; version: number; offerStatusChange: QuoteStatusOffer }> => {
+      const org = requireOrg();
+      const parsed = quoteAcceptSchema.parse(data);
+      return await acceptM({
+        id: quoteId,
+        organizationId: org,
+        acceptedAt: parsed.acceptedAt?.getTime(),
+        acceptanceRef: parsed.acceptanceRef || undefined,
+        actor: actor(),
+        auditId: createId(),
+        now: Date.now(),
+      });
+    },
+
+    markDeclined: async (
+      quoteId: string,
+      data: QuoteDeclineValues,
+    ): Promise<{ id: string; version: number; offerStatusChange: QuoteStatusOffer }> => {
+      const org = requireOrg();
+      const parsed = quoteDeclineSchema.parse(data);
+      return await declineM({
+        id: quoteId,
+        organizationId: org,
+        reason: parsed.reason,
         actor: actor(),
         auditId: createId(),
         now: Date.now(),

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -36,6 +36,7 @@ import {
 } from "./structure-line-items";
 import type { DocumentData, DocumentLineItem, CrewEntry, CallSheetDayData, DocumentType } from "./types";
 import type { OrgDocumentSettings } from "@/lib/org-settings-types";
+import { computeValidUntil, resolveQuoteValidityDays } from "@/lib/quote-validity";
 
 const DEFAULT_DOC_COLOR = "#0d4f4f";
 
@@ -669,8 +670,16 @@ export async function buildDocumentData(
   const totalNum = Number(serialized.total) || 0;
   const depositNum = Number(serialized.depositPaid) || 0;
   const now = new Date();
-  const quoteValidityDays = documentSettings?.quoteValidityDays ?? 30;
-  const quoteValidUntil = new Date(now.getTime() + quoteValidityDays * 24 * 60 * 60 * 1000);
+  // #986 — the validity DEFAULT and the day-boundary maths now come from the one
+  // shared module (`quote-validity.ts`), resolved in the ORG's timezone rather
+  // than the render host's. This is still computed from `now`, which means a
+  // re-render of an un-sent draft still moves the date — Phase B (#987) is what
+  // makes the PDF read the SENT revision's stamped `validUntil` instead of
+  // recomputing. A sent revision already carries an immutable `validUntil`
+  // (stamped by `quotesWrites.sendNative`); nothing extends it after the fact.
+  const quoteValidityDays = resolveQuoteValidityDays(documentSettings?.quoteValidityDays);
+  const orgTimezone = typeof orgSettings.timezone === "string" ? orgSettings.timezone : undefined;
+  const quoteValidUntil = new Date(computeValidUntil(now.getTime(), quoteValidityDays, orgTimezone));
 
   // WS1 (#940) — only the invoice doc type renders this; skip the extra
   // Convex round trip for the other 4 doc types.

--- a/src/lib/quote-validity.ts
+++ b/src/lib/quote-validity.ts
@@ -1,0 +1,145 @@
+import { datePartsInTimezone, type ProjectNumberDateParts } from "@/lib/project-number";
+
+/**
+ * Quote validity + expiry maths (#986) — the SINGLE definition of "how long is a
+ * quote valid" and "has it expired", shared by the send mutation
+ * (`convex/quotesWrites.ts`), the Finance tab and the PDF. Before #986 the
+ * default `30` was hand-copied into `document-settings.tsx` and
+ * `build-document-data.ts`, and validity was computed from `now` **at render
+ * time** — so re-opening a quote silently extended how long it was valid
+ * (`build-document-data.ts` L672-673). `validUntil` is now stamped once, at
+ * send, and only ever read back.
+ *
+ * Every day-boundary calculation resolves in the ORG's timezone, never the
+ * browser's or the server's — a quote must not expire a day early for a PM in
+ * another state (`docs/designs/finance-workflow-ux.md` §3.5). All of it is pure:
+ * `convex/lib/quoteDates.ts` is a byte-for-byte mirror (the Convex bundler can't
+ * resolve `@/`), pinned by `convex/quoteDates.test.ts`.
+ */
+
+/** Days a quote stays valid from its quote date when the org hasn't set one. */
+export const DEFAULT_QUOTE_VALIDITY_DAYS = 30;
+
+/** Bounds on `OrgDocumentSettings.quoteValidityDays` and the send dialog's
+ *  "valid for" input. Mirrored server-side via `assertNumRange` (R-8.6.2) and by
+ *  `orgDocumentSettingsSchema` — one definition, both ends. */
+export const QUOTE_VALIDITY_BOUNDS = { min: 1, max: 365 } as const;
+
+/** A sent quote inside this many days of `validUntil` reads as "expiring soon"
+ *  (warning intent). Authoritative for BOTH the per-project Finance tab and the
+ *  org-level Finance section's "Expiring" bucket — R-3.1. */
+export const QUOTE_EXPIRING_SOON_DAYS = 7;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The UTC-instant offset of `timezone` at a given instant, in ms
+ * (`local - UTC`; e.g. +10h for Australia/Sydney in winter). Returns 0 for an
+ * unresolvable timezone, matching `datePartsInTimezone`'s fallback posture —
+ * a bad timezone string degrades to UTC rather than throwing inside a mutation.
+ */
+function timezoneOffsetMs(instantMs: number, timezone?: string): number {
+  if (!timezone) return 0;
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(new Date(instantMs));
+    const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+    const year = get("year");
+    const month = get("month");
+    const day = get("day");
+    // Some ICU versions emit hour "24" for midnight under hour12:false.
+    const hour = get("hour") % 24;
+    const minute = get("minute");
+    const second = get("second");
+    if (![year, month, day, hour, minute, second].every((n) => Number.isFinite(n))) return 0;
+    const asUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+    // instantMs may carry sub-second precision the formatter dropped — floor to
+    // the second on both sides so the offset lands on a whole minute.
+    return asUtc - Math.floor(instantMs / 1000) * 1000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The UTC instant for a wall-clock time on a calendar date IN `timezone`.
+ * Two-pass: the first pass guesses with the offset in force at the naive UTC
+ * instant, the second re-resolves the offset at that guess — which is what makes
+ * it correct across a DST boundary (the offset that applies is the one at the
+ * *result*, not at the naive input).
+ */
+function zonedWallClockToUtc(
+  parts: ProjectNumberDateParts,
+  time: { hour: number; minute: number; second: number; ms: number },
+  timezone?: string,
+): number {
+  const naive = Date.UTC(parts.year, parts.month - 1, parts.day, time.hour, time.minute, time.second, time.ms);
+  const firstPass = naive - timezoneOffsetMs(naive, timezone);
+  return naive - timezoneOffsetMs(firstPass, timezone);
+}
+
+/** Add `days` calendar days to a Y/M/D triple. Pure UTC arithmetic — UTC has no
+ *  DST, so "add a day" can't land on a phantom or doubled local hour here; the
+ *  timezone only re-enters when the result is converted back to an instant. */
+export function addCalendarDays(parts: ProjectNumberDateParts, days: number): ProjectNumberDateParts {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day) + days * MS_PER_DAY);
+  return { year: shifted.getUTCFullYear(), month: shifted.getUTCMonth() + 1, day: shifted.getUTCDate() };
+}
+
+/** First instant (00:00:00.000 local) of the calendar day `instantMs` falls on
+ *  in `timezone`. Used to normalise a user-picked `quoteDate` so the date printed
+ *  on the PDF doesn't shift with the submitting browser's clock. */
+export function startOfDayInTimezone(instantMs: number, timezone?: string): number {
+  const parts = datePartsInTimezone(new Date(instantMs), timezone);
+  return zonedWallClockToUtc(parts, { hour: 0, minute: 0, second: 0, ms: 0 }, timezone);
+}
+
+/** Last instant (23:59:59.999 local) of the calendar day `instantMs` falls on
+ *  in `timezone` — a quote stays valid through the whole of its final day. */
+export function endOfDayInTimezone(instantMs: number, timezone?: string): number {
+  const parts = datePartsInTimezone(new Date(instantMs), timezone);
+  return zonedWallClockToUtc(parts, { hour: 23, minute: 59, second: 59, ms: 999 }, timezone);
+}
+
+/**
+ * `validUntil` for a quote: the END of the calendar day `validityDays` after the
+ * quote date, in the org's timezone. A quote dated 26 Jul valid for 30 days runs
+ * through the end of 25 Aug.
+ */
+export function computeValidUntil(quoteDateMs: number, validityDays: number, timezone?: string): number {
+  const start = datePartsInTimezone(new Date(quoteDateMs), timezone);
+  const end = addCalendarDays(start, validityDays);
+  return zonedWallClockToUtc(end, { hour: 23, minute: 59, second: 59, ms: 999 }, timezone);
+}
+
+/** Whether a stamped `validUntil` has passed. Timezone-free by construction —
+ *  `validUntil` is already an absolute instant resolved in the org's timezone. */
+export function isPastValidUntil(validUntil: number | null | undefined, nowMs: number): boolean {
+  return validUntil != null && validUntil < nowMs;
+}
+
+/** Whole days remaining until `validUntil` (negative once past, 0 on the final
+ *  day). Drives the `≤7 days` warning copy in the Finance tab. */
+export function daysUntilValidUntil(validUntil: number | null | undefined, nowMs: number): number | null {
+  if (validUntil == null) return null;
+  return Math.floor((validUntil - nowMs) / MS_PER_DAY);
+}
+
+/** Resolve the org's configured quote validity, clamped to the supported bounds.
+ *  A stored value outside them (hand-edited settings blob) falls back to the
+ *  default rather than minting an absurd `validUntil`. */
+export function resolveQuoteValidityDays(configured: number | null | undefined): number {
+  if (configured == null || !Number.isInteger(configured)) return DEFAULT_QUOTE_VALIDITY_DAYS;
+  if (configured < QUOTE_VALIDITY_BOUNDS.min || configured > QUOTE_VALIDITY_BOUNDS.max) {
+    return DEFAULT_QUOTE_VALIDITY_DAYS;
+  }
+  return configured;
+}

--- a/src/lib/validations/org-settings.ts
+++ b/src/lib/validations/org-settings.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { QUOTE_VALIDITY_BOUNDS } from "@/lib/quote-validity";
+
 /**
  * Global document settings (footer text, terms & conditions, quote
  * validity) — org-level, part of the `orgSettings` Convex blob
@@ -12,7 +14,12 @@ export const orgDocumentSettingsSchema = z.object({
   footerSecondLine: z.string().max(200).optional(),
   termsAndConditions: z.string().max(4000).optional(),
   /** Days a quote stays valid from its generation date. Default 30. */
-  quoteValidityDays: z.coerce.number().int().min(1).max(365).optional(),
+  quoteValidityDays: z.coerce
+    .number()
+    .int()
+    .min(QUOTE_VALIDITY_BOUNDS.min)
+    .max(QUOTE_VALIDITY_BOUNDS.max)
+    .optional(),
 });
 
 export type OrgDocumentSettingsValues = z.input<typeof orgDocumentSettingsSchema>;

--- a/src/lib/validations/quote.ts
+++ b/src/lib/validations/quote.ts
@@ -1,12 +1,68 @@
 import { z } from "zod";
 
+import { QUOTE_VALIDITY_BOUNDS } from "@/lib/quote-validity";
+
 /**
- * Quote publish form (WS1 #940) — the only client input on publish is an
- * optional note; every money field is server-computed (buildFinanceLines +
- * the project's own recalc-owned totals — R-9.3, never trust client money).
+ * Quote revision forms (WS1 #940, reworked by #986). ONE base schema; every
+ * variant is DERIVED from it with `.pick()`/`.extend()` rather than re-declaring
+ * the shared fields — a second hand-maintained copy of the same bounds is a
+ * defect even while in sync (R-8.6.3 / R-3.1).
+ *
+ * Client validation is UX only. Every bound here is mirrored server-side in
+ * `convex/quotesWrites.ts` via `convex/lib/fieldGuards.ts`, because these
+ * mutations are browser-direct and a caller with a valid session can invoke them
+ * without ever running this parse (FEATUREDOCS/54 "the write security bar").
+ *
+ * There is no monetary field anywhere in this file, by design (R-9.3): a send
+ * carries dates, a contact and free text; every figure is computed server-side
+ * from the project's own recalc-owned totals.
  */
-export const quoteSchema = z.object({
+const quoteBaseSchema = z.object({
+  /** Notes to the client, printed on the quote. */
   notes: z.string().max(2000).optional(),
+  /** Date printed on the PDF and the anchor for validity. Defaults to today. */
+  quoteDate: z.coerce.date().optional(),
+  /** Defaults to the org's `documents.quoteValidityDays` when omitted. */
+  validityDays: z.coerce
+    .number()
+    .int()
+    .min(QUOTE_VALIDITY_BOUNDS.min)
+    .max(QUOTE_VALIDITY_BOUNDS.max)
+    .optional(),
+  /** A contact on THIS project's client — server-validated against both. */
+  recipientContactId: z.string().optional(),
+  /** PO number, email subject, "verbal — call 26/7" … */
+  acceptanceRef: z.string().max(200).optional(),
+  /** Why a revision was recalled or declined. The floor differs per verb below. */
+  reason: z.string().max(1000).optional(),
+  /** When the client accepted. Defaults to today. */
+  acceptedAt: z.coerce.date().optional(),
 });
 
-export type QuoteFormValues = z.input<typeof quoteSchema>;
+/** Send — freezes the revision. */
+export const quoteSendSchema = quoteBaseSchema.pick({
+  notes: true,
+  quoteDate: true,
+  validityDays: true,
+  recipientContactId: true,
+});
+
+/** Recall — un-send. Reuses #793's 10-character justification floor: this
+ *  un-sends a document the client may already be holding, so "why" isn't
+ *  optional. */
+export const quoteRecallSchema = quoteBaseSchema
+  .pick({ reason: true })
+  .extend({ reason: z.string().min(10).max(1000) });
+
+/** Accept — unblocks CONFIRMED. */
+export const quoteAcceptSchema = quoteBaseSchema.pick({ acceptedAt: true, acceptanceRef: true });
+
+/** Decline — a shorter floor than recall; "Too expensive" is a real answer. */
+export const quoteDeclineSchema = quoteBaseSchema
+  .pick({ reason: true })
+  .extend({ reason: z.string().min(3).max(1000) });
+
+export type QuoteSendValues = z.input<typeof quoteSendSchema>;
+export type QuoteRecallValues = z.input<typeof quoteRecallSchema>;
+export type QuoteAcceptValues = z.input<typeof quoteAcceptSchema>;
+export type QuoteDeclineValues = z.input<typeof quoteDeclineSchema>;


### PR DESCRIPTION
## Summary

Closes #986 — Phase A of the finance version-control program (#985). Design:
[`docs/designs/finance-first-class-version-control.md`](../blob/main/docs/designs/finance-first-class-version-control.md) §3, §8.

`quotes.version` was a number bumped inside `publishNative` by scanning existing rows: no draft state, no send, no dates, no recall, and a `DRAFT` literal nothing ever wrote. The project had no version at all, so "project v2 / quote v2" had nowhere to live. This replaces that with a real revision model.

**One counter, three tables.** `projects.revision` is the authority; `quotes.version` is the revision the row was cut from; `projectSnapshots.revision` is the frozen entity state for it. Project v2 == Quote v2 == the snapshot taken at v2, with no second counter and no quote document number — a quote is `<projectNumber> v<version>` (decision 5), so `project-number.ts` / `invoice-number.ts` are untouched.

`projects.revision` is server-owned: written only by `createNative` (seeded to 1, templates excluded) and `newVersionNative`, stripped from client patches alongside `PROJECT_MONEY_ANCHORS`, and un-clearable. Both service-token create paths (the WooCommerce order → project flow) seed it too.

**Four invariants, each tested:** exactly one quote row per `(projectId, revision)`; at most one `DRAFT`, always at `projects.revision`; at most one live document; and `projects.revision` never decrements or reuses a number.

**Supersede fires on SEND, not on draft.** v1 stays `SENT` while v2 is drafted, so there is always exactly one row representing what the client is holding, and cutting a draft never invalidates it. Recall reverses it symmetrically: un-sending v2 restores v1 to `SENT`, because v1 is then the last thing actually sent.

One consequence worth flagging for review, since it isn't spelled out in the issue: supersede applies to an `ACCEPTED` revision too, so **acceptance does not survive a re-quote**. Accept v1, send v2, and the project needs v2 accepted (or an admin override) before it can advance to `CONFIRMED` again — the client agreed to v1's price, not v2's. Cutting the v2 *draft* changes nothing; only sending it does, and an already-`CONFIRMED` project stays confirmed because the gate fires on transitions. Tested and documented explicitly.

**`EXPIRED` is derived on read** (`validUntil < now && SENT`) — no cron, no clock skew, no stale row. `PUBLISHED` normalises to `SENT` on read so behaviour is identical before, during and after the migration, and stays declared in the validator until a run confirms zero live rows carry it (the `depositPercent` prod-deploy precedent).

**The five verbs** (`sendNative` / `recallNative` / `newVersionNative` / `markAcceptedNative` / `markDeclinedNative`) all take the 4-guard browser-direct shape plus org-checked reference loads and audit logging. Send/accept/decline/new-version check `invoice:publish`; **recall additionally requires `isHardLockOverrideAllowed`** (decision 11) — un-sending a document the client may already hold is trust-sensitive in a way the others aren't. No new permission resource.

**Acceptance gate on CONFIRMED** (decision 3), overridable by the same narrow audience and the same bounded justification as #792/#793. Those 10/1000 bounds were already duplicated inline in `updateStatusNative`, so this collapses them to one exported definition rather than adding a third copy.

Money still never originates from the client (R-9.3): the only send inputs are `quoteDate`, `validityDays`, `recipientContactId`, `notes`.

### Fixed along the way

- `quotes.listForProject` read the **global** `by_projectId` index with no org re-check — a cross-tenant read (R-8.4.3). Every quote read now goes through an org-checking loader.
- `quoteValidityDays`'s default of 30 was hand-copied into `document-settings.tsx` and `build-document-data.ts`, and its 1–365 bounds into `org-settings.ts`. One definition now (`src/lib/quote-validity.ts`), mirrored byte-for-byte into `convex/lib/quoteDates.ts` and pinned by a cross-import test.
- Validity was computed in the render host's timezone with `now + days * 86400000`. `validUntil` is now the end of its calendar day **in the org's timezone**, resolved two-pass so it survives DST in both hemispheres and half/quarter-hour offsets — a quote must not expire a day early for a PM in another state. It is stamped once at send and only read back.

### Backfill

Production has effectively no live quote data (decision 12), so this is a simple forward migration: `revision ← max(quotes.version)` else 1, `PUBLISHED → SENT`, `published*` → `sent*`, dates derived on the org's calendar day, and a `DRAFT` v1 inserted for every project with none. Pre-existing sent quotes get **no artifact** — retro-rendering one from today's project state would manufacture a document that was never sent, which is the exact defect this program removes.

"Effectively none" is a basis for choosing the simple path, not a licence to skip verification: the driver counts first, **halts** on a mismatch against `--expect-quotes` before writing anything, and fails the run unless `verifyQuoteRevisions` reads zero un-migrated rows afterwards.

```
pnpm exec tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts
pnpm exec tsx --env-file=.env --env-file=.env.local scripts/convex-backfill-quote-revisions.ts --apply --expect-quotes=<n>
```

### UI

`<ProjectQuoteRail>` replaces the bare "Publish quote" button with a revision rail — send, cut the next version, accept/decline/recall — with copy stating plainly that Flow doesn't email clients (decision 7). This is Phase A's minimum surface for exercising the model, **not** the designed Finance tab: the send dialog (quote date / valid-until / recipient / watermarked preview), version history with diffs, the invoice issue dialog with due dates, and the drift indicator are Phase D (#989).

### Out of scope (later phases)

Immutable stored artifacts + `pdfFileId` wiring (#987), the unified status × quote-state lock tier (#988), the Finance tab (#989), lock UX (#990), the org-level Finance section (#992).

One forward note is left in the code rather than discovered later: once #988 folds quote state into `resolveLockTier`, `sendNative`'s own `assertLifecycleGuard` call site must treat "cut and send the next revision" as the sanctioned exit from the quote-derived lock, or sending v2 would be blocked by v1's own lock.

### Size rationale (R-2.8 / T-2)

The bot flags this at ~3.8k LOC against a 400-LOC target. Breakdown of the 3607 added lines:

| | Added |
|---|---|
| Tests | 1035 |
| Docs (FEATUREDOCS 66 + 10, CLAUDE.md) | 266 |
| Backfill + its driver script | 444 |
| `quoteDates.ts` + `quote-validity.ts` (one 145-line module, mirrored per the `projectNumber.ts` convention) | 294 |
| Everything else (mutations, queries, schema, hook, UI, validations) | ~1568 |

So ~36% is tests and docs, and ~8% is the deliberate byte-for-byte mirror the Convex bundler forces. The commits are atomic and individually reviewable (7 of them, split by concern).

I don't think this splits usefully. The phase is one indivisible data-model change: the schema, the enum, the five verbs, the acceptance gate and the backfill have to land together or an intermediate commit ships a half-migrated state — a schema without the backfill leaves `PUBLISHED` rows unreadable by the new vocabulary, and verbs without the gate ship an acceptance state nothing enforces. #986 scoped it as one phase for that reason, and the genuinely separable work (artifacts, locks, the Finance tab, lock UX, org finance) is already split out as #987–#992.

## Testing

`pnpm test` — **376 files, 4739 tests, all passing.** `pnpm build`, `tsc --noEmit` and `pnpm lint` (0 errors) clean. Complexity, `any`, `.collect()`, dead-code, import-cycle and client-route ratchets all at or below baseline.

- **`convex/quotesWrites.test.ts`** (29) — the four invariants; supersede-on-send-not-on-draft; acceptance not surviving a re-quote; the recall round trip including restoring the superseded predecessor; monotonicity across recall-then-re-send; server-computed snapshot money; derived `EXPIRED` blocking acceptance until an explicit re-send; the RBAC split (a manager can send but **cannot** recall, and the project's PM can); cross-org IDOR per mutation; and the Zod bounds mirrored server-side.
- **`convex/quoteDates.test.ts`** (15) — pins the `convex/lib` ↔ `src/lib` mirror over a timezone × instant × validity matrix, and asserts `validUntil` lands on the last local instant of its calendar day across DST starts and ends in both hemispheres, at `Asia/Kolkata` and `Pacific/Chatham` offsets, and over month/year/leap boundaries.
- **`convex/backfillQuoteRevisions.test.ts`** (10) — dry-run writes nothing, every migration step, template exclusion, idempotency, monotonicity, SERVICE-only access, the halt-on-mismatch guard, and zero un-migrated rows afterwards.
- **`convex/projectWrites.test.ts`** — the acceptance gate: blocked without an accepted revision; satisfied by one; **not** satisfied by a merely-`SENT` one or by another org's `ACCEPTED` row (IDOR); the admin/PM override with its audited justification; a non-PM member refused even with one; ungated for moves that don't land on `CONFIRMED`; gated again on a re-crossing. Plus `revision` being neither forgeable nor clearable.
- **`convex/validationDrift.test.ts`** — the Zod ↔ Convex field-set parity pair for `quote` becomes four (send / recall / accept / decline).

Two existing suites needed updating for the new gate, both because their subject is snapshot capture rather than acceptance: `projectLifecycleLocks.test.ts` now seeds an accepted revision before advancing to `CONFIRMED`, and `writeParity.test.ts` covers the seeded `revision: 1` on both create paths.

**Not verified here:** the Convex functions could not be pushed from this sandbox (no `CONVEX_DEPLOY_KEY`), so the schema change and mutations have only been exercised against `convex-test`, not a live deployment. The deploy pipeline runs `convex deploy` on merge. The backfill has likewise only been run against test fixtures — it should be run with `--expect-quotes` against prod before Phase B lands.

## Checklist

- [x] New dependency? **None added.**