### PR TITLE
fix(xero): stop pushInvoiceToXero from throwing across the Server Action boundary

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -864,6 +864,37 @@ direct visit to `/settings/xero` shows a "not configured" message instead of
 a "Connect Xero" button that would otherwise throw at click-time
 (`requireXeroAppCredentials()` in `src/server/xero.ts`).
 
+### `pushInvoiceToXero` never throws — it returns `{ ok, ... }`
+
+`src/server/xero.ts`'s `pushInvoiceToXero` is a real Next.js Server Action
+(`"use server"`), invoked from `PushToXeroButton`
+(`project-finance-panel.tsx`) via `useServerMutation`. Next.js redacts every
+UNCAUGHT error thrown out of a Server Action in production to a generic
+"An error occurred in the Server Components render" message plus an opaque
+digest — the actual reason (invoice not ISSUED, client not found, Xero not
+connected for this org, `XERO_CLIENT_ID`/`XERO_CLIENT_SECRET` unset on this
+deployment, or a real Xero API failure) never reaches the browser. This was a
+live bug (2026-07): every one of those precondition checks used a plain
+`throw new Error(...)`, so the button failed with an unreadable 500 no matter
+which one fired.
+
+Fix: `pushInvoiceToXero`'s return type is `XeroPushResult =
+{ ok: true; xeroInvoiceId; varianceNote; autoCreatedContact } | { ok: false; error: string }`
+and the WHOLE function body is wrapped in a top-level try/catch that returns
+`{ ok: false, error }` instead of letting anything escape — the ONLY way a
+Server Action's failure message survives Next's production redaction. The
+existing inner try/catch around the actual `createXeroDraftInvoice` call
+(which marks the invoice `ERROR`, logs the sync event, and writes the
+activity log entry) is unchanged; its re-thrown `Error` is now just an
+internal signal caught by the outer catch, not something that escapes the
+function. `PushToXeroButton` checks `r.ok` in `onSuccess` and shows `r.error`
+via `toast.error` when false — `onError` on the hook stays wired only as a
+last-resort net for a genuinely unexpected framework-level failure. Any new
+`"use server"` action that can fail in an expected way (not-found, wrong
+state, integration not connected, …) should follow this same
+discriminated-result pattern rather than throwing, or it will hit the exact
+same production-only failure mode.
+
 ### Account-coding pickers are searchable, not plain `Select`s
 
 `/settings/xero`'s org-default-account, default-tax-type, and per-service-type
@@ -964,8 +995,10 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
 - `src/lib/xero-client.test.ts` — 16 tests against fixture Xero responses
   (mocked `fetch`).
 - `src/lib/xero-oauth-state.test.ts` — 5 tamper/expiry tests.
-- `src/server/xero.test.ts` — 4 mocked-boundary tests on `pushInvoiceToXero`
-  (auto-create-contact idempotency, the failure path).
+- `src/server/xero.test.ts` — 7 mocked-boundary tests on `pushInvoiceToXero`
+  (auto-create-contact idempotency, the Xero-API-failure path, and three
+  precondition failures — not-ISSUED, not-connected, not-configured —
+  asserting each resolves to `{ ok: false, error }` rather than throwing).
 - `convex/lib/xeroGate.test.ts` — 4 tests, the linked gate + org-scoping.
 - `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 42 tests,
   server-computed money, gapless/namespaced numbering, cross-org IDOR guards,

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -413,9 +413,16 @@ function PushToXeroButton({ invoiceId }: { invoiceId: string }) {
   const pushMutation = useServerMutation({
     mutationFn: () => pushInvoiceToXero(invoiceId),
     onSuccess: (r) => {
+      if (!r.ok) {
+        toast.error(r.error);
+        return;
+      }
       toast.success(r.autoCreatedContact ? "Pushed to Xero (new contact created)" : "Pushed to Xero");
       if (r.varianceNote) toast.warning(r.varianceNote);
     },
+    // pushInvoiceToXero never throws — it always resolves to { ok, ... } so its
+    // failure message survives Next's production Server Action redaction. This
+    // stays only as a last-resort net for a genuinely unexpected framework error.
     onError: (e) => toast.error(e.message),
   });
   return (

--- a/src/server/xero.test.ts
+++ b/src/server/xero.test.ts
@@ -86,6 +86,7 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
 
     expect(findXeroContactByEmail).toHaveBeenCalledWith("billing@acme.test", expect.anything());
     expect(createXeroContact).not.toHaveBeenCalled(); // duplicate protection — no create when found
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
     expect(result.autoCreatedContact).toBe(false);
     // The found contact is stored back onto the client (mutation call present).
     const setContactCall = mutationMock.mock.calls.find((c) => getFunctionName(c[0] as Parameters<typeof getFunctionName>[0]) === "clientXeroWrites:setXeroContactNative");
@@ -102,6 +103,7 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
     const result = await pushInvoiceToXero("inv1");
 
     expect(createXeroContact).toHaveBeenCalledTimes(1);
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
     expect(result.autoCreatedContact).toBe(true);
   });
 
@@ -114,19 +116,82 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
 
     expect(findXeroContactByEmail).not.toHaveBeenCalled();
     expect(createXeroContact).not.toHaveBeenCalled();
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
     expect(result.autoCreatedContact).toBe(false);
     expect(result.xeroInvoiceId).toBe("xero-inv-1");
   });
 
-  test("a Xero API failure marks the invoice ERROR and rethrows, without silently swallowing the error", async () => {
+  test("a Xero API failure marks the invoice ERROR and returns { ok: false }, without silently swallowing the error", async () => {
     const client = { id: "c1", organizationId: "org_1", name: "Acme Events", contactEmail: "billing@acme.test", xeroContactId: "mapped", xeroContactName: "Acme" };
     queryMock.mockImplementation(queryImplFor(client));
     createXeroDraftInvoice.mockRejectedValue(new Error("Xero POST /Invoices returned 400"));
 
     const { pushInvoiceToXero } = await import("./xero");
-    await expect(pushInvoiceToXero("inv1")).rejects.toThrow(/xero push failed/i);
+    const result = await pushInvoiceToXero("inv1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toMatch(/xero push failed/i);
 
     const failCall = mutationMock.mock.calls.find((c) => getFunctionName(c[0] as Parameters<typeof getFunctionName>[0]) === "xeroPush:markXeroPushFailedNative");
     expect(failCall).toBeDefined();
+  });
+
+  // Regression (live bug): every one of these precondition failures used to
+  // throw a plain, uncaught Error straight out of the Server Action. Next.js
+  // redacts uncaught Server Action errors in production to a generic "error
+  // occurred in the Server Components render" message + digest, so the user
+  // pressing "Push to Xero" saw a useless 500 no matter which of these fired.
+  // pushInvoiceToXero must never throw — every failure resolves to
+  // `{ ok: false, error }` so the real reason survives to the client.
+  test("never throws — an invoice not ISSUED yet resolves to { ok: false } with a clear reason", async () => {
+    const client = { id: "c1", organizationId: "org_1", name: "Acme Events" };
+    queryMock.mockImplementation(queryImplFor(client));
+    queryMock.mockImplementation(async (fnRef: unknown) => {
+      const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+      if (name === "invoices:getById") return { ...INVOICE, status: "DRAFT" };
+      throw new Error(`Unmocked query: ${name}`);
+    });
+
+    const { pushInvoiceToXero } = await import("./xero");
+    const result = await pushInvoiceToXero("inv1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toMatch(/only an issued invoice/i);
+  });
+
+  test("never throws — Xero not connected for the org resolves to { ok: false } with a clear reason", async () => {
+    queryMock.mockImplementation(async (fnRef: unknown) => {
+      const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+      if (name === "invoices:getById") return INVOICE;
+      if (name === "xeroIntegrations:getByOrgId") return { ...INTEGRATION, isConnected: false };
+      throw new Error(`Unmocked query: ${name}`);
+    });
+
+    const { pushInvoiceToXero } = await import("./xero");
+    const result = await pushInvoiceToXero("inv1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toMatch(/not connected/i);
+  });
+
+  test("never throws — Xero not configured on this deployment resolves to { ok: false } with a clear reason", async () => {
+    vi.stubEnv("XERO_CLIENT_ID", "");
+    vi.stubEnv("XERO_CLIENT_SECRET", "");
+    // @/env parses process.env into a frozen object once at first import;
+    // vi.resetModules forces a fresh read so the empty stub above takes effect
+    // (a plain vi.stubEnv is invisible to an already-cached `env` object).
+    vi.resetModules();
+    const client = { id: "c1", organizationId: "org_1", name: "Acme Events", xeroContactId: "mapped", xeroContactName: "Acme" };
+    queryMock.mockImplementation(queryImplFor(client));
+
+    const { pushInvoiceToXero } = await import("./xero");
+    const result = await pushInvoiceToXero("inv1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toMatch(/not configured/i);
   });
 });

--- a/src/server/xero.ts
+++ b/src/server/xero.ts
@@ -262,11 +262,9 @@ export async function unlinkXeroContact(clientId: string) {
 
 // ─── Push ────────────────────────────────────────────────────────────────
 
-export interface XeroPushResult {
-  xeroInvoiceId: string;
-  varianceNote: string | null;
-  autoCreatedContact: boolean;
-}
+export type XeroPushResult =
+  | { ok: true; xeroInvoiceId: string; varianceNote: string | null; autoCreatedContact: boolean }
+  | { ok: false; error: string };
 
 /**
  * Push an ISSUED invoice to Xero as a DRAFT (ACCREC) invoice. Ensures the
@@ -274,92 +272,105 @@ export interface XeroPushResult {
  * exact-email match against Xero's contacts LINKS instead of creating (spec
  * requirement). Coding is resolved server-side (convex/xeroPush.ts,
  * convex/lib/xeroAccountCascade.ts) and snapshotted onto invoiceLines.
+ *
+ * NEVER throws — always resolves to `{ ok, ... }`. Next.js redacts every
+ * uncaught error thrown out of a Server Action in production to a generic
+ * "error occurred in the Server Components render" message with a digest,
+ * hiding the actual reason (not connected, not configured, invoice not
+ * ISSUED, a real Xero API failure, …) from the user. Returning a
+ * discriminated result is the only way a Server Action's failure message
+ * survives to the client in production.
  */
 export async function pushInvoiceToXero(invoiceId: string): Promise<XeroPushResult> {
-  const { organizationId, userId, userName } = await requirePermission("invoice", "xero_push");
-  const convex = await getConvexClient();
-
-  const invoice = await convex.query(api.invoices.getById, { id: invoiceId });
-  if (!invoice || invoice.organizationId !== organizationId) throw new Error("Invoice not found.");
-  if (invoice.status !== "ISSUED") throw new Error("Only an ISSUED invoice can be pushed to Xero.");
-  if (!invoice.invoiceNumber) throw new Error("Invoice has no number — this should not happen for an ISSUED invoice.");
-
-  const integration = await requireLinkedIntegration(convex, organizationId);
-  const project = await convex.query(api.projects.getById, { id: invoice.projectId });
-  const client = await convex.query(api.clients.getById, { id: invoice.clientId });
-  if (!client) throw new Error("Client not found.");
-
-  let autoCreatedContact = false;
-  let xeroContactId = client.xeroContactId as string | undefined;
-  const { accessToken } = await getFreshAccessToken(integration.refreshTokenEncrypted!, integration.id, convex);
-  const tenantId = integration.tenantId!;
-
-  if (!xeroContactId) {
-    // Duplicate protection: exact-email match links instead of creating.
-    const email = client.contactEmail || undefined;
-    const existingContact = email ? await findXeroContactByEmail(email, { accessToken, tenantId }) : null;
-    const contact =
-      existingContact ??
-      (await createXeroContact(
-        { name: client.name, email, addressLine1: client.billingAddress || undefined },
-        { accessToken, tenantId },
-      ));
-    xeroContactId = contact.ContactID;
-    autoCreatedContact = existingContact == null;
-    await convex.mutation(api.clientXeroWrites.setXeroContactNative, {
-      clientId: client.id, orgId: organizationId, xeroContactId: contact.ContactID, xeroContactName: contact.Name,
-      actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
-    });
-  }
-
-  const lines = await convex.query(api.invoiceLines.listForInvoice, { orgId: organizationId, invoiceId });
-  const coding = await convex.query(api.xeroPush.resolveCodingForInvoice, { invoiceId, orgId: organizationId });
-  const codingByLineId = new Map(coding.lines.map((l) => [l.lineId, l]));
-
-  const lineItems: XeroInvoiceLineInput[] = lines.map((l) => {
-    const resolved = codingByLineId.get(l.id);
-    return {
-      description: l.description,
-      quantity: l.quantity,
-      unitAmount: l.unitPrice,
-      accountCode: resolved?.accountCode ?? null,
-      taxType: resolved?.taxType ?? null,
-    };
-  });
-
-  const invoiceLabel = `${invoice.kind} invoice ${invoice.invoiceNumber}`;
   try {
-    const created = await createXeroDraftInvoice(
-      {
-        contactId: xeroContactId,
-        invoiceNumber: invoice.invoiceNumber,
-        reference: project ? `Project ${project.projectNumber} — ${project.name}` : undefined,
-        date: toDateOnly(invoice.issuedAt ?? Date.now()),
-        dueDate: invoice.dueDate ? toDateOnly(invoice.dueDate) : undefined,
-        lineItems,
-      },
-      { accessToken, tenantId },
-    );
+    const { organizationId, userId, userName } = await requirePermission("invoice", "xero_push");
+    const convex = await getConvexClient();
 
-    await convex.mutation(api.xeroPush.applyXeroPushResultNative, {
-      invoiceId, orgId: organizationId, xeroInvoiceId: created.InvoiceID, resolvedLines: coding.lines, now: Date.now(),
-    });
-    await logSyncEvent(organizationId, "PUSH_INVOICE", "SUCCESS", { xeroInvoiceId: created.InvoiceID }, invoiceId, created.InvoiceID, client.id);
-    await convex.mutation(api.xeroPush.logXeroPushActivity, {
-      organizationId, invoiceId, invoiceLabel, success: true,
-      actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
+    const invoice = await convex.query(api.invoices.getById, { id: invoiceId });
+    if (!invoice || invoice.organizationId !== organizationId) throw new Error("Invoice not found.");
+    if (invoice.status !== "ISSUED") throw new Error("Only an ISSUED invoice can be pushed to Xero.");
+    if (!invoice.invoiceNumber) throw new Error("Invoice has no number — this should not happen for an ISSUED invoice.");
+
+    const integration = await requireLinkedIntegration(convex, organizationId);
+    const project = await convex.query(api.projects.getById, { id: invoice.projectId });
+    const client = await convex.query(api.clients.getById, { id: invoice.clientId });
+    if (!client) throw new Error("Client not found.");
+
+    let autoCreatedContact = false;
+    let xeroContactId = client.xeroContactId as string | undefined;
+    const { accessToken } = await getFreshAccessToken(integration.refreshTokenEncrypted!, integration.id, convex);
+    const tenantId = integration.tenantId!;
+
+    if (!xeroContactId) {
+      // Duplicate protection: exact-email match links instead of creating.
+      const email = client.contactEmail || undefined;
+      const existingContact = email ? await findXeroContactByEmail(email, { accessToken, tenantId }) : null;
+      const contact =
+        existingContact ??
+        (await createXeroContact(
+          { name: client.name, email, addressLine1: client.billingAddress || undefined },
+          { accessToken, tenantId },
+        ));
+      xeroContactId = contact.ContactID;
+      autoCreatedContact = existingContact == null;
+      await convex.mutation(api.clientXeroWrites.setXeroContactNative, {
+        clientId: client.id, orgId: organizationId, xeroContactId: contact.ContactID, xeroContactName: contact.Name,
+        actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
+      });
+    }
+
+    const lines = await convex.query(api.invoiceLines.listForInvoice, { orgId: organizationId, invoiceId });
+    const coding = await convex.query(api.xeroPush.resolveCodingForInvoice, { invoiceId, orgId: organizationId });
+    const codingByLineId = new Map(coding.lines.map((l) => [l.lineId, l]));
+
+    const lineItems: XeroInvoiceLineInput[] = lines.map((l) => {
+      const resolved = codingByLineId.get(l.id);
+      return {
+        description: l.description,
+        quantity: l.quantity,
+        unitAmount: l.unitPrice,
+        accountCode: resolved?.accountCode ?? null,
+        taxType: resolved?.taxType ?? null,
+      };
     });
 
-    return serialize<XeroPushResult>({ xeroInvoiceId: created.InvoiceID, varianceNote: coding.varianceNote, autoCreatedContact });
+    const invoiceLabel = `${invoice.kind} invoice ${invoice.invoiceNumber}`;
+    try {
+      const created = await createXeroDraftInvoice(
+        {
+          contactId: xeroContactId,
+          invoiceNumber: invoice.invoiceNumber,
+          reference: project ? `Project ${project.projectNumber} — ${project.name}` : undefined,
+          date: toDateOnly(invoice.issuedAt ?? Date.now()),
+          dueDate: invoice.dueDate ? toDateOnly(invoice.dueDate) : undefined,
+          lineItems,
+        },
+        { accessToken, tenantId },
+      );
+
+      await convex.mutation(api.xeroPush.applyXeroPushResultNative, {
+        invoiceId, orgId: organizationId, xeroInvoiceId: created.InvoiceID, resolvedLines: coding.lines, now: Date.now(),
+      });
+      await logSyncEvent(organizationId, "PUSH_INVOICE", "SUCCESS", { xeroInvoiceId: created.InvoiceID }, invoiceId, created.InvoiceID, client.id);
+      await convex.mutation(api.xeroPush.logXeroPushActivity, {
+        organizationId, invoiceId, invoiceLabel, success: true,
+        actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
+      });
+
+      return serialize<XeroPushResult>({ ok: true, xeroInvoiceId: created.InvoiceID, varianceNote: coding.varianceNote, autoCreatedContact });
+    } catch (err) {
+      const message = err instanceof XeroApiError ? err.message : err instanceof Error ? err.message : "Unknown error";
+      await convex.mutation(api.xeroPush.markXeroPushFailedNative, { invoiceId, orgId: organizationId, error: message, now: Date.now() });
+      await logSyncEvent(organizationId, "PUSH_INVOICE", "FAILED", { error: message }, invoiceId, undefined, client.id);
+      await convex.mutation(api.xeroPush.logXeroPushActivity, {
+        organizationId, invoiceId, invoiceLabel, success: false, detail: message,
+        actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
+      });
+      throw new Error(`Xero push failed: ${message}`);
+    }
   } catch (err) {
-    const message = err instanceof XeroApiError ? err.message : err instanceof Error ? err.message : "Unknown error";
-    await convex.mutation(api.xeroPush.markXeroPushFailedNative, { invoiceId, orgId: organizationId, error: message, now: Date.now() });
-    await logSyncEvent(organizationId, "PUSH_INVOICE", "FAILED", { error: message }, invoiceId, undefined, client.id);
-    await convex.mutation(api.xeroPush.logXeroPushActivity, {
-      organizationId, invoiceId, invoiceLabel, success: false, detail: message,
-      actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
-    });
-    throw new Error(`Xero push failed: ${message}`);
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return serialize<XeroPushResult>({ ok: false, error: message });
   }
 }
 


### PR DESCRIPTION
## Summary

- Pressing "Push to Xero" failed with a generic 500 ("An error occurred in the Server Components render...") no matter the actual cause. `pushInvoiceToXero` (`src/server/xero.ts`) is a real Next.js Server Action, and Next.js redacts every uncaught error thrown out of a Server Action in production to that same unhelpful message + digest — hiding whether the real reason was an unissued invoice, a missing client, Xero not connected for the org, missing `XERO_CLIENT_ID`/`XERO_CLIENT_SECRET`, or a genuine Xero API failure.
- Changed `pushInvoiceToXero` to never throw: the whole body is now wrapped in a try/catch that returns `{ ok: false, error }` instead of letting anything escape, and the return type is a discriminated `XeroPushResult` union (`{ ok: true; xeroInvoiceId; varianceNote; autoCreatedContact } | { ok: false; error: string }`). The existing inner try/catch (marks the invoice `ERROR`, logs the sync event/activity log on a real Xero API failure) is unchanged.
- Updated `PushToXeroButton` (`project-finance-panel.tsx`) to branch on `result.ok` and toast the real error message; `onError` on the hook stays only as a last-resort net for a genuinely unexpected framework-level failure.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` to document the fix and the general rule: any Server Action with expected failure modes should return a discriminated result, not throw, or it hits this same production-only redaction.

## Testing

- Added 3 regression tests to `src/server/xero.test.ts` covering exactly the paths that used to throw uncaught — invoice not `ISSUED`, Xero not connected for the org, Xero not configured on the deployment — each asserting `{ ok: false, error }` with a readable message instead of an uncaught throw.
- Updated the 4 existing tests for the new return shape (one previously asserted `.rejects.toThrow(...)`, now asserts `result.ok === false` and `result.error`).
- `src/server/xero.test.ts`: 7/7 pass.
- `tsc --noEmit` and `eslint` clean on all changed files (only pre-existing, unrelated warnings elsewhere).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_