### PR TITLE
Fix MCP/OAuth connection failure: add CORS support

### DIFF
--- a/FEATUREDOCS/56-api-mcp.md
+++ b/FEATUREDOCS/56-api-mcp.md
@@ -558,6 +558,23 @@ on every request; `redirect_uri` is checked for an EXACT match against the
 client's registered list before anything is trusted, including before
 rendering an error (an unverified `redirect_uri` is never followed).
 
+**CORS (fixed 2026-07-29)** — Phase 7 shipped OAuth discovery/registration/token
+endpoints and `/api/v1/mcp` with no `Access-Control-*` headers anywhere in the
+stack (`next.config.ts`'s global `headers()` doesn't set any either). Bearer-only
+auth meant this was believed CSRF-safe by construction (no cookie path,
+R-8.11.1), but it also meant a browser-based MCP client — including claude.ai's
+own connector flow, the client `oauth-errors.ts` names as a target — could
+complete the OAuth consent screen (a top-level navigation, unaffected by CORS)
+and then have its `fetch()` calls to `/api/v1/mcp` and the OAuth endpoints
+silently blocked by the browser's CORS preflight, surfacing as a generic
+"couldn't connect to the server" with no server-side error to debug from. Fixed
+by `src/lib/api/cors.ts` (`withCors`/`corsPreflight`, `Access-Control-Allow-Origin:
+"*"`, no `Allow-Credentials`) wired into `/api/v1/mcp`, both `.well-known/oauth-*`
+routes, and `/api/v1/oauth/{register,token,revoke}` — a wildcard origin doesn't
+reintroduce the CSRF risk the bearer-only design avoided, since a foreign page
+still can't read another origin's `Authorization` header, only present one it
+already holds.
+
 **Token endpoint** — `POST /api/v1/oauth/token`
 (`src/app/api/v1/oauth/token/route.ts`), standard
 `application/x-www-form-urlencoded` body (RFC 6749 §4.1.3) — the documented

--- a/docs/designs/api-mcp-reimplementation.md
+++ b/docs/designs/api-mcp-reimplementation.md
@@ -503,8 +503,10 @@ The Convex guards already throw `ConvexError` with stable codes — `PROJECT_LOC
 - `GET /api/v1/openapi.json`, `GET /llms.txt`.
 
 Cross-cutting: `runtime = "nodejs"` (AsyncLocalStorage + node:crypto), bearer-only auth so
-CSRF is structurally N/A (no cookie path — R-8.11.1), deny-by-default CORS with no
-credentials, `x-request-id` propagated from the existing middleware, per-key request log.
+CSRF is structurally N/A (no cookie path — R-8.11.1), CORS open (`Access-Control-Allow-Origin:
+"*"`, no credentials — required for browser-based MCP/OAuth clients to reach this surface at
+all; see FEATUREDOCS/56's 2026-07-29 fix), `x-request-id` propagated from the existing
+middleware, per-key request log.
 Webhooks already exist (FEATUREDOCS/58) and need only the `api.*` event additions.
 
 ## 12. MCP surface (`/api/v1/mcp`) — phase two, thin by design

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { authorizationServerMetadata } from "@/lib/api/oauth/metadata";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 export const runtime = "nodejs";
 
@@ -7,9 +8,15 @@ export const runtime = "nodejs";
  * RFC 8414 authorization-server metadata (Phase 7, #1003). Deliberately
  * unauthenticated — a discovery document, not org data (same posture as
  * `GET /api/v1/openapi.json`). Public per `src/middleware.ts`'s exemption list.
+ * CORS-open: browser-based MCP clients fetch this document directly to
+ * discover the token/registration endpoints before they hold any credential.
  */
 export async function GET() {
-  return NextResponse.json(authorizationServerMetadata(), {
-    headers: { "Cache-Control": "public, max-age=3600" },
-  });
+  return withCors(
+    NextResponse.json(authorizationServerMetadata(), {
+      headers: { "Cache-Control": "public, max-age=3600" },
+    }),
+  );
 }
+
+export const OPTIONS = corsPreflight;

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { protectedResourceMetadata } from "@/lib/api/oauth/metadata";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 export const runtime = "nodejs";
 
@@ -7,10 +8,14 @@ export const runtime = "nodejs";
  * RFC 9728 protected-resource metadata for `/api/v1/mcp`, per the MCP
  * authorization spec — points an MCP client at the authorization server it
  * should use. Unauthenticated discovery document, same posture as the
- * authorization-server metadata route.
+ * authorization-server metadata route. CORS-open for the same reason.
  */
 export async function GET() {
-  return NextResponse.json(protectedResourceMetadata(), {
-    headers: { "Cache-Control": "public, max-age=3600" },
-  });
+  return withCors(
+    NextResponse.json(protectedResourceMetadata(), {
+      headers: { "Cache-Control": "public, max-age=3600" },
+    }),
+  );
 }
+
+export const OPTIONS = corsPreflight;

--- a/src/app/api/v1/mcp/route.ts
+++ b/src/app/api/v1/mcp/route.ts
@@ -5,6 +5,7 @@ import { toErrorEnvelope, statusForError } from "@/lib/api/errors";
 import { buildMcpServer } from "@/lib/api/mcp/build-server";
 import { API_VERSION, API_VERSION_HEADER } from "@/lib/api/version";
 import { protectedResourceMetadataUrl } from "@/lib/api/oauth/metadata";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 /**
  * `/api/v1/mcp` — streamable HTTP MCP over the SAME dispatcher REST uses
@@ -27,7 +28,7 @@ export const runtime = "nodejs";
 
 function versioned(response: Response): Response {
   response.headers.set(API_VERSION_HEADER, API_VERSION);
-  return response;
+  return withCors(response);
 }
 
 /** RFC 9728 §5.1: a 401 on a protected resource SHOULD carry a `WWW-Authenticate`
@@ -72,3 +73,4 @@ async function handle(request: NextRequest): Promise<Response> {
 export const POST = handle;
 export const GET = handle;
 export const DELETE = handle;
+export const OPTIONS = corsPreflight;

--- a/src/app/api/v1/oauth/register/route.ts
+++ b/src/app/api/v1/oauth/register/route.ts
@@ -4,6 +4,7 @@ import {
   registerOauthClient,
   ClientRegistrationError,
 } from "@/lib/api/oauth/client-registration";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 export const runtime = "nodejs";
 
@@ -11,24 +12,27 @@ export const runtime = "nodejs";
  * RFC 7591 Dynamic Client Registration — `POST /api/v1/oauth/register`
  * (Phase 7, #1003). Deliberately unauthenticated (a client has no credential
  * yet — that's what this endpoint issues), same posture as the token
- * endpoint. Public per `src/middleware.ts`'s bearer-exempt list.
+ * endpoint. Public per `src/middleware.ts`'s bearer-exempt list. CORS-open:
+ * browser-based MCP clients self-register from the page that's connecting.
  */
 export async function POST(request: NextRequest) {
   let body: unknown;
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "invalid_client_metadata", error_description: "Invalid JSON body." }, { status: 400 });
+    return withCors(NextResponse.json({ error: "invalid_client_metadata", error_description: "Invalid JSON body." }, { status: 400 }));
   }
 
   try {
     const validated = validateRegistrationRequest(body);
     const result = await registerOauthClient(validated);
-    return NextResponse.json(result, { status: 201 });
+    return withCors(NextResponse.json(result, { status: 201 }));
   } catch (err) {
     if (err instanceof ClientRegistrationError) {
-      return NextResponse.json({ error: "invalid_client_metadata", error_description: err.message }, { status: 400 });
+      return withCors(NextResponse.json({ error: "invalid_client_metadata", error_description: err.message }, { status: 400 }));
     }
-    return NextResponse.json({ error: "invalid_client_metadata", error_description: "Registration failed." }, { status: 400 });
+    return withCors(NextResponse.json({ error: "invalid_client_metadata", error_description: "Registration failed." }, { status: 400 }));
   }
 }
+
+export const OPTIONS = corsPreflight;

--- a/src/app/api/v1/oauth/revoke/route.ts
+++ b/src/app/api/v1/oauth/revoke/route.ts
@@ -5,6 +5,7 @@ import { hashApiKey } from "@/lib/api-key";
 import { oauthErrorResponse } from "@/lib/api/oauth/oauth-errors";
 import { parseFormBody } from "@/lib/api/oauth/form-body";
 import { authenticateClientRequest } from "@/lib/api/oauth/client-registration";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 export const runtime = "nodejs";
 
@@ -28,8 +29,10 @@ export async function POST(request: NextRequest) {
   }
 
   await revokeIfOwnedByClient(token, auth.client.id);
-  return new Response(null, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } });
+  return withCors(new Response(null, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } }));
 }
+
+export const OPTIONS = corsPreflight;
 
 /** Only a grant this same client was issued (origin "oauth" + matching
  *  oauthClientId) may be revoked here — a raw bearer/manual key hash

--- a/src/app/api/v1/oauth/token/route.ts
+++ b/src/app/api/v1/oauth/token/route.ts
@@ -5,6 +5,7 @@ import { redeemAuthorizationCode } from "@/lib/api/oauth/authorization-code";
 import { verifyPkce } from "@/lib/api/oauth/pkce";
 import { mintOAuthGrant, refreshOAuthGrant, RefreshGrantError } from "@/lib/api/oauth/grant";
 import { authenticateClientRequest, type OAuthClientRecord } from "@/lib/api/oauth/client-registration";
+import { withCors, corsPreflight } from "@/lib/api/cors";
 
 export const runtime = "nodejs";
 
@@ -44,7 +45,7 @@ async function handleAuthorizationCode(form: URLSearchParams, client: OAuthClien
     clientName: client.clientName ?? client.id,
     scopes: redeemed.scopes,
   });
-  return Response.json(tokens, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } });
+  return withCors(Response.json(tokens, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } }));
 }
 
 async function handleRefreshToken(form: URLSearchParams) {
@@ -52,7 +53,7 @@ async function handleRefreshToken(form: URLSearchParams) {
   if (!refreshToken) return oauthErrorResponse("invalid_request", "`refresh_token` is required.");
   try {
     const tokens = await refreshOAuthGrant(refreshToken);
-    return Response.json(tokens, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } });
+    return withCors(Response.json(tokens, { status: 200, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } }));
   } catch (err) {
     if (err instanceof RefreshGrantError) return oauthErrorResponse("invalid_grant", err.message);
     throw err;
@@ -77,3 +78,5 @@ export async function POST(request: NextRequest) {
   if (grantType === "authorization_code") return handleAuthorizationCode(form, auth.client);
   return handleRefreshToken(form);
 }
+
+export const OPTIONS = corsPreflight;

--- a/src/lib/api/cors.test.ts
+++ b/src/lib/api/cors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { withCors, corsPreflight } from "./cors";
+
+describe("withCors", () => {
+  it("sets an open, credential-less CORS header set on the response", () => {
+    const response = withCors(new Response(null, { status: 200 }));
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain("Authorization");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain("Mcp-Session-Id");
+    expect(response.headers.get("Access-Control-Expose-Headers")).toContain("Mcp-Session-Id");
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  it("preserves the response status and existing headers", () => {
+    const response = withCors(new Response(null, { status: 401, headers: { "WWW-Authenticate": "Bearer" } }));
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe("Bearer");
+  });
+});
+
+describe("corsPreflight", () => {
+  it("answers OPTIONS with a bare 204 carrying the same CORS headers", () => {
+    const response = corsPreflight();
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});

--- a/src/lib/api/cors.ts
+++ b/src/lib/api/cors.ts
@@ -1,0 +1,30 @@
+/**
+ * CORS for the machine-to-machine surface (`/api/v1/mcp`, `/.well-known/oauth-*`,
+ * `/api/v1/oauth/*`). These endpoints are bearer-token-only with no cookie path
+ * (R-8.11.1), so there is no CSRF/credentialed-request risk a wildcard origin
+ * could reintroduce — a foreign page can't read another origin's Authorization
+ * header, it has to already hold the token. Browser-based MCP clients (the
+ * Streamable HTTP transport spec calls this out explicitly) call this surface
+ * with `fetch()` from their own origin, which the browser blocks pre-flight
+ * without these headers — this is what let a same-origin curl "work" while
+ * every real client failed with a generic "couldn't connect".
+ */
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate",
+  "Access-Control-Max-Age": "86400",
+};
+
+export function withCors(response: Response): Response {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+/** Shared `OPTIONS` handler for a route exporting `withCors`-wrapped responses. */
+export function corsPreflight(): Response {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/src/lib/api/oauth/oauth-errors.ts
+++ b/src/lib/api/oauth/oauth-errors.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { withCors } from "@/lib/api/cors";
 
 /**
  * The STANDARD OAuth 2.1 error vocabulary (RFC 6749 §5.2 / §4.1.2.1) — deliberately
@@ -29,9 +30,11 @@ const STATUS_FOR_CODE: Record<OAuthErrorCode, number> = {
   server_error: 500,
 };
 
-export function oauthErrorResponse(code: OAuthErrorCode, description?: string): NextResponse {
-  return NextResponse.json(
-    { error: code, ...(description ? { error_description: description } : {}) },
-    { status: STATUS_FOR_CODE[code], headers: { "Cache-Control": "no-store", Pragma: "no-cache" } },
+export function oauthErrorResponse(code: OAuthErrorCode, description?: string): Response {
+  return withCors(
+    NextResponse.json(
+      { error: code, ...(description ? { error_description: description } : {}) },
+      { status: STATUS_FOR_CODE[code], headers: { "Cache-Control": "no-store", Pragma: "no-cache" } },
+    ),
   );
 }


### PR DESCRIPTION
## Summary

A user completed the OAuth consent flow for `https://flow.rvlt.app/api/v1/mcp` (signed in, clicked "allow access") and then got a generic client-side error: *"Couldn't connect to the server. Check that the URL points to a valid MCP server."*

Root cause: the `/api/v1/mcp` route, both `.well-known/oauth-*` discovery endpoints, and `/api/v1/oauth/{register,token,revoke}` set **no `Access-Control-*` headers at all** — verified live against production (`OPTIONS /api/v1/mcp` returns `204` with no CORS headers). This was a deliberate design decision (`docs/designs/api-mcp-reimplementation.md`: "deny-by-default CORS with no credentials"), reasoned as safe because bearer-only auth makes CSRF structurally N/A. That reasoning holds for CSRF, but it misses that **browsers enforce CORS on any cross-origin `fetch()` regardless of auth scheme**. The OAuth consent screen itself works fine (a top-level navigation, unaffected by CORS), but a browser-based MCP client's subsequent `fetch()` calls to the MCP/OAuth endpoints are silently blocked by the browser — surfacing as exactly this generic, undebuggable "couldn't connect" error.

Fix:
- New shared helper `src/lib/api/cors.ts` (`withCors`/`corsPreflight`) — `Access-Control-Allow-Origin: "*"`, no `Allow-Credentials`. A wildcard origin doesn't reintroduce CSRF risk here: a foreign page still can't read another origin's `Authorization` header, only present one it already holds.
- Wired into `/api/v1/mcp`, both `.well-known/oauth-*` metadata routes, and `/api/v1/oauth/{register,token,revoke}` (including `oauthErrorResponse()`, shared by all three OAuth routes).
- Updated `FEATUREDOCS/56-api-mcp.md` with a dated note on the fix, and corrected the stale "deny-by-default CORS" line in `docs/designs/api-mcp-reimplementation.md`.

## Testing

- `pnpm exec eslint` on all touched files — clean.
- `pnpm exec vitest run` on `src/lib/api/cors.test.ts` (new) and the existing OAuth route test suites (`register`, `token`) — all pass.
- `src/app/api/v1/mcp/route.test.ts` could not run in this sandbox (missing generated Prisma client, no `DATABASE_URL` available) — pre-existing environment limitation, unrelated to this change.
- Verified the bug live against production (`curl -X OPTIONS https://flow.rvlt.app/api/v1/mcp`) before writing the fix: no `Access-Control-*` headers on any endpoint in this surface.
- `pnpm exec tsc --noEmit` shows no new errors in touched files (pre-existing unrelated errors are all from a missing generated Prisma client in this sandbox).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_016bjcRtTuBgMtEkgLVxdrLj)_