### PR TITLE
fix(xero): sync discounted line totals to Xero invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Discounted invoice lines now sync correctly to Xero — pushing an invoice used to
+  let Xero recompute each line's total from Quantity × UnitAmount, silently dropping
+  any per-line discount (and multi-day rental duration) already netted into Flow's
+  own total. The Xero push now sends that resolved total explicitly, so the invoice
+  in Xero always matches what the client was actually charged.
+
 - **#790** — The quote layout no longer shows a "/day" (or other rental-period)
   suffix next to prices. Audited discount/item-notes/group-notes rendering on the
   quote end-to-end and confirmed they already flow correctly through the new

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -775,6 +775,29 @@ nothing else). Every equipment line resolves via the RENTAL branch of the
 cascade today; the SALE branch is unit-tested but unreachable until #950
 wires an actual sale line type.
 
+### Line amounts push `LineAmount`, never re-derived from Quantity × UnitAmount
+
+**Live bug fixed:** a discounted line's discount never reached Xero.
+`pushInvoiceToXero` (`src/server/xero.ts`) used to send only `Quantity`/
+`UnitAmount` per line — the Xero `/Invoices` endpoint computes `LineAmount`
+itself as `Quantity × UnitAmount` when it isn't supplied, which knows nothing
+about `projectLineItems.discount`/`projectGroups.discount` already netted
+into `invoiceLines.lineTotal` (`convex/lib/lineTotal.ts` `computeLineTotal` —
+`unitPrice · quantity · duration − discount`). A discounted (or multi-day
+`duration`-rated) line therefore posted to Xero at its pre-discount gross,
+overstating the client's actual charge.
+
+`XeroInvoiceLineInput.lineAmount` (`src/lib/xero-client.ts`) is now populated
+from the invoice line's own `lineTotal` and sent as Xero's `LineAmount` — an
+explicit override Xero accepts alongside `Quantity`/`UnitAmount`, so the
+posted total always matches Flow's already-resolved figure instead of being
+re-derived. `Quantity`/`UnitAmount` are still sent for Xero's own line
+display; `lineTotal` is the one number both a Flow document and the pushed
+Xero invoice now agree on (R-3.1 — no second, divergent total-calculation
+path). No schema change: `invoiceLines.lineTotal` already carried the correct
+net figure — the fix is purely "stop letting Xero recompute a number Flow
+already resolved," matching "Money is never hand-typed" project-wide.
+
 ### Per-entity coding override UI
 
 Every level of the cascade above has a write path + form field:

--- a/src/lib/xero-client.test.ts
+++ b/src/lib/xero-client.test.ts
@@ -287,6 +287,31 @@ describe("upsertXeroDraftInvoice", () => {
     expect(body.Invoices[0].LineItems[0].TaxType).toBe("OUTPUT2");
   });
 
+  // Regression: a discount netted into Flow's lineTotal used to be dropped on
+  // push — this file only ever sent Quantity/UnitAmount, so Xero recomputed
+  // LineAmount itself (Quantity × UnitAmount) with no knowledge of the
+  // discount. `lineAmount` is the explicit override that keeps Xero's total
+  // matching Flow's already-discounted figure.
+  it("passes a supplied lineAmount through as an explicit LineAmount override", async () => {
+    const fixture = { Invoices: [{ InvoiceID: "inv-1", InvoiceNumber: "INV-2026-0001", Status: "DRAFT", Type: "ACCREC" }] };
+    const { impl, calls } = mockFetch(fixture);
+    await upsertXeroDraftInvoice(
+      {
+        contactId: "c1",
+        invoiceNumber: "INV-2026-0001",
+        date: "2026-07-26",
+        lineItems: [
+          { description: "USB Pro DI", quantity: 2, unitAmount: 100, lineAmount: 170, accountCode: "4200", taxType: "OUTPUT2" },
+        ],
+      },
+      { ...authOpts, fetchImpl: impl },
+    );
+    const body = JSON.parse(calls[0]!.init!.body as string);
+    expect(body.Invoices[0].LineItems[0].Quantity).toBe(2);
+    expect(body.Invoices[0].LineItems[0].UnitAmount).toBe(100);
+    expect(body.Invoices[0].LineItems[0].LineAmount).toBe(170);
+  });
+
   // The "make Push to Xero also update" feature: a re-push threads the prior
   // xeroInvoiceId through so Xero's own upsert semantics (InvoiceID present
   // -> update that invoice; absent -> create a new one) edit the SAME Xero

--- a/src/lib/xero-client.ts
+++ b/src/lib/xero-client.ts
@@ -390,6 +390,15 @@ export interface XeroInvoiceLineInput {
   description: string;
   quantity: number;
   unitAmount: number;
+  /**
+   * The authoritative net line amount (tax-exclusive), already discount- and
+   * duration-adjusted — Flow's own `invoiceLines.lineTotal`, not re-derived.
+   * Passed through as Xero's `LineAmount` override so Xero's own
+   * `Quantity × UnitAmount` calc (which knows nothing about Flow's discount)
+   * never silently overrides a discounted total. Optional only so
+   * lower-level tests can omit it and fall back to Xero's default calc.
+   */
+  lineAmount?: number;
   accountCode?: string | null;
   taxType?: string | null;
 }
@@ -443,6 +452,7 @@ export async function upsertXeroDraftInvoice(
           Description: li.description,
           Quantity: li.quantity,
           UnitAmount: li.unitAmount,
+          LineAmount: li.lineAmount,
           AccountCode: li.accountCode || undefined,
           TaxType: li.taxType || undefined,
         })),

--- a/src/server/xero.test.ts
+++ b/src/server/xero.test.ts
@@ -155,6 +155,39 @@ describe("pushInvoiceToXero — auto-create contact idempotency", () => {
     expect(activityCall?.[1]).toMatchObject({ updated: true });
   });
 
+  // Regression: a discounted line's Xero LineAmount used to be silently
+  // dropped — pushInvoiceToXero only sent Quantity/UnitAmount and let Xero
+  // recompute the total itself (Quantity × UnitAmount), which knows nothing
+  // about Flow's discount already netted into invoiceLines.lineTotal. Xero's
+  // invoice total then overstated the client's actual charge by the discount
+  // amount. `lineAmount` must always carry the authoritative, discount- (and
+  // duration-) adjusted `lineTotal`, not a value Xero re-derives.
+  test("a discounted line's Xero LineAmount reflects the net lineTotal, not Quantity × UnitAmount", async () => {
+    const client = { id: "c1", organizationId: "org_1", name: "Acme Events", xeroContactId: "mapped", xeroContactName: "Acme" };
+    queryMock.mockImplementation(async (fnRef: unknown) => {
+      const name = getFunctionName(fnRef as Parameters<typeof getFunctionName>[0]);
+      if (name === "invoices:getById") return INVOICE;
+      if (name === "xeroIntegrations:getByOrgId") return INTEGRATION;
+      if (name === "projects:getById") return PROJECT;
+      if (name === "clients:getById") return client;
+      // Gross would be 2 × $100 = $200; a $30 discount nets lineTotal to $170.
+      if (name === "invoiceLines:listForInvoice") return [{ id: "line1", description: "USB Pro DI", quantity: 2, unitPrice: 100, lineTotal: 170 }];
+      if (name === "xeroPush:resolveCodingForInvoice") return { lines: [{ lineId: "line1", accountCode: "4200", taxType: "OUTPUT2" }], varianceNote: null };
+      throw new Error(`Unmocked query: ${name}`);
+    });
+
+    const { pushInvoiceToXero } = await import("./xero");
+    const result = await pushInvoiceToXero("inv1");
+
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
+    expect(upsertXeroDraftInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lineItems: [expect.objectContaining({ quantity: 2, unitAmount: 100, lineAmount: 170 })],
+      }),
+      expect.anything(),
+    );
+  });
+
   test("a Xero API failure marks the invoice ERROR and returns { ok: false }, without silently swallowing the error", async () => {
     const client = { id: "c1", organizationId: "org_1", name: "Acme Events", contactEmail: "billing@acme.test", xeroContactId: "mapped", xeroContactName: "Acme" };
     queryMock.mockImplementation(queryImplFor(client));

--- a/src/server/xero.ts
+++ b/src/server/xero.ts
@@ -336,6 +336,11 @@ export async function pushInvoiceToXero(invoiceId: string): Promise<XeroPushResu
         description: l.description,
         quantity: l.quantity,
         unitAmount: l.unitPrice,
+        // Xero would otherwise recompute LineAmount as Quantity × UnitAmount,
+        // which knows nothing about Flow's per-line discount (or duration) —
+        // `lineTotal` is the already-resolved net amount, so pass it through
+        // as an explicit override rather than letting Xero re-derive it.
+        lineAmount: l.lineTotal,
         accountCode: resolved?.accountCode ?? null,
         taxType: resolved?.taxType ?? null,
       };


### PR DESCRIPTION
## Summary

Discounts applied to invoice line items in RVLT Flow weren't reaching Xero.

**Root cause:** `pushInvoiceToXero` (`src/server/xero.ts`) only sent `Quantity`/`UnitAmount` per line to Xero's `/Invoices` endpoint. Xero computes `LineAmount` itself as `Quantity × UnitAmount` when it isn't told otherwise — which has no knowledge of `projectLineItems.discount`/`projectGroups.discount`, already netted into `invoiceLines.lineTotal` (`convex/lib/lineTotal.ts`: `unitPrice · quantity · duration − discount`). A discounted (or multi-day-rental) line therefore posted to Xero at its pre-discount gross, overstating the invoice total.

**Fix:**
- Added `lineAmount` to `XeroInvoiceLineInput` (`src/lib/xero-client.ts`), mapped through as Xero's `LineAmount` field — an explicit override Xero accepts alongside `Quantity`/`UnitAmount`.
- `src/server/xero.ts` now populates it from the invoice line's own authoritative `lineTotal`, so Xero never re-derives a number Flow already resolved.
- No schema change — `invoiceLines.lineTotal` already carried the correct net figure.

## Testing

- Added regression tests in `src/lib/xero-client.test.ts` and `src/server/xero.test.ts` covering a discounted line (Quantity 2 × $100 gross, $30 discount → LineAmount 170, not 200).
- Full relevant suite green: `convex/invoicesWrites.test.ts`, `convex/xeroPush.test.ts`, `convex/lib/financeSnapshot.test.ts`, `src/lib/xero-client.test.ts`, `src/server/xero.test.ts`, `src/lib/xero-oauth-state.test.ts` — 66/66 passing.
- `tsc --noEmit` and `eslint` clean on all changed files (repo-wide `tsc` has pre-existing, unrelated failures from `@/generated/prisma/client` not being generated in this sandbox — no `DATABASE_URL` configured here — and a handful of pre-existing `implicit any` errors in unrelated files).
- Updated `FEATUREDOCS/66-finance-quotes-invoices-xero.md` and `CHANGELOG.md` per project convention.

No live Xero credentials in this environment — verified against the fixture-driven mocked Xero client (`src/lib/xero-client.test.ts`), same as the rest of this integration's test coverage.

## Checklist

- [x] New dependency? N/A — no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XD6PP5U87bXmheeT7hzVqn)_