### PR TITLE
fix(finance): resolve model/kit name for line items with no description

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -47,6 +47,26 @@ totals `recalc.ts` already stored on the project. This is the DATA-MODEL
 snapshot, not the PDF's own line structuring (`structure-line-items.ts`,
 unchanged) — that pipeline stays presentation-only.
 
+**A line's DESCRIPTION resolves the same way the PDF pipeline already
+does.** Live bug: a pushed Xero invoice showed an equipment line simply as
+"Line item" instead of e.g. "USB Pro DI". Equipment/kit lines are usually
+added by picking a model/kit, not by typing a description — `projectLineItems.
+description` is commonly unset, and the model/kit's OWN name is the
+canonical source (`structure-line-items.ts` already resolves `model?.name ??
+description` for exactly this reason). `buildFinanceLines` used to check
+only `description`/`groupName`, so any model-linked line with no hand-typed
+description fell straight through to the literal fallback string. It now
+resolves the line's `modelId` (or, for a kit-PARENT line — `kitId` set,
+`isKitChild` false — its `kitId`) to that doc's `name` as an ADDITIONAL
+fallback, ahead of `groupName`: `description || modelOrKitName ||
+groupName || "Line item"`. A hand-typed `description` still always wins
+(unchanged) — this only fixes the case that was silently broken.
+`buildFinanceLines` now takes `orgId` (both call sites already had a
+`project`/`fields.organizationId` in scope) so the model/kit lookup —
+`by_cuid`, a GLOBAL index — is org-checked before its name is trusted
+(R-8.4.3); a cross-org id falls through to the same "Line item" default
+rather than leaking a foreign org's model name.
+
 - **FULL** invoice: the project's full `subtotal`/`taxAmount`/`total`, full
   line breakdown.
 - **DEPOSIT** invoice: % of the tax-**inclusive** total (matches the

--- a/convex/invoicesWrites.ts
+++ b/convex/invoicesWrites.ts
@@ -164,7 +164,7 @@ export const createNative = mutation({
       updatedAt: now,
     });
 
-    const lines = await buildFinanceLines(ctx, fields.projectId);
+    const lines = await buildFinanceLines(ctx, fields.projectId, fields.organizationId);
     // A DEPOSIT/BALANCE invoice doesn't carry the full equipment/service line
     // breakdown (the % is against the total, not itemised) — snapshot a
     // single summary line instead of the full FULL-invoice breakdown.

--- a/convex/lib/financeSnapshot.test.ts
+++ b/convex/lib/financeSnapshot.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+//
+// convex/lib/financeSnapshot.ts — buildFinanceLines, the shared quote/invoice
+// line-breakdown builder. Regression: a model-linked equipment/kit line with
+// no hand-typed description used to snapshot as the literal string "Line
+// item" (a pushed Xero invoice showed that instead of e.g. "USB Pro DI"),
+// because this builder never resolved the model/kit name the way the PDF
+// pipeline (structure-line-items.ts) already does.
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "../schema";
+import { buildFinanceLines } from "./financeSnapshot";
+
+const modules = import.meta.glob("../**/*.ts");
+const ORG = "org_1";
+const OTHER = "org_2";
+
+function makeT() {
+  return convexTest(schema, modules);
+}
+
+async function seedProject(t: ReturnType<typeof makeT>, orgId = ORG) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("projects", {
+      id: "p1", organizationId: orgId, projectNumber: "P1", name: "Gig",
+      isTemplate: false, createdAt: 0, updatedAt: 0,
+    });
+  });
+}
+
+describe("buildFinanceLines", () => {
+  test("resolves an EQUIPMENT line's model name when description is unset", async () => {
+    const t = makeT();
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "USB Pro DI" });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", modelId: "m1",
+        isKitChild: false, isOptional: false, status: "CONFIRMED",
+        quantity: 1, unitPrice: 50, lineTotal: 50,
+      });
+    });
+
+    const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.description).toBe("USB Pro DI");
+  });
+
+  test("resolves a kit-PARENT line's kit name when description is unset", async () => {
+    const t = makeT();
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("kits", { id: "k1", organizationId: ORG, assetTag: "KIT-1", name: "Stage Box Kit" });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", kitId: "k1",
+        isKitChild: false, isOptional: false, status: "CONFIRMED",
+        quantity: 1, unitPrice: 200, lineTotal: 200,
+      });
+    });
+
+    const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+    expect(lines[0]?.description).toBe("Stage Box Kit");
+  });
+
+  test("a hand-typed description still wins over the model name (unchanged behaviour)", async () => {
+    const t = makeT();
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m1", organizationId: ORG, name: "USB Pro DI" });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", modelId: "m1", description: "Custom label",
+        isKitChild: false, isOptional: false, status: "CONFIRMED",
+        quantity: 1, unitPrice: 50, lineTotal: 50,
+      });
+    });
+
+    const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+    expect(lines[0]?.description).toBe("Custom label");
+  });
+
+  test("falls back to the literal 'Line item' when there is truly nothing to resolve (no model/kit/description/groupName)", async () => {
+    const t = makeT();
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1",
+        isKitChild: false, isOptional: false, status: "CONFIRMED",
+        quantity: 1, unitPrice: 50, lineTotal: 50,
+      });
+    });
+
+    const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+    expect(lines[0]?.description).toBe("Line item");
+  });
+
+  // IDOR guard (R-8.4.3): models.by_cuid is a GLOBAL index, so a modelId
+  // could in principle resolve to another org's row — must never leak a
+  // foreign org's model name into this org's invoice/quote snapshot.
+  test("never resolves a cross-org model's name (IDOR guard)", async () => {
+    const t = makeT();
+    await seedProject(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("models", { id: "m1", organizationId: OTHER, name: "Foreign Org's Model" });
+      await ctx.db.insert("projectLineItems", {
+        id: "l1", organizationId: ORG, projectId: "p1", modelId: "m1",
+        isKitChild: false, isOptional: false, status: "CONFIRMED",
+        quantity: 1, unitPrice: 50, lineTotal: 50,
+      });
+    });
+
+    const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+    expect(lines[0]?.description).toBe("Line item");
+  });
+});

--- a/convex/lib/financeSnapshot.ts
+++ b/convex/lib/financeSnapshot.ts
@@ -9,6 +9,43 @@ export interface FinanceSnapshotLine {
   lineTotal: number;
 }
 
+type ProjectLine = { kitId?: string; isKitChild?: boolean; modelId?: string };
+
+/**
+ * Equipment/kit lines are usually added by picking a model/kit, not by
+ * typing a description — `structure-line-items.ts` (the PDF pipeline)
+ * already knows this and resolves `model?.name ?? description` per line.
+ * `buildFinanceLines` used to check ONLY `description`/`groupName`, so any
+ * model-linked line with no hand-typed description (the common case) fell
+ * straight through to the literal string "Line item" — that's what a
+ * pushed Xero invoice showed instead of e.g. "USB Pro DI". Batch-fetch once
+ * per unique id (deduped, org-checked — `by_cuid` is a GLOBAL index,
+ * R-8.4.3) rather than per-line, since a project reuses the same handful of
+ * models/kits across many lines. Split out purely to keep
+ * `buildFinanceLines`'s own complexity manageable (R-3.6), same rationale
+ * as `xeroPush.ts`'s per-source-type resolvers.
+ */
+async function resolveModelAndKitNames(
+  ctx: MutationCtx,
+  projectLines: ProjectLine[],
+  orgId: string,
+): Promise<{ modelNameById: Map<string, string>; kitNameById: Map<string, string> }> {
+  const modelIds = new Set<string>();
+  const kitIds = new Set<string>();
+  for (const li of projectLines) {
+    if (li.kitId && !li.isKitChild) kitIds.add(li.kitId);
+    else if (li.modelId) modelIds.add(li.modelId);
+  }
+  const [modelDocs, kitDocs] = await Promise.all([
+    Promise.all([...modelIds].map((id) => ctx.db.query("models").withIndex("by_cuid", (q) => q.eq("id", id)).first())),
+    Promise.all([...kitIds].map((id) => ctx.db.query("kits").withIndex("by_cuid", (q) => q.eq("id", id)).first())),
+  ]);
+  return {
+    modelNameById: new Map(modelDocs.filter((m) => m && m.organizationId === orgId).map((m) => [m!.id, m!.name])),
+    kitNameById: new Map(kitDocs.filter((k) => k && k.organizationId === orgId).map((k) => [k!.id, k!.name])),
+  };
+}
+
 /**
  * Build the client-facing line breakdown for a project's CURRENT pricing —
  * the single shared builder behind both `Quote.snapshot` (publish) and
@@ -26,12 +63,15 @@ export interface FinanceSnapshotLine {
 export async function buildFinanceLines(
   ctx: MutationCtx,
   projectId: string,
+  orgId: string,
 ): Promise<FinanceSnapshotLine[]> {
   const [groups, projectLines, services] = await Promise.all([
     ctx.db.query("projectGroups").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
     ctx.db.query("projectLineItems").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
     ctx.db.query("projectServices").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect(),
   ]);
+
+  const { modelNameById, kitNameById } = await resolveModelAndKitNames(ctx, projectLines, orgId);
 
   const lines: FinanceSnapshotLine[] = [];
 
@@ -65,10 +105,11 @@ export async function buildFinanceLines(
       continue;
     }
     const qty = li.quantity ?? 1;
+    const modelOrKitName = li.kitId && !li.isKitChild ? kitNameById.get(li.kitId) : li.modelId ? modelNameById.get(li.modelId) : undefined;
     lines.push({
       sourceType: "EQUIPMENT",
       sourceLineItemId: li.id,
-      description: li.description || li.groupName || "Line item",
+      description: li.description || modelOrKitName || li.groupName || "Line item",
       quantity: qty,
       unitPrice: Number(li.unitPrice) || 0,
       lineTotal: Number(li.lineTotal) || 0,

--- a/convex/quotesWrites.ts
+++ b/convex/quotesWrites.ts
@@ -166,7 +166,7 @@ async function buildQuoteSnapshot(
   project: Doc<"projects">,
   notes: string | undefined,
 ): Promise<Record<string, unknown>> {
-  const lines = await buildFinanceLines(ctx, project.id);
+  const lines = await buildFinanceLines(ctx, project.id, project.organizationId);
   return {
     lines,
     subtotal: Number(project.subtotal) || 0,


### PR DESCRIPTION
## Summary

- A pushed Xero invoice showed an equipment line as the literal "Line item" instead of e.g. "USB Pro DI". Equipment/kit lines are usually added by picking a model/kit, not by typing a description, so `projectLineItems.description` is commonly unset — the model/kit's own name is the canonical source, which `structure-line-items.ts` (the PDF pipeline) already knows (`model?.name ?? description`).
- `buildFinanceLines` (`convex/lib/financeSnapshot.ts`) — the shared quote/invoice line-breakdown builder behind both `Quote.snapshot` and `Invoice`/`InvoiceLine` (and, via `pushInvoiceToXero`, every Xero-pushed line too) — only checked `description`/`groupName`, so any model-linked line with no hand-typed description fell straight through to the fallback string.
- `buildFinanceLines` now resolves a line's `modelId` (or, for a kit-parent line, its `kitId`) to that doc's `name` as an additional fallback ahead of `groupName`: `description || modelOrKitName || groupName || "Line item"`. A hand-typed description still always wins — this only fixes the case that was silently broken.
- Takes a new `orgId` param (both call sites already had `project`/`fields.organizationId` in scope) so the model/kit lookup (`by_cuid`, a global index) is org-checked before its name is trusted — a cross-org id falls through to the same default rather than leaking a foreign org's model name.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` to document the fix.

**Note: this doesn't retroactively fix an invoice already synced to Xero.** Flow never re-pushes/edits an invoice once it's in Xero, so an already-created Xero invoice keeps showing "Line item" unless fixed manually there. This only prevents the *next* push (a new invoice, or a voided-and-reissued one) from having the same problem.

## Testing

- Added `convex/lib/financeSnapshot.test.ts` — 5 tests: model name resolves when description is unset, kit name resolves for a kit-parent line, a hand-typed description still wins (unchanged behaviour), the true-fallback case still returns "Line item", and a cross-org model never leaks its name (IDOR guard).
- 94/94 tests pass across `financeSnapshot.test.ts`, `invoicesWrites.test.ts`, `quotesWrites.test.ts` — no regressions.
- `tsc --noEmit` clean. `eslint` clean except one pre-existing complexity warning on `buildFinanceLines` (29 → 33, same kind of warning already present before this change, not a new category of issue).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_