### PR TITLE
Inline edit quantity (with overbook confirm) and project-group price/discount

### DIFF
--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -484,16 +484,16 @@ Custom items are ad-hoc line items for gear not in the system — borrowed equip
 **Distinction from sub-hires:** Sub-hires represent formally ordered gear from a supplier with a structured order workflow. Custom items are anonymous ad-hoc entries with no supplier and no order tracking.
 
 ### Inline editing (equipment table)
-Unit price, discount, description, and notes are editable directly in the
-equipment table row — click the cell, type, then blur (click away or Tab) or
-press Enter to save; Escape reverts without saving. This is a second entry
-point onto the *same* write as the "Edit" pencil's `EditLineItemDialog`, not a
-parallel path: `line-item-inline-cells.tsx`'s cell components call
-`equipment-tab.tsx`'s `handleInlineLineItemUpdate`, which layers the one
-changed field onto `buildLineItemFormDefaults(item)` and resolves it via
-`computeEditLineItemPayload` — the identical helper `EditLineItemDialog`'s
-`handleSave` calls for a full-form save (both now live in
-`src/lib/line-item-edit-payload.ts`, R-3.1). The resulting payload goes
+Unit price, discount, quantity, description, and notes are editable directly
+in the equipment table row — click the cell, type, then blur (click away or
+Tab) or press Enter to save; Escape reverts without saving. This is a second
+entry point onto the *same* write as the "Edit" pencil's
+`EditLineItemDialog`, not a parallel path: `line-item-inline-cells.tsx`'s
+cell components call `equipment-tab.tsx`'s `handleInlineLineItemUpdate`,
+which layers the one changed field onto `buildLineItemFormDefaults(item)` and
+resolves it via `computeEditLineItemPayload` — the identical helper
+`EditLineItemDialog`'s `handleSave` calls for a full-form save (both now live
+in `src/lib/line-item-edit-payload.ts`, R-3.1). The resulting payload goes
 through the same `updateLineItemMut` mutation function (a second
 `useServerMutation` instance, `updateLineItemInlineMut`, shares the identical
 `mutationFn` but skips the dialog-close/success-toast side effects — the
@@ -511,6 +511,20 @@ single-cell save).
   the stored `discount`/`discountMode` pair. An empty discount renders a
   hover-revealed "+ Discount" affordance instead of a $0 line, matching the
   row's other hover-revealed actions.
+- **Quantity** (`InlineEditableQuantity`) reproduces `EditLineItemDialog`'s
+  overbook check, just reactively instead of proactively: no per-row
+  availability query is pre-fetched (no `rentalStartDate`/`rentalEndDate`
+  threaded into `LineItemRow` at all) — the cell attempts the save with
+  `allowOverbook: false`, and `patchNative`'s own re-check is the single
+  source of truth. On a quantity *increase* past availability, the server
+  throws `ConvexError({ code: "INSUFFICIENT_STOCK", message, hint })`; the
+  cell catches exactly that code, shows the server's own message plus a
+  "Cancel" / "Overbook anyway" pair inline, and only resends with
+  `allowOverbook: true` on confirm. `updateLineItemInlineMut`'s `onError`
+  skips its normal toast for this one code (the inline confirm handles it)
+  but still toasts every other error. Quantity is a *structural* field
+  (`LOCKED_LINE_ITEM_FIELDS` doesn't include it), so the cell isn't wrapped in
+  `<LockedField>` — same JUSTIFY-tier/toast treatment as description/notes.
 - **Price/discount lock**: wrapped in the same `<LockedField>` the dialog uses
   for money fields — when the project's financials are locked
   (`moneyLocked`, FEATUREDOCS/62), the cells render read-only with the same
@@ -520,11 +534,27 @@ single-cell save).
   JUSTIFY-tier project without an open session surfaces the server's
   `JUSTIFICATION_REQUIRED` error as a toast (no inline justification prompt
   yet, matching the dialog's current behaviour).
-- **Not offered** on sub-hire group children — those rows' "Edit" pencil opens
-  `SubHireOrderDialog` instead of `EditLineItemDialog` (their price flows
-  through cost/charge on the sub-hire group, not per-line `unitPrice`), so
-  `onInlineUpdate` is simply omitted at those two `LineItemRow` call sites in
-  `equipment-tab.tsx` and the cells stay static.
+- **Sub-hire group children** get all five cells too (added after the initial
+  pass, which excluded them), routed through a different mutation entirely —
+  see FEATUREDOCS/39-sub-hires.md's own "Inline editing" section for why
+  `patchNative` isn't safe for these rows and what routes there instead.
+  Quantity is the one field with no overbook concept for these rows (no
+  `INSUFFICIENT_STOCK` check server-side), so the confirm step simply never
+  triggers.
+- **Project groups** (`GroupRow`, not a line item) also get inline
+  price/discount cells now, wired to the exact `updateGroupPriceNative` call
+  `EditGroupDialog`/`PriceEditDialog`'s project branch already make — `price`
+  is always-required/full-replace (the cell resends the current price when
+  only discount changed); `discount`/`discountMode` are set-or-clear-when-
+  provided (resend the current price, omit discount entirely, when only
+  price changed). This mutation genuinely is `assertLifecycleGuard({kind:
+  "financial"})`-gated server-side (unlike sub-hire groups' `updateGroup`),
+  so `GroupRow`'s cells wrap in `<LockedField>` same as `LineItemRow`'s.
+  Clearing the discount input resolves to `resolveDiscountAmount`'s
+  `undefined` ("nothing to discount"), which the mutation reads as "leave
+  untouched" rather than "clear to zero" — a pre-existing characteristic of
+  `updateGroupPriceNative` shared with `EditGroupDialog`'s own save, not
+  something introduced here.
 
 ## Project Detail Page Layout
 Restructured (v0.x) to a clean hero card + lean sidebar — the old big header,

--- a/FEATUREDOCS/39-sub-hires.md
+++ b/FEATUREDOCS/39-sub-hires.md
@@ -44,12 +44,12 @@ Sub-hires are managed via a **dialog** on the project equipment tab:
 
 ### Inline editing on the equipment table
 
-Price, discount, description, and notes are inline-editable directly on a
-sub-hire **group child** row in the equipment table (`equipment-rows.tsx`'s
-`LineItemRow`, gated on `item.subHireGroupId != null`) — the same
-click-to-edit/save-on-blur cells the regular equipment table uses
-(`src/components/projects/line-item-inline-cells.tsx`), but routed to a
-DIFFERENT write than a normal line item:
+Price, discount, quantity, description, and notes are inline-editable
+directly on a sub-hire **group child** row in the equipment table
+(`equipment-rows.tsx`'s `LineItemRow`, gated on `item.subHireGroupId !=
+null`) — the same click-to-edit/save-on-blur cells the regular equipment
+table uses (`src/components/projects/line-item-inline-cells.tsx`), but
+routed to a DIFFERENT write than a normal line item:
 
 - A sub-hire group child's `ProjectLineItem` row is a **derived/display
   copy** — `regenerateSubHireLines` (`convex/lib/subHireLineGen.ts`) deletes
@@ -69,6 +69,11 @@ DIFFERENT write than a normal line item:
 - **Not lock-gated** — `updateSubHireItemNative` never checks the project's
   financial lock (same as `SubHireOrderDialog`'s item form today), so these
   cells render without the `<LockedField>` wrapper regular money cells use.
+- **Quantity** has no availability/overbook concept for sub-hire items —
+  `updateSubHireItemNative` sets it directly with no stock check, so
+  `InlineEditableQuantity`'s overbook-confirm step (built for the regular
+  `patchNative`/`INSUFFICIENT_STOCK` path) simply never triggers here; the
+  save always succeeds on the first attempt.
 - The sub-hire **group's own row** (`SubHireGroupRow`) also gets inline
   charge/cost cells, calling the same `updateGroup` mutation
   `PriceEditDialog`'s sub-hire branch uses (`onInlinePriceUpdate` prop) — the

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -45,10 +45,10 @@ import { TableCell, TableRow } from "@/components/ui/table";
 import { LockedField } from "@/components/ui/locked-field";
 import { formatCurrency } from "@/lib/formatters";
 import { parsePriceBreakdown, formatPriceBreakdown } from "@/lib/billing-derivation";
-import { lineGrossAmount } from "@/lib/discount-mode";
+import { lineGrossAmount, type DiscountMode } from "@/lib/discount-mode";
 import type { InlineLineItemPatch } from "@/lib/line-item-edit-payload";
 import { cn, focusRing } from "@/lib/utils";
-import { InlineEditableText, InlineEditablePrice, InlineEditableDiscount, InlineEditablePercent } from "./line-item-inline-cells";
+import { InlineEditableText, InlineEditablePrice, InlineEditableDiscount, InlineEditablePercent, InlineEditableQuantity } from "./line-item-inline-cells";
 import { useRowShortcuts } from "./use-row-shortcuts";
 import { ReviewMarkerBadge } from "@/components/collaboration/review-marker-badge";
 import type { MarkerStatus } from "@/components/collaboration/review-marker-badge";
@@ -302,6 +302,17 @@ function OverbookedBadge({ info }: { info?: OverbookedInfo | null }) {
 
 // ─── Sortable group row ─────────────────────────────────────────────────────
 
+/** A single inline-edited field on a project group's own price cells. Unlike
+ *  `InlineLineItemPatch`'s "discount" variant, `price` and `discount` are
+ *  separate variants (not a shared object) because `updateGroupPriceNative`'s
+ *  `price` arg is always-required/full-replace while `discount`/
+ *  `discountMode` are set-or-clear-when-provided — the caller
+ *  (`equipment-tab.tsx`'s `handleInlineGroupPriceUpdate`) needs to know which
+ *  one was actually edited to resend the untouched value for the other. */
+export type GroupInlinePricePatch =
+  | { field: "price"; value: number | undefined }
+  | { field: "discount"; value: number | undefined; discountMode: DiscountMode };
+
 export function GroupRow({
   group,
   isExpanded,
@@ -322,6 +333,10 @@ export function GroupRow({
   onMoveDown,
   canMoveUp,
   canMoveDown,
+  onInlinePriceUpdate,
+  moneyLocked,
+  lockReason,
+  onUnlockExit,
 }: {
   group: GroupData;
   isExpanded: boolean;
@@ -336,7 +351,8 @@ export function GroupRow({
   onToggle: () => void;
   onDelete: () => void;
   onEdit: () => void;
-  /** Phase 6c — opens the unified PriceEditDialog in project-group mode. */
+  /** Phase 6c — opens the unified PriceEditDialog in project-group mode.
+   *  Kept alongside inline editing (below) as a redundant entry point. */
   onEditPrice?: () => void;
   onAddEquipment: () => void;
   onAddKit: () => void;
@@ -344,6 +360,14 @@ export function GroupRow({
    *  want the affordance (e.g. read-only views) can omit it. */
   onMove?: () => void;
   onSaveAsTemplate?: () => void;
+  /** Inline click-to-edit price/discount cells — the same
+   *  `updateGroupPriceNative` write `onEditPrice`'s dialog makes. */
+  onInlinePriceUpdate?: (group: GroupData, patch: GroupInlinePricePatch) => Promise<unknown>;
+  /** Unlike sub-hire groups' cost/charge, a project group's price/discount
+   *  IS financial-lock-gated server-side — real gating, not cosmetic. */
+  moneyLocked?: boolean;
+  lockReason?: string;
+  onUnlockExit?: () => void;
 } & MoveControls) {
   const priceVal = group.price != null ? Number(group.price) : null;
   const discountVal = group.discount != null ? Number(group.discount) : 0;
@@ -478,9 +502,35 @@ export function GroupRow({
       </TableCell>
       <TableCell className="text-center t-data">{group.quantity}</TableCell>
       <TableCell className="text-right whitespace-nowrap t-data">
-        {priceVal != null ? formatCurrency(priceVal) : <span className="text-faint">—</span>}
-        {discountVal > 0 && (
-          <p className="text-micro text-ok">-{formatCurrency(discountVal)} disc.</p>
+        {onInlinePriceUpdate ? (
+          <LockedField
+            locked={!!moneyLocked}
+            reason={lockReason ?? "This project's financials are locked."}
+            exitLabel="Manage unlock"
+            onExit={onUnlockExit}
+          >
+            <div className="flex justify-end">
+              <InlineEditablePrice
+                value={priceVal}
+                onSave={(next) => onInlinePriceUpdate(group, { field: "price", value: next })}
+              />
+            </div>
+            <div className="flex justify-end">
+              <InlineEditableDiscount
+                discount={discountVal > 0 ? discountVal : null}
+                discountMode={group.discountMode}
+                gross={lineGrossAmount({ unitPrice: priceVal, quantity: group.quantity, duration: 1 })}
+                onSave={(amount, mode) => onInlinePriceUpdate(group, { field: "discount", value: amount, discountMode: mode })}
+              />
+            </div>
+          </LockedField>
+        ) : (
+          <>
+            {priceVal != null ? formatCurrency(priceVal) : <span className="text-faint">—</span>}
+            {discountVal > 0 && (
+              <p className="text-micro text-ok">-{formatCurrency(discountVal)} disc.</p>
+            )}
+          </>
         )}
         {group.pricedUnderLock && (
           <div className="mt-0.5 flex justify-end">
@@ -1550,7 +1600,16 @@ export function LineItemRow({
           )
         )}
       </TableCell>
-      <TableCell className="text-center t-data">{item.quantity}</TableCell>
+      <TableCell className="text-center t-data">
+        {onInlineUpdate ? (
+          <InlineEditableQuantity
+            value={item.quantity}
+            onSave={(next, allowOverbook) => onInlineUpdate(item, { field: "quantity", value: next, allowOverbook })}
+          />
+        ) : (
+          item.quantity
+        )}
+      </TableCell>
       <TableCell className="text-right whitespace-nowrap t-data">
         {onInlineUpdate && isSubHireGroupChild ? (
           // Sub-hire GROUP CHILDREN route through updateSubHireItemNative

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
+import { ConvexError } from "convex/values";
 
 import { useProjectServices } from "@/hooks/use-project-services";
 import { useGroupTemplates } from "@/hooks/use-group-templates";
@@ -86,6 +87,7 @@ import {
   type SubHireGroupData,
   type MixedGroupSlot,
   type OverbookedInfo,
+  type GroupInlinePricePatch,
 } from "./equipment-rows";
 import { ReassignProvider, type ReassignTarget, type ReassignSerial } from "./reassign-context";
 import { useWarehouseWrites } from "@/hooks/use-warehouse-writes";
@@ -596,8 +598,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   // Same write as updateLineItemMut, minus the dialog-close/success-toast side
   // effects — a table cell already shows its own save state, and the row's
   // `justChanged` flash (equipment-rows.tsx, on `updatedAt` changing) is
-  // feedback enough. Errors still toast; a silent failure would be worse
-  // than a silent success.
+  // feedback enough. Errors still toast, EXCEPT `INSUFFICIENT_STOCK` — that
+  // one is a quantity overbook, which `InlineEditableQuantity` handles itself
+  // via its own confirm-and-retry step; toasting it here too would just be a
+  // redundant, less actionable copy of the same message.
   const updateLineItemInlineMut = useServerMutation({
     mutationFn: updateLineItemMutationFn,
     onSuccess: (_r: unknown, { id }: { id: string }) => {
@@ -606,7 +610,12 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
     },
     onError: (e: Error, { id }: { id: string }) => {
       clearPendingEdit(id);
-      toast.error(e.message);
+      const isOverbook =
+        e instanceof ConvexError &&
+        typeof e.data === "object" &&
+        e.data !== null &&
+        (e.data as { code?: unknown }).code === "INSUFFICIENT_STOCK";
+      if (!isOverbook) toast.error(e.message);
     },
   });
 
@@ -614,9 +623,11 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   // `onInlineUpdate`. Builds the exact same payload the full edit dialog
   // would (computeInlineLineItemPayload -> computeEditLineItemPayload), just
   // for a single changed field, and runs it through the identical
-  // update/optimistic-overlay path. Never touches quantity, so there's no
-  // overbook confirmation to thread through (allowOverbook: false is always
-  // correct here).
+  // update/optimistic-overlay path. A "quantity" patch carries its own
+  // `allowOverbook` (false on the first attempt, true only on a confirmed
+  // retry from `InlineEditableQuantity`'s overbook prompt) — every other
+  // field never touches availability, so `allowOverbook: false` is always
+  // correct for them.
   const handleInlineLineItemUpdate = useCallback(
     (item: LineItemData, patch: InlineLineItemPatch) => {
       if (item.subHireGroupId != null) {
@@ -663,7 +674,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
       return updateLineItemInlineMut.mutateAsync({
         id: item.id,
         data: payload as unknown as Record<string, unknown>,
-        allowOverbook: false,
+        allowOverbook: patch.field === "quantity" ? patch.allowOverbook : false,
         baseUpdatedAt,
       });
     },
@@ -693,6 +704,34 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
           throw e;
         }),
     [subHireWrites, invalidate],
+  );
+
+  // Inline price/discount cells on a regular PROJECT group's own row
+  // (GroupRow) — the same updateGroupPriceNative call PriceEditDialog's
+  // project branch / EditGroupDialog make. Unlike the sub-hire group's
+  // updateGroup, this mutation IS financial-lock-gated server-side (see
+  // GroupInlinePricePatch's doc comment), so GroupRow wraps these cells in
+  // <LockedField>. `price` is always-required/full-replace (resend the
+  // current value when only discount changed); `discount`/`discountMode` are
+  // set-or-clear-when-provided (resend the current price, omit discount
+  // entirely, when only price changed) — mirrors EditGroupDialog's own
+  // handleSave, which has this exact same "clearing the discount input
+  // doesn't actually clear a stored discount" characteristic already
+  // (resolveDiscountAmount returns undefined for a blank field, and
+  // undefined = "leave untouched" server-side, not "clear").
+  const handleInlineGroupPriceUpdate = useCallback(
+    (group: GroupData, patch: GroupInlinePricePatch) => {
+      const currentPrice = group.price != null ? Number(group.price) : 0;
+      const call =
+        patch.field === "price"
+          ? groupWrites.updatePrice(group.id, patch.value ?? 0)
+          : groupWrites.updatePrice(group.id, currentPrice, patch.value, patch.discountMode);
+      return call.then(() => invalidate()).catch((e: Error) => {
+        toast.error(e.message);
+        throw e;
+      });
+    },
+    [groupWrites, invalidate],
   );
 
   const removeMut = useServerMutation({
@@ -1337,6 +1376,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                               }}
                               onSaveAsTemplate={() => setSaveAsTemplateGroup({ id: group.id, title: group.title })}
                               onMove={() => setMoveProjectGroup({ id: group.id, title: group.title })}
+                              onInlinePriceUpdate={handleInlineGroupPriceUpdate}
+                              moneyLocked={moneyLocked}
+                              lockReason={lockReason}
+                              onUnlockExit={scrollToLockStrip}
                             />
                             {/* Expanded line items */}
                             {isExpanded && groupItems.length === 0 && (
@@ -1548,6 +1591,10 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           setShowUnifiedAdd(true);
                         }}
                         onMove={() => setMoveProjectGroup({ id: group.id, title: group.title })}
+                        onInlinePriceUpdate={handleInlineGroupPriceUpdate}
+                        moneyLocked={moneyLocked}
+                        lockReason={lockReason}
+                        onUnlockExit={scrollToLockStrip}
                       />
                       {isExpanded && groupItems.length === 0 && (
                         isMobile ? (

--- a/src/components/projects/line-item-inline-cells.test.tsx
+++ b/src/components/projects/line-item-inline-cells.test.tsx
@@ -7,10 +7,12 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { ConvexError } from "convex/values";
 import {
   InlineEditableText,
   InlineEditablePrice,
   InlineEditableDiscount,
+  InlineEditableQuantity,
 } from "./line-item-inline-cells";
 
 describe("InlineEditableText", () => {
@@ -125,5 +127,102 @@ describe("InlineEditableDiscount", () => {
     fireEvent.click(screen.getByText("-$150.00 disc."));
     expect((screen.getByLabelText("Discount") as HTMLInputElement).value).toBe("15");
     expect(screen.getByLabelText("Discount mode").textContent).toBe("%");
+  });
+});
+
+describe("InlineEditableQuantity", () => {
+  it("click to edit, blur saves the parsed quantity with allowOverbook: false", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<InlineEditableQuantity value={2} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("2"));
+    const input = screen.getByLabelText("Quantity") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.blur(input);
+
+    expect(onSave).toHaveBeenCalledWith(5, false);
+  });
+
+  it("a no-op edit (unchanged value) never calls onSave", () => {
+    const onSave = vi.fn();
+    render(<InlineEditableQuantity value={3} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("3"));
+    fireEvent.blur(screen.getByLabelText("Quantity"));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("garbage input (< 1) reverts silently without saving", () => {
+    const onSave = vi.fn();
+    render(<InlineEditableQuantity value={3} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("3"));
+    const input = screen.getByLabelText("Quantity") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "0" } });
+    fireEvent.blur(input);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("INSUFFICIENT_STOCK shows an inline overbook-confirm step; confirming retries with allowOverbook: true", async () => {
+    const onSave = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ConvexError({ code: "INSUFFICIENT_STOCK", message: "Only 3 of 5 requested are free during those dates." }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    render(<InlineEditableQuantity value={2} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("2"));
+    const input = screen.getByLabelText("Quantity") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.blur(input);
+
+    expect(await screen.findByText("Only 3 of 5 requested are free during those dates.")).toBeTruthy();
+    expect(onSave).toHaveBeenNthCalledWith(1, 5, false);
+
+    fireEvent.click(screen.getByText("Overbook anyway"));
+
+    expect(onSave).toHaveBeenNthCalledWith(2, 5, true);
+  });
+
+  it("Cancel on the overbook prompt reverts without a retry", async () => {
+    const onSave = vi
+      .fn()
+      .mockRejectedValueOnce(new ConvexError({ code: "INSUFFICIENT_STOCK", message: "Not enough stock." }));
+
+    render(<InlineEditableQuantity value={2} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("2"));
+    const input = screen.getByLabelText("Quantity") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.blur(input);
+
+    await screen.findByText("Not enough stock.");
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("a non-overbook error reverts silently (no confirm step)", async () => {
+    const onSave = vi.fn().mockRejectedValueOnce(new Error("Not ready — try again in a moment."));
+
+    render(<InlineEditableQuantity value={2} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText("2"));
+    const input = screen.getByLabelText("Quantity") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.blur(input);
+
+    // Flush the rejected promise before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(screen.queryByText("Overbook anyway")).toBeNull();
+    expect(screen.getByText("2")).toBeTruthy();
   });
 });

--- a/src/components/projects/line-item-inline-cells.tsx
+++ b/src/components/projects/line-item-inline-cells.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { ConvexError } from "convex/values";
 import { formatCurrency } from "@/lib/formatters";
 import {
   type DiscountMode,
@@ -473,6 +474,157 @@ export function InlineEditableDiscount({
       )}
     >
       -{formatCurrency(Number(discount))} disc.
+    </button>
+  );
+}
+
+/** Reads a `ConvexError`'s structured `data.code`, the pattern
+ *  `use-justified-mutation.ts` already uses for `JUSTIFICATION_REQUIRED`. */
+function convexErrorCode(e: unknown): string | undefined {
+  if (!(e instanceof ConvexError) || typeof e.data !== "object" || e.data === null) return undefined;
+  const code = (e.data as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function convexErrorMessage(e: unknown, fallback: string): string {
+  if (e instanceof ConvexError && typeof e.data === "object" && e.data !== null) {
+    const message = (e.data as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return e instanceof Error ? e.message : fallback;
+}
+
+export interface InlineEditableQuantityProps {
+  value: number;
+  disabled?: boolean;
+  className?: string;
+  /** Resolves on success. On a rejected quantity increase, `patchNative`
+   *  throws a `ConvexError` with `data.code === "INSUFFICIENT_STOCK"` — this
+   *  component catches exactly that code to show a confirm-overbook step
+   *  (mirroring `EditLineItemDialog`'s pre-fetched-availability checkbox,
+   *  just reactive instead of proactive: no per-row availability query, the
+   *  server's own re-check is the single source of truth). Call again with
+   *  `allowOverbook: true` to confirm. Any OTHER rejection is assumed
+   *  already toasted by the caller's mutation — this component just reverts
+   *  silently. */
+  onSave: (next: number, allowOverbook: boolean) => Promise<unknown>;
+}
+
+/** Click-to-edit quantity, with an inline overbook-confirm step in place of
+ *  `EditLineItemDialog`'s checkbox. Not lock-gated — quantity is a
+ *  *structural* field (`LOCKED_LINE_ITEM_FIELDS` doesn't include it), not a
+ *  financial one, so it's ungated the same way description/notes are. */
+export function InlineEditableQuantity({ value, disabled, className, onSave }: InlineEditableQuantityProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  const [saving, setSaving] = useState(false);
+  const [overbook, setOverbook] = useState<{ next: number; message: string } | null>(null);
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    ref.current?.focus();
+    ref.current?.select();
+  }, [editing]);
+
+  function startEditing() {
+    setDraft(String(value));
+    setOverbook(null);
+    setEditing(true);
+  }
+
+  async function attemptSave(next: number, allowOverbook: boolean) {
+    setSaving(true);
+    try {
+      await onSave(next, allowOverbook);
+      setOverbook(null);
+    } catch (e) {
+      if (convexErrorCode(e) === "INSUFFICIENT_STOCK") {
+        setOverbook({ next, message: convexErrorMessage(e, "Not enough stock available for that quantity.") });
+      }
+      // Any other error: the caller's mutation already surfaced a toast —
+      // just fall through and revert to the display value.
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function commit() {
+    setEditing(false);
+    const parsed = Math.round(Number(draft.trim()));
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed === value) return; // garbage/no-op — revert silently
+    await attemptSave(parsed, false);
+  }
+
+  if (overbook) {
+    return (
+      <div
+        className="flex flex-col items-end gap-1"
+        onBlur={(e) => {
+          if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+          setOverbook(null);
+        }}
+      >
+        <span className="max-w-[140px] text-right text-micro text-t-out">{overbook.message}</span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setOverbook(null)}
+            className={cn("rounded-sm border border-line px-1.5 py-0.5 text-micro text-muted hover:bg-elev", focusRing)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => attemptSave(overbook.next, true)}
+            className={cn("rounded-sm border border-out bg-out-soft px-1.5 py-0.5 text-micro text-t-out hover:bg-out-soft/80", focusRing)}
+          >
+            Overbook anyway
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={ref}
+        type="number"
+        min={1}
+        step={1}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onClick={(e) => e.stopPropagation()}
+        onBlur={commit}
+        onKeyDown={(e) => handleEditKeyDown(e, () => setEditing(false), true)}
+        className={cn(
+          "w-14 rounded-sm border border-line bg-paper px-1.5 py-0.5 text-center t-data outline-none",
+          focusRing,
+          className,
+        )}
+        aria-label="Quantity"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={(e) => {
+        e.stopPropagation();
+        startEditing();
+      }}
+      className={cn(
+        "rounded-sm px-1 -mx-1 tabular-nums",
+        !disabled && "cursor-text hover:bg-elev",
+        saving && "opacity-60",
+        focusRing,
+        className,
+      )}
+    >
+      {value}
     </button>
   );
 }

--- a/src/lib/line-item-edit-payload.ts
+++ b/src/lib/line-item-edit-payload.ts
@@ -114,7 +114,16 @@ export type InlineLineItemPatch =
   | { field: "notes"; value: string }
   | { field: "unitPrice"; value: number | undefined }
   | { field: "discount"; value: number | undefined; discountMode: DiscountMode }
-  | { field: "discountPercent"; value: number };
+  | { field: "discountPercent"; value: number }
+  /** `allowOverbook` — set true only on a confirmed retry after the first
+   *  attempt (allowOverbook: false) came back INSUFFICIENT_STOCK. See
+   *  `InlineEditableQuantity` and `equipment-tab.tsx`'s
+   *  `handleInlineLineItemUpdate`, which reads it straight through to the
+   *  mutate call (never routed through this module's own payload — quantity
+   *  IS one of this module's fields, `allowOverbook` is a sibling mutate arg,
+   *  not a payload field). Ignored on the sub-hire-item route — those items
+   *  have no availability concept to overbook. */
+  | { field: "quantity"; value: number; allowOverbook: boolean };
 
 /** Layers a single inline-edited field onto `item`'s current values and
  *  resolves the full update payload — the inline-edit equivalent of the
@@ -134,6 +143,7 @@ export function computeInlineLineItemPayload(
     ...(patch.field === "notes" ? { notes: patch.value } : {}),
     ...(patch.field === "unitPrice" ? { unitPrice: patch.value } : {}),
     ...(patch.field === "discount" ? { discount: patch.value } : {}),
+    ...(patch.field === "quantity" ? { quantity: patch.value } : {}),
   };
   return computeEditLineItemPayload(item, data, discountMode);
 }

--- a/src/lib/sub-hire-item-edit-payload.test.ts
+++ b/src/lib/sub-hire-item-edit-payload.test.ts
@@ -82,4 +82,11 @@ describe("computeInlineSubHireItemInput", () => {
     expect(input.description).toBe("New label");
     expect(input.unitCharge).toBe(100);
   });
+
+  it("a quantity patch overrides only the quantity — no availability concept, allowOverbook is not a field here", () => {
+    const input = computeInlineSubHireItemInput(baseItem, { field: "quantity", value: 7, allowOverbook: false });
+    expect(input.quantity).toBe(7);
+    expect(input.unitCharge).toBe(100);
+    expect(input.discount).toBe(10);
+  });
 });

--- a/src/lib/sub-hire-item-edit-payload.ts
+++ b/src/lib/sub-hire-item-edit-payload.ts
@@ -105,5 +105,9 @@ export function computeInlineSubHireItemInput(
       return { ...base, unitCharge: patch.value ?? 0 };
     case "discountPercent":
       return { ...base, discount: patch.value };
+    case "quantity":
+      // No availability concept for sub-hire items — `allowOverbook` is
+      // meaningless here and simply ignored.
+      return { ...base, quantity: patch.value };
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1047 (merged) — extends the inline-editing table cells to two more fields, per feedback that quantity and project-group price were still missing.

**Quantity, with the overbooking safety net preserved:**
- `InlineEditableQuantity` (`line-item-inline-cells.tsx`) — click-to-edit quantity on every line item row (regular, sub-hire group children, standalone sub-hire items).
- Doesn't pre-fetch availability the way `EditLineItemDialog` does (no `rentalStartDate`/`rentalEndDate` threaded into `LineItemRow`). Instead it attempts the save with `allowOverbook: false` and lets `patchNative`'s own server-side re-check be the single source of truth. On a rejected quantity increase (`ConvexError` with `data.code === "INSUFFICIENT_STOCK"`), it shows the server's own message plus a "Cancel" / "Overbook anyway" pair inline — confirming retries with `allowOverbook: true`. Any other error is assumed already toasted by the mutation's `onError` and just reverts silently.
- Sub-hire items have no availability concept server-side, so the confirm step simply never triggers for those rows — same cell, no special-casing needed.
- Quantity is a *structural* field (not in `LOCKED_LINE_ITEM_FIELDS`), so it's ungated by the financial lock — same treatment as description/notes already have.

**Regular project group price/discount:**
- `GroupRow` (project groups, not sub-hire groups — those already got this) now has inline price/discount cells too, wired to the exact `updateGroupPriceNative` call `EditGroupDialog`/`PriceEditDialog`'s project branch already make.
- This mutation genuinely is financial-lock-gated server-side (unlike sub-hire groups' `updateGroup`), so these cells wrap in `<LockedField>` the same way `LineItemRow`'s money cells do.
- `price` is always resent (full-replace arg); `discount`/`discountMode` are only resent when discount is the field actually being edited (set-or-clear semantics) — mirrors `EditGroupDialog`'s own save logic exactly, including its pre-existing "clearing the discount input doesn't actually clear a stored discount, it leaves it untouched" characteristic (not something new here).

## Testing

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint` on all touched files — 0 errors.
- `node scripts/complexity-ratchet.mjs` — holds exactly at baseline (685).
- `pnpm exec vitest run` — 313 tests passing across the touched files (including a new `InlineEditableQuantity` suite covering the commit/no-op/garbage-input/overbook-confirm/cancel/other-error paths).
- Not manually verified in a running browser session (no live dev server in this environment).

## Size rationale (R-2.8 / T-2)

485 LOC is over the ≤400 SHOULD-target, but only by ~85. Not split because quantity and project-group price are two small, independent additions to the SAME inline-editing surface added in #1047 — each is a few dozen lines (one new cell component + wiring, or one new prop + handler mirroring an existing dialog's mutation call), and both share the same `onInlineUpdate`/`LockedField`/`InlineLineItemPatch` scaffolding this PR doesn't introduce. Splitting into two PRs would mean re-reviewing that shared context twice for no independent value — neither half is comprehensible or mergeable without the other's context already being established (by #1047, already merged).

## Checklist

- [x] New dependency? N/A — no new dependencies added.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CvxsK44Vj79BZtJhvAWLRX