### PR TITLE
Show org ABN on every document type, not just invoices

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -185,10 +185,15 @@ removed (dual pipelines, ~8,300 dead LOC, and the pagination bug it caused).
 | Type | Blocks | `expandProjectGroups` | Status filter |
 |------|--------|------------------------|----------------|
 | `quote` | header (+ "Expiry: {date}" meta line, real computed date), client+project details, table (`clientFacingTable`: no "/day" price suffix, no badges, no kit/accessory children), totals, client notes, T&Cs (omitted if unset) | false (collapse groups) | none |
-| `invoice` | header (+ ABN under address/email when set, + bold "Due: {date}" meta line), client+project details (+ tax ID, payment terms), table (`clientFacingTable`: no "/day" price suffix, no badges, no kit/accessory children), totals (+ deposit/balance, + bold "Due Date" row), payment details (omitted if unset), client notes, T&Cs (omitted unless `showTermsAndConditionsOnInvoice` is on AND text is set) | false | none |
+| `invoice` | header (+ bold "Due: {date}" meta line), client+project details (+ tax ID, payment terms), table (`clientFacingTable`: no "/day" price suffix, no badges, no kit/accessory children), totals (+ deposit/balance, + bold "Due Date" row), payment details (omitted if unset), client notes, T&Cs (omitted unless `showTermsAndConditionsOnInvoice` is on AND text is set) | false | none |
 | `packing-list` | header, client+project details, table (checkboxes, per-unit, asset tags, categories), total-items note | true (expand groups) | none |
 | `return-sheet` | header, client+project details, table (checkboxes, condition columns, per-unit, asset tags), signature (3 cols) | true | `CHECKED_OUT`, `RETURNED` |
 | `delivery-docket` | header, client+project details (+ site contact), table (checkboxes, row numbers, per-unit, asset tags), signature (3 cols) | true | `CHECKED_OUT` |
+
+The `header` block itself is the SAME across all 5 doc types (`document-composer.ts`'s
+one `case "header"` in both `estimateBlockHeight` and `buildEntryFields`) — the org's ABN
+(when set) renders under the address/phone/email lines on **every** doc type, not just
+the invoice. Only the "Expiry"/"Due" meta lines next to the doc number are doc-type-gated.
 
 Call sheets are a 6th `DocumentType` value but are **not** in
 `DOCUMENT_LAYOUTS` — they render via `templates/call-sheet-services.ts`
@@ -250,9 +255,10 @@ card at `/settings/branding` ("Branding & documents").
 Org-level ABN (Australian Business Number, or local equivalent) is a separate
 top-level `OrgSettings.abn` field (not under `documents` — it's business
 identity, edited on the General settings page next to address/email/phone).
-Rendered in the PDF header, under the org's address/phone/email lines,
-**invoice only** — real Tax Invoices need it; the other 4 doc types don't.
-Omitted when unset.
+Rendered in the PDF header, under the org's address/phone/email lines, on
+**every** doc type — Tax Invoices legally require it, but it's shown wherever
+the org details block itself renders rather than singled out to that one
+type. Omitted when unset.
 
 `build-document-data.ts` computes these `DocumentData` fields from the settings
 above each time a document is built: `document_footer_text`,

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -234,7 +234,7 @@ export default function GeneralSettingsPage() {
               disabled={!canEdit}
             />
             <p className="t-micro text-muted">
-              Australian Business Number — required on Tax Invoices. Printed in the PDF header, under your address and email.
+              Australian Business Number — required on Tax Invoices. Printed in the PDF header, under your address and email, on every document type.
             </p>
           </div>
           <div className="space-y-2">

--- a/src/lib/org-settings-types.ts
+++ b/src/lib/org-settings-types.ts
@@ -64,7 +64,9 @@ export interface OrgSettings {
   website?: string;
   address?: string;
   /** Australian Business Number (or local equivalent tax/business
-   *  registration id). Rendered in the PDF header on Tax Invoices only. */
+   *  registration id). Rendered in the PDF header on every doc type, under
+   *  the org's address/phone/email — required on Tax Invoices, but shown
+   *  wherever the org details block renders, not gated to that one type. */
   abn?: string;
   country?: string;
   timezone?: string;

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -423,24 +423,23 @@ describe("composeDocument — invoice T&Cs, payment details, ABN, due date", () 
     expect(result.inputs[0][page0[paymentIdx].name as string]).toBe("Bank: Test Bank\nBSB: 000-000\nAcct: 12345678");
   });
 
-  it("renders the org's ABN under the address/email in the invoice header, never on the quote", () => {
-    const invoiceResult = composeDocument("invoice", soloData({ org_abn: "12 345 678 901" }), "#0d4f4f");
-    const invoiceHeaderSchema = invoiceResult.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
-    const invoiceHeaderConfig = JSON.parse(invoiceResult.inputs[0][invoiceHeaderSchema.name as string]);
-    expect(invoiceHeaderConfig.orgDetails).toContain("ABN: 12 345 678 901");
-    expect(invoiceHeaderConfig.orgDetails.indexOf("ABN:")).toBeGreaterThan(invoiceHeaderConfig.orgDetails.indexOf(soloData().org_address));
-
-    const quoteResult = composeDocument("quote", soloData({ org_abn: "12 345 678 901" }), "#0d4f4f");
-    const quoteHeaderSchema = quoteResult.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
-    const quoteHeaderConfig = JSON.parse(quoteResult.inputs[0][quoteHeaderSchema.name as string]);
-    expect(quoteHeaderConfig.orgDetails).not.toContain("ABN:");
+  it("renders the org's ABN under the address/email, on every doc type — wherever the org details block renders", () => {
+    for (const docType of ["quote", "invoice", "packing-list", "return-sheet", "delivery-docket"] as const) {
+      const result = composeDocument(docType, soloData({ org_abn: "12 345 678 901" }), "#0d4f4f");
+      const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+      const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+      expect(headerConfig.orgDetails).toContain("ABN: 12 345 678 901");
+      expect(headerConfig.orgDetails.indexOf("ABN:")).toBeGreaterThan(headerConfig.orgDetails.indexOf(soloData().org_address));
+    }
   });
 
-  it("omits the ABN line when the org hasn't set one, even on the invoice", () => {
-    const result = composeDocument("invoice", soloData({ org_abn: "" }), "#0d4f4f");
-    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
-    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
-    expect(headerConfig.orgDetails).not.toContain("ABN:");
+  it("omits the ABN line when the org hasn't set one, on every doc type", () => {
+    for (const docType of ["quote", "invoice", "packing-list", "return-sheet", "delivery-docket"] as const) {
+      const result = composeDocument(docType, soloData({ org_abn: "" }), "#0d4f4f");
+      const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+      const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+      expect(headerConfig.orgDetails).not.toContain("ABN:");
+    }
   });
 
   it("renders the invoice due date as a bold header highlight AND as a bold row at the bottom of the totals block", () => {

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -349,10 +349,12 @@ function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: Layout
       // Quote's header meta gains a 3rd line ("Expiry: <date>") — a little
       // extra headroom so it can't ever crowd the details row below it.
       const hasExpiryLine = ctx.docType === "quote" && !!data.quote_valid_until;
-      // Invoice's org-details column gains an extra "ABN: <abn>" line, and
-      // its meta column gains a bold "Due: <date>" highlight line — same
-      // small headroom bump per extra line, same reasoning.
-      const hasAbnLine = ctx.docType === "invoice" && !!data.org_abn;
+      // The org-details column gains an extra "ABN: <abn>" line on EVERY doc
+      // type (wherever the org address/phone/email block renders — not just
+      // Tax Invoices). Invoice's meta column additionally gains a bold
+      // "Due: <date>" highlight line. Same small headroom bump per extra
+      // line, same reasoning.
+      const hasAbnLine = !!data.org_abn;
       const hasDueDateLine = ctx.docType === "invoice" && !!data.invoice_due_date;
       const extraLines = [hasExpiryLine, hasAbnLine, hasDueDateLine].filter(Boolean).length;
       return base + extraLines * 5;
@@ -839,9 +841,11 @@ function buildEntryFields(
       if (data.org_address) orgDetailParts.push(data.org_address);
       if (data.org_phone) orgDetailParts.push(data.org_phone);
       if (data.org_email) orgDetailParts.push(data.org_email);
-      // AU Tax Invoices must carry the org's ABN — invoice-only, placed
-      // under the address/email lines already above it.
-      if (docType === "invoice" && data.org_abn) orgDetailParts.push(`ABN: ${data.org_abn}`);
+      // Business registration id, shown wherever the org address/phone/email
+      // block renders — every doc type, not just Tax Invoices (AU Tax
+      // Invoices require it, but there's no reason to hide it elsewhere).
+      // Placed under the address/email lines already above it.
+      if (data.org_abn) orgDetailParts.push(`ABN: ${data.org_abn}`);
       if (data.org_website) orgDetailParts.push(data.org_website);
 
       // Quote expiry moves from its own bottom-of-document line into the

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -179,7 +179,7 @@ export interface DocumentData {
   org_address: string;
   org_website: string;
   /** Australian Business Number (or local equivalent). Rendered in the
-   *  header, under the org's address/email, on the invoice only. */
+   *  header, under the org's address/email, on every doc type. */
   org_abn: string;
   org_logo: string | null;
   org_icon: string | null;


### PR DESCRIPTION
## Summary

Follow-up to #1049. The org's ABN line was gated to the invoice doc type only. Per feedback, it should show anywhere the org address/phone/email header block renders — quote, packing-list, return-sheet, and delivery-docket now show it too when set, not just Tax Invoices.

- `document-composer.ts`: removed the `docType === "invoice"` gate from both the header render case (`buildEntryFields`) and the header height-estimate case (`estimateBlockHeight`) — the ABN line now renders/reserves height on every doc type.
- `build-document-data.ts`'s `org_abn` field was already doc-type-agnostic (computed unconditionally) — no change needed there, only the composer's rendering gate.
- Settings copy and FEATUREDOCS/13-pdfs.md updated to match ("every document type" instead of "invoice only").
- Tests updated: the two invoice-only ABN tests now assert the line renders (or is correctly omitted when unset) across all 5 project doc types.

## Testing

- `pnpm vitest run src/lib/pdfme/document-composer.test.ts src/lib/validations/org-settings.test.ts` — 77 passing.
- `pnpm exec tsc --noEmit` — no new type errors in touched files.

## Checklist

- [x] New dependency? N/A — no new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFqAq3RAbjxHSFXdvJAoAH)_