### PR TITLE
Show services/logistics on quotes, invoices & Xero when charged

### DIFF
--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -688,23 +688,32 @@ Structured operational tasks attached to a project (deliveries, pickups, bump in
 - `ServiceCard`'s financial line (`services-panel.tsx`) shows charge (`lineTotal`,
   everyone) and, for manager+ only, cost (`costTotal`) + margin (charge - cost,
   with %) — negative margin renders `text-t-out`, UNCLAMPED (a loss-making service
-  is meant to be visible, not hidden). A `showOnDocuments: false` auto-priced
-  service shows an "Internal (not billed)" tag instead of forcing the flag on.
-- **`showOnDocuments` is a manual toggle on the create/edit `ServiceDialog`**
-  ("Show on quotes, invoices & Xero", in the "Charge to client" pricing section) —
-  fixed bug: the dialog only ever seeded this from a matching org-level
-  `serviceTemplates` default (`Generate services`), so a hand-added or hand-edited
-  service (the common case — a PM typing a custom delivery/labour line) had no way
-  to make it billable on documents at all. Not gated by `LockedField`/the financial
-  lock — `updateServiceNative`'s `moneyChanged` check only looks at
-  `unitPrice`/`discount`/`costTotal`, so this flag is a structural change server-side
-  too. This is the ONE flag `buildFinanceLines` (FEATUREDOCS/66), the PDF pipeline's
-  `billableServices` filter (`build-document-data.ts`), and `recalcProjectTotals`'s
-  `serviceRevenue` all gate on — flipping it is what makes a service (labour,
-  delivery, bump in/out, misc) actually show up on a sent quote, an issued invoice,
-  and the pushed Xero invoice's line items (`convex/xeroPush.ts` resolves its
-  account/tax coding via `serviceAccountDefaults`), not just the project's internal
-  P&L.
+  is meant to be visible, not hidden).
+- **A service is billable — shows on quotes/invoices/Xero — iff it has an actual
+  charge, DERIVED from `lineTotal`, never a manually-set flag.** `lineTotal` is
+  null/0 until a `unitPrice` is typed or a crew charge rate auto-prices it
+  (`calculateServiceLineTotal` / `recalcServiceChargeFromCrew`), so "has a charge"
+  and "will bill" are the same condition by construction — nothing to keep in
+  sync (R-3.1). This replaced an earlier `showOnDocuments` boolean (had two
+  failure modes: it defaulted `false` with no UI control at all on a hand-added/
+  hand-edited service, the common case — a PM typing a custom delivery/labour
+  line had no way to ever bill it; and even once a manual toggle was added, it
+  was a second flag that could disagree with whether the service was actually
+  priced). `showOnDocuments` stays in the schema (raw stored field, still readable
+  via the API/MCP mapper `project-service-read.ts` and the `serviceTemplates`
+  "Show on documents by default" seed for `Generate services`) but no longer
+  gates anything — the four call sites below all read `lineTotal` directly:
+  `buildFinanceLines` (FEATUREDOCS/66, quote/invoice snapshot), the PDF pipeline's
+  `billableServices` filter (`build-document-data.ts`), `recalcProjectTotals`'s
+  `serviceRevenue` (`convex/lib/recalc.ts`), and `convex/projectCosts.ts` /
+  `sumProjectServiceRevenue` (`project-services-read.ts`, the Prisma-mirror P&L
+  read). `ServiceCard`'s "On quote" / "Internal (not billed)" badge and the
+  Equipment tab's "Services on documents" section (`equipment-tab.tsx`) are the
+  same derived condition, so what a PM sees in the app always matches what ends
+  up on the document. The create/edit `ServiceDialog`'s pricing section shows a
+  live, non-editable hint ("Has a charge — will show on quotes, invoices & Xero" /
+  "No charge set — stays internal…") instead of a toggle — a UX-only preview of
+  the same server-side rule, mirroring the crew-charge preview it sits next to.
 - The services financial summary panel's third tile used to duplicate the second
   ("Total" and "Internal" both read the same `costTotal`-derived value) — it's now
   "Margin" (`onDocumentsTotal - internalTotal`), gated manager+ along with the

--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -690,6 +690,21 @@ Structured operational tasks attached to a project (deliveries, pickups, bump in
   with %) — negative margin renders `text-t-out`, UNCLAMPED (a loss-making service
   is meant to be visible, not hidden). A `showOnDocuments: false` auto-priced
   service shows an "Internal (not billed)" tag instead of forcing the flag on.
+- **`showOnDocuments` is a manual toggle on the create/edit `ServiceDialog`**
+  ("Show on quotes, invoices & Xero", in the "Charge to client" pricing section) —
+  fixed bug: the dialog only ever seeded this from a matching org-level
+  `serviceTemplates` default (`Generate services`), so a hand-added or hand-edited
+  service (the common case — a PM typing a custom delivery/labour line) had no way
+  to make it billable on documents at all. Not gated by `LockedField`/the financial
+  lock — `updateServiceNative`'s `moneyChanged` check only looks at
+  `unitPrice`/`discount`/`costTotal`, so this flag is a structural change server-side
+  too. This is the ONE flag `buildFinanceLines` (FEATUREDOCS/66), the PDF pipeline's
+  `billableServices` filter (`build-document-data.ts`), and `recalcProjectTotals`'s
+  `serviceRevenue` all gate on — flipping it is what makes a service (labour,
+  delivery, bump in/out, misc) actually show up on a sent quote, an issued invoice,
+  and the pushed Xero invoice's line items (`convex/xeroPush.ts` resolves its
+  account/tax coding via `serviceAccountDefaults`), not just the project's internal
+  P&L.
 - The services financial summary panel's third tile used to duplicate the second
   ("Total" and "Internal" both read the same `costTotal`-derived value) — it's now
   "Margin" (`onDocumentsTotal - internalTotal`), gated manager+ along with the

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -589,8 +589,10 @@ across every page via `runTablePlugin`).
   exists on the Convex `projectServices` schema but has **no UI to set it anywhere
   in the app** (confirmed by grep — the one place it's read,
   `project-service-read.ts`, defaults it to `false` when absent). Gating the
-  existing quote services injection (`build-document-data.ts`'s `showOnDocuments`
-  filter, already live) by `billableToClient` today would silently hide every
+  existing quote services injection (`build-document-data.ts`'s billable-services
+  filter — since superseded to gate on `lineTotal > 0` rather than the old
+  `showOnDocuments` flag, see FEATUREDOCS/10 "Margin Display") by `billableToClient`
+  today would silently hide every
   existing org's services from every quote, since no org has ever been able to set
   the field `true`. Shipping the gate without the UI control would recreate exactly
   the "feature nobody can reach" anti-pattern this redesign removed. Needs a

--- a/convex/lib/financeSnapshot.test.ts
+++ b/convex/lib/financeSnapshot.test.ts
@@ -111,4 +111,54 @@ describe("buildFinanceLines", () => {
     const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
     expect(lines[0]?.description).toBe("Line item");
   });
+
+  // A service bills iff it has an actual charge — DERIVED from lineTotal, no
+  // separate manual flag to keep in sync (R-3.1). Mirrors recalcProjectTotals's
+  // serviceRevenue and the PDF pipeline's billableServices filter.
+  describe("SERVICE lines", () => {
+    test("includes a service with a charge set", async () => {
+      const t = makeT();
+      await seedProject(t);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("projectServices", {
+          id: "s1", organizationId: ORG, projectId: "p1", type: "DELIVERY",
+          title: "Truck delivery", status: "CONFIRMED", quantity: 1,
+          unitPrice: 150, lineTotal: 150,
+        });
+      });
+
+      const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ sourceType: "SERVICE", description: "Truck delivery", lineTotal: 150 });
+    });
+
+    test("excludes a service with no charge set (lineTotal null)", async () => {
+      const t = makeT();
+      await seedProject(t);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("projectServices", {
+          id: "s1", organizationId: ORG, projectId: "p1", type: "BUMP_IN",
+          title: "Bump in", status: "CONFIRMED", quantity: 1,
+        });
+      });
+
+      const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+      expect(lines).toHaveLength(0);
+    });
+
+    test("excludes a CANCELLED service even if it has a charge set", async () => {
+      const t = makeT();
+      await seedProject(t);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("projectServices", {
+          id: "s1", organizationId: ORG, projectId: "p1", type: "LABOUR",
+          title: "Show day", status: "CANCELLED", quantity: 1,
+          unitPrice: 500, lineTotal: 500,
+        });
+      });
+
+      const lines = await t.run((ctx) => buildFinanceLines(ctx, "p1", ORG));
+      expect(lines).toHaveLength(0);
+    });
+  });
 });

--- a/convex/lib/financeSnapshot.ts
+++ b/convex/lib/financeSnapshot.ts
@@ -117,14 +117,22 @@ export async function buildFinanceLines(
   }
 
   for (const s of services) {
-    if (s.status === "CANCELLED" || s.showOnDocuments !== true) continue;
+    if (s.status === "CANCELLED") continue;
+    // A service only appears on a quote/invoice/Xero push once it has an actual
+    // charge — `lineTotal` is null/0 until a unitPrice is typed or a crew charge
+    // rate auto-prices it (calculateServiceLineTotal / recalcServiceChargeFromCrew).
+    // Mirrors recalcProjectTotals's serviceRevenue (convex/lib/recalc.ts), which
+    // sums the SAME lineTotal unconditionally — a $0/unset service already
+    // contributes nothing there, so this is the same rule, not a second one.
+    const lineTotal = Number(s.lineTotal) || 0;
+    if (lineTotal <= 0) continue;
     lines.push({
       sourceType: "SERVICE",
       sourceLineItemId: s.id,
       description: s.title || s.type,
       quantity: s.quantity ?? 1,
       unitPrice: Number(s.unitPrice) || 0,
-      lineTotal: Number(s.lineTotal) || 0,
+      lineTotal,
     });
   }
 

--- a/convex/lib/recalc.ts
+++ b/convex/lib/recalc.ts
@@ -207,9 +207,11 @@ export async function recalcProjectTotals(
     (s) => s.organizationId === orgId && s.status !== "CANCELLED",
   );
   const serviceCostTotal = round(services.reduce((sum, s) => sum + num(s.costTotal), 0));
-  const serviceRevenue = round(
-    services.filter((s) => s.showOnDocuments === true).reduce((sum, s) => sum + num(s.lineTotal), 0),
-  );
+  // Billable iff it has an actual charge — `lineTotal` is null/0 until a unitPrice
+  // is typed or a crew charge rate auto-prices it, so a plain unconditional sum
+  // already excludes an unpriced service (num() reads it as 0). No separate
+  // "show on documents" gate (superseded — a priced service always bills).
+  const serviceRevenue = round(services.reduce((sum, s) => sum + num(s.lineTotal), 0));
 
   // 4. Labour costs from crew assignments NOT already linked to a service — a
   // service-linked assignment's cost is rolled into its service's costTotal instead

--- a/convex/projectCosts.test.ts
+++ b/convex/projectCosts.test.ts
@@ -33,11 +33,13 @@ describe("projectCosts.operationalCosts", () => {
         total: 1000, equipmentRevenue: 800, serviceCostTotal: 100, labourCostTotal: 50, subHireCostTotal: 25,
         createdAt: NOW, updatedAt: NOW,
       });
-      // counted service (non-cancelled, shown on docs)
-      await ctx.db.insert("projectServices", { id: "s1", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CONFIRMED", showOnDocuments: true, lineTotal: 200, createdAt: NOW, updatedAt: NOW });
-      // excluded: cancelled + not-on-docs
-      await ctx.db.insert("projectServices", { id: "s2", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CANCELLED", showOnDocuments: true, lineTotal: 999, createdAt: NOW, updatedAt: NOW });
-      await ctx.db.insert("projectServices", { id: "s3", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CONFIRMED", showOnDocuments: false, lineTotal: 999, createdAt: NOW, updatedAt: NOW });
+      // counted service (non-cancelled, has a charge set)
+      await ctx.db.insert("projectServices", { id: "s1", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CONFIRMED", lineTotal: 200, createdAt: NOW, updatedAt: NOW });
+      // excluded: cancelled (even though charged)
+      await ctx.db.insert("projectServices", { id: "s2", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CANCELLED", lineTotal: 999, createdAt: NOW, updatedAt: NOW });
+      // excluded: no charge set (lineTotal unset) — billable is derived from the
+      // charge, not a separate showOnDocuments flag
+      await ctx.db.insert("projectServices", { id: "s3", organizationId: ORG, projectId: "p1", type: "LABOUR", title: "Svc", status: "CONFIRMED", createdAt: NOW, updatedAt: NOW });
       // maintenance: one counted, one cancelled
       await ctx.db.insert("maintenanceRecords", { id: "mr1", organizationId: ORG, projectId: "p1", type: "REPAIR", status: "SCHEDULED", title: "Fix", reportedById: USER, cost: 40, createdAt: NOW, updatedAt: NOW });
       await ctx.db.insert("maintenanceRecords", { id: "mr2", organizationId: ORG, projectId: "p1", type: "REPAIR", status: "CANCELLED", title: "X", reportedById: USER, cost: 999, createdAt: NOW, updatedAt: NOW });

--- a/convex/projectCosts.ts
+++ b/convex/projectCosts.ts
@@ -68,7 +68,7 @@ export const operationalCosts = query({
       .first();
     if (!project || project.organizationId !== orgId) return EMPTY;
 
-    // Service revenue: mirrors sumProjectServiceRevenue (non-cancelled, shown on docs).
+    // Service revenue: mirrors sumProjectServiceRevenue (non-cancelled, has a charge set).
     const services = await ctx.db
       .query("projectServices")
       .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
@@ -78,9 +78,9 @@ export const operationalCosts = query({
     for (const s of services) {
       if (s.organizationId !== orgId) continue; // defence-in-depth (by_projectId is not org-scoped)
       if (s.status === "CANCELLED") continue;
-      if (s.showOnDocuments !== true) continue;
-      serviceRevenue += s.lineTotal ?? 0;
-      if (s.type === "LABOUR") labourServiceRevenue += s.lineTotal ?? 0;
+      if (!s.lineTotal || s.lineTotal <= 0) continue; // billable iff it has an actual charge
+      serviceRevenue += s.lineTotal;
+      if (s.type === "LABOUR") labourServiceRevenue += s.lineTotal;
     }
 
     // Maintenance cost: mirrors aggregateMaintenanceForProject (non-cancelled).

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -1808,8 +1808,11 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
 
       {/* ─── Billable Services on Documents ─────────────────────────────────── */}
       {(() => {
+        // A service is billable once it has an actual charge — mirrors
+        // buildFinanceLines/build-document-data.ts/recalcProjectTotals (R-3.1),
+        // not a separate "show on documents" flag.
         const billable = (servicesData ?? []).filter(
-          (s: { showOnDocuments: boolean; status: string }) => s.showOnDocuments && s.status !== "CANCELLED"
+          (s: { lineTotal: number | null; status: string }) => s.status !== "CANCELLED" && Number(s.lineTotal) > 0
         );
         if (billable.length === 0) return null;
         return (

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -2137,6 +2137,18 @@ function ServiceDialog({
                   </LockedField>
                 </div>
               </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="svc-showOnDocs"
+                  checked={!!form.watch("showOnDocuments")}
+                  onCheckedChange={(checked) =>
+                    form.setValue("showOnDocuments", !!checked)
+                  }
+                />
+                <Label htmlFor="svc-showOnDocs" className="text-sm font-normal cursor-pointer">
+                  Show on quotes, invoices &amp; Xero
+                </Label>
+              </div>
               {watchCrew.length > 0 && (
                 <div className="space-y-1.5">
                   <Label>Charge rate override ($){rateOverrideUnitSuffix}</Label>

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -925,10 +925,12 @@ function ServiceCard({
                   );
                 })()
               )}
-              {service.showOnDocuments ? (
+              {/* Billable iff it has an actual charge — mirrors buildFinanceLines/
+                  recalcProjectTotals (R-3.1), not a separate manual flag. */}
+              {Number(service.lineTotal) > 0 ? (
                 <span className="text-muted text-caption">· On quote</span>
               ) : (
-                service.crewChargeTotal != null && (
+                service.costTotal != null && Number(service.costTotal) > 0 && (
                   <span className="text-muted text-caption">· Internal (not billed)</span>
                 )
               )}
@@ -2137,18 +2139,25 @@ function ServiceDialog({
                   </LockedField>
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="svc-showOnDocs"
-                  checked={!!form.watch("showOnDocuments")}
-                  onCheckedChange={(checked) =>
-                    form.setValue("showOnDocuments", !!checked)
-                  }
-                />
-                <Label htmlFor="svc-showOnDocs" className="text-sm font-normal cursor-pointer">
-                  Show on quotes, invoices &amp; Xero
-                </Label>
-              </div>
+              {/* Derived, not a toggle — a service shows on the client's quote/
+                  invoice (and the pushed Xero invoice) automatically once it has
+                  a charge, same rule the server applies at build time (R-3.1: no
+                  second flag to keep in sync with the rate typed above). Mirrors
+                  calculateServiceLineTotal: manual rate wins, else the crew
+                  auto-price, minus discount, clamped at 0 — UX preview only. */}
+              {(() => {
+                const watchUnitPrice = Number(form.watch("unitPrice")) || 0;
+                const watchDiscount = Number(form.watch("discount")) || 0;
+                const base = watchUnitPrice > 0 ? watchUnitPrice : crewChargeTotalPreview;
+                const previewCharge = Math.max(0, base - watchDiscount);
+                return (
+                  <p className="text-[11px] text-faint">
+                    {previewCharge > 0
+                      ? "Has a charge — will show on quotes, invoices & Xero."
+                      : "No charge set — stays internal, won't show on quotes, invoices or Xero."}
+                  </p>
+                );
+              })()}
               {watchCrew.length > 0 && (
                 <div className="space-y-1.5">
                   <Label>Charge rate override ($){rateOverrideUnitSuffix}</Label>

--- a/src/lib/dashboard-notifications-read.test.ts
+++ b/src/lib/dashboard-notifications-read.test.ts
@@ -143,17 +143,16 @@ describe("countActiveCrew", () => {
 });
 
 describe("sumProjectServiceRevenue", () => {
-  it("sums lineTotal for non-CANCELLED, showOnDocuments services of the project", () => {
+  it("sums lineTotal for non-CANCELLED services of the project — billable is derived from the charge, not a showOnDocuments flag", () => {
     const rows = [
-      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: true, lineTotal: 100 }),
-      svc({ projectId: "p1", status: "PLANNED", showOnDocuments: true, lineTotal: 50 }),
-      svc({ projectId: "p1", status: "CANCELLED", showOnDocuments: true, lineTotal: 999 }), // excluded
-      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: false, lineTotal: 999 }), // excluded
-      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: undefined, lineTotal: 999 }), // absent → excluded
-      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: true, lineTotal: undefined }), // null total → 0
-      svc({ projectId: "p2", status: "CONFIRMED", showOnDocuments: true, lineTotal: 7 }), // other project
+      svc({ projectId: "p1", status: "CONFIRMED", lineTotal: 100 }),
+      svc({ projectId: "p1", status: "PLANNED", lineTotal: 50 }),
+      svc({ projectId: "p1", status: "CANCELLED", lineTotal: 999 }), // excluded — cancelled
+      svc({ projectId: "p1", status: "CONFIRMED", showOnDocuments: false, lineTotal: 999 }), // showOnDocuments no longer gates — counted
+      svc({ projectId: "p1", status: "CONFIRMED", lineTotal: undefined }), // no charge set → 0
+      svc({ projectId: "p2", status: "CONFIRMED", lineTotal: 7 }), // other project
     ];
-    expect(sumProjectServiceRevenue(rows, "p1")).toBe(150);
+    expect(sumProjectServiceRevenue(rows, "p1")).toBe(1149);
   });
 
   it("returns 0 when nothing matches", () => {

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -367,16 +367,20 @@ export async function buildDocumentData(
   );
 
   // ─── Append billable services as virtual line items ─────────────────────────
-  // Services with showOnDocuments appear on quotes/invoices as their own section.
-  // projectService is dual-written to Convex — read the org's services, filter to
-  // this project (showOnDocuments === true, status != CANCELLED) and order by
-  // sortOrder asc, replicating the dropped Prisma findMany.
+  // A service appears on quotes/invoices as its own section once it has an actual
+  // charge — `lineTotal` is null/0 until a unitPrice is typed or a crew charge
+  // rate auto-prices it (calculateServiceLineTotal / recalcServiceChargeFromCrew).
+  // Mirrors `buildFinanceLines` (convex/lib/financeSnapshot.ts) and
+  // `recalcProjectTotals`'s serviceRevenue (convex/lib/recalc.ts) — same rule,
+  // not a second one (R-3.1). projectService is dual-written to Convex — read the
+  // org's services, filter to this project and order by sortOrder asc,
+  // replicating the dropped Prisma findMany.
   const billableServices = (await getProjectServicesByOrg(organizationId))
     .filter(
       (s) =>
         s.projectId === projectId &&
-        s.showOnDocuments === true &&
-        s.status !== "CANCELLED",
+        s.status !== "CANCELLED" &&
+        Number(s.lineTotal) > 0,
     )
     .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
 

--- a/src/lib/project-services-read.ts
+++ b/src/lib/project-services-read.ts
@@ -21,14 +21,13 @@ export async function getProjectServicesByOrg(
 }
 
 /**
- * Sum of `lineTotal` over a project's non-CANCELLED, document-visible services.
- * Replicates Prisma `aggregate({ where: { projectId, status: { not: CANCELLED },
- * showOnDocuments: true }, _sum: { lineTotal } })`. Org-scoped Convex `list` is
- * filtered to the project here; null `lineTotal` contributes 0.
- *
- * NOTE on `showOnDocuments`: Prisma's `showOnDocuments: true` matches only rows
- * whose column is exactly `true`. The Convex field is optional, so a row with the
- * value absent reads `undefined` and is correctly excluded by the strict `=== true`.
+ * Sum of `lineTotal` over a project's non-CANCELLED, CHARGED services — a service
+ * bills iff it has an actual charge (`lineTotal` is null/0 until a unitPrice is
+ * typed or a crew charge rate auto-prices it). Org-scoped Convex `list` is
+ * filtered to the project here; null/zero `lineTotal` contributes 0, which is
+ * what makes an unpriced (internal-only) service exclude itself with no separate
+ * flag to check. Mirrors `convex/lib/recalc.ts`'s `serviceRevenue` — kept in sync
+ * there (R-3.1).
  */
 export function sumProjectServiceRevenue(
   services: ConvexProjectService[],
@@ -38,7 +37,6 @@ export function sumProjectServiceRevenue(
   for (const s of services) {
     if (s.projectId !== projectId) continue;
     if (s.status === "CANCELLED") continue;
-    if (s.showOnDocuments !== true) continue;
     total += s.lineTotal ?? 0;
   }
   return total;
@@ -59,7 +57,6 @@ export function sumProjectLabourServiceRevenue(
   for (const s of services) {
     if (s.projectId !== projectId) continue;
     if (s.status === "CANCELLED") continue;
-    if (s.showOnDocuments !== true) continue;
     if (s.type !== "LABOUR") continue;
     total += s.lineTotal ?? 0;
   }


### PR DESCRIPTION
## Summary

- Project services (delivery, pickup, bump in/out, labour, misc — the "Labour & logistics" tab) now show up on the client's quote/invoice and the pushed Xero invoice whenever they have an actual charge (`lineTotal > 0`), instead of being silently gated behind an unreachable/manual `showOnDocuments` flag.
- All the places that decide "is this service billable" now derive it from the same charge, instead of drifting: `buildFinanceLines` (quote/invoice snapshot → Xero), the PDF pipeline's billable-services section, `recalcProjectTotals`'s `serviceRevenue`, and both the Convex and Prisma-mirror P&L aggregates.
- `ServiceCard`'s "On quote"/"Internal (not billed)" badge and the Equipment tab's "Services on documents" section now match what actually ends up on the document.
- The create/edit service dialog shows a live, read-only hint ("Has a charge — will show on quotes, invoices & Xero" / "No charge set — stays internal…") instead of a manual toggle.
- `showOnDocuments` stays in the schema as raw stored data (API/MCP field, service-template default) but no longer gates document visibility.

## Testing

- Full suite: 432 test files / 5412 tests passing (`pnpm test`)
- `pnpm exec tsc --noEmit` clean
- `pnpm exec eslint` on touched files: no new errors (pre-existing complexity/max-lines warnings only)
- Added/updated unit tests: `convex/lib/financeSnapshot.test.ts` (SERVICE line inclusion/exclusion), `convex/projectCosts.test.ts`, `src/lib/dashboard-notifications-read.test.ts`

## Checklist

- [x] New dependency? N/A — no new dependencies added


---
_Generated by [Claude Code](https://claude.ai/code/session_016425nT6MLeHaCbFEzTkZ4C)_