### PR TITLE
fix(xero): surface Xero's own validation detail in push-failure messages

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -895,6 +895,34 @@ state, integration not connected, …) should follow this same
 discriminated-result pattern rather than throwing, or it will hit the exact
 same production-only failure mode.
 
+### `xeroGet`/`xeroPost` surface Xero's OWN validation detail, not just the HTTP status
+
+Once `pushInvoiceToXero`'s message could reach the browser (above), a live
+push failed with `"Xero push failed: Xero POST /api.xro/2.0/Invoices returned
+400"` — technically correct, completely useless. Xero's error response for a
+rejected Accounting API call carries the actual reason in the JSON body: a
+top-level `Message` plus, for validation failures, an `Elements[]` array
+whose `ValidationErrors[].Message` names the specific rejected field (e.g.
+`"Account code '9999' is not a valid code for this document."` — a stale or
+wrong-region account/tax code from the coding cascade, convex/lib/
+xeroAccountCascade.ts, is the most likely real-world cause). `XeroApiError`
+always captured this body in its `.body` property, but nothing ever READ
+it — the thrown `.message` was always just the bare `"Xero {METHOD} {path}
+returned {status}"`, so neither the toast nor the persisted
+`invoices.lastSyncError`/`xeroSyncLogs.errorMessage` ever showed it.
+
+`extractXeroErrorDetail`/`xeroErrorMessage` (`src/lib/xero-client.ts`) are the
+one place both `xeroGet` and `xeroPost` build their error message now —
+`Message` + every `Elements[].ValidationErrors[].Message`, best-effort and
+defensive (never throws on an unexpected body shape, since this is diagnostic
+text, not domain data). A future Accounting API call added to this file
+automatically gets full validation detail in its error for free, as long as
+it goes through `xeroGet`/`xeroPost` rather than hand-rolling its own
+`!res.ok` check. The OAuth token/connections endpoints (`postToken`,
+`listXeroConnections`) are deliberately NOT touched — their error body is
+the OAuth2 `{error, error_description}` shape, not this Accounting-API shape,
+and they're outside this bug's scope.
+
 ### Account-coding pickers are searchable, not plain `Select`s
 
 `/settings/xero`'s org-default-account, default-tax-type, and per-service-type
@@ -992,8 +1020,9 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
   rental-vs-sale + service-type branches.
 - `convex/xeroPush.test.ts` — 6 tests, cascade resolution IN CONTEXT (real
   DB reads through model/kit/category/service, not just the pure functions).
-- `src/lib/xero-client.test.ts` — 16 tests against fixture Xero responses
-  (mocked `fetch`).
+- `src/lib/xero-client.test.ts` — 20 tests against fixture Xero responses
+  (mocked `fetch`), including one asserting a realistic `ValidationErrors`
+  body surfaces its specific per-line message, not just the HTTP status.
 - `src/lib/xero-oauth-state.test.ts` — 5 tamper/expiry tests.
 - `src/server/xero.test.ts` — 7 mocked-boundary tests on `pushInvoiceToXero`
   (auto-create-contact idempotency, the Xero-API-failure path, and three

--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -276,4 +276,37 @@ describe("createXeroDraftInvoice", () => {
       ),
     ).rejects.toMatchObject({ status: 400 });
   });
+
+  // Regression (live bug): a bare "Xero POST /api.xro/2.0/Invoices returned
+  // 400" told the user (and the persisted invoices.lastSyncError /
+  // xeroSyncLogs.errorMessage) nothing about WHY Xero rejected the push.
+  // Xero's actual reason (per-line ValidationErrors, e.g. an invalid account
+  // code or tax type) sat unread in the error body. The thrown message must
+  // surface it.
+  it("includes Xero's per-line ValidationErrors detail in the thrown message, not just the status", async () => {
+    const { impl } = mockFetch(
+      {
+        Type: "ValidationException",
+        Message: "A validation exception occurred",
+        Elements: [
+          {
+            LineItems: [{ Description: "PA System hire" }],
+            ValidationErrors: [{ Message: "Account code '9999' is not a valid code for this document." }],
+          },
+        ],
+      },
+      400,
+    );
+    await expect(
+      createXeroDraftInvoice(
+        {
+          contactId: "c1",
+          invoiceNumber: "INV-1",
+          date: "2026-07-26",
+          lineItems: [{ description: "PA System hire", quantity: 1, unitAmount: 500, accountCode: "9999", taxType: "OUTPUT2" }],
+        },
+        { ...authOpts, fetchImpl: impl },
+      ),
+    ).rejects.toThrow(/Account code '9999' is not a valid code for this document/);
+  });
 });

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -70,6 +70,48 @@ export class XeroApiError extends Error {
   }
 }
 
+/**
+ * Xero's error response body carries the ACTUAL reason a request was
+ * rejected (e.g. "Account code '9999' is not a valid code for this
+ * document.") — a per-field `ValidationErrors[].Message` nested under
+ * `Elements`, alongside a top-level `Message`. Every `xeroGet`/`xeroPost`
+ * error previously discarded this: the thrown message was just
+ * "Xero POST /path returned 400" with the actual detail sitting unread in
+ * `XeroApiError.body`, so neither the user's toast nor the persisted
+ * `invoices.lastSyncError`/`xeroSyncLogs.errorMessage` ever showed WHY a
+ * push failed. Best-effort, defensive parsing — this is diagnostic text,
+ * not domain data, so it never throws on an unexpected shape.
+ */
+/** A non-empty trimmed string, or undefined for anything else. */
+function trimmedStringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Every `ValidationErrors[].Message` string across one `Elements` entry. */
+function validationErrorMessages(element: unknown): string[] {
+  if (typeof element !== "object" || element === null) return [];
+  const validationErrors = (element as Record<string, unknown>).ValidationErrors;
+  if (!Array.isArray(validationErrors)) return [];
+  return validationErrors.map((ve) => trimmedStringOrUndefined((ve as Record<string, unknown> | null)?.Message)).filter((m) => m != null);
+}
+
+function extractXeroErrorDetail(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const record = body as Record<string, unknown>;
+  const elements = Array.isArray(record.Elements) ? record.Elements : [];
+  const parts = [trimmedStringOrUndefined(record.Message), ...elements.flatMap(validationErrorMessages)].filter((m) => m != null);
+  return parts.length > 0 ? parts.join(": ") : undefined;
+}
+
+/** `Xero {METHOD} {path} returned {status}` with Xero's own validation detail
+ *  appended when present (see `extractXeroErrorDetail`) — the ONE place every
+ *  `xeroGet`/`xeroPost` caller's error message is built, so the detail is
+ *  never accidentally dropped by a future call site. */
+function xeroErrorMessage(method: "GET" | "POST", path: string, status: number, body: unknown): string {
+  const detail = extractXeroErrorDetail(body);
+  return `Xero ${method} ${path} returned ${status}${detail ? `: ${detail}` : ""}`;
+}
+
 // ─── OAuth2 ──────────────────────────────────────────────────────────────────
 
 export function buildXeroAuthorizeUrl(opts: {
@@ -208,7 +250,7 @@ async function xeroGet(path: string, opts: AuthedRequestOpts): Promise<unknown> 
     },
   });
   const json = await safeJson(res);
-  if (!res.ok) throw new XeroApiError(`Xero GET ${path} returned ${res.status}`, res.status, json);
+  if (!res.ok) throw new XeroApiError(xeroErrorMessage("GET", path, res.status, json), res.status, json);
   return json;
 }
 
@@ -225,7 +267,7 @@ async function xeroPost(path: string, body: unknown, opts: AuthedRequestOpts): P
     body: JSON.stringify(body),
   });
   const json = await safeJson(res);
-  if (!res.ok) throw new XeroApiError(`Xero POST ${path} returned ${res.status}`, res.status, json);
+  if (!res.ok) throw new XeroApiError(xeroErrorMessage("POST", path, res.status, json), res.status, json);
   return json;
 }
 


### PR DESCRIPTION
## Summary

- Following the previous fix (#1042) that let `pushInvoiceToXero`'s real error message reach the client, a live push failed with `"Xero push failed: Xero POST /api.xro/2.0/Invoices returned 400"` — technically correct, useless for diagnosing anything.
- Xero's error response body for a rejected Accounting API call carries the actual reason: a top-level `Message`, plus for validation failures a per-line `Elements[].ValidationErrors[].Message` naming the specific rejected field (e.g. an invalid account/tax code from the coding cascade, `convex/lib/xeroAccountCascade.ts`). `XeroApiError` always captured this body in `.body`, but nothing ever read it — the thrown `.message` was always just the bare `"Xero {METHOD} {path} returned {status}"`, so neither the toast nor the persisted `invoices.lastSyncError`/`xeroSyncLogs.errorMessage` ever showed why a push actually failed.
- `xeroGet`/`xeroPost` (`src/lib/xero-client.ts`) now build their error message through a shared `extractXeroErrorDetail`/`xeroErrorMessage` helper that appends Xero's own `Message` + every `ValidationErrors[].Message`, best-effort (never throws on an unexpected body shape — this is diagnostic text, not domain data). Every Accounting API call through these two functions (Accounts, TaxRates, Contacts, Invoices) gets this for free. The OAuth token/connections endpoints are deliberately untouched — their error body is a different (OAuth2) shape and are outside this bug's scope.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` to document the fix.

## Testing

- Added a regression test to `src/lib/xero-client.test.ts` with a realistic Xero `ValidationException` body (per-line `Elements`/`ValidationErrors`), asserting the thrown message now contains the specific rejected-field detail instead of just the HTTP status.
- `src/lib/xero-client.test.ts`: 20/20 pass.
- `src/server/xero.test.ts`: 7/7 pass (unaffected, confirms no regression).
- `tsc --noEmit` and `eslint` clean on all changed files.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_