### PR TITLE
feat(xero): let Push to Xero update an already-synced invoice

### DIFF
--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -864,6 +864,40 @@ direct visit to `/settings/xero` shows a "not configured" message instead of
 a "Connect Xero" button that would otherwise throw at click-time
 (`requireXeroAppCredentials()` in `src/server/xero.ts`).
 
+### "Push to Xero" both CREATES and UPDATES — same button, same Xero invoice
+
+An issued invoice's `xeroSyncStatus` starts `NOT_SYNCED`, moves to `SYNCED`
+on a successful push, or `ERROR` on a failed one. The button used to
+disappear the moment it went `SYNCED` — so a correction made on the Flow
+side AFTER the first push (a fixed line description, corrected account/tax
+coding from the picker fix above) had no way back into Xero short of
+editing the invoice there by hand.
+
+`upsertXeroDraftInvoice` (`src/lib/xero-client.ts`, renamed from
+`createXeroDraftInvoice`) leans on the fact that Xero's `POST /Invoices` is
+itself an upsert: include `InvoiceID` in the body to edit that exact
+invoice in place, omit it to create a new one — same endpoint, same shape,
+no separate update call. `pushInvoiceToXero` (`src/server/xero.ts`) passes
+`invoice.xeroInvoiceId` through when the invoice already has one, and
+reports which happened via `XeroPushResult`'s new `updated: boolean` — the
+button (`PushToXeroButton`, `project-finance-panel.tsx`) now renders
+whenever an invoice is `ISSUED`, regardless of sync status, showing "Push to
+Xero" / a filled button pre-sync and "Update in Xero" / an outline button
+once `xeroSyncStatus === "SYNCED"`; the toast reads "Updated in Xero" vs.
+"Pushed to Xero" from that same flag. `logXeroPushActivity`
+(`convex/xeroPush.ts`) takes the same `updated` flag so the activity feed
+reads correctly either way, not just "Pushed ... as a draft invoice" on
+every re-push.
+
+Coding re-resolves on every push, not just the first — `resolveCodingForInvoice`
+runs unconditionally, so a corrected category/model account or tax-type
+mapping flows into Xero on the next "Update in Xero" click without any
+special-casing. This only ever edits the invoice while it's still `DRAFT`
+in Xero (Flow never approves it there); if a human has since approved or
+voided it in Xero, the update itself is rejected by Xero and surfaces as a
+normal `XeroApiError` (via the validation-detail fix above), not a silent
+no-op or a duplicate invoice.
+
 ### `pushInvoiceToXero` never throws — it returns `{ ok, ... }`
 
 `src/server/xero.ts`'s `pushInvoiceToXero` is a real Next.js Server Action
@@ -879,11 +913,11 @@ live bug (2026-07): every one of those precondition checks used a plain
 which one fired.
 
 Fix: `pushInvoiceToXero`'s return type is `XeroPushResult =
-{ ok: true; xeroInvoiceId; varianceNote; autoCreatedContact } | { ok: false; error: string }`
+{ ok: true; xeroInvoiceId; varianceNote; autoCreatedContact; updated } | { ok: false; error: string }`
 and the WHOLE function body is wrapped in a top-level try/catch that returns
 `{ ok: false, error }` instead of letting anything escape — the ONLY way a
 Server Action's failure message survives Next's production redaction. The
-existing inner try/catch around the actual `createXeroDraftInvoice` call
+existing inner try/catch around the actual `upsertXeroDraftInvoice` call
 (which marks the invoice `ERROR`, logs the sync event, and writes the
 activity log entry) is unchanged; its re-thrown `Error` is now just an
 internal signal caught by the outer catch, not something that escapes the
@@ -930,7 +964,7 @@ with `"The TaxType code 'INPUT' cannot be used with account code '200'."`
 — an operator had picked an expenses-only GST rate (`INPUT`-family, Xero's
 "GST on Expenses" side) as the org's default tax type, or as a category/
 line override. This integration exclusively creates ACCREC (sales)
-invoices (`createXeroDraftInvoice`, `Type: "ACCREC"`) — an expenses-only
+invoices (`upsertXeroDraftInvoice`, `Type: "ACCREC"`) — an expenses-only
 rate is NEVER valid on any push, regardless of which account it's paired
 with, because Xero ties every tax rate to `CanApplyToRevenue`/
 `CanApplyToExpenses` flags on the rate itself. The Settings -> Xero
@@ -1050,20 +1084,23 @@ push/contact-sync/token-refresh/reference-fetch attempt, success or failure.
   rental-vs-sale + service-type branches.
 - `convex/xeroPush.test.ts` — 6 tests, cascade resolution IN CONTEXT (real
   DB reads through model/kit/category/service, not just the pure functions).
-- `src/lib/xero-client.test.ts` — 21 tests against fixture Xero responses
+- `src/lib/xero-client.test.ts` — 22 tests against fixture Xero responses
   (mocked `fetch`), including one asserting a realistic `ValidationErrors`
-  body surfaces its specific per-line message, not just the HTTP status,
-  and one pinning `CanApplyToRevenue` surviving schema parsing on both an
-  income and an expenses tax rate.
+  body surfaces its specific per-line message, not just the HTTP status;
+  one pinning `CanApplyToRevenue` surviving schema parsing on both an
+  income and an expenses tax rate; and one asserting `upsertXeroDraftInvoice`
+  includes `InvoiceID` in the request body (an UPDATE) when supplied one.
 - `src/components/settings/xero-coding-fields.test.ts` — 3 tests on
   `revenueApplicableTaxRates`, the tax-type picker's income-vs-expenses
   filter (drops `CanApplyToRevenue: false`, keeps a pre-fix cache's
   fieldless rates, empty input).
 - `src/lib/xero-oauth-state.test.ts` — 5 tamper/expiry tests.
-- `src/server/xero.test.ts` — 7 mocked-boundary tests on `pushInvoiceToXero`
-  (auto-create-contact idempotency, the Xero-API-failure path, and three
+- `src/server/xero.test.ts` — 8 mocked-boundary tests on `pushInvoiceToXero`
+  (auto-create-contact idempotency, the Xero-API-failure path, three
   precondition failures — not-ISSUED, not-connected, not-configured —
-  asserting each resolves to `{ ok: false, error }` rather than throwing).
+  asserting each resolves to `{ ok: false, error }` rather than throwing,
+  and one asserting a re-push on an already-`SYNCED` invoice threads its
+  `xeroInvoiceId` through as an UPDATE rather than a duplicate create).
 - `convex/lib/xeroGate.test.ts` — 4 tests, the linked gate + org-scoping.
 - `convex/quotesWrites.test.ts` / `convex/invoicesWrites.test.ts` — 42 tests,
   server-computed money, gapless/namespaced numbering, cross-org IDOR guards,

--- a/convex/xeroPush.ts
+++ b/convex/xeroPush.ts
@@ -238,20 +238,24 @@ export const markXeroPushFailedNative = mutation({
 });
 
 /** Best-effort activity-log write for a Xero push, callable from the server
- *  action after either a success or a caught failure. */
+ *  action after either a success or a caught failure. `updated` distinguishes
+ *  a re-push (the invoice already had a `xeroInvoiceId` — the same Xero
+ *  invoice was edited in place) from the first push (a new Xero invoice was
+ *  created), so the activity feed reads correctly either way. */
 export const logXeroPushActivity = mutation({
   args: {
     organizationId: v.string(),
     invoiceId: v.string(),
     invoiceLabel: v.string(),
     success: v.boolean(),
+    updated: v.optional(v.boolean()),
     detail: v.optional(v.string()),
     actorUserId: v.string(),
     actorUserName: v.string(),
     auditId: v.string(),
     now: v.number(),
   },
-  handler: async (ctx, { organizationId, invoiceId, invoiceLabel, success, detail, actorUserId, actorUserName, auditId, now }) => {
+  handler: async (ctx, { organizationId, invoiceId, invoiceLabel, success, updated, detail, actorUserId, actorUserName, auditId, now }) => {
     await requireService(ctx);
     await writeActivityLog(ctx, {
       id: auditId,
@@ -263,7 +267,9 @@ export const logXeroPushActivity = mutation({
       userId: actorUserId,
       userName: actorUserName,
       summary: success
-        ? `Pushed ${invoiceLabel} to Xero as a draft invoice`
+        ? updated
+          ? `Updated ${invoiceLabel} in Xero`
+          : `Pushed ${invoiceLabel} to Xero as a draft invoice`
         : `Xero push failed for ${invoiceLabel}${detail ? `: ${detail}` : ""}`,
       createdAt: now,
     });

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -331,9 +331,9 @@ function InvoiceRow({
             </Button>
           </CanDo>
         )}
-        {xeroLinked && inv.status === "ISSUED" && inv.xeroSyncStatus !== "SYNCED" && (
+        {xeroLinked && inv.status === "ISSUED" && (
           <CanDo resource="invoice" action="xero_push">
-            <PushToXeroButton invoiceId={inv.id} />
+            <PushToXeroButton invoiceId={inv.id} alreadySynced={inv.xeroSyncStatus === "SYNCED"} />
           </CanDo>
         )}
         <RowActionsMenu actions={menuActions} label={`${inv.invoiceNumber ?? inv.kind} actions`} />
@@ -409,7 +409,17 @@ function NudgeChip({ label, action, onAction }: { label: string; action: string;
   );
 }
 
-function PushToXeroButton({ invoiceId }: { invoiceId: string }) {
+/**
+ * `alreadySynced` only picks the IDLE label/toast wording — pushInvoiceToXero
+ * itself decides create-vs-update from the invoice's own `xeroInvoiceId`
+ * (whichever this button's prop reflects, since both read the same row), so
+ * they can never disagree. A synced invoice keeps showing this button
+ * (rather than disappearing once `xeroSyncStatus === "SYNCED"`, as it used
+ * to) so a Flow-side correction — a fixed line description, a corrected
+ * account/tax coding — has a way back into the SAME Xero invoice instead of
+ * requiring a manual edit there.
+ */
+function PushToXeroButton({ invoiceId, alreadySynced }: { invoiceId: string; alreadySynced: boolean }) {
   const pushMutation = useServerMutation({
     mutationFn: () => pushInvoiceToXero(invoiceId),
     onSuccess: (r) => {
@@ -417,7 +427,11 @@ function PushToXeroButton({ invoiceId }: { invoiceId: string }) {
         toast.error(r.error);
         return;
       }
-      toast.success(r.autoCreatedContact ? "Pushed to Xero (new contact created)" : "Pushed to Xero");
+      if (r.updated) {
+        toast.success("Updated in Xero");
+      } else {
+        toast.success(r.autoCreatedContact ? "Pushed to Xero (new contact created)" : "Pushed to Xero");
+      }
       if (r.varianceNote) toast.warning(r.varianceNote);
     },
     // pushInvoiceToXero never throws — it always resolves to { ok, ... } so its
@@ -426,8 +440,8 @@ function PushToXeroButton({ invoiceId }: { invoiceId: string }) {
     onError: (e) => toast.error(e.message),
   });
   return (
-    <Button type="button" size="sm" loading={pushMutation.isPending} onClick={() => pushMutation.mutate(undefined)}>
-      <UploadCloud className="h-3.5 w-3.5" /> Push to Xero
+    <Button type="button" variant={alreadySynced ? "line" : "primary"} size="sm" loading={pushMutation.isPending} onClick={() => pushMutation.mutate(undefined)}>
+      <UploadCloud className="h-3.5 w-3.5" /> {alreadySynced ? "Update in Xero" : "Push to Xero"}
     </Button>
   );
 }

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -59108,10 +59108,15 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
         "name": "success",
         "optional": false,
         "type": "boolean"
+      },
+      {
+        "name": "updated",
+        "optional": true,
+        "type": "boolean"
       }
     ],
     "privilegedArgs": [],
-    "argsSha": "5c417b55ccbecaa2",
+    "argsSha": "2c995bee0ac5331f",
     "returnsSha": "74234e98afe7498f",
     "stability": "tracks-app",
     "summary": null,

--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildXeroAuthorizeUrl,
   createXeroContact,
-  createXeroDraftInvoice,
+  upsertXeroDraftInvoice,
   exchangeXeroAuthCode,
   fetchXeroAccounts,
   fetchXeroTaxRates,
@@ -260,11 +260,11 @@ describe("createXeroContact", () => {
   });
 });
 
-describe("createXeroDraftInvoice", () => {
-  it("posts a DRAFT ACCREC invoice with Flow's invoice number and line coding", async () => {
+describe("upsertXeroDraftInvoice", () => {
+  it("CREATES a DRAFT ACCREC invoice (no InvoiceID) with Flow's invoice number and line coding", async () => {
     const fixture = { Invoices: [{ InvoiceID: "inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT", Type: "ACCREC" }] };
     const { impl, calls } = mockFetch(fixture);
-    const result = await createXeroDraftInvoice(
+    const result = await upsertXeroDraftInvoice(
       {
         contactId: "c1",
         invoiceNumber: "INV-2026-0001",
@@ -279,6 +279,7 @@ describe("createXeroDraftInvoice", () => {
     );
     expect(result.InvoiceID).toBe("inv-1");
     const body = JSON.parse(calls[0]!.init!.body as string);
+    expect(body.Invoices[0].InvoiceID).toBeUndefined();
     expect(body.Invoices[0].Type).toBe("ACCREC");
     expect(body.Invoices[0].Status).toBe("DRAFT");
     expect(body.Invoices[0].InvoiceNumber).toBe("INV-2026-0001");
@@ -286,10 +287,33 @@ describe("createXeroDraftInvoice", () => {
     expect(body.Invoices[0].LineItems[0].TaxType).toBe("OUTPUT2");
   });
 
+  // The "make Push to Xero also update" feature: a re-push threads the prior
+  // xeroInvoiceId through so Xero's own upsert semantics (InvoiceID present
+  // -> update that invoice; absent -> create a new one) edit the SAME Xero
+  // invoice in place instead of creating a duplicate.
+  it("UPDATES the same Xero invoice when xeroInvoiceId is supplied", async () => {
+    const fixture = { Invoices: [{ InvoiceID: "inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT", Type: "ACCREC" }] };
+    const { impl, calls } = mockFetch(fixture);
+    const result = await upsertXeroDraftInvoice(
+      {
+        xeroInvoiceId: "inv-1",
+        contactId: "c1",
+        invoiceNumber: "INV-2026-0001",
+        date: "2026-07-26",
+        lineItems: [{ description: "USB Pro DI", quantity: 1, unitAmount: 50, accountCode: "4200", taxType: "OUTPUT2" }],
+      },
+      { ...authOpts, fetchImpl: impl },
+    );
+    expect(result.InvoiceID).toBe("inv-1");
+    const body = JSON.parse(calls[0]!.init!.body as string);
+    expect(body.Invoices[0].InvoiceID).toBe("inv-1");
+    expect(body.Invoices[0].LineItems[0].Description).toBe("USB Pro DI");
+  });
+
   it("throws XeroApiError on a non-2xx response with the Xero error payload attached", async () => {
     const { impl } = mockFetch({ Type: "ValidationException", Message: "A validation exception occurred" }, 400);
     await expect(
-      createXeroDraftInvoice(
+      upsertXeroDraftInvoice(
         { contactId: "c1", invoiceNumber: "INV-1", date: "2026-07-26", lineItems: [] },
         { ...authOpts, fetchImpl: impl },
       ),
@@ -317,7 +341,7 @@ describe("createXeroDraftInvoice", () => {
       400,
     );
     await expect(
-      createXeroDraftInvoice(
+      upsertXeroDraftInvoice(
         {
           contactId: "c1",
           invoiceNumber: "INV-1",

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -33,7 +33,7 @@ const AUTHORIZE_BASE = "https://login.xero.com/identity/connect/authorize";
  * scope isn't available to request at all, so asking for it throws
  * `invalid_scope` at the /authorize step for every new app. `accounting.invoices`
  * is the granular replacement covering invoices/credit notes/quotes, which is
- * all this integration pushes (createXeroDraftInvoice). Pre-March-2026 apps can
+ * all this integration pushes (upsertXeroDraftInvoice). Pre-March-2026 apps can
  * still use the broad scope through September 2027, but there's no reason to —
  * the granular scope works for both old and new apps.
  */
@@ -301,7 +301,7 @@ const taxRateSchema = z.object({
   EffectiveRate: z.number().optional(),
   // Xero tags every tax rate with which transaction sides it's valid for
   // (income/revenue vs. expenses/purchases). This integration ONLY ever
-  // creates ACCREC (sales) invoices (createXeroDraftInvoice), so an
+  // creates ACCREC (sales) invoices (upsertXeroDraftInvoice), so an
   // expenses-only TaxType (e.g. "GST on Expenses" / INPUT2) picked for the
   // org default or a coding override is invalid on every single push — Xero
   // rejects it with "The TaxType code '...' cannot be used with account code
@@ -403,11 +403,22 @@ const xeroInvoiceSchema = z.object({
 const invoicesResponseSchema = z.object({ Invoices: z.array(xeroInvoiceSchema) });
 export type XeroInvoice = z.infer<typeof xeroInvoiceSchema>;
 
-/** Create a Xero DRAFT invoice (ACCREC — accounts receivable, i.e. a sales
- *  invoice) carrying Flow's own invoice number as `InvoiceNumber` and
- *  `Reference`. Xero owns the ledger from here — Flow never marks it approved. */
-export async function createXeroDraftInvoice(
+/**
+ * Create OR update a Xero DRAFT invoice (ACCREC — accounts receivable, i.e.
+ * a sales invoice) carrying Flow's own invoice number as `InvoiceNumber` and
+ * `Reference`. Xero's `/Invoices` POST endpoint is itself an upsert: include
+ * `InvoiceID` to update that exact invoice in place, omit it to create a new
+ * one — same endpoint, same body shape, no separate PUT/update call. Xero
+ * owns the ledger from here — Flow never marks it approved, and this only
+ * ever writes an invoice while it's still DRAFT there (Xero rejects the
+ * update itself once a human has approved/voided it in Xero, surfaced as a
+ * normal `XeroApiError`).
+ */
+export async function upsertXeroDraftInvoice(
   input: {
+    /** The Xero-side InvoiceID from a prior push. Present -> UPDATE that
+     *  invoice; absent -> CREATE a new one. */
+    xeroInvoiceId?: string;
     contactId: string;
     invoiceNumber: string;
     reference?: string;
@@ -420,6 +431,7 @@ export async function createXeroDraftInvoice(
   const body = {
     Invoices: [
       {
+        ...(input.xeroInvoiceId ? { InvoiceID: input.xeroInvoiceId } : {}),
         Type: "ACCREC",
         Contact: { ContactID: input.contactId },
         Date: input.date,

--- a/src/server/xero.test.ts
+++ b/src/server/xero.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/crypto/secret-vault", () => ({
 
 const findXeroContactByEmail = vi.fn();
 const createXeroContact = vi.fn();
-const createXeroDraftInvoice = vi.fn(async () => ({ InvoiceID: "xero-inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT" }));
+const upsertXeroDraftInvoice = vi.fn(async () => ({ InvoiceID: "xero-inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT" }));
 const refreshXeroAccessToken = vi.fn(async () => ({ access_token: "access-tok", refresh_token: "new-refresh-tok" }));
 
 vi.mock("@/lib/xero-client", async () => {
@@ -38,7 +38,7 @@ vi.mock("@/lib/xero-client", async () => {
     refreshXeroAccessToken: (...args: unknown[]) => refreshXeroAccessToken(...(args as [])),
     findXeroContactByEmail: (...args: unknown[]) => findXeroContactByEmail(...(args as [])),
     createXeroContact: (...args: unknown[]) => createXeroContact(...(args as [])),
-    createXeroDraftInvoice: (...args: unknown[]) => createXeroDraftInvoice(...(args as [])),
+    upsertXeroDraftInvoice: (...args: unknown[]) => upsertXeroDraftInvoice(...(args as [])),
   };
 });
 
@@ -73,7 +73,7 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
     vi.clearAllMocks();
     vi.stubEnv("XERO_CLIENT_ID", "test-client-id");
     vi.stubEnv("XERO_CLIENT_SECRET", "test-client-secret");
-    createXeroDraftInvoice.mockResolvedValue({ InvoiceID: "xero-inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT" });
+    upsertXeroDraftInvoice.mockResolvedValue({ InvoiceID: "xero-inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT" });
   });
 
   test("links to an existing Xero contact found by exact email match — does NOT create a duplicate", async () => {
@@ -119,12 +119,46 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
     if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
     expect(result.autoCreatedContact).toBe(false);
     expect(result.xeroInvoiceId).toBe("xero-inv-1");
+    expect(result.updated).toBe(false);
+  });
+
+  // The "make Push to Xero also update" feature: re-pushing an ALREADY-synced
+  // invoice (xeroInvoiceId set from a prior push) must update that same Xero
+  // invoice, not create a duplicate — Button visibility used to hide once
+  // xeroSyncStatus === "SYNCED", so a Flow-side fix (wrong description,
+  // corrected coding) had no way back into Xero short of editing it by hand.
+  test("re-pushing an already-synced invoice UPDATES the same Xero invoice, not a new one", async () => {
+    const client = { id: "c1", organizationId: "org_1", name: "Acme Events", xeroContactId: "mapped", xeroContactName: "Acme" };
+    queryMock.mockImplementation(async (fnRef: unknown) => {
+      const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+      if (name === "invoices:getById") return { ...INVOICE, xeroInvoiceId: "xero-inv-1", xeroSyncStatus: "SYNCED" };
+      if (name === "xeroIntegrations:getByOrgId") return INTEGRATION;
+      if (name === "projects:getById") return PROJECT;
+      if (name === "clients:getById") return client;
+      if (name === "invoiceLines:listForInvoice") return [{ id: "line1", description: "USB Pro DI", quantity: 1, unitPrice: 1000 }];
+      if (name === "xeroPush:resolveCodingForInvoice") return { lines: [{ lineId: "line1", accountCode: "4200", taxType: "OUTPUT2" }], varianceNote: null };
+      throw new Error(`Unmocked query: ${name}`);
+    });
+
+    const { pushInvoiceToXero } = await import("./xero");
+    const result = await pushInvoiceToXero("inv1");
+
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
+    expect(result.updated).toBe(true);
+    expect(result.xeroInvoiceId).toBe("xero-inv-1");
+    expect(upsertXeroDraftInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({ xeroInvoiceId: "xero-inv-1" }),
+      expect.anything(),
+    );
+
+    const activityCall = mutationMock.mock.calls.find((c) => getFunctionName(c[0] as Parameters<typeof getFunctionName>[0]) === "xeroPush:logXeroPushActivity");
+    expect(activityCall?.[1]).toMatchObject({ updated: true });
   });
 
   test("a Xero API failure marks the invoice ERROR and returns { ok: false }, without silently swallowing the error", async () => {
     const client = { id: "c1", organizationId: "org_1", name: "Acme Events", contactEmail: "billing@acme.test", xeroContactId: "mapped", xeroContactName: "Acme" };
     queryMock.mockImplementation(queryImplFor(client));
-    createXeroDraftInvoice.mockRejectedValue(new Error("Xero POST /Invoices returned 400"));
+    upsertXeroDraftInvoice.mockRejectedValue(new Error("Xero POST /Invoices returned 400"));
 
     const { pushInvoiceToXero } = await import("./xero");
     const result = await pushInvoiceToXero("inv1");

--- a/src/server/xero.ts
+++ b/src/server/xero.ts
@@ -35,7 +35,7 @@ import {
   findXeroContactByEmail,
   searchXeroContactsByName,
   createXeroContact,
-  createXeroDraftInvoice,
+  upsertXeroDraftInvoice,
   XeroApiError,
   type XeroInvoiceLineInput,
 } from "@/lib/xero-client";
@@ -263,15 +263,22 @@ export async function unlinkXeroContact(clientId: string) {
 // ─── Push ────────────────────────────────────────────────────────────────
 
 export type XeroPushResult =
-  | { ok: true; xeroInvoiceId: string; varianceNote: string | null; autoCreatedContact: boolean }
+  | { ok: true; xeroInvoiceId: string; varianceNote: string | null; autoCreatedContact: boolean; updated: boolean }
   | { ok: false; error: string };
 
 /**
- * Push an ISSUED invoice to Xero as a DRAFT (ACCREC) invoice. Ensures the
- * client has a mapped Xero contact first — duplicate protection: an
- * exact-email match against Xero's contacts LINKS instead of creating (spec
- * requirement). Coding is resolved server-side (convex/xeroPush.ts,
- * convex/lib/xeroAccountCascade.ts) and snapshotted onto invoiceLines.
+ * Push an ISSUED invoice to Xero as a DRAFT (ACCREC) invoice — CREATING it
+ * the first time, UPDATING the same Xero invoice in place on every
+ * subsequent push (`invoice.xeroInvoiceId` from a prior push, threaded
+ * through to `upsertXeroDraftInvoice`). Before this, `xeroSyncStatus ===
+ * "SYNCED"` hid the button entirely (`project-finance-panel.tsx`), so
+ * fixing something in Flow AFTER the first push (a wrong line description,
+ * a coding-cascade correction) had no way back into Xero short of editing
+ * it there by hand. Ensures the client has a mapped Xero contact first —
+ * duplicate protection: an exact-email match against Xero's contacts LINKS
+ * instead of creating (spec requirement). Coding is resolved server-side
+ * (convex/xeroPush.ts, convex/lib/xeroAccountCascade.ts) and snapshotted
+ * onto invoiceLines, so a re-push also refreshes coding, not just amounts.
  *
  * NEVER throws — always resolves to `{ ok, ... }`. Next.js redacts every
  * uncaught error thrown out of a Server Action in production to a generic
@@ -334,10 +341,12 @@ export async function pushInvoiceToXero(invoiceId: string): Promise<XeroPushResu
       };
     });
 
+    const isUpdate = Boolean(invoice.xeroInvoiceId);
     const invoiceLabel = `${invoice.kind} invoice ${invoice.invoiceNumber}`;
     try {
-      const created = await createXeroDraftInvoice(
+      const created = await upsertXeroDraftInvoice(
         {
+          xeroInvoiceId: invoice.xeroInvoiceId ?? undefined,
           contactId: xeroContactId,
           invoiceNumber: invoice.invoiceNumber,
           reference: project ? `Project ${project.projectNumber} — ${project.name}` : undefined,
@@ -351,13 +360,13 @@ export async function pushInvoiceToXero(invoiceId: string): Promise<XeroPushResu
       await convex.mutation(api.xeroPush.applyXeroPushResultNative, {
         invoiceId, orgId: organizationId, xeroInvoiceId: created.InvoiceID, resolvedLines: coding.lines, now: Date.now(),
       });
-      await logSyncEvent(organizationId, "PUSH_INVOICE", "SUCCESS", { xeroInvoiceId: created.InvoiceID }, invoiceId, created.InvoiceID, client.id);
+      await logSyncEvent(organizationId, "PUSH_INVOICE", "SUCCESS", { xeroInvoiceId: created.InvoiceID, updated: isUpdate }, invoiceId, created.InvoiceID, client.id);
       await convex.mutation(api.xeroPush.logXeroPushActivity, {
-        organizationId, invoiceId, invoiceLabel, success: true,
+        organizationId, invoiceId, invoiceLabel, success: true, updated: isUpdate,
         actorUserId: userId, actorUserName: userName, auditId: createId(), now: Date.now(),
       });
 
-      return serialize<XeroPushResult>({ ok: true, xeroInvoiceId: created.InvoiceID, varianceNote: coding.varianceNote, autoCreatedContact });
+      return serialize<XeroPushResult>({ ok: true, xeroInvoiceId: created.InvoiceID, varianceNote: coding.varianceNote, autoCreatedContact, updated: isUpdate });
     } catch (err) {
       const message = err instanceof XeroApiError ? err.message : err instanceof Error ? err.message : "Unknown error";
       await convex.mutation(api.xeroPush.markXeroPushFailedNative, { invoiceId, orgId: organizationId, error: message, now: Date.now() });


### PR DESCRIPTION
## Summary

- The "Push to Xero" button disappeared the moment `xeroSyncStatus` hit `SYNCED`, so a correction made in Flow after the first push (a fixed line description — #1045, a corrected account/tax coding — #1044) had no way back into the Xero invoice short of editing it there by hand.
- `xero-client.ts`'s `createXeroDraftInvoice` is renamed `upsertXeroDraftInvoice` and now includes `InvoiceID` in the request body when one is supplied — Xero's `POST /Invoices` is itself an upsert (`InvoiceID` present updates that invoice in place, absent creates a new one), so no separate update call is needed.
- `pushInvoiceToXero` passes `invoice.xeroInvoiceId` through when the invoice already has one, and `XeroPushResult` reports which happened via a new `updated: boolean`.
- `project-finance-panel.tsx`'s `PushToXeroButton` now renders for any `ISSUED` invoice regardless of sync status: "Push to Xero" (filled) pre-sync, "Update in Xero" (outline) once synced, with matching toast text. Coding re-resolves on every push, not just the first, so a corrected category/model mapping flows through on the next update too.
- `logXeroPushActivity` (`convex/xeroPush.ts`) takes the same `updated` flag so the activity feed reads correctly either way ("Updated ... in Xero" vs "Pushed ... to Xero as a draft invoice").
- Guardrail: this only ever edits the invoice while it's still `DRAFT` in Xero (Flow never approves it there). If a human has since approved or voided it in Xero, the update is rejected by Xero and surfaces as a normal `XeroApiError`, not a silent no-op or a duplicate invoice.
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` to document the new create-vs-update semantics.

## Testing

- Added a test to `src/lib/xero-client.test.ts` asserting `upsertXeroDraftInvoice` includes `InvoiceID` in the request body when supplied (update), and that it's absent when not (create).
- Added a test to `src/server/xero.test.ts` asserting a re-push on an already-`SYNCED` invoice threads `xeroInvoiceId` through to `upsertXeroDraftInvoice`, sets `result.updated: true`, and logs the activity with `updated: true`.
- 60/60 tests pass across `xero-client.test.ts` (22), `xero.test.ts` (8), `xeroPush.test.ts`, `xeroAccountCascade.test.ts` — no regressions.
- `tsc --noEmit` clean. `eslint` clean except pre-existing complexity warnings (same kind already present before this change).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8fiivRCynJGmRhxhK38Xb)_