### PR TITLE
fix(convex): stop invoice create/issue from requiring a finance unlock session

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -648,18 +648,32 @@ through this engine.
 
 ## Lifecycle locks
 
-Quote send/new-version and invoice create/issue/void go through the shared
+Quote send/new-version go through the shared
 `assertLifecycleGuard(ctx, project, { kind: "financial" })` (FEATUREDOCS/62)
 — same FINANCE_LOCKED+ gate every other money-touching mutation uses. Phase C
 (#988) folds quote state into the tier resolution itself (`resolveLockTier`),
 so a sent revision raises the tier and "cut the next revision" becomes the
-sanctioned exit; the gate sites don't change. No new project status was added
-for "ready to invoice" — readiness is derived
-(the payment-profile-driven "deposit not yet invoiced" nudge chips on the
-project's Finance tab), and issuing a BALANCE/FULL invoice offers a UI-chain
-prompt to advance the project to `INVOICED` (the EXISTING project status
-update mutation — not a new nested mutation). Editing a project with an
-issued, non-void invoice warns + requires confirmation; it never blocks.
+sanctioned exit; the gate sites don't change.
+
+**Invoice `createNative`/`issueNative`/`voidNative`/`createCreditNative` do
+NOT call `assertLifecycleGuard`.** They used to (create/issue did, until a
+live bug: accepting a quote and confirming the project — the normal path to
+raising an invoice — puts the project at FINANCE_LOCKED, and the guard's
+"financial" kind requires an open unlock session, so every first invoice on a
+CONFIRMED+ project failed with `FINANCIALS_LOCKED`). The guard exists to gate
+edits to `LOCKED_PROJECT_FIELDS`/`LOCKED_GROUP_FIELDS`/`LOCKED_LINE_ITEM_FIELDS`
+(`unitPrice`, `discount`, `taxRate`, group `price`, …) — invoice mutations
+never touch those; they only snapshot already-computed totals
+(`buildFinanceLines`) into the separate `invoices`/`invoiceLines` tables, which
+is exactly what raising an invoice on a locked, confirmed project is supposed
+to do. `voidNative`/`createCreditNative` never had the guard; `createNative`/
+`issueNative` now match them. No new project status was added for "ready to
+invoice" — readiness is derived (the payment-profile-driven "deposit not yet
+invoiced" nudge chips on the project's Finance tab), and issuing a BALANCE/FULL
+invoice offers a UI-chain prompt to advance the project to `INVOICED` (the
+EXISTING project status update mutation — not a new nested mutation). Editing
+a project with an issued, non-void invoice warns + requires confirmation; it
+never blocks.
 
 ## Permissions
 
@@ -953,9 +967,11 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 - `src/server/xero.test.ts` — 4 mocked-boundary tests on `pushInvoiceToXero`
   (auto-create-contact idempotency, the failure path).
 - `convex/lib/xeroGate.test.ts` — 4 tests, the linked gate + org-scoping.
-- `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 40 tests,
+- `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 42 tests,
   server-computed money, gapless/namespaced numbering, cross-org IDOR guards,
-  RBAC, lifecycle-lock gating. #986 added the four revision invariants,
+  RBAC, lifecycle-lock gating (including createNative/issueNative on a
+  CONFIRMED, finance-locked project raising no unlock-session requirement).
+  #986 added the four revision invariants,
   supersede-on-send-not-on-draft, the recall round trip (including restoring
   the superseded predecessor), derived-`EXPIRED` blocking acceptance, and the
   manager-can-send-but-not-recall / PM-can-recall RBAC split.

--- a/convex/invoicesWrites.test.ts
+++ b/convex/invoicesWrites.test.ts
@@ -122,6 +122,27 @@ describe("invoicesWrites.createNative", () => {
     expect(inv?.total).toBe(825); // 1100 - 275 (the voided 110 does NOT count)
   });
 
+  // Regression: accepting a quote and confirming the project (the normal path
+  // to raising an invoice) puts the project at FINANCE_LOCKED tier. createNative
+  // must NOT route through assertLifecycleGuard's "financial" kind — that guard
+  // is for edits to LOCKED_*_FIELDS (unitPrice/discount/taxRate/group price),
+  // which this mutation never touches (it only snapshots current pricing into
+  // a separate invoices/invoiceLines row). Before the fix this threw
+  // FINANCIALS_LOCKED on every CONFIRMED+ project with no unlock session open.
+  test("creates a DRAFT invoice on a CONFIRMED (finance-locked) project with no unlock session open", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProjectAndClient(t, ORG, "CONFIRMED");
+
+    const { id } = await t.withIdentity(asUser(ORG)).mutation(api.invoicesWrites.createNative, {
+      id: "i1", organizationId: ORG, projectId: "p1", clientId: "c1", kind: "FULL", actor, auditId: "a1", now: NOW,
+    });
+
+    const inv = await getInvoice(t, id);
+    expect(inv?.status).toBe("DRAFT");
+    expect(inv?.total).toBe(1100);
+  });
+
   test("rejects a cross-org projectId (IDOR guard)", async () => {
     const t = makeT();
     await seedMember(t);
@@ -154,6 +175,22 @@ describe("invoicesWrites.createNative", () => {
 });
 
 describe("invoicesWrites.issueNative", () => {
+  // Regression: same FINANCIALS_LOCKED misuse as createNative — issuing a
+  // DRAFT invoice on a CONFIRMED project must not require an unlock session.
+  test("issues a DRAFT invoice on a CONFIRMED (finance-locked) project with no unlock session open", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProjectAndClient(t, ORG, "CONFIRMED");
+    await t.withIdentity(asUser(ORG)).mutation(api.invoicesWrites.createNative, {
+      id: "i1", organizationId: ORG, projectId: "p1", clientId: "c1", kind: "FULL", actor, auditId: "a1", now: NOW,
+    });
+
+    const result = await t.withIdentity(asUser(ORG)).mutation(api.invoicesWrites.issueNative, {
+      id: "i1", orgId: ORG, autoNumber, actor, auditId: "a2", now: NOW,
+    });
+    expect(result.invoiceNumber).toBe("INV-2023-0001");
+  });
+
   test("assigns a gapless invoice number and never re-numbers on a second issue", async () => {
     const t = makeT();
     await seedMember(t);

--- a/convex/invoicesWrites.ts
+++ b/convex/invoicesWrites.ts
@@ -7,7 +7,6 @@ import { enforceBrowserWriteLimit } from "./lib/rateLimiter";
 import { writeActivityLog } from "./lib/audit";
 import { assertNumRange, assertStrLen } from "./lib/fieldGuards";
 import { assertRefInOrg } from "./lib/orgRef";
-import { assertLifecycleGuard } from "./lib/projectLocks";
 import { buildFinanceLines } from "./lib/financeSnapshot";
 import { recalcProjectTotals, orgDefaultTaxRate } from "./lib/recalc";
 import { reserveProjectNumberCounter } from "./lib/projectNumberCounter";
@@ -109,7 +108,6 @@ export const createNative = mutation({
     await assertRefInOrg(ctx, "clients", fields.clientId, fields.organizationId);
     const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", fields.projectId)).first();
     if (!project) throw new ConvexError("Project not found: " + fields.projectId);
-    await assertLifecycleGuard(ctx, project, { kind: "financial" });
 
     const dup = await ctx.db.query("invoices").withIndex("by_cuid", (q) => q.eq("id", fields.id)).first();
     if (dup) throw new ConvexError("Invoice already exists");
@@ -259,9 +257,6 @@ export const issueNative = mutation({
     if (doc.status !== "DRAFT") {
       throw new ConvexError({ code: "INVALID_STATE", message: `Invoice is ${doc.status}, only a DRAFT invoice can be issued.` });
     }
-
-    const project = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", doc.projectId)).first();
-    if (project) await assertLifecycleGuard(ctx, project, { kind: "financial" });
 
     const invoiceNumber = await allocateInvoiceNumber(ctx, orgId, autoNumber, now);
 


### PR DESCRIPTION
## Summary

- Accepting a quote and confirming a project (the normal path to raising an invoice) puts the project at `FINANCE_LOCKED` tier. `invoicesWrites.createNative`/`issueNative` called `assertLifecycleGuard(ctx, project, { kind: "financial" })` unconditionally, so every invoice attempt on a `CONFIRMED`+ project threw `FINANCIALS_LOCKED` (surfacing to users as a masked "Server Error") unless a finance unlock session happened to be open — which is never true for a normal first invoice.
- That guard exists to gate edits to locked pricing-input fields (`unitPrice`, `discount`, `taxRate`, group `price`) — invoice mutations never touch those; they only snapshot already-computed totals into the separate `invoices`/`invoiceLines` tables. Every other caller of `kind: "financial"` in the codebase only uses it when actually writing a locked field, and the sibling invoice mutations `voidNative`/`createCreditNative` never had this guard.
- Fix: removed the two incorrect `assertLifecycleGuard` calls from `createNative`/`issueNative` in `convex/invoicesWrites.ts`, bringing them in line with `voidNative`/`createCreditNative`.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md`'s "Lifecycle locks" section to reflect the corrected behavior.

## Testing

- Reproduced the bug with a Convex test (`CONFIRMED` project + `createNative` → `ConvexError FINANCIALS_LOCKED`) before applying the fix.
- Added two regression tests to `convex/invoicesWrites.test.ts`: creating and issuing a DRAFT invoice on a `CONFIRMED` (finance-locked) project with no unlock session open.
- `convex/invoicesWrites.test.ts`: 18/18 pass.
- Full `pnpm test`: 4,837 tests pass. (48 test files fail only due to this container missing `DATABASE_URL`/generated Prisma client — a pre-existing environment gap, unrelated to this change.)

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_