### PR TITLE
fix(pdfme): tighten header→details gap and GST→Total spacing

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -583,6 +583,43 @@ header prints once across a multi-page group" full-pipeline test (100-item
 single-category fixture spanning 3+ real composed pages, counts header draws
 across every page via `runTablePlugin`).
 
+### Header/totals spacing tightened — reserved height now tracks actual draw geometry (2026-07-31)
+
+**The gap between the header and the client/project details row was
+noticeably larger in `logo` mode than `icon` mode, for no visual reason.**
+`estimateBlockHeight`'s `header` case used flat per-mode constants (`25mm`,
+or `47mm` in `logo` mode, +5mm per extra meta/ABN/due-date line) regardless
+of how much the header actually draws. `gearflow-page-header.ts`'s `logo`
+mode reserves a fixed 50pt-tall logo row whether or not the org name is
+even shown underneath it (`showOrgNameOnDocuments` can be `false`), so a
+common real-world header (logo, org name hidden, 3-4 detail lines) left
+~20mm of dead whitespace before the details row — the reserved height
+assumed a taller org-name+details stack than the header actually drew.
+Fixed by measuring the header's real content instead of guessing at it:
+`estimateBlockHeight`'s `header` case now computes the left column (logo
+row if `mode === "logo"`, org name row if shown, one row per populated
+org-detail line — address/phone/email/ABN/website, mirroring
+`buildEntryFields`'s `orgDetailParts` exactly) and the right column (title
++ meta lines, +1 for a quote's Expiry line, + the invoice due-date
+highlight), reserving `Math.max(leftColumn, rightColumn, iconFloor) + 4mm`
+padding instead of a flat constant. Icon-mode headers (the common case) are
+essentially unchanged (~35mm either way for a typical org); logo-mode
+headers with the org name hidden shrink from ~57mm to ~44mm for the same
+data — the gap that was reported as "a decent gap from the page header to
+the content." `document-composer.test.ts`'s existing full-pipeline tests
+(none of which pinned a specific header height) still pass unmodified.
+
+**GST → Total spacing in the totals block trimmed slightly.** The Total
+row's divider clearance (see "Totals-divider redesign" above, 2026-07-28)
+was deliberately generous — 8pt before the line, 16pt after it — after an
+earlier 6pt/10pt pair visibly touched the bold "Total" text. Tightened to
+6pt/13pt: still 3pt above the known-bad 10pt on the side that actually
+touched (the space before the bold Total text), while trimming ~5pt
+(~1.8mm) of visible gap between the GST row and the Total row.
+`gearflow-financial-summary.test.ts`'s existing clearance assertions
+(divider strictly between the two rows' baselines, Total's real ascent
+still clear of the line) still pass unmodified.
+
 ### Quote-specific fixes (#790 Phase 4)
 
 - **No "/day" (or other period) price suffix on the quote or invoice.** `TablePluginConfig.hidePricingPeriodSuffix`

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -344,20 +344,43 @@ function wrappedLineCount(text: string, fonts: RichTextFonts): number {
 function estimateBlockHeight(block: LayoutBlock, data: DocumentData, ctx: LayoutContext): number {
   switch (block.kind) {
     case "header": {
+      // Measured against gearflow-page-header.ts's actual draw geometry
+      // (rather than flat per-mode constants) so the reservation tracks what
+      // gets drawn instead of padding every header with slack sized for the
+      // worst case — that slack was the visible gap above the details row.
       const mode = data.org_branding?.documentLogoMode ?? "icon";
-      const base = mode === "logo" ? 25 + 22 : 25;
-      // Quote's header meta gains a 3rd line ("Expiry: <date>") — a little
-      // extra headroom so it can't ever crowd the details row below it.
+      const showOrgName = (data.org_branding?.showOrgNameOnDocuments ?? true) && !!data.org_name;
+
+      // Org detail lines (address/phone/email/ABN/website), same fields and
+      // order as buildEntryFields' orgDetailParts below.
+      let orgDetailLines = 0;
+      if (data.org_address) orgDetailLines++;
+      if (data.org_phone) orgDetailLines++;
+      if (data.org_email) orgDetailLines++;
+      if (data.org_abn) orgDetailLines++;
+      if (data.org_website) orgDetailLines++;
+
+      // Left column: logo row (maxLogoH 50pt + 16pt clearance, logo mode
+      // only) + org name row (18pt + spacing, if shown) + 12pt per detail line.
+      const logoRowMm = mode === "logo" ? ptToMm(50 + 16) : 0;
+      const orgNameRowMm = showOrgName ? ptToMm(28) : 0;
+      const leftColumnMm = logoRowMm + orgNameRowMm + orgDetailLines * ptToMm(12);
+
+      // Right column: title (22pt) + 14pt clearance + 13pt per meta line
+      // (doc number + date, +expiry on quotes) + the bold "Due: <date>"
+      // highlight line on invoices.
       const hasExpiryLine = ctx.docType === "quote" && !!data.quote_valid_until;
-      // The org-details column gains an extra "ABN: <abn>" line on EVERY doc
-      // type (wherever the org address/phone/email block renders — not just
-      // Tax Invoices). Invoice's meta column additionally gains a bold
-      // "Due: <date>" highlight line. Same small headroom bump per extra
-      // line, same reasoning.
-      const hasAbnLine = !!data.org_abn;
       const hasDueDateLine = ctx.docType === "invoice" && !!data.invoice_due_date;
-      const extraLines = [hasExpiryLine, hasAbnLine, hasDueDateLine].filter(Boolean).length;
-      return base + extraLines * 5;
+      const metaLineCount = 2 + (hasExpiryLine ? 1 : 0);
+      const rightColumnMm = ptToMm(22 + 14 + metaLineCount * 13 + (hasDueDateLine ? 11 : 0));
+
+      // Icon mode's icon renders inline with the org name/details column
+      // (up to 40pt tall) rather than its own row — floor the column so a
+      // header with an icon but no org name/details still clears it.
+      const iconFloorMm = mode === "icon" ? ptToMm(40) : 0;
+
+      const PADDING_MM = 4; // breathing room below the taller column
+      return Math.max(leftColumnMm, rightColumnMm, iconFloorMm) + PADDING_MM;
     }
 
     case "detailsRow": {

--- a/src/lib/pdfme/plugins/gearflow-financial-summary.ts
+++ b/src/lib/pdfme/plugins/gearflow-financial-summary.ts
@@ -37,18 +37,18 @@ async function pdfRender(arg: PDFRenderProps<FinancialSummarySchema>) {
 
     if (opts?.divider) {
       // Draw the divider line clear of both the row above (space before)
-      // and this row's own bold, larger text (space after). Deliberately
-      // generous — a prior smaller gap (6pt/10pt) still visually touched
-      // the "Total" text on real renders, so this uses a wide safety
-      // margin instead of the tightest theoretically-sufficient value.
-      currentY -= 8;
+      // and this row's own bold, larger text (space after). A prior smaller
+      // gap (6pt/10pt) visually touched the "Total" text on real renders, so
+      // this keeps a safety margin above that rather than the tightest
+      // theoretically-sufficient value — just a narrower one than before.
+      currentY -= 6;
       page.drawLine({
         start: { x: blockX, y: currentY },
         end: { x: blockX + blockWidth, y: currentY },
         thickness: 1,
         color: docColor,
       });
-      currentY -= 16;
+      currentY -= 13;
     }
 
     // Label


### PR DESCRIPTION
## Summary

- The header block's reserved height used flat per-mode constants (`25mm`, or `47mm` in `logo` mode, +5mm per extra meta/ABN/due-date line) regardless of how much the header actually draws. In `logo` mode with the org name hidden underneath the logo (a real config), this reserved ~20mm more than the header's actual content needed, showing up as a visibly larger gap between the header and the client/project details row below it.
- `estimateBlockHeight`'s `header` case (`src/lib/pdfme/document-composer.ts`) now measures the header's real content — logo row, org-name row (if shown), one row per populated org-detail line (address/phone/email/ABN/website, mirroring `buildEntryFields`'s `orgDetailParts`), and the title/meta lines — instead of a flat constant. Icon-mode headers (the common case) are essentially unchanged; the reported logo-mode case drops from ~57mm to ~44mm reserved height.
- Trimmed the `Total` row's divider clearance in `gearflow-financial-summary.ts` from 8pt/16pt to 6pt/13pt — still comfortably above the 6pt/10pt pairing that previously caused the divider to visually touch the bold "Total" text, just a bit tighter, per the ask to shrink the GST → Total gap.

## Testing

- `pnpm vitest run src/lib/pdfme` — 178 tests pass (2 unrelated pre-existing failures from a missing generated Prisma client in this environment, unaffected by this change; verified by stashing the diff and reproducing the same failures on `main`).
- Reproduced the reported PDF's exact header/details positions by feeding equivalent `DocumentData` through `composeDocument` and comparing against the actual page-text coordinates extracted from the attached PDF — confirmed the ~20mm gap was reservation slack, not intentional spacing, before and after the fix.
- `pnpm exec eslint` on both touched files — no new errors (pre-existing complexity/line-count warnings only, unchanged in kind).
- `pnpm exec tsc --noEmit` — no new type errors.

## Checklist

- [x] New dependency? N/A — no new dependencies added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Du7nE2ixZnv45fowsBGxGy)_