### PR TITLE
Phase C — unified lock state: fold the quote-send lock into resolveLockTier

### DIFF
--- a/FEATUREDOCS/62-project-lifecycle-locks.md
+++ b/FEATUREDOCS/62-project-lifecycle-locks.md
@@ -6,6 +6,11 @@ coherent model — a shared status-tier definition, an unlock-session mechanism,
 a snapshot mechanism, and justification-in-audit plumbing — not three
 independent features.
 
+**#988** (Phase C of #985's finance version-control program) extends the same
+model with a second tier input — a sent quote can lock pricing on an
+otherwise-OPEN project — and closes every previously-deferred gate site. See
+"The quote-send lock is a second INPUT, not a second lock" below.
+
 ## Lock-tier model (single source of truth)
 
 `convex/lib/projectLocks.ts` exports `lockTierForStatus()` — the ONE place the
@@ -18,11 +23,67 @@ boundary — a second hand-maintained copy would be a defect even in sync
 
 | Statuses | Tier | What's gated |
 |---|---|---|
-| `ENQUIRY` / `QUOTING` / `QUOTED` | **OPEN** | Nothing |
+| `ENQUIRY` / `QUOTING` / `QUOTED` | **OPEN** | Nothing (unless a quote has been sent — see below) |
 | `CONFIRMED` / `PREPPING` / `CHECKED_OUT` | **FINANCE_LOCKED** | Financial fields locked behind a finance unlock session; new items/groups/services default to $0 |
 | `ON_SITE` / `RETURNED` | **FINANCE_LOCKED + JUSTIFY** | Above, plus structural mutations require per-edit confirm + written justification |
 | `COMPLETED` / `INVOICED` | **HARD_LOCKED** | All structural + financial mutations blocked; full unlock session restricted to org admins/owners + the project's assigned PM(s) |
 | `CANCELLED` | OPEN | Ungated (open question — see below) |
+
+### The quote-send lock is a second INPUT, not a second lock (#988, Phase C)
+
+#985's finance version-control program adds one more input to the SAME
+resolver rather than a second lock mechanism (that would be an R-3.1 defect on
+the most safety-critical code in the app): `convex/lib/projectLocks.ts` exports
+`resolveLockTier({ status, quoteState })`, and `lockTierForStatus(status)` is
+now the STATUS-only half of it.
+
+| Status tier | Current revision's quote state | Effective tier | Reason |
+|---|---|---|---|
+| OPEN (`ENQUIRY`/`QUOTING`/`QUOTED`) | none, or `DRAFT` | **OPEN** | `STATUS` |
+| OPEN | `SENT` / `ACCEPTED` / `DECLINED` / `SUPERSEDED` / `EXPIRED` | **FINANCE_LOCKED** | `QUOTE_SENT` |
+| FINANCE_LOCKED / JUSTIFY / HARD_LOCKED (CONFIRMED+) | any | unchanged | `STATUS` |
+
+"Current revision's quote state" is the quote row at `projects.revision`
+(`quoteState.ts#currentRevisionQuoteStatus`) — NOT any historical row. That's
+what makes "cutting a new version is the unlock" (#985 decision 2) true:
+`newVersionNative` bumps `projects.revision` and inserts a fresh `DRAFT` at the
+new number, so the CURRENT revision reads `DRAFT` again even though the
+previous one is still sitting there `SENT` (soon to flip to `SUPERSEDED` when
+the new one actually sends). Every state other than none/`DRAFT` escalates
+identically — `DECLINED`/`SUPERSEDED`/`EXPIRED` included — because decision 2
+makes `newVersionNative` the ONLY sanctioned way off any of them; there's no
+"quietly keep editing the same revision" path once it's gone out.
+
+Properties that make this safe (see the full truth table in
+`convex/lib/projectLocks.test.ts`):
+- **Monotonic.** Quote state can only ever raise OPEN to FINANCE_LOCKED, never
+  touch (let alone lower) a tier that's already FINANCE_LOCKED/JUSTIFY/
+  HARD_LOCKED from status alone. A sent quote on a COMPLETED project softens
+  nothing.
+- **One function, zero new gate sites.** All ~25 existing call sites still
+  call `assertLifecycleGuard(ctx, project, opts)` completely unchanged —
+  `assertLifecycleGuard` looks up the current revision's quote state itself
+  (only when the status tier is itself OPEN — any higher tier already
+  dominates, so this adds no extra read to the CONFIRMED+/ON_SITE+/COMPLETED+
+  paths that make up most gated writes).
+- **`LockTier` values are unchanged** — `FINANCIALS_LOCKED`/`PROJECT_LOCKED`
+  codes and their `native-writes.ts` toast mappings still apply untouched.
+  `defaultToZero` is likewise unchanged: a quote-sent OPEN-status project
+  defaults new adds to $0 exactly like a CONFIRMED one.
+- **`reason: "STATUS" | "QUOTE_SENT"`** is new on `LifecycleGuardResult` and on
+  `projectLocksRead.status`'s return (alongside `revision` and `quoteState`),
+  so the UI can say _why_ pricing is locked and offer the right exit ("Create
+  quote v(N+1)" / "Recall quote" vs. the existing unlock-session flow) instead
+  of a bare "locked" — Phase E (#990) renders that from this one query.
+
+**The sanctioned-exit exception.** `quotesWrites.ts`'s `sendNative` and
+`newVersionNative` are the two mutations that raise/cut the quote-derived
+lock, so they'd otherwise deadlock against their own not-yet-superseded state
+(`newVersionNative` runs while the current revision is STILL the live `SENT`
+quote it's about to move past). Both pass `bypassQuoteLock: true` to
+`assertLifecycleGuard`, resolving the tier from STATUS alone — the one
+deliberate opt-out `LifecycleGuardOptions` exposes, and the only two call
+sites that should ever set it.
 
 ## The shared guard: `assertLifecycleGuard`
 
@@ -197,24 +258,30 @@ on: `FINANCIALS_LOCKED`, `JUSTIFICATION_REQUIRED`, `PROJECT_LOCKED`,
 Gated: `projectWrites.ts` (`updateNative`, `updateStatusNative`, `deleteNative`'s
 snapshot/session cascade), `lineItemWrites.ts` (`addNative`, `addCustomNative`,
 `addKitNative`, `addLineItemSmartNative`, `patchNative`, `patchManyNative`,
-`removeNative`, `removeManyNative`), `projectGroupsWrites.ts` (`createGroupNative`,
-`updateGroupNative`, `updateGroupPriceNative`, `deleteGroupNative`,
-`moveLineItemNative`, `moveLineItemsNative`), `projectCategoriesWrites.ts`
-(`createCategoryNative`, `updateCategoryNative`, `deleteCategoryNative`),
-`projectServicesWrites.ts` (`createServiceNative`, `updateServiceNative`,
-`deleteServiceNative`), `crewAssignmentsWrites.ts` (`createNative`,
-`updateNative`, `deleteNative`).
+`removeNative`, `removeManyNative`, `reorderNative`), `projectGroupsWrites.ts`
+(`createGroupNative`, `updateGroupNative`, `updateGroupPriceNative`,
+`deleteGroupNative`, `moveLineItemNative`, `moveLineItemsNative`),
+`projectCategoriesWrites.ts` (`createCategoryNative`, `updateCategoryNative`,
+`deleteCategoryNative`), `projectServicesWrites.ts` (`createServiceNative`,
+`updateServiceNative`, `deleteServiceNative`, `bulkDeleteServicesNative`,
+`bulkUpdateServiceStatusNative`, `generateServicesNative`,
+`cloneServicesNative`, `convertLineItemToServiceNative`),
+`crewAssignmentsWrites.ts` (`createNative`, `updateNative`, `deleteNative`,
+`bulkDeleteNative`, `bulkStatusNative`, `generateShiftsNative`).
 
-**Deliberately deferred, not silently dropped:** bulk/generate/clone variants —
-`projectServicesWrites.ts`'s `bulkDeleteServicesNative` /
-`bulkUpdateServiceStatusNative` / `generateServicesNative` /
-`cloneServicesNative` / `convertLineItemToServiceNative`, `lineItemWrites.ts`'s
-`reorderNative` (sortOrder-only, no audit today, mirrors `reorderGroupsNative`),
-and `crewAssignmentsWrites.ts`'s `bulkDeleteNative` / `bulkStatusNative` /
-`generateShiftsNative` are not yet gated. These are lower-blast-radius than the
-primary create/update/delete paths above but should be closed in a follow-up
-PR before this is considered complete coverage of the #791/#793 acceptance
-criteria ("every gate site").
+That closes every site #791/#793's acceptance criteria asked for ("every gate
+site") — the bulk/generate/clone/reorder variants below were the deferred set;
+#988 (Phase C) gates each with `kind: "structural"` (the same family a single
+create/update/delete already uses), a per-distinct-project dedup for the ones
+that can span more than one project (mirroring `patchManyNative`/
+`removeManyNative`'s existing dedup pattern), and `defaultToZero` applied to
+every new/copied money field exactly like a manually-added entity:
+`bulkDeleteServicesNative`, `bulkUpdateServiceStatusNative`,
+`generateServicesNative`, `cloneServicesNative` (gated on the TARGET project —
+the source isn't written to), `convertLineItemToServiceNative`,
+`lineItemWrites.reorderNative`, `crewAssignmentsWrites.bulkDeleteNative`,
+`bulkStatusNative`, `generateShiftsNative`. Each has a "rejects on an ON_SITE
+project without justification, succeeds with one" test.
 
 ## Open questions (from #957, unresolved)
 

--- a/convex/crewAssignmentsWrites.test.ts
+++ b/convex/crewAssignmentsWrites.test.ts
@@ -213,4 +213,53 @@ describe("crewAssignments reads", () => {
     expect(c1?.conflicts[0]?.projectId).toBe("p2");
     expect(c1?.isUnavailable).toBe(true);
   });
+
+  // #988 (Phase C) — bulkDeleteNative/bulkStatusNative/generateShiftsNative were
+  // FEATUREDOCS/62's "deliberately deferred" gate sites; each is now gated the
+  // same structural way createNative/updateNative/deleteNative already are.
+  const JUSTIFICATION = "Client requested a change while on site today.";
+
+  test("bulkStatusNative + bulkDeleteNative reject on an ON_SITE project without justification, succeed with one", async () => {
+    const t = makeT(); await seed(t);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      if (p) await ctx.db.patch(p._id, { status: "ON_SITE" });
+    });
+    await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.createNative, { ...base, justification: JUSTIFICATION });
+    await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.createNative, { ...base, id: "a2", auditId: "l2", justification: JUSTIFICATION });
+
+    await expect(
+      t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.bulkStatusNative, { orgId: ORG, ids: ["a1", "a2"], status: "CONFIRMED", now: NOW, actor, auditId: "l3" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const s = await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.bulkStatusNative, {
+      orgId: ORG, ids: ["a1", "a2"], status: "CONFIRMED", now: NOW + 1, actor, auditId: "l3b", justification: JUSTIFICATION,
+    });
+    expect(s.updated).toBe(2);
+
+    await expect(
+      t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.bulkDeleteNative, { orgId: ORG, ids: ["a1", "a2"], now: NOW + 2, actor, auditId: "l4" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const d = await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.bulkDeleteNative, {
+      orgId: ORG, ids: ["a1", "a2"], now: NOW + 3, actor, auditId: "l4b", justification: JUSTIFICATION,
+    });
+    expect(d.deleted).toBe(2);
+  });
+
+  test("generateShiftsNative rejects on an ON_SITE project without justification, succeeds with one", async () => {
+    const t = makeT(); await seed(t);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      if (p) await ctx.db.patch(p._id, { status: "ON_SITE" });
+    });
+    await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.createNative, {
+      ...base, startDate: NOW, endDate: NOW + DAY, justification: JUSTIFICATION,
+    });
+    await expect(
+      t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.generateShiftsNative, { assignmentId: "a1", orgId: ORG }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser).mutation(api.crewAssignmentsWrites.generateShiftsNative, {
+      assignmentId: "a1", orgId: ORG, justification: JUSTIFICATION,
+    });
+    expect(res.count).toBe(2);
+  });
 });

--- a/convex/crewAssignmentsWrites.ts
+++ b/convex/crewAssignmentsWrites.ts
@@ -22,6 +22,23 @@ async function requireCrewProjectInOrg(ctx: MutationCtx, projectId: string, orgI
   return p;
 }
 
+/** #988 — gate a project exactly once per bulk mutation, no matter how many of
+ *  its rows the selection touches. Pulled out of the bulk handlers themselves
+ *  (rather than inlined per-row) to keep their cyclomatic complexity down —
+ *  same "kind: structural" gate a single create/update/delete already uses. */
+async function guardProjectOnce(
+  ctx: MutationCtx,
+  orgId: string,
+  projectId: string,
+  guardedProjectIds: Set<string>,
+  justification: string | undefined,
+): Promise<void> {
+  if (guardedProjectIds.has(projectId)) return;
+  const project = await requireCrewProjectInOrg(ctx, projectId, orgId);
+  await assertLifecycleGuard(ctx, project, { kind: "structural", justification });
+  guardedProjectIds.add(projectId);
+}
+
 /**
  * Reject a non-finite OR negative money/hours input before it flows into resolveRate /
  * calculateEstimatedCost → estimatedCost → project labourCostTotal. Convex `v.number()`
@@ -345,7 +362,15 @@ export const deleteNative = mutation({
 
 export const bulkDeleteNative = mutation({
   returns: v.object({ deleted: v.number(), skipped: v.number() }),
-  args: { orgId: v.string(), ids: v.array(v.string()), now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    orgId: v.string(),
+    ids: v.array(v.string()),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once a touched project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "crew");
     await enforceBrowserWriteLimit(ctx);
@@ -356,9 +381,13 @@ export const bulkDeleteNative = mutation({
     let deleted = 0, skipped = 0;
     const projectIds = new Set<string>();
     const serviceIds = new Set<string>();
+    // #988: deleting is structural (same "kind" a single deleteNative uses),
+    // gated once per distinct project this selection touches.
+    const guardedProjectIds = new Set<string>();
     for (const id of a.ids) {
       const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).first();
       if (!doc || doc.organizationId !== a.orgId) { skipped++; continue; }
+      await guardProjectOnce(ctx, a.orgId, doc.projectId, guardedProjectIds, a.justification);
       projectIds.add(doc.projectId);
       if (doc.serviceId) serviceIds.add(doc.serviceId);
       await cascadeDelete(ctx, doc, a.orgId);
@@ -374,7 +403,16 @@ export const bulkDeleteNative = mutation({
 
 export const bulkStatusNative = mutation({
   returns: v.object({ updated: v.number(), skipped: v.number() }),
-  args: { orgId: v.string(), ids: v.array(v.string()), status: enums.AssignmentStatus, now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    orgId: v.string(),
+    ids: v.array(v.string()),
+    status: enums.AssignmentStatus,
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once a touched project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "crew");
     await enforceBrowserWriteLimit(ctx);
@@ -384,9 +422,12 @@ export const bulkStatusNative = mutation({
 
     let updated = 0, skipped = 0;
     const projectIds = new Set<string>();
+    // #988: a status change is structural, gated once per distinct project.
+    const guardedProjectIds = new Set<string>();
     for (const id of a.ids) {
       const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", id)).first();
       if (!doc || doc.organizationId !== a.orgId) { skipped++; continue; }
+      await guardProjectOnce(ctx, a.orgId, doc.projectId, guardedProjectIds, a.justification);
       const patch: Record<string, unknown> = { status: a.status, updatedAt: a.now };
       if (a.status === "CONFIRMED" && !doc.confirmedAt) { patch.confirmedAt = a.now; patch.confirmedById = actor.userId; }
       await ctx.db.patch(doc._id, patch);
@@ -402,14 +443,23 @@ export const bulkStatusNative = mutation({
 // generateShifts is no-audit (parity — the old action logged none), so resolveActor omitted.
 export const generateShiftsNative = mutation({
   returns: v.object({ count: v.number() }),
-  args: { assignmentId: v.string(), orgId: v.string() },
-  handler: async (ctx, { assignmentId, orgId }) => {
+  args: {
+    assignmentId: v.string(),
+    orgId: v.string(),
+    // #988: required once the project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
+  handler: async (ctx, { assignmentId, orgId, justification }) => {
     await assertWritesEnabled(ctx, "crew");
     await enforceBrowserWriteLimit(ctx);
     await requireOrgPermission(ctx, orgId, "crew", "update");
 
     const doc = await ctx.db.query("crewAssignments").withIndex("by_cuid", (q) => q.eq("id", assignmentId)).first();
     if (!doc || doc.organizationId !== orgId) throw new ConvexError("Assignment not found");
+    // #988: regenerating shifts is structural (creates/removes crewShifts rows,
+    // no money touched).
+    const shiftsProject = await requireCrewProjectInOrg(ctx, doc.projectId, orgId);
+    await assertLifecycleGuard(ctx, shiftsProject, { kind: "structural", justification });
     if (doc.startDate == null || doc.endDate == null) throw new ConvexError("Assignment must have start and end dates to generate shifts");
 
     // Delete existing SCHEDULED shifts (preserve non-SCHEDULED), then regenerate.

--- a/convex/lib/projectLocks.test.ts
+++ b/convex/lib/projectLocks.test.ts
@@ -8,6 +8,8 @@ import {
   isRevertOutOfHardLock,
   shouldDefaultToZero,
   lifecycleAuditMetadata,
+  resolveLockTier,
+  type LockTier,
 } from "./projectLocks";
 
 describe("lockTierForStatus", () => {
@@ -37,6 +39,80 @@ describe("lockTierForStatus", () => {
     expect(isConfirmedOrLater("CONFIRMED")).toBe(true);
     expect(isConfirmedOrLater("COMPLETED")).toBe(true);
     expect(isConfirmedOrLater("CANCELLED")).toBe(false);
+  });
+});
+
+// #988 (Phase C) — the quote-send lock folds into the SAME tier resolver.
+// Full truth table across every status × every quote state, since this is the
+// safety-critical function every gate site relies on.
+describe("resolveLockTier", () => {
+  const ALL_STATUSES = [
+    "ENQUIRY", "QUOTING", "QUOTED",
+    "CONFIRMED", "PREPPING", "CHECKED_OUT",
+    "ON_SITE", "RETURNED",
+    "COMPLETED", "INVOICED",
+    "CANCELLED",
+  ] as const;
+  const STATUSLESS = [null, undefined] as const;
+  const OPEN_KEEPING_QUOTE_STATES = [undefined, null, "DRAFT"] as const;
+  const ESCALATING_QUOTE_STATES = ["SENT", "ACCEPTED", "DECLINED", "SUPERSEDED", "EXPIRED"] as const;
+  const ALL_QUOTE_STATES = [...OPEN_KEEPING_QUOTE_STATES, ...ESCALATING_QUOTE_STATES] as const;
+
+  describe("status alone already resolves a non-OPEN tier — quote state never overrides it", () => {
+    const NON_OPEN_STATUSES = ALL_STATUSES.filter((s) => lockTierForStatus(s) !== "OPEN");
+
+    test.each(NON_OPEN_STATUSES)("%s", (status) => {
+      const expectedTier = lockTierForStatus(status);
+      for (const quoteState of ALL_QUOTE_STATES) {
+        expect(resolveLockTier({ status, quoteState })).toEqual({ tier: expectedTier, reason: "STATUS" });
+      }
+      // Omitting quoteState entirely resolves identically.
+      expect(resolveLockTier({ status })).toEqual({ tier: expectedTier, reason: "STATUS" });
+    });
+  });
+
+  describe("status alone resolves OPEN (ENQUIRY/QUOTING/QUOTED/CANCELLED) — quote state decides", () => {
+    const OPEN_STATUSES = ALL_STATUSES.filter((s) => lockTierForStatus(s) === "OPEN");
+
+    test.each(OPEN_STATUSES)("%s + no quote / DRAFT quote stays OPEN", (status) => {
+      for (const quoteState of OPEN_KEEPING_QUOTE_STATES) {
+        expect(resolveLockTier({ status, quoteState })).toEqual({ tier: "OPEN", reason: "STATUS" });
+      }
+    });
+
+    test.each(OPEN_STATUSES)("%s + a quote that's gone out (SENT/ACCEPTED/DECLINED/SUPERSEDED/EXPIRED) escalates to FINANCE_LOCKED", (status) => {
+      for (const quoteState of ESCALATING_QUOTE_STATES) {
+        expect(resolveLockTier({ status, quoteState })).toEqual({ tier: "FINANCE_LOCKED", reason: "QUOTE_SENT" });
+      }
+    });
+
+    test.each(STATUSLESS)("null/undefined status behaves exactly like an OPEN status", (status) => {
+      for (const quoteState of OPEN_KEEPING_QUOTE_STATES) {
+        expect(resolveLockTier({ status, quoteState })).toEqual({ tier: "OPEN", reason: "STATUS" });
+      }
+      for (const quoteState of ESCALATING_QUOTE_STATES) {
+        expect(resolveLockTier({ status, quoteState })).toEqual({ tier: "FINANCE_LOCKED", reason: "QUOTE_SENT" });
+      }
+    });
+  });
+
+  test("monotonicity property: no (status, quoteState) pair EVER resolves to a lower tier than status alone", () => {
+    // A simple total order sufficient for this property: OPEN is the floor,
+    // everything else is at or above it, and HARD_LOCKED is the ceiling.
+    // Quote state, per the rule above, can only move OPEN -> FINANCE_LOCKED —
+    // it never touches (let alone lowers) any already-locked status tier.
+    const rank: Record<LockTier, number> = { OPEN: 0, FINANCE_LOCKED: 1, JUSTIFY: 1, HARD_LOCKED: 2 };
+    for (const status of [...ALL_STATUSES, ...STATUSLESS]) {
+      const floor = rank[lockTierForStatus(status)];
+      for (const quoteState of ALL_QUOTE_STATES) {
+        const { tier } = resolveLockTier({ status, quoteState });
+        expect(rank[tier]).toBeGreaterThanOrEqual(floor);
+      }
+    }
+  });
+
+  test("a SENT quote on an already-HARD_LOCKED project softens nothing (still HARD_LOCKED, reason STATUS)", () => {
+    expect(resolveLockTier({ status: "COMPLETED", quoteState: "SENT" })).toEqual({ tier: "HARD_LOCKED", reason: "STATUS" });
   });
 });
 

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -2,6 +2,7 @@ import { ConvexError } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { assertStrLen } from "./fieldGuards";
+import { currentRevisionQuoteStatus, projectRevision, type EffectiveQuoteStatus } from "./quoteState";
 
 /**
  * Project lifecycle lock-tier module (#957) — the SINGLE source of truth for the
@@ -20,6 +21,12 @@ import { assertStrLen } from "./fieldGuards";
  *   COMPLETED / INVOICED                 → HARD_LOCKED     (everything gated,
  *                                                            no per-edit path)
  *   CANCELLED                            → OPEN            (ungated — #957 open Q)
+ *
+ * #988 (Phase C, part of #985's finance version-control program) folds ONE
+ * more input into this same resolver rather than adding a second lock: a
+ * `resolveLockTier({ status, quoteState })` on top of `lockTierForStatus`,
+ * where an OPEN-status project whose current quote revision has been sent
+ * escalates to FINANCE_LOCKED too. See `resolveLockTier` below.
  */
 
 export type LockTier = "OPEN" | "FINANCE_LOCKED" | "JUSTIFY" | "HARD_LOCKED";
@@ -47,6 +54,60 @@ export function lockTierForStatus(status: string | null | undefined): LockTier {
 
 export function isConfirmedOrLater(status: string | null | undefined): boolean {
   return lockTierForStatus(status) !== "OPEN";
+}
+
+// ─── #988 (Phase C) — the quote-send lock folds into the SAME tier resolver ──
+
+/** Why the effective tier is what it is — lets the UI explain itself and offer
+ *  the right exit (Phase E). `STATUS` covers both "nothing is locked" and
+ *  every status-driven tier (FINANCE_LOCKED/JUSTIFY/HARD_LOCKED via CONFIRMED+);
+ *  `QUOTE_SENT` is the one new case — an OPEN-status project (ENQUIRY/QUOTING/
+ *  QUOTED) whose current revision has already gone out. */
+export type LockTierReason = "STATUS" | "QUOTE_SENT";
+
+export interface ResolveLockTierResult {
+  tier: LockTier;
+  reason: LockTierReason;
+}
+
+/**
+ * A quote state that keeps pricing OPEN when the status tier is itself OPEN:
+ * nothing has ever been sent for this revision (`null`), or the current
+ * revision is a fresh, unsent `DRAFT`. Every other state — `SENT`, `ACCEPTED`,
+ * `DECLINED`, `SUPERSEDED`, `EXPIRED` — means this exact revision has already
+ * gone out and is either still live or terminal; decision 2 ("cutting a new
+ * version is the unlock") makes `newVersionNative` the ONLY way out of any of
+ * them, so all five raise the tier identically. `DECLINED`/`SUPERSEDED` are
+ * defensive completeness — a project's CURRENT revision is never SUPERSEDED in
+ * normal flow (only an older, already-superseded one is), and a declined
+ * revision still needs a new version rather than silent re-editing.
+ */
+function quoteStateKeepsOpen(quoteState: EffectiveQuoteStatus | null | undefined): boolean {
+  return quoteState == null || quoteState === "DRAFT";
+}
+
+/**
+ * `lockTierForStatus(status)` → `resolveLockTier({ status, quoteState })` — the
+ * quote-send lock (decision 2, #985) is not a second lock mechanism, it is a
+ * second INPUT to this one. `quoteState` is the CURRENT revision's quote status
+ * (`quoteState.ts#currentRevisionQuoteStatus`, or an already-resolved
+ * `effectiveQuoteStatus` for a caller that has one to hand, e.g. a read query
+ * with real EXPIRED detection).
+ *
+ * Monotonic by construction: a quote state can only ever raise OPEN to
+ * FINANCE_LOCKED, never touch (let alone lower) FINANCE_LOCKED/JUSTIFY/
+ * HARD_LOCKED — those are already at or above FINANCE_LOCKED from status alone.
+ * `LockTier` values are unchanged, so every existing `FINANCIALS_LOCKED` /
+ * `PROJECT_LOCKED` code and toast mapping still applies untouched.
+ */
+export function resolveLockTier(input: {
+  status: string | null | undefined;
+  quoteState?: EffectiveQuoteStatus | null;
+}): ResolveLockTierResult {
+  const statusTier = lockTierForStatus(input.status);
+  if (statusTier !== "OPEN") return { tier: statusTier, reason: "STATUS" };
+  if (quoteStateKeepsOpen(input.quoteState)) return { tier: "OPEN", reason: "STATUS" };
+  return { tier: "FINANCE_LOCKED", reason: "QUOTE_SENT" };
 }
 
 /** The linear pipeline order (CANCELLED is off-pipeline, reachable from any
@@ -148,10 +209,26 @@ export interface LifecycleGuardOptions {
   /** Caller-supplied justification text (#793), checked only when the tier
    *  requires it and no session is already open. */
   justification?: string | null;
+  /**
+   * Skip the #988 quote-derived escalation and resolve the tier from STATUS
+   * alone. Reserved for `quotesWrites.ts`'s `sendNative`/`newVersionNative` —
+   * the two mutations that raise/cut the quote-derived lock are also the
+   * SANCTIONED EXIT from it ("cutting a new version is the unlock", decision
+   * 2), so gating them against their own revision's not-yet-superseded state
+   * would be a chicken-and-egg deadlock: `newVersionNative` runs while the
+   * current revision is still the live `SENT` quote it's about to move past.
+   * No other gate site should ever set this — the entire point of #988 is
+   * that the other ~25 sites pick up the quote lock with ZERO changes.
+   */
+  bypassQuoteLock?: boolean;
 }
 
 export interface LifecycleGuardResult {
   tier: LockTier;
+  /** Why `tier` is what it is (#988) — STATUS-driven or raised by a sent quote
+   *  on an otherwise-OPEN project. Lets the UI explain itself and offer the
+   *  right exit instead of a bare "locked". */
+  reason: LockTierReason;
   openSession: Doc<"projectUnlockSessions"> | null;
   /** True when a $0 default should be applied to a NEW add (see shouldDefaultToZero). */
   defaultToZero: boolean;
@@ -190,22 +267,35 @@ export function requireJustification(justification: string | null | undefined, m
  *  - JUSTIFY structural write: open session suppresses the prompt (no double-
  *    prompt); otherwise requires a bounded justification.
  *
+ * #988 (Phase C) folds one more input into the SAME tier: an OPEN-status
+ * project (ENQUIRY/QUOTING/QUOTED) whose current revision has already been
+ * sent resolves to FINANCE_LOCKED too (`resolveLockTier`) — every rule above
+ * still applies unchanged, just against a tier that can now come from either
+ * source. The quote lookup only runs when the status tier is itself OPEN
+ * (any higher tier already dominates — monotonic), so this adds no DB read to
+ * the CONFIRMED+/ON_SITE+/COMPLETED+ paths that make up most gated writes.
+ *
  * Throws `ConvexError` with a stable `code` the client can branch on:
  * `PROJECT_LOCKED` | `FINANCIALS_LOCKED` | `JUSTIFICATION_REQUIRED`.
  */
 export async function assertLifecycleGuard(
   ctx: MutationCtx,
-  project: Pick<Doc<"projects">, "id" | "organizationId" | "status">,
+  project: Pick<Doc<"projects">, "id" | "organizationId" | "status" | "revision">,
   opts: LifecycleGuardOptions,
 ): Promise<LifecycleGuardResult> {
-  const tier = lockTierForStatus(project.status);
-  if (tier === "OPEN") return { tier, openSession: null, defaultToZero: false };
+  const statusTier = lockTierForStatus(project.status);
+  const quoteState =
+    statusTier === "OPEN" && !opts.bypassQuoteLock
+      ? await currentRevisionQuoteStatus(ctx, project.organizationId, project.id, projectRevision(project))
+      : null;
+  const { tier, reason } = resolveLockTier({ status: project.status, quoteState });
+  if (tier === "OPEN") return { tier, reason, openSession: null, defaultToZero: false };
 
   const openSession = await getOpenUnlockSession(ctx, project.organizationId, project.id);
   const defaultToZero = shouldDefaultToZero(tier, openSession);
 
   if (tier === "HARD_LOCKED") {
-    if (openSession?.scope === "FULL") return { tier, openSession, defaultToZero };
+    if (openSession?.scope === "FULL") return { tier, reason, openSession, defaultToZero };
     throw new ConvexError({
       code: "PROJECT_LOCKED",
       message: "This project is completed and hard-locked. Open a full unlock session to make changes.",
@@ -213,22 +303,26 @@ export async function assertLifecycleGuard(
   }
 
   if (opts.kind === "financial") {
-    if (openSession) return { tier, openSession, defaultToZero };
+    if (openSession) return { tier, reason, openSession, defaultToZero };
     throw new ConvexError({
       code: "FINANCIALS_LOCKED",
-      message: "This project's financials are locked. Open an unlock session (Financials tab) to edit money fields.",
+      message:
+        reason === "QUOTE_SENT"
+          ? "This quote has already been sent, which locks pricing. Create a new quote version to change prices, or open an unlock session."
+          : "This project's financials are locked. Open an unlock session (Financials tab) to edit money fields.",
     });
   }
 
   // structural
   if (tier === "FINANCE_LOCKED") {
     // #793's structural gate doesn't start until ON_SITE — CONFIRMED/PREPPING/
-    // CHECKED_OUT only gate financial fields (handled above).
-    return { tier, openSession, defaultToZero };
+    // CHECKED_OUT (or an OPEN-status project whose quote was sent) only gate
+    // financial fields (handled above).
+    return { tier, reason, openSession, defaultToZero };
   }
 
   // tier === "JUSTIFY"
-  if (openSession) return { tier, openSession, defaultToZero }; // no double-prompt
+  if (openSession) return { tier, reason, openSession, defaultToZero }; // no double-prompt
   const justification = opts.justification?.trim();
   if (!justification || justification.length < JUSTIFICATION_BOUNDS.min) {
     throw new ConvexError({
@@ -237,7 +331,7 @@ export async function assertLifecycleGuard(
     });
   }
   assertStrLen(justification, "justification", JUSTIFICATION_BOUNDS);
-  return { tier, openSession, defaultToZero };
+  return { tier, reason, openSession, defaultToZero };
 }
 
 /** Persist the justification onto an activity-log write's `metadata` (#793:

--- a/convex/lib/quoteState.ts
+++ b/convex/lib/quoteState.ts
@@ -170,6 +170,27 @@ export async function requireProjectInOrg(
   return project;
 }
 
+/**
+ * The quote at the project's CURRENT revision, normalised, with NO time-based
+ * `EXPIRED` resolution — #988 (Phase C)'s `resolveLockTier` treats `SENT` and
+ * `EXPIRED` identically (both are "sent and not yet superseded by a new
+ * version"), so distinguishing them isn't needed to gate a write. That in turn
+ * means `assertLifecycleGuard` doesn't need a `now` argument threaded through
+ * the ~25 existing gate sites that call it — none of them pass one today.
+ * Null when no row exists at this revision yet (a project that has never
+ * quoted, or a fresh `DRAFT` created by `newVersionNative`) — reads exactly
+ * like a `DRAFT` for lock purposes.
+ */
+export async function currentRevisionQuoteStatus(
+  ctx: QueryCtx | MutationCtx,
+  orgId: string,
+  projectId: string,
+  revision: number,
+): Promise<EffectiveQuoteStatus | null> {
+  const quote = await findQuoteAtRevision(ctx, orgId, projectId, revision);
+  return quote ? normalizeStoredQuoteStatus(quote.status) : null;
+}
+
 /** Human label for a revision — `<projectNumber> v<version>`. There is
  *  deliberately no quote number (decision 5): the project number is already the
  *  shared reference with the client, and a second counter would be one more

--- a/convex/lineItemWrites.test.ts
+++ b/convex/lineItemWrites.test.ts
@@ -887,6 +887,31 @@ describe("lineItemWrites.reorderNative", () => {
     await member(t, "viewer");
     await expect(t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, { orgId: ORG, items: [], now: NOW })).rejects.toThrow(/insufficient permissions/i);
   });
+
+  // #988 (Phase C) — reorderNative was FEATUREDOCS/62's "deliberately deferred"
+  // gate site; it's now a structural gate like every other line-item write.
+  test("rejects on an ON_SITE project without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projects", { id: "p1", organizationId: ORG, projectNumber: "P1", name: "Gig", status: "ON_SITE", isTemplate: false, createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItems", { id: "l1", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 0 });
+      await ctx.db.insert("projectLineItems", { id: "l2", organizationId: ORG, projectId: "p1", status: "CONFIRMED", type: "EQUIPMENT", isKitChild: false, sortOrder: 1 });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, {
+        orgId: ORG, items: [{ id: "l2", sortOrder: 0 }, { id: "l1", sortOrder: 1 }], now: NOW,
+      }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    await t.withIdentity(asUser(ORG)).mutation(api.lineItemWrites.reorderNative, {
+      orgId: ORG, items: [{ id: "l2", sortOrder: 0 }, { id: "l1", sortOrder: 1 }], now: NOW + 1,
+      justification: "Client requested a change while on site today.",
+    });
+    await t.run(async (ctx) => {
+      const l2 = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "l2")).first();
+      expect(l2?.sortOrder).toBe(0);
+    });
+  });
 });
 
 describe("lineItemWrites.addLineItemSmartNative", () => {

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -1821,15 +1821,26 @@ export const reorderNative = mutation({
     orgId: v.string(),
     items: v.array(v.object({ id: v.string(), sortOrder: v.number(), groupName: v.optional(v.string()) })),
     now: v.number(),
+    // #988: required once a touched project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
   },
-  handler: async (ctx, { orgId, items, now }) => {
+  handler: async (ctx, { orgId, items, now, justification }) => {
     await assertWritesEnabled(ctx, "lineItem");
     await enforceBrowserWriteLimit(ctx);
     await assertBulkSizeOk(ctx, items.length);
     await requireOrgPermission(ctx, orgId, "project", "manage_line_items");
+    // #988: reordering is structural (sortOrder-only, no money touched) — gated
+    // once per distinct project this selection touches, same dedup pattern as
+    // patchManyNative/removeManyNative.
+    const guardedProjectIds = new Set<string>();
     for (const it of items) {
       const doc = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", it.id)).first();
       if (doc && doc.organizationId === orgId) {
+        if (!guardedProjectIds.has(doc.projectId)) {
+          const project = await requireLineProjectInOrg(ctx, doc.projectId, orgId);
+          await assertLifecycleGuard(ctx, project, { kind: "structural", justification });
+          guardedProjectIds.add(doc.projectId);
+        }
         await ctx.db.patch(doc._id, { sortOrder: it.sortOrder, groupName: it.groupName, updatedAt: now });
       }
     }

--- a/convex/projectLifecycleLocks.test.ts
+++ b/convex/projectLifecycleLocks.test.ts
@@ -455,3 +455,172 @@ describe("#791 unlock-session lifecycle", () => {
     });
   });
 });
+
+/**
+ * #988 (Phase C) — the quote-send lock folds into `assertLifecycleGuard` as a
+ * SECOND input, not a second mechanism: an OPEN-status project (ENQUIRY/
+ * QUOTING/QUOTED) whose current revision has already been SENT resolves to
+ * FINANCE_LOCKED too, with `reason: "QUOTE_SENT"`. Exercises the real quote
+ * mutations rather than hand-inserted rows wherever the flow matters (the
+ * sanctioned-exit tests) — see convex/lib/projectLocks.test.ts for the pure
+ * `resolveLockTier` truth table.
+ */
+describe("#988 quote-derived lock tier", () => {
+  async function sentQuote(t: ReturnType<typeof makeT>, version = 1, extra: Record<string, unknown> = {}) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("quotes", {
+        id: `q${version}`, organizationId: ORG, projectId: "p1", version, status: "SENT",
+        snapshot: null, sentAt: NOW, ...extra,
+      });
+    });
+  }
+
+  test("a SENT quote locks money fields on an otherwise-OPEN (QUOTED) project", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Speaker", unitPrice: 100, quantity: 1, isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(asUser()).mutation(api.lineItemWrites.patchNative, {
+        id: "li1", orgId: ORG, set: { unitPrice: 200 }, clear: [], entityName: "Speaker", allowOverbook: false, actor: ACTOR, auditId: "log1", now: NOW,
+      }),
+    ).rejects.toThrow(/FINANCIALS_LOCKED|locked/i);
+  });
+
+  test("structural fields stay editable under a quote-derived lock (FINANCE_LOCKED's structural gate starts at ON_SITE, not here)", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Speaker", unitPrice: 100, quantity: 1, isKitChild: false });
+    });
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.patchNative, {
+      id: "li1", orgId: ORG, set: { description: "Speaker (updated)" }, clear: [], entityName: "Speaker", allowOverbook: false, actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.description).toBe("Speaker (updated)");
+    });
+  });
+
+  test("a new add $0-defaults under a quote-derived lock, exactly like a CONFIRMED project", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Extra cable", quantity: 1, unitPrice: 500 },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.unitPrice).toBe(0);
+    });
+  });
+
+  test("an unlock session is still a valid exit while the quote is sent", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    await t.withIdentity(asUser()).mutation(api.projectUnlockSessionsWrites.openNative, {
+      projectId: "p1", orgId: ORG, scope: "FINANCIAL", justification: JUSTIFICATION, actor: ACTOR, auditId: "openlog", now: NOW,
+    });
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Extra cable", quantity: 1, unitPrice: 500 },
+      actor: ACTOR, auditId: "log1", now: NOW + 1,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(Number(li?.unitPrice)).toBe(500); // auto-pricing resumes inside an open session
+    });
+  });
+
+  test("a sent quote on an ALREADY status-locked (COMPLETED) project softens nothing", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "COMPLETED");
+    await sentQuote(t);
+    await expect(
+      t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+        id: "li1", organizationId: ORG, projectId: "p1", fields: { description: "x", quantity: 1 }, actor: ACTOR, auditId: "log1", now: NOW,
+      }),
+    ).rejects.toThrow(/PROJECT_LOCKED/i);
+  });
+
+  test("sanctioned exit: newVersionNative is NOT blocked by the very lock it's cutting past", async () => {
+    const t = makeT();
+    await member(t, "manager"); // invoice:publish
+    await project(t, "QUOTED");
+    await sentQuote(t); // v1 SENT — would otherwise raise the tier to FINANCE_LOCKED
+    const res = await t.withIdentity(asUser()).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor: ACTOR, auditId: "logv2", now: NOW + 1,
+    });
+    expect(res.version).toBe(2);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.revision).toBe(2);
+      const q2 = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", "q2")).first();
+      expect(q2?.status).toBe("DRAFT");
+    });
+  });
+
+  test("after cutting v2, pricing is open again — the current revision's quote is a fresh DRAFT", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    await t.withIdentity(asUser()).mutation(api.quotesWrites.newVersionNative, {
+      id: "q2", organizationId: ORG, projectId: "p1", actor: ACTOR, auditId: "logv2", now: NOW + 1,
+    });
+    // No unlock session needed — v1's SENT lock no longer applies once v2 (a
+    // fresh DRAFT) is the project's current revision.
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Extra cable", quantity: 1, unitPrice: 500 },
+      actor: ACTOR, auditId: "log1", now: NOW + 2,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(Number(li?.unitPrice)).toBe(500);
+    });
+  });
+
+  test("sanctioned exit: sendNative isn't blocked sending v1 for the very first time", async () => {
+    const t = makeT();
+    await member(t, "manager");
+    await project(t, "QUOTED"); // no quote row yet at all
+    const res = await t.withIdentity(asUser()).mutation(api.quotesWrites.sendNative, {
+      id: "q1", organizationId: ORG, projectId: "p1", quoteDate: NOW, actor: ACTOR, auditId: "logsend", now: NOW,
+    });
+    expect(res.version).toBe(1);
+  });
+
+  test("projectLocksRead.status reports reason QUOTE_SENT + the revision + quote state", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await sentQuote(t);
+    const status = await t.withIdentity(asUser()).query(api.projectLocksRead.status, { projectId: "p1", orgId: ORG });
+    expect(status?.tier).toBe("FINANCE_LOCKED");
+    expect(status?.reason).toBe("QUOTE_SENT");
+    expect(status?.revision).toBe(1);
+    expect(status?.quoteState).toBe("SENT");
+  });
+
+  test("projectLocksRead.status reports STATUS-driven FINANCE_LOCKED unaffected by quote state on a CONFIRMED project", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "CONFIRMED");
+    const status = await t.withIdentity(asUser()).query(api.projectLocksRead.status, { projectId: "p1", orgId: ORG });
+    expect(status?.tier).toBe("FINANCE_LOCKED");
+    expect(status?.reason).toBe("STATUS");
+    expect(status?.quoteState).toBeNull();
+  });
+});

--- a/convex/projectLocksRead.ts
+++ b/convex/projectLocksRead.ts
@@ -1,9 +1,10 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { requireOrgPermission } from "./lib/auth";
-import { getOpenUnlockSession, isHardLockOverrideAllowed, lockTierForStatus } from "./lib/projectLocks";
+import { getOpenUnlockSession, isHardLockOverrideAllowed, resolveLockTier } from "./lib/projectLocks";
 import { getAuthContext } from "./lib/auth";
 import { collectCurrentEntries } from "./lib/projectSnapshots";
+import { effectiveQuoteStatus, findQuoteAtRevision, projectRevision } from "./lib/quoteState";
 
 const ENTRY_RETURNS = v.array(
   v.object({
@@ -29,11 +30,37 @@ const ENTRY_RETURNS = v.array(
  */
 
 export const status = query({
-  args: { projectId: v.string(), orgId: v.string() },
+  args: {
+    projectId: v.string(),
+    orgId: v.string(),
+    // Optional (like `quotes.ts`'s reads) — a Convex query must be deterministic
+    // to stay reactively cacheable, so `now` is client-supplied rather than
+    // `Date.now()`. Only used to resolve a real EXPIRED for display; omitting it
+    // still resolves the correct TIER (#988's lock escalation treats SENT and
+    // EXPIRED identically — see `quoteState.ts#currentRevisionQuoteStatus`).
+    now: v.optional(v.number()),
+  },
   returns: v.union(
     v.null(),
     v.object({
       tier: v.union(v.literal("OPEN"), v.literal("FINANCE_LOCKED"), v.literal("JUSTIFY"), v.literal("HARD_LOCKED")),
+      // #988 — why `tier` is what it is, so the UI can explain itself and offer
+      // the right exit (Create quote v(N+1) / Recall vs. the existing unlock
+      // session flow) instead of a bare "locked".
+      reason: v.union(v.literal("STATUS"), v.literal("QUOTE_SENT")),
+      // #988 — the shared revision counter + the current revision's quote state,
+      // so Phase E can render one coherent banner from this single query instead
+      // of a second round trip.
+      revision: v.number(),
+      quoteState: v.union(
+        v.null(),
+        v.literal("DRAFT"),
+        v.literal("SENT"),
+        v.literal("ACCEPTED"),
+        v.literal("DECLINED"),
+        v.literal("SUPERSEDED"),
+        v.literal("EXPIRED"),
+      ),
       canOverrideHardLock: v.boolean(),
       openSession: v.union(
         v.null(),
@@ -48,12 +75,15 @@ export const status = query({
       ),
     }),
   ),
-  handler: async (ctx, { projectId, orgId }) => {
+  handler: async (ctx, { projectId, orgId, now }) => {
     await requireOrgPermission(ctx, orgId, "project", "read");
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", projectId)).first();
     if (!project || project.organizationId !== orgId) return null;
 
-    const tier = lockTierForStatus(project.status);
+    const revision = projectRevision(project);
+    const currentQuote = await findQuoteAtRevision(ctx, orgId, projectId, revision);
+    const quoteState = currentQuote ? effectiveQuoteStatus(currentQuote, now ?? 0) : null;
+    const { tier, reason } = resolveLockTier({ status: project.status, quoteState });
     const session = await getOpenUnlockSession(ctx, orgId, projectId);
 
     const auth = await getAuthContext(ctx);
@@ -63,6 +93,9 @@ export const status = query({
 
     return {
       tier,
+      reason,
+      revision,
+      quoteState,
       canOverrideHardLock,
       openSession: session
         ? {

--- a/convex/projectServicesWrites.test.ts
+++ b/convex/projectServicesWrites.test.ts
@@ -602,3 +602,121 @@ describe("service template CRUD", () => {
     ).rejects.toThrow(/Template not found/i);
   });
 });
+
+// ─── #988 (Phase C) — the previously-deferred bulk/generate/clone/convert gate
+// sites (FEATUREDOCS/62 "Deliberately deferred") are now gated. Each of these
+// is a "kind: structural" gate (same family a single create/update/delete
+// already uses), so an ON_SITE project (JUSTIFY tier) rejects without a
+// justification and succeeds with one. ─────────────────────────────────────
+describe("#988 previously-deferred gate sites", () => {
+  const JUSTIFICATION = "Client requested a change while on site today.";
+
+  test("bulkDeleteServicesNative rejects on ON_SITE without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { status: "ON_SITE" });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceNative, {
+      id: "s1", orgId: ORG, projectId: "p1", ...baseInput, justification: JUSTIFICATION, now: NOW, actor: ACTOR, auditId: "logc",
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.bulkDeleteServicesNative, { ids: ["s1"], orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logbd" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.bulkDeleteServicesNative, {
+      ids: ["s1"], orgId: ORG, now: NOW + 2, actor: ACTOR, auditId: "logbd2", justification: JUSTIFICATION,
+    });
+    expect(res.deleted).toBe(1);
+  });
+
+  test("bulkUpdateServiceStatusNative rejects on ON_SITE without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { status: "ON_SITE" });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceNative, {
+      id: "s1", orgId: ORG, projectId: "p1", ...baseInput, justification: JUSTIFICATION, now: NOW, actor: ACTOR, auditId: "logc",
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.bulkUpdateServiceStatusNative, { ids: ["s1"], orgId: ORG, status: "CONFIRMED", now: NOW + 1, actor: ACTOR, auditId: "logbs" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.bulkUpdateServiceStatusNative, {
+      ids: ["s1"], orgId: ORG, status: "CONFIRMED", now: NOW + 2, actor: ACTOR, auditId: "logbs2", justification: JUSTIFICATION,
+    });
+    expect(res.updated).toBe(1);
+  });
+
+  test("generateServicesNative rejects on ON_SITE without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { status: "ON_SITE", projectStartDate: NOW, projectEndDate: NOW });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.generateServicesNative, { projectId: "p1", orgId: ORG, now: NOW, actor: ACTOR, auditId: "logg" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.generateServicesNative, {
+      projectId: "p1", orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logg2", justification: JUSTIFICATION,
+    });
+    expect(res.created).toBeGreaterThan(0);
+  });
+
+  test("generateServicesNative $0-defaults new services when the project is locked with no open session", async () => {
+    const t = makeT();
+    await member(t, "admin"); // orgSettings:update (template create) + project:update
+    await seedProject(t, "p1", ORG, { status: "CONFIRMED", projectStartDate: NOW, projectEndDate: NOW });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceTemplateNative, {
+      id: "tp1", orgId: ORG, type: "DELIVERY", title: "Std Delivery", showOnDocuments: true, isAutoAdded: true, isActive: true, defaultUnitPrice: 150, now: NOW, actor: ACTOR, auditId: "logtc",
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.generateServicesNative, {
+      projectId: "p1", orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logg",
+    });
+    expect(res.created).toBe(1);
+    const svcs = await t.run(async (ctx) => ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", "p1")).collect());
+    expect(svcs[0].unitPrice).toBeUndefined(); // template's defaultUnitPrice was zeroed, not copied
+  });
+
+  test("cloneServicesNative rejects on an ON_SITE target without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { projectStartDate: NOW });
+    await seedProject(t, "p2", ORG, { status: "ON_SITE", projectStartDate: NOW });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceNative, {
+      id: "s1", orgId: ORG, projectId: "p1", ...baseInput, now: NOW, actor: ACTOR, auditId: "logc",
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.cloneServicesNative, { targetProjectId: "p2", sourceProjectId: "p1", orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logcl" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.cloneServicesNative, {
+      targetProjectId: "p2", sourceProjectId: "p1", orgId: ORG, now: NOW + 2, actor: ACTOR, auditId: "logcl2", justification: JUSTIFICATION,
+    });
+    expect(res.cloned).toBe(1);
+  });
+
+  test("cloneServicesNative $0-defaults copied pricing when the target is locked with no open session", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { projectStartDate: NOW });
+    await seedProject(t, "p2", ORG, { status: "CONFIRMED", projectStartDate: NOW });
+    await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.createServiceNative, {
+      id: "s1", orgId: ORG, projectId: "p1", ...baseInput, unitPrice: 250, now: NOW, actor: ACTOR, auditId: "logc",
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.cloneServicesNative, {
+      targetProjectId: "p2", sourceProjectId: "p1", orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logcl",
+    });
+    expect(res.cloned).toBe(1);
+    const targetServices = await t.run(async (ctx) => ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", "p2")).collect());
+    expect(targetServices[0].unitPrice).toBeUndefined();
+  });
+
+  test("convertLineItemToServiceNative rejects on ON_SITE without justification, succeeds with one", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t, "p1", ORG, { status: "ON_SITE" });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", type: "SERVICE", description: "Rigging", quantity: 1, lineTotal: 50, isKitChild: false, status: "CONFIRMED" });
+    });
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.convertLineItemToServiceNative, { serviceId: "s1", lineItemId: "li1", orgId: ORG, now: NOW, actor: ACTOR, auditId: "logcv" }),
+    ).rejects.toThrow(/JUSTIFICATION_REQUIRED/i);
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.projectServicesWrites.convertLineItemToServiceNative, {
+      serviceId: "s1", lineItemId: "li1", orgId: ORG, now: NOW + 1, actor: ACTOR, auditId: "logcv2", justification: JUSTIFICATION,
+    });
+    expect(res.id).toBe("s1");
+  });
+});

--- a/convex/projectServicesWrites.ts
+++ b/convex/projectServicesWrites.ts
@@ -827,7 +827,15 @@ export const updateServiceStatusNative = mutation({
 // ─────────────────────────────────────────────────────────────────────────────
 export const bulkDeleteServicesNative = mutation({
   returns: v.object({ deleted: v.number(), skipped: v.number() }),
-  args: { ids: v.array(v.string()), orgId: v.string(), now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    ids: v.array(v.string()),
+    orgId: v.string(),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once a touched project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "projectService");
     await enforceBrowserWriteLimit(ctx);
@@ -836,10 +844,20 @@ export const bulkDeleteServicesNative = mutation({
     if (a.ids.length === 0) return { deleted: 0, skipped: 0 };
 
     const projectIds = new Set<string>();
+    // #988: gate once per distinct project this selection touches (deleting is
+    // structural — #793's JUSTIFY-tier per-edit gate, same "kind" a single
+    // deleteServiceNative uses). Mirrors patchManyNative/removeManyNative's
+    // per-project dedup for a multi-project bulk write.
+    const guardedProjectIds = new Set<string>();
     let deleted = 0, skipped = 0;
     for (const id of a.ids) {
       const service = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).first();
       if (!service || service.organizationId !== a.orgId) { skipped++; continue; }
+      if (!guardedProjectIds.has(service.projectId)) {
+        const svcProject = await requireProjectInOrg(ctx, service.projectId, a.orgId);
+        await assertLifecycleGuard(ctx, svcProject, { kind: "structural", justification: a.justification });
+        guardedProjectIds.add(service.projectId);
+      }
       projectIds.add(service.projectId);
       await cascadeDeleteService(ctx, service, a.orgId);
       deleted++;
@@ -868,7 +886,16 @@ export const bulkDeleteServicesNative = mutation({
 // ─────────────────────────────────────────────────────────────────────────────
 export const bulkUpdateServiceStatusNative = mutation({
   returns: v.object({ updated: v.number(), skipped: v.number() }),
-  args: { ids: v.array(v.string()), orgId: v.string(), status: enums.ServiceStatus, now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    ids: v.array(v.string()),
+    orgId: v.string(),
+    status: enums.ServiceStatus,
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once a touched project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "projectService");
     await enforceBrowserWriteLimit(ctx);
@@ -877,10 +904,17 @@ export const bulkUpdateServiceStatusNative = mutation({
     if (a.ids.length === 0) return { updated: 0, skipped: 0 };
 
     const projectIds = new Set<string>();
+    // #988: a status change is structural, gated once per distinct project.
+    const guardedProjectIds = new Set<string>();
     let updated = 0, skipped = 0;
     for (const id of a.ids) {
       const service = await ctx.db.query("projectServices").withIndex("by_cuid", (q) => q.eq("id", id)).first();
       if (!service || service.organizationId !== a.orgId) { skipped++; continue; }
+      if (!guardedProjectIds.has(service.projectId)) {
+        const svcProject = await requireProjectInOrg(ctx, service.projectId, a.orgId);
+        await assertLifecycleGuard(ctx, svcProject, { kind: "structural", justification: a.justification });
+        guardedProjectIds.add(service.projectId);
+      }
       await ctx.db.patch(service._id, { status: a.status, updatedAt: a.now });
       projectIds.add(service.projectId);
       updated++;
@@ -946,7 +980,15 @@ const dayKeyOf = (ms: number | null): string => (ms != null ? new Date(ms).toISO
 
 export const generateServicesNative = mutation({
   returns: v.object({ created: v.number() }),
-  args: { orgId: v.string(), projectId: v.string(), now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    orgId: v.string(),
+    projectId: v.string(),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once the project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "projectService");
     await enforceBrowserWriteLimit(ctx);
@@ -954,6 +996,9 @@ export const generateServicesNative = mutation({
     const actor = await resolveActor(ctx, a.actor);
 
     const project = await requireProjectInOrg(ctx, a.projectId, a.orgId);
+    // #988: generating is an add (structural) — a $0-priced template while
+    // locked mirrors createServiceNative's own defaultToZero handling below.
+    const guard = await assertLifecycleGuard(ctx, project, { kind: "structural", justification: a.justification });
     // WS2 (#941) — service generation reads the PROJECT window (falls back to
     // rental when unset), not the deprecated loadIn/loadOut/event* fields.
     const window = getProjectWindow(project);
@@ -1055,6 +1100,12 @@ export const generateServicesNative = mutation({
 
     if (toCreate.length === 0) return { created: 0 };
 
+    // #988: locked with no open session — every generated service lands at
+    // $0/unpriced, same as a manually-added one (createServiceNative).
+    if (guard.defaultToZero) {
+      for (const svc of toCreate) svc.unitPrice = null;
+    }
+
     let sortOrder = existingServices.reduce((m, s) => Math.max(m, s.sortOrder ?? 0), -1) + 1;
     let created = 0;
     for (const svc of toCreate) {
@@ -1091,6 +1142,7 @@ export const generateServicesNative = mutation({
       orgId: a.orgId, actor, auditId: a.auditId, now: a.now,
       action: "generated", entityId: a.projectId, entityName: project.name,
       summary: `Generated ${created} services for ${project.projectNumber}`, projectId: a.projectId,
+      metadata: lifecycleAuditMetadata(guard, a.justification),
     });
 
     return { created };
@@ -1111,6 +1163,8 @@ export const cloneServicesNative = mutation({
     now: v.number(),
     actor: actorValidator,
     auditId: v.string(),
+    // #988: required once the TARGET project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
   },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "projectService");
@@ -1120,6 +1174,9 @@ export const cloneServicesNative = mutation({
 
     const target = await requireProjectInOrg(ctx, a.targetProjectId, a.orgId);
     const source = await requireProjectInOrg(ctx, a.sourceProjectId, a.orgId);
+    // #988: gated on the TARGET only — that's where the new (add) services
+    // land; the source project isn't written to.
+    const guard = await assertLifecycleGuard(ctx, target, { kind: "structural", justification: a.justification });
 
     const sourceServices = (
       await ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", a.sourceProjectId)).collect()
@@ -1174,6 +1231,15 @@ export const cloneServicesNative = mutation({
       const newServiceId = createId();
       const clonedDate = offsetDate(svc.date);
       const clonedEndDate = offsetDate(svc.endDate);
+      // #988: locked target with no open session — the clone is an add, so its
+      // copied money fields land at $0/unset exactly like a manually-added
+      // service (createServiceNative), never the source's live pricing.
+      const unitPrice = guard.defaultToZero ? null : (svc.unitPrice ?? null);
+      const discount = guard.defaultToZero ? null : (svc.discount ?? null);
+      const lineTotal = guard.defaultToZero ? null : (svc.lineTotal ?? null);
+      const costTotal = guard.defaultToZero ? null : (svc.costTotal ?? null);
+      const chargeRateOverride = guard.defaultToZero ? null : (svc.chargeRateOverride ?? null);
+      const crewChargeTotal = guard.defaultToZero ? null : (svc.crewChargeTotal ?? null);
       await ctx.db.insert("projectServices", {
         id: newServiceId,
         organizationId: a.orgId,
@@ -1192,17 +1258,17 @@ export const cloneServicesNative = mutation({
         ...(svc.latitude != null ? { latitude: svc.latitude } : {}),
         ...(svc.longitude != null ? { longitude: svc.longitude } : {}),
         showOnDocuments: svc.showOnDocuments ?? false,
-        ...(svc.unitPrice != null ? { unitPrice: svc.unitPrice } : {}),
+        ...(unitPrice != null ? { unitPrice } : {}),
         quantity: svc.quantity ?? 1,
         ...(svc.pricingType != null ? { pricingType: svc.pricingType } : {}),
         ...(svc.duration != null ? { duration: svc.duration } : {}),
-        ...(svc.discount != null ? { discount: svc.discount } : {}),
-        ...(svc.lineTotal != null ? { lineTotal: svc.lineTotal } : {}),
-        ...(svc.costTotal != null ? { costTotal: svc.costTotal } : {}),
+        ...(discount != null ? { discount } : {}),
+        ...(lineTotal != null ? { lineTotal } : {}),
+        ...(costTotal != null ? { costTotal } : {}),
         // Charge-side fields copy verbatim, same as costTotal above — no recalc call
         // here (parity with the pre-existing cost-side clone behaviour).
-        ...(svc.chargeRateOverride != null ? { chargeRateOverride: svc.chargeRateOverride } : {}),
-        ...(svc.crewChargeTotal != null ? { crewChargeTotal: svc.crewChargeTotal } : {}),
+        ...(chargeRateOverride != null ? { chargeRateOverride } : {}),
+        ...(crewChargeTotal != null ? { crewChargeTotal } : {}),
         taxable: svc.taxable ?? true,
         ...(svc.vehicleDescription != null ? { vehicleDescription: svc.vehicleDescription } : {}),
         ...(svc.numberOfTrips != null ? { numberOfTrips: svc.numberOfTrips } : {}),
@@ -1244,6 +1310,7 @@ export const cloneServicesNative = mutation({
       action: "cloned", entityId: a.targetProjectId, entityName: target.name,
       summary: `Cloned ${cloned} services from ${source.projectNumber} to ${target.projectNumber}`,
       projectId: a.targetProjectId,
+      metadata: lifecycleAuditMetadata(guard, a.justification),
     });
 
     return { cloned };
@@ -1257,7 +1324,16 @@ export const cloneServicesNative = mutation({
 // ─────────────────────────────────────────────────────────────────────────────
 export const convertLineItemToServiceNative = mutation({
   returns: v.object({ id: v.string() }),
-  args: { serviceId: v.string(), orgId: v.string(), lineItemId: v.string(), now: v.number(), actor: actorValidator, auditId: v.string() },
+  args: {
+    serviceId: v.string(),
+    orgId: v.string(),
+    lineItemId: v.string(),
+    now: v.number(),
+    actor: actorValidator,
+    auditId: v.string(),
+    // #988: required once the project is JUSTIFY+ and no session is open.
+    justification: v.optional(v.string()),
+  },
   handler: async (ctx, a) => {
     await assertWritesEnabled(ctx, "projectService");
     await enforceBrowserWriteLimit(ctx);
@@ -1266,7 +1342,10 @@ export const convertLineItemToServiceNative = mutation({
 
     const line = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", a.lineItemId)).first();
     if (!line || line.organizationId !== a.orgId) throw new ConvexError("Line item not found");
-    await requireProjectInOrg(ctx, line.projectId, a.orgId);
+    const convertProject = await requireProjectInOrg(ctx, line.projectId, a.orgId);
+    // #988: converting creates a new service (an add) linked to the line — its
+    // copied pricing is gated the same way createServiceNative's is.
+    const guard = await assertLifecycleGuard(ctx, convertProject, { kind: "structural", justification: a.justification });
 
     const typeMap: Record<string, string> = { TRANSPORT: "DELIVERY", LABOUR: "LABOUR", SERVICE: "MISC" };
     const serviceType = typeMap[line.type ?? "EQUIPMENT"] || "MISC";
@@ -1288,6 +1367,11 @@ export const convertLineItemToServiceNative = mutation({
     const sortOrder = existingForProject.reduce((m, s) => Math.max(m, s.sortOrder ?? 0), -1) + 1;
 
     const pricingType = line.pricingType && String(line.pricingType) !== "" ? line.pricingType : null;
+    // #988: locked with no open session — the converted service is an add, so
+    // its copied pricing lands at $0/unset, never the line's live price.
+    const unitPrice = guard.defaultToZero ? null : (line.unitPrice ?? null);
+    const discount = guard.defaultToZero ? null : (line.discount ?? null);
+    const lineTotal = guard.defaultToZero ? null : (line.lineTotal ?? null);
     await ctx.db.insert("projectServices", {
       id: a.serviceId,
       organizationId: a.orgId,
@@ -1295,12 +1379,12 @@ export const convertLineItemToServiceNative = mutation({
       type: serviceType as Doc<"projectServices">["type"],
       title: line.description || SERVICE_TYPE_LABELS[serviceType],
       showOnDocuments: true,
-      ...(line.unitPrice != null ? { unitPrice: line.unitPrice } : {}),
+      ...(unitPrice != null ? { unitPrice } : {}),
       quantity: line.quantity ?? 1,
       ...(pricingType ? { pricingType: pricingType as Doc<"projectServices">["pricingType"] } : {}),
       ...(line.duration ? { duration: Number(line.duration) } : {}),
-      ...(line.discount ? { discount: Number(line.discount) } : {}),
-      ...(line.lineTotal ? { lineTotal: Number(line.lineTotal) } : {}),
+      ...(discount != null ? { discount: Number(discount) } : {}),
+      ...(lineTotal != null ? { lineTotal: Number(lineTotal) } : {}),
       lineItemId: line.id,
       sortOrder,
       createdAt: a.now,
@@ -1314,6 +1398,7 @@ export const convertLineItemToServiceNative = mutation({
       action: "converted", entityId: a.serviceId, entityName: line.description || SERVICE_TYPE_LABELS[serviceType],
       summary: `Converted line item "${line.description}" to ${SERVICE_TYPE_LABELS[serviceType]} service`,
       projectId: line.projectId,
+      metadata: lifecycleAuditMetadata(guard, a.justification),
     });
 
     return { id: a.serviceId };

--- a/convex/quotesWrites.ts
+++ b/convex/quotesWrites.ts
@@ -183,12 +183,14 @@ async function prepareSend(
     throw new ConvexError({ code: "TEMPLATE_QUOTE", message: "Templates don't have quotes." });
   }
   // Same financial gate every money-touching mutation uses, so a hard-locked
-  // project can't emit a quote out of band. NOTE for #988 (Phase C): once
-  // `resolveLockTier` folds quote state in, a SENT quote itself raises the tier —
-  // this call site must then treat "cut and send the NEXT revision" as the
-  // sanctioned exit from the quote-derived lock, or sending v2 would be blocked
-  // by v1's own lock.
-  await assertLifecycleGuard(ctx, project, { kind: "financial" });
+  // (or status-FINANCE_LOCKED, e.g. CONFIRMED+) project can't emit a quote out
+  // of band. `bypassQuoteLock: true` (#988) because THIS is the mutation that
+  // freezes the current revision's own quote lock — gating it against its own
+  // not-yet-sent state would be a no-op (a fresh/DRAFT revision never raises
+  // the tier anyway) and gating a RESEND against the revision's own prior SENT
+  // state would be a chicken-and-egg deadlock. STATUS-driven tiers (CONFIRMED+
+  // / ON_SITE+ / COMPLETED+) are unaffected by this flag and still gate normally.
+  await assertLifecycleGuard(ctx, project, { kind: "financial", bypassQuoteLock: true });
 
   // The recipient must belong to THIS project's client — otherwise a caller could
   // stamp another client's contact onto the revision and leak their PII onto the
@@ -450,7 +452,13 @@ export const newVersionNative = mutation({
     if (project.isTemplate) {
       throw new ConvexError({ code: "TEMPLATE_QUOTE", message: "Templates don't have quotes." });
     }
-    await assertLifecycleGuard(ctx, project, { kind: "financial" });
+    // `bypassQuoteLock: true` (#988) — THIS is the sanctioned exit from a
+    // quote-derived lock ("cutting a new version is the unlock", decision 2).
+    // At call time the current revision is still the live SENT/ACCEPTED/etc.
+    // quote this mutation is about to move past, so gating against its own
+    // escalation would make the unlock action unreachable. STATUS-driven tiers
+    // (CONFIRMED+/ON_SITE+/COMPLETED+) still gate normally.
+    await assertLifecycleGuard(ctx, project, { kind: "financial", bypassQuoteLock: true });
 
     const revision = projectRevision(project);
     const current = await findQuoteAtRevision(ctx, organizationId, projectId, revision);

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -11197,6 +11197,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "array"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -11207,8 +11212,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "6c012673b4cd07b8",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "171d09f36dccd4bc",
     "returnsSha": "bec0cd60d81a5175"
   },
   {
@@ -11243,6 +11250,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "array"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -11258,8 +11270,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "union"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "117f2bb2ab75ea78",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "7074dcef8d9702c8",
     "returnsSha": "04471d174c91281a"
   },
   {
@@ -11475,13 +11489,20 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "orgId",
         "optional": false,
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "56f39965728b3fac",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "7eed1de1dd291c44",
     "returnsSha": "ca20c8538a3cc095"
   },
   {
@@ -21191,6 +21212,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "array"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -21201,8 +21227,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "aaf0b683ae95206d",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "e6c1a2f24c1b92f5",
     "returnsSha": "efde83ecf2efd768"
   },
   {
@@ -30190,6 +30218,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "agentReachable": true,
     "args": [
       {
+        "name": "now",
+        "optional": true,
+        "type": "number"
+      },
+      {
         "name": "orgId",
         "optional": false,
         "type": "string"
@@ -30201,8 +30234,8 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
       }
     ],
     "privilegedArgs": [],
-    "argsSha": "fefad8ad30daf59f",
-    "returnsSha": "01c68efecbfae39d"
+    "argsSha": "8f3456c860a78207",
+    "returnsSha": "d8256f5e1e3ca1ff"
   },
   {
     "operation": "projectManagers.applyDiff",
@@ -32646,6 +32679,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "array"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -32656,8 +32694,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "a12d4885e3521cab",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "f8c0a774a625c95a",
     "returnsSha": "bec0cd60d81a5175"
   },
   {
@@ -32692,6 +32732,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "array"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -32707,8 +32752,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "union"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "aebc53739f87fc9c",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "bde61e4f154287cc",
     "returnsSha": "04471d174c91281a"
   },
   {
@@ -32738,6 +32785,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -32758,8 +32810,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "f5c283a774e01e69",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "284ec9d64e3a082c",
     "returnsSha": "400f378b3746f7c8"
   },
   {
@@ -32789,6 +32843,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "lineItemId",
         "optional": false,
         "type": "string"
@@ -32809,8 +32868,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "9b953d2d794458ef",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "c11e2197bf58b40c",
     "returnsSha": "8b114161049d5d20"
   },
   {
@@ -33238,6 +33299,11 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       },
       {
+        "name": "justification",
+        "optional": true,
+        "type": "string"
+      },
+      {
         "name": "now",
         "optional": false,
         "type": "number"
@@ -33253,8 +33319,10 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "type": "string"
       }
     ],
-    "privilegedArgs": [],
-    "argsSha": "9faae7a468ef5dd4",
+    "privilegedArgs": [
+      "justification"
+    ],
+    "argsSha": "d3e6c9c5f8632774",
     "returnsSha": "055fda7228358ed7"
   },
   {


### PR DESCRIPTION
## Summary

Implements #988 (Phase C of the #985 finance version-control program):

- **`resolveLockTier({ status, quoteState })`** in `convex/lib/projectLocks.ts` replaces the direct use of `lockTierForStatus` inside `assertLifecycleGuard`. An OPEN-status project (`ENQUIRY`/`QUOTING`/`QUOTED`) whose current revision has already been sent now escalates to `FINANCE_LOCKED` too — the quote-send lock (decision 2) is a second **input** to the existing tier resolver, not a second lock mechanism. Monotonic by construction: quote state can only ever raise `OPEN` → `FINANCE_LOCKED`, never touch an already-locked status tier.
- `assertLifecycleGuard` fetches the current revision's quote state itself (only when the status tier is itself `OPEN`), so **all ~25 existing gate sites need zero changes**.
- `LifecycleGuardResult` gains `reason: "STATUS" | "QUOTE_SENT"`; `projectLocksRead.status` returns that reason plus the current `revision` and `quoteState`, so a future UI (Phase E, #990) can render one coherent banner from a single query.
- **Sanctioned-exit fix**: `quotesWrites.ts`'s `sendNative` and `newVersionNative` are the two mutations that raise/cut the quote-derived lock, so they'd otherwise deadlock against their own not-yet-superseded state. Both pass a new `bypassQuoteLock: true` option to `assertLifecycleGuard` — the only two call sites that should ever set it.
- **Closed every deferred gate site** from FEATUREDOCS/62: `projectServicesWrites.ts`'s `bulkDeleteServicesNative`/`bulkUpdateServiceStatusNative`/`generateServicesNative`/`cloneServicesNative`/`convertLineItemToServiceNative`, `lineItemWrites.ts`'s `reorderNative`, and `crewAssignmentsWrites.ts`'s `bulkDeleteNative`/`bulkStatusNative`/`generateShiftsNative` — each now calls `assertLifecycleGuard` (`kind: "structural"`, deduped per distinct project for bulk ops), with `defaultToZero` applied to every new/copied money field exactly like a manually-added entity.
- Updated `FEATUREDOCS/62-project-lifecycle-locks.md` — documents the new tier table and folds the now-empty "Deliberately deferred" section into gate site coverage.

## Testing

- Full status × quote-state truth table + a monotonicity property test (`convex/lib/projectLocks.test.ts`).
- Integration coverage for the quote-derived lock against real quote mutations (`convex/projectLifecycleLocks.test.ts`): locks money fields while leaving structural fields open, $0-defaults new adds, unlock sessions still work, a sent quote on an already-locked status softens nothing, both sanctioned exits are not blocked, and `projectLocksRead.status` reports the right reason/revision/quote state.
- A "rejects on an ON_SITE project without justification, succeeds with one" test for each of the 9 newly-gated mutations.
- `pnpm vitest run` — 391 files / 5025 tests pass.
- `npx tsc --noEmit` — clean.
- `pnpm lint` — 0 errors (pre-existing warnings only).
- `pnpm run complexity-ratchet` / `any-ratchet` / `knip-ratchet` / `depcruise-ratchet` / `collect-ratchet` — all pass (complexity ratchet required extracting a shared `guardProjectOnce` helper in `crewAssignmentsWrites.ts` to stay under the R-3.6 threshold).
- `pnpm run build` + `pnpm run bundle-ratchet` — clean, against a local throwaway Postgres matching the CI `build` job.
- `pnpm run api:registry:check` — current.

## Size rationale (R-2.8 / T-2)

Over the ~400 LOC SHOULD target (924 LOC). #988 is explicitly the safety-critical function every gate site relies on — the issue's own acceptance criteria require closing *every* previously-deferred gate site (9 mutations across 3 files) plus a full status × quote-state truth table before this phase is complete, so a partial PR would ship the resolver without the coverage that makes it trustworthy. Docs (FEATUREDOCS/62) update in the same PR as the behaviour per R-5.2/5.3/5.8. Split into 9 atomic, independently-revertable commits by concern (resolver → sanctioned-exit fix → read query → each gate-site group → tests → docs → registry regen) to keep review tractable despite the total size.

## Checklist

- [x] New dependency? N/A — no new dependencies.
