### PR TITLE
fix(xero): stop the tax-type picker offering expenses-only rates

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -923,6 +923,36 @@ it goes through `xeroGet`/`xeroPost` rather than hand-rolling its own
 the OAuth2 `{error, error_description}` shape, not this Accounting-API shape,
 and they're outside this bug's scope.
 
+### The tax-type picker only offers rates valid for a SALES invoice
+
+With Xero's own validation detail now visible (above), a real push failed
+with `"The TaxType code 'INPUT' cannot be used with account code '200'."`
+— an operator had picked an expenses-only GST rate (`INPUT`-family, Xero's
+"GST on Expenses" side) as the org's default tax type, or as a category/
+line override. This integration exclusively creates ACCREC (sales)
+invoices (`createXeroDraftInvoice`, `Type: "ACCREC"`) — an expenses-only
+rate is NEVER valid on any push, regardless of which account it's paired
+with, because Xero ties every tax rate to `CanApplyToRevenue`/
+`CanApplyToExpenses` flags on the rate itself. The Settings -> Xero
+tax-type picker (`XeroTaxTypeField`, `xero-coding-fields.tsx`) offered
+every cached rate from BOTH sides identically, with nothing in the UI
+distinguishing "GST on Income" from "GST on Expenses" beyond the name —
+an easy, silent misconfiguration to make, and one that only ever surfaces
+downstream, at push time, on whichever invoice happens to be pushed first.
+
+Fix, at the source rather than downstream: `taxRateSchema`
+(`src/lib/xero-client.ts`) now models Xero's `CanApplyToRevenue` boolean
+(previously dropped — this file's schemas only model fields the
+integration actually reads), so it survives into `xeroIntegrations.
+cachedTaxRates`. `revenueApplicableTaxRates()` (`xero-coding-fields.tsx`)
+filters `useXeroCodingOptions()`'s `taxRateOptions` to
+`CanApplyToRevenue !== false` — deliberately NOT `=== true`, so a cache
+written before this field existed (every org's cache, until their next
+Settings -> Xero "Refresh") still offers all its rates rather than going
+empty. This is the ONE picker instance shared by the org default AND every
+category/line/service override (R-3.1) — fixing it here closes the gap at
+every level of the cascade in one place, not just the org default.
+
 ### Account-coding pickers are searchable, not plain `Select`s
 
 `/settings/xero`'s org-default-account, default-tax-type, and per-service-type
@@ -1020,9 +1050,15 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
   rental-vs-sale + service-type branches.
 - `convex/xeroPush.test.ts` — 6 tests, cascade resolution IN CONTEXT (real
   DB reads through model/kit/category/service, not just the pure functions).
-- `src/lib/xero-client.test.ts` — 20 tests against fixture Xero responses
+- `src/lib/xero-client.test.ts` — 21 tests against fixture Xero responses
   (mocked `fetch`), including one asserting a realistic `ValidationErrors`
-  body surfaces its specific per-line message, not just the HTTP status.
+  body surfaces its specific per-line message, not just the HTTP status,
+  and one pinning `CanApplyToRevenue` surviving schema parsing on both an
+  income and an expenses tax rate.
+- `src/components/settings/xero-coding-fields.test.ts` — 3 tests on
+  `revenueApplicableTaxRates`, the tax-type picker's income-vs-expenses
+  filter (drops `CanApplyToRevenue: false`, keeps a pre-fix cache's
+  fieldless rates, empty input).
 - `src/lib/xero-oauth-state.test.ts` — 5 tamper/expiry tests.
 - `src/server/xero.test.ts` — 7 mocked-boundary tests on `pushInvoiceToXero`
   (auto-create-contact idempotency, the Xero-API-failure path, and three

--- a/src/components/settings/xero-coding-fields.test.ts
+++ b/src/components/settings/xero-coding-fields.test.ts
@@ -1,0 +1,36 @@
+/**
+ * src/components/settings/xero-coding-fields.tsx — `revenueApplicableTaxRates`,
+ * the pure filter behind the Settings -> Xero tax-type picker. Split out of a
+ * .test.tsx so this doesn't need to render the picker or mock
+ * useXeroIntegration.
+ *
+ * Regression (live bug): a push failed with "The TaxType code 'INPUT' cannot
+ * be used with account code '200'" because the org-default tax type picker
+ * offered every cached Xero tax rate — income AND expense side — with no
+ * filtering, even though this integration only ever creates ACCREC (sales)
+ * invoices. An expenses-only rate is never a valid choice for any push.
+ */
+import { describe, test, expect } from "vitest";
+import { revenueApplicableTaxRates } from "./xero-coding-fields";
+
+describe("revenueApplicableTaxRates", () => {
+  test("drops a rate explicitly marked CanApplyToRevenue: false", () => {
+    const rates = [
+      { Name: "GST on Income", TaxType: "OUTPUT2", CanApplyToRevenue: true },
+      { Name: "GST on Expenses", TaxType: "INPUT2", CanApplyToRevenue: false },
+    ];
+    expect(revenueApplicableTaxRates(rates).map((r) => r.TaxType)).toEqual(["OUTPUT2"]);
+  });
+
+  // A cache written before CanApplyToRevenue was modeled (src/lib/xero-client.ts)
+  // has no such field on any rate — treat "unknown" as still-offerable rather
+  // than hiding every option until the next Settings -> Xero "Refresh".
+  test("keeps a rate with CanApplyToRevenue absent (pre-fix cache)", () => {
+    const rates: { Name: string; TaxType: string; CanApplyToRevenue?: boolean }[] = [{ Name: "GST on Income", TaxType: "OUTPUT2" }];
+    expect(revenueApplicableTaxRates(rates).map((r) => r.TaxType)).toEqual(["OUTPUT2"]);
+  });
+
+  test("empty input returns empty output", () => {
+    expect(revenueApplicableTaxRates([])).toEqual([]);
+  });
+});

--- a/src/components/settings/xero-coding-fields.tsx
+++ b/src/components/settings/xero-coding-fields.tsx
@@ -26,6 +26,22 @@ interface XeroAccountOption {
 interface XeroTaxRateOption {
   Name: string;
   TaxType: string;
+  CanApplyToRevenue?: boolean;
+}
+
+/**
+ * Every Xero tax rate this integration could ever legally send, given it
+ * only ever creates ACCREC (sales) invoices — an expenses-only rate (e.g.
+ * "GST on Expenses" / INPUT2) is always rejected by Xero on push
+ * ("The TaxType code '...' cannot be used with account code '...'"),
+ * regardless of which account it's paired with. `CanApplyToRevenue` is only
+ * absent for a cache written before this field was added (src/lib/
+ * xero-client.ts) — treat that as "unknown, don't hide it" rather than
+ * silently dropping a still-valid option until the next Settings -> Xero
+ * "Refresh". Exported so its unit test doesn't need to render the picker.
+ */
+export function revenueApplicableTaxRates<T extends { CanApplyToRevenue?: boolean }>(taxRates: T[]): T[] {
+  return taxRates.filter((t) => t.CanApplyToRevenue !== false);
 }
 
 /** Exported so Settings -> Xero's org-default pickers share this exact
@@ -52,7 +68,7 @@ export function useXeroCodingOptions() {
       label: a.Name,
       description: a.Code,
     }));
-  const taxRateOptions = taxRates
+  const taxRateOptions = revenueApplicableTaxRates(taxRates)
     .filter((t) => !!t.TaxType)
     .map((t) => ({
       value: t.TaxType,

--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -176,6 +176,25 @@ describe("fetchXeroTaxRates", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.TaxType).toBe("OUTPUT2");
   });
+
+  // Regression (live bug): a push failed with "The TaxType code 'INPUT'
+  // cannot be used with account code '200'" because the org's default tax
+  // type was set to an expenses-only rate — nothing modeled or surfaced
+  // Xero's own CanApplyToRevenue flag that would have caught this at
+  // configuration time. It must survive schema parsing so the Settings ->
+  // Xero picker can filter on it (xero-coding-fields.test.tsx).
+  it("preserves CanApplyToRevenue on both income and expense rates", async () => {
+    const fixture = {
+      TaxRates: [
+        { Name: "GST on Income", TaxType: "OUTPUT2", Status: "ACTIVE", CanApplyToRevenue: true, CanApplyToExpenses: false },
+        { Name: "GST on Expenses", TaxType: "INPUT2", Status: "ACTIVE", CanApplyToRevenue: false, CanApplyToExpenses: true },
+      ],
+    };
+    const { impl } = mockFetch(fixture);
+    const result = await fetchXeroTaxRates({ ...authOpts, fetchImpl: impl });
+    expect(result.find((r) => r.TaxType === "OUTPUT2")?.CanApplyToRevenue).toBe(true);
+    expect(result.find((r) => r.TaxType === "INPUT2")?.CanApplyToRevenue).toBe(false);
+  });
 });
 
 describe("findXeroContactByEmail", () => {

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -299,6 +299,16 @@ const taxRateSchema = z.object({
   Status: z.string().optional(),
   DisplayTaxRate: z.number().optional(),
   EffectiveRate: z.number().optional(),
+  // Xero tags every tax rate with which transaction sides it's valid for
+  // (income/revenue vs. expenses/purchases). This integration ONLY ever
+  // creates ACCREC (sales) invoices (createXeroDraftInvoice), so an
+  // expenses-only TaxType (e.g. "GST on Expenses" / INPUT2) picked for the
+  // org default or a coding override is invalid on every single push — Xero
+  // rejects it with "The TaxType code '...' cannot be used with account code
+  // '...'". Modeled here so `CanApplyToRevenue` survives the cache and the
+  // Settings -> Xero picker (xero-coding-fields.tsx) can filter it out at
+  // the source, instead of every push failing downstream.
+  CanApplyToRevenue: z.boolean().optional(),
 });
 const taxRatesResponseSchema = z.object({ TaxRates: z.array(taxRateSchema) });
 export type XeroTaxRate = z.infer<typeof taxRateSchema>;


### PR DESCRIPTION
## Summary

- A live push failed with `"The TaxType code 'INPUT' cannot be used with account code '200'."` — the org's default tax type (or a category/line override) had been set to an expenses-only GST rate. This integration exclusively creates ACCREC (sales) invoices (`Type: "ACCREC"` in `createXeroDraftInvoice`), so an expenses-only (`INPUT`-family) rate is never valid on any push regardless of which account it's paired with — Xero ties every tax rate to `CanApplyToRevenue`/`CanApplyToExpenses` flags on the rate itself.
- The Settings → Xero tax-type picker (`XeroTaxTypeField`, `xero-coding-fields.tsx` — the ONE picker instance shared by the org default and every category/model/kit/line/service override) offered every cached Xero tax rate from both the income and expense side identically, with nothing in the UI distinguishing "GST on Income" from "GST on Expenses" beyond the name. An easy, silent misconfiguration that only ever surfaced downstream, at push time.
- `taxRateSchema` (`src/lib/xero-client.ts`) now models Xero's own `CanApplyToRevenue` flag on each tax rate (previously silently dropped — this file's schemas only model fields the integration actually reads). Added `revenueApplicableTaxRates()`, applied inside `useXeroCodingOptions()`, filtering to `CanApplyToRevenue !== false` — deliberately not `=== true`, so a cache written before this field existed (every org, until their next Settings → Xero "Refresh") still offers all its rates rather than going empty.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` to document the root cause and fix.

**Note: this doesn't retroactively fix already-saved config.** It prevents picking an invalid rate going forward. Whoever owns the Xero settings still needs to go to Settings → Xero after this deploys and re-pick the correct "GST on Income" / `OUTPUT`-type rate wherever it's currently set wrong (org default and/or any category/model/line override), then retry the push.

## Testing

- Added a test confirming `CanApplyToRevenue` survives schema parsing on both an income and an expense tax rate (`src/lib/xero-client.test.ts`).
- Added `src/components/settings/xero-coding-fields.test.ts` — 3 tests on `revenueApplicableTaxRates` (drops `CanApplyToRevenue: false`, keeps a pre-fix cache's fieldless rates, empty input).
- 61/61 tests pass across every affected file: `xero-client.test.ts`, `src/server/xero.test.ts`, `xero-coding-fields.test.ts`, `convex/xeroPush.test.ts`, `convex/lib/xeroAccountCascade.test.ts`.
- `tsc --noEmit` and `eslint` clean on all changed files.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_