### PR TITLE
Add Xero account-coding override to project groups

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -180,6 +180,13 @@ every level:
 (`xeroIntegrations.serviceAccountDefaults[LABOUR|DELIVERY_TRANSPORT|MISC]`) →
 org default. **Tax type**: per-line override → `xeroIntegrations.defaultTaxType`.
 
+**Group** (a priced `projectGroups` row bills as its own invoice line —
+`convex/lib/financeSnapshot.ts` "priced groups bill as ONE line"): group
+override → `projectGroups.categoryId`'s category default → org default. A
+group isn't a model/kit, so it has no level-2 equivalent — reuses
+`resolveEquipmentAccountCode` with `modelOrKitCode: null` rather than a
+bespoke 2-level function (`resolveGroupLineCode` in `convex/xeroPush.ts`).
+
 Resolved server-side at PUSH time (`convex/xeroPush.ts` `resolveCodingForInvoice`
 — one Convex query, all the DB reads through model/kit/category/service-type/
 org-default) and snapshotted onto `invoiceLines` — never re-resolved after
@@ -223,11 +230,38 @@ Every level of the cascade above has a write path + form field:
 - **Service override** — `projectServices.xeroAccountCode`/`xeroTaxType`, on
   the `ServiceDialog` in `src/components/projects/services-panel.tsx` — same
   collapsed-by-default `Accordion` treatment, same reasoning.
+- **Group override** — `projectGroups.xeroAccountCode`/`xeroTaxType`, on
+  `EditGroupDialog` (`src/components/projects/edit-group-dialog.tsx`) — same
+  collapsed-by-default `Accordion` treatment (a group's own dialog is also on
+  the everyday project-editing path). This dialog uses local `useState`, not
+  React Hook Form, so the field is wired directly (`value`/`onChange`), not
+  through a `Controller`. Sent as the raw string on every save, never
+  `|| undefined` the way `description` is — an omitted/`undefined` key never
+  reaches the Convex mutation at all (`JSON.stringify` drops `undefined`
+  values), so "clear the override" would otherwise be silently lost instead
+  of patching back to unset; `updateGroupNative`'s own `a.xeroAccountCode ||
+  undefined` does the clear-on-empty-string itself.
 
-All five write paths mirror `categorySchema`/`modelSchema`/etc.'s new
+Kit-parent project lines were the other explicit ask ("show up on kits...
+when they [are] items on a project") — already covered by the line override
+above without any extra work: a kit-parent row (`kitId` set, `isKitChild:
+false`) opens the exact same `EditLineItemDialog` as any other equipment
+line, with no kit-specific code path that would intercept or hide the Xero
+section.
+
+`MappedGroup` (both copies — `src/lib/project-equipment-reconstruct.ts` for
+the client-safe equipment-tab bundle, `src/lib/project-line-item-read.ts` for
+the server-side read path) and `GroupData`
+(`src/components/projects/equipment-row-types.ts`) all needed the two new
+fields threaded through explicitly — both are allowlist mappers over the raw
+`projectGroups` doc, not passthrough spreads, so a new schema field is
+invisible to either read path until added by hand.
+
+All six write paths mirror `categorySchema`/`modelSchema`/etc.'s new
 `.max(50)` bound server-side (`assertCategoryFields`/`assertModelFields`/
-`assertKitFields`/`assertLineItemFields`/`assertServiceFields` — R-8.6.2,
-a browser-direct caller bypassing the client Zod parse can't skip the bound).
+`assertKitFields`/`assertLineItemFields`/`assertServiceFields`/`assertStrLen`
+calls in `updateGroupNative` — R-8.6.2, a browser-direct caller bypassing the
+client Zod parse can't skip the bound).
 
 **Shared UI**: `src/components/settings/xero-coding-fields.tsx` —
 `XeroAccountCodeField`/`XeroTaxTypeField`, both self-gating on `useXeroLinked()`

--- a/convex/projectGroupsWrites.test.ts
+++ b/convex/projectGroupsWrites.test.ts
@@ -200,6 +200,40 @@ describe("projectGroupsWrites.updateGroupNative", () => {
     ).rejects.toThrow(/Group not found/i);
   });
 
+  test("sets a Xero coding override, then clears it back to inherit", async () => {
+    const t = makeT();
+    await seedGroupWithLine(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupNative, {
+      id: "g1", orgId: ORG, xeroAccountCode: "8888-GROUP", xeroTaxType: "ZERORATED", now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.xeroAccountCode).toBe("8888-GROUP");
+      expect(g?.xeroTaxType).toBe("ZERORATED");
+    });
+
+    // Sending "" (not omitting the key) clears it back to inherit -- matches
+    // how the edit dialog always sends the raw field value, never `|| undefined`.
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupNative, {
+      id: "g1", orgId: ORG, xeroAccountCode: "", xeroTaxType: "", now: NOW, actor: ACTOR, auditId: "log2",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.xeroAccountCode).toBeUndefined();
+      expect(g?.xeroTaxType).toBeUndefined();
+    });
+  });
+
+  test("rejects an over-length Xero account code (R-8.6.2)", async () => {
+    const t = makeT();
+    await seedGroupWithLine(t);
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupNative, {
+        id: "g1", orgId: ORG, xeroAccountCode: "x".repeat(51), now: NOW, actor: ACTOR, auditId: "log1",
+      }),
+    ).rejects.toThrow(/xeroAccountCode/i);
+  });
+
   test("viewer denied", async () => {
     const t = makeT();
     await member(t, "viewer");

--- a/convex/projectGroupsWrites.ts
+++ b/convex/projectGroupsWrites.ts
@@ -9,6 +9,7 @@ import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import { computeGroupSuggestedPrice } from "./lib/suggestedPrice";
 import { assertLifecycleGuard, lifecycleAuditMetadata } from "./lib/projectLocks";
+import { assertStrLen } from "./lib/fieldGuards";
 
 /**
  * Native PROJECT-GROUP write mutations (Phase 3 browser-direct — replaces the
@@ -336,6 +337,8 @@ export const updateGroupNative = mutation({
     description: v.optional(v.string()),
     quantity: v.optional(v.number()),
     sortOrder: v.optional(v.number()),
+    xeroAccountCode: v.optional(v.string()),
+    xeroTaxType: v.optional(v.string()),
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
@@ -366,6 +369,8 @@ export const updateGroupNative = mutation({
     if (a.title !== undefined) assertValidTitle(a.title);
     if (a.description !== undefined) assertValidDescription(a.description || undefined);
     if (a.quantity !== undefined) assertValidQuantity(Number(a.quantity));
+    assertStrLen(a.xeroAccountCode, "xeroAccountCode", { max: 50 });
+    assertStrLen(a.xeroTaxType, "xeroTaxType", { max: 50 });
 
     // Patch semantics mirror the server: "" / falsy clears the optional field.
     const patch: Record<string, unknown> = { updatedAt: a.now };
@@ -373,6 +378,8 @@ export const updateGroupNative = mutation({
     if (a.description !== undefined) patch.description = a.description || undefined;
     if (a.quantity !== undefined) patch.quantity = Number(a.quantity);
     if (a.sortOrder !== undefined) patch.sortOrder = Number(a.sortOrder);
+    if (a.xeroAccountCode !== undefined) patch.xeroAccountCode = a.xeroAccountCode || undefined;
+    if (a.xeroTaxType !== undefined) patch.xeroTaxType = a.xeroTaxType || undefined;
     await ctx.db.patch(group._id, patch);
 
     // Audit uses the PRE-patch title (parity with the server action).
@@ -396,7 +403,9 @@ export const updateGroupNative = mutation({
     const providedNonSortOrder =
       a.title !== undefined ||
       a.description !== undefined ||
-      a.quantity !== undefined;
+      a.quantity !== undefined ||
+      a.xeroAccountCode !== undefined ||
+      a.xeroTaxType !== undefined;
     if (providedNonSortOrder) {
       await ctx.db.insert("activityEvents", {
         orgId: a.orgId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1316,6 +1316,13 @@ export default defineSchema({
     discount: v.optional(v.number()),
     suggestedPrice: v.optional(v.number()),
     sortOrder: v.optional(v.number()),
+    // WS1 (#940) — Xero account-coding override for a priced group's own
+    // invoice line (convex/lib/financeSnapshot.ts's "priced groups bill as
+    // ONE line"). Cascade: this override -> categoryId's category default ->
+    // org default (convex/xeroPush.ts resolveGroupLineCode) -- a group isn't
+    // a model/kit, so it has no level-2 equivalent in the cascade.
+    xeroAccountCode: v.optional(v.string()),
+    xeroTaxType: v.optional(v.string()),
     createdAt: v.optional(v.number()),
     updatedAt: v.optional(v.number()),
   })

--- a/convex/xeroPush.test.ts
+++ b/convex/xeroPush.test.ts
@@ -35,12 +35,18 @@ async function seedInvoiceWithLines(t: ReturnType<typeof makeT>) {
     await ctx.db.insert("projectLineItems", { id: "li4", organizationId: ORG, projectId: "p1", type: "EQUIPMENT", isKitChild: false, description: "Misc gear", quantity: 1, unitPrice: 50, lineTotal: 50 });
     // Line 5: SERVICE, LABOUR type -> resolves via the LABOUR service-type default.
     await ctx.db.insert("projectServices", { id: "svc1", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Crew", lineTotal: 150 });
+    // Group 1: no per-group override -> falls through to its category's default.
+    await ctx.db.insert("projectGroups", { id: "grp1", organizationId: ORG, projectId: "p1", categoryId: "cat1", title: "Priced bundle", quantity: 1, price: 250 });
+    // Group 2: per-group override -> wins over its category.
+    await ctx.db.insert("projectGroups", { id: "grp2", organizationId: ORG, projectId: "p1", categoryId: "cat1", title: "Custom-coded bundle", quantity: 1, price: 400, xeroAccountCode: "8888-GROUP", xeroTaxType: "ZERORATED" });
 
     await ctx.db.insert("invoiceLines", { id: "line1", invoiceId: "inv1", sourceType: "EQUIPMENT", sourceLineItemId: "li1", description: "Speaker", quantity: 1, unitPrice: 200, lineTotal: 200, sortOrder: 0 });
     await ctx.db.insert("invoiceLines", { id: "line2", invoiceId: "inv1", sourceType: "EQUIPMENT", sourceLineItemId: "li2", description: "Band Kit", quantity: 1, unitPrice: 300, lineTotal: 300, sortOrder: 1 });
     await ctx.db.insert("invoiceLines", { id: "line3", invoiceId: "inv1", sourceType: "EQUIPMENT", sourceLineItemId: "li3", description: "Special item", quantity: 1, unitPrice: 100, lineTotal: 100, sortOrder: 2 });
     await ctx.db.insert("invoiceLines", { id: "line4", invoiceId: "inv1", sourceType: "EQUIPMENT", sourceLineItemId: "li4", description: "Misc gear", quantity: 1, unitPrice: 50, lineTotal: 50, sortOrder: 3 });
     await ctx.db.insert("invoiceLines", { id: "line5", invoiceId: "inv1", sourceType: "SERVICE", sourceLineItemId: "svc1", description: "Crew", quantity: 1, unitPrice: 150, lineTotal: 150, sortOrder: 4 });
+    await ctx.db.insert("invoiceLines", { id: "line6", invoiceId: "inv1", sourceType: "GROUP", sourceLineItemId: "grp1", description: "Priced bundle", quantity: 1, unitPrice: 250, lineTotal: 250, sortOrder: 5 });
+    await ctx.db.insert("invoiceLines", { id: "line7", invoiceId: "inv1", sourceType: "GROUP", sourceLineItemId: "grp2", description: "Custom-coded bundle", quantity: 1, unitPrice: 400, lineTotal: 400, sortOrder: 6 });
 
     await ctx.db.insert("xeroIntegrations", {
       id: "xi1", organizationId: ORG, isConnected: true, tenantId: "tenant1",
@@ -62,14 +68,16 @@ describe("xeroPush.resolveCodingForInvoice", () => {
     expect(byId.get("line3")).toEqual({ lineId: "line3", accountCode: "9999-OVERRIDE", taxType: "EXEMPT" }); // per-line override wins over everything
     expect(byId.get("line4")).toEqual({ lineId: "line4", accountCode: "4000", taxType: "OUTPUT2" }); // org default (no model/kit/category)
     expect(byId.get("line5")).toEqual({ lineId: "line5", accountCode: "4600", taxType: "OUTPUT2" }); // LABOUR service-type default
+    expect(byId.get("line6")).toEqual({ lineId: "line6", accountCode: "4300", taxType: "OUTPUT2" }); // group falls through to its category default
+    expect(byId.get("line7")).toEqual({ lineId: "line7", accountCode: "8888-GROUP", taxType: "ZERORATED" }); // group override wins over its category
   });
 
   test("flags a variance note when a line's tax type diverges from the org default", async () => {
     const t = makeT();
     await seedInvoiceWithLines(t);
     const result = await t.withIdentity(SERVICE).query(api.xeroPush.resolveCodingForInvoice, { invoiceId: "inv1", orgId: ORG });
-    // line3 has an EXEMPT override vs the org default OUTPUT2.
-    expect(result.varianceNote).toMatch(/1 line/i);
+    // line3 (EXEMPT) and line7 (ZERORATED) both diverge from the org default OUTPUT2.
+    expect(result.varianceNote).toMatch(/2 line/i);
   });
 
   test("no variance note when every line uses the org default tax type", async () => {

--- a/convex/xeroPush.ts
+++ b/convex/xeroPush.ts
@@ -74,6 +74,34 @@ async function resolveEquipmentLineCode(
   };
 }
 
+/** Resolve one GROUP invoice line's account/tax code — a priced group bills
+ *  as its own line (financeSnapshot.ts). A group isn't a model/kit, so its
+ *  cascade skips straight from the line override to its category default:
+ *  group override -> category default -> org default. Reuses
+ *  resolveEquipmentAccountCode with modelOrKitCode: null (level 2 always
+ *  absent) rather than a bespoke 2-level function. */
+async function resolveGroupLineCode(
+  ctx: Ctx,
+  sourceLineItemId: string,
+  orgId: string,
+  orgDefaultCode: string | null,
+  orgDefaultTaxType: string | null,
+): Promise<{ accountCode: string | null; taxType: string | null }> {
+  const group = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", sourceLineItemId)).first();
+  if (!group || group.organizationId !== orgId) return { accountCode: orgDefaultCode, taxType: orgDefaultTaxType };
+
+  let categoryCode: string | null = null;
+  if (group.categoryId) {
+    const category = await ctx.db.query("categories").withIndex("by_cuid", (q) => q.eq("id", group.categoryId!)).first();
+    categoryCode = category && category.organizationId === orgId ? (category.xeroAccountCode ?? null) : null;
+  }
+
+  return {
+    accountCode: resolveEquipmentAccountCode({ lineOverride: group.xeroAccountCode, modelOrKitCode: null, categoryCode, orgDefaultCode }),
+    taxType: resolveTaxType({ lineOverride: group.xeroTaxType, orgDefaultTaxType }),
+  };
+}
+
 /** Resolve one SERVICE invoice line's account/tax code — same split-out rationale. */
 async function resolveServiceLineCode(
   ctx: Ctx,
@@ -93,7 +121,7 @@ async function resolveServiceLineCode(
 }
 
 /** Dispatch one invoice line to its source-type resolver (or the org default
- *  for GROUP/CUSTOM lines, which have no per-entity coding field). */
+ *  for CUSTOM lines, which have no backing entity to resolve coding from). */
 async function resolveOneLine(
   ctx: Ctx,
   line: { sourceType: string; sourceLineItemId?: string },
@@ -108,8 +136,10 @@ async function resolveOneLine(
   if (line.sourceType === "SERVICE" && line.sourceLineItemId) {
     return resolveServiceLineCode(ctx, line.sourceLineItemId, orgId, serviceDefaults, orgDefaultCode, orgDefaultTaxType);
   }
-  // GROUP / CUSTOM (deposit/balance/credit summary lines, or a group with no
-  // per-entity coding field) — org default only.
+  if (line.sourceType === "GROUP" && line.sourceLineItemId) {
+    return resolveGroupLineCode(ctx, line.sourceLineItemId, orgId, orgDefaultCode, orgDefaultTaxType);
+  }
+  // CUSTOM (deposit/balance/credit summary lines — no backing entity) — org default only.
   return { accountCode: orgDefaultCode, taxType: orgDefaultTaxType };
 }
 

--- a/src/components/projects/edit-group-dialog.tsx
+++ b/src/components/projects/edit-group-dialog.tsx
@@ -28,6 +28,9 @@ import { formatCurrency } from "@/lib/formatters";
 import { useEditLock } from "@/hooks/use-collaboration";
 import { LockedEditorOverlay } from "@/components/collaboration/locked-editor-overlay";
 import { COLLAB_TARGET_TYPES } from "@/lib/collaboration-targets";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
+import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
 import type { GroupData } from "./equipment-rows";
 
@@ -35,6 +38,8 @@ export interface EditGroupFormValues {
   title: string;
   description?: string;
   quantity: number;
+  xeroAccountCode?: string;
+  xeroTaxType?: string;
 }
 
 interface EditGroupDialogProps {
@@ -93,6 +98,9 @@ function EditGroupDialogBody({
   const [price, setPrice] = useState(priceVal != null ? String(priceVal) : "");
   const [discount, setDiscount] = useState(discountVal != null ? String(discountVal) : "");
   const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
+  const [xeroAccountCode, setXeroAccountCode] = useState(group.xeroAccountCode ?? "");
+  const [xeroTaxType, setXeroTaxType] = useState(group.xeroTaxType ?? "");
+  const xeroLinked = useXeroLinked();
 
   function handleSave() {
     if (!title.trim() || formDisabled) return;
@@ -105,6 +113,14 @@ function EditGroupDialogBody({
         title: title.trim(),
         description: description.trim() || undefined,
         quantity: parseInt(quantity) || 1,
+        // NOT `|| undefined` (unlike description above): an omitted/undefined
+        // key never reaches the Convex mutation at all (JSON.stringify drops
+        // `undefined` values), so "clear the override" would be silently lost
+        // instead of patching back to unset. Always send the raw string —
+        // updateGroupNative's `a.xeroAccountCode || undefined` does the
+        // clear-on-empty itself, the way it's meant to work.
+        xeroAccountCode,
+        xeroTaxType,
       },
       resolvedPrice,
       resolvedDiscount,
@@ -178,6 +194,20 @@ function EditGroupDialogBody({
           onModeChange={setDiscountMode}
           disabled={formDisabled}
         />
+        {xeroLinked && (
+          <Accordion type="single" collapsible>
+            <AccordionItem value="xero-coding" className="border-line">
+              <AccordionTrigger>Advanced: Xero coding</AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-4 pt-1">
+                  <p className="text-caption text-muted">Overrides the category default for this group&apos;s invoice line only.</p>
+                  <XeroAccountCodeField value={xeroAccountCode} onChange={setXeroAccountCode} label="Account" placeholder="Inherit default" />
+                  <XeroTaxTypeField value={xeroTaxType} onChange={setXeroTaxType} label="Tax type" placeholder="Use org default" />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
       </div>
       <DialogFooter>
         <Button variant="line" onClick={onClose}>

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -73,6 +73,11 @@ export interface GroupData {
   suggestedPrice: unknown;
   sortOrder: number;
   lineItems?: LineItemData[];
+  /** Per-group Xero coding override (WS1 #940 cascade) — a priced group
+   *  bills as its own invoice line (financeSnapshot.ts). See
+   *  convex/xeroPush.ts resolveGroupLineCode. */
+  xeroAccountCode?: string | null;
+  xeroTaxType?: string | null;
 }
 
 export interface SubHireGroupData {

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -701,7 +701,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   });
 
   const updateGroupMut = useServerMutation({
-    mutationFn: ({ groupId, data }: { groupId: string; data: Partial<{ title: string; description: string; quantity: number }> }) =>
+    mutationFn: ({ groupId, data }: { groupId: string; data: Partial<{ title: string; description: string; quantity: number; xeroAccountCode: string; xeroTaxType: string }> }) =>
       groupWrites.update(groupId, data),
     onSuccess: () => {
       invalidate();

--- a/src/hooks/use-project-groups-writes.ts
+++ b/src/hooks/use-project-groups-writes.ts
@@ -57,7 +57,7 @@ export function useProjectGroupWrites() {
 
     update: async (
       groupId: string,
-      data: Partial<{ title: string; description: string; quantity: number }>,
+      data: Partial<{ title: string; description: string; quantity: number; xeroAccountCode: string; xeroTaxType: string }>,
     ): Promise<void> => {
       await updateM({
         id: groupId,
@@ -65,6 +65,8 @@ export function useProjectGroupWrites() {
         title: data.title,
         description: data.description,
         quantity: data.quantity,
+        xeroAccountCode: data.xeroAccountCode,
+        xeroTaxType: data.xeroTaxType,
         now: Date.now(),
         actor: actor(),
         auditId: createId(),

--- a/src/lib/project-equipment-reconstruct.ts
+++ b/src/lib/project-equipment-reconstruct.ts
@@ -342,6 +342,8 @@ export interface MappedGroup {
   discount: number | null;
   suggestedPrice: number | null;
   sortOrder: number;
+  xeroAccountCode: string | null;
+  xeroTaxType: string | null;
   createdAt: Date | null;
   updatedAt: Date | null;
 }
@@ -359,6 +361,8 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     discount: d.discount ?? null,
     suggestedPrice: d.suggestedPrice ?? null,
     sortOrder: d.sortOrder ?? 0,
+    xeroAccountCode: d.xeroAccountCode ?? null,
+    xeroTaxType: d.xeroTaxType ?? null,
     createdAt: msToDate(d.createdAt),
     updatedAt: msToDate(d.updatedAt),
   };

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -349,6 +349,8 @@ export type MappedGroup = Omit<
   | "discount"
   | "suggestedPrice"
   | "sortOrder"
+  | "xeroAccountCode"
+  | "xeroTaxType"
   | "createdAt"
   | "updatedAt"
 > & {
@@ -359,6 +361,8 @@ export type MappedGroup = Omit<
   discount: number | null;
   suggestedPrice: number | null;
   sortOrder: number;
+  xeroAccountCode: string | null;
+  xeroTaxType: string | null;
   createdAt: Date | null;
   updatedAt: Date | null;
 };
@@ -376,6 +380,8 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     discount: d.discount ?? null,
     suggestedPrice: d.suggestedPrice ?? null,
     sortOrder: d.sortOrder ?? 0,
+    xeroAccountCode: d.xeroAccountCode ?? null,
+    xeroTaxType: d.xeroTaxType ?? null,
     createdAt: msToDate(d.createdAt),
     updatedAt: msToDate(d.updatedAt),
   };

--- a/src/lib/validations/project-group.ts
+++ b/src/lib/validations/project-group.ts
@@ -12,6 +12,8 @@ export const projectGroupSchema = z.object({
   // (src/lib/validations/line-item.ts discountField).
   discount: z.coerce.number().min(0).max(999999.99).optional(),
   sortOrder: z.coerce.number().int().min(0).optional().default(0),
+  xeroAccountCode: z.string().max(50).optional(),
+  xeroTaxType: z.string().max(50).optional(),
 });
 
 export type ProjectGroupFormValues = z.input<typeof projectGroupSchema>;


### PR DESCRIPTION
## Summary

Per user request: "The xero coding stuff should show up on kits and groups and such too when they [are] items on a project."

**Kits — already covered, no code needed.** A kit-parent project line (`kitId` set, `isKitChild: false`) opens the exact same `EditLineItemDialog` as any other equipment line — no kit-specific code path intercepts or hides the Xero coding section added in the prior PR. Confirmed by inspection: `EditLineItemDialog`'s Xero section is gated only on `xeroLinked`, nothing kit-related.

**Groups — a real, total gap, now fixed.** A priced `projectGroups` row bills as its own invoice line (`financeSnapshot.ts`'s "priced groups bill as ONE line"), but had zero Xero coding support: no schema field, and `xeroPush.ts` explicitly fell straight through to org-default only for `GROUP` invoice lines.

- `projectGroups.xeroAccountCode`/`xeroTaxType` (schema), wired through `updateGroupNative` (`convex/projectGroupsWrites.ts`) with the same `.max(50)` `assertStrLen` bound the other 5 entities got.
- `resolveGroupLineCode` in `convex/xeroPush.ts`, wired into `resolveOneLine`'s dispatch: group override → its category's default → org default. Reuses `resolveEquipmentAccountCode` with `modelOrKitCode: null` (a group isn't a model/kit, no level-2 equivalent) rather than a bespoke 2-level function.
- UI: a collapsed-by-default "Advanced: Xero coding" section on `EditGroupDialog`, matching the line-item/service treatment from the prior PR (this dialog is on the everyday project-editing path too). The dialog uses local `useState`, not React Hook Form — the field is wired directly, and sends the raw string on every save (never `|| undefined`) so a cleared override actually reaches the mutation instead of the key silently vanishing over the wire (`JSON.stringify` drops `undefined` values — same class of bug as the previous PR's account-picker fix, caught before shipping this time).
- Both `MappedGroup` mappers (`project-equipment-reconstruct.ts` for the client-safe equipment-tab bundle, `project-line-item-read.ts` for the server read path) and `GroupData` needed the two new fields threaded through by hand — allowlist mappers over the raw doc, not passthrough spreads, so a new schema field is invisible until added explicitly.

`FEATUREDOCS/66` updated with the group cascade level and all of the above.

## Testing

- `pnpm exec vitest run` — 263 tests passing (added: a full cascade test in `xeroPush.test.ts` covering a group that falls through to its category default and a group with an explicit override winning over it; a set-then-clear-back-to-inherit test plus an over-length rejection test in `projectGroupsWrites.test.ts`).
- `pnpm exec tsc --noEmit` — zero new errors (one pre-existing, unrelated prisma-client-generation error confirmed present without this diff).
- `pnpm exec eslint` — no new warnings/errors beyond one already-oversized dialog function nudged slightly higher, same pattern as every other entity touched this week.
- `pnpm exec convex dev --once` — not runnable in this sandbox (no `CONVEX_DEPLOY_KEY` configured here); the schema/function push happens via the deploy pipeline's own `convex deploy -y` step on merge, same as every other Convex change this session.
- Not manually exercised in a live browser (no connected Xero org with project group data in this sandbox).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HoeQabDo6GQpTgSKQfxdqa)_