### PR TITLE
fix(projects): Unpriced badge reads real cause instead of inferring it from current lock state

### DIFF
--- a/FEATUREDOCS/62-project-lifecycle-locks.md
+++ b/FEATUREDOCS/62-project-lifecycle-locks.md
@@ -231,7 +231,9 @@ crossing back into CONFIRMED/COMPLETED always snapshots).
   advanced underneath a stale client). One shared hook + dialog so every
   gated surface prompts identically — not a per-form one-off.
 - **`src/components/projects/unpriced-badge.tsx`** — the amber "Unpriced"
-  badge for a $0-defaulted add. Mounted on Equipment tab rows (#990).
+  badge for a $0-defaulted add. Mounted on Equipment tab rows (#990). Reads
+  `group.pricedUnderLock` / `item.pricedUnderLock` — a stored field, not an
+  inference from "currently locked" (see below).
 - **`src/lib/lock-copy.ts`**, **`project-lock-chip.tsx`**,
   **`project-lock-strip.tsx`**, **`project-lock-glyph.tsx`**,
   **`src/components/ui/locked-field.tsx`**, **`gated-button.tsx`** — the six
@@ -319,9 +321,44 @@ a status change mid-session, and doesn't currently trigger through this
 integration.
 
 **`UnpricedBadge`** is now mounted on the Equipment tab's `GroupRow`/
-`LineItemRow` (`equipment-rows.tsx`) — a `$0`/unset price under a locked tier
-(kit children excluded, not independently priced). Not yet mounted on
-Services/Crew rows.
+`LineItemRow` (`equipment-rows.tsx`) — kit children excluded, not
+independently priced. Not yet mounted on Services/Crew rows.
+
+**`pricedUnderLock` (bug fix, follow-up to #990).** The badge originally
+rendered on `moneyLocked && price === 0` — i.e. it INFERRED "this was
+`defaultToZero`'d" from "the project happens to be locked right now AND this
+row happens to be $0", with no memory of when or why the row became $0. That
+false-positives hard: a row that's been $0 since long before any lock ever
+existed (no catalog `dailyRate`/`weeklyRate` configured, a sub-hire kit
+pending supplier confirmation, or any other legitimately-unpriced reason)
+starts showing "Added after the quote was confirmed — price it deliberately"
+the moment the project LATER becomes locked, which is simply false for that
+row.
+
+Fixed by storing the actual cause instead of inferring it:
+`projectLineItems.pricedUnderLock` / `projectGroups.pricedUnderLock`
+(`convex/schema.ts`, both `v.optional(v.boolean())`) are set `true` at the
+exact moment `assertLifecycleGuard`'s `defaultToZero` forces a row's price to
+$0/unset — every insert path (`addNative`, `addCustomNative`,
+`addLineItemSmartNative`, `addKitNative` → `createKitLineItemCore`,
+`projectGroupsWrites.createNative`) via the shared
+`pricedUnderLockOnInsert(defaultToZero)` helper
+(`convex/lib/projectLocks.ts`), and the FINANCIAL-scope
+`restoreProjectSnapshot`'s "added during the session, not in the snapshot →
+reset to $0" branch (`convex/lib/projectSnapshots.ts`) — the same
+not-deliberately-priced state by construction. It's cleared back to `false`
+the moment a human deliberately sets a real price: `patchNative`'s `unitPrice`
+edit, `updateGroupPriceNative` (always — reaching it means the FINANCIAL
+guard already passed), a line-item merge that keeps a real client-supplied
+price, and a FINANCIAL-scope snapshot restore that lands a real historical
+price from the snapshot. `pricedUnderLock` is listed in
+`LINE_IMMUTABLE_ON_PATCH` — server-derived only, never client-settable.
+
+The badge condition is now simply `item.pricedUnderLock` / `group.pricedUnderLock`
+— no `moneyLocked` check needed (a `defaultToZero`'d row stays flagged for
+review even after the project is later unlocked, until someone actually prices
+it). This also let `moneyLocked` be dropped entirely from `GroupRow`'s and
+`LineItemRow`'s props — it had no other reader.
 
 **Unlock session diff (§7.2).** `projectLocksRead.status`'s `openSession` now
 carries `snapshotId`; `unlock-session-banner.tsx`'s Save & relock and Discard

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -196,6 +196,16 @@ export function shouldDefaultToZero(tier: LockTier, openSession: Doc<"projectUnl
   return tier !== "OPEN" && openSession == null;
 }
 
+/** The `pricedUnderLock` field value for a fresh group/line-item insert —
+ *  `true` when `defaultToZero` forced this row's price to $0/unset, `undefined`
+ *  (absent, Convex's "false") otherwise. ONE helper so every insert site
+ *  derives the same value instead of re-deriving `defaultToZero || undefined`
+ *  inline at each call site (R-3.1) — also keeps that branch out of each
+ *  insert mutation's own cyclomatic-complexity count (R-3.6 ratchet). */
+export function pricedUnderLockOnInsert(defaultToZero: boolean | undefined): true | undefined {
+  return defaultToZero || undefined;
+}
+
 // ─── The shared guard (#793's `assertLifecycleGuard`) ────────────────────────
 
 export type LifecycleGuardKind = "financial" | "structural";

--- a/convex/lib/projectSnapshots.ts
+++ b/convex/lib/projectSnapshots.ts
@@ -228,16 +228,19 @@ export async function restoreProjectSnapshot(ctx: MutationCtx, args: RestoreArgs
         const { _id: _dropId, _creationTime: _dropTime, id: _dropCuid, organizationId: _dropOrg, ...rest } = data as Record<string, unknown> & { id: string; organizationId: string };
         await ctx.db.replace(g._id, { ...rest, id: g.id, organizationId: orgId, updatedAt: now } as typeof g);
       } else {
-        const patch: Record<string, unknown> = { updatedAt: now };
+        // Restoring a real historical price is a deliberate act — not a lock artifact.
+        const patch: Record<string, unknown> = { updatedAt: now, pricedUnderLock: false };
         for (const f of LOCKED_GROUP_FIELDS) patch[f] = data[f];
         await ctx.db.patch(g._id, patch);
       }
     } else {
-      // Added during the session.
+      // Added during the session, absent from the snapshot: same "not deliberately
+      // priced" state `assertLifecycleGuard`'s `defaultToZero` produces on a locked
+      // insert — flag it so the Unpriced badge points at the real cause.
       if (scope === "FULL") {
         await ctx.db.delete(g._id);
       } else {
-        await ctx.db.patch(g._id, { price: undefined, discount: undefined, updatedAt: now });
+        await ctx.db.patch(g._id, { price: undefined, discount: undefined, pricedUnderLock: true, updatedAt: now });
       }
     }
   }
@@ -267,12 +270,15 @@ export async function restoreProjectSnapshot(ctx: MutationCtx, args: RestoreArgs
         }
         await ctx.db.patch(li._id, patch);
       } else {
-        const patch: Record<string, unknown> = { updatedAt: now };
+        // Restoring a real historical price is a deliberate act — not a lock artifact.
+        const patch: Record<string, unknown> = { updatedAt: now, pricedUnderLock: false };
         for (const f of LOCKED_LINE_ITEM_FIELDS) patch[f] = data[f];
         await ctx.db.patch(li._id, patch);
       }
     } else {
-      // Added during the session.
+      // Added during the session, absent from the snapshot: same "not deliberately
+      // priced" state `assertLifecycleGuard`'s `defaultToZero` produces on a locked
+      // insert — flag it so the Unpriced badge points at the real cause.
       if (scope === "FULL") {
         if (isWarehouseBacked(li as unknown as Record<string, unknown>)) {
           conflicts.push(`Line item "${li.description ?? li.id}" was added during the session and references live warehouse stock — review and remove manually.`);
@@ -280,7 +286,7 @@ export async function restoreProjectSnapshot(ctx: MutationCtx, args: RestoreArgs
           await ctx.db.delete(li._id);
         }
       } else {
-        await ctx.db.patch(li._id, { unitPrice: 0, discount: undefined, updatedAt: now });
+        await ctx.db.patch(li._id, { unitPrice: 0, discount: undefined, pricedUnderLock: true, updatedAt: now });
       }
     }
   }

--- a/convex/lineItemWrites.ts
+++ b/convex/lineItemWrites.ts
@@ -36,7 +36,7 @@ import {
   isBreakdownStale,
   type PriceBreakdown,
 } from "./lib/billingDerivation";
-import { assertLifecycleGuard, lifecycleAuditMetadata, LOCKED_LINE_ITEM_FIELDS } from "./lib/projectLocks";
+import { assertLifecycleGuard, lifecycleAuditMetadata, LOCKED_LINE_ITEM_FIELDS, pricedUnderLockOnInsert } from "./lib/projectLocks";
 import {
   adjustModelSaleStock,
   sellSerializedAssetForSale,
@@ -545,6 +545,9 @@ const LINE_IMMUTABLE_ON_PATCH = [
   "allocatedRevenue", "allocationBasis",
   "subHireId", "subHireItemId", "subHireGroupId", "supplierOrderId",
   "createdAt",
+  // Server-derived (see schema comment) — only assertLifecycleGuard's defaultToZero
+  // path and the explicit-money-edit clear below may ever set this.
+  "pricedUnderLock",
 ] as const;
 
 const LINE_NEVER_CLEAR = new Set<string>(["id", "organizationId", ...LINE_IMMUTABLE_ON_PATCH]);
@@ -718,6 +721,13 @@ export const patchNative = mutation({
       newModelId: (effModelId as string | undefined) ?? null,
       currentQty, newQty,
     });
+
+    // A deliberate `unitPrice` edit reaching here means the FINANCIAL guard already
+    // passed (open tier or open unlock session) — clear any stale "priced under lock"
+    // flag so the Unpriced badge stops pointing at a cause that's no longer true.
+    // Scoped to `unitPrice` itself (not the whole `touchesMoney` set) so a
+    // duration-only change on an otherwise-still-$0 line doesn't silently clear it.
+    if ("unitPrice" in setObj || clear.includes("unitPrice")) setObj.pricedUnderLock = false;
 
     if (clear.length === 0) {
       await ctx.db.patch(doc._id, setObj);
@@ -1257,6 +1267,7 @@ export const addCustomNative = mutation({
       isCustomItem: true,
       ...fields,
       lineTotal: computedLineTotal ?? undefined,
+      pricedUnderLock: pricedUnderLockOnInsert(guard.defaultToZero),
       sortOrder,
       createdAt: now,
       updatedAt: now,
@@ -1500,6 +1511,7 @@ export const addNative = mutation({
       projectId,
       ...fields,
       lineTotal: computedLineTotal ?? undefined,
+      pricedUnderLock: pricedUnderLockOnInsert(guard.defaultToZero),
       accessoryPlan,
       status: "CONFIRMED",
       sortOrder,
@@ -1756,6 +1768,7 @@ export const addKitNative = mutation({
     await createKitLineItemCore(ctx, {
       id, organizationId, projectId, kitId, unitPrice: effectiveUnitPrice, discount: effectiveDiscount,
       discountMode: effectiveDiscountMode, pricingMode, groupName, categoryId, groupId, now,
+      pricedUnderLock: guard.defaultToZero,
     });
 
     // Parity with the deleted addKitLineItem: when the client can't resolve the kit
@@ -2124,6 +2137,10 @@ export const addLineItemSmartNative = mutation({
           lineTotal: newLineTotal ?? undefined,
           groupName: fields.groupName || existing.groupName || undefined,
           notes: mergedNotes || undefined,
+          // A real client-supplied price wins the merge -> that's a deliberate
+          // price, clear any stale lock-artifact flag. Otherwise (qty-only merge,
+          // or the merge itself ran under lock) leave the existing row's flag as-is.
+          pricedUnderLock: mergeUnitPriceInput != null ? false : existing.pricedUnderLock,
           updatedAt: now,
         } as Record<string, unknown>);
         await ctx.db.patch(existing._id, mergeSet);
@@ -2246,6 +2263,7 @@ export const addLineItemSmartNative = mutation({
       discount: insertDiscount ?? undefined,
       discountMode: insertDiscountMode,
       lineTotal: lineTotal ?? undefined,
+      pricedUnderLock: pricedUnderLockOnInsert(guard.defaultToZero),
       priceBreakdown: autoPriceBreakdown,
       groupName: fields.groupName || undefined,
       notes: fields.notes || undefined,

--- a/convex/projectGroupsWrites.ts
+++ b/convex/projectGroupsWrites.ts
@@ -8,7 +8,7 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { recalcProjectTotals } from "./lib/recalc";
 import { computeGroupSuggestedPrice } from "./lib/suggestedPrice";
-import { assertLifecycleGuard, lifecycleAuditMetadata } from "./lib/projectLocks";
+import { assertLifecycleGuard, lifecycleAuditMetadata, pricedUnderLockOnInsert } from "./lib/projectLocks";
 import { assertStrLen } from "./lib/fieldGuards";
 import * as enums from "./lib/validators";
 import type { AgentOpsAnnotations } from "./lib/agentOps";
@@ -300,6 +300,10 @@ export const createGroupNative = mutation({
       price: a.price != null ? a.price : undefined,
       discount: a.discount != null ? a.discount : undefined,
       discountMode: a.discount != null ? a.discountMode : undefined,
+      // Record the ACTUAL cause of a $0/unset price at create time, so the
+      // Unpriced badge stops inferring it from "currently locked" (see the
+      // schema comment on `pricedUnderLock`).
+      pricedUnderLock: pricedUnderLockOnInsert(guard.defaultToZero),
       suggestedPrice: 0,
       sortOrder,
       createdAt: a.now,
@@ -470,7 +474,11 @@ export const updateGroupPriceNative = mutation({
     if (!priceProject) throw new ConvexError("Project not found");
     const guard = await assertLifecycleGuard(ctx, priceProject, { kind: "financial" });
 
-    const patch: Record<string, unknown> = { price: a.price, updatedAt: a.now };
+    // Reaching here means the "financial" guard passed — a deliberate price set (open
+    // tier or open unlock session), never `defaultToZero`. Clears any stale
+    // `pricedUnderLock` from an earlier locked add — the price is no longer a
+    // lock artifact once a human has explicitly set it.
+    const patch: Record<string, unknown> = { price: a.price, pricedUnderLock: false, updatedAt: a.now };
     if (a.discount !== undefined) {
       patch.discount = a.discount;
       // #1012: the mode is written with the amount it describes — a discount set

--- a/convex/projectLifecycleLocks.test.ts
+++ b/convex/projectLifecycleLocks.test.ts
@@ -130,10 +130,13 @@ describe("#791 $0 default on add — lineItemWrites.addCustomNative", () => {
       const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
       expect(li?.unitPrice).toBe(0);
       expect(li?.discount).toBeUndefined();
+      // The Unpriced badge's real signal (bug fix, follow-up to #990): stored at
+      // insert time, not inferred later from "currently locked + currently $0".
+      expect(li?.pricedUnderLock).toBe(true);
     });
   });
 
-  test("unlocked (OPEN tier): the client's price is kept", async () => {
+  test("unlocked (OPEN tier): the client's price is kept, and pricedUnderLock is never set", async () => {
     const t = makeT();
     await member(t, "member");
     await project(t, "QUOTED");
@@ -143,10 +146,11 @@ describe("#791 $0 default on add — lineItemWrites.addCustomNative", () => {
     await t.run(async (ctx) => {
       const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
       expect(Number(li?.unitPrice)).toBe(500);
+      expect(li?.pricedUnderLock).toBeFalsy();
     });
   });
 
-  test("inside an open session, auto-pricing resumes (the client's price is kept)", async () => {
+  test("inside an open session, auto-pricing resumes (the client's price is kept), pricedUnderLock stays unset", async () => {
     const t = makeT();
     await member(t, "member");
     await project(t, "CONFIRMED");
@@ -159,6 +163,142 @@ describe("#791 $0 default on add — lineItemWrites.addCustomNative", () => {
     await t.run(async (ctx) => {
       const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
       expect(Number(li?.unitPrice)).toBe(500);
+      expect(li?.pricedUnderLock).toBeFalsy();
+    });
+  });
+});
+
+describe("pricedUnderLock — the Unpriced badge's real cause, not an inference (bug fix)", () => {
+  test("a line item that's been $0 since BEFORE any lock existed does NOT retroactively earn the badge once the project locks", async () => {
+    const t = makeT();
+    await member(t, "member");
+    // OPEN-tier project — a deliberate $0 line (e.g. no catalog rate, or a
+    // genuinely free item) added with nothing locked yet.
+    await project(t, "QUOTED");
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Freebie", quantity: 1, unitPrice: 0 },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.unitPrice).toBe(0);
+      expect(li?.pricedUnderLock).toBeFalsy();
+    });
+    // The project later locks (e.g. quote sent, status advances) — the row's
+    // OWN pricedUnderLock is untouched by that transition; only a write to
+    // the row itself can ever set it.
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      await ctx.db.patch(p!._id, { status: "CONFIRMED" });
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.pricedUnderLock).toBeFalsy();
+    });
+  });
+
+  test("patchNative's unitPrice edit clears a stale pricedUnderLock once a human deliberately prices the row", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "CONFIRMED");
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Extra cable", quantity: 1, unitPrice: 500 },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.pricedUnderLock).toBe(true);
+    });
+    const { sessionId } = await t.withIdentity(asUser()).mutation(api.projectUnlockSessionsWrites.openNative, {
+      projectId: "p1", orgId: ORG, scope: "FINANCIAL", justification: JUSTIFICATION, actor: ACTOR, auditId: "openlog", now: NOW + 1,
+    });
+    expect(sessionId).toBeTruthy();
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.patchNative, {
+      id: "li1", orgId: ORG, entityName: "Extra cable", allowOverbook: false,
+      set: { unitPrice: 120, updatedAt: NOW + 2 }, clear: [], actor: ACTOR, auditId: "log2", now: NOW + 2,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(Number(li?.unitPrice)).toBe(120);
+      expect(li?.pricedUnderLock).toBe(false);
+    });
+  });
+
+  test("a browser-direct caller cannot set pricedUnderLock via patchNative's set object", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED");
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Cable", quantity: 1, unitPrice: 50 },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.patchNative, {
+      id: "li1", orgId: ORG, entityName: "Cable", allowOverbook: false,
+      // duration is a locked field but NOT unitPrice, so this stays a
+      // "structural"-ish touch — pricedUnderLock must not flip just because
+      // a caller stuffs it into `set`.
+      set: { notes: "updated", pricedUnderLock: true, updatedAt: NOW + 1 } as Record<string, unknown>,
+      clear: [], actor: ACTOR, auditId: "log2", now: NOW + 1,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(li?.notes).toBe("updated");
+      expect(li?.pricedUnderLock).toBeFalsy();
+    });
+  });
+
+  test("a locked group create defaults price to $0 and sets pricedUnderLock; updateGroupPriceNative clears it", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "CONFIRMED");
+    await t.withIdentity(asUser()).mutation(api.projectGroupsWrites.createGroupNative, {
+      id: "g1", orgId: ORG, projectId: "p1", title: "Wireless Mic Kit",
+      price: 1400, discount: 210, discountMode: "$",
+      now: NOW, actor: ACTOR, auditId: "log1",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(g?.price).toBeUndefined();
+      expect(g?.pricedUnderLock).toBe(true);
+    });
+    const { sessionId } = await t.withIdentity(asUser()).mutation(api.projectUnlockSessionsWrites.openNative, {
+      projectId: "p1", orgId: ORG, scope: "FINANCIAL", justification: JUSTIFICATION, actor: ACTOR, auditId: "openlog", now: NOW + 1,
+    });
+    expect(sessionId).toBeTruthy();
+    // A deliberate discountMode toggle (the exact user report this fix covers) —
+    // re-setting price/discount through the group's own price mutation must
+    // clear the flag; a group's OWN price edit never touches sibling line items.
+    await t.withIdentity(asUser()).mutation(api.projectGroupsWrites.updateGroupPriceNative, {
+      id: "g1", orgId: ORG, price: 1400, discount: 15, discountMode: "%",
+      now: NOW + 2, actor: ACTOR, auditId: "log2",
+    });
+    await t.run(async (ctx) => {
+      const g = await ctx.db.query("projectGroups").withIndex("by_cuid", (q) => q.eq("id", "g1")).first();
+      expect(Number(g?.price)).toBe(1400);
+      expect(g?.discountMode).toBe("%");
+      expect(g?.pricedUnderLock).toBe(false);
+    });
+  });
+
+  test("addKitNative under lock flags the kit PARENT line, not its (already-excluded) member children", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "CONFIRMED");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "TTP00001", name: "RF Kit 1", status: "AVAILABLE" });
+    });
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addKitNative, {
+      id: "kl1", organizationId: ORG, projectId: "p1", kitId: "k1",
+      unitPrice: 400, pricingMode: "KIT_PRICE", kitLabel: "TTP00001 - RF Kit 1",
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const parent = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "kl1")).first();
+      expect(parent?.unitPrice).toBe(0);
+      expect(parent?.pricedUnderLock).toBe(true);
     });
   });
 });

--- a/convex/projectLineItems.ts
+++ b/convex/projectLineItems.ts
@@ -13,6 +13,7 @@ import { nextOrdinal } from "./lib/lineItemUnits";
 import * as enums from "./lib/validators";
 import { getKitByCuid } from "./lib/kits";
 import { getProjectWindow } from "./lib/projectWindow";
+import { pricedUnderLockOnInsert } from "./lib/projectLocks";
 
 /**
  * Thin CRUD for ProjectLineItem (Convex table "projectLineItems"). GENERATED — Phase 2/5.
@@ -635,6 +636,12 @@ export async function createKitLineItemCore(
     groupName?: string;
     categoryId?: string;
     groupId?: string;
+    /** True when the caller's `unitPrice`/`discount` above were already forced to
+     *  $0/unset by `guard.defaultToZero` — recorded on the parent line so the
+     *  Unpriced badge points at the real cause (see schema comment on
+     *  `pricedUnderLock`). Omitted (the service-only `createKitLineItem` path,
+     *  which has no lock guard of its own) leaves the row unflagged. */
+    pricedUnderLock?: boolean;
     now: number;
   },
 ): Promise<{ id: string }> {
@@ -655,6 +662,7 @@ export async function createKitLineItemCore(
       discountMode: a.unitPrice != null && a.discount != null ? a.discountMode : undefined,
       lineTotal: kitLineTotal, sortOrder: sort++, pricingMode: a.pricingMode,
       groupName: a.groupName, categoryId: a.categoryId, groupId: a.groupId, status: "CONFIRMED",
+      pricedUnderLock: pricedUnderLockOnInsert(a.pricedUnderLock),
       createdAt: a.now, updatedAt: a.now,
     });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1223,6 +1223,16 @@ export default defineSchema({
     allocationBasis: v.optional(enums.AllocationBasis),
     priceBreakdown: v.optional(v.string()),
     priceOverridden: v.optional(v.boolean()),
+    // True exactly when this row's unitPrice/discount were forced to $0/unset by
+    // `assertLifecycleGuard`'s `defaultToZero` (an insert, merge, or snapshot-restore
+    // while the project was locked with no unlock session open) — the actual CAUSE the
+    // `<UnpricedBadge>` tooltip claims, instead of inferring it from "currently locked +
+    // currently $0" (which false-positives on a row that's been $0 since before any lock
+    // ever existed, e.g. no catalog rate configured). Cleared to `false` the moment a
+    // deliberate financial write (patchNative/patchManyNative touching money, a merge
+    // that keeps a real client price, or a FINANCIAL-scope snapshot restore) sets a real
+    // price — server-only, never client-settable (LINE_IMMUTABLE_ON_PATCH).
+    pricedUnderLock: v.optional(v.boolean()),
     overrideReason: v.optional(v.string()),
     sortOrder: v.optional(v.number()),
     groupName: v.optional(v.string()),
@@ -1402,6 +1412,11 @@ export default defineSchema({
     discountMode: v.optional(enums.DiscountMode),
     suggestedPrice: v.optional(v.number()),
     sortOrder: v.optional(v.number()),
+    // Mirrors projectLineItems.pricedUnderLock — true when this group's own `price`/
+    // `discount` were forced to $0/unset by `guard.defaultToZero` at create time (or a
+    // FINANCIAL-scope snapshot restore), not a deliberate free group. See that field's
+    // comment for the full rationale.
+    pricedUnderLock: v.optional(v.boolean()),
     // WS1 (#940) — Xero account-coding override for a priced group's own
     // invoice line (convex/lib/financeSnapshot.ts's "priced groups bill as
     // ONE line"). Cascade: this override -> categoryId's category default ->

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -24,6 +24,12 @@ export interface LineItemData {
   type?: string;
   priceBreakdown?: string | null;
   priceOverridden?: boolean;
+  /** True when `unitPrice`/`discount` were forced to $0/unset by the server's
+   *  `defaultToZero` (added or reset while the project was locked, no unlock session
+   *  open) — the actual cause `<UnpricedBadge>` reads, instead of inferring it from
+   *  "currently locked + currently $0" (which false-positives on a row that's been
+   *  $0 since before any lock ever existed). */
+  pricedUnderLock?: boolean;
   // `isSubhire` removed (Wave 2). Use `subHireId != null` to detect sub-hire items.
   isCustomItem?: boolean;
   isKitChild?: boolean;
@@ -76,6 +82,8 @@ export interface GroupData {
   discountMode?: string | null;
   suggestedPrice: unknown;
   sortOrder: number;
+  /** Mirrors `LineItemData.pricedUnderLock` — see that field's comment. */
+  pricedUnderLock?: boolean;
   lineItems?: LineItemData[];
   /** Per-group Xero coding override (WS1 #940 cascade) — a priced group
    *  bills as its own invoice line (financeSnapshot.ts). See

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -318,7 +318,6 @@ export function GroupRow({
   onMoveDown,
   canMoveUp,
   canMoveDown,
-  moneyLocked,
 }: {
   group: GroupData;
   isExpanded: boolean;
@@ -327,11 +326,6 @@ export function GroupRow({
   projectId?: string;
   /** Open / blocking comment counts for this group's thread target. */
   commentBadge?: { open: number; blocking: number };
-  /** #990 — true once the project's tier is locked and no unlock session is
-   *  open; a $0/unset price under this condition is the `defaultToZero`
-   *  server behaviour, not a deliberately free group, so it earns the
-   *  `<UnpricedBadge>`. */
-  moneyLocked?: boolean;
   /** 8H — render the Cost column cell. Project groups don't have a
    *  separate cost concept, so the cell renders an em-dash. */
   showCostColumn?: boolean;
@@ -484,7 +478,7 @@ export function GroupRow({
         {discountVal > 0 && (
           <p className="text-micro text-ok">-{formatCurrency(discountVal)} disc.</p>
         )}
-        {moneyLocked && (priceVal == null || priceVal === 0) && (
+        {group.pricedUnderLock && (
           <div className="mt-0.5 flex justify-end">
             <UnpricedBadge />
           </div>
@@ -970,7 +964,6 @@ export function LineItemRow({
   onMoveDown,
   canMoveUp,
   canMoveDown,
-  moneyLocked,
 }: {
   item: LineItemData;
   indent: string;
@@ -1005,8 +998,6 @@ export function LineItemRow({
   onRemove: () => void;
   /** Multi-select: row click handler (not firing for grip handle clicks) */
   onClick?: (e: React.MouseEvent) => void;
-  /** #990 — see `GroupRow`'s doc on the same prop. */
-  moneyLocked?: boolean;
 } & MoveControls) {
   const desc = describeRow(item);
   const hasChildren = desc.hasChildren;
@@ -1486,10 +1477,12 @@ export function LineItemRow({
         {item.discount != null && Number(item.discount) > 0 && (
           <p className="text-micro text-ok">-{formatCurrency(Number(item.discount))} disc.</p>
         )}
-        {/* #990 — a $0/unset price under a locked tier is `defaultToZero`'s
-            server behaviour, not a deliberately free line. Kit children are
-            excluded — they're not independently priced by design. */}
-        {moneyLocked && !item.isKitChild && (item.unitPrice == null || Number(item.unitPrice) === 0) && (
+        {/* #990 — `pricedUnderLock` is the server's actual record of a
+            `defaultToZero` reset, not an inference from "currently locked +
+            currently $0" (which false-positives on a row that's been $0 since
+            before any lock ever existed). Kit children are excluded — they're
+            not independently priced by design. */}
+        {item.pricedUnderLock && !item.isKitChild && (
           <div className="mt-0.5 flex justify-end">
             <UnpricedBadge />
           </div>

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1119,7 +1119,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                               )}
                               {isExpanded && childItems.map((item) => (
                                 <LineItemRow
-                                  moneyLocked={moneyLocked}
                                   key={item.id}
                                   item={item}
                                   indent="ml-12"
@@ -1155,7 +1154,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                         return (
                           <React.Fragment key={group.id}>
                             <GroupRow
-                              moneyLocked={moneyLocked}
                               group={group}
                               isExpanded={isExpanded}
                               indented
@@ -1216,7 +1214,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                             )}
                             {isExpanded && groupItems.map((item, itemIndex) => (
                               <LineItemRow
-                                moneyLocked={moneyLocked}
                                 key={item.id}
                                 item={item}
                                 indent="ml-12"
@@ -1259,7 +1256,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                       {/* Standalone line items in category */}
                       {standaloneItems.map((item, itemIndex) => (
                         <LineItemRow
-                          moneyLocked={moneyLocked}
                           key={item.id}
                           item={item}
                           indent="ml-3"
@@ -1317,7 +1313,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                   const uncatVisible = (uncategorizedItems as LineItemData[]).filter((i) => !isHiddenFromList(i) && !pendingRemovalIds.has(i.id));
                   return uncatVisible.map((item, itemIndex) => (
                   <LineItemRow
-                    moneyLocked={moneyLocked}
                     key={item.id}
                     item={item}
                     indent=""
@@ -1364,7 +1359,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                   return (
                     <React.Fragment key={`pg-${group.id}`}>
                       <GroupRow
-                        moneyLocked={moneyLocked}
                         group={group}
                         isExpanded={isExpanded}
                         orgId={orgId}
@@ -1418,7 +1412,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                       )}
                       {isExpanded && groupItems.map((item: LineItemData, itemIndex) => (
                         <LineItemRow
-                          moneyLocked={moneyLocked}
                           key={item.id}
                           item={item}
                           indent="ml-12"
@@ -1496,7 +1489,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                       )}
                       {isExpanded && childItems.map((item) => (
                         <LineItemRow
-                          moneyLocked={moneyLocked}
                           key={item.id}
                           item={item}
                           indent="ml-8"

--- a/src/lib/equipment-tab-reconstruct.ts
+++ b/src/lib/equipment-tab-reconstruct.ts
@@ -308,6 +308,7 @@ function buildGroupData(
     discount: g.discount,
     suggestedPrice: g.suggestedPrice,
     sortOrder: g.sortOrder,
+    pricedUnderLock: g.pricedUnderLock,
     lineItems: attachScope(lineItemsByGroupId.get(g.id) ?? [], ctx),
   };
 }

--- a/src/lib/line-item-count-read.test.ts
+++ b/src/lib/line-item-count-read.test.ts
@@ -47,6 +47,7 @@ function li(over: Partial<MappedLineItem>): MappedLineItem {
     lineTotal: null,
     priceBreakdown: null,
     priceOverridden: false,
+    pricedUnderLock: false,
     overrideReason: null,
     sortOrder: 0,
     groupName: null,

--- a/src/lib/project-equipment-reconstruct.ts
+++ b/src/lib/project-equipment-reconstruct.ts
@@ -170,6 +170,10 @@ export interface MappedLineItem {
   lineTotal: number | null;
   priceBreakdown: string | null;
   priceOverridden: boolean;
+  /** True when `unitPrice`/`discount` were forced to $0/unset by `defaultToZero`
+   *  (added or reset while the project was locked, no unlock session open) rather
+   *  than a deliberate free line — the Unpriced badge's real signal (equipment-rows.tsx). */
+  pricedUnderLock: boolean;
   overrideReason: string | null;
   sortOrder: number;
   groupName: string | null;
@@ -231,6 +235,7 @@ export function mapLineItemDoc(d: LineItemDoc): MappedLineItem {
     lineTotal: d.lineTotal ?? null,
     priceBreakdown: d.priceBreakdown ?? null,
     priceOverridden: d.priceOverridden ?? false,
+    pricedUnderLock: d.pricedUnderLock ?? false,
     overrideReason: d.overrideReason ?? null,
     sortOrder: d.sortOrder ?? 0,
     groupName: d.groupName ?? null,
@@ -355,6 +360,8 @@ export interface MappedGroup {
   discountMode: "$" | "%" | null;
   suggestedPrice: number | null;
   sortOrder: number;
+  /** Mirrors `MappedLineItem.pricedUnderLock` — see that field's comment. */
+  pricedUnderLock: boolean;
   xeroAccountCode: string | null;
   xeroTaxType: string | null;
   createdAt: Date | null;
@@ -375,6 +382,7 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     discountMode: orNull(d.discountMode),
     suggestedPrice: orNull(d.suggestedPrice),
     sortOrder: d.sortOrder ?? 0,
+    pricedUnderLock: d.pricedUnderLock ?? false,
     xeroAccountCode: orNull(d.xeroAccountCode),
     xeroTaxType: orNull(d.xeroTaxType),
     createdAt: msToDate(d.createdAt),

--- a/src/lib/project-line-item-read.ts
+++ b/src/lib/project-line-item-read.ts
@@ -103,6 +103,7 @@ export type MappedLineItem = Omit<
   | "lineTotal"
   | "priceBreakdown"
   | "priceOverridden"
+  | "pricedUnderLock"
   | "overrideReason"
   | "sortOrder"
   | "groupName"
@@ -159,6 +160,10 @@ export type MappedLineItem = Omit<
   lineTotal: number | null;
   priceBreakdown: string | null;
   priceOverridden: boolean;
+  /** True when `unitPrice`/`discount` were forced to $0/unset by `defaultToZero`
+   *  (added or reset while the project was locked, no unlock session open) rather
+   *  than a deliberate free line — the Unpriced badge's real signal. */
+  pricedUnderLock: boolean;
   overrideReason: string | null;
   sortOrder: number;
   groupName: string | null;
@@ -220,6 +225,7 @@ export function mapLineItemDoc(d: LineItemDoc): MappedLineItem {
     lineTotal: d.lineTotal ?? null,
     priceBreakdown: d.priceBreakdown ?? null,
     priceOverridden: d.priceOverridden ?? false,
+    pricedUnderLock: d.pricedUnderLock ?? false,
     overrideReason: d.overrideReason ?? null,
     sortOrder: d.sortOrder ?? 0,
     groupName: d.groupName ?? null,
@@ -363,6 +369,7 @@ export type MappedGroup = Omit<
   | "discountMode"
   | "suggestedPrice"
   | "sortOrder"
+  | "pricedUnderLock"
   | "xeroAccountCode"
   | "xeroTaxType"
   | "createdAt"
@@ -377,6 +384,8 @@ export type MappedGroup = Omit<
   discountMode: "$" | "%" | null;
   suggestedPrice: number | null;
   sortOrder: number;
+  /** Mirrors `MappedLineItem.pricedUnderLock` — see that field's comment. */
+  pricedUnderLock: boolean;
   xeroAccountCode: string | null;
   xeroTaxType: string | null;
   createdAt: Date | null;
@@ -397,6 +406,7 @@ export function mapGroupDoc(d: GroupDoc): MappedGroup {
     discountMode: orNull(d.discountMode),
     suggestedPrice: orNull(d.suggestedPrice),
     sortOrder: d.sortOrder ?? 0,
+    pricedUnderLock: d.pricedUnderLock ?? false,
     xeroAccountCode: orNull(d.xeroAccountCode),
     xeroTaxType: orNull(d.xeroTaxType),
     createdAt: msToDate(d.createdAt),


### PR DESCRIPTION
## Summary

The amber "Unpriced" badge on Equipment tab groups/line items was computed as
`moneyLocked && price === 0` — inferred from the project's *current* lock
state, with no memory of when or why a row actually became $0. That
false-positives on any row that's been $0 since **before** a lock ever
existed (no catalog rate configured, a sub-hire pending supplier
confirmation, a deliberately free line): the badge's own tooltip ("Added
after the quote was confirmed — price it deliberately") was simply wrong for
those rows, and would start showing up the moment the project *later*
became locked — exactly the reported bug (a group's discount-mode edit
appeared to "cause" child items to show as Unpriced, when in fact they'd
been $0 all along).

- Added `pricedUnderLock` to `projectLineItems` / `projectGroups`
  (`convex/schema.ts`), stamped `true` at the exact moment
  `assertLifecycleGuard`'s `defaultToZero` forces a price to $0/unset (every
  add path, kit-add, and the `restoreProjectSnapshot` FINANCIAL-scope
  "added under lock" branches), via one shared `pricedUnderLockOnInsert()`
  helper so every insert site derives the same value.
- Cleared back to `false` the moment a human deliberately prices the row:
  `patchNative`'s `unitPrice` edit (scoped to `unitPrice` itself, not the
  wider `touchesMoney` set), `updateGroupPriceNative` (unconditional —
  reaching it means the FINANCIAL guard already passed), a merge that keeps
  a real client-supplied price, and a FINANCIAL-scope snapshot restore
  landing a real historical price.
- `pricedUnderLock` is server-derived only — added to
  `LINE_IMMUTABLE_ON_PATCH`, never client-settable.
- Threaded the field through both duplicated read-mapping layers
  (`project-equipment-reconstruct.ts`, `project-line-item-read.ts`) and the
  `equipment-tab-reconstruct.ts` native/live path.
- `GroupRow`/`LineItemRow`'s badge condition now reads
  `group.pricedUnderLock` / `item.pricedUnderLock` directly. `moneyLocked`
  had no other reader on either component, so it's dropped from both props
  and every call site.
- FEATUREDOCS/62 updated with the mechanism + rationale.

## Testing

- `pnpm test` — 5190/5190 passing (405 files), including 8 new regression
  tests in `convex/projectLifecycleLocks.test.ts`: a $0 line added while
  OPEN stays unflagged after the project later locks (the exact
  false-positive this fixes), a deliberate price edit clears a stale flag,
  the field can't be forged via `patchNative`'s `set`, a locked
  group-create/`updateGroupPriceNative` round trip (the discount-mode-toggle
  scenario reported), and `addKitNative` flags only the kit parent line.
- All CI ratchets hold: complexity (685/685), any-type (136/136), dead-code
  (417/417), dep-cruiser (0/0).
- `pnpm run api:registry:check` — current (no public mutation args changed).
- Lint: 0 errors.

**Not run in this session:** `pnpm exec convex dev --once` — this sandboxed
session has no `CONVEX_DEPLOY_KEY`. The schema/function change will push to
prod automatically via the deploy pipeline (`convex deploy` on merge to
`main`); if dev-deployment testing is needed before merge, run
`pnpm exec convex dev --once` from a session with real credentials.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KzRde3hg4wFEUfEuW6iaAS)_