### PR TITLE
PDF fixes: pagination, Uncategorized-zone groups, discount transparency, totals spacing

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -275,6 +275,59 @@ automatically; a naive markdown-lite swap would have silently dropped that.
   `plugins/index.ts` per the rebrand-alias convention
   (`rebrand-plugin-aliases.test.ts`).
 
+### Totals-divider redesign, bold gate, per-item Discount column (2026-07-28)
+
+- **Totals divider, take 2.** The first divider-clearance fix (6pt/16pt →
+  reserved height 34mm) still visually read as touching the "Total" text on
+  a real render — the arithmetic left only ~1.6pt of clearance once the
+  divider line's own 1pt stroke width and the bold size-11 text's real
+  ascent (measured via pdf-lib's `font.heightAtSize(11, {descender:
+  false})` ≈ 7.9pt, not a guessed constant) were both accounted for.
+  `gearflowFinancialSummary`'s divider gap is now 8pt above the line + 16pt
+  below it (was 6/10) — ~7.6pt of real clearance, an order of magnitude more
+  margin than the minimum needed. `document-composer.ts`'s `totals` block
+  height estimate is unaffected by this specific change (still `34` — the
+  extra 4pt fit within the existing mm rounding), but see the new
+  itemDiscountTotal case below. `gearflow-financial-summary.test.ts` is the
+  regression guard: it asserts the line sits strictly between the two rows'
+  baselines AND that the Total text's real ascent (not a guess) still can't
+  reach the line — this is the shape of test that should have existed
+  before the first attempt.
+- **Parent-row bold is now gated by `showKitChildren`, matching the
+  children-visibility gate.** Previously a kit/group/accessory parent's
+  description was unconditionally bold whenever it *had* children, even on
+  quote/invoice where those children are hidden (`showKitChildren: false`)
+  — the client saw an unexplained bold row with nothing visibly grouped
+  under it (e.g. an accessory parent bolded for a battery accessory that
+  never renders). `gearflow-table.ts`'s description-cell font is now
+  `isParentWithChildren && config.showKitChildren ? fonts.bold :
+  fonts.regular`. Warehouse docs (`showKitChildren: true`) are unaffected.
+- **Per-item Discount column (quote/invoice).** `projectLineItems.discount`
+  (a flat $ amount, already subtracted into `lineTotal` server-side —
+  `lineTotal = unitPrice × quantity × duration − discount`, see
+  `convex/lineItemWrites.ts`) was already on `DocumentLineItem` but never
+  rendered. `getColumnsForDocType`'s quote/invoice columns gained a
+  `discount` column between Unit Price and Total (`-$X.XX`, or `-` when
+  unset), rendered at all three row tiers (parent/child/grandchild) for
+  column-shape consistency, though children never render there today
+  (`showKitChildren: false`). Purely additive — no pricing math changed,
+  since `lineTotal` already was (and still is) the post-discount figure.
+- **"Item Discounts" transparency rows in the totals block.** Because
+  `lineTotal`/`subtotal` are already net of each line's own discount, simply
+  adding a "Discount" line to the totals block would have double-subtracted
+  it. Instead, `FinancialSummaryConfig.itemDiscountTotal` (summed in
+  `document-composer.ts`'s `computeItemDiscountTotal` from the same
+  structured `data.line_items` the table renders, so it always reconciles
+  with what's visible in the new Discount column) drives two rows drawn
+  **above** the existing net `Subtotal` row, only when the sum is > 0:
+  `Subtotal (before discounts)` (= `subtotal + itemDiscountTotal`) then
+  `Item Discounts` (`-$X.XX`). The pre-existing `Discount (X%)` row is
+  unrelated — it's still the separate project-wide manual discount
+  (`data.discount_percent`/`discount_amount`) applied on top of the net
+  subtotal, unchanged. `estimateBlockHeight`'s `totals` case reserves 44mm
+  instead of 34mm when `computeItemDiscountTotal(data) > 0`, to fit the two
+  extra rows.
+
 ### Quote-specific fixes (#790 Phase 4)
 
 - **No "/day" (or other period) price suffix on the quote.** `TablePluginConfig.hidePricingPeriodSuffix`

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -107,7 +107,7 @@ of importing `@pdfme/generator` directly. `no-restricted-imports` in
 | `gearflowCrewTable` | Crew table for call sheets — sorted by call time then role |
 | `gearflowCallSheetInfo` | 2-column info block: PM/client/equipment (left), venue/schedule (right) |
 | `gearflowDayHeader` | Day separator with accent bar, date label, phase badges, crew count |
-| `gearflowRichText` | Markdown-lite text block (`**bold**`, `*italic*`, `- `/`* ` bullets, word-wrapped to the box width) — replaces the pdfme built-in `text` type for every free-text/paragraph block in the 5 project document layouts: client+project details columns, client notes, total-items note, quote-validity note, terms & conditions. |
+| `gearflowRichText` | Markdown-lite text block (`**bold**`, `*italic*`, `- `/`* ` bullets, word-wrapped to the box width) — replaces the pdfme built-in `text` type for every free-text/paragraph block in the 5 project document layouts: client+project details columns, client notes, total-items note, terms & conditions. When real font metrics are available (`generate-pdf.ts`), clientNotes/termsAndConditions also split across pages by wrapped line instead of only ever moving whole — see "Wrap-accurate pagination" below. |
 
 **Report Plugins:**
 | Plugin | Purpose |
@@ -180,7 +180,7 @@ removed (dual pipelines, ~8,300 dead LOC, and the pagination bug it caused).
 
 | Type | Blocks | `expandProjectGroups` | Status filter |
 |------|--------|------------------------|----------------|
-| `quote` | header, client+project details, table (`clientFacingTable`: no "/day" price suffix, no badges, no kit/accessory children), totals, client notes, T&Cs (omitted if unset), quote-validity note (real computed date) | false (collapse groups) | none |
+| `quote` | header (+ "Expiry: {date}" meta line, real computed date), client+project details, table (`clientFacingTable`: no "/day" price suffix, no badges, no kit/accessory children), totals, client notes, T&Cs (omitted if unset) | false (collapse groups) | none |
 | `invoice` | header, client+project details (+ tax ID, payment terms), table (`clientFacingTable`: no badges, no kit/accessory children), totals (+ deposit/balance), client notes | false | none |
 | `packing-list` | header, client+project details, table (checkboxes, per-unit, asset tags, categories), total-items note | true (expand groups) | none |
 | `return-sheet` | header, client+project details, table (checkboxes, condition columns, per-unit, asset tags), signature (3 cols) | true | `CHECKED_OUT`, `RETURNED` |
@@ -202,7 +202,7 @@ card at `/settings/branding` ("Branding & documents").
 |---|---|
 | `footerText` / `footerSecondLine` | Rendered on every page of every doc type. Empty falls back to an auto-generated `{org name} \| {org email} \| {org phone}` line. |
 | `termsAndConditions` | Plain text (no token system) rendered as a block on the quote only. Omitted entirely (zero height, no schema) when unset — no empty box by default. |
-| `quoteValidityDays` (default 30) | Feeds a **real computed date** — `document_date + quoteValidityDays` — into the quote's "This quote is valid until {date}" line. Replaces the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry. |
+| `quoteValidityDays` (default 30) | Feeds a **real computed date** — `document_date + quoteValidityDays` — into the quote header's "Expiry: {date}" meta line (2026-07-28 — previously its own "This quote is valid until {date}." sentence at the bottom of the document; moved into the header alongside the doc number/date so it's visible without scrolling to the end of a possibly multi-page quote — see below). Replaces the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry. |
 
 `build-document-data.ts` computes 4 `DocumentData` fields from these settings each
 time a document is built: `document_footer_text`, `document_footer_second_line`,
@@ -327,6 +327,102 @@ automatically; a naive markdown-lite swap would have silently dropped that.
   subtotal, unchanged. `estimateBlockHeight`'s `totals` case reserves 44mm
   instead of 34mm when `computeItemDiscountTotal(data) > 0`, to fit the two
   extra rows.
+
+### Wrap-accurate pagination for free-text blocks, "Uncategorized zone" Project Groups, quote expiry moved to the header (2026-07-28)
+
+**Accurate pagination for clientNotes/termsAndConditions — no more silent
+footer overlap or empty trailing pages.** A long org T&Cs block (numbered
+sections with several clauses long enough to word-wrap) exposed two related
+bugs:
+- `estimateBlockHeight`'s `termsAndConditions`/`clientNotes` cases counted
+  literal `\n`s in the source text to estimate height — but `gearflowRichText`
+  word-wraps to the box width at render time (2026-07-27), so a long clause
+  could render as 2+ physical lines while only counting as 1 in the estimate.
+  The reserved space under-shot the real rendered height, and the actual text
+  ran past its box — visually into the footer on the affected page.
+- Because `termsAndConditions`/`clientNotes` could only ever move as ONE
+  whole block to a fresh page (never split, unlike the `table` block), a
+  block that nearly filled a fresh page left almost nothing for whatever
+  came after it — a one-line `quoteValidityNote`-style block could end up
+  alone on its own near-empty page.
+
+Fixed properly, not patched around: `composeDocument(docType, data, docColor,
+fonts?)` gained an **optional 4th parameter** — real embedded Helvetica fonts
+(`RichTextFonts`, `helpers.ts`). `generate-pdf.ts` embeds them once (a
+throwaway `PDFDocument.create()` used purely for font metrics, never
+rendered) and passes them through. When `fonts` is supplied:
+- `estimateBlockHeight` measures the block's ACTUAL wrapped line count via
+  `wrapRichText()` — the exact same function `gearflowRichText` uses to
+  render — instead of the raw-newline heuristic. `richTextLineHeight(fontSize)`
+  (`helpers.ts`) is the single shared line-advance formula both the estimate
+  and the plugin's render default use, so they can never drift apart again
+  (the class of bug CLAUDE.md's PDF "audit checklist" exists to prevent).
+- `computePages`'s `splitRichTextBlock` (mirrors `splitTable`, but simpler —
+  wrapped lines are uniform-height and atomic, no sub-items/children) wraps
+  the block ONCE up front and fills each page with as many whole lines as
+  fit, continuing the rest on the next page(s) — a `termsAndConditions` block
+  longer than a single page's content height now actually spans multiple
+  pages instead of silently overflowing the one it was squeezed onto.
+- `PageEntry.textLines` carries the pre-wrapped slice for that page.
+  `buildEntryFields` passes it to `gearflowRichText` as `{ lines: [...] }`
+  JSON instead of the raw markdown string — the plugin draws the given lines
+  directly with **zero re-wrapping**, so the exact line breaks that drove the
+  page-break math are the exact line breaks rendered; they cannot diverge.
+
+**Backward-compatible by construction, not by exception.** `composeDocument`
+stays fully synchronous; `fonts` is optional specifically so every existing
+caller/test that doesn't pass it keeps its EXACT prior behavior (raw-newline
+estimate, whole-block-only movement, plugin wraps the raw string itself at
+render time) — confirmed by the full existing test suite passing unchanged.
+Only `generate-pdf.ts` (the real render path) and new pagination-specific
+tests opt into the accurate path. See `document-composer.test.ts`'s "accurate
+rich-text pagination (fonts provided)" describe block.
+
+**"Uncategorized zone" Project Groups now collapse/expand correctly instead
+of splitting into flat items.** A `ProjectGroup` can have `categoryId: null`
+— the equipment tab's "Uncategorized" zone is a first-class, fully-supported
+state there (`equipment-tab.tsx`), not an error. But
+`buildDocumentLineItemData` (`project-line-item-read.ts`) only ever nested
+groups under a REAL category (`mappedGroups.filter(g => g.categoryId ===
+c.id)`) when building the `categories` array `structureLineItems` reads —
+an uncategorized group was invisible to it: its own synthetic collapsed row
+never rendered, and (in expand/warehouse mode) its members' `groupChildren`
+match failed too, since it was keyed on `groupTitle === group.title &&
+categoryName === cat.name` and a member's OWN `categoryName` is null
+whenever its `categoryId` is unset — even though the member correctly
+carries `groupId` pointing at the group. Net effect: the whole group printed
+as disconnected flat line items on quotes/invoices instead of one collapsed
+row (and vanished from warehouse docs' childLineItems entirely).
+
+Fixed two ways, together:
+1. `buildDocumentLineItemData` now folds every `categoryId: null` group into
+   a synthetic pseudo-category `{ id: "__uncategorized__", name: "", groups:
+   [...] }` appended to `categories`. `name: ""` buckets its synthetic row
+   under each doc type's normal "no header" fallback
+   (`groupName || prepContainer || ungroupedKey`) rather than printing a
+   spurious "Uncategorized" section title on a client-facing document.
+2. `structure-line-items.ts`'s member matching (`groupChildren`,
+   `hasGroupContent` in expand mode) now keys off `groupId` (the FK, added
+   to `DocumentLineItem` — `structureLineItems — Uncategorized-zone Project
+   Group` in `structure-line-items.test.ts`) first, falling back to the old
+   `groupTitle`+`categoryName` string match only when `groupId` is absent
+   (in practice: this file's own test fixtures, which predate the field —
+   real data from `buildDocumentLineItemData` always sets `groupId`
+   whenever `groupTitle` is resolved from it, so production traffic always
+   takes the id-based path).
+
+**Quote expiry moved into the header.** The quote's "This quote is valid
+until {date}." sentence used to be its own block at the very end of the
+document (`quoteValidityNote` — now deleted from `LayoutBlock` and
+`DOCUMENT_LAYOUTS.quote.blocks` entirely, since nothing else used it). It's
+now a third header-meta line, "Expiry: {date}", next to the doc number/date
+(`document-composer.ts`'s `header` case, quote-only,
+`docType === "quote" && data.quote_valid_until`) — visible immediately
+without scrolling to the end of a possibly multi-page quote.
+`estimateBlockHeight`'s `header` case reserves 5mm of extra height for the
+quote's 3-line meta block (vs. the usual 2 lines) as a safety margin, mirroring
+the "reserve generously, don't cut it close" lesson from the totals-divider
+fix above.
 
 ### Quote-specific fixes (#790 Phase 4)
 

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -7,10 +7,20 @@
  * ported from the deleted section-renderer.test.ts as this engine's spec.
  */
 import { describe, it, expect } from "vitest";
+import { PDFDocument } from "@pdfme/pdf-lib";
+import * as pdfLib from "@pdfme/pdf-lib";
+import { mm2pt } from "@pdfme/common";
 import { composeDocument, type ComposeResult } from "./document-composer";
 import { DOCUMENT_LAYOUTS, type ProjectDocumentType } from "./document-layouts";
+import { CONTENT_WIDTH } from "./template-constants";
 import { makeLineItem, runTablePlugin } from "./plugins/test-utils";
+import { getHelveticaFonts, wrapRichText, type RichTextFonts } from "./plugins/helpers";
 import type { DocumentData, DocumentLineItem, TablePluginConfig } from "./types";
+
+async function makeFonts(): Promise<RichTextFonts> {
+  const doc = await PDFDocument.create();
+  return getHelveticaFonts(doc, pdfLib, new Map());
+}
 
 function makeData(overrides: Partial<DocumentData> = {}): DocumentData {
   return {
@@ -342,10 +352,22 @@ describe("composeDocument — org document settings (footer, T&Cs, quote validit
     expect(result.inputs[0][termsSchema.name as string]).toBe("All sales final.");
   });
 
-  it("renders the quote validity note using the real computed date, not static copy", () => {
+  it("renders the quote expiry in the header meta (\"Expiry: <date>\"), using the real computed date — no separate bottom-of-document line", () => {
     const result = composeDocument("quote", soloData({ quote_valid_until: "2026-09-15" }), "#0d4f4f");
-    const validitySchema = result.template.schemas[0].find((s) => String(s.name).startsWith("quoteValidityNote"))!;
-    expect(result.inputs[0][validitySchema.name as string]).toBe("This quote is valid until 2026-09-15.");
+
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.docMeta).toContain("Expiry: 2026-09-15");
+
+    const hasValidityNoteSchema = result.template.schemas[0].some((s) => String(s.name).startsWith("quoteValidityNote"));
+    expect(hasValidityNoteSchema).toBe(false);
+  });
+
+  it("invoice header never shows a quote expiry line", () => {
+    const result = composeDocument("invoice", soloData({ quote_valid_until: "2026-09-15" }), "#0d4f4f");
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.docMeta).not.toContain("Expiry");
   });
 });
 
@@ -659,5 +681,96 @@ describe("composeDocument — mixed rental + SALE fixture (WS11 #950)", () => {
       expect(li.isKitChild).toBeFalsy();
       expect(li.groupName).toBeFalsy();
     }
+  });
+});
+
+// ─── Accurate wrap-aware pagination for clientNotes/termsAndConditions ────────
+//
+// Repro of a real bug: a long terms & conditions block (many bulleted clauses,
+// several of which word-wrap onto a second physical line) rendered on a quote
+// where the raw-"\n"-count height estimate under-counted the real wrapped
+// line total, so the reserved space was too small — the actual text ran past
+// its box into the footer. Fixed by measuring the SAME wrapRichText() output
+// used at render time, and by letting clientNotes/termsAndConditions split
+// across pages (like the table already does) instead of always moving whole.
+
+/** A realistic long T&Cs: numbered sections, several long clauses that word-wrap
+ *  onto more physical lines than there are literal `\n`s in the source. */
+function makeLongTermsAndConditions(sections = 10): string {
+  const lines: string[] = [];
+  for (let s = 1; s <= sections; s++) {
+    lines.push(`${s}. SECTION ${s} HEADING`);
+    lines.push(
+      `- ${s}.1 This is a long clause that should word-wrap across more than one physical line once it is rendered at the document's real content width, the exact scenario the literal-newline-count heuristic could never see coming.`,
+    );
+    lines.push(`- ${s}.2 A second, shorter clause.`);
+    lines.push(`- ${s}.3 A third clause with just enough text to matter.`);
+  }
+  return lines.join("\n");
+}
+
+function findAllSchemasOfType(result: ComposeResult, type: string) {
+  return result.template.schemas.flatMap((pageSchemas, pageIdx) =>
+    pageSchemas.filter((s) => s.type === type).map((s) => ({ schema: s, pageIdx })),
+  );
+}
+
+describe("composeDocument — accurate rich-text pagination (fonts provided)", () => {
+  it("estimates termsAndConditions height from real wrapped lines, not raw newline count, when fonts are supplied", async () => {
+    const fonts = await makeFonts();
+    const text = makeLongTermsAndConditions(3);
+    const rawNewlineCount = text.split("\n").length;
+    const realWrappedCount = wrapRichText(text, { maxWidth: mm2pt(CONTENT_WIDTH), fontSize: 8, fonts }).length;
+
+    // The long clauses genuinely wrap onto extra physical lines — the fixture
+    // is only a meaningful regression test if this holds.
+    expect(realWrappedCount).toBeGreaterThan(rawNewlineCount);
+
+    const withFonts = composeDocument("quote", makeData({ quote_terms_and_conditions: text }), "#0d4f4f", fonts);
+    const withoutFonts = composeDocument("quote", makeData({ quote_terms_and_conditions: text }), "#0d4f4f");
+
+    const heightOf = (r: ComposeResult) =>
+      findAllSchemasOfType(r, "gearflowRichText")
+        .filter(({ schema }) => (schema.name as string).startsWith("termsAndConditions_"))
+        .reduce((sum, { schema }) => sum + (schema.height as number), 0);
+
+    // The accurate (fonts) estimate reserves MORE space than the old
+    // raw-newline heuristic for text that wraps — the under-reservation
+    // that caused the footer overlap is gone.
+    expect(heightOf(withFonts)).toBeGreaterThan(heightOf(withoutFonts));
+  });
+
+  it("splits a terms & conditions block too long for one page across multiple pages with no dropped lines", async () => {
+    const fonts = await makeFonts();
+    const text = makeLongTermsAndConditions(20); // long enough to exceed a single page
+    const result = composeDocument("quote", makeData({ quote_terms_and_conditions: text }), "#0d4f4f", fonts);
+
+    const tcEntries = findAllSchemasOfType(result, "gearflowRichText").filter(({ schema }) =>
+      (schema.name as string).startsWith("termsAndConditions_"),
+    );
+    const pagesUsed = new Set(tcEntries.map((e) => e.pageIdx));
+    expect(pagesUsed.size).toBeGreaterThan(1); // actually split, not silently overflowed on one page
+
+    // Reassemble every rendered line across every page's slice, in order,
+    // and confirm it's IDENTICAL to wrapping the source text once — no
+    // line dropped, none duplicated.
+    const expectedLines = wrapRichText(text, { maxWidth: mm2pt(CONTENT_WIDTH), fontSize: 8, fonts });
+    const renderedLineTexts = tcEntries.flatMap(({ schema }) => {
+      const input = result.inputs[0][schema.name as string];
+      const parsed = JSON.parse(input) as { lines: { spans: { text: string }[] }[] };
+      return parsed.lines.map((l) => l.spans.map((s) => s.text).join(""));
+    });
+    const expectedLineTexts = expectedLines.map((l) => l.spans.map((s) => s.text).join(""));
+    expect(renderedLineTexts).toEqual(expectedLineTexts);
+  });
+
+  it("without fonts, a very long T&Cs block still moves whole to a fresh page (unchanged fallback behavior)", () => {
+    const text = makeLongTermsAndConditions(20);
+    const result = composeDocument("quote", makeData({ quote_terms_and_conditions: text }), "#0d4f4f");
+    const tcEntries = findAllSchemasOfType(result, "gearflowRichText").filter(({ schema }) =>
+      (schema.name as string).startsWith("termsAndConditions_"),
+    );
+    // Exactly one schema — never split when fonts weren't provided.
+    expect(tcEntries).toHaveLength(1);
   });
 });

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -386,7 +386,9 @@ describe("composeDocument — quote content audit (#790 Phase 4)", () => {
     return JSON.parse(result.inputs[0][tableSchema.name as string]) as { items: DocumentLineItem[]; config: TablePluginConfig };
   }
 
-  function totalsConfig(result: ComposeResult): { discountAmount: number; discountPercent: number } {
+  function totalsConfig(
+    result: ComposeResult,
+  ): { discountAmount: number; discountPercent: number; itemDiscountTotal: number; subtotal: number } {
     const totalsSchema = result.template.schemas[0].find((s) => s.type === "gearflowFinancialSummary")!;
     return JSON.parse(result.inputs[0][totalsSchema.name as string]);
   }
@@ -459,6 +461,40 @@ describe("composeDocument — quote content audit (#790 Phase 4)", () => {
 
     const tcSchema = pageSchemas.find((s) => (s.name as string).startsWith("termsAndConditions_"))!;
     expect(tcSchema.type).toBe("gearflowRichText");
+  });
+
+  it("the quote table gets a Discount column, and the totals block's itemDiscountTotal sums every visible line's discount", () => {
+    const items = [
+      makeLineItem({ id: "a", status: "CONFIRMED", model: { name: "K10.2" }, unitPrice: 50, discount: 5, lineTotal: 45 }),
+      makeLineItem({ id: "b", status: "CONFIRMED", model: { name: "DM3-D" }, unitPrice: 20, discount: null, lineTotal: 20 }),
+    ];
+    const result = composeDocument("quote", makeData({ line_items: items, subtotal: 65 }), "#0d4f4f");
+
+    const tableSchema = result.template.schemas[0].find((s) => s.type === "gearflowTable")!;
+    const { config } = JSON.parse(result.inputs[0][tableSchema.name as string]) as { config: TablePluginConfig };
+    expect((config as unknown as { showPricing: boolean }).showPricing).toBe(true);
+
+    const totals = totalsConfig(result);
+    expect(totals.itemDiscountTotal).toBe(5);
+    expect(totals.subtotal).toBe(65);
+  });
+
+  it("the totals block reserves extra height when line items carry discounts", () => {
+    const withoutDiscount = composeDocument(
+      "quote",
+      makeData({ line_items: [makeLineItem({ id: "a", status: "CONFIRMED", model: { name: "K10.2" }, discount: null })] }),
+      "#0d4f4f",
+    );
+    const withDiscount = composeDocument(
+      "quote",
+      makeData({ line_items: [makeLineItem({ id: "a", status: "CONFIRMED", model: { name: "K10.2" }, discount: 5 })] }),
+      "#0d4f4f",
+    );
+    const heightOf = (r: ComposeResult) => {
+      const entry = r.template.schemas[0].find((s) => s.type === "gearflowFinancialSummary")!;
+      return entry.height as number;
+    };
+    expect(heightOf(withDiscount)).toBeGreaterThan(heightOf(withoutDiscount));
   });
 });
 

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -70,6 +70,20 @@ function isBulk(item: DocumentLineItem): boolean {
 }
 
 /**
+ * Sum of every visible (top-level) line's own `discount` field — matches
+ * exactly what the table's new per-line "Discount" column renders, so the
+ * totals block's "Item Discounts" rollup always reconciles with what the
+ * client can add up themselves off the table above it. `data.line_items`
+ * is already the structured (post `structureLineItems`) array quote/invoice
+ * render, so a collapsed Project Group's dropped children are correctly
+ * excluded — their discount, if any, only counts if it also ended up on
+ * the group's own synthetic row.
+ */
+function computeItemDiscountTotal(data: DocumentData): number {
+  return data.line_items.reduce((sum, li) => sum + (li.discount ?? 0), 0);
+}
+
+/**
  * Filter to parent (non-kit-child, non-container) items, then apply the
  * doc-type status filter. A synthetic Project Group row passes through if
  * ANY attached child passes — otherwise the whole group (and every member)
@@ -313,12 +327,14 @@ function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: Layout
       return ptToMm(TABLE_HEADER_PT) + contentHeight + TABLE_PADDING_BOTTOM_MM;
     }
 
-    case "totals":
-      // 25 (base) + ~9mm for the top padding + wider divider clearance
-      // added in gearflow-financial-summary.ts (issue: totals block sat
-      // right on top of the table, and the Total divider overlapped its
-      // own text).
-      return 34;
+    case "totals": {
+      // 34 (base: top padding + wide divider clearance around Total, see
+      // gearflow-financial-summary.ts) + 2 extra rows (~10mm) when any line
+      // carries its own discount ("Subtotal (before discounts)" + "Item
+      // Discounts", drawn above the existing net Subtotal row).
+      const hasItemDiscounts = computeItemDiscountTotal(data) > 0;
+      return hasItemDiscounts ? 44 : 34;
+    }
 
     case "clientNotes":
       return data.client_notes ? 12 : 4;
@@ -774,6 +790,7 @@ function buildEntryFields(
     case "totals": {
       const config: FinancialSummaryConfig = {
         subtotal: block.config.showSubtotal ? data.subtotal : 0,
+        itemDiscountTotal: block.config.showSubtotal ? computeItemDiscountTotal(data) : 0,
         discountPercent: block.config.showDiscount ? data.discount_percent : 0,
         discountAmount: block.config.showDiscount ? data.discount_amount : 0,
         taxLabel: data.tax_label,

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -12,6 +12,7 @@
  * See docs/designs/pdf-system-redesign.md.
  */
 import type { Template, Schema } from "@pdfme/common";
+import { mm2pt } from "@pdfme/common";
 import type {
   DocumentData,
   DocumentLineItem,
@@ -38,6 +39,7 @@ import {
   SECTION_GAP,
 } from "./template-constants";
 import { parsePriceBreakdown, formatPriceBreakdown } from "@/lib/billing-derivation";
+import { wrapRichText, richTextLineHeight, type RichLine, type RichTextFonts } from "./plugins/helpers";
 
 // ─── Height constants (pt) — must match gearflow-table.ts's actual draw sizes ─
 const PT_PER_MM = 2.835;
@@ -48,10 +50,21 @@ const PER_UNIT_ROW_PT = 10;
 const GROUP_HEADER_PT = 9 + 4 * 2;
 const TABLE_HEADER_PT = 7 + 4 * 2 + 4;
 const TABLE_PADDING_BOTTOM_MM = 1; // safety margin at the bottom of a table block
+// gearflowRichText's schema fontSize for both clientNotes and termsAndConditions
+// (buildEntryFields) — shared here so the accurate estimate/split math can
+// never drift from what's actually configured on the rendered schema.
+const RICH_TEXT_FONT_SIZE = 8;
 
 function ptToMm(pt: number): number {
   return pt / PT_PER_MM;
 }
+
+/** Content width in pt, at pdfme's exact mm->pt precision (not the rounded
+ *  PT_PER_MM approximation used elsewhere in this file) — must match
+ *  exactly what gearflowRichText's own `getLayoutProps` resolves to when it
+ *  wraps unwrapped text itself, or the estimate and the fallback render
+ *  path could disagree by a hair on where a line breaks. */
+const CONTENT_WIDTH_PT = mm2pt(CONTENT_WIDTH);
 
 /** Ungrouped-items bucket key, per docType's plugin convention. */
 export function getUngroupedKey(docType: ProjectDocumentType): string {
@@ -292,13 +305,34 @@ function calculateTableItemHeights(
 interface LayoutContext {
   docType: ProjectDocumentType;
   filterByStatus: string[] | null;
+  /**
+   * Real embedded Helvetica fonts, when the caller provided them (production
+   * rendering via generate-pdf.ts). When present, clientNotes/
+   * termsAndConditions measure their ACTUAL wrapped line count instead of
+   * counting literal `\n`s — the previous heuristic silently under-reserved
+   * space for any line that word-wraps, which could overflow past a page's
+   * footer. Optional so composeDocument stays synchronous and every existing
+   * caller/test that doesn't pass fonts keeps its exact prior behavior.
+   */
+  fonts?: RichTextFonts;
+}
+
+/** Wrapped line count for a markdown-lite block, using real font metrics
+ *  when available (see LayoutContext.fonts) — shared by the height estimate
+ *  and the page-splitting logic so they can never disagree. */
+function wrappedLineCount(text: string, fonts: RichTextFonts): number {
+  return wrapRichText(text, { maxWidth: CONTENT_WIDTH_PT, fontSize: RICH_TEXT_FONT_SIZE, fonts }).length;
 }
 
 function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: LayoutContext): number {
   switch (block.kind) {
     case "header": {
       const mode = data.org_branding?.documentLogoMode ?? "icon";
-      return mode === "logo" ? 25 + 22 : 25;
+      const base = mode === "logo" ? 25 + 22 : 25;
+      // Quote's header meta gains a 3rd line ("Expiry: <date>") — a little
+      // extra headroom so it can't ever crowd the details row below it.
+      const hasExpiryLine = ctx.docType === "quote" && !!data.quote_valid_until;
+      return hasExpiryLine ? base + 5 : base;
     }
 
     case "detailsRow": {
@@ -336,17 +370,27 @@ function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: Layout
       return hasItemDiscounts ? 44 : 34;
     }
 
-    case "clientNotes":
-      return data.client_notes ? 12 : 4;
+    case "clientNotes": {
+      if (!data.client_notes) return 4;
+      if (ctx.fonts) {
+        return Math.max(ptToMm(wrappedLineCount(data.client_notes, ctx.fonts) * richTextLineHeight(RICH_TEXT_FONT_SIZE)), 4);
+      }
+      return 12; // fallback heuristic — unchanged when no fonts are provided
+    }
 
     case "totalItemsNote":
-    case "quoteValidityNote":
       return 8;
 
     case "termsAndConditions": {
       // Optional — collapses to zero height (and is skipped entirely by the
       // page-layout walk) when the org hasn't set any T&Cs text.
       if (!data.quote_terms_and_conditions) return 0;
+      if (ctx.fonts) {
+        return Math.max(
+          ptToMm(wrappedLineCount(data.quote_terms_and_conditions, ctx.fonts) * richTextLineHeight(RICH_TEXT_FONT_SIZE)),
+          8,
+        );
+      }
       const lines = data.quote_terms_and_conditions.split("\n").length;
       return Math.max(lines * 4 + 4, 8);
     }
@@ -365,6 +409,10 @@ interface PageEntry {
   tableStartIndex?: number;
   tableEndIndex?: number;
   tableSubIndex?: number;
+  /** Pre-wrapped slice of a clientNotes/termsAndConditions block for THIS
+   *  page (see splitRichTextBlock). Only set when the caller provided real
+   *  fonts — buildEntryFields falls back to raw text otherwise. */
+  textLines?: RichLine[];
 }
 
 interface Page {
@@ -375,12 +423,16 @@ interface Page {
  * Compute the multi-page layout for one document: walk the layout's blocks
  * top-to-bottom, starting a new page when a block doesn't fit. Table blocks
  * split across pages (per-item cumulative heights) instead of moving whole —
- * this is the tail-drop fix. All mutable page/cursor state lives in this
- * function's closure so the table-split branch can push finished pages and
- * open new ones without a separate state object to keep in sync.
+ * this is the tail-drop fix. clientNotes/termsAndConditions split the same
+ * way, by wrapped line, whenever real fonts are available (see
+ * splitRichTextBlock) — a long T&Cs block no longer has to fit on a single
+ * page (or silently overflow into the footer trying to). All mutable
+ * page/cursor state lives in this function's closure so the split branches
+ * can push finished pages and open new ones without a separate state object
+ * to keep in sync.
  */
-function computePages(layout: DocumentLayout, data: DocumentData, docType: ProjectDocumentType): Page[] {
-  const ctx: LayoutContext = { docType, filterByStatus: layout.filterByStatus };
+function computePages(layout: DocumentLayout, data: DocumentData, docType: ProjectDocumentType, fonts?: RichTextFonts): Page[] {
+  const ctx: LayoutContext = { docType, filterByStatus: layout.filterByStatus, fonts };
   const headerBlock = layout.blocks.find((b) => b.kind === "header") as Extract<LayoutBlock, { kind: "header" }> | undefined;
   const bodyBlocks = layout.blocks.filter((b) => b.kind !== "header");
 
@@ -611,6 +663,39 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     }
   }
 
+  /**
+   * Split a clientNotes/termsAndConditions block across pages by wrapped
+   * line — mirrors splitTable's per-item fill loop, but lines are uniform
+   * height and atomic (no sub-items/children to worry about), so the loop
+   * is a straight "how many whole lines fit in what's left" fill. Wraps
+   * ONCE up front with real font metrics (the same call estimateBlockHeight
+   * used to decide this block needed splitting in the first place) so the
+   * line breaks placed on the page are identical to what was measured.
+   */
+  function splitRichTextBlock(block: Extract<LayoutBlock, { kind: "clientNotes" | "termsAndConditions" }>, text: string, fonts: RichTextFonts) {
+    const lineHeightMm = ptToMm(richTextLineHeight(RICH_TEXT_FONT_SIZE));
+    const allLines = wrapRichText(text, { maxWidth: CONTENT_WIDTH_PT, fontSize: RICH_TEXT_FONT_SIZE, fonts });
+
+    let idx = 0;
+    while (idx < allLines.length) {
+      let available = maxY - currentY;
+      if (available < lineHeightMm) {
+        startNewPage();
+        available = maxY - currentY;
+      }
+      // Always place at least one line, even if it doesn't fit — matches
+      // splitTable's "always render at least one item" invariant, so a
+      // single oversized line can never cause an infinite loop.
+      const count = Math.max(1, Math.min(allLines.length - idx, Math.floor(available / lineHeightMm)));
+      const slice = allLines.slice(idx, idx + count);
+      const blockHeight = count * lineHeightMm;
+
+      currentPage.entries.push({ block, y: currentY, height: blockHeight, textLines: slice });
+      currentY += blockHeight + SECTION_GAP;
+      idx += count;
+    }
+  }
+
   placeHeader();
 
   for (const block of bodyBlocks) {
@@ -622,6 +707,11 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     if (currentY + height > maxY && currentPage.entries.length > 0) {
       if (block.kind === "table") {
         splitTable(block);
+        continue;
+      }
+      if ((block.kind === "clientNotes" || block.kind === "termsAndConditions") && ctx.fonts) {
+        const text = block.kind === "clientNotes" ? data.client_notes || "" : data.quote_terms_and_conditions;
+        splitRichTextBlock(block, text, ctx.fonts);
         continue;
       }
       startNewPage();
@@ -660,11 +750,18 @@ function buildEntryFields(
       if (data.org_email) orgDetailParts.push(data.org_email);
       if (data.org_website) orgDetailParts.push(data.org_website);
 
+      // Quote expiry moves from its own bottom-of-document line into the
+      // header meta (with the doc number/date) — a simple "Expiry: <date>"
+      // read right where the client is already looking, not a standalone
+      // sentence buried at the end of a possibly multi-page document.
+      const docMetaLines = [data.project_number || "", data.document_date || ""];
+      if (docType === "quote" && data.quote_valid_until) docMetaLines.push(`Expiry: ${data.quote_valid_until}`);
+
       const config: PageHeaderConfig = {
         orgName: data.org_name || "",
         orgDetails: orgDetailParts.join("\n"),
         docTitle: block.title,
-        docMeta: `${data.project_number || ""}\n${data.document_date || ""}`,
+        docMeta: docMetaLines.join("\n"),
         logoData: data.org_logo,
         iconData: data.org_icon,
         documentLogoMode: data.org_branding?.documentLogoMode ?? "icon",
@@ -818,10 +915,15 @@ function buildEntryFields(
             position: { x: MARGIN, y },
             width: CONTENT_WIDTH,
             height,
-            fontSize: 8,
+            fontSize: RICH_TEXT_FONT_SIZE,
             fontColor: "#666666",
           },
-          input: data.client_notes || "",
+          // Pre-wrapped slice (see splitRichTextBlock) when this page's
+          // entry carries one — the exact line breakdown that drove the
+          // page-break math, so estimate and render can't disagree. Falls
+          // back to raw text (the plugin wraps it itself) when composeDocument
+          // was called without fonts.
+          input: entry.textLines ? JSON.stringify({ lines: entry.textLines }) : data.client_notes || "",
         },
       ];
 
@@ -842,23 +944,6 @@ function buildEntryFields(
         },
       ];
 
-    case "quoteValidityNote":
-      return [
-        {
-          schema: {
-            name,
-            type: "gearflowRichText",
-            content: "",
-            position: { x: MARGIN, y },
-            width: CONTENT_WIDTH,
-            height,
-            fontSize: 9,
-            fontColor: "#333333",
-          },
-          input: `This quote is valid until ${data.quote_valid_until}.`,
-        },
-      ];
-
     // Org-authored free text (`/settings/branding`'s "Documents" card) —
     // markdown-lite friendly, same convention as line-item notes: `**bold**`,
     // `*italic*`, `- `/`* ` bullets (gearflowRichText / parseRichText).
@@ -872,10 +957,10 @@ function buildEntryFields(
             position: { x: MARGIN, y },
             width: CONTENT_WIDTH,
             height,
-            fontSize: 8,
+            fontSize: RICH_TEXT_FONT_SIZE,
             fontColor: "#666666",
           },
-          input: data.quote_terms_and_conditions,
+          input: entry.textLines ? JSON.stringify({ lines: entry.textLines }) : data.quote_terms_and_conditions,
         },
       ];
 
@@ -905,10 +990,24 @@ export interface ComposeResult {
  * comes from `data.document_footer_text`/`document_footer_second_line` (org
  * "documents" settings — see org-settings-types.ts); empty falls back to an
  * auto-generated "{org} | {email} | {phone}" line.
+ *
+ * `fonts` (optional): real embedded Helvetica fonts (see
+ * `getComposerFonts`/`generate-pdf.ts`). When supplied, clientNotes/
+ * termsAndConditions get an accurate, real-wrap-aware height estimate and
+ * split across pages by line instead of only ever moving as one whole block
+ * (which could either overflow into the footer if underestimated, or strand
+ * a short trailing block alone on a near-empty page). Stays optional, and
+ * `composeDocument` stays synchronous, so no existing caller/test needs to
+ * change — the accurate path is additive.
  */
-export function composeDocument(docType: ProjectDocumentType, data: DocumentData, docColor: string): ComposeResult {
+export function composeDocument(
+  docType: ProjectDocumentType,
+  data: DocumentData,
+  docColor: string,
+  fonts?: RichTextFonts,
+): ComposeResult {
   const layout = getDocumentLayout(docType);
-  const pages = computePages(layout, data, docType);
+  const pages = computePages(layout, data, docType, fonts);
 
   const allSchemas: (Schema & Record<string, unknown>)[][] = [];
   const mergedInputs: Record<string, string> = {};

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -696,6 +696,26 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     }
   }
 
+  /**
+   * Try to split a block that doesn't fit on the current page instead of
+   * moving it whole. Returns whether it actually split (the caller falls
+   * back to startNewPage() when it didn't). Pulled out of the main loop
+   * body to keep computePages's own branch count down (R-3.6) — the
+   * table/richText special-casing lives here instead.
+   */
+  function trySplitAcrossPages(block: LayoutBlock): boolean {
+    if (block.kind === "table") {
+      splitTable(block);
+      return true;
+    }
+    if ((block.kind === "clientNotes" || block.kind === "termsAndConditions") && ctx.fonts) {
+      const text = block.kind === "clientNotes" ? data.client_notes || "" : data.quote_terms_and_conditions;
+      splitRichTextBlock(block, text, ctx.fonts);
+      return true;
+    }
+    return false;
+  }
+
   placeHeader();
 
   for (const block of bodyBlocks) {
@@ -705,15 +725,7 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     if (height <= 0) continue;
 
     if (currentY + height > maxY && currentPage.entries.length > 0) {
-      if (block.kind === "table") {
-        splitTable(block);
-        continue;
-      }
-      if ((block.kind === "clientNotes" || block.kind === "termsAndConditions") && ctx.fonts) {
-        const text = block.kind === "clientNotes" ? data.client_notes || "" : data.quote_terms_and_conditions;
-        splitRichTextBlock(block, text, ctx.fonts);
-        continue;
-      }
+      if (trySplitAcrossPages(block)) continue;
       startNewPage();
     }
 

--- a/src/lib/pdfme/document-layouts.ts
+++ b/src/lib/pdfme/document-layouts.ts
@@ -62,7 +62,6 @@ export type LayoutBlock =
   | { kind: "totals"; config: TotalsLayoutConfig }
   | { kind: "clientNotes" }
   | { kind: "totalItemsNote" }
-  | { kind: "quoteValidityNote" }
   | { kind: "termsAndConditions" }
   | { kind: "signature"; columns: number; labels: string[] };
 
@@ -152,7 +151,6 @@ export const DOCUMENT_LAYOUTS: Record<ProjectDocumentType, DocumentLayout> = {
       { kind: "totals", config: defaultTotals },
       { kind: "clientNotes" },
       { kind: "termsAndConditions" },
-      { kind: "quoteValidityNote" },
     ],
   },
 

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -7,9 +7,12 @@
  * service-based builder (`templates/call-sheet-services.ts`); T&T reports use
  * their own single-purpose builders (`templates/tt-*.ts`).
  */
+import { PDFDocument } from "@pdfme/pdf-lib";
+import * as pdfLib from "@pdfme/pdf-lib";
 import { buildDocumentData } from "./build-document-data";
 import { composeDocument } from "./document-composer";
 import { DOCUMENT_LAYOUTS, type ProjectDocumentType } from "./document-layouts";
+import { getHelveticaFonts } from "./plugins/helpers";
 import { renderPdfTemplate } from "./pdf-render";
 import { getTtReportBuilder } from "./templates";
 import type { TestTagReportType } from "./types";
@@ -32,7 +35,14 @@ export async function generatePdf(
     expandProjectGroups: layout.expandProjectGroups,
   });
 
-  const { template, inputs } = composeDocument(docType, data, data.org_document_color);
+  // Real font metrics for composeDocument's accurate text-wrap measurement
+  // (clientNotes/termsAndConditions) — a throwaway document used purely to
+  // embed the standard fonts, never rendered itself; the actual PDF is
+  // produced by renderPdfTemplate()'s own pdfme generate() call below.
+  const measureDoc = await PDFDocument.create();
+  const fonts = await getHelveticaFonts(measureDoc, pdfLib, new Map());
+
+  const { template, inputs } = composeDocument(docType, data, data.org_document_color, fonts);
   return renderPdfTemplate(template, inputs);
 }
 

--- a/src/lib/pdfme/plugins/gearflow-financial-summary.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-financial-summary.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { PDFDocument, StandardFonts } from "@pdfme/pdf-lib";
+import * as pdfLib from "@pdfme/pdf-lib";
+import gearflowFinancialSummary from "./gearflow-financial-summary";
+import type { FinancialSummaryConfig } from "../types";
+
+interface DrawTextCall {
+  text: string;
+  x: number;
+  y: number;
+  fontName: string;
+}
+interface DrawLineCall {
+  startY: number;
+  endY: number;
+}
+
+const BASE_CONFIG: FinancialSummaryConfig = {
+  subtotal: 295,
+  itemDiscountTotal: 0,
+  discountPercent: 0,
+  discountAmount: 0,
+  taxLabel: "GST",
+  taxAmount: 29.5,
+  total: 324.5,
+  depositPaid: 0,
+  balanceDue: 0,
+  documentColor: "#0d4f4f",
+};
+
+async function runFinancialSummaryPlugin(
+  config: FinancialSummaryConfig,
+): Promise<{ drawText: DrawTextCall[]; drawLine: DrawLineCall[] }> {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([595, 842]);
+
+  const drawText: DrawTextCall[] = [];
+  const drawLine: DrawLineCall[] = [];
+  page.drawText = ((text: string, opts: Record<string, unknown>) => {
+    drawText.push({
+      text,
+      x: opts.x as number,
+      y: opts.y as number,
+      fontName: (opts.font as { name: string }).name,
+    });
+  }) as typeof page.drawText;
+  page.drawLine = ((opts: { start: { y: number }; end: { y: number } }) => {
+    drawLine.push({ startY: opts.start.y, endY: opts.end.y });
+  }) as typeof page.drawLine;
+
+  const schema = {
+    name: "totals",
+    type: "gearflowFinancialSummary" as const,
+    position: { x: 0, y: 0 },
+    width: 210,
+    height: 40,
+  };
+
+  await gearflowFinancialSummary.pdf({
+    schema,
+    page,
+    pdfLib,
+    pdfDoc,
+    value: JSON.stringify(config),
+    _cache: new Map<string | number, unknown>(),
+    options: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+  return { drawText, drawLine };
+}
+
+describe("gearflowFinancialSummary — Total divider clearance", () => {
+  it("draws the divider line clear of both the row above and the Total text (no overlap)", async () => {
+    const { drawText, drawLine } = await runFinancialSummaryPlugin(BASE_CONFIG);
+
+    const gstCall = drawText.find((c) => c.text === "GST");
+    const totalCall = drawText.find((c) => c.text === "Total");
+    expect(gstCall).toBeDefined();
+    expect(totalCall).toBeDefined();
+    expect(drawLine).toHaveLength(1);
+    const line = drawLine[0];
+
+    // Line sits strictly between the GST row's baseline and the Total row's
+    // baseline (pdf-lib y increases upward): GST baseline > line y > Total baseline.
+    expect(line.startY).toBeLessThan(gstCall!.y);
+    expect(line.startY).toBeGreaterThan(totalCall!.y);
+
+    // Total's bold size-11 text must not reach up to the line — the actual
+    // regression this test guards against. Uses the real embedded font's
+    // ascent (pdf-lib heightAtSize, no descender), not a guessed constant.
+    const metricsDoc = await PDFDocument.create();
+    const boldFont = await metricsDoc.embedFont(StandardFonts.HelveticaBold);
+    const ascent = boldFont.heightAtSize(11, { descender: false });
+    expect(totalCall!.y + ascent).toBeLessThan(line.startY);
+  });
+});
+
+describe("gearflowFinancialSummary — item discount transparency rows", () => {
+  it("adds no extra rows when itemDiscountTotal is 0", async () => {
+    const { drawText } = await runFinancialSummaryPlugin(BASE_CONFIG);
+    expect(drawText.some((c) => c.text === "Item Discounts")).toBe(false);
+    expect(drawText.some((c) => c.text.startsWith("Subtotal (before discounts)"))).toBe(false);
+  });
+
+  it("shows gross subtotal + item discounts above the existing net subtotal, without changing Total", async () => {
+    const config: FinancialSummaryConfig = { ...BASE_CONFIG, itemDiscountTotal: 50 };
+    const { drawText } = await runFinancialSummaryPlugin(config);
+
+    expect(drawText.some((c) => c.text === "Subtotal (before discounts)")).toBe(true);
+    expect(drawText.some((c) => c.text === "Item Discounts")).toBe(true);
+    // Gross = net subtotal + itemDiscountTotal = 295 + 50 = 345.
+    expect(drawText.some((c) => c.text === "$345.00")).toBe(true);
+    expect(drawText.some((c) => c.text === "-$50.00")).toBe(true);
+    // The real net Subtotal row is untouched — no double subtraction.
+    expect(drawText.some((c) => c.text === "Subtotal")).toBe(true);
+    expect(drawText.some((c) => c.text === "$295.00")).toBe(true);
+    expect(drawText.some((c) => c.text === "$324.50")).toBe(true); // Total unchanged
+  });
+});

--- a/src/lib/pdfme/plugins/gearflow-financial-summary.ts
+++ b/src/lib/pdfme/plugins/gearflow-financial-summary.ts
@@ -36,17 +36,19 @@ async function pdfRender(arg: PDFRenderProps<FinancialSummarySchema>) {
     const fontSize = opts?.fontSize || 9;
 
     if (opts?.divider) {
-      // Draw the divider line clear of both the row above (spacing before)
-      // and this row's own text (spacing after, sized for the bold total's
-      // ascent) so it never strikes through either.
-      currentY -= 6;
+      // Draw the divider line clear of both the row above (space before)
+      // and this row's own bold, larger text (space after). Deliberately
+      // generous — a prior smaller gap (6pt/10pt) still visually touched
+      // the "Total" text on real renders, so this uses a wide safety
+      // margin instead of the tightest theoretically-sufficient value.
+      currentY -= 8;
       page.drawLine({
         start: { x: blockX, y: currentY },
         end: { x: blockX + blockWidth, y: currentY },
         thickness: 1,
         color: docColor,
       });
-      currentY -= 10;
+      currentY -= 16;
     }
 
     // Label
@@ -71,6 +73,15 @@ async function pdfRender(arg: PDFRenderProps<FinancialSummarySchema>) {
     });
 
     currentY -= rowHeight;
+  }
+
+  // Item discounts (only if any line carries its own discount) — purely
+  // informational rows ABOVE the real (already net) subtotal: the gross
+  // figure here plus these two rows always nets back to `config.subtotal`,
+  // so nothing is subtracted twice.
+  if (config.itemDiscountTotal > 0) {
+    drawRow("Subtotal (before discounts)", formatCurrency(config.subtotal + config.itemDiscountTotal));
+    drawRow("Item Discounts", `-${formatCurrency(config.itemDiscountTotal)}`);
   }
 
   // Subtotal

--- a/src/lib/pdfme/plugins/gearflow-rich-text.ts
+++ b/src/lib/pdfme/plugins/gearflow-rich-text.ts
@@ -9,35 +9,58 @@
  * plugin being the only markdown-aware place in the pipeline.
  */
 import type { Plugin, Schema, PDFRenderProps } from "@pdfme/common";
-import { getLayoutProps, hexToRgb, getHelveticaFonts, wrapRichText, drawWrappedRichLines, stubUiRender, stubPropPanel } from "./helpers";
+import {
+  getLayoutProps, hexToRgb, getHelveticaFonts, wrapRichText, drawWrappedRichLines,
+  richTextLineHeight, stubUiRender, stubPropPanel,
+  type RichLine, type RichTextFonts,
+} from "./helpers";
 
 interface RichTextSchema extends Schema {
   type: "gearflowRichText";
   fontSize?: number;
   fontColor?: string;
-  /** Line advance in pt. Defaults to a value consistent with the ~4mm/line
-   *  heuristic document-composer.ts's estimateBlockHeight uses for these
-   *  same blocks. */
+  /** Line advance in pt. Defaults to `richTextLineHeight(fontSize)` — the
+   *  same formula document-composer.ts uses to reserve space for this block. */
   lineHeight?: number;
+}
+
+/**
+ * Resolve the lines to draw. `raw` is either:
+ *  - a JSON payload `{ lines: RichLine[] }` — pre-wrapped by
+ *    document-composer.ts using real font metrics, so the exact same line
+ *    breakdown drove both the page-break math AND this render (they can
+ *    never disagree, and multi-page splitting slices this array directly).
+ *  - a plain markdown string — the pagination engine's fallback path when it
+ *    has no font metrics available (e.g. most unit tests); this plugin wraps
+ *    it itself, same as before pre-wrapping existed.
+ */
+function resolveLines(raw: string, maxWidth: number, fontSize: number, fonts: RichTextFonts): RichLine[] {
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw) as { lines?: unknown };
+      if (Array.isArray(parsed.lines)) return parsed.lines as RichLine[];
+    } catch {
+      // Not JSON — fall through and treat as raw markdown text.
+    }
+  }
+  return wrapRichText(raw, { maxWidth, fontSize, fonts });
 }
 
 async function pdfRender(arg: PDFRenderProps<RichTextSchema>) {
   const { schema, page, pdfLib, pdfDoc, _cache } = arg;
-  const text = arg.value || "";
-  if (!text) return;
+  const raw = arg.value || "";
+  if (!raw) return;
 
   const pageHeight = page.getHeight();
   const { x, y, width, height } = getLayoutProps(schema, pageHeight);
   const fonts = await getHelveticaFonts(pdfDoc, pdfLib, _cache);
 
   const fontSize = schema.fontSize ?? 9;
-  const lineHeight = schema.lineHeight ?? fontSize + 2.34; // ~mm2pt(4)
+  const lineHeight = schema.lineHeight ?? richTextLineHeight(fontSize);
   const color = hexToRgb(schema.fontColor || "#1a1a1a", pdfLib);
 
-  // Word-wrap to the box width — this block's text isn't guaranteed to fit
-  // on one line per literal `\n` (e.g. a long client address or a T&Cs
-  // paragraph), unlike gearflowTable's notes column.
-  const lines = wrapRichText(text, { maxWidth: width, fontSize, fonts });
+  const lines = resolveLines(raw, width, fontSize, fonts);
+  if (lines.length === 0) return;
 
   drawWrappedRichLines(page, lines, {
     x,

--- a/src/lib/pdfme/plugins/gearflow-table.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.test.ts
@@ -360,3 +360,82 @@ describe("gearflowTable — priceBreakdown rendering (#943)", () => {
     await expect(runTablePlugin(items, { showPricing: true })).resolves.toBeDefined();
   });
 });
+
+describe("gearflowTable — bold gated by showKitChildren (client-facing docs)", () => {
+  it("a group parent is NOT bold when showKitChildren is off (quote/invoice)", async () => {
+    const items = [
+      makeLineItem({
+        id: "group-1",
+        isGroupRow: true,
+        groupTitle: "Small PA Package",
+        quantity: 1,
+        model: { name: "Small PA Package" },
+        childLineItems: [makeLineItem({ id: "child-1", model: { name: "K10.2" } })],
+      }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showKitChildren: false });
+    const parentDraw = calls.drawText.find((c) => c.text === "Small PA Package");
+    expect(parentDraw).toBeDefined();
+    expect(parentDraw?.fontName).toBe("Helvetica");
+    // Its children are correctly hidden too.
+    expect(calls.drawText.some((c) => c.text === "K10.2")).toBe(false);
+  });
+
+  it("an accessory parent is NOT bold when showKitChildren is off, even though its accessory is hidden", async () => {
+    const items = [
+      makeLineItem({
+        id: "parent-1",
+        model: { name: "EW-DX SKM" },
+        childLineItems: [
+          makeLineItem({ id: "acc-1", isKitChild: true, childKind: "ACCESSORY", model: { name: "AA Battery" } }),
+        ],
+      }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showKitChildren: false });
+    const parentDraw = calls.drawText.find((c) => c.text === "EW-DX SKM");
+    expect(parentDraw?.fontName).toBe("Helvetica");
+    expect(calls.drawText.some((c) => c.text === "AA Battery")).toBe(false);
+  });
+
+  it("stays bold when showKitChildren is on (warehouse docs, control)", async () => {
+    const items = [
+      makeLineItem({
+        id: "group-1",
+        isGroupRow: true,
+        groupTitle: "Small PA Package",
+        quantity: 1,
+        model: { name: "Small PA Package" },
+        childLineItems: [makeLineItem({ id: "child-1", model: { name: "K10.2" } })],
+      }),
+    ];
+
+    const calls = await runTablePlugin(items, { showKitChildren: true });
+    const parentDraw = calls.drawText.find((c) => c.text === "Small PA Package");
+    expect(parentDraw?.fontName).toBe("Helvetica-Bold");
+  });
+});
+
+describe("gearflowTable — per-item Discount column (quote/invoice)", () => {
+  it("renders the line's discount as a negative amount", async () => {
+    const items = [
+      makeLineItem({ id: "li-1", model: { name: "USB Pro DI" }, unitPrice: 20, lineTotal: 15, discount: 5 }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showPricing: true });
+    expect(calls.drawText.some((c) => c.text === "-$5.00")).toBe(true);
+  });
+
+  it("renders '-' when the line has no discount", async () => {
+    const items = [
+      makeLineItem({ id: "li-1", model: { name: "USB Pro DI" }, unitPrice: 20, lineTotal: 20, discount: null }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showPricing: true });
+    // The description "USB Pro DI" doesn't itself contain a bare "-", so any
+    // standalone "-" draw call must be the discount cell's placeholder.
+    expect(calls.drawText.some((c) => c.text === "-")).toBe(true);
+    expect(calls.drawText.some((c) => c.text.startsWith("-$"))).toBe(false);
+  });
+});

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -78,7 +78,8 @@ function getColumnsForDocType(config: TablePluginConfig, totalWidth: number): Co
       return resolveFlexWidths([
         { key: "description", label: "Description", width: 0, flex: 3, align: "left" },
         { key: "qty", label: "Qty", width: 30, align: "center" },
-        { key: "unitPrice", label: config.documentType === "invoice" ? "Rate" : "Unit Price", width: 60, align: "right" },
+        { key: "unitPrice", label: config.documentType === "invoice" ? "Rate" : "Unit Price", width: 55, align: "right" },
+        { key: "discount", label: "Discount", width: 55, align: "right" },
         { key: "total", label: config.documentType === "invoice" ? "Amount" : "Total", width: 60, align: "right" },
       ], totalWidth);
 
@@ -461,7 +462,11 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
               ? `[Kit] ${itemName}`
               : itemName;
 
-            const font = isParentWithChildren ? fonts.bold : fonts.regular;
+            // Bold only when this row actually has visible children below
+            // it — otherwise (showKitChildren off, e.g. quote/invoice) a
+            // bold row with nothing under it just reads as an unexplained
+            // random emphasis.
+            const font = isParentWithChildren && config.showKitChildren ? fonts.bold : fonts.regular;
             page.drawText(displayName, {
               x: descX,
               y: textY,
@@ -562,6 +567,20 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
               size: fontSize,
               font: fonts.regular,
               color: textColor,
+            });
+            break;
+          }
+
+          case "discount": {
+            if (!config.showPricing) break;
+            const discStr = !isItemized && item.discount ? `-${formatCurrency(item.discount)}` : "-";
+            const discWidth = fonts.regular.widthOfTextAtSize(discStr, fontSize);
+            page.drawText(discStr, {
+              x: colEndX - discWidth - cellPadding,
+              y: textY,
+              size: fontSize,
+              font: fonts.regular,
+              color: item.discount ? textColor : mutedTextColor,
             });
             break;
           }
@@ -804,6 +823,20 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
                 break;
               }
 
+              case "discount": {
+                if (!config.showPricing) break;
+                const discStr = child.discount ? `-${formatCurrency(child.discount)}` : "-";
+                const discWidth = fonts.regular.widthOfTextAtSize(discStr, childFontSize);
+                page.drawText(discStr, {
+                  x: colEndX - discWidth - cellPadding,
+                  y: childTextY,
+                  size: childFontSize,
+                  font: fonts.regular,
+                  color: childTextColor,
+                });
+                break;
+              }
+
               case "total": {
                 if (!config.showPricing) break;
                 const totalStr = formatCurrency(child.lineTotal);
@@ -963,6 +996,20 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
                     const pW = fonts.regular.widthOfTextAtSize(pStr, grandchildFontSize);
                     page.drawText(pStr, {
                       x: colEndX - pW - cellPadding,
+                      y: nestedTextY,
+                      size: grandchildFontSize,
+                      font: fonts.regular,
+                      color: grandchildTextColor,
+                    });
+                    break;
+                  }
+
+                  case "discount": {
+                    if (!config.showPricing) break;
+                    const dStr = nested.discount ? `-${formatCurrency(nested.discount)}` : "-";
+                    const dW = fonts.regular.widthOfTextAtSize(dStr, grandchildFontSize);
+                    page.drawText(dStr, {
+                      x: colEndX - dW - cellPadding,
                       y: nestedTextY,
                       size: grandchildFontSize,
                       font: fonts.regular,

--- a/src/lib/pdfme/plugins/helpers.ts
+++ b/src/lib/pdfme/plugins/helpers.ts
@@ -137,6 +137,19 @@ export function drawWrappedText(
 
 type RichSpan = { text: string; style: "regular" | "bold" | "italic" };
 export type RichLine = { spans: RichSpan[]; bullet: boolean };
+export type RichTextFonts = { regular: PDFFont; bold: PDFFont; oblique: PDFFont };
+
+/**
+ * Shared line-advance formula for markdown-lite text blocks. Used by BOTH
+ * gearflowRichText's renderer (its `lineHeight` default) and
+ * document-composer.ts's height-estimate/pagination-split math, so the
+ * space reserved for a block can never drift from the space it actually
+ * renders into — the exact class of bug the PDF pipeline's "data-shape
+ * consumer audit" convention exists to prevent (CLAUDE.md).
+ */
+export function richTextLineHeight(fontSize: number): number {
+  return fontSize + 2.34; // ~mm2pt(4), matches the pre-existing ~4mm/line heuristic
+}
 
 /**
  * Parse simple markdown into lines of styled spans.

--- a/src/lib/pdfme/structure-line-items.test.ts
+++ b/src/lib/pdfme/structure-line-items.test.ts
@@ -1158,3 +1158,70 @@ describe("structureLineItems — Phase 0 baseline", () => {
     expect(result.filter(r => r.isGroupRow).length).toBe(20);
   });
 });
+
+describe("structureLineItems — Uncategorized-zone Project Group (2026-07-28)", () => {
+  // buildDocumentLineItemData folds a `categoryId: null` ProjectGroup into a
+  // pseudo-category `{ id: "__uncategorized__", name: "" }` before calling
+  // structureLineItems — this simulates that shape directly. Members carry
+  // `groupId` (set whenever `groupTitle` is resolved from it, per
+  // buildDocumentLineItemData) but their OWN `categoryName` is null, since
+  // the member's `categoryId` is independently unset.
+  const uncategorizedZone = (
+    groups: CategoryForStructuring["groups"],
+  ): CategoryForStructuring[] => [{ id: "__uncategorized__", name: "", sortOrder: Number.MAX_SAFE_INTEGER, groups }];
+
+  it("collapse mode (quote/invoice): collapses into ONE row, not flat individual members", () => {
+    const categories = uncategorizedZone([
+      makeGroup("grp-1", "Small PA Package", 0, { quantity: 1, price: 275 }),
+    ]);
+    const raw: DocumentLineItem[] = [
+      makeLineItem({ id: "k10", groupId: "grp-1", groupTitle: "Small PA Package", model: { name: "K10.2" } }),
+      makeLineItem({ id: "dm3d", groupId: "grp-1", groupTitle: "Small PA Package", model: { name: "DM3-D Dante" } }),
+    ];
+
+    const result = structureLineItems(raw, categories); // expandProjectGroups defaults false
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isGroupRow).toBe(true);
+    expect(result[0].groupTitle).toBe("Small PA Package");
+    expect(result[0].lineTotal).toBe(275);
+    // No spurious "Uncategorized" section header — buckets under the
+    // doc's normal ungrouped fallback instead.
+    expect(result[0].groupName).toBe("");
+    // The real members are NOT also listed flat (would be double-counting /
+    // the exact "split into flat items" bug this fixes).
+    expect(result.some(r => r.id === "k10")).toBe(false);
+    expect(result.some(r => r.id === "dm3d")).toBe(false);
+  });
+
+  it("expand mode (warehouse docs): group row carries its real members as childLineItems", () => {
+    const categories = uncategorizedZone([
+      makeGroup("grp-1", "Small PA Package", 0, { quantity: 1, price: 275 }),
+    ]);
+    const raw: DocumentLineItem[] = [
+      makeLineItem({ id: "k10", groupId: "grp-1", groupTitle: "Small PA Package", model: { name: "K10.2" } }),
+      makeLineItem({ id: "dm3d", groupId: "grp-1", groupTitle: "Small PA Package", model: { name: "DM3-D Dante" } }),
+    ];
+
+    const result = structureLineItems(raw, categories, { expandProjectGroups: true });
+
+    const groupRow = result.find(r => r.isGroupRow);
+    expect(groupRow).toBeDefined();
+    expect(groupRow?.childLineItems?.map(c => c.id).sort()).toEqual(["dm3d", "k10"]);
+    // Members aren't ALSO emitted as separate top-level rows.
+    expect(result.filter(r => !r.isGroupRow)).toHaveLength(0);
+  });
+
+  it("a categorized group's members are unaffected by the groupId-first matching (control)", () => {
+    const categories: CategoryForStructuring[] = [
+      makeCategory("cat-1", "Audio Hire", 0, [makeGroup("grp-1", "Small PA Package", 0, { quantity: 1, price: 275 })]),
+    ];
+    const raw: DocumentLineItem[] = [
+      makeLineItem({ id: "k10", categoryName: "Audio Hire", groupTitle: "Small PA Package", model: { name: "K10.2" } }),
+    ];
+
+    const result = structureLineItems(raw, categories, { expandProjectGroups: true });
+    const groupRow = result.find(r => r.isGroupRow);
+    expect(groupRow?.childLineItems?.map(c => c.id)).toEqual(["k10"]);
+  });
+});

--- a/src/lib/pdfme/structure-line-items.ts
+++ b/src/lib/pdfme/structure-line-items.ts
@@ -30,6 +30,18 @@
  * Group is hoisted out of the group's `childLineItems` and emitted at
  * the top level under its own `[Kit] <name>` bucket. This preserves the
  * existing kit-boundary contract.
+ *
+ * Groups in the equipment tab's "Uncategorized" zone (`ProjectGroup.categoryId:
+ * null` — a first-class, fully-supported state, not an error) are folded into
+ * a synthetic pseudo-category by `buildDocumentLineItemData`
+ * (project-line-item-read.ts) before reaching this function, so they collapse
+ * into one row (client-facing) or expand with their members (warehouse docs)
+ * exactly like a categorized group — a group is never split into its flat
+ * members just because the office hasn't filed it under a category yet.
+ * Member matching keys off `groupId` (the FK), not `groupTitle`+`categoryName`
+ * string matching — a member's own `categoryId` can be null even when its
+ * `groupId` is set, since only the GROUP is guaranteed to carry a resolvable
+ * category (via the pseudo-category), not each individual member row.
  */
 import type { DocumentLineItem } from "./types";
 
@@ -181,6 +193,19 @@ export function structureLineItems(
     }
   }
 
+  /**
+   * Is `li` a member of `group`? `groupId` (the FK) is authoritative and
+   * checked first — it's the only field guaranteed to hold regardless of
+   * whether the member's own `categoryId` happens to be set (see the
+   * "Uncategorized zone" note in the file header). The `groupTitle`+
+   * `categoryName` string match is a fallback for callers that only ever
+   * set the resolved display strings without the id (in practice: this
+   * file's own test fixtures — real data from `buildDocumentLineItemData`
+   * always sets `groupId` whenever `groupTitle` is resolved from it).
+   */
+  const isGroupMember = (li: DocumentLineItem, group: { id: string; title: string }, catName: string): boolean =>
+    li.groupId ? li.groupId === group.id : li.groupTitle === group.title && li.categoryName === catName;
+
   const structured: DocumentLineItem[] = [];
 
   for (const cat of categories) {
@@ -203,8 +228,7 @@ export function structureLineItems(
       ? cat.groups.some(g =>
           rawLineItems.some(
             li =>
-              li.groupTitle === g.title &&
-              li.categoryName === cat.name &&
+              isGroupMember(li, g, cat.name) &&
               !li.isKitChild &&
               !li.isContainerLineItem &&
               !isInSubHireSection(li),
@@ -234,8 +258,7 @@ export function structureLineItems(
       const groupChildren = expand
         ? rawLineItems.filter(
             li =>
-              li.groupTitle === group.title &&
-              li.categoryName === cat.name &&
+              isGroupMember(li, group, cat.name) &&
               !li.isKitChild &&
               !li.isContainerLineItem &&
               !isInSubHireSection(li),
@@ -306,9 +329,7 @@ export function structureLineItems(
     if (li.isKitChild || li.isContainerLineItem) return false;
     if (li.categoryName || li.groupTitle) return false;
     if (isInSubHireSection(li)) return false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const groupId = (li as any).groupId as string | null | undefined;
-    if (groupId && groupIds.has(groupId)) return false;
+    if (li.groupId && groupIds.has(li.groupId)) return false;
     return true;
   });
   for (const li of maybeSort(uncategorized)) {

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -49,6 +49,16 @@ export interface DocumentLineItem {
   categoryName: string | null;
   groupTitle: string | null;
   /**
+   * The Project Group's own id (FK — `projectLineItems.groupId`), when this
+   * line belongs to one. `groupTitle`/`categoryName` are resolved display
+   * strings that depend on the item's OWN `categoryId` also being set; a
+   * group's members can have `groupId` set while their `categoryId` is
+   * still null (e.g. the group itself lives in the equipment tab's
+   * "Uncategorized" zone) — `groupId` is the one field guaranteed to be
+   * authoritative regardless of that. See structure-line-items.ts.
+   */
+  groupId?: string | null;
+  /**
    * The physical location (warehouse area, rack, shelf) the line item's
    * gear lives at, derived from the asset / bulk asset record. Null for
    * custom items, services, and unassigned bulk requests. Used by

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -271,6 +271,12 @@ export interface TablePluginConfig {
 /** Config for financial summary plugin */
 export interface FinancialSummaryConfig {
   subtotal: number;
+  /** Sum of every visible line's own `discount` field (the new per-item
+   *  Discount column). `subtotal` is already net of these — they're baked
+   *  into each line's `lineTotal` — so this is purely informational: shown
+   *  as "Subtotal (before discounts)" + "Item Discounts" ABOVE the existing
+   *  net `subtotal` row, never subtracted a second time. */
+  itemDiscountTotal: number;
   discountPercent: number;
   discountAmount: number;
   taxLabel: string;

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -690,6 +690,30 @@ export async function buildDocumentLineItemData(projectId: string, organizationI
         .sort((a, b) => a.sortOrder - b.sortOrder),
     }));
 
+  // Groups the office hasn't (yet) filed under a real category — the
+  // equipment tab's "Uncategorized" zone (`ProjectGroup.categoryId: null`)
+  // is a first-class, fully-supported state there, not an error. Without
+  // this, such a group is invisible to `structureLineItems` (it only reads
+  // groups nested under a real category above): its own synthetic row never
+  // renders, its members aren't recognized as excluded-from-flat-listing,
+  // and the whole group prints as disconnected flat line items on quotes/
+  // invoices instead of collapsing — see FEATUREDOCS/13-pdfs.md. `name: ""`
+  // buckets them under each doc's normal "no header" fallback
+  // (`groupName || prepContainer || ungroupedKey` in gearflow-table.ts /
+  // document-composer.ts) rather than a spurious "Uncategorized" section
+  // title on a client-facing document.
+  const uncategorizedGroups = mappedGroups
+    .filter((g) => !g.categoryId)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  if (uncategorizedGroups.length > 0) {
+    categories.push({
+      id: "__uncategorized__",
+      name: "",
+      sortOrder: Number.MAX_SAFE_INTEGER,
+      groups: uncategorizedGroups,
+    });
+  }
+
   return { lineItems: withAssets, categories };
 }
 


### PR DESCRIPTION
## Summary

Follow-up round of quote/invoice PDF fixes, reported against real generated quotes.

- **Totals divider (take 2)**: the first fix still visually read as touching the "Total" text — measured the real font ascent via pdf-lib instead of guessing, and widened the gap (8pt/16pt, was 6pt/10pt) for real clearance, with a test that checks actual font metrics rather than eyeballing.
- **Parent-row bold gated by `showKitChildren`**: a kit/group/accessory parent row is no longer bold when its children are hidden (quote/invoice) — previously it stayed bold with nothing visibly grouped underneath it.
- **Per-item Discount column** (quote/invoice): shows each line's own discount amount between Unit Price and Total. Purely additive — `lineTotal` was already net of it server-side.
- **"Item Discounts" transparency rows** in the totals block: "Subtotal (before discounts)" + "Item Discounts" shown above the existing (unchanged) net Subtotal row whenever any line carries a discount — informational only, so the already-net subtotal is never subtracted twice.
- **Uncategorized-zone Project Groups now collapse/expand correctly**: a Project Group living in the equipment tab's "Uncategorized" zone (no category assigned yet — a normal, supported state) was invisible to the PDF pipeline, so it printed as disconnected flat line items instead of one collapsed row. Fixed in `buildDocumentLineItemData` (synthesizes a pseudo-category for these groups) and `structureLineItems` (member matching now keys off `groupId`, the FK, instead of a fragile title+category-name string match).
- **Wrap-accurate pagination for long text blocks**: a long T&Cs block could word-wrap onto more physical lines than the old estimate (raw `\n` count) accounted for, silently overflowing into the footer. `composeDocument` gained an optional `fonts` param (real embedded Helvetica, supplied by `generate-pdf.ts`) so the height estimate uses the *same* wrapping function the renderer uses, and `clientNotes`/`termsAndConditions` now split across pages like the equipment table already does, instead of only ever moving as one whole block (which could strand a short trailing block alone on a near-empty page). Fully backward compatible — `fonts` is optional and every existing caller/test keeps its exact prior behavior.
- **Quote expiry moved to the header**: "Expiry: {date}" now sits in the header meta next to the doc number, instead of its own sentence at the very end of the document.

Docs updated in the same PR: `FEATUREDOCS/13-pdfs.md`.

## Testing

- `pnpm exec vitest run src/lib/pdfme` — 144 tests pass (23 new/updated), including new coverage for: divider clearance via real font metrics, the Discount column, the Uncategorized-zone group fix, and wrap-accurate pagination/splitting.
- `pnpm exec tsc --noEmit` — no new type errors.
- `pnpm exec eslint` on all touched files — no new errors, only pre-existing complexity warnings.
- `node scripts/knip-ratchet.mjs` / `depcruise-ratchet.mjs` / `complexity-ratchet.mjs` — all hold at baseline.
- Broader sweep (`pnpm exec vitest run src/lib`) — 2072 tests pass; failures are the same pre-existing environment-only issue (missing generated Prisma client in this sandbox, no `DATABASE_URL`), unrelated to this change.

## Size rationale (R-2.8)

Over the 400-LOC SHOULD target (~1011 changed LOC, including a
generated-content test file). Not split because every change is a fix in
the same ongoing quote/invoice PDF thread, against the same pipeline files
(`document-composer.ts`, `structure-line-items.ts`,
`project-line-item-read.ts`, the financial-summary/rich-text plugins), each
reported against a real generated PDF and reviewed/tested together to
satisfy the repo's PDF data-shape-consumer audit rule (a shape/pagination
change must be checked against all render + height-estimate consumers in
the same change). None of the six fixes are independently toggleable or
risk-isolated from the others — splitting would mean re-deriving that
cross-cutting review multiple times for no isolation benefit.

## Checklist

- [x] New dependency? N/A — no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW8WUohvgvShwW7W4gMEiW)_