### PR TITLE
Finance tab: lead with Quotes & Invoices, consolidate row actions

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -280,13 +280,34 @@ regardless of what the UI shows.
   Plain confirm dialog, no reason field — `UnacceptDialog` in
   `project-quote-rail.tsx`, same "are you sure" shape as `DeleteDraftDialog`.
 
-`QuoteRevisionRow`'s conditions are split into `StandardQuoteActions` (the
-`invoice:publish` cluster) and `OwnerOnlyQuoteActions` (protect/correct/
-delete-permanently), sharing one `quoteRowFlags()` helper — kept the row's own
-cyclomatic complexity down without duplicating the status-derivation logic
-(R-3.1). jsdom smoke tests: `correct-quote-dialog.smoke.test.tsx`,
+`QuoteRevisionRow`'s conditions are split into `standardQuoteRowActions()` (the
+`invoice:publish` cluster) and `ownerOnlyQuoteRowActions()` (protect/correct/
+delete-permanently) — pure functions sharing one `quoteRowFlags()` helper,
+kept the row's own cyclomatic complexity down without duplicating the
+status-derivation logic (R-3.1). jsdom smoke tests: `correct-quote-dialog.smoke.test.tsx`,
 `delete-recalled-dialog.smoke.test.tsx` (CLAUDE.md's standing "new overlay UI
 needs a render-it smoke test" rule).
+
+**Row actions are one Document button + one overflow menu, not a button wall
+(#1038)** — a `SENT`, unprotected, owner-viewed revision used to render up to
+six separate `Button`s (Document, Mark accepted, Declined, Recall, Correct
+date, Protect), which wrapped across 2-3 lines on mobile and read as visual
+noise even on desktop (Mobbin review against Jobber/Wave/Square's own quote
+and invoice list rows — DESIGN.md §10 Mobbin Research Protocol). Both clusters
+above now return `RowAction[]` (`{ key, label, icon, onClick, destructive?,
+loading? }`) instead of JSX, combined into one array and handed to
+`<RowActionsMenu>` (`src/components/ui/row-actions-menu.tsx`) — a shared
+Radix `DropdownMenu` wrapper (`asChild` trigger, `touch-target` 44px hit area
+per DESIGN.md §15) that renders nothing when the array is empty. `QuoteRowActions`
+reads `useCanDo("invoice","publish")`/`useIsOwner()` directly (same permission
+checks `<CanDo>`/the old owner gate used, just read as booleans up front so
+both clusters can merge into one list) — the server-side gates are unchanged,
+this is UX only. The invoice list (`project-finance-panel.tsx`'s `InvoiceRow`)
+uses the same component: Document + the one contextual "next step" action
+(Issue on a draft, Push to Xero on an unsynced issued invoice) stay visible,
+Delete draft/Void move into the menu via `invoiceRowMenuActions()`. Unit tests
+for the action-list logic: `quote-row-actions.test.ts`, `invoice-row-actions.test.ts`;
+smoke test for the shared menu: `row-actions-menu.smoke.test.tsx`.
 
 ### Acceptance gate on CONFIRMED
 
@@ -417,7 +438,20 @@ The structured workflow that replaces "press the Documents button and hope."
 Finance · Tasks · Notes · Files`) — the old `Financials` tab's content
 (`StalePricingBanner`, the unlock banner, `FinancialSummary`, `ProjectCostsPanel`)
 moved in wholesale rather than being duplicated; only the tab's `value`/label
-changed (`financials` → `finance`). Full UI/UX spec:
+changed (`financials` → `finance`).
+
+**Section order leads with the workflow, not the reference data (#1038).**
+`src/app/(app)/projects/[id]/page.tsx`'s Finance `TabsContent` renders
+`StalePricingBanner` (the one alert), then `<ProjectFinancePanel>` — quote
+revisions + invoices, the tab's actual actionable content — THEN a divider,
+`BillingSummaryRow`/`FinancialSummary`/`ProjectCostsPanel` (read-only reference
+figures a PM checks less often). Quotes/invoices previously rendered LAST,
+after three reference panels — a PM opening the Finance tab to send a quote
+had to scroll past a billing summary, a financial summary, and an operational
+P&L panel first. No component moved between tabs, nothing was duplicated —
+only the render order within this one `TabsContent` changed.
+
+Full UI/UX spec:
 [`docs/designs/finance-workflow-ux.md`](../docs/designs/finance-workflow-ux.md).
 
 ### Send dialog (`src/components/projects/finance/send-quote-dialog.tsx`)

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -587,11 +587,28 @@ export default function ProjectDetailPage({
                     this is that content, not a duplicate of it. The lock
                     strip/banner used to live here (Phase D's `QuoteLockStrip`)
                     but is now the page-level `<ProjectLockStrip>` (#990) above
-                    the tabs — visible from every tab, not just this one. */}
+                    the tabs — visible from every tab, not just this one.
+
+                    Section order is deliberate (#1038 IA pass): the alert
+                    banner, then Quotes & Invoices — the tab's actual workflow,
+                    what a PM opens this tab to DO — leads. Financial summary
+                    and operational P&L are read-only reference figures a PM
+                    checks less often; they follow behind a divider rather than
+                    burying the actionable content below them. */}
                 {!project.isTemplate && (
                   <TabsContent value="finance">
                     <div className="space-y-6 pt-4">
                       <StalePricingBanner projectId={project.id} orgId={orgId} />
+                      <ProjectFinancePanel
+                        projectId={project.id}
+                        projectNumber={project.projectNumber}
+                        clientId={project.clientId as string | null | undefined}
+                        projectStatus={project.status as string | null | undefined}
+                        subtotal={project.subtotal as number | null}
+                        taxAmount={project.taxAmount as number | null}
+                        total={project.total as number | null}
+                      />
+                      <div className="h-px bg-line" />
                       <BillingSummaryRow
                         projectId={project.id}
                         orgId={orgId}
@@ -638,17 +655,6 @@ export default function ProjectDetailPage({
                       })()}
                       <div className="h-px bg-line" />
                       <ProjectCostsPanel projectId={project.id} />
-                      <div className="h-px bg-line" />
-                      {/* WS1 (#940), Phase D (#989) — Quotes & Invoices */}
-                      <ProjectFinancePanel
-                        projectId={project.id}
-                        projectNumber={project.projectNumber}
-                        clientId={project.clientId as string | null | undefined}
-                        projectStatus={project.status as string | null | undefined}
-                        subtotal={project.subtotal as number | null}
-                        taxAmount={project.taxAmount as number | null}
-                        total={project.total as number | null}
-                      />
                     </div>
                   </TabsContent>
                 )}

--- a/src/components/projects/__tests__/invoice-row-actions.test.ts
+++ b/src/components/projects/__tests__/invoice-row-actions.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { invoiceRowMenuActions } from "@/components/projects/project-finance-panel";
+
+/**
+ * #1038 — unit coverage for the invoice row's overflow-menu logic (Delete
+ * draft / Void), extracted out of `InvoiceRow` so the state × permission
+ * matrix is testable without mounting the full Convex-wired panel.
+ */
+function handlers() {
+  return { onDeleteDraft: vi.fn(), onVoidRequest: vi.fn() };
+}
+
+describe("invoiceRowMenuActions", () => {
+  it("offers Delete draft on a DRAFT invoice when permitted", () => {
+    const actions = invoiceRowMenuActions(
+      { id: "i1", status: "DRAFT", kind: "FULL", total: 100 },
+      { canDelete: true, canVoid: true },
+      handlers(),
+    );
+    expect(actions.map((a) => a.key)).toEqual(["delete-draft"]);
+    expect(actions[0].destructive).toBe(true);
+  });
+
+  it("hides Delete draft on a DRAFT invoice without invoice:delete", () => {
+    const actions = invoiceRowMenuActions(
+      { id: "i1", status: "DRAFT", kind: "FULL", total: 100 },
+      { canDelete: false, canVoid: true },
+      handlers(),
+    );
+    expect(actions).toEqual([]);
+  });
+
+  it("offers Void on an ISSUED invoice when permitted", () => {
+    const actions = invoiceRowMenuActions(
+      { id: "i1", status: "ISSUED", kind: "FULL", total: 100 },
+      { canDelete: true, canVoid: true },
+      handlers(),
+    );
+    expect(actions.map((a) => a.key)).toEqual(["void"]);
+  });
+
+  it("offers nothing for a VOID invoice regardless of permissions", () => {
+    const actions = invoiceRowMenuActions(
+      { id: "i1", status: "VOID", kind: "FULL", total: 100 },
+      { canDelete: true, canVoid: true },
+      handlers(),
+    );
+    expect(actions).toEqual([]);
+  });
+});

--- a/src/components/projects/__tests__/quote-row-actions.test.ts
+++ b/src/components/projects/__tests__/quote-row-actions.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  quoteRowFlags,
+  standardQuoteRowActions,
+  ownerOnlyQuoteRowActions,
+} from "@/components/projects/project-quote-rail";
+
+/**
+ * #1038 — unit coverage for the action-list logic behind the row's overflow
+ * menu. This is the part that actually changed: which action shows up for
+ * which revision state/permission combo. The presentational half (menu vs.
+ * button wall) is covered by row-actions-menu.smoke.test.tsx.
+ */
+function noopHandlers() {
+  return {
+    onAccept: vi.fn(),
+    onUnaccept: vi.fn(),
+    onDecline: vi.fn(),
+    onRecall: vi.fn(),
+    onDeleteDraft: vi.fn(),
+  };
+}
+
+function keys(actions: { key: string }[]) {
+  return actions.map((a) => a.key);
+}
+
+describe("quoteRowFlags", () => {
+  it("flags a never-sent draft", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT" });
+    expect(flags).toMatchObject({ isSent: false, isAccepted: false, isHeldByClient: false, isNeverSentDraft: true, isRecalledDraft: false });
+  });
+
+  it("flags a recalled draft (has send history) distinctly from a never-sent draft", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT", sentAt: 100 });
+    expect(flags).toMatchObject({ isNeverSentDraft: false, isRecalledDraft: true });
+  });
+
+  it("treats EXPIRED as held-by-client but not sent", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "EXPIRED" });
+    expect(flags).toMatchObject({ isSent: false, isHeldByClient: true });
+  });
+});
+
+describe("standardQuoteRowActions", () => {
+  it("offers Mark accepted (only) on a SENT, unprotected revision", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 2, effectiveStatus: "SENT", sentAt: 1 });
+    const actions = standardQuoteRowActions(flags, noopHandlers());
+    expect(keys(actions)).toEqual(["accept", "decline", "recall"]);
+  });
+
+  it("hides Recall (but keeps Decline) once the revision is protected", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 2, effectiveStatus: "SENT", sentAt: 1, protected: true });
+    const actions = standardQuoteRowActions(flags, noopHandlers());
+    expect(keys(actions)).toEqual(["accept", "decline"]);
+  });
+
+  it("offers Unapprove on an ACCEPTED revision, not Mark accepted again", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 2, effectiveStatus: "ACCEPTED", sentAt: 1 });
+    const actions = standardQuoteRowActions(flags, noopHandlers());
+    expect(keys(actions)).toEqual(["unaccept"]);
+  });
+
+  it("offers only Delete draft on a never-sent draft", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT" });
+    const actions = standardQuoteRowActions(flags, noopHandlers());
+    expect(keys(actions)).toEqual(["delete-draft"]);
+    expect(actions[0].destructive).toBe(true);
+  });
+
+  it("offers nothing on a SUPERSEDED revision", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "SUPERSEDED", sentAt: 1 });
+    expect(standardQuoteRowActions(flags, noopHandlers())).toEqual([]);
+  });
+});
+
+describe("ownerOnlyQuoteRowActions", () => {
+  const handlers = () => ({
+    onCorrect: vi.fn(),
+    onDeleteRecalled: vi.fn(),
+    onToggleProtect: vi.fn(),
+    protectPending: false,
+  });
+
+  it("offers Correct date and Protect on a SENT, unprotected revision", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 2, effectiveStatus: "SENT", sentAt: 1 });
+    expect(keys(ownerOnlyQuoteRowActions(flags, handlers()))).toEqual(["correct", "protect"]);
+  });
+
+  it("hides Correct date but still offers Unprotect once protected", () => {
+    const flags = quoteRowFlags({ id: "q1", version: 2, effectiveStatus: "SENT", sentAt: 1, protected: true });
+    const actions = ownerOnlyQuoteRowActions(flags, handlers());
+    expect(keys(actions)).toEqual(["protect"]);
+    expect(actions[0].label).toBe("Unprotect");
+  });
+
+  it("offers Delete permanently only on a recalled (send-history) draft that isn't protected", () => {
+    const recalled = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT", sentAt: 1 });
+    expect(keys(ownerOnlyQuoteRowActions(recalled, handlers()))).toEqual(["delete-recalled"]);
+
+    const neverSent = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT" });
+    expect(ownerOnlyQuoteRowActions(neverSent, handlers())).toEqual([]);
+
+    const protectedRecalled = quoteRowFlags({ id: "q1", version: 1, effectiveStatus: "DRAFT", sentAt: 1, protected: true });
+    expect(ownerOnlyQuoteRowActions(protectedRecalled, handlers())).toEqual([]);
+  });
+});

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -11,6 +11,7 @@ import { ProjectQuoteRail } from "@/components/projects/project-quote-rail";
 import { useInvoiceWrites } from "@/hooks/use-invoice-writes";
 import { useNativeProjectStatus } from "@/hooks/use-native-project-writes";
 import { useXeroLinked } from "@/hooks/use-xero-linked";
+import { useCanDo } from "@/lib/use-permissions";
 import { pushInvoiceToXero } from "@/server/xero";
 import { generateInvoiceArtifact } from "@/server/finance-documents";
 import { useServerMutation } from "@/hooks/use-server-mutation";
@@ -21,6 +22,7 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { RowActionsMenu, type RowAction } from "@/components/ui/row-actions-menu";
 import { CanDo } from "@/components/auth/permission-gate";
 import { IssueInvoiceDialog } from "@/components/projects/finance/issue-invoice-dialog";
 
@@ -266,6 +268,24 @@ interface InvoiceRowDoc {
   issuedAt?: number;
 }
 
+/** The overflow-menu cluster for an invoice row — Delete draft / Void.
+ *  `canDelete`/`canVoid` mirror the `<CanDo>` gates these replaced; still UX
+ *  only, the server re-checks `invoice:delete`/`invoice:void` unconditionally. */
+export function invoiceRowMenuActions(
+  inv: InvoiceRowDoc,
+  perms: { canDelete: boolean; canVoid: boolean },
+  handlers: { onDeleteDraft: () => void; onVoidRequest: () => void },
+): RowAction[] {
+  const actions: RowAction[] = [];
+  if (inv.status === "DRAFT" && perms.canDelete) {
+    actions.push({ key: "delete-draft", label: "Delete draft", icon: Trash2, onClick: handlers.onDeleteDraft, destructive: true });
+  }
+  if (inv.status === "ISSUED" && perms.canVoid) {
+    actions.push({ key: "void", label: "Void invoice", icon: Ban, onClick: handlers.onVoidRequest, destructive: true });
+  }
+  return actions;
+}
+
 function InvoiceRow({
   invoice: inv,
   projectId,
@@ -281,9 +301,17 @@ function InvoiceRow({
   onDeleteDraft: () => void;
   onVoidRequest: () => void;
 }) {
+  // Document + at most one visible "primary" action (Issue on a draft, Push
+  // to Xero on an unsynced issued invoice) — everything else (Void, Delete
+  // draft) collapses into the overflow menu (#1038) instead of a row of
+  // pill buttons. Mirrors QuoteRowActions' consolidation in project-quote-rail.tsx.
+  const canDelete = useCanDo("invoice", "delete");
+  const canVoid = useCanDo("invoice", "void");
+  const menuActions = invoiceRowMenuActions(inv, { canDelete, canVoid }, { onDeleteDraft, onVoidRequest });
+
   return (
-    <li className="flex flex-wrap items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
-      <div className="flex min-w-0 items-center gap-2">
+    <li className="flex items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
         <Badge status={INVOICE_STATUS_BADGE[inv.status] ?? "neutral"}>{inv.status}</Badge>
         <span className="font-medium text-fg">{inv.invoiceNumber ?? `${inv.kind} (draft)`}</span>
         <span className="text-fg-4">{formatCurrency(inv.total)}</span>
@@ -294,7 +322,7 @@ function InvoiceRow({
           </span>
         )}
       </div>
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-1.5">
         <InvoiceDocumentAction invoice={inv} projectId={projectId} />
         {inv.status === "DRAFT" && (
           <CanDo resource="invoice" action="issue">
@@ -303,25 +331,12 @@ function InvoiceRow({
             </Button>
           </CanDo>
         )}
-        {inv.status === "DRAFT" && (
-          <CanDo resource="invoice" action="delete">
-            <Button type="button" variant="line" size="sm" onClick={onDeleteDraft}>
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          </CanDo>
-        )}
-        {inv.status === "ISSUED" && (
-          <CanDo resource="invoice" action="void">
-            <Button type="button" variant="line" size="sm" onClick={onVoidRequest}>
-              <Ban className="h-3.5 w-3.5" /> Void
-            </Button>
-          </CanDo>
-        )}
         {xeroLinked && inv.status === "ISSUED" && inv.xeroSyncStatus !== "SYNCED" && (
           <CanDo resource="invoice" action="xero_push">
             <PushToXeroButton invoiceId={inv.id} />
           </CanDo>
         )}
+        <RowActionsMenu actions={menuActions} label={`${inv.invoiceNumber ?? inv.kind} actions`} />
       </div>
     </li>
   );

--- a/src/components/projects/project-quote-rail.tsx
+++ b/src/components/projects/project-quote-rail.tsx
@@ -27,11 +27,12 @@ import { useServerMutation } from "@/hooks/use-server-mutation";
 import { formatCurrency, formatDate } from "@/lib/formatters";
 import { quoteStatusIntent } from "@/lib/status-colors";
 import { daysUntilValidUntil, QUOTE_EXPIRING_SOON_DAYS } from "@/lib/quote-validity";
-import { useIsOwner } from "@/lib/use-permissions";
+import { useCanDo, useIsOwner } from "@/lib/use-permissions";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { RowActionsMenu, type RowAction } from "@/components/ui/row-actions-menu";
 import { CanDo } from "@/components/auth/permission-gate";
 import { SendQuoteDialog } from "@/components/projects/finance/send-quote-dialog";
 import { AcceptQuoteDialog } from "@/components/projects/finance/accept-quote-dialog";
@@ -473,7 +474,7 @@ function QuoteRailTargetDialogs({
 /** Derived booleans shared by `QuoteRevisionRow` and its two action clusters —
  *  computed once so the split-out components read as pure props, not a second
  *  copy of the same status checks (R-3.1). */
-function quoteRowFlags(quote: QuoteRevisionDoc) {
+export function quoteRowFlags(quote: QuoteRevisionDoc) {
   const isSent = quote.effectiveStatus === "SENT";
   const isAccepted = quote.effectiveStatus === "ACCEPTED";
   // A sent-or-expired revision is the one the client is holding: it can be
@@ -489,72 +490,81 @@ function quoteRowFlags(quote: QuoteRevisionDoc) {
   return { isSent, isAccepted, isHeldByClient, isProtected, isRecalledDraft, isNeverSentDraft };
 }
 
-/** The `invoice:publish` cluster — accept/decline/recall/delete-draft. Same
- *  audience every other verb in this file already used before #1026. */
-function StandardQuoteActions({
+/**
+ * Every state-transition action for a revision, collapsed into ONE overflow
+ * menu (#1038) instead of a wall of pill buttons that wrapped across 2-3
+ * lines on mobile with a sent-and-unprotected row (Mark accepted / Declined /
+ * Recall could join Correct date / Protect, all as separate buttons). Same
+ * two audiences as before — `invoice:publish` (`useCanDo`, mirrors `<CanDo>`)
+ * for the standard cluster, owner-only (`useIsOwner`) for protect/correct/
+ * delete-permanently — just read as booleans up front so both clusters can
+ * merge into one action list instead of two side-by-side button groups.
+ * `requireQuoteOwnerOnly`/the `invoice:publish` permission check are still the
+ * real server-side gates; this is UX only.
+ */
+/** The `invoice:publish` cluster's actions — accept/decline/recall/delete-draft. */
+export function standardQuoteRowActions(
+  flags: ReturnType<typeof quoteRowFlags>,
+  handlers: { onAccept: () => void; onUnaccept: () => void; onDecline: () => void; onRecall: () => void; onDeleteDraft: () => void },
+): RowAction[] {
+  const { isSent, isAccepted, isHeldByClient, isProtected, isNeverSentDraft } = flags;
+  const actions: RowAction[] = [];
+  if (isSent) actions.push({ key: "accept", label: "Mark accepted", icon: CheckCircle2, onClick: handlers.onAccept });
+  if (isAccepted) actions.push({ key: "unaccept", label: "Unapprove", icon: RotateCcw, onClick: handlers.onUnaccept });
+  if (isHeldByClient) actions.push({ key: "decline", label: "Declined", icon: XCircle, onClick: handlers.onDecline });
+  if (isHeldByClient && !isProtected) actions.push({ key: "recall", label: "Recall", icon: Undo2, onClick: handlers.onRecall });
+  if (isNeverSentDraft) actions.push({ key: "delete-draft", label: "Delete draft", icon: Trash2, onClick: handlers.onDeleteDraft, destructive: true });
+  return actions;
+}
+
+/** The owner-only cluster's actions (#1026 follow-up program) —
+ *  protect/unprotect, correct-date, recall-then-delete. */
+export function ownerOnlyQuoteRowActions(
+  flags: ReturnType<typeof quoteRowFlags>,
+  handlers: { onCorrect: () => void; onDeleteRecalled: () => void; onToggleProtect: () => void; protectPending: boolean },
+): RowAction[] {
+  const { isSent, isAccepted, isProtected, isRecalledDraft } = flags;
+  const actions: RowAction[] = [];
+  if ((isSent || isAccepted) && !isProtected) {
+    actions.push({ key: "correct", label: "Correct date", icon: Pencil, onClick: handlers.onCorrect });
+  }
+  if (isSent || isAccepted) {
+    actions.push({
+      key: "protect",
+      label: isProtected ? "Unprotect" : "Protect",
+      icon: isProtected ? Unlock : Lock,
+      onClick: handlers.onToggleProtect,
+      loading: handlers.protectPending,
+    });
+  }
+  if (isRecalledDraft && !isProtected) {
+    actions.push({ key: "delete-recalled", label: "Delete permanently", icon: Trash2, onClick: handlers.onDeleteRecalled, destructive: true });
+  }
+  return actions;
+}
+
+function QuoteRowActions({
+  quote,
   flags,
   onAccept,
   onUnaccept,
   onDecline,
   onRecall,
   onDeleteDraft,
+  onDeleteRecalled,
+  onCorrect,
 }: {
+  quote: QuoteRevisionDoc;
   flags: ReturnType<typeof quoteRowFlags>;
   onAccept: () => void;
   onUnaccept: () => void;
   onDecline: () => void;
   onRecall: () => void;
   onDeleteDraft: () => void;
-}) {
-  const { isSent, isAccepted, isHeldByClient, isProtected, isNeverSentDraft } = flags;
-  return (
-    <CanDo resource="invoice" action="publish">
-      <div className="flex items-center gap-1.5">
-        {isSent && (
-          <Button type="button" variant="line" size="sm" onClick={onAccept}>
-            <CheckCircle2 className="h-3.5 w-3.5" /> Mark accepted
-          </Button>
-        )}
-        {isAccepted && (
-          <Button type="button" variant="line" size="sm" onClick={onUnaccept}>
-            <RotateCcw className="h-3.5 w-3.5" /> Unapprove
-          </Button>
-        )}
-        {isHeldByClient && (
-          <Button type="button" variant="line" size="sm" onClick={onDecline}>
-            <XCircle className="h-3.5 w-3.5" /> Declined
-          </Button>
-        )}
-        {isHeldByClient && !isProtected && (
-          <Button type="button" variant="line" size="sm" onClick={onRecall}>
-            <Undo2 className="h-3.5 w-3.5" /> Recall
-          </Button>
-        )}
-        {isNeverSentDraft && (
-          <Button type="button" variant="line" size="sm" onClick={onDeleteDraft}>
-            <Trash2 className="h-3.5 w-3.5" /> Delete draft
-          </Button>
-        )}
-      </div>
-    </CanDo>
-  );
-}
-
-/** The owner-only cluster (#1026 follow-up program) — protect/unprotect,
- *  correct-date, recall-then-delete. `requireQuoteOwnerOnly` server-side is
- *  the real gate; `useIsOwner` here is UX only (hide, don't just disable, so
- *  a non-owner isn't shown a button that will only ever 403). */
-function OwnerOnlyQuoteActions({
-  quote,
-  flags,
-  onDeleteRecalled,
-  onCorrect,
-}: {
-  quote: QuoteRevisionDoc;
-  flags: ReturnType<typeof quoteRowFlags>;
   onDeleteRecalled: () => void;
   onCorrect: () => void;
 }) {
+  const canPublish = useCanDo("invoice", "publish");
   const isOwner = useIsOwner();
   const quoteWrites = useQuoteWrites();
   const protectMutation = useServerMutation({
@@ -562,37 +572,20 @@ function OwnerOnlyQuoteActions({
     onSuccess: (r) => toast.success(r.protected ? `Protected v${quote.version}` : `Unprotected v${quote.version}`),
     onError: (e) => toast.error(e.message),
   });
-  if (!isOwner) return null;
 
-  const { isSent, isAccepted, isProtected, isRecalledDraft } = flags;
-  return (
-    <>
-      {(isSent || isAccepted) && (
-        <div className="flex items-center gap-1.5">
-          {!isProtected && (
-            <Button type="button" variant="line" size="sm" onClick={onCorrect}>
-              <Pencil className="h-3.5 w-3.5" /> Correct date
-            </Button>
-          )}
-          <Button
-            type="button"
-            variant="line"
-            size="sm"
-            loading={protectMutation.isPending}
-            onClick={() => protectMutation.mutate(!isProtected)}
-          >
-            {isProtected ? <Unlock className="h-3.5 w-3.5" /> : <Lock className="h-3.5 w-3.5" />}
-            {isProtected ? "Unprotect" : "Protect"}
-          </Button>
-        </div>
-      )}
-      {isRecalledDraft && !isProtected && (
-        <Button type="button" variant="line" size="sm" onClick={onDeleteRecalled}>
-          <Trash2 className="h-3.5 w-3.5" /> Delete permanently
-        </Button>
-      )}
-    </>
-  );
+  const actions: RowAction[] = [
+    ...(canPublish ? standardQuoteRowActions(flags, { onAccept, onUnaccept, onDecline, onRecall, onDeleteDraft }) : []),
+    ...(isOwner
+      ? ownerOnlyQuoteRowActions(flags, {
+          onCorrect,
+          onDeleteRecalled,
+          onToggleProtect: () => protectMutation.mutate(!flags.isProtected),
+          protectPending: protectMutation.isPending,
+        })
+      : []),
+  ];
+
+  return <RowActionsMenu actions={actions} label={`v${quote.version} actions`} />;
 }
 
 function QuoteRevisionRow({
@@ -623,21 +616,23 @@ function QuoteRevisionRow({
   const flags = quoteRowFlags(quote);
 
   return (
-    <li className="flex flex-wrap items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
-      <button type="button" className="flex min-w-0 items-center gap-2 text-left" onClick={onView}>
+    <li className="flex items-center justify-between gap-2 rounded-[var(--r)] border border-line px-3 py-2 text-table-cell">
+      <button type="button" className="flex min-w-0 flex-1 items-center gap-2 text-left" onClick={onView}>
         <RevisionMeta quote={quote} now={now} />
       </button>
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-1.5">
         <QuoteDocumentAction quote={quote} projectId={projectId} />
-        <StandardQuoteActions
+        <QuoteRowActions
+          quote={quote}
           flags={flags}
           onAccept={onAccept}
           onUnaccept={onUnaccept}
           onDecline={onDecline}
           onRecall={onRecall}
           onDeleteDraft={onDeleteDraft}
+          onDeleteRecalled={onDeleteRecalled}
+          onCorrect={onCorrect}
         />
-        <OwnerOnlyQuoteActions quote={quote} flags={flags} onDeleteRecalled={onDeleteRecalled} onCorrect={onCorrect} />
       </div>
     </li>
   );

--- a/src/components/ui/__tests__/row-actions-menu.smoke.test.tsx
+++ b/src/components/ui/__tests__/row-actions-menu.smoke.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Trash2 } from "lucide-react";
+
+import { RowActionsMenu, type RowAction } from "@/components/ui/row-actions-menu";
+
+/**
+ * #1038 — the row-level overflow menu that replaces walls of pill buttons on
+ * the Finance tab's quote/invoice rows. New overlay UI, so it gets the
+ * standing jsdom-smoke rule (CLAUDE.md): typecheck/lint/build all pass on a
+ * menu that throws at render time, only actually mounting it catches that.
+ */
+describe("RowActionsMenu smoke", () => {
+  it("renders nothing when there are no actions", () => {
+    const { container } = render(<RowActionsMenu actions={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a trigger and opens the menu with every action", async () => {
+    const onClick = vi.fn();
+    const actions: RowAction[] = [
+      { key: "a", label: "Mark accepted", icon: Trash2, onClick },
+      { key: "b", label: "Delete draft", icon: Trash2, onClick: vi.fn(), destructive: true },
+    ];
+    const user = userEvent.setup();
+    render(<RowActionsMenu actions={actions} label="Row actions" />);
+
+    expect(screen.queryByText("Mark accepted")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Row actions" }));
+    expect(await screen.findByText("Mark accepted")).toBeTruthy();
+    expect(screen.getByText("Delete draft")).toBeTruthy();
+
+    await user.click(screen.getByText("Mark accepted"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables a loading action", async () => {
+    const user = userEvent.setup();
+    const actions: RowAction[] = [{ key: "a", label: "Protect", icon: Trash2, onClick: vi.fn(), loading: true }];
+    render(<RowActionsMenu actions={actions} />);
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    const item = await screen.findByText("Protect");
+    expect(item.closest('[role="menuitem"]')?.getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/src/components/ui/row-actions-menu.tsx
+++ b/src/components/ui/row-actions-menu.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export interface RowAction {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  onClick: () => void;
+  destructive?: boolean;
+  loading?: boolean;
+}
+
+/**
+ * A row's secondary actions collapsed behind one "..." trigger instead of a
+ * wall of pill buttons — the list-row pattern reference apps (Wave, Square,
+ * Jobber invoice/quote lists) use once a row has more than one or two
+ * actions. Keeps every row to a fixed, small button count regardless of how
+ * many state-dependent actions apply, so it never wraps into multiple lines
+ * on mobile. Renders nothing when there's nothing to show — callers should
+ * build `actions` from already permission-filtered entries (only include an
+ * action the caller has confirmed the user may take).
+ */
+export function RowActionsMenu({ actions, label = "More actions" }: { actions: RowAction[]; label?: string }) {
+  if (actions.length === 0) return null;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="line" size="icon" className="touch-target size-8" aria-label={label}>
+          <MoreHorizontal className="h-3.5 w-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {actions.map((action) => (
+          <DropdownMenuItem
+            key={action.key}
+            disabled={action.loading}
+            onClick={action.onClick}
+            className={action.destructive ? "text-destructive focus:text-destructive" : undefined}
+          >
+            <action.icon className="h-3.5 w-3.5" /> {action.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

- Quotes & Invoices (`<ProjectFinancePanel>`) now render first in the project Finance tab, right after the stale-pricing alert — previously they rendered last, after the billing summary, financial summary, and operational P&L panels, so opening the tab to send a quote meant scrolling past three read-only reference panels first. No component moved tabs or was duplicated, only the render order changed.
- Quote revision rows and invoice rows no longer render a wall of pill buttons (up to 6 on a sent/unprotected/owner-viewed quote row), which wrapped across 2-3 lines on mobile and read as clutter on desktop. Reviewed against this app's own named competitors on Mobbin (Jobber, Wave, Square — DESIGN.md §10 requires this before redesigning a product area); all three collapse secondary row actions behind one "..." overflow menu. Added a shared `<RowActionsMenu>` component and applied it to both rows: Document (+ one contextual next-step action like Issue/Push to Xero) stays visible, everything else moves into the menu. Same permission checks as before (`useCanDo`/`useIsOwner` mirror the `<CanDo>`/owner gates they replace) — server-side authorization is unchanged.
- Updated FEATUREDOCS/66 to reflect both changes.

## Testing

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors (pre-existing style warnings only, none new)
- `vitest run`: full suite green (5352 tests), plus 18 new tests covering the action-list logic per quote/invoice status/permission combo and the new menu component
- Could not verify visually in a running browser — this sandbox has no Convex/Postgres credentials to boot the app

## Checklist

- [x] New dependency? N/A — no new dependencies added

## Size rationale (R-2.8 / T-2)

557 LOC over the 400 SHOULD-target. Kept as one PR because it's a single cohesive change (a shared `RowActionsMenu` component plus its two consumers, both needing consistent behavior) split across 5 atomic commits for review; splitting into separate PRs would leave the two consumer-file commits depending on a component not yet merged, and ~40% of the diff is new/updated tests and docs rather than logic.
