### PR TITLE
Hide sub-hire "via Supplier" text when "Show as sub-hired" is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sub-hire items/groups toggled "Show as sub-hired" off still showed a
+  "via {supplier}" line on client-facing quote/invoice PDFs (the `SUBHIRE`
+  badge already respected the toggle; the supplier line didn't) — a client
+  could see which supplier an item was sourced from even with the toggle
+  off. Also hid the same text in the internal project view for consistency
+  (the badge/icon there stays visible to staff regardless of the toggle).
+
 - **#790** — The quote layout no longer shows a "/day" (or other rental-period)
   suffix next to prices. Audited discount/item-notes/group-notes rendering on the
   quote end-to-end and confirmed they already flow correctly through the new

--- a/FEATUREDOCS/39-sub-hires.md
+++ b/FEATUREDOCS/39-sub-hires.md
@@ -90,6 +90,12 @@ Each sub-hire item and group has exactly two display toggles:
 
 These replace the previous order-level showOnDocs toggle and per-item eye/eyeoff controls. Toggles are available in the item add/edit dialog and the group edit dialog.
 
+**Where the "sub-hired" indicator is gated, and where it isn't:** `showSubhireOnDocs` governs two independent renders that must never drift apart — the `SUBHIRE` badge and the "via {supplier}" line drawn beneath the item description:
+
+- **Client-facing PDFs (quote, invoice):** both the badge and the "via {supplier}" line are gated by `isSubhireIndicatorVisible()` (`src/lib/pdfme/plugins/gearflow-table.ts`) — visible only when `showSubhireOnDocs` is true. `document-composer.ts`'s `calculateItemHeight` mirrors the same gate (with the doc's `documentType` threaded in) for its row-height reservation, or pagination silently diverges from the real render (tail-drop — see that function's comment).
+- **Internal-only PDFs (packing-list, return-sheet, delivery-docket):** both always show, regardless of the toggle — warehouse staff always need to know an item is sub-hired.
+- **Internal project view** (`src/components/projects/equipment-rows.tsx`, staff-only, no client ever sees this page): the `Subhire` badge and the group row's `Handshake` icon always show (staff need at-a-glance visibility). The "via {supplier}" text — naming the actual supplier — is gated by `item.showSubhireOnDocs` / `group.showOnDocs`, matching the client-doc toggle even though this page is internal, so the item's supplier-visibility setting reads consistently everywhere.
+
 ## Payment Status
 
 Sub-hire orders track payment to the supplier via `paymentStatus`:

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -34,6 +34,11 @@ export interface LineItemData {
   isCustomItem?: boolean;
   isKitChild?: boolean;
   subHireId?: string | null;
+  /** Client-document sub-hire visibility toggle ("Show as sub-hired").
+   *  Gates the "via {supplier}" text on both client-facing PDFs and this
+   *  internal project view; the Subhire badge itself stays unconditional
+   *  here since staff always need to see which items are sub-hired. */
+  showSubhireOnDocs?: boolean | null;
   /** Sub-hire group this synthetic line item belongs to. Used by the
    *  flat-list filter to suppress sub-hire group parent rows now that
    *  SubHireGroupRow renders the group itself (Phase 5c). */

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -638,6 +638,12 @@ export function SubHireGroupRow({
   const supplierName = group.subHire.supplier?.name ?? "Supplier";
   const shortcuts = useRowShortcuts({ e: onEdit, m: onMove }, "equipment");
   const isMobile = useIsMobile();
+  // "Show as sub-hired" (showOnDocs) only governs client-document visibility —
+  // staff always see the Subhire badge/icon here — but the "via {supplier}"
+  // text names the actual supplier, so it's suppressed with the same toggle
+  // the client-facing docs use, even in this internal-only project view.
+  const marginLabel = margin != null ? `${formatCurrency(margin * group.quantity)} margin` : null;
+  const subhireLine = [group.showOnDocs ? `via ${supplierName}` : null, marginLabel].filter(Boolean).join(" · ") || null;
 
   // ── Mobile: sub-hire group header card (children render as sibling cards). ──
   if (isMobile) {
@@ -645,12 +651,7 @@ export function SubHireGroupRow({
       <GroupCard
         title={group.title}
         isSubHire
-        subtext={
-          <>
-            via {supplierName}
-            {margin != null && <> · {formatCurrency(margin * group.quantity)} margin</>}
-          </>
-        }
+        subtext={subhireLine}
         qty={group.quantity}
         total={charge != null ? charge * group.quantity : null}
         isExpanded={isExpanded}
@@ -720,15 +721,7 @@ export function SubHireGroupRow({
                 <Handshake className="h-3.5 w-3.5 text-muted" />
                 {group.title}
               </span>
-              <span className="text-caption text-muted">
-                via {supplierName}
-                {margin != null && (
-                  <>
-                    {" · "}
-                    {formatCurrency(margin * group.quantity)} margin
-                  </>
-                )}
-              </span>
+              {subhireLine && <span className="text-caption text-muted">{subhireLine}</span>}
             </div>
           </button>
         </div>
@@ -1246,7 +1239,7 @@ export function LineItemRow({
           />
           {badges}
         </div>
-        {desc.isSubhire && item.supplier && (
+        {desc.isSubhire && item.supplier && item.showSubhireOnDocs && (
           <p className="text-caption text-muted">via {item.supplier.name}</p>
         )}
         {item.notes && (
@@ -1526,7 +1519,7 @@ export function LineItemRow({
             />
           )}
         </div>
-        {desc.isSubhire && item.supplier && (
+        {desc.isSubhire && item.supplier && item.showSubhireOnDocs && (
           <p className={`text-caption text-muted mt-0.5 ${indent}`}>via {item.supplier.name}</p>
         )}
         {onInlineUpdate ? (

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -891,25 +891,34 @@ describe("composeDocument — termsAndConditions.forceNewPage", () => {
 
 // ─── Sub-hire "via <Supplier>" line height (tail-drop regression) ────────────
 //
-// Real bug: calculateItemHeight (the pagination estimate) had no case for
-// the "via <Supplier>" line gearflow-table.ts always draws under a sub-hire
-// item's description — every sub-hire row's real rendered height silently
-// exceeded what was reserved. On a quote with many sub-hire lines (a normal
-// shape — most of a production's gear is commonly hired in from suppliers)
-// this compounds: document-composer.ts believes more items fit on page 1
-// than actually do, the table's own render-time overflow guard then quietly
-// stops mid-page, and since no continuation page was ever scheduled for the
-// table, everything after that point — potentially entire trailing
-// categories — is silently dropped from the PDF while still counted in the
-// (independently-computed) subtotal.
-describe("calculateItemHeight — sub-hire 'via Supplier' line (tail-drop regression)", () => {
+// Real bug #1 (fixed): calculateItemHeight (the pagination estimate) had no
+// case for the "via <Supplier>" line gearflow-table.ts always draws under a
+// sub-hire item's description — every sub-hire row's real rendered height
+// silently exceeded what was reserved. On a quote with many sub-hire lines
+// (a normal shape — most of a production's gear is commonly hired in from
+// suppliers) this compounds: document-composer.ts believes more items fit
+// on page 1 than actually do, the table's own render-time overflow guard
+// then quietly stops mid-page, and since no continuation page was ever
+// scheduled for the table, everything after that point — potentially entire
+// trailing categories — is silently dropped from the PDF while still
+// counted in the (independently-computed) subtotal.
+//
+// Real bug #2 (fixed): the "via <Supplier>" line ignored the item's
+// showSubhireOnDocs toggle entirely — a sub-hire item toggled OFF still
+// showed "via <Supplier>" on client-facing quote/invoice PDFs, leaking a
+// detail the toggle exists specifically to hide from the client. It's now
+// gated by isSubhireIndicatorVisible() (gearflow-table.ts), same as the
+// SUBHIRE badge: always visible on internal docs (packing-list,
+// return-sheet, delivery-docket), gated by showSubhireOnDocs on client docs
+// (quote, invoice).
+describe("calculateItemHeight — sub-hire 'via Supplier' line (tail-drop + visibility regression)", () => {
   function quoteTableConfig() {
     const block = DOCUMENT_LAYOUTS.quote.blocks.find((b) => b.kind === "table");
     if (block?.kind !== "table") throw new Error("quote layout has no table block");
     return block.config;
   }
 
-  it("reserves extra height for a sub-hire item with a supplier name", () => {
+  it("reserves extra height for a sub-hire item with showSubhireOnDocs on, on a client doc", () => {
     const config = quoteTableConfig();
     const plain = makeLineItem({ id: "a", model: { name: "GrandMA 3 Console" } });
     const subHire = makeLineItem({
@@ -917,14 +926,43 @@ describe("calculateItemHeight — sub-hire 'via Supplier' line (tail-drop regres
       model: { name: "GrandMA 3 Console" },
       subHireId: "sh-1",
       supplierName: "Resolution X",
+      showSubhireOnDocs: true,
     });
-    expect(calculateItemHeight(subHire, config)).toBeGreaterThan(calculateItemHeight(plain, config));
+    expect(calculateItemHeight(subHire, config, "quote")).toBeGreaterThan(calculateItemHeight(plain, config, "quote"));
+  });
+
+  it("reserves NO extra height for a sub-hire item with showSubhireOnDocs off, on a client doc", () => {
+    const config = quoteTableConfig();
+    const plain = makeLineItem({ id: "a", model: { name: "GrandMA 3 Console" } });
+    const subHireHidden = makeLineItem({
+      id: "b",
+      model: { name: "GrandMA 3 Console" },
+      subHireId: "sh-1",
+      supplierName: "Resolution X",
+      showSubhireOnDocs: false,
+    });
+    expect(calculateItemHeight(subHireHidden, config, "quote")).toBe(calculateItemHeight(plain, config, "quote"));
+  });
+
+  it("reserves extra height for a sub-hire item on an internal doc regardless of showSubhireOnDocs", () => {
+    const config = quoteTableConfig();
+    const plain = makeLineItem({ id: "a", model: { name: "GrandMA 3 Console" } });
+    const subHire = makeLineItem({
+      id: "b",
+      model: { name: "GrandMA 3 Console" },
+      subHireId: "sh-1",
+      supplierName: "Resolution X",
+      showSubhireOnDocs: false,
+    });
+    expect(calculateItemHeight(subHire, config, "packing-list")).toBeGreaterThan(
+      calculateItemHeight(plain, config, "packing-list"),
+    );
   });
 
   it("full pipeline: a quote with many sub-hire lines across several categories paginates with no tail-drop", () => {
     // Mirrors the real reported shape: several categories, most rows are
-    // sub-hire ("via <Supplier>"), long enough to force the table across
-    // multiple pages.
+    // sub-hire ("via <Supplier>", visible on this client doc via
+    // showSubhireOnDocs), long enough to force the table across multiple pages.
     const suppliers = ["Resolution X", "Madzin Productions"];
     const categoryNames = ["Power Distribution", "Site", "Audio", "Lighting", "Staging"];
     const items: DocumentLineItem[] = [];
@@ -942,6 +980,7 @@ describe("calculateItemHeight — sub-hire 'via Supplier' line (tail-drop regres
             lineTotal: 100 + i,
             subHireId: n % 2 === 0 ? `sh-${i}` : null,
             supplierName: n % 2 === 0 ? suppliers[i % suppliers.length] : null,
+            showSubhireOnDocs: n % 2 === 0,
           }),
         );
         i++;

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -42,6 +42,7 @@ import {
 } from "./template-constants";
 import { parsePriceBreakdown, formatPriceBreakdown } from "@/lib/billing-derivation";
 import { wrapRichText, richTextLineHeight, type RichLine, type RichTextFonts } from "./plugins/helpers";
+import { isSubhireIndicatorVisible } from "./plugins/gearflow-table";
 
 // ─── Height constants (pt) — must match gearflow-table.ts's actual draw sizes ─
 const PT_PER_MM = 2.835;
@@ -211,20 +212,20 @@ function calculateRemainingItemHeight(item: DocumentLineItem, config: TableLayou
 }
 
 /** Rendered height (mm) of one parent item incl. all sub-rows (per-unit, kit/group/accessory children, grandchildren). */
-export function calculateItemHeight(item: DocumentLineItem, config: TableLayoutConfig): number {
+export function calculateItemHeight(item: DocumentLineItem, config: TableLayoutConfig, documentType?: string): number {
   let heightPt = PARENT_ROW_PT;
 
   // Sub-hire "via <Supplier>" line — must match gearflow-table.ts's own
-  // unconditional `item.subHireId != null && item.supplierName` check
-  // exactly (fontSize(9) + 1 = 10pt there), or every sub-hire row's real
-  // rendered height silently exceeds what was reserved for it. On a doc
-  // with many sub-hire lines this compounds fast: document-composer.ts
-  // ends up believing more items fit on a page than actually do, the
-  // table's own render-time overflow guard then quietly stops mid-page
-  // with no continuation page ever scheduled — a silent tail-drop that
-  // can lose entire trailing categories, not just one row (the exact class
-  // of bug the #790 redesign's "no tail-drop" guarantee exists to prevent).
-  if (item.subHireId != null && item.supplierName) {
+  // isSubhireIndicatorVisible() gate exactly (fontSize(9) + 1 = 10pt there),
+  // or every sub-hire row's real rendered height silently diverges from what
+  // was reserved for it. On a doc with many sub-hire lines this compounds
+  // fast: document-composer.ts ends up believing a different number of items
+  // fit on a page than actually do, the table's own render-time overflow
+  // guard then quietly stops mid-page with no continuation page ever
+  // scheduled — a silent tail-drop that can lose entire trailing categories,
+  // not just one row (the exact class of bug the #790 redesign's
+  // "no tail-drop" guarantee exists to prevent).
+  if (item.supplierName && isSubhireIndicatorVisible(item, documentType)) {
     heightPt += 9 + 1;
   }
 
@@ -310,7 +311,7 @@ function calculateTableItemHeights(
 
   for (const groupKey of groupOrder) {
     if (groupKey !== ungrouped && config.showGroupHeaders) heights.push(ptToMm(GROUP_HEADER_PT));
-    for (const item of groups.get(groupKey)!) heights.push(calculateItemHeight(item, config));
+    for (const item of groups.get(groupKey)!) heights.push(calculateItemHeight(item, config, docType));
   }
 
   return heights;

--- a/src/lib/pdfme/plugins/gearflow-table.ts
+++ b/src/lib/pdfme/plugins/gearflow-table.ts
@@ -52,6 +52,17 @@ function breakdownLabel(item: DocumentLineItem, config: TablePluginConfig): stri
   return parsed ? formatPriceBreakdown(parsed) : "";
 }
 
+/** Internal docs (packing-list, return-sheet, delivery-docket) always show the
+ *  sub-hire indicator (badge + "via Supplier" line); client-facing docs (quote,
+ *  invoice) only show it when the item's showSubhireOnDocs toggle is on. Shared
+ *  by the badge, the "via Supplier" line, and its row-height reservation so
+ *  none of them can drift out of sync with each other. */
+export function isSubhireIndicatorVisible(item: DocumentLineItem, documentType?: string): boolean {
+  if (item.subHireId == null) return false;
+  const isInternalDoc = documentType === "packing-list" || documentType === "return-sheet" || documentType === "delivery-docket";
+  return isInternalDoc || !!item.showSubhireOnDocs;
+}
+
 interface TableSchema extends Schema {
   type: "gearflowTable";
 }
@@ -426,7 +437,7 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
         // Calculate row content height
         const noteLineHeight = noteFontSize + 2;
         let rowContentHeight = fontSize + rowPadding * 2;
-        if (item.subHireId != null && item.supplierName) {
+        if (item.supplierName && isSubhireIndicatorVisible(item, config.documentType)) {
           rowContentHeight += fontSize + 1; // "via Supplier" line
         }
         if (breakdownLabel(item, config)) {
@@ -519,9 +530,11 @@ async function pdfRender(arg: PDFRenderProps<TableSchema>) {
               }
             }
 
-            // "via Supplier" for sub-hire items on internal docs
+            // "via Supplier" for sub-hire items — internal docs always, client
+            // docs only when showSubhireOnDocs is on (must match isSubhireIndicatorVisible
+            // used for the badge and the row-height reservation above).
             let supplierLineOffset = 0;
-            if (item.subHireId != null && item.supplierName) {
+            if (item.supplierName && isSubhireIndicatorVisible(item, config.documentType)) {
               const viaText = `via ${item.supplierName}`;
               supplierLineOffset = fontSize + 1;
               page.drawText(viaText, {
@@ -1285,10 +1298,7 @@ function getBadges(item: DocumentLineItem, documentType?: string): typeof BADGE_
     }
   }
 
-  // Internal docs (packing-list, return-sheet, delivery-docket) always show subhire badge
-  // Client-facing docs (quote, invoice) only show when showSubhireOnDocs is true
-  const isInternalDoc = documentType === "packing-list" || documentType === "return-sheet" || documentType === "delivery-docket";
-  if (item.subHireId != null && (isInternalDoc || item.showSubhireOnDocs)) {
+  if (isSubhireIndicatorVisible(item, documentType)) {
     badges.push(BADGE_STYLES.subhire);
   }
 


### PR DESCRIPTION
## Summary

- The `SUBHIRE` badge on client-facing quote/invoice PDFs already respected the item's "Show as sub-hired" toggle (`showSubhireOnDocs`), but the "via {supplier}" line drawn beneath the item description did not — it always rendered, leaking the supplier name to the client even with the toggle off.
- Extracted the badge's existing internal-doc/`showSubhireOnDocs` gate into a shared `isSubhireIndicatorVisible()` helper (`src/lib/pdfme/plugins/gearflow-table.ts`) and applied it to the via-supplier line's draw call and row-height reservation, and to `document-composer.ts`'s `calculateItemHeight` pagination estimate (threading `documentType` through so the reservation can't silently diverge from the render and drop trailing rows).
- Applied the same fix to the internal (staff-only) project view (`equipment-rows.tsx`): the `Subhire` badge/`Handshake` icon stay visible to staff regardless of the toggle, but the "via {supplier}" text is now gated by the same `showSubhireOnDocs`/`showOnDocs` field, so the setting reads consistently everywhere.
- Updated `FEATUREDOCS/39-sub-hires.md` and `CHANGELOG.md` to document the gating behavior across all surfaces (client PDFs, internal PDFs, internal project view).

## Testing

- `pnpm test` — full suite, 5411 tests passed (added/updated cases in `document-composer.test.ts` covering: toggle on/off on a client doc, and internal docs always showing regardless of toggle).
- `pnpm exec tsc --noEmit` — no type errors.
- `pnpm lint` — 0 errors (only pre-existing warnings elsewhere in the repo).

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLdzaZT1dv415uk2q5gJoC)_