### PR TITLE
Phase B — immutable finance documents: render-and-store quote/invoice PDFs, kill the rogue Documents path (#987)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,26 @@ taken at v2). It is server-owned — written only by `createNative` and
 `quotesWrites.newVersionNative`, and stripped from client patches the same way
 `PROJECT_MONEY_ANCHORS` are. See FEATUREDOCS/66.
 
+### ⚠️ A client-facing finance document is STORED BYTES — never a fresh render
+A sent quote / issued invoice PDF is rendered **once** (`src/server/finance-documents.ts`)
+and its Convex `_storage` id attached to the row (`quotes.pdfFileId` / `invoices.pdfFileId`,
+via `convex/financeArtifacts.ts`). Downloads stream those bytes
+(`/api/finance/{quote,invoice}/[id]/pdf`); there is deliberately **no regeneration
+fallback anywhere**, because a route that can regenerate is a route that can hand the
+client a different document under the same name (#987). Three rules follow:
+
+1. **Never add a live-render path for `type=quote`/`type=invoice`.** `/api/documents/[projectId]`
+   serves those only behind `preview=1`, which requires `invoice:read` and stamps a
+   DRAFT PREVIEW — NOT SENT watermark on every page. The header's Documents ▾ is
+   warehouse artifacts only; putting a finance doc back in it re-opens the rogue path.
+2. **Never overwrite or delete an artifact.** `attach*Artifact` returns `attached: false`
+   rather than replacing one, which is what makes the "generate" retry safe on a row whose
+   render failed. A recalled/superseded/voided row keeps its document — the client may be
+   holding that copy.
+3. **A finance render takes its dates from the row**, never `now`
+   (`buildDocumentData`'s `stampedDates`). Recomputing `quote_valid_until` at render time
+   is what used to silently extend how long a quote was valid every time it was re-opened.
+
 ### Prisma v7
 - Import from `@/generated/prisma/client` (NOT `@/generated/prisma`)
 - After schema changes: `pnpm exec prisma migrate dev` → `pnpm exec prisma generate` → restart dev
@@ -402,6 +422,13 @@ one and shipping leaves silent bugs in the others:
 1. **`gearflow-table.ts` rendering** — what gets drawn (bold, indented, etc.)
 2. **`document-composer.ts`'s `calculateItemHeight`** — pagination space reservation (miss this → silent tail-drop)
 3. **`document-composer.ts`'s `getFilteredParentItems`** — top-level status filter (miss this → items disappear from docket / return-sheet). `gearflow-table.ts`'s own top-level filter mirrors this and must stay in sync (documented cross-reference in both files).
+
+A new **`LayoutBlock` kind** (`draftWatermark` was the first, #987) is a smaller but
+equally silent audit: `estimateBlockHeight` must reserve its height (miss it → it draws
+over the block below, or the tail drops) and `buildEntryFields` must emit its schema
+(miss it → nothing renders). Both are exhaustive switches, so a missing arm fails the
+build — keep the union closed. A block that belongs on EVERY page is page furniture
+(`isPageFurniture`/`measurePageFurniture`), not a body block.
 
 **Synthetic rows (e.g. `isGroupRow: true`) are footguns.** Their hard-coded fields (`status: "CONFIRMED"`, etc.) silently fail any filter that compares against them. Every status/filter site must special-case the synthetic row type, or compute the field dynamically from children.
 

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -713,6 +713,17 @@ Structured operational tasks attached to a project (deliveries, pickups, bump in
 - Uses existing pdfme infrastructure (gearflowPageHeader/Footer plugins)
 - Available via Documents dropdown on project detail page
 
+### Documents ▾ is warehouse-only (#987)
+The project header's **Documents ▾** offers Pull slip, Delivery docket, Return
+sheet, Call sheet and Project timeline — all artifacts of LIVE project state,
+which is correct for them (a packer wants today's list).
+
+"Quote / proposal" and "Invoice" were removed. A client-facing finance document
+is the STORED revision, downloaded from the finance panel
+(`/api/finance/{quote,invoice}/…/pdf`), never a fresh render — two clicks a week
+apart used to produce two different documents under the same name. See
+[FEATUREDOCS/66](./66-finance-quotes-invoices-xero.md) "Immutable documents".
+
 ## Duplicate Model Handling
 Adding a model that already exists as a line item on the project **auto-merges** into the existing line item (increments quantity) by default. When a duplicate is detected, the add dialog presents a choice:
 - **Combine with existing** (default) — merges quantity into the existing line item

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -1,6 +1,6 @@
 # PDF Document Generation
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-27 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-28 (review quarterly — POLICY.md R-5.5)_
 
 ## Architecture
 
@@ -91,6 +91,9 @@ of importing `@pdfme/generator` directly. `no-restricted-imports` in
 | `src/lib/pdfme/types.ts` | `DocumentType`, `TestTagReportType`, `DocumentData`, plugin config types |
 | `src/lib/pdfme/plugins/index.ts` | Plugin registry — all custom + built-in plugins |
 | `src/lib/pdfme/fonts.ts` | Font configuration for pdfme |
+| `src/server/finance-documents.ts` | **Immutable finance artifacts (#987)** — renders a quote/invoice PDF ONCE at send/issue, uploads it to Convex `_storage`, attaches the storage id. The only writer of `quotes.pdfFileId` / `invoices.pdfFileId`. |
+| `src/lib/finance-artifacts.ts` | Artifact file naming (`RVLT-2026-0087-quote-v2.pdf`) + filename sanitising — one definition shared by the upload and the download routes. |
+| `src/lib/finance-artifact-response.ts` | Streaming half of the two artifact routes: org re-check on the stored file, headers, and deliberately **no** regeneration fallback. |
 | `src/lib/pdfme/template-constants.ts` | Shared height/dimension constants (row heights, padding, font sizes, page dimensions) — the composer's single source of truth for pagination math |
 
 ### Custom Plugins (`src/lib/pdfme/plugins/`)
@@ -107,6 +110,7 @@ of importing `@pdfme/generator` directly. `no-restricted-imports` in
 | `gearflowCrewTable` | Crew table for call sheets — sorted by call time then role |
 | `gearflowCallSheetInfo` | 2-column info block: PM/client/equipment (left), venue/schedule (right) |
 | `gearflowDayHeader` | Day separator with accent bar, date label, phase badges, crew count |
+| `gearflowDraftWatermark` | "DRAFT PREVIEW — NOT SENT" banner (#987). Only ever produced by `?preview=1`; a stored artifact never carries one. Page furniture — repeated under the header on **every** page (see "Immutable finance artifacts"). Helvetica can't encode an em dash, so the plugin normalises `—`/curly quotes before drawing. |
 | `gearflowRichText` | Markdown-lite text block (`**bold**`, `*italic*`, `- `/`* ` bullets, word-wrapped to the box width) — replaces the pdfme built-in `text` type for every free-text/paragraph block in the 5 project document layouts: client+project details columns, client notes, total-items note, terms & conditions. When real font metrics are available (`generate-pdf.ts`), clientNotes/termsAndConditions also split across pages by wrapped line instead of only ever moving whole — see "Wrap-accurate pagination" below. |
 
 **Report Plugins:**
@@ -190,6 +194,42 @@ Call sheets are a 6th `DocumentType` value but are **not** in
 `DOCUMENT_LAYOUTS` — they render via `templates/call-sheet-services.ts`
 instead (`ProjectDocumentType = Exclude<DocumentType, "call-sheet">`).
 
+`getDocumentLayout(docType, { draftPreview: true })` (#987) returns the same
+layout with one extra block spliced in after the header: `draftWatermark`. It is
+the ONE variant of a fixed layout that exists, it is never persisted, and only
+`/api/documents/[projectId]?preview=1` asks for it.
+
+## Immutable finance artifacts (#987)
+
+A quote or invoice PDF is **rendered once and stored**, then never regenerated:
+
+```
+send / issue ──▶ src/server/finance-documents.ts (pdfme runs in Node)
+                   └─▶ generatePdf(...) ──▶ uploadToS3()   [= Convex _storage]
+                         └─▶ storageId ──▶ quotes.pdfFileId / invoices.pdfFileId
+                                            (convex/financeArtifacts.ts — attach ONCE)
+```
+
+Before this, `/api/documents/[projectId]?type=quote` re-rendered from live
+project state on every click: two downloads a week apart produced two different
+documents under the same name, and the document the client was actually holding
+existed nowhere in the system. Storing the bytes makes immutability structural
+instead of disciplinary — a "reconstruct it from the snapshot" path would
+re-execute ~1,400 lines of `build-document-data.ts` plus the composer, so any
+later change to that code would silently rewrite historical documents.
+
+What this changes in the PDF pipeline itself:
+
+| Concern | Behaviour |
+|---|---|
+| **Dates** | `buildDocumentData(..., { stampedDates })` takes `documentDate` / `quoteValidUntil` from the frozen row. `quote_valid_until` used to be recomputed from `now` on every render, so re-opening an old quote silently extended how long it was valid. The `now` fallback now only applies to a preview, which has no stamped dates because nothing has been sent. |
+| **Watermark** | `draftWatermark` is **page furniture** (like the header): `measurePageFurniture()` reserves its height and `placePageFurniture()` repeats it on every page. A banner on page 1 of a 4-page quote is not a warning — and an unreserved block is the v0.8.1.1 tail-drop bug. |
+| **Retrieval** | `/api/finance/{quote,invoice}/…/pdf` streams the stored bytes. There is deliberately no regeneration fallback: a route that can regenerate is a route that can hand the client a different document under the same name. |
+| **Failure** | A `SENT` quote with a null `pdfFileId` is a real state — the render runs after the Convex transaction commits and can fail on its own. The finance panel shows "Document missing — generate", and the attach mutation refuses to overwrite, so a retry can never rewrite history. |
+
+Superseded, recalled and voided rows keep their artifacts: the client may be
+holding that copy, so deleting ours makes the record worse, not better.
+
 ## Global Document Settings
 
 Org-level, stored in the existing `orgSettings` Convex blob (`OrgSettings.documents`,
@@ -202,7 +242,7 @@ card at `/settings/branding` ("Branding & documents").
 |---|---|
 | `footerText` / `footerSecondLine` | Rendered on every page of every doc type. Empty falls back to an auto-generated `{org name} \| {org email} \| {org phone}` line. |
 | `termsAndConditions` | Plain text (no token system) rendered as a block on the quote only. Omitted entirely (zero height, no schema) when unset — no empty box by default. |
-| `quoteValidityDays` (default 30) | Feeds a **real computed date** — `document_date + quoteValidityDays` — into the quote header's "Expiry: {date}" meta line (2026-07-28 — previously its own "This quote is valid until {date}." sentence at the bottom of the document; moved into the header alongside the doc number/date so it's visible without scrolling to the end of a possibly multi-page quote — see below). Replaces the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry. |
+| `quoteValidityDays` (default 30) | The org DEFAULT `sendNative` stamps `validUntil` from at send time (#986). A SENT revision's document renders that stamped date, not a fresh computation (#987); only the draft preview still derives it live. Feeds a **real computed date** — `document_date + quoteValidityDays` — into the quote header's "Expiry: {date}" meta line (2026-07-28 — previously its own "This quote is valid until {date}." sentence at the bottom of the document; moved into the header alongside the doc number/date so it's visible without scrolling to the end of a possibly multi-page quote — see below). Replaces the two hardcoded "valid for 30 days" static-text copies the deleted customization layer used to carry. |
 
 `build-document-data.ts` computes 4 `DocumentData` fields from these settings each
 time a document is built: `document_footer_text`, `document_footer_second_line`,
@@ -525,7 +565,9 @@ other fields:
 
 | Route | Method | Purpose |
 |-------|--------|---------|
-| `/api/documents/[projectId]` | GET | Generate project document. Param: `type` (quote/invoice/pull-slip/delivery-docket/return-sheet) |
+| `/api/documents/[projectId]` | GET | Generate a **warehouse** project document from live state. Param: `type` (pull-slip/delivery-docket/return-sheet). `type=quote`/`type=invoice` are **400 unless `preview=1`** (#987), which additionally requires `invoice:read` and stamps the DRAFT PREVIEW watermark. |
+| `/api/finance/quote/[quoteId]/pdf` | GET | Stream the **stored** quote artifact. `invoice:read` + org check (`quotes.by_cuid` is global — R-8.4.3). No regeneration path; 404 when a revision has no artifact. |
+| `/api/finance/invoice/[invoiceId]/pdf` | GET | Stream the **stored** invoice artifact. Same guards. A VOIDed invoice keeps its document. |
 | `/api/documents/call-sheet/[projectId]` | GET | Generate call sheet. Params: `date`, `dates` (comma-separated), `allDates=true`, `crewMemberId`, `crewRoleId` (all optional). |
 | `/api/documents/timeline/[projectId]` | GET | Generate project timeline PDF |
 | `/api/test-tag-reports/[reportType]` | GET | Generate T&T report. Params: `format` (pdf/csv), filters (dateFrom, dateTo, status, equipmentClass, etc.) |
@@ -594,6 +636,13 @@ PDF footgun section for the pre-#790 history of exactly this):
 2. **`document-composer.ts`'s `calculateItemHeight`** — pagination space reservation (miss this → silent tail-drop)
 3. **`document-composer.ts`'s `getFilteredParentItems`** — status filter (miss this → items disappear from docket / return-sheet)
 4. **`gearflow-table.ts`'s own top-level filter** — mirrors #3, must stay in sync (documented cross-reference in both files)
+
+A new **LayoutBlock kind** (e.g. `draftWatermark`, #987) is a different audit
+with two entries, not four: `estimateBlockHeight`'s switch (miss it → the block
+draws over whatever follows, or is silently dropped) and `buildEntryFields`'s
+switch (miss it → nothing renders). Both are exhaustive `switch`es over
+`LayoutBlock["kind"]`, so TypeScript fails the build on a missing arm — which is
+the point of keeping the block union closed.
 
 This is down from 5 consumers in 2 files pre-redesign (the dual pipeline
 meant `section-renderer.ts` and `gearflow-table.ts` each had their own filter

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -210,7 +210,9 @@ calendar day; and a `DRAFT` v1 inserted for every project with no quote row.
 
 Pre-existing sent quotes get **no artifact** — retro-rendering one from today's
 project state would manufacture a document that was never sent, which is the
-exact defect this program removes.
+exact defect this program removes. Their rows show the retry action rather than a
+download; taking it renders from current state, which is a deliberate,
+user-initiated choice and not something the migration does behind their back.
 
 "Effectively none" is a basis for choosing the simple path, not a licence to skip
 verification. The driver counts first, **halts** on a mismatch against
@@ -219,11 +221,74 @@ verification. The driver counts first, **halts** on a mismatch against
 
 ### Not in Phase A
 
-Immutable stored artifacts and `pdfFileId` wiring (#987), the unified
-status × quote-state lock tier (#988), the real Finance tab with its send and
-invoice-issue dialogs and drift indicator (#989), lock UX (#990), and the
-org-level Finance section (#992). The current UI surface is
-`<ProjectQuoteRail>` — enough to exercise the five verbs, not the designed tab.
+The unified status × quote-state lock tier (#988), the real Finance tab with its
+send and invoice-issue dialogs and drift indicator (#989), lock UX (#990), and
+the org-level Finance section (#992). The current UI surface is
+`<ProjectQuoteRail>` + `<ProjectFinancePanel>` — enough to exercise the five
+verbs and the documents, not the designed tab.
+
+## Immutable documents (#987 — Phase B of #985)
+
+A quote's money was already frozen at send and an invoice's row was already
+immutable once ISSUED — but the **document** was live-rendered on every click,
+so both guarantees stopped at the database boundary. Now the PDF is rendered
+once, at the freeze moment, and the bytes are kept:
+
+```
+sendNative / issueNative  (Convex transaction — the row)
+        └─▶ src/server/finance-documents.ts  (server action — the document)
+              generatePdf() ─▶ uploadToS3() [Convex _storage] ─▶ storageId
+                    └─▶ convex/financeArtifacts.ts attach*Artifact
+                          └─▶ quotes.pdfFileId / invoices.pdfFileId
+```
+
+Chosen over "reconstruct the document from the snapshot on demand" because it is
+the only option that is actually immutable: a reconstruction path re-executes
+~1,400 lines of `build-document-data.ts` plus the composer against a snapshot
+that would have to grow to carry every token, and any future change to that code
+would silently rewrite historical documents. Storing bytes makes the guarantee
+structural rather than disciplinary — the same reasoning as `withValidatedBody`.
+
+### The rules
+
+- **Attach once, never overwrite.** `attachQuoteArtifact` / `attachInvoiceArtifact`
+  return `{ attached: false, pdfFileId }` when one is already there instead of
+  replacing it. That is what makes exposing a retry button safe: a retry racing a
+  slow first attempt loses harmlessly, and the server action bins its orphan
+  upload.
+- **Nothing deletes one.** A recalled, superseded, declined or voided row keeps
+  its artifact — the client may be holding that copy, so destroying ours makes
+  the record worse. The rail badges the state next to the download.
+- **A draft has no artifact**, and the mutations refuse to give it one. Its only
+  document is the watermarked preview, which is never stored.
+- **Dates come from the row.** The render is handed the stamped
+  `quoteDate`/`validUntil` (or an invoice's `issuedAt`), never `now`.
+- **No regeneration path on read.** `/api/finance/{quote,invoice}/…/pdf` streams
+  the stored bytes or 404s. A route that can regenerate is a route that can hand
+  the client a different document under the same name.
+
+### Failure handling
+
+The render runs after the Convex transaction commits, so it can fail on its own.
+A `SENT` quote (or `ISSUED` invoice) with a null `pdfFileId` is therefore a real
+state, and it is never silent: the row renders "Document missing — generate", and the
+retry is only reachable while `pdfFileId` is null. The send/issue itself is never
+rolled back for a render failure — the money is frozen either way.
+
+### Surfaces
+
+| Surface | Behaviour |
+|---|---|
+| Quote revision row | Download (stored artifact) · Preview draft (watermarked) · Document missing — generate. Exactly one of the three, always — the wording covers a failed render and a pre-#987 row alike, neither of which is a state the user should have to guess at. |
+| Invoice row | Same three states, keyed on `issuedAt` instead of `sentAt`. |
+| Header **Documents ▾** | Warehouse artifacts only. "Quote / proposal" and "Invoice" are gone — that dropdown was the rogue path. |
+| `/api/documents/[projectId]?type=quote` | 400 without `preview=1`; with it, requires `invoice:read` and stamps DRAFT PREVIEW — NOT SENT on every page. |
+
+Permissions: `invoice:read` to download or preview, `invoice:publish` to
+generate/retry a quote artifact, `invoice:issue` for an invoice one — the same
+audiences that can send and issue in the first place. Both routes carry explicit
+cross-org tests (`quotes.by_cuid`/`invoices.by_cuid` are GLOBAL indexes,
+R-8.4.3).
 
 ## Numbering (zero engine change)
 
@@ -528,7 +593,11 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 | `convex/lib/quoteState.ts` | Derived `EXPIRED`, `PUBLISHED`→`SENT` normalisation, `hasAcceptedQuote`, org-checked quote/project loaders |
 | `convex/lib/quoteDates.ts` / `src/lib/quote-validity.ts` | Validity default + bounds + timezone-correct `validUntil`/expiry (mirrored pair) |
 | `convex/backfillQuoteRevisions.ts` | Forward migration + `verifyQuoteRevisions` |
-| `src/hooks/use-quote-writes.ts` / `src/components/projects/project-quote-rail.tsx` | Client wiring for the five verbs |
+| `src/hooks/use-quote-writes.ts` / `src/components/projects/project-quote-rail.tsx` | Client wiring for the five verbs + the revision row's document action |
+| `convex/financeArtifacts.ts` | Attach-once artifact mutations + the org-checked context queries the download routes authorise against (#987) |
+| `src/server/finance-documents.ts` | `generateQuoteArtifact` / `generateInvoiceArtifact` — render, upload, attach, bin the orphan on a lost race |
+| `src/lib/finance-artifacts.ts` / `src/lib/finance-artifact-response.ts` | Artifact file naming + the shared streaming/org-check half of both routes |
+| `src/app/api/finance/{quote,invoice}/[id]/pdf/route.ts` | Download the stored document — no regeneration path |
 | `convex/invoicesWrites.ts` | `createNative`/`issueNative`/`voidNative`/`deleteDraftNative`/`createCreditNative` |
 | `convex/lib/financeSnapshot.ts` | `buildFinanceLines` — the shared quote/invoice line-breakdown builder |
 | `convex/lib/xeroAccountCascade.ts` | Pure cascade resolver functions |
@@ -572,6 +641,22 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 - `convex/backfillQuoteRevisions.test.ts` — dry-run/apply split, every migration
   step, idempotency, template exclusion, monotonicity, SERVICE-only access, and
   zero un-migrated rows afterwards.
+- `convex/financeArtifacts.test.ts` — 13 tests: attach-once (never overwrites),
+  the sent/issued preconditions, service-only access, and a cross-org case per
+  function including "the quote is mine but the project isn't".
+- `src/server/finance-documents.test.ts` — 11 tests, led by *"a sent quote's PDF
+  is byte-identical on repeat download while the live project changes underneath
+  it"*: the pipeline is re-primed with different bytes between calls and the
+  stored artifact does not move. Plus the invoice equivalent, stamped dates
+  (never `now`), the retry path, and orphan cleanup on a lost attach race.
+- `src/app/api/finance/__tests__/artifact-routes.test.ts` — 15 tests: streams
+  stored bytes and never calls `generatePdf`, cross-org 404s on both routes, a
+  403 when the stored file's org doesn't match, `?type=quote` without `preview=1`
+  is a 400, and preview requires `invoice:read`.
+- `src/lib/pdfme/document-composer.test.ts` / `plugins/gearflow-draft-watermark.test.ts`
+  — the watermark reserves exactly its own height, repeats on every page, drops
+  no line items, is absent from a normal render, and survives the em dash
+  Helvetica can't encode.
 - `convex/projectWrites.test.ts` — the acceptance gate on `CONFIRMED`: blocked
   without an accepted revision, satisfied by one, unsatisfied by a merely-SENT
   one or another org's (IDOR), the admin/PM override with its audited

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as emails from "../emails.js";
 import type * as equipmentTab from "../equipmentTab.js";
 import type * as fileUploads from "../fileUploads.js";
 import type * as files from "../files.js";
+import type * as financeArtifacts from "../financeArtifacts.js";
 import type * as globalSearch from "../globalSearch.js";
 import type * as groupTemplateItems from "../groupTemplateItems.js";
 import type * as groupTemplates from "../groupTemplates.js";
@@ -337,6 +338,7 @@ declare const fullApi: ApiFromModules<{
   equipmentTab: typeof equipmentTab;
   fileUploads: typeof fileUploads;
   files: typeof files;
+  financeArtifacts: typeof financeArtifacts;
   globalSearch: typeof globalSearch;
   groupTemplateItems: typeof groupTemplateItems;
   groupTemplates: typeof groupTemplates;

--- a/convex/financeArtifacts.test.ts
+++ b/convex/financeArtifacts.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment node
+//
+// convex/financeArtifacts.ts (#987) — the attach-once guarantee and the org
+// checks the two artifact routes rest on.
+//
+// Two properties are load-bearing enough to be machine-checked rather than
+// argued: an artifact can NEVER be replaced once attached (which is what makes
+// exposing a retry button safe), and every function re-checks the ROW's org
+// (`quotes.by_cuid` / `invoices.by_cuid` are GLOBAL indexes and the service
+// token authorises nothing about the row — R-8.4.3). These routes are the
+// highest-risk new surface in the program.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+const NOW = 1_700_000_000_000;
+
+/** The server identity every function here demands (requireService). */
+const asService = { subject: "gearflow-service", svc: true };
+
+function makeT() {
+  return convexTest(schema, modules);
+}
+
+async function seed(t: ReturnType<typeof makeT>, orgId = ORG) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", {
+      id: "p1", organizationId: orgId, projectNumber: "RVLT-2026-0087", name: "Gig",
+      status: "QUOTED", isTemplate: false, revision: 2, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("quotes", {
+      id: "q1", organizationId: orgId, projectId: "p1", version: 2, status: "SENT",
+      snapshot: { total: 110 }, sentAt: NOW, quoteDate: NOW, validUntil: NOW + 86_400_000 * 30,
+      createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("quotes", {
+      id: "q_draft", organizationId: orgId, projectId: "p1", version: 3, status: "DRAFT",
+      snapshot: null, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("invoices", {
+      id: "inv1", organizationId: orgId, projectId: "p1", clientId: "c1", kind: "FULL",
+      status: "ISSUED", invoiceNumber: "INV-2026-0001", issuedAt: NOW,
+      subtotal: 100, taxAmount: 10, total: 110, createdAt: NOW, updatedAt: NOW,
+    });
+    await ctx.db.insert("invoices", {
+      id: "inv_draft", organizationId: orgId, projectId: "p1", clientId: "c1", kind: "DEPOSIT",
+      status: "DRAFT", subtotal: 25, taxAmount: 2.5, total: 27.5, createdAt: NOW, updatedAt: NOW,
+    });
+  });
+}
+
+const svc = (t: ReturnType<typeof makeT>) => t.withIdentity(asService);
+
+describe("attachQuoteArtifact", () => {
+  test("attaches the storage id to a SENT revision", async () => {
+    const t = makeT();
+    await seed(t);
+
+    const result = await svc(t).mutation(api.financeArtifacts.attachQuoteArtifact, {
+      quoteId: "q1", orgId: ORG, storageId: "storage_1", now: NOW,
+    });
+
+    expect(result).toEqual({ attached: true, pdfFileId: "storage_1" });
+    const quote = await t.run(async (ctx) =>
+      ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", "q1")).first());
+    expect(quote?.pdfFileId).toBe("storage_1");
+  });
+
+  test("NEVER overwrites an existing artifact — it reports the one already there", async () => {
+    const t = makeT();
+    await seed(t);
+    await svc(t).mutation(api.financeArtifacts.attachQuoteArtifact, {
+      quoteId: "q1", orgId: ORG, storageId: "storage_first", now: NOW,
+    });
+
+    const second = await svc(t).mutation(api.financeArtifacts.attachQuoteArtifact, {
+      quoteId: "q1", orgId: ORG, storageId: "storage_second", now: NOW + 1000,
+    });
+
+    expect(second).toEqual({ attached: false, pdfFileId: "storage_first" });
+    const quote = await t.run(async (ctx) =>
+      ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", "q1")).first());
+    expect(quote?.pdfFileId).toBe("storage_first");
+  });
+
+  test("refuses a never-sent draft — a draft's only document is the watermarked preview", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).mutation(api.financeArtifacts.attachQuoteArtifact, {
+        quoteId: "q_draft", orgId: ORG, storageId: "storage_1", now: NOW,
+      }),
+    ).rejects.toThrow(/sent quote revision/i);
+  });
+
+  test("cross-org attach is NOT_FOUND, not a silent write (R-8.4.3)", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).mutation(api.financeArtifacts.attachQuoteArtifact, {
+        quoteId: "q1", orgId: OTHER, storageId: "storage_evil", now: NOW,
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    const quote = await t.run(async (ctx) =>
+      ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", "q1")).first());
+    expect(quote?.pdfFileId).toBeUndefined();
+  });
+
+  test("requires the service identity — a plain user session cannot attach", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      t.withIdentity({ subject: "user_1", orgId: ORG }).mutation(api.financeArtifacts.attachQuoteArtifact, {
+        quoteId: "q1", orgId: ORG, storageId: "storage_1", now: NOW,
+      }),
+    ).rejects.toThrow(/requires the RVLT Flow server/i);
+  });
+});
+
+describe("attachInvoiceArtifact", () => {
+  test("attaches to an ISSUED invoice and never overwrites", async () => {
+    const t = makeT();
+    await seed(t);
+
+    const first = await svc(t).mutation(api.financeArtifacts.attachInvoiceArtifact, {
+      invoiceId: "inv1", orgId: ORG, storageId: "storage_a", now: NOW,
+    });
+    const second = await svc(t).mutation(api.financeArtifacts.attachInvoiceArtifact, {
+      invoiceId: "inv1", orgId: ORG, storageId: "storage_b", now: NOW + 1,
+    });
+
+    expect(first).toEqual({ attached: true, pdfFileId: "storage_a" });
+    expect(second).toEqual({ attached: false, pdfFileId: "storage_a" });
+  });
+
+  test("refuses a DRAFT invoice — its amounts are still mutable", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).mutation(api.financeArtifacts.attachInvoiceArtifact, {
+        invoiceId: "inv_draft", orgId: ORG, storageId: "storage_1", now: NOW,
+      }),
+    ).rejects.toThrow(/issued invoice/i);
+  });
+
+  test("cross-org attach is NOT_FOUND", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).mutation(api.financeArtifacts.attachInvoiceArtifact, {
+        invoiceId: "inv1", orgId: OTHER, storageId: "storage_evil", now: NOW,
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("artifact context queries (what the download routes authorise against)", () => {
+  test("a quote's context carries the STAMPED dates, not today's", async () => {
+    const t = makeT();
+    await seed(t);
+
+    const ctx = await svc(t).query(api.financeArtifacts.quoteArtifactContext, {
+      quoteId: "q1", orgId: ORG, now: NOW,
+    });
+
+    expect(ctx).toMatchObject({
+      quoteId: "q1",
+      projectNumber: "RVLT-2026-0087",
+      version: 2,
+      effectiveStatus: "SENT",
+      label: "RVLT-2026-0087 v2",
+      quoteDate: NOW,
+      validUntil: NOW + 86_400_000 * 30,
+      pdfFileId: null,
+    });
+  });
+
+  test("a SUPERSEDED revision stays readable — the client may still hold that copy", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      const q = await ctx.db.query("quotes").withIndex("by_cuid", (x) => x.eq("id", "q1")).first();
+      await ctx.db.patch(q!._id, { status: "SUPERSEDED", pdfFileId: "storage_old" });
+    });
+
+    const ctx = await svc(t).query(api.financeArtifacts.quoteArtifactContext, {
+      quoteId: "q1", orgId: ORG, now: NOW,
+    });
+
+    expect(ctx.effectiveStatus).toBe("SUPERSEDED");
+    expect(ctx.pdfFileId).toBe("storage_old");
+  });
+
+  test("cross-org quote read is NOT_FOUND — the artifact route's IDOR guard", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).query(api.financeArtifacts.quoteArtifactContext, { quoteId: "q1", orgId: OTHER, now: NOW }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("cross-org invoice read is NOT_FOUND", async () => {
+    const t = makeT();
+    await seed(t);
+
+    await expect(
+      svc(t).query(api.financeArtifacts.invoiceArtifactContext, { invoiceId: "inv1", orgId: OTHER }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("a quote whose PROJECT belongs to another org is NOT_FOUND (no cross-tenant join)", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (x) => x.eq("id", "p1")).first();
+      await ctx.db.patch(p!._id, { organizationId: OTHER });
+    });
+
+    await expect(
+      svc(t).query(api.financeArtifacts.quoteArtifactContext, { quoteId: "q1", orgId: ORG, now: NOW }),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/convex/financeArtifacts.ts
+++ b/convex/financeArtifacts.ts
@@ -1,0 +1,195 @@
+import { v, ConvexError } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import { requireService } from "./lib/auth";
+import { effectiveQuoteStatus, quoteLabel, requireQuoteInOrg } from "./lib/quoteState";
+
+/**
+ * Immutable finance ARTIFACTS (#987, Phase B) — the storage-id side of
+ * "render once, keep the bytes".
+ *
+ * Before this, `/api/documents/[projectId]?type=quote` re-rendered from LIVE
+ * project state on every click: two downloads a week apart produced two
+ * different documents under the same name, and the document the client was
+ * actually holding existed nowhere in the system. `quotes.pdfFileId` was
+ * declared with zero readers and zero writers. Invoices had the same hole — the
+ * ROW was immutable once ISSUED, but the artifact was not, so the guarantee
+ * stopped at the database boundary.
+ *
+ * The freeze is now structural rather than disciplinary (the `withValidatedBody`
+ * reasoning in CLAUDE.md): the PDF is rendered once by the server action
+ * (`src/server/finance-documents.ts` — pdfme runs in Node, not Convex), the
+ * bytes are stored in Convex `_storage` via `src/lib/storage.ts`, and the
+ * storage id is attached HERE, **once**. There is deliberately no mutation that
+ * can replace an artifact:
+ *
+ * - `attachQuoteArtifact` / `attachInvoiceArtifact` refuse to overwrite a
+ *   non-null `pdfFileId`, reporting `attached: false` and handing back the id
+ *   that is already there so the caller can bin its orphan upload. That is what
+ *   makes the retry path (for a send whose render failed) safe to expose: it
+ *   physically cannot rewrite history, so a retry racing a first attempt loses
+ *   harmlessly instead of swapping the client's document.
+ * - Nothing deletes one. A recalled or superseded revision KEEPS its artifact —
+ *   the client may be holding that copy, so destroying ours makes the record
+ *   worse, not better.
+ *
+ * SERVICE-gated (the Next.js server is the only caller, exactly like
+ * `convex/files.ts`): rendering needs Node, and authorisation — `invoice:read`
+ * to download, `invoice:publish`/`invoice:issue` to generate — happens in the
+ * server action / route handler before we get here. Per CLAUDE.md rule 1, there
+ * is NO agent escape hatch; an API key reaches these only through a server
+ * action that has already resolved its RBAC.
+ *
+ * ⚠️ R-8.4.3: `quotes.by_cuid` / `invoices.by_cuid` are GLOBAL indexes and the
+ * service token authorises nothing about the ROW. Every function here takes the
+ * caller's `orgId` (resolved from the session upstream) and re-checks it against
+ * the document, throwing the same `NOT_FOUND` for "missing" and "another org's"
+ * so a cross-tenant probe can't distinguish them. The two artifact routes are
+ * the highest-risk new surface in this program — see `financeArtifacts.test.ts`.
+ */
+
+/** Load an invoice by cuid, org-checked (`by_cuid` is global). */
+async function requireInvoiceInOrg(
+  ctx: QueryCtx | MutationCtx,
+  invoiceId: string,
+  orgId: string,
+): Promise<Doc<"invoices">> {
+  const invoice = await ctx.db.query("invoices").withIndex("by_cuid", (q) => q.eq("id", invoiceId)).first();
+  if (!invoice || invoice.organizationId !== orgId) {
+    throw new ConvexError({ code: "NOT_FOUND", message: "Invoice not found." });
+  }
+  return invoice;
+}
+
+/** The project a finance row hangs off, org-checked. Only its number/name are
+ *  used (artifact file naming), never its live money. */
+async function requireProjectInOrg(
+  ctx: QueryCtx | MutationCtx,
+  projectId: string,
+  orgId: string,
+): Promise<Doc<"projects">> {
+  const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
+  if (!project || project.organizationId !== orgId) {
+    throw new ConvexError({ code: "NOT_FOUND", message: "Project not found." });
+  }
+  return project;
+}
+
+/**
+ * Everything the render path and the download route need about a quote
+ * revision, in one org-checked round trip.
+ *
+ * `quoteDate`/`validUntil` are the STAMPED values from the row — the whole point
+ * of Phase B on the validity side. `build-document-data.ts` used to compute
+ * `quoteValidUntil` from `now` at render time, so simply re-opening an old quote
+ * silently extended how long it was valid.
+ */
+export const quoteArtifactContext = query({
+  args: { quoteId: v.string(), orgId: v.string(), now: v.optional(v.number()) },
+  handler: async (ctx, { quoteId, orgId, now }) => {
+    await requireService(ctx);
+    const quote = await requireQuoteInOrg(ctx, quoteId, orgId);
+    const project = await requireProjectInOrg(ctx, quote.projectId, orgId);
+    return {
+      quoteId: quote.id,
+      projectId: quote.projectId,
+      projectNumber: project.projectNumber,
+      version: quote.version,
+      effectiveStatus: effectiveQuoteStatus(quote, now ?? 0),
+      label: quoteLabel(project.projectNumber, quote.version),
+      pdfFileId: quote.pdfFileId ?? null,
+      // `sentAt || publishedAt` — a pre-#986 row the backfill hasn't reached
+      // still counts as sent (convex/lib/quoteState.ts normalises the same way).
+      sentAt: quote.sentAt ?? quote.publishedAt ?? null,
+      quoteDate: quote.quoteDate ?? null,
+      validUntil: quote.validUntil ?? null,
+    };
+  },
+});
+
+/** The invoice equivalent. `issuedAt` is the document date an issued invoice
+ *  freezes at — the same "don't recompute from now" rule as a quote's dates. */
+export const invoiceArtifactContext = query({
+  args: { invoiceId: v.string(), orgId: v.string() },
+  handler: async (ctx, { invoiceId, orgId }) => {
+    await requireService(ctx);
+    const invoice = await requireInvoiceInOrg(ctx, invoiceId, orgId);
+    const project = await requireProjectInOrg(ctx, invoice.projectId, orgId);
+    return {
+      invoiceId: invoice.id,
+      projectId: invoice.projectId,
+      projectNumber: project.projectNumber,
+      invoiceNumber: invoice.invoiceNumber ?? null,
+      kind: invoice.kind,
+      status: invoice.status,
+      pdfFileId: invoice.pdfFileId ?? null,
+      issuedAt: invoice.issuedAt ?? null,
+      dueDate: invoice.dueDate ?? null,
+    };
+  },
+});
+
+const attachResult = v.object({
+  attached: v.boolean(),
+  pdfFileId: v.string(),
+});
+
+/**
+ * Attach the rendered artifact to a SENT revision — the write that makes the
+ * document immutable.
+ *
+ * Refuses (without throwing) when one is already attached: the caller gets
+ * `attached: false` plus the existing id, deletes the bytes it just uploaded,
+ * and serves the original. "Never overwrite" is enforced here rather than by the
+ * caller remembering to check first, so the retry path can be exposed to the UI
+ * without a second render path opening up for a quote that already has one.
+ */
+export const attachQuoteArtifact = mutation({
+  returns: attachResult,
+  args: { quoteId: v.string(), orgId: v.string(), storageId: v.string(), now: v.number() },
+  handler: async (ctx, { quoteId, orgId, storageId, now }) => {
+    await requireService(ctx);
+    const quote = await requireQuoteInOrg(ctx, quoteId, orgId);
+
+    if (quote.pdfFileId) return { attached: false, pdfFileId: quote.pdfFileId };
+
+    // A never-sent draft has no frozen document to stand behind — its figures
+    // are still the project's live totals. The watermarked DRAFT PREVIEW
+    // (`/api/documents/[projectId]?type=quote&preview=1`) is the only document a
+    // draft ever produces, and it is deliberately never stored.
+    if (quote.sentAt == null && quote.publishedAt == null) {
+      throw new ConvexError({
+        code: "QUOTE_NOT_SENT",
+        message: "Only a sent quote revision has a stored document.",
+      });
+    }
+
+    await ctx.db.patch(quote._id, { pdfFileId: storageId, updatedAt: now });
+    return { attached: true, pdfFileId: storageId };
+  },
+});
+
+/** Invoice counterpart — same never-overwrite guarantee, gated on ISSUED
+ *  rather than sent (a DRAFT invoice's amounts are still mutable). A VOID
+ *  invoice keeps the artifact it was issued with. */
+export const attachInvoiceArtifact = mutation({
+  returns: attachResult,
+  args: { invoiceId: v.string(), orgId: v.string(), storageId: v.string(), now: v.number() },
+  handler: async (ctx, { invoiceId, orgId, storageId, now }) => {
+    await requireService(ctx);
+    const invoice = await requireInvoiceInOrg(ctx, invoiceId, orgId);
+
+    if (invoice.pdfFileId) return { attached: false, pdfFileId: invoice.pdfFileId };
+
+    if (invoice.issuedAt == null) {
+      throw new ConvexError({
+        code: "INVOICE_NOT_ISSUED",
+        message: "Only an issued invoice has a stored document.",
+      });
+    }
+
+    await ctx.db.patch(invoice._id, { pdfFileId: storageId, updatedAt: now });
+    return { attached: true, pdfFileId: storageId };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2137,7 +2137,11 @@ export default defineSchema({
   // `publishedAt`/`publishedById` are the DEPRECATED pre-#986 names, kept
   // declared until `backfillQuoteRevisions.ts` confirms zero remaining rows
   // carry them (schema-validation precedent: FEATUREDOCS/66 `depositPercent`).
-  // `pdfFileId` links the stored immutable artifact — written in Phase B (#987).
+  // `pdfFileId` links the stored immutable artifact (a Convex `_storage` id): the
+  // PDF is rendered ONCE at send and the bytes kept, so re-downloading a sent
+  // revision can never produce a different document from the one the client is
+  // holding (#987). Written once and never overwritten — see
+  // convex/financeArtifacts.ts. A recalled/superseded revision KEEPS its artifact.
   quotes: defineTable({
     id: v.string(),
     organizationId: v.string(),
@@ -2189,6 +2193,12 @@ export default defineSchema({
   // + reissue, or a CREDIT invoice — never an in-place patch of issued amounts.
   // `paymentStatus` mirrors SubHirePaymentStatus's vocabulary and is written ONLY
   // by the Xero payment-status poll (phase 2), never by the client.
+  //
+  // `pdfFileId` (#987) is the stored immutable artifact rendered at ISSUE time —
+  // the row was already immutable once ISSUED, but until Phase B the DOCUMENT was
+  // re-rendered from live project state on every click, so the guarantee stopped
+  // at the database boundary. Written once, never overwritten
+  // (convex/financeArtifacts.ts).
   invoices: defineTable({
     id: v.string(),
     organizationId: v.string(),
@@ -2201,6 +2211,7 @@ export default defineSchema({
     issuedAt: v.optional(v.number()),
     issuedById: v.optional(v.string()),
     dueDate: v.optional(v.number()),
+    pdfFileId: v.optional(v.string()),
     // Money snapshot, frozen at create/issue time (never recomputed from live
     // project pricing after issue — R-9.3 "server is the authority", but the
     // authoritative moment is issue, not "whenever read").

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -22,9 +22,9 @@ convention:
 
 | | Total public | Agent-reachable | SERVICE-only | Org-read (fails closed for agents) | Unclassified |
 |---|---|---|---|---|---|
-| Queries | 395 | 22 | 155 | 216 | 2 |
-| Mutations | 725 | 269 | 449 | 1 | 6 |
-| **Total** | **1120** | **291** | **604** | **217** | **8** |
+| Queries | 397 | 22 | 157 | 216 | 2 |
+| Mutations | 727 | 269 | 451 | 1 | 6 |
+| **Total** | **1124** | **291** | **608** | **217** | **8** |
 
 <!-- reachability-floor: 291 -->
 
@@ -86,6 +86,7 @@ add a redacted sibling, or record as permanently denied with a reason.
 | `emails` | 1 |
 | `fileUploads` | 8 |
 | `files` | 4 |
+| `financeArtifacts` | 4 |
 | `globalSearch` | 1 |
 | `groupTemplateItems` | 6 |
 | `groupTemplates` | 6 |

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -352,9 +352,13 @@ export default function ProjectDetailPage({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      {/* Warehouse artifacts only. Quote and Invoice are
+                          deliberately absent (#987): a client-facing finance
+                          document comes from the Finance panel as the STORED
+                          revision, never a fresh render of live state — two
+                          clicks a week apart used to produce two different
+                          documents under the same name. */}
                       {([
-                        { label: "Quote / proposal", apiType: "quote" },
-                        { label: "Invoice", apiType: "invoice" },
                         { label: "Pull slip", apiType: "pull-slip" },
                         { label: "Delivery docket", apiType: "delivery-docket" },
                         { label: "Return sheet", apiType: "return-sheet" },

--- a/src/app/api/documents/[projectId]/route.tsx
+++ b/src/app/api/documents/[projectId]/route.tsx
@@ -1,8 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireOrganization } from "@/lib/auth-server";
+import { requirePermission } from "@/lib/org-context";
 import { generatePdf } from "@/lib/pdfme/generate-pdf";
 import type { ProjectDocumentType } from "@/lib/pdfme/document-layouts";
+
+/**
+ * Warehouse document rendering — pull slip, delivery docket, return sheet.
+ * These are internal artifacts of live project state by design: a packer wants
+ * TODAY's list, so re-rendering is the correct behaviour for them.
+ *
+ * Quote and invoice are NOT in that category and no longer have a live path
+ * here (#987). The document the client holds is the stored artifact
+ * (`/api/finance/{quote,invoice}/…/pdf`); this route will only produce one for
+ * them behind `preview=1`, which stamps a "DRAFT PREVIEW — NOT SENT" watermark
+ * on every page and requires `invoice:read`. That is what removes the rogue
+ * path the header's Documents ▾ used to expose.
+ */
 
 /** Map URL type param values to pdfme ProjectDocumentType */
 const typeMap: Record<string, ProjectDocumentType> = {
@@ -13,6 +27,9 @@ const typeMap: Record<string, ProjectDocumentType> = {
   "delivery-docket": "delivery-docket",
 };
 
+/** Client-facing finance docs — reachable here ONLY as a watermarked preview. */
+const PREVIEW_ONLY_TYPES = new Set<ProjectDocumentType>(["quote", "invoice"]);
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ projectId: string }> }
@@ -20,6 +37,7 @@ export async function GET(
   const { projectId } = await params;
   const url = new URL(request.url);
   const type = url.searchParams.get("type") || "quote";
+  const preview = url.searchParams.get("preview") === "1";
 
   let session;
   try {
@@ -35,8 +53,30 @@ export async function GET(
     return NextResponse.json({ error: `Unknown document type: ${type}` }, { status: 400 });
   }
 
+  if (PREVIEW_ONLY_TYPES.has(docType)) {
+    if (!preview) {
+      return NextResponse.json(
+        {
+          error:
+            "Quotes and invoices are served from the Finance tab as stored documents. " +
+            "Use /api/finance/quote/{quoteId}/pdf or add preview=1 for a watermarked draft preview.",
+        },
+        { status: 400 },
+      );
+    }
+    try {
+      await requirePermission("invoice", "read");
+    } catch {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
   try {
-    const pdf = await generatePdf(projectId, organizationId, docType);
+    // `draftPreview` is set for the finance types only — a warehouse doc is not
+    // a draft of anything, so it never carries the banner.
+    const pdf = await generatePdf(projectId, organizationId, docType, {
+      draftPreview: preview && PREVIEW_ONLY_TYPES.has(docType),
+    });
     const filename = `${docType}-${projectId}.pdf`;
     return new NextResponse(Buffer.from(pdf), {
       headers: {

--- a/src/app/api/finance/__tests__/artifact-routes.test.ts
+++ b/src/app/api/finance/__tests__/artifact-routes.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The two finance artifact routes + the draft-preview gate (#987).
+ *
+ * These are the highest-risk NEW surfaces in the finance program: they take an
+ * id straight off the URL and stream bytes, and `quotes.by_cuid` /
+ * `invoices.by_cuid` are GLOBAL Convex indexes, so "the caller is authenticated"
+ * says nothing about whose document this is (R-8.4.3). Every cross-org path is
+ * asserted here, plus the two properties that make the artifact immutable in
+ * practice: the route NEVER regenerates, and a quote/invoice can no longer be
+ * live-rendered out of the Documents menu.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { getFunctionName } from "convex/server";
+
+const requirePermission = vi.fn(async () => ({ organizationId: "org_1", userId: "u1", userName: "Alice" }));
+vi.mock("@/lib/org-context", () => ({ requirePermission: (...a: unknown[]) => requirePermission(...(a as [])) }));
+
+const requireOrganization = vi.fn(async () => ({ organizationId: "org_1", userId: "u1" }));
+vi.mock("@/lib/auth-server", () => ({ requireOrganization: () => requireOrganization() }));
+
+const queryMock = vi.fn();
+vi.mock("@/lib/convex-client", () => ({
+  getConvexClient: vi.fn(async () => ({ query: queryMock, mutation: vi.fn() })),
+}));
+
+const getServeInfo = vi.fn();
+vi.mock("@/lib/storage", () => ({ getServeInfo: (...a: unknown[]) => getServeInfo(...(a as [string])) }));
+
+const fetchWithTimeout = vi.fn();
+vi.mock("@/lib/fetch-with-timeout", () => ({ fetchWithTimeout: (...a: unknown[]) => fetchWithTimeout(...a) }));
+
+const generatePdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
+vi.mock("@/lib/pdfme/generate-pdf", () => ({ generatePdf: (...a: unknown[]) => generatePdf(...(a as [])) }));
+
+import { GET as getQuotePdf } from "../quote/[quoteId]/pdf/route";
+import { GET as getInvoicePdf } from "../invoice/[invoiceId]/pdf/route";
+import { GET as getProjectDocument } from "../../documents/[projectId]/route";
+
+const STORED_BYTES = new Uint8Array([37, 80, 68, 70]); // "%PDF"
+
+const QUOTE_CONTEXT = {
+  quoteId: "q1", projectId: "p1", projectNumber: "RVLT-2026-0087", version: 2,
+  effectiveStatus: "SENT", label: "RVLT-2026-0087 v2", pdfFileId: "storage_1",
+  sentAt: 1_700_000_000_000, quoteDate: 1_700_000_000_000, validUntil: 1_702_000_000_000,
+};
+const INVOICE_CONTEXT = {
+  invoiceId: "inv1", projectId: "p1", projectNumber: "RVLT-2026-0087",
+  invoiceNumber: "INV-2026-0001", kind: "FULL", status: "ISSUED",
+  pdfFileId: "storage_2", issuedAt: 1_700_000_000_000, dueDate: null,
+};
+
+const req = (url = "http://localhost/x") => new Request(url) as never;
+const quoteParams = { params: Promise.resolve({ quoteId: "q1" }) };
+const invoiceParams = { params: Promise.resolve({ invoiceId: "inv1" }) };
+const projectParams = { params: Promise.resolve({ projectId: "p1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requirePermission.mockResolvedValue({ organizationId: "org_1", userId: "u1", userName: "Alice" });
+  requireOrganization.mockResolvedValue({ organizationId: "org_1", userId: "u1" });
+  queryMock.mockImplementation(async (fnRef: unknown) => {
+    const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+    if (name === "financeArtifacts:quoteArtifactContext") return QUOTE_CONTEXT;
+    if (name === "financeArtifacts:invoiceArtifactContext") return INVOICE_CONTEXT;
+    throw new Error(`Unmocked query: ${name}`);
+  });
+  getServeInfo.mockResolvedValue({
+    organizationId: "org_1",
+    url: "https://convex.example/file",
+    contentType: "application/pdf",
+    size: STORED_BYTES.length,
+    fileName: "stored.pdf",
+  });
+  fetchWithTimeout.mockResolvedValue(new Response(STORED_BYTES, { status: 200 }));
+});
+
+describe("GET /api/finance/quote/[quoteId]/pdf", () => {
+  test("streams the STORED bytes and never re-renders", async () => {
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.status).toBe(200);
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(STORED_BYTES);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("names the download after the revision, so v2 and v3 can't collide", async () => {
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.headers.get("Content-Disposition")).toContain('filename="RVLT-2026-0087-quote-v2.pdf"');
+  });
+
+  test("another org's quote id is a 404 — indistinguishable from a missing one", async () => {
+    queryMock.mockRejectedValue(new Error("Quote not found."));
+
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.status).toBe(404);
+    expect(getServeInfo).not.toHaveBeenCalled();
+  });
+
+  test("a stored file belonging to another org is refused even if the row check passed", async () => {
+    getServeInfo.mockResolvedValue({
+      organizationId: "org_2", url: "https://convex.example/file", contentType: "application/pdf", size: 4, fileName: "x.pdf",
+    });
+
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.status).toBe(403);
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  test("a revision with no artifact yet is a 404 — never a silent live render", async () => {
+    queryMock.mockResolvedValue({ ...QUOTE_CONTEXT, pdfFileId: null });
+
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.status).toBe(404);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("requires invoice:read", async () => {
+    requirePermission.mockRejectedValue(new Error("You don't have permission to perform this action."));
+
+    const res = await getQuotePdf(req(), quoteParams);
+
+    expect(res.status).toBe(401);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/finance/invoice/[invoiceId]/pdf", () => {
+  test("streams the stored bytes, named for the invoice number", async () => {
+    const res = await getInvoicePdf(req(), invoiceParams);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toContain('filename="INV-2026-0001-invoice.pdf"');
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("another org's invoice id is a 404", async () => {
+    queryMock.mockRejectedValue(new Error("Invoice not found."));
+
+    const res = await getInvoicePdf(req(), invoiceParams);
+
+    expect(res.status).toBe(404);
+  });
+
+  test("a VOIDed invoice keeps its document — the record has to show what was sent", async () => {
+    queryMock.mockResolvedValue({ ...INVOICE_CONTEXT, status: "VOID" });
+
+    const res = await getInvoicePdf(req(), invoiceParams);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /api/documents/[projectId] — the rogue path is closed", () => {
+  test("a bare ?type=quote is refused: there is no live client-facing quote render any more", async () => {
+    const res = await getProjectDocument(req("http://localhost/api/documents/p1?type=quote") as never, projectParams);
+
+    expect(res.status).toBe(400);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("a bare ?type=invoice is refused the same way", async () => {
+    const res = await getProjectDocument(req("http://localhost/api/documents/p1?type=invoice") as never, projectParams);
+
+    expect(res.status).toBe(400);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("preview=1 renders WITH the watermark and requires invoice:read", async () => {
+    const res = await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=quote&preview=1") as never,
+      projectParams,
+    );
+
+    expect(res.status).toBe(200);
+    expect(requirePermission).toHaveBeenCalledWith("invoice", "read");
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", { draftPreview: true });
+  });
+
+  test("preview=1 without invoice:read is a 403, not a document", async () => {
+    requirePermission.mockRejectedValue(new Error("You don't have permission to perform this action."));
+
+    const res = await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=quote&preview=1") as never,
+      projectParams,
+    );
+
+    expect(res.status).toBe(403);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("warehouse documents are untouched — they SHOULD reflect live state, and carry no watermark", async () => {
+    const res = await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=pull-slip") as never,
+      projectParams,
+    );
+
+    expect(res.status).toBe(200);
+    expect(requirePermission).not.toHaveBeenCalled();
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "packing-list", { draftPreview: false });
+  });
+
+  test("a warehouse doc can't be tricked into a watermark by adding preview=1", async () => {
+    await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=delivery-docket&preview=1") as never,
+      projectParams,
+    );
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "delivery-docket", { draftPreview: false });
+  });
+});

--- a/src/app/api/finance/invoice/[invoiceId]/pdf/route.ts
+++ b/src/app/api/finance/invoice/[invoiceId]/pdf/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../../../../../../convex/_generated/api";
+import { requirePermission } from "@/lib/org-context";
+import { invoiceArtifactFileName } from "@/lib/finance-artifacts";
+import { artifactNotFound, streamStoredArtifact } from "@/lib/finance-artifact-response";
+
+export const runtime = "nodejs";
+
+/**
+ * `GET /api/finance/invoice/[invoiceId]/pdf` — the stored, immutable invoice
+ * document (#987). The invoice ROW has been immutable once ISSUED since WS1
+ * (#940); this is what extends that guarantee past the database boundary to the
+ * artifact the client is actually holding. No regeneration path.
+ *
+ * A VOIDed invoice keeps its document for the same reason a superseded quote
+ * does: it was sent, so the record has to show what was sent.
+ *
+ * Auth: `invoice:read` + the org check inside
+ * `financeArtifacts.invoiceArtifactContext` (`invoices.by_cuid` is GLOBAL —
+ * R-8.4.3).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ invoiceId: string }> },
+) {
+  const { invoiceId } = await params;
+
+  let organizationId: string;
+  try {
+    ({ organizationId } = await requirePermission("invoice", "read"));
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const convex = await getConvexClient();
+  let invoice;
+  try {
+    invoice = await convex.query(api.financeArtifacts.invoiceArtifactContext, {
+      invoiceId,
+      orgId: organizationId,
+    });
+  } catch {
+    return artifactNotFound("Invoice not found.");
+  }
+
+  if (!invoice.pdfFileId) {
+    return artifactNotFound("This invoice has no stored document yet.");
+  }
+
+  return streamStoredArtifact({
+    storageId: invoice.pdfFileId,
+    fileName: invoiceArtifactFileName(invoice.projectNumber, invoice.invoiceNumber),
+    organizationId,
+  });
+}

--- a/src/app/api/finance/quote/[quoteId]/pdf/route.ts
+++ b/src/app/api/finance/quote/[quoteId]/pdf/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../../../../../../convex/_generated/api";
+import { requirePermission } from "@/lib/org-context";
+import { quoteArtifactFileName } from "@/lib/finance-artifacts";
+import { artifactNotFound, streamStoredArtifact } from "@/lib/finance-artifact-response";
+
+export const runtime = "nodejs";
+
+/**
+ * `GET /api/finance/quote/[quoteId]/pdf` — the stored, immutable quote document
+ * (#987). Streams the bytes rendered at SEND time and nothing else: there is no
+ * regeneration path here, which is the entire point. Two downloads a week apart
+ * are byte-identical even as the project changes underneath them.
+ *
+ * A SUPERSEDED or recalled revision stays downloadable — the client may be
+ * holding that copy, so deleting ours would make the record worse, not better.
+ * The Finance tab badges the state next to the download.
+ *
+ * Auth: `invoice:read`, plus the org check inside
+ * `financeArtifacts.quoteArtifactContext` (`quotes.by_cuid` is a GLOBAL index —
+ * R-8.4.3; this and its invoice twin are the highest-risk new surfaces in the
+ * program, so both carry explicit cross-org tests).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ quoteId: string }> },
+) {
+  const { quoteId } = await params;
+
+  let organizationId: string;
+  try {
+    ({ organizationId } = await requirePermission("invoice", "read"));
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const convex = await getConvexClient();
+  let quote;
+  try {
+    quote = await convex.query(api.financeArtifacts.quoteArtifactContext, {
+      quoteId,
+      orgId: organizationId,
+      now: Date.now(),
+    });
+  } catch {
+    // Missing and another org's are indistinguishable by design.
+    return artifactNotFound("Quote not found.");
+  }
+
+  if (!quote.pdfFileId) {
+    return artifactNotFound("This revision has no stored document yet.");
+  }
+
+  return streamStoredArtifact({
+    storageId: quote.pdfFileId,
+    fileName: quoteArtifactFileName(quote.projectNumber, quote.version),
+    organizationId,
+  });
+}

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { Send, Ban, Trash2, UploadCloud, AlertCircle } from "lucide-react";
+import { Send, Ban, Trash2, UploadCloud, AlertCircle, AlertTriangle, Download, Eye } from "lucide-react";
 
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { useActiveOrganization } from "@/lib/auth-client";
@@ -12,6 +12,7 @@ import { useInvoiceWrites } from "@/hooks/use-invoice-writes";
 import { useNativeProjectStatus } from "@/hooks/use-native-project-writes";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { pushInvoiceToXero } from "@/server/xero";
+import { generateInvoiceArtifact } from "@/server/finance-documents";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { formatCurrency, formatDate } from "@/lib/formatters";
 import { Button } from "@/components/ui/button";
@@ -43,10 +44,16 @@ const INVOICE_STATUS_BADGE: Record<string, "ok" | "warn" | "neutral" | "overbook
  * accept/decline. Sending does NOT email anyone — it records the send and
  * freezes the numbers.
  *
- * Invoices are unchanged: create/issue/void per the client's payment profile,
- * and (Xero-linked orgs) push an issued invoice as a Xero draft. "Deposit not
- * yet invoiced" nudge chips are DERIVED (kind/status of existing invoices), not
- * a stored flag — there is no READY_TO_INVOICE project status.
+ * Invoices: create/issue/void per the client's payment profile, and (Xero-linked
+ * orgs) push an issued invoice as a Xero draft. "Deposit not yet invoiced" nudge
+ * chips are DERIVED (kind/status of existing invoices), not a stored flag —
+ * there is no READY_TO_INVOICE project status.
+ *
+ * Both halves now carry a DOCUMENT action (#987): the stored, immutable artifact
+ * for anything sent or issued, a watermarked preview for anything still a draft,
+ * and an explicit retry when a render failed. Quote and Invoice are no longer in
+ * the header's Documents ▾ — a client-facing finance document is never a fresh
+ * render of live project state.
  *
  * The full Finance tab — send dialog, version history + diffs, invoice issue
  * dialog with due dates, drift indicator — is Phase D (#989).
@@ -97,6 +104,11 @@ export function ProjectFinancePanel({ projectId, clientId, projectStatus }: Proj
     try {
       const result = await invoiceWrites.issue(id);
       toast.success(`Issued ${result.invoiceNumber}`);
+      // Issued, but the document render failed — the row's retry action fixes
+      // it. Never silent (#987).
+      if (!result.artifactReady) {
+        toast.warning(`The document for ${result.invoiceNumber} didn't generate — use “Document missing” on that invoice to make one.`);
+      }
       // UI chain (not a nested mutation) — offer to advance the project once a
       // BALANCE/FULL invoice is issued (spec: "issuing offers to advance status").
       const invoice = invoices?.find((i) => i.id === id);
@@ -161,6 +173,7 @@ export function ProjectFinancePanel({ projectId, clientId, projectStatus }: Proj
               <InvoiceRow
                 key={inv.id}
                 invoice={inv}
+                projectId={projectId}
                 xeroLinked={xeroLinked}
                 onIssue={() => void issueInvoice(inv.id)}
                 onDeleteDraft={() =>
@@ -202,16 +215,22 @@ interface InvoiceRowDoc {
   total: number;
   xeroSyncStatus?: string;
   lastSyncError?: string;
+  /** The STORED document, rendered once at issue (#987). Null on a draft, and
+   *  on an issued invoice whose render failed — hence the retry. */
+  pdfFileId?: string;
+  issuedAt?: number;
 }
 
 function InvoiceRow({
   invoice: inv,
+  projectId,
   xeroLinked,
   onIssue,
   onDeleteDraft,
   onVoidRequest,
 }: {
   invoice: InvoiceRowDoc;
+  projectId: string;
   xeroLinked: boolean;
   onIssue: () => void;
   onDeleteDraft: () => void;
@@ -230,7 +249,8 @@ function InvoiceRow({
           </span>
         )}
       </div>
-      <div className="flex items-center gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <InvoiceDocumentAction invoice={inv} projectId={projectId} />
         {inv.status === "DRAFT" && (
           <CanDo resource="invoice" action="issue">
             <Button type="button" variant="line" size="sm" onClick={onIssue}>
@@ -259,6 +279,60 @@ function InvoiceRow({
         )}
       </div>
     </li>
+  );
+}
+
+/**
+ * The document side of an invoice (#987). An ISSUED invoice's PDF is rendered
+ * once and stored, so re-downloading it can never produce a different document
+ * from the one the client was sent — the row was already immutable, this is what
+ * carries that past the database boundary. A VOIDed invoice keeps its document.
+ *
+ * A DRAFT has none by design: its amounts are still mutable, so the only
+ * document it can produce is the watermarked preview.
+ */
+function InvoiceDocumentAction({ invoice: inv, projectId }: { invoice: InvoiceRowDoc; projectId: string }) {
+  const retry = useServerMutation({
+    mutationFn: () => generateInvoiceArtifact(inv.id),
+    onSuccess: () => toast.success("Generated the invoice document"),
+    onError: (e) => toast.error(e.message),
+  });
+
+  if (inv.pdfFileId) {
+    return (
+      <Button variant="line" size="sm" asChild>
+        <a href={`/api/finance/invoice/${inv.id}/pdf`} target="_blank" rel="noopener noreferrer">
+          <Download className="h-3.5 w-3.5" /> Document
+        </a>
+      </Button>
+    );
+  }
+
+  // A draft's only document is the watermarked preview — the one place a
+  // client-facing finance PDF is still rendered from live state, and it says
+  // "NOT SENT" on every page.
+  if (inv.issuedAt == null) {
+    return (
+      <Button variant="line" size="sm" asChild>
+        <a href={`/api/documents/${projectId}?type=invoice&preview=1`} target="_blank" rel="noopener noreferrer">
+          <Eye className="h-3.5 w-3.5" /> Preview
+        </a>
+      </Button>
+    );
+  }
+
+  return (
+    <CanDo resource="invoice" action="issue">
+      <Button
+        type="button"
+        variant="line"
+        size="sm"
+        loading={retry.isPending}
+        onClick={() => retry.mutate(undefined)}
+      >
+        <AlertTriangle className="h-3.5 w-3.5 text-warn" /> Document missing — generate
+      </Button>
+    </CanDo>
   );
 }
 

--- a/src/components/projects/project-quote-rail.tsx
+++ b/src/components/projects/project-quote-rail.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { CheckCircle2, FileText, Send, Undo2, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Download, Eye, FileText, Send, Undo2, XCircle } from "lucide-react";
 
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { api } from "../../../convex/_generated/api";
 import { useQuoteWrites } from "@/hooks/use-quote-writes";
+import { generateQuoteArtifact } from "@/server/finance-documents";
 import { useServerMutation } from "@/hooks/use-server-mutation";
 import { formatCurrency, formatDate } from "@/lib/formatters";
 import { Button } from "@/components/ui/button";
@@ -51,6 +52,10 @@ interface QuoteRevisionDoc {
   sentAt?: number;
   validUntil?: number;
   snapshot?: unknown;
+  /** The STORED document for this revision (#987) — the bytes the client was
+   *  given. Null on a never-sent draft, and on a sent revision whose render
+   *  failed (which is what the retry action is for). */
+  pdfFileId?: string;
 }
 
 type ReasonVerb = "recall" | "decline";
@@ -76,7 +81,14 @@ export function ProjectQuoteRail({ projectId, orgId }: { projectId: string; orgI
 
   const sendMutation = useServerMutation({
     mutationFn: () => quoteWrites.send(projectId),
-    onSuccess: (r) => toast.success(`Sent quote v${r.version} — pricing is now frozen at this revision`),
+    onSuccess: (r) => {
+      toast.success(`Sent quote v${r.version} — pricing is now frozen at this revision`);
+      // The send itself succeeded; only the document render didn't. Say so, and
+      // leave the row's retry action to fix it — never silently.
+      if (!r.artifactReady) {
+        toast.warning(`The document for v${r.version} didn't generate — use “Document missing” on that revision to make one.`);
+      }
+    },
     onError: (e) => toast.error(e.message),
   });
   const newVersionMutation = useServerMutation({
@@ -124,6 +136,7 @@ export function ProjectQuoteRail({ projectId, orgId }: { projectId: string; orgI
             <QuoteRevisionRow
               key={quote.id}
               quote={quote}
+              projectId={projectId}
               onAccept={() => void acceptQuote(quote)}
               onDecline={() => setReasonTarget({ id: quote.id, version: quote.version, verb: "decline" })}
               onRecall={() => setReasonTarget({ id: quote.id, version: quote.version, verb: "recall" })}
@@ -184,11 +197,13 @@ function RailHeader({
  */
 function QuoteRevisionRow({
   quote,
+  projectId,
   onAccept,
   onDecline,
   onRecall,
 }: {
   quote: QuoteRevisionDoc;
+  projectId: string;
   onAccept: () => void;
   onDecline: () => void;
   onRecall: () => void;
@@ -201,26 +216,84 @@ function QuoteRevisionRow({
   return (
     <li className="flex flex-wrap items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
       <RevisionMeta quote={quote} />
-      <CanDo resource="invoice" action="publish">
-        <div className="flex items-center gap-1.5">
-          {isSent && (
-            <Button type="button" variant="line" size="sm" onClick={onAccept}>
-              <CheckCircle2 className="h-3.5 w-3.5" /> Mark accepted
-            </Button>
-          )}
-          {isHeldByClient && (
-            <Button type="button" variant="line" size="sm" onClick={onDecline}>
-              <XCircle className="h-3.5 w-3.5" /> Declined
-            </Button>
-          )}
-          {isHeldByClient && (
-            <Button type="button" variant="line" size="sm" onClick={onRecall}>
-              <Undo2 className="h-3.5 w-3.5" /> Recall
-            </Button>
-          )}
-        </div>
-      </CanDo>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <QuoteDocumentAction quote={quote} projectId={projectId} />
+        <CanDo resource="invoice" action="publish">
+          <div className="flex items-center gap-1.5">
+            {isSent && (
+              <Button type="button" variant="line" size="sm" onClick={onAccept}>
+                <CheckCircle2 className="h-3.5 w-3.5" /> Mark accepted
+              </Button>
+            )}
+            {isHeldByClient && (
+              <Button type="button" variant="line" size="sm" onClick={onDecline}>
+                <XCircle className="h-3.5 w-3.5" /> Declined
+              </Button>
+            )}
+            {isHeldByClient && (
+              <Button type="button" variant="line" size="sm" onClick={onRecall}>
+                <Undo2 className="h-3.5 w-3.5" /> Recall
+              </Button>
+            )}
+          </div>
+        </CanDo>
+      </div>
     </li>
+  );
+}
+
+/**
+ * The document side of a revision (#987) — exactly one of three states, so the
+ * absence of a document is never silent:
+ *
+ * 1. **Stored artifact** → download the bytes the client was given. Still
+ *    offered on a superseded/recalled/declined revision: they may be holding
+ *    that copy, and the record is worse without it.
+ * 2. **Sent, but no artifact** → the render failed after the send committed.
+ *    Retry (only ever callable while `pdfFileId` is null — the server refuses to
+ *    overwrite, so this can't rewrite history).
+ * 3. **Never sent** → a watermarked DRAFT PREVIEW, which is deliberately not
+ *    stored anywhere and says "NOT SENT" on every page.
+ */
+function QuoteDocumentAction({ quote, projectId }: { quote: QuoteRevisionDoc; projectId: string }) {
+  const retry = useServerMutation({
+    mutationFn: () => generateQuoteArtifact(quote.id),
+    onSuccess: () => toast.success(`Generated the document for v${quote.version}`),
+    onError: (e) => toast.error(e.message),
+  });
+
+  if (quote.pdfFileId) {
+    return (
+      <Button variant="line" size="sm" asChild>
+        <a href={`/api/finance/quote/${quote.id}/pdf`} target="_blank" rel="noopener noreferrer">
+          <Download className="h-3.5 w-3.5" /> Document
+        </a>
+      </Button>
+    );
+  }
+
+  if (quote.sentAt != null) {
+    return (
+      <CanDo resource="invoice" action="publish">
+        <Button
+          type="button"
+          variant="line"
+          size="sm"
+          loading={retry.isPending}
+          onClick={() => retry.mutate(undefined)}
+        >
+          <AlertTriangle className="h-3.5 w-3.5 text-warn" /> Document missing — generate
+        </Button>
+      </CanDo>
+    );
+  }
+
+  return (
+    <Button variant="line" size="sm" asChild>
+      <a href={`/api/documents/${projectId}?type=quote&preview=1`} target="_blank" rel="noopener noreferrer">
+        <Eye className="h-3.5 w-3.5" /> Preview draft
+      </a>
+    </Button>
   );
 }
 

--- a/src/hooks/use-invoice-writes.ts
+++ b/src/hooks/use-invoice-writes.ts
@@ -6,6 +6,7 @@ import { useSession, useActiveOrganization } from "@/lib/auth-client";
 import { api } from "../../convex/_generated/api";
 import { invoiceSchema, type InvoiceFormValues } from "@/lib/validations/invoice";
 import { getInvoiceNumberConfig } from "@/server/settings";
+import { generateInvoiceArtifact } from "@/server/finance-documents";
 import { datePartsInTimezone } from "@/lib/project-number";
 
 /** Browser-direct INVOICE writes (WS1 #940) — mirrors use-native-client-writes.ts. */
@@ -48,14 +49,25 @@ export function useInvoiceWrites() {
         now: Date.now(),
       });
     },
-    /** Assigns the invoice number — reads the CURRENT invoice-number format
-     *  config (server action, small read-only call, matches
-     *  getProjectNumberConfig's precedent) and allocates in-mutation. */
-    issue: async (id: string, dueDate?: Date): Promise<{ id: string; invoiceNumber: string }> => {
+    /**
+     * Assigns the invoice number — reads the CURRENT invoice-number format
+     * config (server action, small read-only call, matches
+     * getProjectNumberConfig's precedent) and allocates in-mutation. Then
+     * renders and stores the invoice PDF (#987), which is what makes an ISSUED
+     * invoice immutable as a DOCUMENT and not only as a row.
+     *
+     * Same failure contract as sending a quote: a render failure leaves the
+     * invoice issued with `artifactReady: false` and a retry in the finance
+     * panel, never an unissued invoice or a silent gap.
+     */
+    issue: async (
+      id: string,
+      dueDate?: Date,
+    ): Promise<{ id: string; invoiceNumber: string; artifactReady: boolean }> => {
       const org = requireOrg();
       const config = await getInvoiceNumberConfig();
       const now = new Date();
-      return await issueM({
+      const result = await issueM({
         id,
         orgId: org,
         autoNumber: {
@@ -69,6 +81,14 @@ export function useInvoiceWrites() {
         auditId: createId(),
         now: now.getTime(),
       });
+
+      let artifactReady = true;
+      try {
+        await generateInvoiceArtifact(result.id);
+      } catch {
+        artifactReady = false;
+      }
+      return { ...result, artifactReady };
     },
     void: async (id: string, reason: string): Promise<void> => {
       const org = requireOrg();

--- a/src/hooks/use-quote-writes.ts
+++ b/src/hooks/use-quote-writes.ts
@@ -3,6 +3,7 @@
 import { useMutation } from "convex/react";
 import { createId } from "@paralleldrive/cuid2";
 import { useSession, useActiveOrganization } from "@/lib/auth-client";
+import { generateQuoteArtifact } from "@/server/finance-documents";
 import { api } from "../../convex/_generated/api";
 import {
   quoteAcceptSchema,
@@ -44,15 +45,30 @@ export function useQuoteWrites() {
   };
 
   return {
-    /** Freeze the current revision and stamp it sent. Does NOT email the client
-     *  (decision 7) — it records the send and, from Phase B, stores the PDF. */
+    /**
+     * Freeze the current revision and stamp it sent. Does NOT email the client
+     * (decision 7) — it records the send, freezes the money, and then renders
+     * and stores the PDF (#987).
+     *
+     * The artifact render runs in a server action AFTER the Convex transaction
+     * commits, so it can fail independently. It never fails the send: the row is
+     * already `SENT`, and a `SENT` revision with no `pdfFileId` renders a
+     * "document failed — retry" state in the rail rather than a silent gap. That
+     * is why `artifactReady` is reported rather than thrown.
+     */
     send: async (
       projectId: string,
       data: QuoteSendValues = {},
-    ): Promise<{ id: string; version: number; validUntil: number; offerStatusChange: QuoteStatusOffer }> => {
+    ): Promise<{
+      id: string;
+      version: number;
+      validUntil: number;
+      offerStatusChange: QuoteStatusOffer;
+      artifactReady: boolean;
+    }> => {
       const org = requireOrg();
       const parsed = quoteSendSchema.parse(data);
-      return await sendM({
+      const result = await sendM({
         id: createId(),
         organizationId: org,
         projectId,
@@ -64,6 +80,14 @@ export function useQuoteWrites() {
         auditId: createId(),
         now: Date.now(),
       });
+
+      let artifactReady = true;
+      try {
+        await generateQuoteArtifact(result.id);
+      } catch {
+        artifactReady = false;
+      }
+      return { ...result, artifactReady };
     },
 
     /** Un-send a revision. Needs admin/owner or one of the project's PMs on top

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -16240,6 +16240,135 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "returnsSha": "74234e98afe7498f"
   },
   {
+    "operation": "financeArtifacts.attachInvoiceArtifact",
+    "module": "financeArtifacts",
+    "fn": "attachInvoiceArtifact",
+    "kind": "mutation",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "invoiceId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "now",
+        "optional": false,
+        "type": "number"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "storageId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "7514c8a5fd874eab",
+    "returnsSha": "82f81e090dcc6b52"
+  },
+  {
+    "operation": "financeArtifacts.attachQuoteArtifact",
+    "module": "financeArtifacts",
+    "fn": "attachQuoteArtifact",
+    "kind": "mutation",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "now",
+        "optional": false,
+        "type": "number"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "quoteId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "storageId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "7a7816d7a8c25004",
+    "returnsSha": "82f81e090dcc6b52"
+  },
+  {
+    "operation": "financeArtifacts.invoiceArtifactContext",
+    "module": "financeArtifacts",
+    "fn": "invoiceArtifactContext",
+    "kind": "query",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "invoiceId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "84248e6f6265683d",
+    "returnsSha": "74234e98afe7498f"
+  },
+  {
+    "operation": "financeArtifacts.quoteArtifactContext",
+    "module": "financeArtifacts",
+    "fn": "quoteArtifactContext",
+    "kind": "query",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "now",
+        "optional": true,
+        "type": "number"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "quoteId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "6e90c446e495449b",
+    "returnsSha": "74234e98afe7498f"
+  },
+  {
     "operation": "globalSearch.search",
     "module": "globalSearch",
     "fn": "search",
@@ -50337,10 +50466,10 @@ export const API_REGISTRY_BY_OPERATION: ReadonlyMap<string, RegistryOperation> =
 
 /** Counts published so the coverage table and any consumer agree by construction. */
 export const REGISTRY_COUNTS = {
-  total: 1120,
+  total: 1124,
   agentReachable: 291,
-  queries: 395,
-  mutations: 725,
+  queries: 397,
+  mutations: 727,
   agentReachableQueries: 22,
   agentReachableMutations: 269,
 } as const;

--- a/src/lib/finance-artifact-response.ts
+++ b/src/lib/finance-artifact-response.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { getServeInfo } from "@/lib/storage";
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+
+/**
+ * Streaming half of the two finance artifact routes (#987) — shared so the
+ * org check, the header shape and the "no regeneration path" guarantee exist
+ * exactly once (R-3.1). Each route resolves ITS OWN row (org-checked in Convex)
+ * and hands the storage id here.
+ *
+ * There is deliberately no fallback that renders a PDF when the bytes are
+ * missing: a route that can regenerate is a route that can hand the client a
+ * different document under the same name, which is the defect this program
+ * exists to remove. A missing artifact is a 404 the UI turns into a retry.
+ */
+
+/** 404 body used for "no such row" and "row has no artifact" alike — the UI
+ *  distinguishes them from the row it already has, and a cross-tenant probe
+ *  learns nothing either way. */
+export function artifactNotFound(message: string): NextResponse {
+  return NextResponse.json({ error: message }, { status: 404 });
+}
+
+export async function streamStoredArtifact(options: {
+  storageId: string;
+  fileName: string;
+  organizationId: string;
+}): Promise<NextResponse> {
+  const { storageId, fileName, organizationId } = options;
+
+  const info = await getServeInfo(storageId);
+  if (!info) return artifactNotFound("Stored document not found.");
+  // Belt-and-braces on top of the row's own org check (R-8.4.3): the file record
+  // must also belong to the caller's org before a single byte is streamed.
+  if (info.organizationId !== organizationId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const upstream = await fetchWithTimeout(info.url);
+    if (!upstream.ok || !upstream.body) return artifactNotFound("Stored document not found.");
+
+    const encodedName = encodeURIComponent(fileName);
+    const headers: Record<string, string> = {
+      "Content-Type": info.contentType || "application/pdf",
+      "Content-Disposition": `inline; filename="${fileName}"; filename*=UTF-8''${encodedName}`,
+      // The bytes behind a storage id never change — but the URL is org-private,
+      // so it stays out of shared caches.
+      "Cache-Control": "private, max-age=3600",
+    };
+    if (info.size) headers["Content-Length"] = String(info.size);
+
+    return new NextResponse(upstream.body, { headers });
+  } catch (error) {
+    logger.error("Finance artifact serve error", { error });
+    return artifactNotFound("Stored document not found.");
+  }
+}

--- a/src/lib/finance-artifacts.test.ts
+++ b/src/lib/finance-artifacts.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { quoteArtifactFileName, invoiceArtifactFileName, sanitizeFileName } from "./finance-artifacts";
+
+/**
+ * The names a client actually sees on the documents we hand them (#987). The
+ * revision has to be in a quote's name — v2 and v3 are different documents and
+ * must never overwrite each other in someone's downloads folder.
+ */
+describe("quoteArtifactFileName", () => {
+  it("carries the project number and the revision", () => {
+    expect(quoteArtifactFileName("RVLT-2026-0087", 2)).toBe("RVLT-2026-0087-quote-v2.pdf");
+  });
+
+  it("gives consecutive revisions distinct names", () => {
+    expect(quoteArtifactFileName("RVLT-2026-0087", 2)).not.toBe(quoteArtifactFileName("RVLT-2026-0087", 3));
+  });
+});
+
+describe("invoiceArtifactFileName", () => {
+  it("leads with the invoice number once issued", () => {
+    expect(invoiceArtifactFileName("RVLT-2026-0087", "INV-2026-0001")).toBe("INV-2026-0001-invoice.pdf");
+  });
+
+  it("falls back to the project number rather than emitting 'null'", () => {
+    expect(invoiceArtifactFileName("RVLT-2026-0087", null)).toBe("RVLT-2026-0087-invoice.pdf");
+  });
+});
+
+describe("sanitizeFileName", () => {
+  it("strips characters that would break a Content-Disposition header", () => {
+    expect(sanitizeFileName('a"b\\c/d:e.pdf')).toBe("a_b_c_d_e.pdf");
+  });
+
+  it("defuses traversal — no `..` and no separator survives", () => {
+    const cleaned = sanitizeFileName("../../etc/passwd");
+    expect(cleaned).not.toContain("..");
+    expect(cleaned).not.toContain("/");
+  });
+
+  it("never leaves a leading dot", () => {
+    expect(sanitizeFileName(".hidden.pdf").startsWith(".")).toBe(false);
+  });
+
+  it("never returns an empty name", () => {
+    expect(sanitizeFileName("   ")).toBe("document");
+  });
+});

--- a/src/lib/finance-artifacts.ts
+++ b/src/lib/finance-artifacts.ts
@@ -1,0 +1,41 @@
+/**
+ * Artifact file naming for the immutable finance documents (#987).
+ *
+ * ONE definition (R-3.1), shared by the three places a name is needed: the
+ * upload (`src/server/finance-documents.ts`), the `Content-Disposition` on the
+ * download routes, and the tests that assert what a client actually receives. A
+ * second hand-maintained copy would be a defect even while in sync — and this
+ * particular string is the one the client sees, so drift is visible to them.
+ *
+ * Names carry the REVISION, deliberately: `RVLT-2026-0087-quote-v2.pdf` and
+ * `RVLT-2026-0087-quote-v3.pdf` are different documents and must never share a
+ * filename in someone's downloads folder. There is no quote number of its own
+ * (decision 5) — the project number plus `v<n>` IS the reference.
+ */
+
+/** Strip everything that could break a `Content-Disposition` header or escape a
+ *  directory, mirroring the `/api/files` proxy's own sanitiser. */
+export function sanitizeFileName(name: string): string {
+  const cleaned = name
+    .replace(/[\r\n"\\/:]/g, "_")
+    .replace(/\.\./g, "_")
+    .replace(/^\.+/, "")
+    .trim();
+  return cleaned || "document";
+}
+
+export function quoteArtifactFileName(projectNumber: string, version: number): string {
+  return sanitizeFileName(`${projectNumber || "quote"}-quote-v${version}.pdf`);
+}
+
+/**
+ * An issued invoice already has a unique, client-facing number, so it leads —
+ * falling back to the project number for the (theoretically impossible) issued
+ * row with no number rather than emitting "undefined".
+ */
+export function invoiceArtifactFileName(
+  projectNumber: string,
+  invoiceNumber: string | null,
+): string {
+  return sanitizeFileName(`${invoiceNumber || projectNumber || "invoice"}-invoice.pdf`);
+}

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -83,6 +83,17 @@ export async function buildDocumentData(
      * `DOCUMENT_LAYOUTS[docType].expandProjectGroups`.
      */
     expandProjectGroups?: boolean;
+    /**
+     * Dates FROZEN onto the finance row this render represents (#987) — a
+     * quote's stamped `quoteDate`/`validUntil`, or an issued invoice's
+     * `issuedAt`. Absent ⇒ live render (previews and warehouse docs), which
+     * still uses `now`.
+     *
+     * This closes the silent-validity-extension bug: `quote_valid_until` used
+     * to be recomputed from `now` on every render, so merely re-opening an old
+     * quote moved the expiry date the client had been given.
+     */
+    stampedDates?: { documentDate?: number; quoteValidUntil?: number };
   }
 ): Promise<DocumentData> {
   const expandProjectGroups = options?.expandProjectGroups ?? false;
@@ -670,16 +681,21 @@ export async function buildDocumentData(
   const totalNum = Number(serialized.total) || 0;
   const depositNum = Number(serialized.depositPaid) || 0;
   const now = new Date();
-  // #986 — the validity DEFAULT and the day-boundary maths now come from the one
+  // #986/#987 — the validity DEFAULT and the day-boundary maths come from the one
   // shared module (`quote-validity.ts`), resolved in the ORG's timezone rather
-  // than the render host's. This is still computed from `now`, which means a
-  // re-render of an un-sent draft still moves the date — Phase B (#987) is what
-  // makes the PDF read the SENT revision's stamped `validUntil` instead of
-  // recomputing. A sent revision already carries an immutable `validUntil`
-  // (stamped by `quotesWrites.sendNative`); nothing extends it after the fact.
+  // than the render host's. When this render represents a SENT revision, both
+  // dates come from the row (`options.stampedDates`) and NOTHING here recomputes
+  // them — that is what stops re-opening an old quote from silently extending how
+  // long it is valid. The `now`-derived fallback is the DRAFT PREVIEW case, where
+  // no date has been stamped yet because nothing has been sent.
   const quoteValidityDays = resolveQuoteValidityDays(documentSettings?.quoteValidityDays);
   const orgTimezone = typeof orgSettings.timezone === "string" ? orgSettings.timezone : undefined;
-  const quoteValidUntil = new Date(computeValidUntil(now.getTime(), quoteValidityDays, orgTimezone));
+  const stamped = options?.stampedDates;
+  const documentDate = stamped?.documentDate != null ? new Date(stamped.documentDate) : now;
+  const quoteValidUntil =
+    stamped?.quoteValidUntil != null
+      ? new Date(stamped.quoteValidUntil)
+      : new Date(computeValidUntil(documentDate.getTime(), quoteValidityDays, orgTimezone));
 
   // WS1 (#940) — only the invoice doc type renders this; skip the extra
   // Convex round trip for the other 4 doc types.
@@ -749,7 +765,9 @@ export async function buildDocumentData(
     internal_notes: serialized.internalNotes || "",
 
     // Metadata
-    document_date: formatDate(now),
+    // The date PRINTED on the document — a frozen finance row's own date when
+    // this render represents one, `now` otherwise (#987).
+    document_date: formatDate(documentDate),
     invoice_number: invoiceNumber || "",
     document_footer_text: documentSettings?.footerText || "",
     document_footer_second_line: documentSettings?.footerSecondLine || "",

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -12,7 +12,7 @@ import * as pdfLib from "@pdfme/pdf-lib";
 import { mm2pt } from "@pdfme/common";
 import { composeDocument, type ComposeResult } from "./document-composer";
 import { DOCUMENT_LAYOUTS, type ProjectDocumentType } from "./document-layouts";
-import { CONTENT_WIDTH } from "./template-constants";
+import { CONTENT_WIDTH, SECTION_GAP } from "./template-constants";
 import { makeLineItem, runTablePlugin } from "./plugins/test-utils";
 import { getHelveticaFonts, wrapRichText, type RichTextFonts } from "./plugins/helpers";
 import type { DocumentData, DocumentLineItem, TablePluginConfig } from "./types";
@@ -772,5 +772,65 @@ describe("composeDocument — accurate rich-text pagination (fonts provided)", (
     );
     // Exactly one schema — never split when fonts weren't provided.
     expect(tcEntries).toHaveLength(1);
+  });
+});
+
+describe("composeDocument — draft preview watermark (#987)", () => {
+  const soloItems = () => [
+    makeLineItem({ id: "only-item", status: "CHECKED_OUT", checkedOutQuantity: 1, model: { name: "Solo Item" } }),
+  ];
+
+  it("is absent by default — a STORED artifact must never carry it", () => {
+    for (const docType of PROJECT_DOC_TYPES) {
+      const result = composeDocument(docType, makeData({ line_items: soloItems() }), "#0d4f4f");
+      expect(findAllSchemasOfType(result, "gearflowDraftWatermark")).toHaveLength(0);
+    }
+  });
+
+  it("stamps 'DRAFT PREVIEW — NOT SENT' on the preview render", () => {
+    const result = composeDocument("quote", makeData({ line_items: soloItems() }), "#0d4f4f", undefined, {
+      draftPreview: true,
+    });
+
+    const marks = findAllSchemasOfType(result, "gearflowDraftWatermark");
+    expect(marks).toHaveLength(1);
+    const config = JSON.parse(result.inputs[0][marks[0].schema.name as string]);
+    expect(config.title).toBe("DRAFT PREVIEW — NOT SENT");
+    expect(config.subtitle.length).toBeGreaterThan(0);
+  });
+
+  it("reserves its own height — the block below it starts lower than it would without the banner", () => {
+    const data = makeData({ line_items: soloItems() });
+    const plain = composeDocument("quote", data, "#0d4f4f");
+    const preview = composeDocument("quote", data, "#0d4f4f", undefined, { draftPreview: true });
+
+    const mark = findAllSchemasOfType(preview, "gearflowDraftWatermark")[0].schema;
+    expect(mark.height).toBeGreaterThan(0);
+
+    const firstTableY = (r: ComposeResult) => findAllSchemasOfType(r, "gearflowTable")[0].schema.position.y;
+    // Exactly the banner + its section gap — no more, no less: an unreserved
+    // (or over-reserved) block is the v0.8.1.1 tail-drop class of bug.
+    expect(firstTableY(preview) - firstTableY(plain)).toBeCloseTo((mark.height as number) + SECTION_GAP, 5);
+  });
+
+  it("repeats on EVERY page — a banner on page 1 of a 4-page quote is not a warning", () => {
+    const lineItems = makeLongLineItemList(120);
+    const result = composeDocument("quote", makeData({ line_items: lineItems, total_items: lineItems.length }), "#0d4f4f", undefined, {
+      draftPreview: true,
+    });
+
+    expect(result.template.schemas.length).toBeGreaterThan(1);
+    for (const pageSchemas of result.template.schemas) {
+      expect(pageSchemas.some((s) => s.type === "gearflowDraftWatermark")).toBe(true);
+    }
+  });
+
+  it("still renders every line item — the banner steals space without dropping the tail", () => {
+    const lineItems = makeLongLineItemList(120);
+    const data = makeData({ line_items: lineItems, total_items: lineItems.length });
+    const result = composeDocument("quote", data, "#0d4f4f", undefined, { draftPreview: true });
+
+    const expectedParents = lineItems.filter((i) => !i.isKitChild && !i.isContainerLineItem).length;
+    assertFullCoverage(result, expectedParents);
   });
 });

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -22,10 +22,12 @@ import type {
   PageHeaderConfig,
   FooterConfig,
   SignatureLineConfig,
+  DraftWatermarkConfig,
 } from "./types";
 import {
   getDocumentLayout,
   type DocumentLayout,
+  type DocumentLayoutOptions,
   type LayoutBlock,
   type TableLayoutConfig,
   type ProjectDocumentType,
@@ -381,6 +383,13 @@ function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: Layout
     case "totalItemsNote":
       return 8;
 
+    // Title (14pt ≈ 5mm) + subtitle (7.5pt ≈ 2.6mm) + the banner's own padding,
+    // matching gearflow-draft-watermark.ts's draw sizes. Reserved like any other
+    // block — an unreserved overlay is exactly how the v0.8.1.1 tail-drop
+    // happened, and this one repeats on every page.
+    case "draftWatermark":
+      return 14;
+
     case "termsAndConditions": {
       // Optional — collapses to zero height (and is skipped entirely by the
       // page-layout walk) when the org hasn't set any T&Cs text.
@@ -420,6 +429,30 @@ interface Page {
 }
 
 /**
+ * Page FURNITURE — the blocks repeated on EVERY page rather than flowing with
+ * the body: the header, and (preview renders only) the draft watermark. A
+ * "DRAFT PREVIEW — NOT SENT" banner that appeared only on page 1 of a 4-page
+ * quote would not be a warning, so it lives here alongside the header rather
+ * than in the body walk (#987).
+ */
+function isPageFurniture(block: LayoutBlock): boolean {
+  return block.kind === "header" || block.kind === "draftWatermark";
+}
+
+/** Furniture blocks with their measured heights, plus the vertical space they
+ *  consume at the top of every page (each block + its trailing section gap). */
+function measurePageFurniture(
+  layout: DocumentLayout,
+  data: DocumentData,
+  ctx: LayoutContext,
+): { blocks: { block: LayoutBlock; height: number }[]; totalHeight: number } {
+  const blocks = layout.blocks
+    .filter(isPageFurniture)
+    .map((block) => ({ block, height: estimateBlockHeight(block, data, ctx) }));
+  return { blocks, totalHeight: blocks.reduce((sum, b) => sum + b.height + SECTION_GAP, 0) };
+}
+
+/**
  * Compute the multi-page layout for one document: walk the layout's blocks
  * top-to-bottom, starting a new page when a block doesn't fit. Table blocks
  * split across pages (per-item cumulative heights) instead of moving whole —
@@ -433,12 +466,11 @@ interface Page {
  */
 function computePages(layout: DocumentLayout, data: DocumentData, docType: ProjectDocumentType, fonts?: RichTextFonts): Page[] {
   const ctx: LayoutContext = { docType, filterByStatus: layout.filterByStatus, fonts };
-  const headerBlock = layout.blocks.find((b) => b.kind === "header") as Extract<LayoutBlock, { kind: "header" }> | undefined;
-  const bodyBlocks = layout.blocks.filter((b) => b.kind !== "header");
+  const furniture = measurePageFurniture(layout, data, ctx);
+  const bodyBlocks = layout.blocks.filter((b) => !isPageFurniture(b));
 
   const maxY = PAGE_HEIGHT - MARGIN - FOOTER_HEIGHT;
-  const headerHeight = headerBlock ? estimateBlockHeight(headerBlock, data, ctx) : 0;
-  const continuationContentHeight = maxY - MARGIN - (headerBlock ? headerHeight + SECTION_GAP : 0);
+  const continuationContentHeight = maxY - MARGIN - furniture.totalHeight;
   const tableHeaderMm = ptToMm(TABLE_HEADER_PT);
   const groupHeaderMm = ptToMm(GROUP_HEADER_PT);
 
@@ -446,17 +478,18 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
   let currentPage: Page = { entries: [] };
   let currentY = MARGIN;
 
-  function placeHeader() {
-    if (!headerBlock) return;
-    currentPage.entries.push({ block: headerBlock, y: currentY, height: headerHeight });
-    currentY += headerHeight + SECTION_GAP;
+  function placePageFurniture() {
+    for (const { block, height } of furniture.blocks) {
+      currentPage.entries.push({ block, y: currentY, height });
+      currentY += height + SECTION_GAP;
+    }
   }
 
   function startNewPage() {
     pages.push(currentPage);
     currentPage = { entries: [] };
     currentY = MARGIN;
-    placeHeader();
+    placePageFurniture();
   }
 
   /** Split a table block across pages using per-item cumulative heights. */
@@ -716,7 +749,7 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     return false;
   }
 
-  placeHeader();
+  placePageFurniture();
 
   for (const block of bodyBlocks) {
     const height = estimateBlockHeight(block, data, ctx);
@@ -783,6 +816,16 @@ function buildEntryFields(
       return [
         {
           schema: { name, type: "gearflowPageHeader", content: "", position: { x: MARGIN, y }, width: CONTENT_WIDTH, height },
+          input: JSON.stringify(config),
+        },
+      ];
+    }
+
+    case "draftWatermark": {
+      const config: DraftWatermarkConfig = { title: block.title, subtitle: block.subtitle };
+      return [
+        {
+          schema: { name, type: "gearflowDraftWatermark", content: "", position: { x: MARGIN, y }, width: CONTENT_WIDTH, height },
           input: JSON.stringify(config),
         },
       ];
@@ -1011,14 +1054,19 @@ export interface ComposeResult {
  * a short trailing block alone on a near-empty page). Stays optional, and
  * `composeDocument` stays synchronous, so no existing caller/test needs to
  * change — the accurate path is additive.
+ *
+ * `options.draftPreview` (#987) splices the "DRAFT PREVIEW — NOT SENT" banner in
+ * as page furniture. Only the preview route sets it; the stored artifact is
+ * always rendered without it.
  */
 export function composeDocument(
   docType: ProjectDocumentType,
   data: DocumentData,
   docColor: string,
   fonts?: RichTextFonts,
+  options?: DocumentLayoutOptions,
 ): ComposeResult {
-  const layout = getDocumentLayout(docType);
+  const layout = getDocumentLayout(docType, options);
   const pages = computePages(layout, data, docType, fonts);
 
   const allSchemas: (Schema & Record<string, unknown>)[][] = [];

--- a/src/lib/pdfme/document-layouts.ts
+++ b/src/lib/pdfme/document-layouts.ts
@@ -57,6 +57,13 @@ export interface TotalsLayoutConfig {
 
 export type LayoutBlock =
   | { kind: "header"; title: string }
+  /**
+   * "DRAFT PREVIEW — NOT SENT" banner (#987). Never part of a stored layout —
+   * `getDocumentLayout(docType, { draftPreview: true })` splices it in for the
+   * preview render only, and `document-composer.ts` repeats it under the header
+   * on EVERY page (a banner on page 1 of a 4-page quote is not a warning).
+   */
+  | { kind: "draftWatermark"; title: string; subtitle: string }
   | { kind: "detailsRow"; client: ClientDetailsConfig; project: ProjectDetailsConfig }
   | { kind: "table"; config: TableLayoutConfig }
   | { kind: "totals"; config: TotalsLayoutConfig }
@@ -244,6 +251,40 @@ export const DOCUMENT_LAYOUTS: Record<ProjectDocumentType, DocumentLayout> = {
   },
 };
 
-export function getDocumentLayout(docType: ProjectDocumentType): DocumentLayout {
-  return DOCUMENT_LAYOUTS[docType];
+/** The banner text per doc type. One place, so the composer's height reservation
+ *  and the plugin's render can never disagree about what is being drawn. */
+const DRAFT_PREVIEW_TITLE = "DRAFT PREVIEW — NOT SENT";
+const DRAFT_PREVIEW_SUBTITLE: Partial<Record<ProjectDocumentType, string>> = {
+  quote: "Live pricing, not frozen — this is not the document the client holds. Send the quote to produce that.",
+  invoice: "Live pricing, not frozen — this invoice has not been issued and has no invoice number.",
+};
+
+export interface DocumentLayoutOptions {
+  /**
+   * Stamp the draft-preview watermark (#987). Set ONLY by
+   * `/api/documents/[projectId]?preview=1`; a stored artifact is rendered
+   * without it, which is what makes "the file you downloaded is the file the
+   * client got" checkable by eye as well as by byte.
+   */
+  draftPreview?: boolean;
+}
+
+export function getDocumentLayout(
+  docType: ProjectDocumentType,
+  options?: DocumentLayoutOptions,
+): DocumentLayout {
+  const layout = DOCUMENT_LAYOUTS[docType];
+  if (!options?.draftPreview) return layout;
+
+  const watermark: LayoutBlock = {
+    kind: "draftWatermark",
+    title: DRAFT_PREVIEW_TITLE,
+    subtitle: DRAFT_PREVIEW_SUBTITLE[docType] ?? "This is a preview. It has not been sent to the client.",
+  };
+  // Directly after the header — the composer treats it as page furniture and
+  // repeats both on every page, so ordering here only fixes which comes first.
+  const headerIdx = layout.blocks.findIndex((b) => b.kind === "header");
+  const blocks = [...layout.blocks];
+  blocks.splice(headerIdx + 1, 0, watermark);
+  return { ...layout, blocks };
 }

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -18,21 +18,41 @@ import { getTtReportBuilder } from "./templates";
 import type { TestTagReportType } from "./types";
 
 /**
+ * Options for a project document render (#987).
+ *
+ * Two mutually exclusive modes in practice:
+ * - **artifact** — `stampedDates` supplied, `draftPreview` off. Rendered ONCE at
+ *   send/issue by `src/server/finance-documents.ts`; the bytes are stored and
+ *   every later download streams them back untouched.
+ * - **preview** — `draftPreview` on, no stamped dates. Watermarked, never stored.
+ */
+export interface ProjectPdfOptions {
+  /** Dates frozen on the finance row this render represents — see
+   *  `buildDocumentData`'s `stampedDates`. */
+  stampedDates?: { documentDate?: number; quoteValidUntil?: number };
+  /** Stamp the "DRAFT PREVIEW — NOT SENT" banner on every page. */
+  draftPreview?: boolean;
+}
+
+/**
  * Generate a PDF document for a project.
  *
  * @param projectId - The project to generate a document for
  * @param organizationId - The organization the project belongs to
  * @param docType - The type of document to generate
+ * @param options - Artifact/preview render options (see ProjectPdfOptions)
  * @returns PDF as Uint8Array
  */
 export async function generatePdf(
   projectId: string,
   organizationId: string,
   docType: ProjectDocumentType,
+  options?: ProjectPdfOptions,
 ): Promise<Uint8Array> {
   const layout = DOCUMENT_LAYOUTS[docType];
   const data = await buildDocumentData(projectId, organizationId, docType, undefined, {
     expandProjectGroups: layout.expandProjectGroups,
+    stampedDates: options?.stampedDates,
   });
 
   // Real font metrics for composeDocument's accurate text-wrap measurement
@@ -42,7 +62,9 @@ export async function generatePdf(
   const measureDoc = await PDFDocument.create();
   const fonts = await getHelveticaFonts(measureDoc, pdfLib, new Map());
 
-  const { template, inputs } = composeDocument(docType, data, data.org_document_color, fonts);
+  const { template, inputs } = composeDocument(docType, data, data.org_document_color, fonts, {
+    draftPreview: options?.draftPreview,
+  });
   return renderPdfTemplate(template, inputs);
 }
 

--- a/src/lib/pdfme/plugins/gearflow-draft-watermark.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-draft-watermark.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { PDFDocument } from "@pdfme/pdf-lib";
+import * as pdfLib from "@pdfme/pdf-lib";
+import gearflowDraftWatermark from "./gearflow-draft-watermark";
+import type { DraftWatermarkConfig } from "../types";
+
+/**
+ * The draft-preview banner actually draws (#987). Two things matter beyond
+ * "it doesn't crash": the words a client would see, and the em dash — pdfme is
+ * Helvetica-only (CLAUDE.md), and Helvetica cannot encode `—`, so an unfiltered
+ * title would throw at render time on the one document type whose entire job is
+ * to be unmistakable.
+ */
+
+interface DrawTextCall {
+  text: string;
+  x: number;
+  y: number;
+  size: number;
+}
+
+async function runWatermark(config: Partial<DraftWatermarkConfig>): Promise<{
+  texts: DrawTextCall[];
+  rectangles: number;
+}> {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([595, 842]);
+  const font = await pdfDoc.embedFont(pdfLib.StandardFonts.Helvetica);
+
+  const texts: DrawTextCall[] = [];
+  let rectangles = 0;
+  page.drawText = ((text: string, opts: Record<string, unknown>) => {
+    // Encoding the string is what would throw on an em dash — do it for real,
+    // exactly as pdf-lib would when the page is serialised.
+    font.encodeText(text);
+    texts.push({ text, x: opts.x as number, y: opts.y as number, size: opts.size as number });
+  }) as typeof page.drawText;
+  page.drawRectangle = (() => {
+    rectangles++;
+  }) as typeof page.drawRectangle;
+
+  await gearflowDraftWatermark.pdf({
+    schema: { name: "wm", type: "gearflowDraftWatermark" as const, position: { x: 10, y: 10 }, width: 170, height: 14 },
+    page,
+    pdfLib,
+    pdfDoc,
+    value: JSON.stringify(config),
+    _cache: new Map<string | number, unknown>(),
+    options: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+  return { texts, rectangles };
+}
+
+describe("gearflowDraftWatermark", () => {
+  it("draws the banner box plus the title and subtitle", async () => {
+    const { texts, rectangles } = await runWatermark({
+      title: "DRAFT PREVIEW - NOT SENT",
+      subtitle: "Live pricing, not frozen.",
+    });
+
+    expect(rectangles).toBe(1);
+    expect(texts.map((t) => t.text)).toEqual(["DRAFT PREVIEW - NOT SENT", "Live pricing, not frozen."]);
+    // The title has to dominate — it is the whole point of the block.
+    expect(texts[0].size).toBeGreaterThan(texts[1].size);
+  });
+
+  it("renders an em-dash title without throwing (Helvetica can't encode it)", async () => {
+    const { texts } = await runWatermark({ title: "DRAFT PREVIEW — NOT SENT", subtitle: "" });
+
+    expect(texts).toHaveLength(1);
+    expect(texts[0].text).toBe("DRAFT PREVIEW - NOT SENT");
+  });
+
+  it("falls back to the standard warning when handed nothing", async () => {
+    const { texts } = await runWatermark({});
+
+    expect(texts[0].text).toContain("NOT SENT");
+  });
+});

--- a/src/lib/pdfme/plugins/gearflow-draft-watermark.ts
+++ b/src/lib/pdfme/plugins/gearflow-draft-watermark.ts
@@ -1,0 +1,100 @@
+/**
+ * gearflowDraftWatermark plugin (#987) — the "DRAFT PREVIEW — NOT SENT" banner.
+ *
+ * Rendered ONLY by the `preview=1` path (`/api/documents/[projectId]`), never by
+ * a stored artifact: a preview shows live, un-frozen pricing and has no record
+ * anywhere in Flow, so a client who receives one by accident must be able to
+ * tell at a glance. It is a flow BLOCK (drawn at the top of every page,
+ * reserving its own height in `document-composer.ts`) rather than a rotated
+ * overlay, because the composer paginates by measured block height — an overlay
+ * that reserved nothing would be the v0.8.1.1 tail-drop bug with extra steps.
+ */
+import type { Plugin, Schema, PDFRenderProps } from "@pdfme/common";
+import { getLayoutProps, hexToRgb, getHelveticaFonts, truncateText, stubUiRender, stubPropPanel } from "./helpers";
+import type { DraftWatermarkConfig } from "../types";
+
+interface DraftWatermarkSchema extends Schema {
+  type: "gearflowDraftWatermark";
+}
+
+/** Deliberately NOT the org's document colour — this banner is a warning about
+ *  the document, not part of its branding, and must read as foreign to it. */
+const BANNER_BG = "#fdeceb";
+const BANNER_BORDER = "#b42318";
+const TITLE_COLOR = "#b42318";
+const SUBTITLE_COLOR = "#7a271a";
+
+const TITLE_SIZE = 14;
+const SUBTITLE_SIZE = 7.5;
+const PADDING_X = 8;
+
+async function pdfRender(arg: PDFRenderProps<DraftWatermarkSchema>) {
+  const { schema, page, pdfLib, pdfDoc, _cache } = arg;
+  const config = JSON.parse(arg.value || "{}") as Partial<DraftWatermarkConfig>;
+  const title = config.title || "DRAFT PREVIEW — NOT SENT";
+  const subtitle = config.subtitle || "";
+
+  const { x, y, width, height } = getLayoutProps(schema, page.getHeight());
+  const fonts = await getHelveticaFonts(pdfDoc, pdfLib, _cache);
+
+  page.drawRectangle({
+    x,
+    y,
+    width,
+    height,
+    color: hexToRgb(BANNER_BG, pdfLib),
+    borderColor: hexToRgb(BANNER_BORDER, pdfLib),
+    borderWidth: 1,
+  });
+
+  const innerWidth = width - PADDING_X * 2;
+  // Helvetica has no em dash (pdfme is Helvetica-only, no Unicode — CLAUDE.md),
+  // so normalise anything outside WinAnsi to a hyphen before measuring/drawing.
+  const safeTitle = toHelvetica(title);
+  const safeSubtitle = toHelvetica(subtitle);
+
+  const titleText = truncateText(safeTitle, fonts.bold, TITLE_SIZE, innerWidth);
+  const titleWidth = fonts.bold.widthOfTextAtSize(titleText, TITLE_SIZE);
+  page.drawText(titleText, {
+    x: x + (width - titleWidth) / 2,
+    y: y + height - TITLE_SIZE - (subtitle ? 6 : (height - TITLE_SIZE) / 2),
+    size: TITLE_SIZE,
+    font: fonts.bold,
+    color: hexToRgb(TITLE_COLOR, pdfLib),
+  });
+
+  if (safeSubtitle) {
+    const subtitleText = truncateText(safeSubtitle, fonts.regular, SUBTITLE_SIZE, innerWidth);
+    const subtitleWidth = fonts.regular.widthOfTextAtSize(subtitleText, SUBTITLE_SIZE);
+    page.drawText(subtitleText, {
+      x: x + (width - subtitleWidth) / 2,
+      y: y + 6,
+      size: SUBTITLE_SIZE,
+      font: fonts.regular,
+      color: hexToRgb(SUBTITLE_COLOR, pdfLib),
+    });
+  }
+}
+
+/** Replace the handful of typographic characters our copy uses with WinAnsi
+ *  equivalents Helvetica can actually encode (an em dash throws in pdf-lib). */
+function toHelvetica(text: string): string {
+  return text
+    .replace(/[—–]/g, "-")
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"');
+}
+
+const gearflowDraftWatermark: Plugin<DraftWatermarkSchema> = {
+  pdf: pdfRender,
+  ui: stubUiRender(),
+  propPanel: stubPropPanel({
+    name: "",
+    type: "gearflowDraftWatermark",
+    position: { x: 0, y: 0 },
+    width: 170,
+    height: 14,
+  }),
+};
+
+export default gearflowDraftWatermark;

--- a/src/lib/pdfme/plugins/index.ts
+++ b/src/lib/pdfme/plugins/index.ts
@@ -13,6 +13,7 @@ import gearflowCrewTable from "./gearflow-crew-table";
 import gearflowCallSheetInfo from "./gearflow-call-sheet-info";
 import gearflowDayHeader from "./gearflow-day-header";
 import gearflowRichText from "./gearflow-rich-text";
+import gearflowDraftWatermark from "./gearflow-draft-watermark";
 import { gearflowDataTable } from "./gearflow-data-table";
 import { gearflowSummaryBox } from "./gearflow-summary-box";
 import { gearflowTextBlock } from "./gearflow-text-block";
@@ -31,6 +32,7 @@ export const gearflowPlugins = {
   gearflowCallSheetInfo,
   gearflowDayHeader,
   gearflowRichText,
+  gearflowDraftWatermark,
   // Custom plugins — reports
   gearflowDataTable,
   gearflowSummaryBox,
@@ -52,6 +54,7 @@ export const gearflowPlugins = {
   rvltFlowCallSheetInfo: gearflowCallSheetInfo,
   rvltFlowDayHeader: gearflowDayHeader,
   rvltFlowRichText: gearflowRichText,
+  rvltFlowDraftWatermark: gearflowDraftWatermark,
   rvltFlowDataTable: gearflowDataTable,
   rvltFlowSummaryBox: gearflowSummaryBox,
   rvltFlowTextBlock: gearflowTextBlock,
@@ -75,3 +78,7 @@ export {
   gearflowSummaryBox,
   gearflowTextBlock,
 };
+// NOTE: gearflowDraftWatermark is deliberately NOT re-exported by name — it is
+// only ever resolved through the registry above (by schema `type`), and an
+// unused named re-export trips the dead-code ratchet (R-4.2). Import it from
+// ./gearflow-draft-watermark directly if you ever need the plugin itself.

--- a/src/lib/pdfme/rebrand-plugin-aliases.test.ts
+++ b/src/lib/pdfme/rebrand-plugin-aliases.test.ts
@@ -19,6 +19,7 @@ const PLUGIN_SUFFIXES = [
   "CallSheetInfo",
   "DayHeader",
   "RichText",
+  "DraftWatermark",
   "DataTable",
   "SummaryBox",
   "TextBlock",

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -310,6 +310,16 @@ export interface PageHeaderConfig {
   documentColor: string;
 }
 
+/**
+ * Config for the draft-watermark plugin (#987) — the "this is NOT the document
+ * the client has" banner stamped on a preview render. Only ever produced by the
+ * `preview=1` path; a stored artifact never carries one.
+ */
+export interface DraftWatermarkConfig {
+  title: string;
+  subtitle: string;
+}
+
 /** Config for signature line plugin */
 export interface SignatureLineConfig {
   columns: { label: string; subLabel?: string }[];

--- a/src/server/finance-documents.test.ts
+++ b/src/server/finance-documents.test.ts
@@ -1,0 +1,275 @@
+/**
+ * src/server/finance-documents.ts — render-and-store, with every external
+ * boundary mocked (Convex client, Convex `_storage`, the pdfme pipeline,
+ * permission + activity-log plumbing).
+ *
+ * The first test in this file is the point of the whole #985 program: a sent
+ * quote's document must be byte-identical on a repeat download WHILE THE LIVE
+ * PROJECT CHANGES UNDERNEATH IT. Everything else here — the never-overwrite
+ * guard, the retry path, orphan cleanup, stamped dates — exists to make that
+ * property hold rather than merely be intended.
+ *
+ * The pdfme pipeline itself is mocked deliberately: it needs Prisma + a live
+ * Convex deployment, and what is under test here is that it is called ONCE and
+ * never again, not what it draws. `document-composer.test.ts` covers the render.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { getFunctionName } from "convex/server";
+
+const mutationMock = vi.fn();
+const queryMock = vi.fn();
+
+vi.mock("@/lib/convex-client", () => ({
+  getConvexClient: vi.fn(async () => ({ query: queryMock, mutation: mutationMock })),
+}));
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: vi.fn(async () => ({ organizationId: "org_1", userId: "user_1", userName: "Alice" })),
+}));
+vi.mock("@/lib/activity-log", () => ({ logActivity: vi.fn(async () => {}) }));
+
+const generatePdf = vi.fn();
+vi.mock("@/lib/pdfme/generate-pdf", () => ({ generatePdf: (...a: unknown[]) => generatePdf(...a) }));
+
+const uploadToS3 = vi.fn();
+const deleteFromS3 = vi.fn(async () => {});
+vi.mock("@/lib/storage", () => ({
+  uploadToS3: (...a: unknown[]) => uploadToS3(...a),
+  deleteFromS3: (...a: unknown[]) => deleteFromS3(...(a as [string])),
+}));
+
+import { generateQuoteArtifact, generateInvoiceArtifact } from "./finance-documents";
+
+const SENT_AT = 1_700_000_000_000;
+const QUOTE_DATE = 1_699_999_000_000;
+const VALID_UNTIL = 1_702_591_000_000;
+
+/** A minimal fake of Convex `_storage`: bytes keyed by storage id, so a test can
+ *  assert what a later download would actually serve. */
+const storedBytes = new Map<string, Uint8Array>();
+
+type QuoteRow = {
+  quoteId: string;
+  projectId: string;
+  projectNumber: string;
+  version: number;
+  label: string;
+  pdfFileId: string | null;
+  sentAt: number | null;
+  quoteDate: number | null;
+  validUntil: number | null;
+  effectiveStatus?: string;
+};
+
+/** The Convex row, mutated by the attach mutation exactly as the real one is. */
+let quoteRow: QuoteRow;
+let invoiceRow: {
+  invoiceId: string;
+  projectId: string;
+  projectNumber: string;
+  invoiceNumber: string | null;
+  kind: string;
+  status: string;
+  pdfFileId: string | null;
+  issuedAt: number | null;
+  dueDate: number | null;
+};
+
+function wireConvex() {
+  queryMock.mockImplementation(async (fnRef: unknown) => {
+    const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+    if (name === "financeArtifacts:quoteArtifactContext") return { ...quoteRow };
+    if (name === "financeArtifacts:invoiceArtifactContext") return { ...invoiceRow };
+    throw new Error(`Unmocked query: ${name}`);
+  });
+
+  // Mirrors convex/financeArtifacts.ts: attach ONCE, never overwrite.
+  mutationMock.mockImplementation(async (fnRef: unknown, args: { storageId: string }) => {
+    const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+    if (name === "financeArtifacts:attachQuoteArtifact") {
+      if (quoteRow.pdfFileId) return { attached: false, pdfFileId: quoteRow.pdfFileId };
+      quoteRow.pdfFileId = args.storageId;
+      return { attached: true, pdfFileId: args.storageId };
+    }
+    if (name === "financeArtifacts:attachInvoiceArtifact") {
+      if (invoiceRow.pdfFileId) return { attached: false, pdfFileId: invoiceRow.pdfFileId };
+      invoiceRow.pdfFileId = args.storageId;
+      return { attached: true, pdfFileId: args.storageId };
+    }
+    throw new Error(`Unmocked mutation: ${name}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storedBytes.clear();
+  quoteRow = {
+    quoteId: "q1",
+    projectId: "p1",
+    projectNumber: "RVLT-2026-0087",
+    version: 2,
+    label: "RVLT-2026-0087 v2",
+    pdfFileId: null,
+    sentAt: SENT_AT,
+    quoteDate: QUOTE_DATE,
+    validUntil: VALID_UNTIL,
+    effectiveStatus: "SENT",
+  };
+  invoiceRow = {
+    invoiceId: "inv1",
+    projectId: "p1",
+    projectNumber: "RVLT-2026-0087",
+    invoiceNumber: "INV-2026-0001",
+    kind: "FULL",
+    status: "ISSUED",
+    pdfFileId: null,
+    issuedAt: SENT_AT,
+    dueDate: null,
+  };
+  wireConvex();
+
+  let uploadCount = 0;
+  uploadToS3.mockImplementation(async (file: Buffer) => {
+    const storageKey = `storage_${++uploadCount}`;
+    storedBytes.set(storageKey, new Uint8Array(file));
+    return { storageKey, url: `/api/files/${storageKey}` };
+  });
+});
+
+describe("a sent quote's PDF is byte-identical on repeat download while the live project changes underneath it", () => {
+  test("the second download serves the ORIGINAL bytes — the re-priced project never reaches the client's document", async () => {
+    // Render #1: the project as it was when the quote was sent.
+    generatePdf.mockResolvedValueOnce(new Uint8Array([1, 2, 3, 4]));
+    const first = await generateQuoteArtifact("q1");
+    expect(first.generated).toBe(true);
+
+    // ── The project changes underneath: prices edited, lines added, whatever.
+    //    The live renderer would now produce a completely different document.
+    generatePdf.mockResolvedValue(new Uint8Array([9, 9, 9, 9]));
+
+    const second = await generateQuoteArtifact("q1");
+
+    // Same artifact, no second render, and the bytes on disk are untouched.
+    expect(second.pdfFileId).toBe(first.pdfFileId);
+    expect(second.generated).toBe(false);
+    expect(generatePdf).toHaveBeenCalledTimes(1);
+    expect(uploadToS3).toHaveBeenCalledTimes(1);
+    expect(Array.from(storedBytes.get(first.pdfFileId)!)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("an issued invoice's document is frozen at issue in exactly the same way", async () => {
+    generatePdf.mockResolvedValueOnce(new Uint8Array([5, 6, 7]));
+    const first = await generateInvoiceArtifact("inv1");
+    generatePdf.mockResolvedValue(new Uint8Array([0, 0, 0]));
+
+    const second = await generateInvoiceArtifact("inv1");
+
+    expect(second.pdfFileId).toBe(first.pdfFileId);
+    expect(second.generated).toBe(false);
+    expect(generatePdf).toHaveBeenCalledTimes(1);
+    expect(Array.from(storedBytes.get(first.pdfFileId)!)).toEqual([5, 6, 7]);
+  });
+});
+
+describe("generateQuoteArtifact — stamped dates (the silent-validity-extension bug)", () => {
+  test("renders with the ROW's quoteDate/validUntil, never with `now`", async () => {
+    generatePdf.mockResolvedValue(new Uint8Array([1]));
+    await generateQuoteArtifact("q1");
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", {
+      stampedDates: { documentDate: QUOTE_DATE, quoteValidUntil: VALID_UNTIL },
+    });
+  });
+
+  test("falls back to sentAt when a pre-#986 row carries no quoteDate", async () => {
+    quoteRow.quoteDate = null;
+    quoteRow.validUntil = null;
+    generatePdf.mockResolvedValue(new Uint8Array([1]));
+
+    await generateQuoteArtifact("q1");
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", {
+      stampedDates: { documentDate: SENT_AT, quoteValidUntil: undefined },
+    });
+  });
+
+  test("an issued invoice's document date is its issuedAt", async () => {
+    generatePdf.mockResolvedValue(new Uint8Array([1]));
+    await generateInvoiceArtifact("inv1");
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "invoice", {
+      stampedDates: { documentDate: SENT_AT },
+    });
+  });
+});
+
+describe("generateQuoteArtifact — the retry path", () => {
+  test("a SENT revision whose render failed keeps a null artifact, and the retry fills it", async () => {
+    generatePdf.mockRejectedValueOnce(new Error("pdfme exploded"));
+    await expect(generateQuoteArtifact("q1")).rejects.toThrow("pdfme exploded");
+    expect(quoteRow.pdfFileId).toBeNull();
+    expect(uploadToS3).not.toHaveBeenCalled();
+
+    generatePdf.mockResolvedValueOnce(new Uint8Array([7, 7]));
+    const retried = await generateQuoteArtifact("q1");
+
+    expect(retried.generated).toBe(true);
+    expect(quoteRow.pdfFileId).toBe(retried.pdfFileId);
+  });
+
+  test("a never-sent draft has no stored document and cannot be given one", async () => {
+    quoteRow.sentAt = null;
+    quoteRow.effectiveStatus = "DRAFT";
+
+    await expect(generateQuoteArtifact("q1")).rejects.toThrow(/sent quote revision/i);
+    expect(generatePdf).not.toHaveBeenCalled();
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  test("a DRAFT invoice cannot be given one either", async () => {
+    invoiceRow.issuedAt = null;
+    invoiceRow.status = "DRAFT";
+    invoiceRow.invoiceNumber = null;
+
+    await expect(generateInvoiceArtifact("inv1")).rejects.toThrow(/issued invoice/i);
+    expect(generatePdf).not.toHaveBeenCalled();
+  });
+
+  test("losing the attach race deletes the orphan upload and serves the winner's artifact", async () => {
+    generatePdf.mockResolvedValue(new Uint8Array([1, 2]));
+    // The row reads as empty (this caller's snapshot), but another attempt has
+    // already attached by the time the mutation lands.
+    mutationMock.mockResolvedValueOnce({ attached: false, pdfFileId: "storage_winner" });
+
+    const result = await generateQuoteArtifact("q1");
+
+    expect(result).toEqual({ pdfFileId: "storage_winner", generated: false });
+    expect(deleteFromS3).toHaveBeenCalledWith("storage_1");
+  });
+});
+
+describe("artifact file naming", () => {
+  test("a quote artifact is named for its REVISION, so v2 and v3 never collide", async () => {
+    generatePdf.mockResolvedValue(new Uint8Array([1]));
+    await generateQuoteArtifact("q1");
+
+    expect(uploadToS3).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationId: "org_1",
+        folder: "finance/quotes",
+        fileName: "RVLT-2026-0087-quote-v2.pdf",
+        mimeType: "application/pdf",
+      }),
+    );
+  });
+
+  test("an invoice artifact leads with the invoice number", async () => {
+    generatePdf.mockResolvedValue(new Uint8Array([1]));
+    await generateInvoiceArtifact("inv1");
+
+    expect(uploadToS3).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ folder: "finance/invoices", fileName: "INV-2026-0001-invoice.pdf" }),
+    );
+  });
+});

--- a/src/server/finance-documents.ts
+++ b/src/server/finance-documents.ts
@@ -1,0 +1,186 @@
+"use server";
+
+/**
+ * Immutable finance ARTIFACTS — render once, store the bytes (#987, Phase B).
+ *
+ * This is the freeze moment for the *document*, the way `quotesWrites.sendNative`
+ * is the freeze moment for the *money*. The PDF is rendered here (pdfme needs
+ * Node, so it can't live in a Convex mutation), uploaded to Convex `_storage`
+ * via `src/lib/storage.ts`, and its storage id attached to the row by
+ * `convex/financeArtifacts.ts` — which refuses to overwrite an existing one.
+ *
+ * Why bytes and not "re-render from the snapshot on demand": a reconstruction
+ * path would re-execute ~1,400 lines of `build-document-data.ts` plus the
+ * composer against a snapshot that would have to grow to carry every token, and
+ * any future change to that code would silently rewrite historical documents.
+ * Storing the bytes makes immutability structural instead of disciplinary — the
+ * same reasoning as `withValidatedBody` in CLAUDE.md.
+ *
+ * **Failure handling.** The Convex row is written first (inside its own
+ * transaction); this runs immediately after. If it fails, the quote is `SENT`
+ * with a null `pdfFileId` and the Finance tab renders a "document still
+ * generating / failed — retry" state wired to these same two actions. The retry
+ * is safe to expose precisely because `attach*Artifact` can't overwrite: a retry
+ * that races a slow first attempt loses the race harmlessly, and its orphan
+ * upload is deleted here rather than left to accumulate.
+ *
+ * Both actions are idempotent and cheap to call twice.
+ */
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { requirePermission } from "@/lib/org-context";
+import { serialize } from "@/lib/serialize";
+import { logActivity } from "@/lib/activity-log";
+import { logger } from "@/lib/logger";
+import { generatePdf } from "@/lib/pdfme/generate-pdf";
+import { uploadToS3, deleteFromS3 } from "@/lib/storage";
+import { quoteArtifactFileName, invoiceArtifactFileName } from "@/lib/finance-artifacts";
+
+export interface ArtifactResult {
+  /** The storage id now on the row — never null on success. */
+  pdfFileId: string;
+  /** False when an artifact already existed (nothing was overwritten). */
+  generated: boolean;
+}
+
+/**
+ * Render + store the PDF for a SENT quote revision.
+ *
+ * Called immediately after `quotesWrites.sendNative` and by the retry action on
+ * a sent revision whose render failed. Requires `invoice:publish` — the same
+ * audience that can send in the first place.
+ */
+export async function generateQuoteArtifact(quoteId: string): Promise<ArtifactResult> {
+  const { organizationId, userId, userName } = await requirePermission("invoice", "publish");
+  const convex = await getConvexClient();
+
+  const quote = await convex.query(api.financeArtifacts.quoteArtifactContext, {
+    quoteId,
+    orgId: organizationId,
+    now: Date.now(),
+  });
+
+  // Already frozen — hand back the existing artifact. This is the property the
+  // whole program rests on: there is no code path that re-renders over one.
+  if (quote.pdfFileId) return serialize({ pdfFileId: quote.pdfFileId, generated: false });
+  if (quote.sentAt == null) {
+    throw new Error("Only a sent quote revision has a stored document. Send it first.");
+  }
+
+  const pdf = await generatePdf(quote.projectId, organizationId, "quote", {
+    // From the ROW, never `now` — re-rendering must not move the client's dates.
+    stampedDates: {
+      documentDate: quote.quoteDate ?? quote.sentAt,
+      quoteValidUntil: quote.validUntil ?? undefined,
+    },
+  });
+
+  const fileName = quoteArtifactFileName(quote.projectNumber, quote.version);
+  const upload = await uploadToS3(Buffer.from(pdf), {
+    organizationId,
+    folder: "finance/quotes",
+    entityId: quote.quoteId,
+    fileName,
+    mimeType: "application/pdf",
+  });
+
+  const attached = await convex.mutation(api.financeArtifacts.attachQuoteArtifact, {
+    quoteId,
+    orgId: organizationId,
+    storageId: upload.storageKey,
+    now: Date.now(),
+  });
+
+  if (!attached.attached) {
+    await discardOrphan(upload.storageKey);
+    return serialize({ pdfFileId: attached.pdfFileId, generated: false });
+  }
+
+  await logActivity({
+    organizationId,
+    action: "CREATE",
+    entityType: "quote",
+    entityId: quote.quoteId,
+    entityName: quote.label,
+    userId,
+    userName,
+    summary: `Stored the quote document for ${quote.label}`,
+    details: { version: quote.version, fileName },
+    projectId: quote.projectId,
+  });
+
+  return serialize({ pdfFileId: attached.pdfFileId, generated: true });
+}
+
+/**
+ * Render + store the PDF for an ISSUED invoice. Requires `invoice:issue` — the
+ * audience that can issue one.
+ */
+export async function generateInvoiceArtifact(invoiceId: string): Promise<ArtifactResult> {
+  const { organizationId, userId, userName } = await requirePermission("invoice", "issue");
+  const convex = await getConvexClient();
+
+  const invoice = await convex.query(api.financeArtifacts.invoiceArtifactContext, {
+    invoiceId,
+    orgId: organizationId,
+  });
+
+  if (invoice.pdfFileId) return serialize({ pdfFileId: invoice.pdfFileId, generated: false });
+  if (invoice.issuedAt == null) {
+    throw new Error("Only an issued invoice has a stored document. Issue it first.");
+  }
+
+  const pdf = await generatePdf(invoice.projectId, organizationId, "invoice", {
+    stampedDates: { documentDate: invoice.issuedAt },
+  });
+
+  const fileName = invoiceArtifactFileName(invoice.projectNumber, invoice.invoiceNumber);
+  const upload = await uploadToS3(Buffer.from(pdf), {
+    organizationId,
+    folder: "finance/invoices",
+    entityId: invoice.invoiceId,
+    fileName,
+    mimeType: "application/pdf",
+  });
+
+  const attached = await convex.mutation(api.financeArtifacts.attachInvoiceArtifact, {
+    invoiceId,
+    orgId: organizationId,
+    storageId: upload.storageKey,
+    now: Date.now(),
+  });
+
+  if (!attached.attached) {
+    await discardOrphan(upload.storageKey);
+    return serialize({ pdfFileId: attached.pdfFileId, generated: false });
+  }
+
+  await logActivity({
+    organizationId,
+    action: "CREATE",
+    entityType: "invoice",
+    entityId: invoice.invoiceId,
+    entityName: invoice.invoiceNumber ?? invoice.invoiceId,
+    userId,
+    userName,
+    summary: `Stored the invoice document for ${invoice.invoiceNumber ?? invoice.invoiceId}`,
+    details: { fileName },
+    projectId: invoice.projectId,
+  });
+
+  return serialize({ pdfFileId: attached.pdfFileId, generated: true });
+}
+
+/** Bin the bytes we uploaded but didn't attach (another attempt won the race).
+ *  Best-effort: a leaked blob is not worth failing a download over, but it is
+ *  worth logging, because a pattern of them means the retry path is being hit. */
+async function discardOrphan(storageKey: string): Promise<void> {
+  try {
+    await deleteFromS3(storageKey);
+  } catch (error) {
+    logger.warn("[FinanceArtifacts] failed to delete an unattached artifact upload", {
+      storageKey,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
Closes #987. Phase B of #985. Design: [`docs/designs/finance-first-class-version-control.md`](../blob/main/docs/designs/finance-first-class-version-control.md) §4.

## Summary

Phase A froze a quote's **money** at send. This freezes the **document**.

Before this, `/api/documents/[projectId]?type=quote` rendered from live project state and consulted the `quotes` table not at all — two clicks a week apart produced two different documents under the same name, and the document the client was actually holding existed nowhere in the system. `quotes.pdfFileId` was declared in `convex/schema.ts` with zero readers and zero writers. Invoices had the same hole: the row was immutable once ISSUED, but the artifact was still live-rendered, so the guarantee stopped at the database boundary.

Now the PDF is rendered **once**, at the freeze moment, and the bytes are kept:

```
sendNative / issueNative        (Convex transaction — the row)
      └─▶ src/server/finance-documents.ts   (server action — the document; pdfme needs Node)
            generatePdf() ─▶ uploadToS3() [Convex _storage] ─▶ storageId
                  └─▶ convex/financeArtifacts.ts attach*Artifact
                        └─▶ quotes.pdfFileId / invoices.pdfFileId
```

Chosen over "reconstruct from the snapshot on demand" because it's the only option that is *actually* immutable: reconstruction re-executes ~1,400 lines of `build-document-data.ts` plus the composer against a snapshot that would have to grow to carry every token, and any later change to that code would silently rewrite historical documents. Storing bytes makes the guarantee structural rather than disciplinary — the `withValidatedBody` reasoning in CLAUDE.md.

### The rules this establishes

- **Attach once, never overwrite.** `attach*Artifact` returns `{ attached: false, pdfFileId }` instead of replacing. That's what makes exposing a retry safe: a retry racing a slow first attempt loses harmlessly, and the server action bins its orphan upload.
- **Nothing deletes one.** Recalled / superseded / declined / voided rows keep their document — the client may be holding that copy.
- **No regeneration path on read.** `/api/finance/{quote,invoice}/[id]/pdf` streams stored bytes or 404s. A route that can regenerate is a route that can hand the client a different document under the same name.
- **Dates come from the row.** `quote_valid_until` used to be recomputed from `now` on every render, so merely re-opening an old quote silently extended how long it was valid. A finance render now takes `quoteDate`/`validUntil` (or an invoice's `issuedAt`) from the frozen row; the `now` fallback survives only for the preview, which has nothing stamped because nothing was sent.
- **The rogue path is closed.** "Quote / proposal" and "Invoice" are gone from the header's Documents ▾ (warehouse artifacts only — those *should* reflect live state). `?type=quote|invoice` on `/api/documents/[projectId]` is a 400 unless `preview=1`, which requires `invoice:read` and stamps **DRAFT PREVIEW — NOT SENT** on every page.

### Failure handling

The render runs after the Convex transaction commits, so it can fail on its own. A `SENT` quote (or `ISSUED` invoice) with a null `pdfFileId` is therefore a real state, and it's never silent: the row shows **"Document missing — generate"** and the toast says so. The send/issue is never rolled back for a render failure — the money is frozen either way. That wording also covers pre-#987 rows the Phase A backfill deliberately left artifact-less, which "Document failed" would have mislabelled.

Every quote revision and invoice row is now in exactly one of three document states: **download** the stored artifact, **preview** the un-frozen draft (watermarked), or **generate** a missing one. A draft invoice keeps a preview in the finance panel, so nothing reachable before became unreachable.

### PDF pipeline audit (CLAUDE.md standing rule)

No `DocumentLineItem` shape change — confirmed by walking the send path: it consumes `buildFinanceLines`, the data-model snapshot builder, explicitly not the PDF's line structuring. So the three-consumer audit doesn't apply; what does is the composer's block-height switch. `draftWatermark` is a new `LayoutBlock` kind and **page furniture**, not a body block: `measurePageFurniture()` reserves its height and it repeats under the header on every page (a banner on page 1 of a 4-page quote is not a warning), with an explicit "reserves exactly its own height + section gap" test. Extracting the furniture measurement also kept `computePages` under the complexity ratchet.

## Size rationale (R-2.8 / T-2 — the bot's advisory comment)

~2,300 LOC, of which **~1,000 is tests and ~500 is documentation**. The production change is ~800 LOC across six atomic commits, and it does not split cleanly any further: the schema field, the attach mutation, the render action, the download route and the UI state are one guarantee — landing any subset gives you a `pdfFileId` nothing writes, or a download route with nothing to serve, i.e. exactly the half-built state (`pdfFileId` with zero readers and zero writers) this PR exists to remove. The six commits are individually reviewable and revertable in order.

## Testing

`pnpm test` — 390 files / 4943 tests green. Typecheck + lint clean. Ratchets green: complexity 686/686, knip 419/419, any, collect, depcruise, migration drift, client routes, `api:registry:check` (1124 ops, 291 agent-reachable).

New coverage:

- **`src/server/finance-documents.test.ts`** (11) — led by *"a sent quote's PDF is byte-identical on repeat download while the live project changes underneath it"*: the pipeline is re-primed with different bytes between calls and the stored artifact does not move. Plus the invoice equivalent frozen at issue, stamped dates (never `now`, incl. the pre-#986 `sentAt` fallback), the retry path, the never-sent/never-issued refusals, and orphan cleanup on a lost attach race.
- **`convex/financeArtifacts.test.ts`** (13) — attach-once, sent/issued preconditions, service-only access, and a cross-org case per function including "the quote is mine but the project isn't".
- **`src/app/api/finance/__tests__/artifact-routes.test.ts`** (15) — streams stored bytes and never calls `generatePdf`, cross-org 404 on both routes (R-8.4.3), 403 when the stored file's org doesn't match, `?type=quote` without `preview=1` is a 400, preview requires `invoice:read`, and a warehouse doc can't be tricked into a watermark.
- **`document-composer.test.ts`** (+5) — watermark absent by default, exact height reservation, repeats on every page, and a 120-item fixture asserting full parent coverage *with* the banner stealing space.
- **`gearflow-draft-watermark.test.ts`** (3) — draws the box + title + subtitle, and survives the em dash Helvetica can't encode (an unfiltered `—` would throw at render time).
- **`finance-artifacts.test.ts`** (8) — revision-carrying names, `Content-Disposition` sanitising.

### Not verified here

- No live end-to-end run: this sandbox has no Postgres/Convex deployment, so `pnpm build` and a real render→upload→download round trip weren't executed. The pdfme pipeline is mocked in the server-action tests by design — what's under test is that it is called once and never again.
- Convex functions were **not** pushed (`pnpm exec convex dev --once` needs `CONVEX_DEPLOY_KEY`, absent here). The deploy pipeline runs `convex deploy` on merge to `main`.
- No jsdom smoke test for the new rail/panel document actions — plain buttons and links, no overlay; the three-state logic is a straight conditional over `pdfFileId`/`sentAt`.

## Checklist

- [x] New dependency? None added.
- [x] FEATUREDOCS/13 + FEATUREDOCS/66 updated in the same PR (plus FEATUREDOCS/10 for the Documents ▾ change and CLAUDE.md for the standing rule) — R-5.2/5.3/5.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3sHFfZMPVxPNbh68MTxx