### PR TITLE
Persist the discount entry mode ($ vs %) so PDFs print the discount as it was entered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,27 @@ classified deliberately. `assertBulkSizeOk(ctx, count)` is async and ctx-taking 
 the same reason: the cap (50 agent / 500 human) has to come from the verified
 identity, not a caller-supplied hint.
 
+### Discount: the AMOUNT is stored, the PERCENTAGE is derived
+`projectLineItems.discount` / `projectGroups.discount` are always the **resolved
+flat dollar amount** — recalc, allocation, invoicing and `lineTotal` read that
+number and nothing else. `discountMode` (`"$" | "%"`, #1012) sits next to it and
+records only how the operator *entered* it, so documents can print `-15%`
+instead of `-$150.00`. Absent = `"$"` (every pre-#1012 row; no backfill).
+
+The percentage itself is **never stored** — `discountCellText`
+(`gearflow-table.ts`) / `discountEntryValue` recompute it from the stored dollar
+amount against the row's own gross. Storing the typed `15` would let a document
+contradict itself once the unit price changed (the dollar amount is frozen at
+save). Don't "fix" that by adding a `discountValue` column.
+
+`discountMode` must never outlive the amount it describes: every write path that
+clears/zeroes `discount` clears the mode too (patchNative, patchManyNative,
+updateGroupPriceNative, and each lifecycle-lock `defaultToZero` branch). The
+mode union + both conversions live in `src/lib/discount-mode.ts` — a plain
+module, so Convex mutations, Zod schemas, the seven add/edit forms and the PDF
+renderer share one definition. `line-item-form-fields.tsx` re-exports them for
+the forms; don't re-declare `"$" | "%"` anywhere else.
+
 ### ⚠️ Quote status is DERIVED — never branch on the stored column
 A quote's `status` column is not the whole answer. `EXPIRED` is computed on read
 (`validUntil < now && status === "SENT"`) and never stored, and the deprecated

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -373,6 +373,19 @@ See [FEATUREDOCS/66-finance-quotes-invoices-xero.md](./66-finance-quotes-invoice
   for the full plumbing list. There is no discount UI at group *creation*
   (`AddGroupToolbarDialog`) — same as `price`, which is also only set
   after creation via one of the two edit surfaces above.
+- `discountMode` (`"$" | "%"`, issue #1012) records **how that discount was
+  entered**, next to the resolved dollar amount. It is display-only — recalc,
+  allocation and invoicing still read `discount` and nothing else — and exists
+  so quote/invoice PDFs can print `-10%` instead of `-$100.00`
+  ([FEATUREDOCS/13](./13-pdfs.md)). Absent on every pre-#1012 row and read as
+  `"$"`, so no backfill was needed. It is written **only alongside the amount
+  it describes**: `updateGroupPriceNative` drops a stale mode when the discount
+  is zeroed, and the lifecycle-lock `defaultToZero` path clears both together.
+  Both edit surfaces seed the toggle *and* the input from the stored mode on
+  open (`discountEntryValue`), so reopening a 10% group shows "10 %" rather
+  than silently rewriting it back to `$`. `LOCKED_GROUP_FIELDS` /
+  `LOCKED_LINE_ITEM_FIELDS` include `discountMode` so a FINANCIAL-scope revert
+  restores the entry shape with the amount.
 - `categoryId` is **nullable since v0.10.0.0** — a group can live in
   the project's Uncategorized zone (mirrors `SubHireGroup.targetCategoryId`).
   The toolbar "Add Group" dialog and per-group Move dialog both offer

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -632,6 +632,46 @@ Three additional behaviours layer onto expand mode:
 - Pull slip: per-unit checkboxes for qty > 1 items, ticked for already-deployed units
 - Per-unit rows (`showPerUnitCheckboxes`): a qty > 1 line expands to one row per assigned unit ("Unit 1 — TTP00042", …) instead of collapsing tags to "tag, tag +N". On for `packing-list`, `return-sheet`, and `delivery-docket` — a single literal in each doc type's `DOCUMENT_LAYOUTS` entry (there is exactly one default source now, not two that have to be kept in sync).
 
+### Discount column prints the discount as it was ENTERED (#1012, 2026-07-28)
+
+The Discount column always resolved to dollars — a line negotiated at "15%"
+printed `-$150.00`, because **discount mode was never persisted anywhere**.
+`resolveDiscountAmount` converted `%` → flat dollars client-side and only the
+resulting number crossed into the mutation, by design (`discount` is the one
+number recalc / invoicing / `lineTotal` all read).
+
+`projectLineItems.discountMode` and `projectGroups.discountMode`
+(`v.optional(enums.DiscountMode)` — `"$" | "%"`) now record the **entry shape**
+alongside that dollar amount. Absent = `"$"`, which is byte-identical to the old
+behaviour, so **no backfill** was needed. Nothing about pricing math changed:
+the mode is display-only.
+
+- **The percentage is DERIVED, never stored.** `discountCellText` in
+  `gearflow-table.ts` recomputes it from the stored dollar amount against the
+  row's own gross (`unitPrice × quantity × duration`, via `lineGrossAmount`).
+  Storing the typed `15` would let a document contradict itself: the dollar
+  amount is frozen at save time, so a later unit-price change would print "15%"
+  next to numbers that say 7.5%. Deriving keeps the printed percentage and the
+  printed line total in agreement by construction, and leaves one source of
+  truth for the discount (R-3.1). A `%` row whose gross is `0` (no percentage
+  is expressible) falls back to the dollar amount.
+- **One helper, three row tiers.** `discountCellText` is shared by the parent,
+  kit/accessory-child and per-unit-grandchild renderers, which previously had
+  three hand-rolled copies of the same `-${formatCurrency(...)}` expression.
+- **Synthetic Project Group rows** carry `discountMode` through
+  `structure-line-items.ts`; the row's `unitPrice`/`quantity`/`duration`
+  (bundle price × qty × 1) are the gross the percentage is measured against.
+- **No pagination impact** — the cell is still a single line at every tier, so
+  `calculateItemHeight` is unchanged (checklist item 2 below: verified, no
+  change required).
+
+The conversions live in `src/lib/discount-mode.ts` (plain module, no
+`"use client"`) so the Convex mutations, the Zod schemas, the seven add/edit
+forms and this renderer all share one definition of the mode union,
+`resolveDiscountAmount`, and its inverse. See
+[FEATUREDOCS/10](./10-projects.md#groups-projectgroup--the-billable-unit) for
+the write side.
+
 ## PDF Data-Shape Consumers (audit checklist)
 
 Any change to the `DocumentLineItem` shape (new field, new synthetic row

--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -259,11 +259,21 @@ three independently hand-rolled implementations (`equipment-add-form`,
 `edit-line-item-dialog`, `bulk-edit-line-items-dialog`) that had quietly
 drifted in exact classes — now `DiscountField` (labelled) and
 `DiscountAmountInput` (bare, for callers with their own label, e.g.
-`bulk-edit-line-items-dialog`'s checkbox-gated rows). The mode is a pure
-client-side display convenience: every caller resolves a `%` value to a
-flat dollar amount before it reaches the schema/mutation — discount is
-*always* persisted as a flat $ amount (see `line-item.ts`'s `discountField`
-and the new `project-group.ts` `discount` field below).
+`bulk-edit-line-items-dialog`'s checkbox-gated rows). Every caller resolves
+a `%` value to a flat dollar amount before it reaches the schema/mutation —
+discount is *always* persisted as a flat $ amount (see `line-item.ts`'s
+`discountField` and the new `project-group.ts` `discount` field below).
+
+> **Superseded in part by #1012** (2026-07-28): the mode is no longer *purely*
+> a client-side display convenience. `discount` is still always the resolved
+> flat dollar amount, but the mode itself is now persisted next to it as
+> `discountMode` (`"$" | "%"`, on `projectLineItems` + `projectGroups`) so
+> quote/invoice PDFs can print the discount the way it was entered. The
+> conversions moved out of this file into `src/lib/discount-mode.ts` (a plain
+> module the Convex mutations, Zod schemas and PDF renderer can all import);
+> `line-item-form-fields.tsx` re-exports them so the forms' imports are
+> unchanged. See [FEATUREDOCS/13](./13-pdfs.md) and
+> [FEATUREDOCS/10](./10-projects.md).
 
 **RHF + Zod everywhere.** `custom-item-add-form.tsx` moved from hand-rolled
 `useState` per field (only `.parse()`d at submit) to

--- a/convex/lib/moneyGuards.ts
+++ b/convex/lib/moneyGuards.ts
@@ -21,6 +21,20 @@ export function assertFinite(value: number | null | undefined, field: string): v
 }
 
 /**
+ * #1012 — reject a `discountMode` that isn't one of the two literals. Mutations
+ * whose arg validator is `enums.DiscountMode` get this for free; this exists for
+ * the untyped surfaces (`patchNative`'s `set: v.any()`, and `patchManyNative`'s
+ * `mode: v.string()` legacy shape), where a browser-direct caller could otherwise
+ * write an arbitrary string into the column and break the PDF's mode switch.
+ */
+export function assertDiscountMode(mode: unknown): void {
+  if (mode == null) return;
+  if (mode !== "$" && mode !== "%") {
+    throw new ConvexError({ code: "INVALID_DISCOUNT_MODE", message: 'Discount mode must be "$" or "%".' });
+  }
+}
+
+/**
  * Validate the numeric line-item fields to the same bounds `lineItemSchema` /
  * `customLineItemSchema` enforce, EXCEPT the two derived values that can legitimately
  * exceed their input caps and so are only checked finite + non-negative:
@@ -36,9 +50,11 @@ export function assertLineMoneyFields(f: {
   quantity?: number | null;
   unitPrice?: number | null;
   discount?: number | null;
+  discountMode?: unknown;
   duration?: number | null;
   lineTotal?: number | null;
 }): void {
+  assertDiscountMode(f.discountMode);
   if (f.quantity != null) {
     // No upper cap — the merge path sums two Zod-capped quantities (see doc above).
     if (!Number.isFinite(f.quantity) || !Number.isInteger(f.quantity) || f.quantity < 1) {

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -94,9 +94,13 @@ export const LOCKED_PROJECT_FIELDS = [
   "discountPercent",
 ] as const;
 
-export const LOCKED_GROUP_FIELDS = ["price", "discount", "rentalPeriod", "rentalQuantity"] as const;
+// `discountMode` (#1012) travels with `discount` in both lists: it is the entry
+// shape of that exact number, so a FINANCIAL-scope revert that restores the
+// dollar amount must restore how it was entered too — otherwise a reverted line
+// keeps printing "%" for a `$` discount (or vice versa).
+export const LOCKED_GROUP_FIELDS = ["price", "discount", "discountMode", "rentalPeriod", "rentalQuantity"] as const;
 
-export const LOCKED_LINE_ITEM_FIELDS = ["unitPrice", "discount", "duration"] as const;
+export const LOCKED_LINE_ITEM_FIELDS = ["unitPrice", "discount", "discountMode", "duration"] as const;
 
 /** `costTotal` is locked only for CREW-LESS services — a crew-attached service's
  *  costTotal keeps auto-deriving from the crew rate table even post-CONFIRMED

--- a/convex/lib/validators.ts
+++ b/convex/lib/validators.ts
@@ -132,6 +132,14 @@ export const SaleMode = v.union(
   v.literal("NEW_STOCK"),
   v.literal("FROM_RENTAL_STOCK"),
 );
+/** #1012 — how the operator ENTERED a discount ($ off, or % of the line/bundle
+ *  gross). `discount` itself is always the resolved flat dollar amount; this is
+ *  the entry shape, kept only so documents can print it back the way it was
+ *  typed. Absent on every pre-#1012 row = `"$"` (see src/lib/discount-mode.ts). */
+export const DiscountMode = v.union(
+  v.literal("$"),
+  v.literal("%"),
+);
 export const PricingType = v.union(
   v.literal("PER_DAY"),
   v.literal("PER_WEEK"),

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -706,6 +706,131 @@ describe("lineItemWrites.addKitNative", () => {
   });
 });
 
+describe("lineItemWrites — discount entry mode (#1012)", () => {
+  // `discount` stays the resolved flat dollar amount everywhere; `discountMode`
+  // records how it was ENTERED so quote/invoice PDFs can print "-15%" instead of
+  // "-$150.00". These lock in that the mode actually LANDS (it used to be
+  // consumed and thrown away) and that it never outlives the amount it describes.
+
+  test("patchManyNative stores the mode alongside the resolved % amount", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT",
+        isKitChild: false, unitPrice: 100, quantity: 2, duration: 1,
+      });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchManyNative, {
+      ids: ["l1"], orgId: ORG, patch: { discount: { mode: "%", value: 15 } },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const l1 = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "l1")).first();
+      expect(l1?.discount).toBe(30); // 15% of the 200.00 gross, resolved server-side
+      expect(l1?.discountMode).toBe("%");
+    });
+  });
+
+  test("patchManyNative clears the mode when the discount is cleared", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT",
+        isKitChild: false, unitPrice: 100, quantity: 2, duration: 1, discount: 30, discountMode: "%",
+      });
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchManyNative, {
+      ids: ["l1"], orgId: ORG, patch: { discount: null },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const l1 = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "l1")).first();
+      expect(l1?.discount).toBeUndefined();
+      // A stale "%" hanging off no amount would print a phantom percentage.
+      expect(l1?.discountMode).toBeUndefined();
+    });
+  });
+
+  test("patchManyNative rejects a mode that isn't one of the two literals", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT",
+        isKitChild: false, unitPrice: 100, quantity: 1, duration: 1,
+      });
+    });
+    // `mode` is a bare v.string() in this mutation's arg shape, so the literal
+    // check has to be explicit — a browser-direct caller could otherwise write
+    // arbitrary text into the column and break the PDF's mode switch.
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchManyNative, {
+        ids: ["l1"], orgId: ORG, patch: { discount: { mode: "pct", value: 15 } },
+        actor: ACTOR, auditId: "log1", now: NOW,
+      }),
+    ).rejects.toThrow(/Discount mode/i);
+  });
+
+  test("patchNative clears the mode whenever the amount is cleared", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT",
+        isKitChild: false, unitPrice: 100, quantity: 1, duration: 1, discount: 15, discountMode: "%",
+      });
+    });
+    // The client only asked to clear `discount`; the server keeps the pair in step.
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, {
+      ...args, set: { quantity: 1 }, clear: ["discount"], entityName: "Light", allowOverbook: false,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.discount).toBeUndefined();
+      expect(li?.discountMode).toBeUndefined();
+    });
+  });
+
+  test("patchNative rejects a bogus mode smuggled through the `set: v.any()` surface", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "li1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT",
+        isKitChild: false, unitPrice: 100, quantity: 1, duration: 1,
+      });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.patchNative, {
+        ...args, set: { discount: 10, discountMode: "EUR" }, clear: [], entityName: "Light", allowOverbook: false,
+      }),
+    ).rejects.toThrow(/Discount mode/i);
+  });
+
+  test("addCustomNative persists the mode with the line", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Rigging", quantity: 1, unitPrice: 500, duration: 1, discount: 50, discountMode: "%" },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.discount).toBe(50);
+      expect(li?.discountMode).toBe("%");
+    });
+  });
+});
+
 describe("lineItemWrites bulk-size cap", () => {
   // Array size, not per-item body, so build cheap oversized arrays inline.
   const bigIds = Array.from({ length: 501 }, (_, i) => `id-${i}`);

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -8,7 +8,7 @@ import { assertWritesEnabled } from "./lib/writeGuard";
 import { enforceBrowserWriteLimit, assertBulkSizeOk } from "./lib/rateLimiter";
 import { assertOverbookAllowed } from "./lib/agentArgs";
 import { sanitizeClientSet } from "./lib/sanitizeSet";
-import { assertLineMoneyFields } from "./lib/moneyGuards";
+import { assertDiscountMode, assertLineMoneyFields } from "./lib/moneyGuards";
 import { assertStrLen, assertArrayMax } from "./lib/fieldGuards";
 import { roundCurrency, computeLineTotal } from "./lib/lineTotal";
 import { writeActivityLog } from "./lib/audit";
@@ -613,8 +613,11 @@ export const patchNative = mutation({
     });
 
     assertLineMoneyFields(setObj as {
-      quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
+      quantity?: number; unitPrice?: number; discount?: number; discountMode?: unknown; duration?: number; lineTotal?: number;
     });
+    // #1012: `discountMode` describes `discount`, so it never outlives it — a patch
+    // that clears the amount clears the mode too, whatever the client sent.
+    if (clear.includes("discount") && !clear.includes("discountMode")) clear.push("discountMode");
     assertLineItemFields(setObj as { description?: string; subhireOrderNumber?: string; xeroAccountCode?: string; xeroTaxType?: string }); // R-8.6.2
 
     // lineTotal is a DERIVED value — assertLineMoneyFields only bounds it, it never
@@ -846,17 +849,25 @@ export const patchManyNative = mutation({
       }
 
       if (patch.discount !== undefined) {
+        // #1012: `mode` used to be consumed here and thrown away — it now lands
+        // in `discountMode` alongside the resolved amount so documents can print
+        // the discount the way it was entered. `mode` arrives as a bare
+        // `v.string()` (pre-#1012 arg shape), so validate it explicitly.
+        assertDiscountMode(patch.discount?.mode);
         let discountApplied: number | undefined;
         if (patch.discount == null || patch.discount.value <= 0) {
           clear.push("discount");
+          clear.push("discountMode");
           discountApplied = undefined;
         } else if (patch.discount.mode === "%") {
           const base = (doc.unitPrice ?? 0) * (doc.quantity ?? 0) * (doc.duration ?? 1);
           discountApplied = roundCurrency((base * patch.discount.value) / 100);
           set.discount = discountApplied;
+          set.discountMode = "%";
         } else {
           discountApplied = patch.discount.value;
           set.discount = discountApplied;
+          set.discountMode = "$";
         }
         // Discount feeds the stored line total — recompute from the item's own
         // price/quantity/duration (unchanged) + the new discount.
@@ -873,7 +884,7 @@ export const patchManyNative = mutation({
       // Belt-and-braces bound-check on the money fields this bulk edit can touch (a
       // browser-direct caller bypasses the server-side Zod).
       assertLineMoneyFields(set as {
-        quantity?: number; unitPrice?: number; discount?: number; duration?: number; lineTotal?: number;
+        quantity?: number; unitPrice?: number; discount?: number; discountMode?: unknown; duration?: number; lineTotal?: number;
       });
 
       if (clear.length === 0) {
@@ -1171,6 +1182,9 @@ export const addCustomNative = mutation({
       pricingType: v.optional(enums.PricingType),
       duration: v.optional(v.number()),
       discount: v.optional(v.number()),
+      // #1012 — entry shape of `discount` (display only; the number above is
+      // still the resolved flat dollar amount every money path reads).
+      discountMode: v.optional(enums.DiscountMode),
       notes: v.optional(v.string()),
       isOptional: v.optional(v.boolean()),
       categoryId: v.optional(v.string()),
@@ -1208,9 +1222,12 @@ export const addCustomNative = mutation({
     if (guard.defaultToZero) {
       fields.unitPrice = 0;
       fields.discount = undefined;
+      fields.discountMode = undefined; // #1012: no amount, no entry shape
     }
 
     assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
+    // #1012: `discountMode` describes `discount` — it never lands without one.
+    if (fields.discount == null) fields.discountMode = undefined;
     // customLineItemSchema bounds (src/lib/validations/line-item.ts): description is
     // required 1-200 chars, notes optional up to 500 — DIFFERENT from lineItemSchema's
     // bounds (assertLineItemFields), so checked inline rather than shared.
@@ -1318,6 +1335,8 @@ export const addNative = mutation({
       pricingType: v.optional(enums.PricingType),
       duration: v.optional(v.number()),
       discount: v.optional(v.number()),
+      // #1012 — entry shape of `discount` (display only).
+      discountMode: v.optional(enums.DiscountMode),
       lineTotal: v.optional(v.number()),
       groupName: v.optional(v.string()),
       notes: v.optional(v.string()),
@@ -1363,9 +1382,12 @@ export const addNative = mutation({
     if (guard.defaultToZero) {
       fields.unitPrice = 0;
       fields.discount = undefined;
+      fields.discountMode = undefined; // #1012: no amount, no entry shape
     }
 
     assertLineMoneyFields(fields); // reject NaN/Infinity/out-of-range before it reaches recalc
+    // #1012: `discountMode` describes `discount` — it never lands without one.
+    if (fields.discount == null) fields.discountMode = undefined;
     assertLineItemFields(fields); // description/subhireOrderNumber length bounds (R-8.6.2)
     assertAccessoryPlanFields(accessoryPlan);
     forceSaleFlatPricing(fields); // WS11 (#950) — SALE always FLAT/duration:1
@@ -1638,6 +1660,8 @@ export const addKitNative = mutation({
     /** Flat $ discount off unitPrice — KIT_PRICE mode only. Mirrors the
      *  equipment/custom line-item discount field (#883). */
     discount: v.optional(v.number()),
+    /** #1012 — entry shape of the discount above (display only). */
+    discountMode: v.optional(enums.DiscountMode),
     pricingMode: enums.KitPricingMode,
     groupName: v.optional(v.string()),
     categoryId: v.optional(v.string()),
@@ -1661,7 +1685,7 @@ export const addKitNative = mutation({
     justification: v.optional(v.string()),
     now: v.number(),
   },
-  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, discount, pricingMode, groupName, categoryId, groupId, kitLabel, emitActivity, actor: suppliedActor, auditId, justification, now }) => {
+  handler: async (ctx, { id, organizationId, projectId, kitId, unitPrice, discount, discountMode, pricingMode, groupName, categoryId, groupId, kitLabel, emitActivity, actor: suppliedActor, auditId, justification, now }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, organizationId, "project", "manage_line_items");
@@ -1676,6 +1700,8 @@ export const addKitNative = mutation({
     const guard = await assertLifecycleGuard(ctx, kitProject, { kind: "structural", justification });
     const effectiveUnitPrice = guard.defaultToZero ? 0 : unitPrice;
     const effectiveDiscount = guard.defaultToZero ? undefined : discount;
+    // #1012: no amount, no entry shape.
+    const effectiveDiscountMode = effectiveDiscount != null ? discountMode : undefined;
 
     // Every other add* mutation in this file bounds unitPrice/lineTotal before insert
     // (assertLineMoneyFields) — this one didn't, so a browser caller sending
@@ -1724,7 +1750,8 @@ export const addKitNative = mutation({
     }
 
     await createKitLineItemCore(ctx, {
-      id, organizationId, projectId, kitId, unitPrice: effectiveUnitPrice, discount: effectiveDiscount, pricingMode, groupName, categoryId, groupId, now,
+      id, organizationId, projectId, kitId, unitPrice: effectiveUnitPrice, discount: effectiveDiscount,
+      discountMode: effectiveDiscountMode, pricingMode, groupName, categoryId, groupId, now,
     });
 
     // Parity with the deleted addKitLineItem: when the client can't resolve the kit
@@ -1889,6 +1916,8 @@ export const addLineItemSmartNative = mutation({
       pricingType: v.optional(enums.PricingType),
       duration: v.optional(v.number()),
       discount: v.optional(v.number()),
+      // #1012 — entry shape of `discount` (display only).
+      discountMode: v.optional(enums.DiscountMode),
       groupName: v.optional(v.string()),
       notes: v.optional(v.string()),
       isOptional: v.optional(v.boolean()),
@@ -2053,6 +2082,10 @@ export const addLineItemSmartNative = mutation({
         // an already-priced existing line also isn't reset to $0 just because it grew.
         const mergeUnitPriceInput = guard.defaultToZero ? undefined : fields.unitPrice;
         const mergeDiscountInput = guard.defaultToZero ? undefined : fields.discount;
+        // #1012: the entry shape follows the amount it describes — when the
+        // client's discount is the one that wins, so is its mode; when the
+        // existing line's amount is kept, its stored mode is kept too.
+        const mergeDiscountModeInput = mergeDiscountInput != null ? fields.discountMode : undefined;
         // lineTotal recomputed server-side (never trusts the client). Mirrors the server
         // merge exactly: parsed value first, else the existing row's value.
         const mergedUnitPrice = mergeUnitPriceInput ?? (existing.unitPrice != null ? Number(existing.unitPrice) : undefined);
@@ -2071,6 +2104,7 @@ export const addLineItemSmartNative = mutation({
           pricingType: fields.pricingType || existing.pricingType,
           duration: fields.duration || existing.duration || undefined,
           discount: mergeDiscountInput ?? existing.discount ?? undefined,
+          discountMode: mergeDiscountModeInput ?? existing.discountMode ?? undefined,
           lineTotal: newLineTotal ?? undefined,
           groupName: fields.groupName || existing.groupName || undefined,
           notes: mergedNotes || undefined,
@@ -2133,6 +2167,8 @@ export const addLineItemSmartNative = mutation({
     let autoDuration = fields.duration;
     let autoPriceBreakdown: string | undefined;
     const insertDiscount = guard.defaultToZero ? undefined : fields.discount;
+    // #1012: no amount, no entry shape (the lock drops both together).
+    const insertDiscountMode = insertDiscount != null ? fields.discountMode : undefined;
     // `== null` (not `!unitPrice`) — an EXPLICIT $0 manual price (a free item) is a real
     // choice and must be kept, not overwritten by the model rate.
     if (fields.type === "SALE") {
@@ -2192,6 +2228,7 @@ export const addLineItemSmartNative = mutation({
       pricingType: fields.pricingType,
       duration: autoDuration ?? undefined,
       discount: insertDiscount ?? undefined,
+      discountMode: insertDiscountMode,
       lineTotal: lineTotal ?? undefined,
       priceBreakdown: autoPriceBreakdown,
       groupName: fields.groupName || undefined,

--- a/convex/projectGroupsWrites.test.ts
+++ b/convex/projectGroupsWrites.test.ts
@@ -302,6 +302,41 @@ describe("projectGroupsWrites.updateGroupPriceNative", () => {
     });
   });
 
+  // #1012 — the ENTRY shape of the discount rides with the amount so quote/
+  // invoice PDFs can print a priced group's discount as "10%" rather than
+  // "-$30.00". Display only: `discount` stays the number recalc reads.
+  test("stores discountMode alongside the resolved discount", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 150, discount: 30, discountMode: "%", now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.discount).toBe(30);
+      expect(g?.discountMode).toBe("%");
+      // The mode is inert for money: 150 × 2 − 30 = 270, + 10% tax = 297.
+      const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(project?.total).toBe(297);
+    });
+  });
+
+  test("drops a stale discountMode when the discount is zeroed", async () => {
+    const t = makeT();
+    await seedPricedGroup(t);
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 150, discount: 30, discountMode: "%", now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 150, discount: 0, now: NOW + 1, actor: ACTOR, auditId: "log2",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.discount).toBe(0);
+      expect(g?.discountMode).toBeUndefined();
+    });
+  });
+
   test("rejects a non-finite discount (NaN/Infinity would poison recalc)", async () => {
     const t = makeT();
     await seedPricedGroup(t);

--- a/convex/projectGroupsWrites.ts
+++ b/convex/projectGroupsWrites.ts
@@ -10,6 +10,7 @@ import { recalcProjectTotals } from "./lib/recalc";
 import { computeGroupSuggestedPrice } from "./lib/suggestedPrice";
 import { assertLifecycleGuard, lifecycleAuditMetadata } from "./lib/projectLocks";
 import { assertStrLen } from "./lib/fieldGuards";
+import * as enums from "./lib/validators";
 
 /**
  * Native PROJECT-GROUP write mutations (Phase 3 browser-direct — replaces the
@@ -224,6 +225,9 @@ export const createGroupNative = mutation({
     quantity: v.optional(v.number()),
     price: v.optional(v.number()),
     discount: v.optional(v.number()),
+    // #1012 — entry shape of the discount above ($ off vs % of `price × quantity`).
+    // Display only; `discount` stays the resolved flat dollar amount.
+    discountMode: v.optional(enums.DiscountMode),
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
@@ -248,6 +252,7 @@ export const createGroupNative = mutation({
     if (guard.defaultToZero) {
       a.price = undefined;
       a.discount = undefined;
+      a.discountMode = undefined; // #1012: no amount, no entry shape
     }
 
     assertValidTitle(a.title);
@@ -293,6 +298,7 @@ export const createGroupNative = mutation({
       quantity,
       price: a.price != null ? a.price : undefined,
       discount: a.discount != null ? a.discount : undefined,
+      discountMode: a.discount != null ? a.discountMode : undefined,
       suggestedPrice: 0,
       sortOrder,
       createdAt: a.now,
@@ -441,6 +447,9 @@ export const updateGroupPriceNative = mutation({
     // or leaves the arg out entirely, mirroring how discount already works for
     // patchNative on line items).
     discount: v.optional(v.number()),
+    // #1012 — entry shape of the discount above. Only meaningful when `discount`
+    // is also supplied; omitted alongside an omitted discount ("leave untouched").
+    discountMode: v.optional(enums.DiscountMode),
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
@@ -461,7 +470,13 @@ export const updateGroupPriceNative = mutation({
     const guard = await assertLifecycleGuard(ctx, priceProject, { kind: "financial" });
 
     const patch: Record<string, unknown> = { price: a.price, updatedAt: a.now };
-    if (a.discount !== undefined) patch.discount = a.discount;
+    if (a.discount !== undefined) {
+      patch.discount = a.discount;
+      // #1012: the mode is written with the amount it describes — a discount set
+      // back to 0 (or with no mode supplied) drops the stale mode rather than
+      // leaving the previous entry shape hanging off a different number.
+      patch.discountMode = a.discount > 0 ? a.discountMode : undefined;
+    }
     await ctx.db.patch(group._id, patch);
 
     await logGroupChange(ctx, {

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -627,6 +627,9 @@ export async function createKitLineItemCore(
     /** Flat dollar amount off `unitPrice`, KIT_PRICE mode only — mirrors how
      *  discount already works for equipment/custom line items. */
     discount?: number;
+    /** #1012 — entry shape of `discount` ($ off vs % of `unitPrice`). Display
+     *  only; stored alongside the resolved dollar amount above. */
+    discountMode?: "$" | "%";
     pricingMode: "KIT_PRICE" | "ITEMIZED";
     groupName?: string;
     categoryId?: string;
@@ -647,7 +650,9 @@ export async function createKitLineItemCore(
     await ctx.db.insert("projectLineItems", {
       id: a.id, organizationId: a.organizationId, projectId: a.projectId, type: "EQUIPMENT", kitId: a.kitId,
       description: `${kit.assetTag} - ${kit.name}`, quantity: 1, unitPrice: a.unitPrice, pricingType: "PER_DAY",
-      duration: 1, discount: a.unitPrice != null ? a.discount : undefined, lineTotal: kitLineTotal, sortOrder: sort++, pricingMode: a.pricingMode,
+      duration: 1, discount: a.unitPrice != null ? a.discount : undefined,
+      discountMode: a.unitPrice != null && a.discount != null ? a.discountMode : undefined,
+      lineTotal: kitLineTotal, sortOrder: sort++, pricingMode: a.pricingMode,
       groupName: a.groupName, categoryId: a.categoryId, groupId: a.groupId, status: "CONFIRMED",
       createdAt: a.now, updatedAt: a.now,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1176,6 +1176,11 @@ export default defineSchema({
     pricingType: v.optional(enums.PricingType),
     duration: v.optional(v.number()),
     discount: v.optional(v.number()),
+    // #1012 — how `discount` was ENTERED ($ off vs % of the line gross). The
+    // number above stays the resolved flat dollar amount every money path
+    // reads; this only lets a document print it back as "15%" instead of
+    // "-$150.00". Absent = "$" (every pre-#1012 row; no backfill needed).
+    discountMode: v.optional(enums.DiscountMode),
     lineTotal: v.optional(v.number()),
     allocatedRevenue: v.optional(v.number()),
     allocationBasis: v.optional(enums.AllocationBasis),
@@ -1354,6 +1359,10 @@ export default defineSchema({
     price: v.optional(v.number()),
     // Flat $ amount off `price × quantity` (#883) — mirrors projectLineItems.discount.
     discount: v.optional(v.number()),
+    // #1012 — mirrors projectLineItems.discountMode: the ENTRY shape of the
+    // discount above ($ off vs % of `price × quantity`), for document display
+    // only. Absent = "$".
+    discountMode: v.optional(enums.DiscountMode),
     suggestedPrice: v.optional(v.number()),
     sortOrder: v.optional(v.number()),
     // WS1 (#940) — Xero account-coding override for a priced group's own

--- a/src/components/projects/custom-item-add-form.tsx
+++ b/src/components/projects/custom-item-add-form.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/ui/select";
 import { DialogFooter } from "@/components/ui/dialog";
 import { PlacementFields } from "./placement-fields";
-import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
+import { SectionTitle, Field, DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 
 type CustomItemPricingType = "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR";
@@ -94,17 +94,16 @@ export function CustomItemAddForm({
 
   const addMut = useServerMutation({
     mutationFn: (data: CustomLineItemFormValues) => {
-      let disc = data.discount;
-      if (discountMode === "%" && disc && data.unitPrice) {
-        const gross = Number(data.unitPrice) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
-        disc = Math.round((gross * Number(disc)) / 100 * 100) / 100;
-      }
+      // #1012: shared conversion + the mode is submitted, not discarded.
+      const gross = Number(data.unitPrice ?? 0) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
+      const disc = resolveDiscountAmount(discountMode, data.discount as number | string | undefined, gross);
       // Browser-direct native path. addCustomNative folds recalc + audit + collab into one
       // transaction; reactive useQuery renders the new row. groupName is resolved locally
       // from the categories the form already holds (no round-trip).
       const parsed = customLineItemSchema.parse({
         ...data,
         discount: disc,
+        discountMode,
         categoryId: categoryId || undefined,
         groupId: groupId || undefined,
       });

--- a/src/components/projects/edit-group-dialog.tsx
+++ b/src/components/projects/edit-group-dialog.tsx
@@ -31,7 +31,13 @@ import { COLLAB_TARGET_TYPES } from "@/lib/collaboration-targets";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xero-coding-fields";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
-import { DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
+import {
+  DiscountField,
+  discountEntryValue,
+  resolveDiscountAmount,
+  toDiscountMode,
+  type DiscountMode,
+} from "./line-item-form-fields";
 import type { GroupData } from "./equipment-rows";
 
 export interface EditGroupFormValues {
@@ -57,6 +63,8 @@ interface EditGroupDialogProps {
     values: EditGroupFormValues,
     price: number | undefined,
     discount: number | undefined,
+    /** #1012 — how `discount` was entered; persisted for document display. */
+    discountMode: DiscountMode | undefined,
   ) => void;
 }
 
@@ -96,8 +104,14 @@ function EditGroupDialogBody({
   const [description, setDescription] = useState(group.description ?? "");
   const [quantity, setQuantity] = useState(String(group.quantity));
   const [price, setPrice] = useState(priceVal != null ? String(priceVal) : "");
-  const [discount, setDiscount] = useState(discountVal != null ? String(discountVal) : "");
-  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
+  // #1012 — reopen showing the discount the way it was ENTERED (a group saved
+  // as 10% comes back as "10" with the `%` toggle), not the resolved dollar
+  // amount with the toggle reset to `$`.
+  const initialDiscountMode = toDiscountMode(group.discountMode);
+  const [discount, setDiscount] = useState(
+    discountEntryValue(discountVal, initialDiscountMode, (priceVal ?? 0) * (group.quantity || 1)),
+  );
+  const [discountMode, setDiscountMode] = useState<DiscountMode>(initialDiscountMode);
   const [xeroAccountCode, setXeroAccountCode] = useState(group.xeroAccountCode ?? "");
   const [xeroTaxType, setXeroTaxType] = useState(group.xeroTaxType ?? "");
   const xeroLinked = useXeroLinked();
@@ -124,6 +138,7 @@ function EditGroupDialogBody({
       },
       resolvedPrice,
       resolvedDiscount,
+      discountMode,
     );
   }
 

--- a/src/components/projects/edit-line-item-dialog.tsx
+++ b/src/components/projects/edit-line-item-dialog.tsx
@@ -45,7 +45,15 @@ import { XeroAccountCodeField, XeroTaxTypeField } from "@/components/settings/xe
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
 import { PlacementFields } from "./placement-fields";
-import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
+import {
+  SectionTitle,
+  Field,
+  DiscountField,
+  discountEntryValue,
+  resolveDiscountAmount,
+  toDiscountMode,
+  type DiscountMode,
+} from "./line-item-form-fields";
 import type { LineItemData, CategoryData } from "./equipment-rows";
 
 export interface EditLineItemPayload {
@@ -56,10 +64,26 @@ export interface EditLineItemPayload {
   pricingType: string;
   duration: number;
   discount?: number;
+  /** #1012 — how the discount above was entered; persisted for document display. */
+  discountMode?: DiscountMode;
   notes?: string;
   isOptional: boolean;
   xeroAccountCode?: string;
   xeroTaxType?: string;
+}
+
+/**
+ * #1012 — reopen the editor showing the discount the way it was ENTERED: a line
+ * saved as 15% comes back as "15" with the toggle on `%`, not as the resolved
+ * dollar amount with the toggle reset to `$` (which would silently rewrite the
+ * stored mode on the next save). The percentage is derived from the stored
+ * dollar amount against the line's current gross — see
+ * `src/lib/discount-mode.ts` for why it isn't stored.
+ */
+function initialDiscountEntry(item: LineItemData): { value: string; mode: DiscountMode } {
+  const mode = toDiscountMode(item.discountMode);
+  const gross = Number(item.unitPrice ?? 0) * Number(item.quantity ?? 1) * Number(item.duration ?? 1);
+  return { value: discountEntryValue(item.discount != null ? Number(item.discount) : null, mode, gross), mode };
 }
 
 export interface EditLineItemPlacement {
@@ -138,6 +162,8 @@ function EditLineItemDialogBody({
   const formDisabled = isLocked;
   const xeroLinked = useXeroLinked();
 
+  const initialDiscount = initialDiscountEntry(item);
+
   const form = useForm<LineItemFormValues>({
     resolver: zodResolver(lineItemSchema),
     defaultValues: {
@@ -147,14 +173,14 @@ function EditLineItemDialogBody({
       unitPrice: item.unitPrice != null ? Number(item.unitPrice) : undefined,
       pricingType: (item.pricingType as LineItemFormValues["pricingType"]) ?? "PER_DAY",
       duration: item.duration ?? 1,
-      discount: item.discount != null && Number(item.discount) > 0 ? Number(item.discount) : undefined,
+      discount: initialDiscount.value !== "" ? Number(initialDiscount.value) : undefined,
       notes: item.notes ?? "",
       isOptional: item.isOptional ?? false,
       xeroAccountCode: item.xeroAccountCode ?? "",
       xeroTaxType: item.xeroTaxType ?? "",
     },
   });
-  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
+  const [discountMode, setDiscountMode] = useState<DiscountMode>(initialDiscount.mode);
   const [overbookConfirmed, setOverbookConfirmed] = useState(false);
 
   // Placement — kit children move with their parent kit, not independently.
@@ -207,10 +233,9 @@ function EditLineItemDialogBody({
     const qty = Number(data.quantity) || 1;
     const price = data.unitPrice != null ? Number(data.unitPrice) : undefined;
     const dur = Number(data.duration) || item.duration || 1;
-    let disc = data.discount != null ? Number(data.discount) : undefined;
-    if (disc && discountMode === "%" && price != null) {
-      disc = Math.round((price * qty * dur * disc) / 100 * 100) / 100;
-    }
+    // #1012: shared conversion (resolveDiscountAmount) + the mode is submitted
+    // alongside the resolved amount instead of being discarded.
+    const disc = resolveDiscountAmount(discountMode, data.discount as number | string | undefined, (price ?? 0) * qty * dur);
     onSubmit(
       item.id,
       {
@@ -221,6 +246,7 @@ function EditLineItemDialogBody({
         pricingType: data.pricingType ?? item.pricingType ?? "PER_DAY",
         duration: dur,
         discount: disc,
+        discountMode,
         notes: data.notes || undefined,
         isOptional: data.isOptional ?? false,
         xeroAccountCode: data.xeroAccountCode || undefined,

--- a/src/components/projects/equipment-add-form.tsx
+++ b/src/components/projects/equipment-add-form.tsx
@@ -42,7 +42,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { ComboboxPicker } from "@/components/ui/combobox-picker";
 import { PlacementFields } from "./placement-fields";
-import { SectionTitle, Field, DiscountField, type DiscountMode } from "./line-item-form-fields";
+import { SectionTitle, Field, DiscountField, resolveDiscountAmount, type DiscountMode } from "./line-item-form-fields";
 import type { CategoryData } from "./equipment-rows";
 import { useActiveOrganization } from "@/lib/auth-client";
 
@@ -209,11 +209,11 @@ export function EquipmentAddForm({
 
   const mutation = useServerMutation({
     mutationFn: async (data: LineItemFormValues) => {
-      let disc = data.discount;
-      if (discountMode === "%" && disc && data.unitPrice) {
-        const gross = Number(data.unitPrice) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
-        disc = Math.round((gross * Number(disc)) / 100 * 100) / 100;
-      }
+      // #1012: one shared conversion (resolveDiscountAmount) instead of a
+      // hand-rolled copy, and the MODE is submitted alongside the resolved
+      // dollar amount so documents can print it back as entered.
+      const gross = Number(data.unitPrice ?? 0) * Number(data.quantity ?? 1) * Number(data.duration ?? 1);
+      const disc = resolveDiscountAmount(discountMode, data.discount as number | string | undefined, gross);
       const effectiveCategoryId = categoryId || selectedCategoryId || undefined;
       const effectiveGroupId = groupId || selectedGroupId || undefined;
       // Browser-direct native path. addLineItemSmartNative folds availability +
@@ -223,6 +223,7 @@ export function EquipmentAddForm({
       const parsed = lineItemSchema.parse({
         ...data,
         discount: disc,
+        discountMode,
         categoryId: effectiveCategoryId,
         groupId: effectiveGroupId,
       });

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -17,6 +17,8 @@ export interface LineItemData {
   pricingType?: string;
   duration?: number;
   discount?: unknown;
+  /** #1012 — how `discount` was entered ("$" | "%"). Absent = "$". */
+  discountMode?: string | null;
   notes?: string | null;
   isOptional?: boolean;
   type?: string;
@@ -70,6 +72,8 @@ export interface GroupData {
   quantity: number;
   price: unknown;
   discount: unknown;
+  /** #1012 — how `discount` was entered ("$" | "%"). Absent = "$". */
+  discountMode?: string | null;
   suggestedPrice: unknown;
   sortOrder: number;
   lineItems?: LineItemData[];

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1155,6 +1155,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                                 quantity: group.quantity,
                                 price: priceVal,
                                 discount: group.discount != null ? Number(group.discount) : null,
+                                discountMode: group.discountMode ?? null,
                               })}
                               onAddEquipment={() => {
                                 setUnifiedAddTarget({ categoryId: cat.id, groupId: group.id, label: `${cat.name} > ${group.title}` });
@@ -1358,6 +1359,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           quantity: group.quantity,
                           price: priceVal,
                           discount: group.discount != null ? Number(group.discount) : null,
+                          discountMode: group.discountMode ?? null,
                         })}
                         onAddEquipment={() => {
                           setUnifiedAddTarget({ groupId: group.id, label: `Uncategorized > ${group.title}` });
@@ -1941,10 +1943,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         projectId={projectId}
         orgId={orgId}
         onClose={() => setEditGroupData(null)}
-        onSubmit={(groupId, values, price, discount) => {
+        onSubmit={(groupId, values, price, discount, discountMode) => {
           updateGroupMut.mutate({ groupId, data: values });
           if (price !== undefined) {
-            groupWrites.updatePrice(groupId, price, discount)
+            groupWrites.updatePrice(groupId, price, discount, discountMode)
               .then(() => invalidate())
               .catch((e: Error) => toast.error(e.message));
           }

--- a/src/components/projects/kit-add-form.tsx
+++ b/src/components/projects/kit-add-form.tsx
@@ -133,6 +133,8 @@ export function KitAddForm({
         pricingMode: kitPricingMode,
         unitPrice: kitUnitPriceResolved,
         discount: kitDiscountResolved,
+        // #1012 — persist the entry shape alongside the resolved amount.
+        discountMode: kitDiscountMode,
         groupName: undefined,
         categoryId: effectiveCategoryId,
         groupId: effectiveGroupId,

--- a/src/components/projects/line-item-form-fields.tsx
+++ b/src/components/projects/line-item-form-fields.tsx
@@ -13,33 +13,20 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn, focusRing } from "@/lib/utils";
+import {
+  discountEntryValue,
+  resolveDiscountAmount,
+  toDiscountMode,
+  type DiscountMode,
+} from "@/lib/discount-mode";
 
-export type DiscountMode = "$" | "%";
-
-/**
- * Resolves a raw discount input to the flat dollar amount the schema/mutation
- * expects — discount is always persisted as a flat $ amount (never a
- * percentage), so every caller needs this same conversion before submit.
- * `%` mode multiplies against `grossAmount` (the pre-discount line/bundle
- * total); `$` mode passes the value through unchanged. Returns `undefined`
- * for blank/zero/invalid input — "nothing to discount".
- */
-export function resolveDiscountAmount(
-  mode: DiscountMode,
-  rawValue: number | string | null | undefined,
-  grossAmount: number,
-): number | undefined {
-  // Blank/unset is distinct from an explicit 0 — a blank field means "no
-  // discount" (or, for callers with an omit-to-preserve mutation like
-  // updateGroupPriceNative, "don't touch the existing discount"), while a
-  // deliberately typed 0 clears/zeroes a previously-set discount. Checking
-  // the raw value BEFORE Number() coercion is what keeps that distinction —
-  // `Number(0)` is falsy too, so a truthiness check alone would collapse them.
-  if (rawValue === "" || rawValue == null) return undefined;
-  const raw = Number(rawValue);
-  if (!Number.isFinite(raw) || raw < 0) return undefined;
-  return mode === "%" ? Math.round(grossAmount * raw) / 100 : raw;
-}
+// The mode union + both conversions live in `src/lib/discount-mode.ts` (#1012)
+// so the Convex mutations, the Zod schemas and the PDF renderer — none of which
+// can import a `"use client"` module — share this file's definitions instead of
+// re-deriving them. Re-exported here so the seven add/edit forms keep their
+// existing single import from this module.
+export { discountEntryValue, resolveDiscountAmount, toDiscountMode };
+export type { DiscountMode };
 
 export function SectionTitle({ title, hint }: { title: string; hint?: string }) {
   return (
@@ -85,10 +72,11 @@ export interface DiscountAmountInputProps {
  * Discount amount input + $/% mode toggle, with no Field/Label wrapper — for
  * callers that supply their own label (e.g. bulk-edit-line-items-dialog's
  * checkbox-gated field rows). Most callers want `DiscountField` below instead.
- * The mode is a pure client-side display convenience — callers are responsible
- * for resolving a `%` value to a dollar amount before it reaches the
- * schema/mutation (discount is always persisted as a flat dollar amount; see
- * `src/lib/validations/line-item.ts`).
+ * Callers are responsible for resolving a `%` value to a dollar amount before
+ * it reaches the schema/mutation (discount is always persisted as a flat dollar
+ * amount; see `src/lib/validations/line-item.ts`) AND for submitting the mode
+ * itself alongside it, so documents can print the discount the way it was
+ * entered (#1012 — see `src/lib/discount-mode.ts`).
  */
 export function DiscountAmountInput({
   id,

--- a/src/components/projects/price-edit-dialog.tsx
+++ b/src/components/projects/price-edit-dialog.tsx
@@ -32,7 +32,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { DiscountField, type DiscountMode } from "./line-item-form-fields";
+import {
+  DiscountField,
+  discountEntryValue,
+  resolveDiscountAmount,
+  toDiscountMode,
+  type DiscountMode,
+} from "./line-item-form-fields";
 
 export type PriceEditTarget =
   | {
@@ -42,6 +48,8 @@ export type PriceEditTarget =
       quantity: number;
       price: number | null;
       discount: number | null;
+      /** #1012 — how `discount` was entered ("$" | "%"). Absent = "$". */
+      discountMode?: string | null;
     }
   | {
       kind: "subHire";
@@ -51,6 +59,16 @@ export type PriceEditTarget =
       cost: number | null;
       charge: number | null;
     };
+
+/** #1012 — the stored discount re-expressed as the operator entered it, for
+ *  seeding the amount input + `$`/`%` toggle. Sub-hire groups have no discount
+ *  field at all (they price by cost/charge), so they seed blank. */
+function initialDiscountEntry(target: PriceEditTarget): { value: string; mode: DiscountMode } {
+  if (target.kind !== "project") return { value: "", mode: "$" };
+  const mode = toDiscountMode(target.discountMode);
+  const gross = Number(target.price ?? 0) * (target.quantity || 1);
+  return { value: discountEntryValue(target.discount, mode, gross), mode };
+}
 
 interface PriceEditDialogProps {
   target: PriceEditTarget | null;
@@ -89,10 +107,12 @@ function PriceEditDialogBody({
   const [priceInput, setPriceInput] = useState<string>(
     target.kind === "project" && target.price != null ? String(target.price) : "",
   );
-  const [discountInput, setDiscountInput] = useState<string>(
-    target.kind === "project" && target.discount != null ? String(target.discount) : "",
-  );
-  const [discountMode, setDiscountMode] = useState<DiscountMode>("$");
+  // #1012 — seed both the value and the toggle from the stored entry shape, so a
+  // group priced at 10% reopens as "10 %" instead of the resolved dollar amount
+  // with the toggle silently reset to "$".
+  const initialDiscount = initialDiscountEntry(target);
+  const [discountInput, setDiscountInput] = useState<string>(initialDiscount.value);
+  const [discountMode, setDiscountMode] = useState<DiscountMode>(initialDiscount.mode);
 
   // Sub-hire-mode state
   const [chargeInput, setChargeInput] = useState<string>(
@@ -106,8 +126,9 @@ function PriceEditDialogBody({
   const subHireWrites = useSubHireWrites();
 
   const projectMut = useServerMutation({
-    mutationFn: ({ groupId, price, discount }: { groupId: string; price: number; discount?: number }) =>
-      groupWrites.updatePrice(groupId, price, discount),
+    mutationFn: ({ groupId, price, discount, discountMode: mode }: {
+      groupId: string; price: number; discount?: number; discountMode?: DiscountMode;
+    }) => groupWrites.updatePrice(groupId, price, discount, mode),
     onSuccess: () => {
       onInvalidate();
       toast.success("Group price updated");
@@ -140,20 +161,15 @@ function PriceEditDialogBody({
   function handleSubmit() {
     if (target.kind === "project") {
       const price = parseFloat(priceInput) || 0;
-      // Resolve a `%` discount to a flat $ amount before it reaches the mutation —
-      // discount is always persisted as a flat dollar amount off price × quantity
-      // (mirrors the line-item discount convention).
-      let discount: number | undefined;
-      if (discountInput) {
-        const raw = parseFloat(discountInput);
-        if (Number.isFinite(raw) && raw > 0) {
-          const gross = price * (target.quantity || 1);
-          discount = discountMode === "%" ? Math.round(gross * raw) / 100 : raw;
-        } else {
-          discount = 0;
-        }
-      }
-      projectMut.mutate({ groupId: target.groupId, price, discount });
+      // #1012: the shared conversion (resolveDiscountAmount) resolves a `%` entry
+      // to the flat dollar amount the mutation stores — and the MODE now travels
+      // with it so documents can print the discount the way it was entered.
+      // `?? 0` keeps the pre-#1012 behaviour of a non-blank-but-invalid entry
+      // ("abc", "-5") clearing the discount rather than leaving it untouched.
+      const discount = discountInput
+        ? resolveDiscountAmount(discountMode, discountInput, price * (target.quantity || 1)) ?? 0
+        : undefined;
+      projectMut.mutate({ groupId: target.groupId, price, discount, discountMode });
     } else {
       subHireMut.mutate();
     }

--- a/src/hooks/use-line-item-writes.ts
+++ b/src/hooks/use-line-item-writes.ts
@@ -6,6 +6,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { useSession, useActiveOrganization } from "@/lib/auth-client";
 import { mapNativeWriteError } from "@/lib/native-writes";
 import { computeLineTotal } from "@/hooks/use-native-line-item-writes";
+import type { DiscountMode } from "@/lib/discount-mode";
 import {
   lineItemSchema,
   customLineItemSchema,
@@ -25,8 +26,10 @@ type ParsedCustomLineItem = z.output<typeof customLineItemSchema>;
  */
 export interface BulkLineItemPatch {
   pricingType?: "PER_DAY" | "PER_WEEK" | "FLAT" | "PER_HOUR" | "OPTIMIZED";
-  /** `null` or a non-positive value clears the discount. `%` is resolved per-item. */
-  discount?: { mode: "$" | "%"; value: number } | null;
+  /** `null` or a non-positive value clears the discount. `%` is resolved per-item.
+   *  The `mode` is ALSO persisted (as `discountMode`) so documents can print the
+   *  discount the way it was entered (#1012). */
+  discount?: { mode: DiscountMode; value: number } | null;
   /** `null`/empty clears the note. */
   notes?: string | null;
   isOptional?: boolean;
@@ -80,6 +83,9 @@ function buildAddFields(parsed: ParsedLineItem) {
     pricingType: parsed.pricingType,
     duration: parsed.duration ?? undefined,
     discount: parsed.discount ?? undefined,
+    // #1012 — the entry shape rides with the resolved amount. The mutations
+    // enforce "no amount, no mode" server-side, so no client-side guard here.
+    discountMode: parsed.discountMode,
     groupName: parsed.groupName || undefined,
     notes: parsed.notes || undefined,
     isOptional: parsed.isOptional,
@@ -131,6 +137,11 @@ export function buildLineItemSetClear(parsed: ParsedLineItem): {
   setStr("description", parsed.description);
   setNum("unitPrice", parsed.unitPrice ?? null);
   setNum("discount", parsed.discount ?? null);
+  // #1012 — `discountMode` is set/cleared in lockstep with `discount` (it
+  // describes that exact number, so it must never outlive it). patchNative
+  // re-asserts the same invariant server-side.
+  if (parsed.discount != null) set.discountMode = parsed.discountMode ?? "$";
+  else clear.push("discountMode");
   setNum("lineTotal", lineTotal);
   setStr("groupName", parsed.groupName);
   setStr("notes", parsed.notes);
@@ -234,6 +245,7 @@ export function useLineItemWrites() {
             pricingType: parsed.pricingType,
             duration: parsed.duration,
             discount: parsed.discount ?? undefined,
+            discountMode: parsed.discountMode,
             notes: parsed.notes ?? undefined,
             isOptional: parsed.isOptional,
             categoryId: parsed.categoryId ?? undefined,
@@ -260,6 +272,8 @@ export function useLineItemWrites() {
         pricingMode: "KIT_PRICE" | "ITEMIZED";
         unitPrice?: number;
         discount?: number;
+        /** #1012 — how `discount` was entered; stored for document display. */
+        discountMode?: DiscountMode;
         groupName?: string;
         categoryId?: string;
         groupId?: string;
@@ -274,6 +288,7 @@ export function useLineItemWrites() {
           kitId,
           unitPrice: opts.unitPrice ?? undefined,
           discount: opts.discount ?? undefined,
+          discountMode: opts.discount != null ? opts.discountMode : undefined,
           pricingMode: opts.pricingMode,
           groupName: opts.groupName || undefined,
           categoryId: opts.categoryId || undefined,

--- a/src/hooks/use-project-groups-writes.ts
+++ b/src/hooks/use-project-groups-writes.ts
@@ -4,6 +4,7 @@ import { useMutation } from "convex/react";
 import { createId } from "@paralleldrive/cuid2";
 import { useSession, useActiveOrganization } from "@/lib/auth-client";
 import { api } from "../../convex/_generated/api";
+import type { DiscountMode } from "@/lib/discount-mode";
 
 /**
  * Browser-direct PROJECT-GROUP writes (Phase 3 — replaces the create/update/
@@ -73,12 +74,19 @@ export function useProjectGroupWrites() {
       });
     },
 
-    updatePrice: async (groupId: string, price: number, discount?: number): Promise<void> => {
+    updatePrice: async (
+      groupId: string,
+      price: number,
+      discount?: number,
+      /** #1012 — how `discount` was entered; persisted for document display. */
+      discountMode?: DiscountMode,
+    ): Promise<void> => {
       await updatePriceM({
         id: groupId,
         orgId: requireOrg(),
         price,
         discount,
+        discountMode: discount != null ? discountMode : undefined,
         now: Date.now(),
         actor: actor(),
         auditId: createId(),

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -20366,7 +20366,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "privilegedArgs": [
       "justification"
     ],
-    "argsSha": "6e40b4ae9447367f",
+    "argsSha": "9398503fdb975de4",
     "returnsSha": "8b114161049d5d20"
   },
   {
@@ -20404,6 +20404,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "name": "discount",
         "optional": true,
         "type": "number"
+      },
+      {
+        "name": "discountMode",
+        "optional": true,
+        "type": "union"
       },
       {
         "name": "emitActivity",
@@ -20474,7 +20479,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "privilegedArgs": [
       "justification"
     ],
-    "argsSha": "a17baf9e971bdc2e",
+    "argsSha": "55cfc9c05853293e",
     "returnsSha": "8b114161049d5d20"
   },
   {
@@ -20573,7 +20578,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
       "forceSeparate",
       "justification"
     ],
-    "argsSha": "3e1600f51d7419c8",
+    "argsSha": "5770d4dbaf53b101",
     "returnsSha": "6f1a1d586199c07b"
   },
   {
@@ -20661,7 +20666,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
       "allowOverbook",
       "justification"
     ],
-    "argsSha": "311a0467d2110601",
+    "argsSha": "44de6ce05a129219",
     "returnsSha": "b462b96a443b48b3"
   },
   {
@@ -27885,6 +27890,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "number"
       },
       {
+        "name": "discountMode",
+        "optional": true,
+        "type": "union"
+      },
+      {
         "name": "id",
         "optional": false,
         "type": "string"
@@ -27928,7 +27938,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "privilegedArgs": [
       "justification"
     ],
-    "argsSha": "2cc9d4c58527033e",
+    "argsSha": "03cef26c41f3f16d",
     "returnsSha": "e2697643f2e08227"
   },
   {
@@ -28266,6 +28276,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "number"
       },
       {
+        "name": "discountMode",
+        "optional": true,
+        "type": "union"
+      },
+      {
         "name": "id",
         "optional": false,
         "type": "string"
@@ -28287,7 +28302,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
       }
     ],
     "privilegedArgs": [],
-    "argsSha": "380f9941af80e6a8",
+    "argsSha": "80d77a6e0365a610",
     "returnsSha": "efde83ecf2efd768"
   },
   {

--- a/src/lib/discount-mode.test.ts
+++ b/src/lib/discount-mode.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the discount entry-mode conversions (#1012).
+ *
+ * The property that matters: `resolveDiscountAmount` and `discountPercentOf`
+ * are inverses over the values a form can produce, so a discount entered as
+ * `15%` resolves to a dollar amount that renders back as `15%` — the printed
+ * percentage and the printed line total never contradict each other.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  DISCOUNT_MODES,
+  discountEntryValue,
+  discountPercentOf,
+  isDiscountMode,
+  lineGrossAmount,
+  resolveDiscountAmount,
+} from "./discount-mode";
+
+describe("DISCOUNT_MODES / isDiscountMode", () => {
+  it("is exactly the two literals the schema and Convex validator accept", () => {
+    expect(DISCOUNT_MODES).toEqual(["$", "%"]);
+  });
+
+  it("narrows only the two literals", () => {
+    expect(isDiscountMode("$")).toBe(true);
+    expect(isDiscountMode("%")).toBe(true);
+    for (const bad of ["", "pct", "USD", 0, null, undefined, {}]) {
+      expect(isDiscountMode(bad)).toBe(false);
+    }
+  });
+});
+
+describe("resolveDiscountAmount", () => {
+  it("passes a $ entry through unchanged", () => {
+    expect(resolveDiscountAmount("$", 40, 1000)).toBe(40);
+    expect(resolveDiscountAmount("$", "40.5", 1000)).toBe(40.5);
+  });
+
+  it("multiplies a % entry against the gross, rounded to cents", () => {
+    expect(resolveDiscountAmount("%", 15, 1000)).toBe(150);
+    expect(resolveDiscountAmount("%", 7.5, 333.33)).toBe(25);
+  });
+
+  it("distinguishes a blank field from a deliberate 0", () => {
+    // Blank = "no discount" / "don't touch it"; a typed 0 CLEARS an existing one.
+    expect(resolveDiscountAmount("$", "", 1000)).toBeUndefined();
+    expect(resolveDiscountAmount("$", null, 1000)).toBeUndefined();
+    expect(resolveDiscountAmount("$", undefined, 1000)).toBeUndefined();
+    expect(resolveDiscountAmount("$", 0, 1000)).toBe(0);
+    expect(resolveDiscountAmount("%", "0", 1000)).toBe(0);
+  });
+
+  it("rejects garbage and negatives rather than storing them", () => {
+    expect(resolveDiscountAmount("$", "abc", 1000)).toBeUndefined();
+    expect(resolveDiscountAmount("%", -5, 1000)).toBeUndefined();
+  });
+});
+
+describe("discountPercentOf", () => {
+  it("inverts resolveDiscountAmount's % branch", () => {
+    for (const [pct, gross] of [
+      [15, 1000],
+      [7.5, 480],
+      [33.33, 900],
+      [100, 250],
+    ] as const) {
+      const amount = resolveDiscountAmount("%", pct, gross)!;
+      expect(discountPercentOf(amount, gross)).toBe(pct);
+    }
+  });
+
+  it("returns null when there is nothing to express as a percentage", () => {
+    expect(discountPercentOf(null, 1000)).toBeNull();
+    expect(discountPercentOf(0, 1000)).toBeNull();
+    // A $0-gross row: a percentage would be Infinity/NaN, so callers fall back
+    // to rendering the dollar amount instead.
+    expect(discountPercentOf(50, 0)).toBeNull();
+    expect(discountPercentOf(50, null)).toBeNull();
+  });
+});
+
+describe("lineGrossAmount", () => {
+  it("mirrors the lineTotal gross term (unitPrice × quantity × duration)", () => {
+    expect(lineGrossAmount({ unitPrice: 20, quantity: 5, duration: 2 })).toBe(200);
+  });
+
+  it("treats an absent duration as 1 and an absent price/quantity as 0", () => {
+    expect(lineGrossAmount({ unitPrice: 20, quantity: 5 })).toBe(100);
+    expect(lineGrossAmount({ quantity: 5, duration: 2 })).toBe(0);
+    // A synthetic Project Group row carries its bundle price as unitPrice.
+    expect(lineGrossAmount({ unitPrice: 500, quantity: 2, duration: 1 })).toBe(1000);
+  });
+});
+
+describe("discountEntryValue", () => {
+  it("re-displays a % discount as the percentage that was entered", () => {
+    const gross = 1000;
+    const stored = resolveDiscountAmount("%", 15, gross)!;
+    expect(discountEntryValue(stored, "%", gross)).toBe("15");
+  });
+
+  it("re-displays a $ discount as the dollar amount", () => {
+    expect(discountEntryValue(150, "$", 1000)).toBe("150");
+  });
+
+  it("treats an absent mode as $ — every pre-#1012 row", () => {
+    expect(discountEntryValue(150, null, 1000)).toBe("150");
+    expect(discountEntryValue(150, undefined, 1000)).toBe("150");
+  });
+
+  it("falls back to the dollar amount when a % row has no gross", () => {
+    expect(discountEntryValue(50, "%", 0)).toBe("50");
+  });
+
+  it("returns a blank string for no discount", () => {
+    expect(discountEntryValue(null, "%", 1000)).toBe("");
+    expect(discountEntryValue(0, "$", 1000)).toBe("");
+  });
+});

--- a/src/lib/discount-mode.ts
+++ b/src/lib/discount-mode.ts
@@ -1,0 +1,125 @@
+/**
+ * Discount entry mode ($ vs %) — the single source of truth for the literal
+ * union, the two conversions between an entered discount and the flat dollar
+ * amount every money path stores, and the display string documents render.
+ *
+ * ## Why a mode is persisted at all (#1012)
+ *
+ * `discount` is, and stays, a flat dollar amount everywhere: recalc, invoicing,
+ * `lineTotal` derivation and the Xero push all read that one number. What was
+ * missing was the *shape of the entry* — a line discounted "15%" and a line
+ * discounted "$150" are indistinguishable once resolved, so a quote PDF could
+ * only ever print `-$150.00` even when the operator (and the client they
+ * negotiated with) think in percent. `discountMode` records which one the
+ * operator typed.
+ *
+ * ## Why the percentage is DERIVED, not stored
+ *
+ * Only the mode is persisted — never the raw `15`. The percentage shown on a
+ * document is always recomputed from the stored dollar amount against the
+ * row's own gross (`discountPercentOf`). That is deliberate: the dollar amount
+ * is frozen at save time (see `resolveDiscountAmount`), so if the unit price
+ * later changes, a stored `15` would print "15%" next to a line whose numbers
+ * say 7.5% — a client-facing document contradicting itself. Deriving keeps the
+ * printed percentage and the printed totals in agreement by construction, and
+ * it means there is no second copy of the same fact to keep in sync (R-3.1).
+ *
+ * Rows written before #1012 have no mode; absent is treated as `"$"`
+ * everywhere, which is byte-identical to the old behaviour (no backfill).
+ */
+
+export const DISCOUNT_MODES = ["$", "%"] as const;
+
+export type DiscountMode = (typeof DISCOUNT_MODES)[number];
+
+/** Narrowing guard for the `v.any()` / unknown boundaries (patchNative's `set`). */
+export function isDiscountMode(value: unknown): value is DiscountMode {
+  return value === "$" || value === "%";
+}
+
+/** A stored/untrusted mode coerced to one of the two literals, defaulting to
+ *  `"$"` — the reading every consumer applies to a pre-#1012 row (absent mode)
+ *  and to anything unrecognised. */
+export function toDiscountMode(value: unknown): DiscountMode {
+  return isDiscountMode(value) ? value : "$";
+}
+
+/**
+ * Resolves a raw discount input to the flat dollar amount the schema/mutation
+ * expects — discount is always persisted as a flat $ amount (never a
+ * percentage), so every caller needs this same conversion before submit.
+ * `%` mode multiplies against `grossAmount` (the pre-discount line/bundle
+ * total); `$` mode passes the value through unchanged. Returns `undefined`
+ * for blank/zero/invalid input — "nothing to discount".
+ */
+export function resolveDiscountAmount(
+  mode: DiscountMode,
+  rawValue: number | string | null | undefined,
+  grossAmount: number,
+): number | undefined {
+  // Blank/unset is distinct from an explicit 0 — a blank field means "no
+  // discount" (or, for callers with an omit-to-preserve mutation like
+  // updateGroupPriceNative, "don't touch the existing discount"), while a
+  // deliberately typed 0 clears/zeroes a previously-set discount. Checking
+  // the raw value BEFORE Number() coercion is what keeps that distinction —
+  // `Number(0)` is falsy too, so a truthiness check alone would collapse them.
+  if (rawValue === "" || rawValue == null) return undefined;
+  const raw = Number(rawValue);
+  if (!Number.isFinite(raw) || raw < 0) return undefined;
+  return mode === "%" ? Math.round(grossAmount * raw) / 100 : raw;
+}
+
+/**
+ * The inverse of `resolveDiscountAmount`'s `%` branch: what percentage of
+ * `grossAmount` the stored flat `discount` represents, rounded to 2dp.
+ *
+ * Returns `null` when there is nothing meaningful to express as a percentage —
+ * no discount, or a zero/negative/non-finite gross (a $0 line discounted by a
+ * dollar amount has no percentage; callers fall back to the `$` rendering).
+ */
+export function discountPercentOf(
+  discount: number | null | undefined,
+  grossAmount: number | null | undefined,
+): number | null {
+  if (discount == null || !Number.isFinite(discount) || discount <= 0) return null;
+  if (grossAmount == null || !Number.isFinite(grossAmount) || grossAmount <= 0) return null;
+  return Math.round((discount / grossAmount) * 10000) / 100;
+}
+
+/**
+ * The pre-discount total a `%` discount is measured against, for a single line
+ * item. Mirrors `computeLineTotal`/`calcLineTotalNative`'s gross term
+ * (`unitPrice × quantity × duration`) — the same base the forms hand to
+ * `resolveDiscountAmount`. A synthetic Project Group row carries its bundle
+ * price as `unitPrice` with `duration: 1`, so the same formula covers it.
+ */
+export function lineGrossAmount(item: {
+  unitPrice?: number | null;
+  quantity?: number | null;
+  duration?: number | null;
+}): number {
+  const unitPrice = Number(item.unitPrice ?? 0);
+  const quantity = Number(item.quantity ?? 0);
+  const duration = Number(item.duration ?? 1);
+  if (!Number.isFinite(unitPrice) || !Number.isFinite(quantity) || !Number.isFinite(duration)) return 0;
+  return unitPrice * quantity * (duration || 1);
+}
+
+/**
+ * The discount as the operator entered it, for re-display in an edit form:
+ * the percentage when the row was entered in `%` mode (derived — see the file
+ * header), otherwise the flat dollar amount. Returns `""` for "no discount",
+ * which is what the form inputs expect for a blank field.
+ */
+export function discountEntryValue(
+  discount: number | null | undefined,
+  mode: DiscountMode | null | undefined,
+  grossAmount: number,
+): string {
+  if (discount == null || !(discount > 0)) return "";
+  if (mode === "%") {
+    const pct = discountPercentOf(discount, grossAmount);
+    if (pct != null) return String(pct);
+  }
+  return String(discount);
+}

--- a/src/lib/line-item-count-read.test.ts
+++ b/src/lib/line-item-count-read.test.ts
@@ -43,6 +43,7 @@ function li(over: Partial<MappedLineItem>): MappedLineItem {
     pricingType: "PER_DAY",
     duration: 1,
     discount: null,
+    discountMode: null,
     lineTotal: null,
     priceBreakdown: null,
     priceOverridden: false,

--- a/src/lib/pdfme/plugins/gearflow-table.test.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.test.ts
@@ -10,6 +10,10 @@
  */
 import { describe, it, expect } from "vitest";
 import { runTablePlugin, makeLineItem } from "./test-utils";
+import {
+  structureLineItems,
+  type CategoryForStructuring,
+} from "../structure-line-items";
 
 describe("gearflowTable — Project Group rendering", () => {
   it("group parent with childLineItems renders the parent name in bold", async () => {
@@ -437,5 +441,144 @@ describe("gearflowTable — per-item Discount column (quote/invoice)", () => {
     // standalone "-" draw call must be the discount cell's placeholder.
     expect(calls.drawText.some((c) => c.text === "-")).toBe(true);
     expect(calls.drawText.some((c) => c.text.startsWith("-$"))).toBe(false);
+  });
+
+  // #1012 — the column prints the discount the way it was ENTERED.
+  it("renders a percentage when the line was discounted in % mode", async () => {
+    const items = [
+      makeLineItem({
+        id: "li-1",
+        model: { name: "USB Pro DI" },
+        unitPrice: 20,
+        quantity: 5,
+        duration: 2,
+        // 15% of the 200.00 gross.
+        discount: 30,
+        discountMode: "%",
+        lineTotal: 170,
+      }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showPricing: true });
+    expect(calls.drawText.some((c) => c.text === "-15%")).toBe(true);
+    expect(calls.drawText.some((c) => c.text === "-$30.00")).toBe(false);
+  });
+
+  it("falls back to the dollar amount for a pre-#1012 row with no stored mode", async () => {
+    const items = [
+      makeLineItem({ id: "li-1", model: { name: "USB Pro DI" }, unitPrice: 20, quantity: 5, duration: 2, discount: 30, lineTotal: 170 }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showPricing: true });
+    expect(calls.drawText.some((c) => c.text === "-$30.00")).toBe(true);
+    expect(calls.drawText.some((c) => c.text.endsWith("%"))).toBe(false);
+  });
+
+  it("falls back to the dollar amount when a % row has no gross to measure against", async () => {
+    // A $0-priced line can't express its discount as a percentage — printing
+    // "-Infinity%" / "-0%" would be worse than the amount it actually is.
+    const items = [
+      makeLineItem({ id: "li-1", model: { name: "USB Pro DI" }, unitPrice: 0, quantity: 1, duration: 1, discount: 5, discountMode: "%", lineTotal: 0 }),
+    ];
+
+    const calls = await runTablePlugin(items, { documentType: "quote", showPricing: true });
+    expect(calls.drawText.some((c) => c.text === "-$5.00")).toBe(true);
+  });
+
+  it("renders a kit child's % discount as a percentage too", async () => {
+    const items = [
+      makeLineItem({
+        id: "kit-1",
+        kitId: "k1",
+        model: { name: "Small PA Kit" },
+        unitPrice: 100,
+        lineTotal: 100,
+        childLineItems: [
+          makeLineItem({
+            id: "child-1",
+            isKitChild: true,
+            model: { name: "K10.2" },
+            unitPrice: 50,
+            quantity: 2,
+            duration: 1,
+            discount: 20,
+            discountMode: "%",
+            lineTotal: 80,
+          }),
+        ],
+      }),
+    ];
+
+    const calls = await runTablePlugin(items, {
+      documentType: "quote",
+      showPricing: true,
+      showKitChildren: true,
+    });
+    expect(calls.drawText.some((c) => c.text === "-20%")).toBe(true);
+  });
+});
+
+// CLAUDE.md's PDF rule: a DocumentLineItem shape change needs at least one test
+// that runs the FULL pipeline, not just the plugin in isolation — a plugin-only
+// assertion would pass even if structureLineItems never populated the new field.
+describe("gearflowTable — discount entry mode end-to-end (#1012)", () => {
+  it("a % -discounted Project Group prints as a percentage on a quote", async () => {
+    const categories: CategoryForStructuring[] = [
+      {
+        id: "cat-1",
+        name: "Lighting",
+        sortOrder: 0,
+        groups: [
+          {
+            id: "grp-1",
+            title: "Lighting Package",
+            description: null,
+            sortOrder: 0,
+            quantity: 2,
+            price: 500,
+            // 10% of the 1,000.00 bundle gross.
+            discount: 100,
+            discountMode: "%",
+          },
+        ],
+      },
+    ];
+
+    const structured = structureLineItems([], categories);
+    const calls = await runTablePlugin(structured, { documentType: "quote", showPricing: true });
+
+    expect(calls.drawText.some((c) => c.text === "-10%")).toBe(true);
+    expect(calls.drawText.some((c) => c.text === "-$100.00")).toBe(false);
+    // The printed total still comes from the stored dollar amount — the mode is
+    // display-only, so the percentage and the total agree by construction.
+    expect(calls.drawText.some((c) => c.text === "$900.00")).toBe(true);
+  });
+
+  it("a $ -discounted Project Group still prints the dollar amount", async () => {
+    const categories: CategoryForStructuring[] = [
+      {
+        id: "cat-1",
+        name: "Lighting",
+        sortOrder: 0,
+        groups: [
+          {
+            id: "grp-1",
+            title: "Lighting Package",
+            description: null,
+            sortOrder: 0,
+            quantity: 2,
+            price: 500,
+            discount: 100,
+            discountMode: "$",
+          },
+        ],
+      },
+    ];
+
+    const structured = structureLineItems([], categories);
+    const calls = await runTablePlugin(structured, { documentType: "quote", showPricing: true });
+
+    expect(calls.drawText.some((c) => c.text === "-$100.00")).toBe(true);
+    expect(calls.drawText.some((c) => c.text.endsWith("%"))).toBe(false);
   });
 });

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -15,6 +15,32 @@ import {
 } from "./helpers";
 import type { DocumentLineItem, TablePluginConfig } from "../types";
 import { parsePriceBreakdown, formatPriceBreakdown } from "@/lib/billing-derivation";
+import { discountPercentOf, lineGrossAmount } from "@/lib/discount-mode";
+
+/**
+ * The Discount cell's text for one row (#1012) — the discount printed the way
+ * the operator entered it: `-15%` for a line discounted by percentage, and
+ * `-$40.00` for a flat amount. `"-"` when the row carries no discount.
+ *
+ * `discountMode` is the ENTRY shape; the percentage itself is derived here from
+ * the stored dollar amount against the row's own gross, so the printed percent
+ * and the printed line total can never contradict each other (see
+ * `src/lib/discount-mode.ts`). A row with no stored mode — every row written
+ * before #1012 — prints the dollar amount, exactly as it did before.
+ *
+ * Shared by all three renderers in this file (parent rows, kit/accessory
+ * children, per-unit grandchildren) so the three can never drift apart.
+ */
+function discountCellText(item: DocumentLineItem): string {
+  if (!item.discount) return "-";
+  if (item.discountMode === "%") {
+    const pct = discountPercentOf(item.discount, lineGrossAmount(item));
+    // A $0-gross row has no meaningful percentage — fall back to the amount
+    // rather than printing a nonsense "-0%" / "-Infinity%".
+    if (pct != null) return `-${pct}%`;
+  }
+  return `-${formatCurrency(item.discount)}`;
+}
 
 /** Formatted breakdown label for a line, or "" when there's nothing to show
  *  (no stored breakdown, malformed JSON, or a manually-priced line). Shared by
@@ -573,7 +599,7 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
 
           case "discount": {
             if (!config.showPricing) break;
-            const discStr = !isItemized && item.discount ? `-${formatCurrency(item.discount)}` : "-";
+            const discStr = !isItemized ? discountCellText(item) : "-";
             const discWidth = fonts.regular.widthOfTextAtSize(discStr, fontSize);
             page.drawText(discStr, {
               x: colEndX - discWidth - cellPadding,
@@ -825,7 +851,7 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
 
               case "discount": {
                 if (!config.showPricing) break;
-                const discStr = child.discount ? `-${formatCurrency(child.discount)}` : "-";
+                const discStr = discountCellText(child);
                 const discWidth = fonts.regular.widthOfTextAtSize(discStr, childFontSize);
                 page.drawText(discStr, {
                   x: colEndX - discWidth - cellPadding,
@@ -1006,7 +1032,7 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
 
                   case "discount": {
                     if (!config.showPricing) break;
-                    const dStr = nested.discount ? `-${formatCurrency(nested.discount)}` : "-";
+                    const dStr = discountCellText(nested);
                     const dW = fonts.regular.widthOfTextAtSize(dStr, grandchildFontSize);
                     page.drawText(dStr, {
                       x: colEndX - dW - cellPadding,

--- a/src/lib/pdfme/structure-line-items.test.ts
+++ b/src/lib/pdfme/structure-line-items.test.ts
@@ -148,6 +148,41 @@ describe("structureLineItems — Phase 0 baseline", () => {
     expect(result[0].discount).toBe(200);
   });
 
+  // #1012 — the synthetic group row must carry the ENTRY shape too, or a priced
+  // group's discount always prints as dollars even when it was entered as a
+  // percentage (the row is built here, not mapped from a line-item doc).
+  it("carries a Project Group's discountMode onto the synthetic row", () => {
+    const categories: CategoryForStructuring[] = [
+      makeCategory("cat-1", "Lighting", 0, [
+        makeGroup("grp-1", "Lighting Package", 0, {
+          quantity: 2, price: 500, discount: 100, discountMode: "%",
+        }),
+      ]),
+    ];
+    const result = structureLineItems([], categories);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].discount).toBe(100);
+    expect(result[0].discountMode).toBe("%");
+    // The row's own gross (unitPrice × quantity × duration) is the base the
+    // renderer derives the percentage from: 500 × 2 × 1 = 1000 → 10%.
+    expect(result[0].unitPrice).toBe(500);
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].duration).toBe(1);
+  });
+
+  it("drops the mode when a Project Group has no discount", () => {
+    const categories: CategoryForStructuring[] = [
+      makeCategory("cat-1", "Lighting", 0, [
+        makeGroup("grp-1", "Lighting Package", 0, { quantity: 1, price: 500, discountMode: "%" }),
+      ]),
+    ];
+    const result = structureLineItems([], categories);
+
+    expect(result[0].discount).toBeNull();
+    expect(result[0].discountMode).toBeNull();
+  });
+
   it("clamps a Project Group's discount at 0 rather than going negative", () => {
     const categories: CategoryForStructuring[] = [
       makeCategory("cat-1", "Lighting", 0, [

--- a/src/lib/pdfme/structure-line-items.ts
+++ b/src/lib/pdfme/structure-line-items.ts
@@ -57,6 +57,9 @@ export interface CategoryForStructuring {
     quantity: number;
     price: number | null;
     discount: number | null;
+    /** #1012 — how `discount` was entered; carried onto the synthetic group row
+     *  so the Discount column can print "10%" instead of "-$120.00". */
+    discountMode?: "$" | "%" | null;
     sortOrder: number;
   }>;
 }
@@ -289,6 +292,7 @@ export function structureLineItems(
         pricingType: "FLAT",
         duration: 1,
         discount: discount > 0 ? discount : null,
+        discountMode: discount > 0 ? group.discountMode ?? null : null,
         lineTotal: total,
         groupName: bucketLabel,
         categoryName: cat.name,

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -42,6 +42,15 @@ export interface DocumentLineItem {
   pricingType: string;
   duration: number;
   discount: number | null;
+  /**
+   * #1012 — how the operator ENTERED `discount`: `"%"` off the line's gross, or
+   * a flat `"$"` amount. `discount` itself is always the resolved dollar amount;
+   * this only drives how the Discount column prints it. Absent/null (every row
+   * written before #1012) renders as `"$"`, which is exactly the old behaviour.
+   * The percentage shown is DERIVED from `discount` against the row's own gross
+   * — see `src/lib/discount-mode.ts` for why it isn't stored.
+   */
+  discountMode?: "$" | "%" | null;
   lineTotal: number | null;
   priceBreakdown?: string | null;
   priceOverridden?: boolean;

--- a/src/lib/project-equipment-reconstruct.ts
+++ b/src/lib/project-equipment-reconstruct.ts
@@ -37,6 +37,14 @@ type GroupDoc = Doc<"projectGroups">;
 
 // ─── Date helpers ───────────────────────────────────────────────────────────
 
+/** Convex's "field absent" (`undefined`) → the Prisma row shape's `null`. One
+ *  helper rather than a `?? null` per field — the mapper below is a straight
+ *  field-for-field projection, and the repeated null-coalescing was all this
+ *  function's cyclomatic complexity (R-3.6). */
+function orNull<T>(value: T | undefined | null): T | null {
+  return value ?? null;
+}
+
 /** epoch-ms (Convex) → `Date`; absent/`null` → `null`. */
 function msToDate(n: number | null | undefined): Date | null {
   return n == null ? null : new Date(n);
@@ -157,6 +165,8 @@ export interface MappedLineItem {
   pricingType: string;
   duration: number;
   discount: number | null;
+  /** #1012 — how `discount` was ENTERED. Null = `"$"` (every pre-#1012 row). */
+  discountMode: "$" | "%" | null;
   lineTotal: number | null;
   priceBreakdown: string | null;
   priceOverridden: boolean;
@@ -217,6 +227,7 @@ export function mapLineItemDoc(d: LineItemDoc): MappedLineItem {
     pricingType: d.pricingType ?? "PER_DAY",
     duration: d.duration ?? 1,
     discount: d.discount ?? null,
+    discountMode: d.discountMode ?? null,
     lineTotal: d.lineTotal ?? null,
     priceBreakdown: d.priceBreakdown ?? null,
     priceOverridden: d.priceOverridden ?? false,
@@ -340,6 +351,8 @@ export interface MappedGroup {
   quantity: number;
   price: number | null;
   discount: number | null;
+  /** #1012 — how `discount` was ENTERED. Null = `"$"` (every pre-#1012 row). */
+  discountMode: "$" | "%" | null;
   suggestedPrice: number | null;
   sortOrder: number;
   xeroAccountCode: string | null;
@@ -353,16 +366,17 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     id: d.id,
     organizationId: d.organizationId,
     projectId: d.projectId,
-    categoryId: d.categoryId ?? null,
+    categoryId: orNull(d.categoryId),
     title: d.title,
-    description: d.description ?? null,
+    description: orNull(d.description),
     quantity: d.quantity ?? 1,
-    price: d.price ?? null,
-    discount: d.discount ?? null,
-    suggestedPrice: d.suggestedPrice ?? null,
+    price: orNull(d.price),
+    discount: orNull(d.discount),
+    discountMode: orNull(d.discountMode),
+    suggestedPrice: orNull(d.suggestedPrice),
     sortOrder: d.sortOrder ?? 0,
-    xeroAccountCode: d.xeroAccountCode ?? null,
-    xeroTaxType: d.xeroTaxType ?? null,
+    xeroAccountCode: orNull(d.xeroAccountCode),
+    xeroTaxType: orNull(d.xeroTaxType),
     createdAt: msToDate(d.createdAt),
     updatedAt: msToDate(d.updatedAt),
   };

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -61,6 +61,14 @@ type UnitDoc = Doc<"projectLineItemUnits">;
 type CategoryDoc = Doc<"projectCategories">;
 type GroupDoc = Doc<"projectGroups">;
 
+/** Convex's "field absent" (`undefined`) → the Prisma row shape's `null`. One
+ *  helper rather than a `?? null` per field — the mapper below is a straight
+ *  field-for-field projection, and the repeated null-coalescing was all this
+ *  function's cyclomatic complexity (R-3.6). */
+function orNull<T>(value: T | undefined | null): T | null {
+  return value ?? null;
+}
+
 /** epoch-ms (Convex) → `Date`; absent/`null` → `null`. */
 function msToDate(n: number | null | undefined): Date | null {
   return n == null ? null : new Date(n);
@@ -91,6 +99,7 @@ export type MappedLineItem = Omit<
   | "pricingType"
   | "duration"
   | "discount"
+  | "discountMode"
   | "lineTotal"
   | "priceBreakdown"
   | "priceOverridden"
@@ -144,6 +153,9 @@ export type MappedLineItem = Omit<
   pricingType: string;
   duration: number;
   discount: number | null;
+  /** #1012 — how `discount` was ENTERED. Null on every pre-#1012 row, which the
+   *  document renderer reads as `"$"` (the pre-#1012 behaviour, no backfill). */
+  discountMode: "$" | "%" | null;
   lineTotal: number | null;
   priceBreakdown: string | null;
   priceOverridden: boolean;
@@ -204,6 +216,7 @@ export function mapLineItemDoc(d: LineItemDoc): MappedLineItem {
     pricingType: d.pricingType ?? "PER_DAY",
     duration: d.duration ?? 1,
     discount: d.discount ?? null,
+    discountMode: d.discountMode ?? null,
     lineTotal: d.lineTotal ?? null,
     priceBreakdown: d.priceBreakdown ?? null,
     priceOverridden: d.priceOverridden ?? false,
@@ -347,6 +360,7 @@ export type MappedGroup = Omit<
   | "quantity"
   | "price"
   | "discount"
+  | "discountMode"
   | "suggestedPrice"
   | "sortOrder"
   | "xeroAccountCode"
@@ -359,6 +373,8 @@ export type MappedGroup = Omit<
   quantity: number;
   price: number | null;
   discount: number | null;
+  /** #1012 — how `discount` was ENTERED. Null = `"$"` (every pre-#1012 row). */
+  discountMode: "$" | "%" | null;
   suggestedPrice: number | null;
   sortOrder: number;
   xeroAccountCode: string | null;
@@ -372,16 +388,17 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     id: d.id,
     organizationId: d.organizationId,
     projectId: d.projectId,
-    categoryId: d.categoryId ?? null,
+    categoryId: orNull(d.categoryId),
     title: d.title,
-    description: d.description ?? null,
+    description: orNull(d.description),
     quantity: d.quantity ?? 1,
-    price: d.price ?? null,
-    discount: d.discount ?? null,
-    suggestedPrice: d.suggestedPrice ?? null,
+    price: orNull(d.price),
+    discount: orNull(d.discount),
+    discountMode: orNull(d.discountMode),
+    suggestedPrice: orNull(d.suggestedPrice),
     sortOrder: d.sortOrder ?? 0,
-    xeroAccountCode: d.xeroAccountCode ?? null,
-    xeroTaxType: d.xeroTaxType ?? null,
+    xeroAccountCode: orNull(d.xeroAccountCode),
+    xeroTaxType: orNull(d.xeroTaxType),
     createdAt: msToDate(d.createdAt),
     updatedAt: msToDate(d.updatedAt),
   };

--- a/src/lib/validations/line-item.test.ts
+++ b/src/lib/validations/line-item.test.ts
@@ -482,3 +482,29 @@ describe("customLineItemSchema", () => {
     });
   });
 });
+
+// #1012 — the discount ENTRY mode rides alongside the resolved dollar amount.
+describe("discountMode (#1012)", () => {
+  for (const schema of [lineItemSchema, customLineItemSchema]) {
+    const base = schema === lineItemSchema ? {} : { description: "Item" };
+
+    it(`accepts "$" and "%" (${schema === lineItemSchema ? "lineItemSchema" : "customLineItemSchema"})`, () => {
+      for (const mode of ["$", "%"] as const) {
+        const result = schema.safeParse({ ...base, discount: 10, discountMode: mode });
+        expect(result.success).toBe(true);
+        if (result.success) expect(result.data.discountMode).toBe(mode);
+      }
+    });
+
+    it(`is optional — absent means "$" downstream (${schema === lineItemSchema ? "lineItemSchema" : "customLineItemSchema"})`, () => {
+      const result = schema.safeParse({ ...base, discount: 10 });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.discountMode).toBeUndefined();
+    });
+
+    it(`rejects any other string (${schema === lineItemSchema ? "lineItemSchema" : "customLineItemSchema"})`, () => {
+      expect(schema.safeParse({ ...base, discount: 10, discountMode: "pct" }).success).toBe(false);
+      expect(schema.safeParse({ ...base, discount: 10, discountMode: "USD" }).success).toBe(false);
+    });
+  }
+});

--- a/src/lib/validations/line-item.ts
+++ b/src/lib/validations/line-item.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { DISCOUNT_MODES } from "@/lib/discount-mode";
+
 // Shared field pieces (R-3.1/R-8.6.1 single source of truth) — `lineItemSchema` and
 // `customLineItemSchema` used to hand-duplicate these bounds character-for-character;
 // a divergence between the two copies would be a defect even while they stayed in sync
@@ -11,6 +13,10 @@ const quantityField = z.coerce.number().int().min(1).max(99999).default(1);
 const unitPriceField = z.coerce.number().min(0).max(999999.99).optional();
 const durationField = z.coerce.number().int().min(1).max(3650).default(1);
 const discountField = z.coerce.number().min(0).max(999999.99).optional();
+// #1012 — the ENTRY shape of `discountField` ($ off vs % of the line gross).
+// `discount` stays the resolved flat dollar amount; this rides alongside it so
+// documents can print the discount the way it was typed. Optional/absent = "$".
+export const discountModeField = z.enum(DISCOUNT_MODES).optional();
 const categoryIdField = z.string().optional();
 const groupIdField = z.string().optional();
 const isOptionalField = z.boolean().default(false);
@@ -36,6 +42,7 @@ export const lineItemSchema = z.object({
   pricingType: z.enum(["PER_DAY", "PER_WEEK", "FLAT", "PER_HOUR", "OPTIMIZED"]).default("PER_DAY"),
   duration: durationField,
   discount: discountField,
+  discountMode: discountModeField,
   priceBreakdown: z.string().optional(),
   priceOverridden: z.boolean().default(false),
   overrideReason: z.string().max(200).optional(),
@@ -59,6 +66,7 @@ export const customLineItemSchema = z.object({
   pricingType: z.enum(["PER_DAY", "PER_WEEK", "FLAT", "PER_HOUR"]).default("FLAT"),
   duration: durationField,
   discount: discountField,
+  discountMode: discountModeField,
   categoryId: categoryIdField,
   groupId: groupIdField,
   notes: z.string().max(500).optional(),

--- a/src/lib/validations/project-group.test.ts
+++ b/src/lib/validations/project-group.test.ts
@@ -223,3 +223,26 @@ describe("moveLineItemSchema", () => {
     expect(result.success).toBe(false);
   });
 });
+
+// #1012 — the discount ENTRY mode, shared with the line-item schema.
+describe("discountMode (#1012)", () => {
+  it("accepts the two modes on projectGroupSchema", () => {
+    for (const mode of ["$", "%"] as const) {
+      const result = projectGroupSchema.safeParse({ ...validMinimal, discount: 10, discountMode: mode });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.discountMode).toBe(mode);
+    }
+  });
+
+  it("rejects any other string", () => {
+    expect(projectGroupSchema.safeParse({ ...validMinimal, discount: 10, discountMode: "pct" }).success).toBe(false);
+  });
+
+  it("is carried through to updateGroupPriceSchema (derived, not re-declared)", () => {
+    const result = updateGroupPriceSchema.safeParse({ price: 100, discount: 10, discountMode: "%" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.discountMode).toBe("%");
+    // Still optional there — omitting it leaves the stored mode untouched.
+    expect(updateGroupPriceSchema.safeParse({ price: 100 }).success).toBe(true);
+  });
+});

--- a/src/lib/validations/project-group.ts
+++ b/src/lib/validations/project-group.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { discountModeField } from "./line-item";
+
 export const projectGroupSchema = z.object({
   // Nullable since v0.9.4.0 — a group can be created directly in the
   // project's Uncategorized zone (categoryId stays null on the row).
@@ -11,6 +13,9 @@ export const projectGroupSchema = z.object({
   // Flat $ amount off `price × quantity` (#883) — same bound as line-item discount
   // (src/lib/validations/line-item.ts discountField).
   discount: z.coerce.number().min(0).max(999999.99).optional(),
+  // #1012 — entry shape of the discount above, shared with the line-item schema
+  // (R-3.1: one definition of the mode union, not a second `z.enum`).
+  discountMode: discountModeField,
   sortOrder: z.coerce.number().int().min(0).optional().default(0),
   xeroAccountCode: z.string().max(50).optional(),
   xeroTaxType: z.string().max(50).optional(),
@@ -23,7 +28,7 @@ export type ProjectGroupFormValues = z.input<typeof projectGroupSchema>;
 // `price` is required (the mutation always needs one to set); `discount` stays
 // optional so callers can omit it to leave the existing discount untouched.
 export const updateGroupPriceSchema = projectGroupSchema
-  .pick({ price: true, discount: true })
+  .pick({ price: true, discount: true, discountMode: true })
   .required({ price: true });
 
 export const moveLineItemSchema = z.object({


### PR DESCRIPTION
Closes #1012.

## Summary

A line negotiated at "15%" printed `-$150.00` on the quote, because **discount mode was never persisted** — `resolveDiscountAmount` converted `%` → flat dollars client-side and only the resulting number crossed into the mutation.

`projectLineItems.discountMode` and `projectGroups.discountMode` (`"$" | "%"`) now record the **entry shape** alongside that dollar amount. Nothing about pricing math changed: `discount` is still the only number recalc, allocation, `lineTotal` and the Xero push read. Absent mode = `"$"`, byte-identical to today's behaviour, so **no backfill** was needed.

**The percentage is derived, not stored.** Only the mode is persisted; the printed percentage is recomputed from the stored dollar amount against the row's own gross. Storing the typed `15` would let a client-facing document contradict itself — the dollar amount is frozen at save, so a later unit-price change would print "15%" next to numbers that say 7.5%. Deriving keeps the printed percentage and the printed total in agreement by construction, and leaves one source of truth (R-3.1). A `%` row with no gross to measure against falls back to the dollar amount.

### Size rationale (R-2.8 / T-2)

Over the ≤400 LOC target at ~1190 changed LOC. Breakdown against `main`: **588 source**, 508 tests, 94 docs, 27 generated (`registry.generated.ts`). The source half is one column threaded through the paths that must move together — splitting it ships a half-feature in an intermediate state:

- a column with no writers is dead schema;
- writers with no column fail validation;
- forms submitting a field the mutations don't accept is a runtime error;
- and the renderer — the entire point of the issue — reads a field nothing populates.

The eight commits are individually reviewable and ordered so each builds on the last (shared module → schema/guards → mutations → validations → forms → read → PDF → docs). No single commit is a sensible standalone PR.

### What changed

- **Schema/guards** — `enums.DiscountMode`, the two optional columns, `assertDiscountMode` for the untyped boundaries (`patchNative`'s `set: v.any()`, `patchManyNative`'s `mode: v.string()`), and `discountMode` added to `LOCKED_LINE_ITEM_FIELDS` / `LOCKED_GROUP_FIELDS` so a FINANCIAL-scope revert restores the entry shape with the amount.
- **Mutations** — every discount-accepting write stores the mode: `addNative`, `addCustomNative`, `addLineItemSmartNative` (insert + merge), `addKitNative`/`createKitLineItemCore`, `patchNative`, `patchManyNative`, `createGroupNative`, `updateGroupPriceNative`. `patchManyNative` already accepted `{ mode, value }` and resolved `%` server-side — it just discarded the mode. The invariant "no amount, no mode" is enforced **server-side** on every clear/zero/lock-default path, not left to the client.
- **Validations** — one `discountModeField`, shared by `lineItemSchema`, `customLineItemSchema`, `projectGroupSchema`; `updateGroupPriceSchema` picks it up through its existing `.pick()` derivation.
- **Forms (7)** — submit the mode instead of dropping it. The three edit surfaces also *seed* from the stored mode on open, so a 15% line reopens as "15 %" rather than silently rewriting itself back to `$` on the next save.
- **PDF** — one shared `discountCellText` for all three row tiers (parent / kit child / per-unit grandchild), replacing three copies of the same expression. Synthetic Project Group rows carry the mode through `structureLineItems`.
- The `$`/`%` union and both conversions moved out of the `"use client"` `line-item-form-fields.tsx` into `src/lib/discount-mode.ts` so the mutations, schemas, forms and renderer share one definition; the forms' imports are unchanged via a re-export.

### Decisions on the issue's open questions

- **Sub-hire items/groups**: deferred, as the issue allowed. They have a `discount` field but no UI mode toggle to source one from, so there is nothing to persist yet.
- **`%` recomputed live vs frozen**: frozen, per the issue's recommendation — the dollar amount stays the value calculated at save. See the derivation note above for how the display stays consistent with it.

### Drive-bys (both from touching this code)

- `equipment-add-form`, `custom-item-add-form`, `edit-line-item-dialog` and `price-edit-dialog` each hand-rolled the `%` → dollars math instead of calling the shared `resolveDiscountAmount` (R-3.1). All four now use it — which also fixes a latent bug in the copies: `if (mode === "%" && disc && unitPrice)` stored the **raw percentage as a dollar amount** when the line had no unit price.
- `mapGroupDoc` gained a small `orNull` helper; the repeated `?? null` was that function's entire cyclomatic complexity (R-3.6).

## Testing

- `pnpm test` — 386 files / 4928 tests pass (was 4888; +40 new).
- `pnpm exec tsc --noEmit` clean, `pnpm lint` 0 errors.
- All CI ratchets pass locally: complexity (686, at baseline — three functions that crossed the threshold were simplified back under it), knip (419), any (136 ≤ 137), depcruise (0), collect (0), `api:registry:check`, client-boundary, docs npm/npx, brand guard. Coverage 56.8% statements vs the 48% floor.

New coverage:
- `src/lib/discount-mode.test.ts` — the round-trip property (`resolveDiscountAmount` ↔ `discountPercentOf` are inverses), blank-vs-explicit-0, and the no-gross fallbacks.
- `convex/lineItemWrites.test.ts` — the mode lands on `patchManyNative`/`addCustomNative`, is cleared with the amount on `patchNative`/`patchManyNative`, and a bogus mode is rejected through both untyped surfaces.
- `convex/projectGroupsWrites.test.ts` — mode stored with a group discount (and totals unaffected), stale mode dropped when the discount is zeroed.
- `src/lib/pdfme/plugins/gearflow-table.test.ts` — `%` and `$` rendering at parent and kit-child tiers, the pre-#1012 no-mode fallback, the $0-gross fallback, plus a **full-pipeline** test (`structureLineItems` → plugin render) per CLAUDE.md's PDF rule.
- `src/lib/pdfme/structure-line-items.test.ts` — the synthetic group row carries the mode, and drops it when there is no discount.
- Validation-schema tests for both schemas and the derived `updateGroupPriceSchema`.

**PDF consumer audit** (CLAUDE.md's checklist): #1 rendering changed; #2 `calculateItemHeight` needs no change (the Discount cell is still a single line at every tier); #3/#4 the top-level status filters don't read discount at all.

## Checklist

- [x] New dependency? None added.