### PR TITLE
fix(pdf): separate Uncategorized items visually; stop repeating group headers on continuation pages

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -473,6 +473,58 @@ column leads with the client's name; `document-composer.ts` now wraps it in
 `**...**` before handing it to `gearflowRichText`, the same convention
 already used to bold the project column's leading line.
 
+### Uncategorized section gets a real header; group headers stop repeating on continuation pages (2026-07-28)
+
+**Uncategorized items were visually merging into the category printed above
+them.** Two spots fed rows into the table with a falsy `groupName`, and
+`gearflow-table.ts`'s bucketing (`item.groupName || item.prepContainer ||
+ungroupedKey`) treats any falsy `groupName` as "no section, no header" —
+correct for items that genuinely have no place on the doc, wrong for items
+the office just hasn't filed under a category yet:
+
+1. `buildDocumentLineItemData` (`src/lib/project-line-item-read.ts`) folds
+   Project Groups living in the equipment tab's "Uncategorized" zone
+   (`ProjectGroup.categoryId: null`) into a synthetic pseudo-category —
+   previously `{ id: "__uncategorized__", name: "" }`, deliberately blank so
+   it fell through to the same silent fallback. Now `name: "Uncategorized"`.
+2. `structureLineItems`'s final branch (line items with no category AND no
+   group at all) pushed them through with whatever `groupName` they already
+   had (typically none). Now explicitly bucketed under `"Uncategorized"` via
+   the existing `kitBucketLabel` helper, same as every other category bucket.
+
+Both now get a normal section header + divider, same visual treatment as any
+named category — no more silent blending into whatever printed above them.
+Regression coverage: `structure-line-items.test.ts`'s "Uncategorized-zone
+Project Group" describe block (updated to assert `groupName: "Uncategorized"`
+instead of `""`) plus the Phase-0 integration fixture's uncategorized custom
+item.
+
+**A long category's header was redrawing at the top of every continuation
+page it spanned.** `gearflow-table.ts` recomputes the full `groups` Map on
+every page render call (each page gets the complete `items` array plus its
+own `startIndex`/`endIndex` slice) and used to draw a group's header
+whenever *any* of its items fell within that page's slice — including a page
+that only continues a group whose header already printed on the page
+before. Fixed by tracking `groupStartIdx` (the group's position before its
+own items) and skipping the header draw when `groupStartIdx < startIndex`
+(the group started on an earlier page). `document-composer.ts`'s
+`splitTable` height budget had a matching "reserve extra `GROUP_HEADER_PT`
+on a continuation page whose leading group already printed its header
+earlier" branch — that was deliberately compensating for the old
+repeat-on-continuation render behavior, so it's now dead weight and was
+removed in lockstep (along with the `groupHeaderIdx`/`entryGroupKey`
+bookkeeping that only existed to feed it). Leaving either side unfixed alone
+would have reintroduced a height/render mismatch — the exact class of bug
+the "PDF Data-Shape Consumers" checklist below exists to catch, extended
+here to cover a render *condition* change, not just a shape change.
+Regression coverage: `gearflow-table.test.ts`'s "group header does not
+repeat on a continuation page" describe block (renders page 1 and a
+simulated continuation page directly via `runTablePlugin`'s new
+`startIndex`/`endIndex` param) and `document-composer.test.ts`'s "group
+header prints once across a multi-page group" full-pipeline test (100-item
+single-category fixture spanning 3+ real composed pages, counts header draws
+across every page via `runTablePlugin`).
+
 ### Quote-specific fixes (#790 Phase 4)
 
 - **No "/day" (or other period) price suffix on the quote.** `TablePluginConfig.hidePricingPeriodSuffix`
@@ -622,6 +674,11 @@ Three additional behaviours layer onto expand mode:
   bottom of each bucket via a sentinel character. Sort is controlled
   by `options.packerSort`, tied 1:1 to `expandProjectGroups` (every
   expand-mode doc also wants packer order).
+
+Applies to both modes: line items with no category and no group at all
+bucket under a literal `"Uncategorized"` section (2026-07-28) — same
+section header + divider treatment as a real category, not a blank/falsy
+`groupName` that silently merges them into whichever bucket printed above.
 
 ## Constraints
 - **Helvetica only** — no Unicode symbols (use ASCII: `-` not `—`, `|` not `•`)

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -894,3 +894,74 @@ describe("calculateItemHeight — sub-hire 'via Supplier' line (tail-drop regres
     assertFullCoverage(result, items.length);
   });
 });
+
+// ─── Group header does not repeat on continuation pages (2026-07-28) ────────
+//
+// Real bug: every page recomputed the full groups Map and drew a group's
+// header whenever ANY of its items fell in that page's slice — including a
+// page that merely continues a group started on the page before. On a doc
+// with a category long enough to span several pages, its header printed at
+// the top of every one of them. Fixed by only drawing a group's header on
+// the page where it *starts*; the composer's height budget for continuation
+// pages was updated in lockstep (it used to reserve extra space assuming the
+// header would repeat).
+describe("composeDocument + gearflowTable — group header prints once across a multi-page group", () => {
+  it("a single long group spanning 3+ pages draws its header exactly once, and every item still renders", async () => {
+    const items: DocumentLineItem[] = [];
+    for (let i = 0; i < 100; i++) {
+      items.push(
+        makeLineItem({
+          id: `li-${i}`,
+          status: "CONFIRMED",
+          categoryName: "Lighting",
+          groupName: "Lighting",
+          model: { name: `Lighting Item ${i}` },
+          unitPrice: 100 + i,
+          lineTotal: 100 + i,
+        }),
+      );
+    }
+
+    const data = makeData({ line_items: items, subtotal: items.reduce((s, li) => s + (li.lineTotal ?? 0), 0) });
+    const result = composeDocument("quote", data, "#0d4f4f");
+
+    expect(result.template.schemas.length).toBeGreaterThan(2); // actually spans several pages
+    assertFullCoverage(result, items.length);
+
+    const tableBlock = DOCUMENT_LAYOUTS.quote.blocks.find((b) => b.kind === "table");
+    if (tableBlock?.kind !== "table") throw new Error("quote layout has no table block");
+    const tableConfig: TablePluginConfig = {
+      documentType: "quote",
+      documentColor: "#0d4f4f",
+      showGroupHeaders: tableBlock.config.showGroupHeaders,
+      showKitChildren: tableBlock.config.showKitChildren,
+      showCheckboxes: tableBlock.config.showCheckboxes,
+      showConditionColumns: tableBlock.config.showConditionColumns,
+      showPricing: tableBlock.config.showPricing,
+      showBadges: tableBlock.config.showBadges,
+      showNotes: tableBlock.config.showNotes,
+      showPerUnitCheckboxes: tableBlock.config.showPerUnitCheckboxes,
+      showAssetTags: tableBlock.config.showAssetTags,
+      showCategories: tableBlock.config.showCategories,
+      showRowNumbers: tableBlock.config.showRowNumbers,
+      filterOptional: false,
+      filterByStatus: null,
+      hidePricingPeriodSuffix: tableBlock.config.hidePricingPeriodSuffix ?? false,
+    };
+
+    let headerDrawCount = 0;
+    for (const pageSchemas of result.template.schemas) {
+      const tableSchema = pageSchemas.find((s) => s.type === "gearflowTable");
+      if (!tableSchema) continue;
+      const value = JSON.parse(result.inputs[0][tableSchema.name as string]) as {
+        startIndex?: number;
+        endIndex?: number;
+        startSubIndex?: number;
+      };
+      const calls = await runTablePlugin(items, tableConfig, value);
+      headerDrawCount += calls.drawText.filter((c) => c.text === "Lighting").length;
+    }
+
+    expect(headerDrawCount).toBe(1);
+  });
+});

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -454,7 +454,6 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
   const headerHeight = headerBlock ? estimateBlockHeight(headerBlock, data, ctx) : 0;
   const continuationContentHeight = maxY - MARGIN - (headerBlock ? headerHeight + SECTION_GAP : 0);
   const tableHeaderMm = ptToMm(TABLE_HEADER_PT);
-  const groupHeaderMm = ptToMm(GROUP_HEADER_PT);
 
   const pages: Page[] = [];
   let currentPage: Page = { entries: [] };
@@ -505,23 +504,16 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     // heightToParentIdx[i] maps a height-array entry to a parent-item index,
     // or -1 for a group header (not a startIndex-addressable item).
     const heightToParentIdx: number[] = [];
-    const entryGroupKey: string[] = [];
     let parentIdx = 0;
     for (const groupKey of groupOrder) {
       if (groupKey !== ungrouped && config.showGroupHeaders) {
         heightToParentIdx.push(-1);
-        entryGroupKey.push(groupKey);
       }
       for (let gi = 0; gi < groups.get(groupKey)!.length; gi++) {
         heightToParentIdx.push(parentIdx);
-        entryGroupKey.push(groupKey);
         parentIdx++;
       }
     }
-    const groupHeaderIdx = new Map<string, number>();
-    heightToParentIdx.forEach((pi, i) => {
-      if (pi === -1) groupHeaderIdx.set(entryGroupKey[i], i);
-    });
 
     const getItemAt = (idx: number): DocumentLineItem | null => {
       if (idx >= heightToParentIdx.length) return null;
@@ -610,12 +602,11 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
     while (remainingIdx < itemHeights.length) {
       startNewPage();
 
-      let pageContent = continuationContentHeight - tableHeaderMm - TABLE_PADDING_BOTTOM_MM;
-      if (config.showGroupHeaders && remainingIdx < entryGroupKey.length) {
-        const firstGroupOnPage = entryGroupKey[remainingIdx];
-        const headerPos = groupHeaderIdx.get(firstGroupOnPage);
-        if (headerPos !== undefined && headerPos < remainingIdx) pageContent -= groupHeaderMm;
-      }
+      // No extra reservation for a group header repeating on this
+      // continuation page — gearflow-table.ts only draws a group's header
+      // where it *starts* (2026-07-28), never again on pages that merely
+      // continue it.
+      const pageContent = continuationContentHeight - tableHeaderMm - TABLE_PADDING_BOTTOM_MM;
 
       const fit = fitItems(remainingIdx, pageContent, pendingSubIndex);
       const pageItems = fit.count;
@@ -640,12 +631,8 @@ function computePages(layout: DocumentLayout, data: DocumentData, docType: Proje
 
       let tableHeight = continuationContentHeight;
       if (isLastPage) {
+        // Same no-repeat-header accounting as the pageContent budget above.
         let actualMm = tableHeaderMm + TABLE_PADDING_BOTTOM_MM;
-        if (config.showGroupHeaders && remainingIdx < entryGroupKey.length) {
-          const grp = entryGroupKey[remainingIdx];
-          const hPos = groupHeaderIdx.get(grp);
-          if (hPos !== undefined && hPos < remainingIdx) actualMm += groupHeaderMm;
-        }
         for (let i = remainingIdx; i < remainingIdx + pageItems && i < itemHeights.length; i++) {
           let h = itemHeights[i];
           if (i === remainingIdx && pendingSubIndex > 0) {

--- a/src/lib/pdfme/plugins/gearflow-table.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.test.ts
@@ -272,6 +272,31 @@ describe("gearflowTable — Project Group rendering", () => {
   });
 });
 
+describe("gearflowTable — group header does not repeat on a continuation page (2026-07-28)", () => {
+  const bandItems = [
+    makeLineItem({ id: "b-1", groupName: "Band", model: { name: "e602 ii" } }),
+    makeLineItem({ id: "b-2", groupName: "Band", model: { name: "e604" } }),
+    makeLineItem({ id: "b-3", groupName: "Band", model: { name: "e906" } }),
+  ];
+
+  it("draws the header once on the page where the group starts (startIndex 0)", async () => {
+    const calls = await runTablePlugin(bandItems, {}, { startIndex: 0 });
+
+    expect(calls.drawText.filter(c => c.text === "Band")).toHaveLength(1);
+  });
+
+  it("does NOT redraw the header on a page that only continues the group", async () => {
+    // Simulates a second page: item b-1 (globalIdx 1) already rendered on
+    // page 1, so this page's slice starts at globalIdx 2 — mid-group.
+    const calls = await runTablePlugin(bandItems, {}, { startIndex: 1 });
+
+    expect(calls.drawText.filter(c => c.text === "Band")).toHaveLength(0);
+    // The remaining items still render.
+    expect(calls.drawText.some(c => c.text === "e604")).toBe(true);
+    expect(calls.drawText.some(c => c.text === "e906")).toBe(true);
+  });
+});
+
 // ─── #943 — derived billing weeks/days price breakdown ────────────────────
 
 describe("gearflowTable — priceBreakdown rendering (#943)", () => {

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -322,11 +322,20 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
 
     // Check if any items in this group will actually be rendered
     // (skip group header if all items are before startIndex)
-    const groupEndIdx = globalIdx + groupItems.length;
+    const groupStartIdx = globalIdx;
+    const groupEndIdx = groupStartIdx + groupItems.length;
     const hasVisibleItems = groupEndIdx > startIndex;
+    // True when this group's first item already rendered on an earlier
+    // page — this page is a continuation of it, not a fresh start. Every
+    // page recomputes the full `groups` map and evaluates every group
+    // against its own startIndex/endIndex slice, so without this check a
+    // long group's header redraws at the top of every continuation page
+    // it spans (2026-07-28) instead of only where the group begins.
+    const isContinuationOfEarlierPage = groupStartIdx < startIndex;
 
-    // Group header — only draw if this group has visible items on this page
-    if (groupName !== ungroupedKey && config.showGroupHeaders && hasVisibleItems) {
+    // Group header — only draw if this group has visible items on this
+    // page AND is starting fresh here (not continuing from a prior page).
+    if (groupName !== ungroupedKey && config.showGroupHeaders && hasVisibleItems && !isContinuationOfEarlierPage) {
       const ghHeight = fontSize + rowPadding * 2;
       // Orphan-check: reserve space for the header AND at least one body
       // row underneath, so headers never strand at a page bottom with

--- a/src/lib/pdfme/plugins/test-utils.ts
+++ b/src/lib/pdfme/plugins/test-utils.ts
@@ -72,6 +72,7 @@ const DEFAULT_CONFIG: TablePluginConfig = {
 export async function runTablePlugin(
   items: DocumentLineItem[],
   configOverrides: Partial<TablePluginConfig> = {},
+  pageSlice: { startIndex?: number; startSubIndex?: number; endIndex?: number } = {},
 ): Promise<RendererCalls> {
   const pdfDoc = await PDFDocument.create();
   // A4 portrait — matches the default packing-list layout.
@@ -118,7 +119,7 @@ export async function runTablePlugin(
   // some internal validation; the no-op stubs above are enough.
 
   const config = { ...DEFAULT_CONFIG, ...configOverrides };
-  const value = JSON.stringify({ items, config });
+  const value = JSON.stringify({ items, config, ...pageSlice });
 
   const schema = {
     name: "table",

--- a/src/lib/pdfme/structure-line-items.test.ts
+++ b/src/lib/pdfme/structure-line-items.test.ts
@@ -1042,7 +1042,7 @@ describe("structureLineItems — Phase 0 baseline", () => {
     expect(result.find(r => r.id === "owned-loose")?.groupName).toBe("Lighting");
     expect(result.find(r => r.id === "kit-foh")?.groupName).toBe("[Kit] FOH Rack");
     expect(result.find(r => r.id === "hired-1")?.groupName).toBe("Sub-Hire: Mainstage AV — Moving Lights");
-    expect(result.find(r => r.id === "custom-1")?.groupName).toBeNull(); // uncategorized
+    expect(result.find(r => r.id === "custom-1")?.groupName).toBe("Uncategorized");
 
     // Kit child is filtered out of top-level structuring
     expect(result.find(r => r.id === "kit-foh-child")).toBeUndefined();
@@ -1161,14 +1161,16 @@ describe("structureLineItems — Phase 0 baseline", () => {
 
 describe("structureLineItems — Uncategorized-zone Project Group (2026-07-28)", () => {
   // buildDocumentLineItemData folds a `categoryId: null` ProjectGroup into a
-  // pseudo-category `{ id: "__uncategorized__", name: "" }` before calling
-  // structureLineItems — this simulates that shape directly. Members carry
-  // `groupId` (set whenever `groupTitle` is resolved from it, per
-  // buildDocumentLineItemData) but their OWN `categoryName` is null, since
-  // the member's `categoryId` is independently unset.
+  // pseudo-category `{ id: "__uncategorized__", name: "Uncategorized" }`
+  // before calling structureLineItems — this simulates that shape directly.
+  // Members carry `groupId` (set whenever `groupTitle` is resolved from it,
+  // per buildDocumentLineItemData) but their OWN `categoryName` is null,
+  // since the member's `categoryId` is independently unset.
   const uncategorizedZone = (
     groups: CategoryForStructuring["groups"],
-  ): CategoryForStructuring[] => [{ id: "__uncategorized__", name: "", sortOrder: Number.MAX_SAFE_INTEGER, groups }];
+  ): CategoryForStructuring[] => [
+    { id: "__uncategorized__", name: "Uncategorized", sortOrder: Number.MAX_SAFE_INTEGER, groups },
+  ];
 
   it("collapse mode (quote/invoice): collapses into ONE row, not flat individual members", () => {
     const categories = uncategorizedZone([
@@ -1185,9 +1187,10 @@ describe("structureLineItems — Uncategorized-zone Project Group (2026-07-28)",
     expect(result[0].isGroupRow).toBe(true);
     expect(result[0].groupTitle).toBe("Small PA Package");
     expect(result[0].lineTotal).toBe(275);
-    // No spurious "Uncategorized" section header — buckets under the
-    // doc's normal ungrouped fallback instead.
-    expect(result[0].groupName).toBe("");
+    // Gets its own "Uncategorized" section header (2026-07-28) — a blank
+    // bucket label used to silently merge it into whatever category printed
+    // above it on the doc.
+    expect(result[0].groupName).toBe("Uncategorized");
     // The real members are NOT also listed flat (would be double-counting /
     // the exact "split into flat items" bug this fixes).
     expect(result.some(r => r.id === "k10")).toBe(false);

--- a/src/lib/pdfme/structure-line-items.ts
+++ b/src/lib/pdfme/structure-line-items.ts
@@ -322,9 +322,11 @@ export function structureLineItems(
     }
   }
 
-  // Items not in any category and not inside a group — render as-is,
-  // sorted in packer-walk order when the option is on. Sub-hire items
-  // are excluded so they don't double-appear (they render below).
+  // Items not in any category and not inside a group — render under their
+  // own "Uncategorized" section (2026-07-28) so they're visibly separated
+  // from whatever category prints above them, sorted in packer-walk order
+  // when the option is on. Sub-hire items are excluded so they don't
+  // double-appear (they render below).
   const uncategorized = rawLineItems.filter(li => {
     if (li.isKitChild || li.isContainerLineItem) return false;
     if (li.categoryName || li.groupTitle) return false;
@@ -333,7 +335,7 @@ export function structureLineItems(
     return true;
   });
   for (const li of maybeSort(uncategorized)) {
-    structured.push(li);
+    structured.push({ ...li, groupName: kitBucketLabel(li, "Uncategorized") });
   }
 
   // Sub-hire sections — one per SubHireGroup that has actual items.

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -703,18 +703,17 @@ export async function buildDocumentLineItemData(projectId: string, organizationI
   // groups nested under a real category above): its own synthetic row never
   // renders, its members aren't recognized as excluded-from-flat-listing,
   // and the whole group prints as disconnected flat line items on quotes/
-  // invoices instead of collapsing — see FEATUREDOCS/13-pdfs.md. `name: ""`
-  // buckets them under each doc's normal "no header" fallback
-  // (`groupName || prepContainer || ungroupedKey` in gearflow-table.ts /
-  // document-composer.ts) rather than a spurious "Uncategorized" section
-  // title on a client-facing document.
+  // invoices instead of collapsing — see FEATUREDOCS/13-pdfs.md. `name:
+  // "Uncategorized"` gives it a real section header (2026-07-28) — a blank
+  // name used to bucket it under each doc's silent "no header" fallback,
+  // which visually merged it into whatever category printed above it.
   const uncategorizedGroups = mappedGroups
     .filter((g) => !g.categoryId)
     .sort((a, b) => a.sortOrder - b.sortOrder);
   if (uncategorizedGroups.length > 0) {
     categories.push({
       id: "__uncategorized__",
-      name: "",
+      name: "Uncategorized",
       sortOrder: Number.MAX_SAFE_INTEGER,
       groups: uncategorizedGroups,
     });


### PR DESCRIPTION
## Summary

- **Uncategorized items no longer blend into the category above them.** Two spots fed the table a falsy `groupName` for uncategorized rows, and `gearflow-table.ts`'s bucketing (`item.groupName || item.prepContainer || ungroupedKey`) treats any falsy `groupName` as "no header" — correct for items with genuinely nowhere to go, wrong for items the office just hasn't categorized yet:
  - `buildDocumentLineItemData` folds "Uncategorized zone" Project Groups (`categoryId: null`) into a pseudo-category that was deliberately named `""`.
  - `structureLineItems`'s fallback for loose line items with no category and no group at all didn't assign any bucket label.
  
  Both now render under a real `"Uncategorized"` section — same header + divider treatment as any named category.

- **Group headers no longer reprint on every continuation page.** `gearflow-table.ts` recomputes the full groups map per page and used to redraw a group's header whenever any of its items fell in that page's slice — including pages that only continue a group whose header already printed earlier. Headers now only draw on the page where a group *starts*. `document-composer.ts` had matching height-budget logic that reserved extra space specifically to compensate for the old repeat-on-continuation behavior — removed in lockstep so the pagination budget stays accurate (along with the bookkeeping that only existed to feed it).

## Testing

- `pnpm exec vitest run src/lib/pdfme` — 151 passing (2 unrelated pre-existing environment failures — missing generated Prisma client in this sandbox, not caused by this change)
- `node scripts/complexity-ratchet.mjs` / `knip-ratchet.mjs` / `depcruise-ratchet.mjs` — all hold at baseline
- New tests:
  - `gearflow-table.test.ts`: header draws once on the page a group starts, never again on a continuation page (new `startIndex`/`endIndex` param added to the `runTablePlugin` test harness)
  - `document-composer.test.ts`: full-pipeline test — a single 100-item category spanning 3+ real composed pages draws its header exactly once
  - `structure-line-items.test.ts`: updated Uncategorized-zone fixtures to expect the `"Uncategorized"` label instead of a blank `groupName`

FEATUREDOCS/13-pdfs.md updated with both fixes.

## Checklist

- [x] New dependency? N/A — no new dependencies


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW8WUohvgvShwW7W4gMEiW)_