### PR TITLE
Unify status-revert lock gate with unlock sessions; fix dead-end justification prompt

### DIFF
--- a/FEATUREDOCS/62-project-lifecycle-locks.md
+++ b/FEATUREDOCS/62-project-lifecycle-locks.md
@@ -204,6 +204,39 @@ requires a bounded `justification` arg whenever `isRevertOutOfHardLock(from, to)
 normal forward move, ungated). Re-completing captures a fresh snapshot (any
 crossing back into CONFIRMED/COMPLETED always snapshots).
 
+**Unified with unlock sessions, not a second lock system.** An **OPEN `FULL`**
+unlock session on the project satisfies this check with NO fresh justification
+required — its own stored `justification` is reused, and the audit row records
+`metadata.justificationSource: "unlock_session"` instead of `"manual"` so the
+trail still shows which one applied. This is the one outlier that used to
+demand a brand-new justification even while a FULL session sat open (fixed
+2026-07); every other HARD_LOCKED write already got this for free via
+`assertLifecycleGuard`. A `FINANCIAL`-scope session does **not** satisfy it
+(matches `assertLifecycleGuard`'s own FULL-only rule for HARD_LOCKED), and
+neither does an already-`COMMITTED`/`DISCARDED` session — reusing a *closed*
+session's justification for a later, unrelated action would be stale
+authorization, so a caller who already relocked still types one fresh reason.
+The separate CONFIRMED-without-accepted-quote gate (#986, below) is
+deliberately **not** folded into this — "did the client accept a quote" has
+no relationship to "is there an open unlock session", so it always requires
+its own explicit justification.
+
+**Client wiring:** `src/hooks/use-native-project-writes.ts`'s
+`useNativeProjectStatus().updateStatus` takes an optional third
+`justification` param. The project detail page wraps it in the same
+`useJustifiedMutation` + `<JustificationDialog>` pattern the equipment/
+services/crew tabs already use for #793 — `lockStatus.tier` is never
+`"JUSTIFY"` for these two transitions, so it always takes the hook's reactive
+path (try once, catch the server's `JUSTIFICATION_REQUIRED`, prompt, retry)
+rather than the proactive one. That reactive catch (`isJustificationRequired`
+in `use-justified-mutation.ts`) now recognizes a `UserFacingError` in addition
+to a raw `ConvexError` — every native-write hook rethrows
+`mapNativeWriteError(e)`, so the raw `ConvexError` a mutation throws never
+actually reaches a caller further up the stack; this was a latent gap that
+only didn't matter for the existing #793 call sites because they always
+already know `tier === "JUSTIFY"` before calling and never fall through to the
+reactive path in practice.
+
 ## Versions / diff UI
 
 - **`convex/projectLocksRead.ts`** — `status` (tier + open session, for the

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -272,6 +272,112 @@ describe("projectWrites.updateStatusNative — acceptance gate on CONFIRMED (#98
   });
 });
 
+// #792 — reverting a project's status OUT of HARD_LOCKED (COMPLETED/INVOICED →
+// earlier) requires the same admin/owner/PM audience as opening a full unlock
+// session, plus a bounded justification — UNLESS an OPEN FULL unlock session
+// already covers it (unified with `assertLifecycleGuard`'s own escape for every
+// other HARD_LOCKED write, rather than demanding a second, brand-new reason).
+describe("projectWrites.updateStatusNative — hard-lock revert (#792)", () => {
+  const revert = { id: "p1", orgId: ORG, status: "QUOTING" as const, actor: ACTOR, auditId: "log1", now: NOW };
+
+  async function seedUnlockSession(
+    t: ReturnType<typeof makeT>,
+    scope: "FINANCIAL" | "FULL",
+    outcome: "OPEN" | "COMMITTED" = "OPEN",
+  ) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectUnlockSessions", {
+        id: "sess1", organizationId: ORG, projectId: "p1", scope,
+        justification: "Client requested a correction after the invoice was voided.",
+        openedBy: USER, openedByName: "Alice", openedAt: NOW - 1000,
+        snapshotId: "snap1", outcome,
+        ...(outcome === "COMMITTED" ? { closedAt: NOW - 500, closedBy: USER } : {}),
+      });
+    });
+  }
+
+  test("blocks the revert with no justification and no open session", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "INVOICED");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, revert),
+    ).rejects.toThrow(/justification/i);
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("INVOICED");
+  });
+
+  test("a non-admin/non-PM member is denied regardless of justification", async () => {
+    const t = makeT();
+    await seedProject(t, "member", false, "INVOICED");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+        ...revert,
+        justification: "Client asked us to redo the whole quote from scratch.",
+      }),
+    ).rejects.toThrow(/admins.*owners.*PM/i);
+  });
+
+  test("an admin/owner with a valid typed justification succeeds — audited as manual", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "INVOICED");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, {
+      ...revert,
+      justification: "Client asked us to redo the whole quote from scratch.",
+    });
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.status).toBe("QUOTING");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.metadata).toEqual({
+        justification: "Client asked us to redo the whole quote from scratch.",
+        justificationSource: "manual",
+      });
+    });
+  });
+
+  test("an OPEN FULL unlock session satisfies the gate with no justification arg — audited as unlock_session", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "INVOICED");
+    await seedUnlockSession(t, "FULL");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, revert);
+    await t.run(async (ctx) => {
+      const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
+      expect(p?.status).toBe("QUOTING");
+      const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
+      expect(log?.metadata).toEqual({
+        justification: "Client requested a correction after the invoice was voided.",
+        justificationSource: "unlock_session",
+      });
+    });
+  });
+
+  test("an OPEN FINANCIAL (not FULL) unlock session does NOT satisfy the gate", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "INVOICED");
+    await seedUnlockSession(t, "FINANCIAL");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, revert),
+    ).rejects.toThrow(/justification/i);
+  });
+
+  test("a COMMITTED (already-closed) FULL session does NOT satisfy the gate — a fresh justification is still required", async () => {
+    const t = makeT();
+    await seedProject(t, "owner", false, "INVOICED");
+    await seedUnlockSession(t, "FULL", "COMMITTED");
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, revert),
+    ).rejects.toThrow(/justification/i);
+  });
+
+  test("COMPLETED -> INVOICED is not a revert (stays HARD_LOCKED) — ungated regardless of session/justification", async () => {
+    const t = makeT();
+    await seedProject(t, "member", false, "COMPLETED");
+    await t.withIdentity(asUser(ORG)).mutation(api.projectWrites.updateStatusNative, { ...revert, status: "INVOICED" as const });
+    const p = await t.run(async (ctx) => ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first());
+    expect(p?.status).toBe("INVOICED");
+  });
+});
+
 // #986 — `projects.revision` is the shared quote/project version counter and is
 // SERVER-OWNED: written only by createNative (seeded to 1) and
 // quotesWrites.newVersionNative, never by a client patch.

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -20,6 +20,7 @@ import { enqueueWebhookEvent } from "./lib/webhookEnqueue";
 import {
   assertLifecycleGuard,
   crossesIntoSnapshotStatus,
+  getOpenUnlockSession,
   isRevertOutOfHardLock,
   lifecycleAuditMetadata,
   LOCKED_PROJECT_FIELDS,
@@ -159,12 +160,29 @@ export const updateStatusNative = mutation({
     // FULL unlock session — audience (admin/owner/PM) + a bounded justification,
     // audited. COMPLETED → INVOICED stays HARD_LOCKED on both ends and is NOT a
     // revert (normal forward move, ungated here).
+    //
+    // Unified with the unlock-session mechanism (not a second lock system): an
+    // OPEN FULL session already satisfies the SAME "deliberately correcting a
+    // hard-locked project" intent this check exists for — `assertLifecycleGuard`
+    // grants the identical escape for every other HARD_LOCKED write, so this is
+    // the one outlier that used to demand a brand-new justification even while a
+    // FULL session sat open. A FINANCIAL session does NOT count here, matching
+    // `assertLifecycleGuard`'s own FULL-only rule for HARD_LOCKED. No session
+    // (or a FINANCIAL one) still requires the caller's own justification, same
+    // as before.
+    let revertJustification: string | undefined;
     if (from !== status && isRevertOutOfHardLock(from, status)) {
       await requireHardLockOverrideAllowed(ctx, orgId, id, actor.userId);
-      requireJustification(
-        justification,
-        "Reverting a completed project's status requires a justification (at least 10 characters).",
-      );
+      const openSession = await getOpenUnlockSession(ctx, orgId, id);
+      if (openSession?.scope === "FULL") {
+        revertJustification = openSession.justification;
+      } else {
+        requireJustification(
+          justification,
+          "Reverting a completed project's status requires a justification (at least 10 characters).",
+        );
+        revertJustification = justification?.trim();
+      }
     }
 
     // #986 (decision 3): a project may not advance to CONFIRMED until a quote
@@ -225,7 +243,16 @@ export const updateStatusNative = mutation({
       userName: actor.userName,
       summary: `Changed project ${project.projectNumber} status from ${from} to ${status}`,
       details: { changes: [{ field: "status", from, to: status }] },
-      metadata: justification?.trim() ? { justification: justification.trim() } : undefined,
+      metadata: revertJustification
+        ? {
+            justification: revertJustification,
+            // Distinguishes "typed a fresh reason" from "an already-open FULL
+            // unlock session covered it" in the audit trail (#792 unification).
+            justificationSource: justification?.trim() ? "manual" : "unlock_session",
+          }
+        : justification?.trim()
+          ? { justification: justification.trim() } // CONFIRMED-without-quote gate path, unchanged
+          : undefined,
       projectId: id,
       createdAt: now,
     });

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -83,6 +83,8 @@ import { ProjectActivityFeed } from "@/components/collaboration/activity-feed";
 import { formatCurrency, formatDate } from "@/lib/formatters";
 import { useProjectLockStatus, useUnlockSession } from "@/hooks/use-project-lock";
 import { UnlockSessionDialog } from "@/components/projects/unlock-session-dialog";
+import { useJustifiedMutation } from "@/hooks/use-justified-mutation";
+import { JustificationDialog } from "@/components/projects/justification-dialog";
 import { ProjectVersionsPanel } from "@/components/projects/project-versions-panel";
 
 const projectStatusLabels: Record<string, string> = {
@@ -188,9 +190,25 @@ export default function ProjectDetailPage({
   // so it re-renders on its own once the native mutation commits.
   const statusBrowser = useNativeProjectStatus(orgId);
   const projectWrites = useProjectWrites(orgId);
+
+  // #792: a status change can require a justification (reverting out of
+  // HARD_LOCKED, or confirming with no accepted quote) — `useJustifiedMutation`
+  // catches the server's `JUSTIFICATION_REQUIRED` and prompts via
+  // `JustificationDialog` instead of dead-ending on a toast. `lockStatus.tier` is
+  // never `"JUSTIFY"` for either gated transition here, so this always takes the
+  // reactive (try once, prompt on rejection) path — an OPEN FULL unlock session
+  // still short-circuits the server-side check entirely, so nothing prompts at
+  // all in that case (same "unlocked in one place = unlocked" behaviour every
+  // other locked write already has via `assertLifecycleGuard`).
+  const justifiedStatusChange = useJustifiedMutation(
+    (args: { status: string; justification?: string }) =>
+      statusBrowser.updateStatus(id, args.status, args.justification),
+    lockStatus,
+  );
+
   const statusMutation = useServerMutation({
     mutationFn: async (nextStatus: string) => {
-      await statusBrowser.updateStatus(id, nextStatus);
+      await justifiedStatusChange.run({ status: nextStatus });
     },
     onSuccess: () => {
       toast.success("Status updated");
@@ -910,6 +928,7 @@ export default function ProjectDetailPage({
         }}
         pending={archiveMutation.isPending}
       />
+      <JustificationDialog {...justifiedStatusChange.dialogProps} status={project.status ?? undefined} />
       {orgId && (
         <>
           <UnlockSessionDialog

--- a/src/hooks/use-justified-mutation.ts
+++ b/src/hooks/use-justified-mutation.ts
@@ -2,14 +2,17 @@
 
 import { useCallback, useRef, useState } from "react";
 import { ConvexError } from "convex/values";
+import { isUserFacingError } from "@/lib/errors/user-facing-error";
 
 /**
  * #793 shared wrapper: pre-checks the project's lock tier and prompts for a
  * justification BEFORE invoking a gated mutation, and also catches the
  * server's `JUSTIFICATION_REQUIRED` as a fallback (the project may have
- * advanced to ON_SITE+ underneath a stale client). One shared hook so every
- * equipment/group/service/crew surface prompts the same way — not a
- * per-form one-off (CLAUDE.md / #793 acceptance criteria).
+ * advanced to ON_SITE+ underneath a stale client, or — #792 — the caller's
+ * gate never sets `tier === "JUSTIFY"` at all, e.g. a HARD_LOCKED status
+ * revert, so the reactive catch is the ONLY path that ever fires). One shared
+ * hook so every equipment/group/service/crew/status surface prompts the same
+ * way — not a per-form one-off (CLAUDE.md / #793 acceptance criteria).
  *
  * Usage:
  *   const { run, dialogProps } = useJustifiedMutation(mutateFn, lockStatus);
@@ -17,7 +20,12 @@ import { ConvexError } from "convex/values";
  *   <JustificationDialog {...dialogProps} />
  */
 
+/** Most native-write hooks (`use-line-item-writes.ts`, `use-native-project-writes.ts`,
+ *  ...) catch the raw `ConvexError` and rethrow `mapNativeWriteError(e)` — a
+ *  `UserFacingError` — so the reactive fallback must recognize BOTH shapes, not
+ *  just the raw `ConvexError` a caller that skips that wrapping might throw. */
 function isJustificationRequired(e: unknown): boolean {
+  if (isUserFacingError(e)) return e.code === "JUSTIFICATION_REQUIRED";
   return (
     e instanceof ConvexError &&
     !!e.data &&

--- a/src/hooks/use-native-project-writes.ts
+++ b/src/hooks/use-native-project-writes.ts
@@ -101,14 +101,22 @@ export function useNativeProjectStatus(orgId: string | undefined) {
 
   const enabled = !!orgId && !!session?.user;
 
-  /** Change a project's status browser-direct. Resolves once the server confirms. */
-  const updateStatus = async (projectId: string, status: string): Promise<void> => {
+  /**
+   * Change a project's status browser-direct. Resolves once the server confirms.
+   * `justification` (#792) is only required by the server for two specific
+   * transitions (reverting out of HARD_LOCKED, or confirming with no accepted
+   * quote) — omit it for every other transition. `useJustifiedMutation` supplies
+   * it after prompting via `JustificationDialog` when the server rejects with
+   * `JUSTIFICATION_REQUIRED`.
+   */
+  const updateStatus = async (projectId: string, status: string, justification?: string): Promise<void> => {
     if (!orgId || !session?.user) throw new Error("Not ready");
     try {
       await mutate({
         id: projectId,
         orgId,
         status: status as StatusArg,
+        justification,
         emitSideEffects: true,
         actor: { userId: session.user.id, userName: session.user.name ?? "" },
         auditId: createId(),


### PR DESCRIPTION
## Summary

- Reverting a project's status out of `HARD_LOCKED` (e.g. `INVOICED` → `QUOTING`, as hit live when voiding an invoice) required a fresh justification via `requireJustification`, but the frontend never exposed a way to supply one — a dead end. `useNativeProjectStatus.updateStatus` now threads an optional `justification`, and the project detail page wires it through the existing `useJustifiedMutation` + `JustificationDialog` pattern (same one `equipment-tab`/`services-panel`/`crew-panel` already use for #793), so the dialog now opens instead of a dead-end toast.
- Unified that gate with the project's shared unlock-session mechanism: an **open `FULL`** unlock session now satisfies the hard-lock-revert check automatically (audited as `justificationSource: "unlock_session"`), matching every other `HARD_LOCKED` write's existing behavior via `assertLifecycleGuard`. A `FINANCIAL`-scope or already-closed session still requires a fresh justification (no stale-authorization reuse). The separate CONFIRMED-without-accepted-quote gate is deliberately left untouched — different kind of check, unrelated to unlock sessions.
- Fixed a latent bug in the shared `useJustifiedMutation` hook: its reactive `JUSTIFICATION_REQUIRED` detection only recognized a raw `ConvexError`, but every native-write hook (including the one this PR touches) rethrows `mapNativeWriteError(e)` — a `UserFacingError` — so the dialog could never actually open for any gate that isn't pre-empted by the hook's proactive `tier === "JUSTIFY"` check. This repo's existing #793 call sites never hit the bug only because they always already know the tier before calling.

Root-caused live against a real production project (`260722`) via the RVLT_Flow MCP tools — see conversation history for the investigation.

## Testing

- `pnpm exec vitest run convex/projectWrites.test.ts` — 89/89 pass, including 7 new integration tests for the hard-lock-revert gate (previously zero coverage: open-FULL-session bypass, FINANCIAL-doesn't-count, closed-session-doesn't-count, audience checks, audit metadata shape).
- `pnpm test` (full suite) — 4862/4862 tests pass. The 48 "failed" test *files* are a pre-existing sandbox gap (Prisma client never generated locally — `Cannot find module '@/generated/prisma/client'`), unrelated to this diff.
- `pnpm exec tsc --noEmit` — 97 pre-existing errors, identical count before and after this diff (confirmed via `git stash`) — zero new type errors.
- `pnpm exec eslint` on all changed files — 0 errors, only pre-existing complexity/line-count warnings.
- `pnpm run api:registry:check` — registry unaffected (no new args/guards exposed externally).
- Docs updated in `FEATUREDOCS/62-project-lifecycle-locks.md` in the same PR (POLICY.md R-5.2/R-5.8).

## Checklist

- [x] New dependency? N/A — no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KBhz4TGDNpKSKgyErmXgm)_