### PR TITLE
Activity log: capture finance events and surface justifications

### DIFF
--- a/FEATUREDOCS/24-activity-log.md
+++ b/FEATUREDOCS/24-activity-log.md
@@ -1,6 +1,6 @@
 # Activity Log (Audit Trail)
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-07-23 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-07-31 (review quarterly — POLICY.md R-5.5)_
 
 ## Overview
 Tracks every significant write operation across all entities. Full audit
@@ -40,9 +40,61 @@ equivalent for them anymore.
 - Full-width table with filter bar: entity type, action, date range, search, CSV export.
 - Expandable rows show field changes ("field: old -> new").
 - Paginated, sortable by timestamp (newest first).
+- **Reason / Justification column** (`src/app/(app)/activity/page.tsx`): reads
+  `metadata.justification ?? metadata.reason` — the two names the codebase uses
+  for "why a caller had to type an explanation" (see below) — and renders it
+  next to the summary, truncated with a full-text tooltip. Em dash when absent.
 
 ## Entity Detail Integration
-**`ActivityTimeline`** component (`src/components/activity/activity-timeline.tsx`): Compact timeline for entity detail pages.
+**`ActivityTimeline`** component (`src/components/activity/activity-timeline.tsx`): Compact timeline for entity detail pages. Also renders the same
+`metadata.justification`/`metadata.reason` text as a "Reason: …" line under the
+summary when present.
+
+## Finance events (quotes, invoices, Xero, project locks)
+
+Every quote/invoice lifecycle mutation and the Xero push already wrote an audit
+row before this section existed; what changed (2026-07-31) is that each now
+uses a **specific `action` string** instead of a generic `CREATE`/`UPDATE`/`DELETE`,
+so the log is filterable/labelable per verb. `action` is still free-form text
+(no schema enum) — see `src/app/(app)/activity/page.tsx`'s `actionLabels` dict
+for the display label of every value below; add a new entry there whenever a
+finance mutation gains a new action string.
+
+**Quotes** (`convex/quotesWrites.ts`, `entityType: "quote"`):
+`QUOTE_CREATED` (new draft / new version / reprice-from-revision), `QUOTE_SENT`,
+`QUOTE_RECALLED` (reason in `metadata.reason`), `QUOTE_DELETED` (draft delete or
+recall-then-delete), `QUOTE_ACCEPTED`, `QUOTE_DECLINED` (reason in
+`metadata.reason`), `QUOTE_UNACCEPTED`, `QUOTE_PROTECTED`/`QUOTE_UNPROTECTED`,
+`QUOTE_CORRECTED`. The PDF-store step (`generateQuoteArtifact`,
+`src/server/finance-documents.ts`) separately logs `QUOTE_DOCUMENT_STORED` —
+this fires right after `QUOTE_SENT` but is a distinct row (rendering/storage
+succeeding is not the same event as the send itself).
+
+**Invoices** (`convex/invoicesWrites.ts`, `entityType: "invoice"`):
+`INVOICE_CREATED`, `INVOICE_ISSUED`, `INVOICE_VOIDED` (reason in
+`metadata.reason` — there is no separate "recall" verb for invoices, since an
+issued invoice is immutable; void is the un-issue action, see FEATUREDOCS/66),
+`INVOICE_DELETED` (draft only), `INVOICE_CREDIT_CREATED`. PDF storage
+(`generateInvoiceArtifact`) logs `INVOICE_DOCUMENT_STORED`.
+
+**Xero sync** (`convex/xeroPush.ts`'s `logXeroPushActivity`, called from
+`src/server/xero.ts`'s `pushInvoiceToXero()`): `INVOICE_XERO_SYNCED` on success
+(summary distinguishes first push vs. re-push/update), `INVOICE_XERO_SYNC_FAILED`
+on failure (`summary` carries the error detail). Separate from `xeroSyncLogs`
+(`convex/xeroSyncLogs.ts`), a narrower Xero-specific sync log not shown on
+`/activity` — this row is the general-audience audit entry.
+
+**Project lock/unlock** (`entityType: "project"`): opening/closing an unlock
+session is already its own explicit action —
+`UNLOCK_OPENED`/`UNLOCK_COMMITTED`/`UNLOCK_DISCARDED`/`UNLOCK_AUTO_COMMITTED`
+(`convex/projectUnlockSessionsWrites.ts`, justification in `metadata.justification`).
+Entering a locked tier has no separate action of its own — it's a normal
+`STATUS_CHANGE` (`convex/projectWrites.ts`'s `updateStatusNative`) — but that
+row is enriched whenever the transition crosses a lock-tier boundary
+(`lockTierForStatus`/`LOCK_TIER_RANK` in `convex/lib/projectLocks.ts`): the
+summary gets a `— project locked (TIER)` / `— project unlocked (TIER)` suffix,
+and `metadata.lockTierFrom`/`lockTierTo` are stamped for anyone querying the
+log programmatically. See FEATUREDOCS/62 for the tier table itself.
 
 ## Sidebar & Navigation
 - Sidebar: "Activity Log" with `ScrollText` icon, gated by `reports` read permission.

--- a/FEATUREDOCS/62-project-lifecycle-locks.md
+++ b/FEATUREDOCS/62-project-lifecycle-locks.md
@@ -19,7 +19,21 @@ status → tier boundary is defined. Every gate site across
 `projectCategoriesWrites.ts`/`projectServicesWrites.ts`/`crewAssignmentsWrites.ts`
 imports it (directly or via `assertLifecycleGuard`) rather than re-deriving the
 boundary — a second hand-maintained copy would be a defect even in sync
-(POLICY.md R-3.1).
+(POLICY.md R-3.1). The same module exports `LOCK_TIER_RANK`, an ordering of the
+four tiers — the single place that answers "did this transition make the
+project MORE or LESS locked" — consumed by `updateStatusNative`'s activity-log
+write (below) so a second hand-maintained ordering doesn't grow elsewhere.
+
+**Activity log visibility.** Opening/closing an unlock session is its own
+explicit `activityLogs` action (`UNLOCK_OPENED`/`UNLOCK_COMMITTED`/
+`UNLOCK_DISCARDED`/`UNLOCK_AUTO_COMMITTED`, justification in
+`metadata.justification` — see below). Entering or leaving a lock tier via an
+ordinary status change has no action of its own — it's a `STATUS_CHANGE`
+(`convex/projectWrites.ts`'s `updateStatusNative`) — but that row is enriched
+whenever `lockTierForStatus(from) !== lockTierForStatus(to)`: the summary gets
+a `— project locked (TIER)` / `— project unlocked (TIER)` suffix, and
+`metadata.lockTierFrom`/`lockTierTo` are stamped for programmatic queries. See
+FEATUREDOCS/24's "Finance events" section.
 
 | Statuses | Tier | What's gated |
 |---|---|---|

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -180,10 +180,21 @@ standing precedent).
 | **Accept** (`markAcceptedNative`) | `SENT → ACCEPTED` + acceptance date + optional reference (PO number, email subject). An `EXPIRED` revision cannot be accepted without an explicit re-send. Unblocks `CONFIRMED`. |
 | **Decline** (`markDeclinedNative`) | `SENT`/`EXPIRED` → `DECLINED` + bounded reason. Offers `CANCELLED`, never forces it. |
 
-All five take the standard 4-guard browser-direct shape (FEATUREDOCS/54) plus
-org-checked reference loads and `writeActivityLog`. `sendNative` and
-`newVersionNative` keep `assertLifecycleGuard(…, { kind: "financial" })`, so a
-hard-locked project can't emit a quote out of band.
+All five (and the Delete/Protect follow-ups below) take the standard 4-guard
+browser-direct shape (FEATUREDOCS/54) plus org-checked reference loads and
+`writeActivityLog`. `sendNative` and `newVersionNative` keep
+`assertLifecycleGuard(…, { kind: "financial" })`, so a hard-locked project
+can't emit a quote out of band.
+
+**Every verb writes its own `action` string** (`QUOTE_CREATED`/`QUOTE_SENT`/
+`QUOTE_RECALLED`/`QUOTE_DELETED`/`QUOTE_ACCEPTED`/`QUOTE_DECLINED`/
+`QUOTE_UNACCEPTED`/`QUOTE_PROTECTED`/`QUOTE_UNPROTECTED`/`QUOTE_CORRECTED`, plus
+`QUOTE_DOCUMENT_STORED` for the PDF-store step) rather than a generic
+`CREATE`/`UPDATE`/`DELETE` — see FEATUREDOCS/24's "Finance events" section for
+the full vocabulary shared with invoices/Xero/project locks, and
+`src/app/(app)/activity/page.tsx`'s `actionLabels` for the UI label of each.
+Recall/Decline's bounded reason is stored in `metadata.reason`, read back by
+the activity log's Reason/Justification column.
 
 **"Send" does not email anyone.** Flow records the send, freezes pricing and
 (Phase B, #987) stores the PDF for the user to attach to their own mail. The UI
@@ -930,7 +941,10 @@ once `xeroSyncStatus === "SYNCED"`; the toast reads "Updated in Xero" vs.
 "Pushed to Xero" from that same flag. `logXeroPushActivity`
 (`convex/xeroPush.ts`) takes the same `updated` flag so the activity feed
 reads correctly either way, not just "Pushed ... as a draft invoice" on
-every re-push.
+every re-push. The `activityLogs` row's `action` is `INVOICE_XERO_SYNCED` on
+success or `INVOICE_XERO_SYNC_FAILED` on a caught failure (`metadata.detail`
+carries the error) — distinct from the narrower, Xero-specific `xeroSyncLogs`
+row (below), which isn't shown on `/activity`.
 
 Coding re-resolves on every push, not just the first — `resolveCodingForInvoice`
 runs unconditionally, so a corrected category/model account or tax-type

--- a/convex/invoicesWrites.ts
+++ b/convex/invoicesWrites.ts
@@ -202,7 +202,7 @@ export const createNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: fields.organizationId,
-      action: "CREATE",
+      action: "INVOICE_CREATED",
       entityType: "invoice",
       entityId: fields.id,
       entityName: `${fields.kind} invoice — ${project.name}`,
@@ -287,7 +287,7 @@ export const issueNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
-      action: "UPDATE",
+      action: "INVOICE_ISSUED",
       entityType: "invoice",
       entityId: id,
       entityName: invoiceNumber,
@@ -357,13 +357,14 @@ export const voidNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
-      action: "UPDATE",
+      action: "INVOICE_VOIDED",
       entityType: "invoice",
       entityId: id,
       entityName: doc.invoiceNumber ?? id,
       userId: actor.userId,
       userName: actor.userName,
-      summary: `Voided invoice ${doc.invoiceNumber ?? id}: ${reason}`,
+      summary: `Voided invoice ${doc.invoiceNumber ?? id}`,
+      metadata: { reason },
       projectId: doc.projectId,
       createdAt: now,
     });
@@ -395,7 +396,7 @@ export const deleteDraftNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
-      action: "DELETE",
+      action: "INVOICE_DELETED",
       entityType: "invoice",
       entityId: id,
       entityName: `${doc.kind} invoice draft`,
@@ -472,7 +473,7 @@ export const createCreditNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
-      action: "CREATE",
+      action: "INVOICE_CREDIT_CREATED",
       entityType: "invoice",
       entityId: id,
       entityName: `Credit for ${original.invoiceNumber ?? creditForInvoiceId}`,

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -52,6 +52,17 @@ export function lockTierForStatus(status: string | null | undefined): LockTier {
   return TIER_BY_STATUS[status] ?? "OPEN";
 }
 
+/** Restrictiveness order of the four tiers — the single place that answers
+ *  "did this transition make the project MORE or LESS locked", so callers
+ *  (e.g. `projectWrites.updateStatusNative`'s activity-log summary) don't grow
+ *  a second hand-maintained ordering of `LockTier` (R-3.1). */
+export const LOCK_TIER_RANK: Record<LockTier, number> = {
+  OPEN: 0,
+  FINANCE_LOCKED: 1,
+  JUSTIFY: 2,
+  HARD_LOCKED: 3,
+};
+
 export function isConfirmedOrLater(status: string | null | undefined): boolean {
   return lockTierForStatus(status) !== "OPEN";
 }

--- a/convex/projectWrites.test.ts
+++ b/convex/projectWrites.test.ts
@@ -215,7 +215,11 @@ describe("projectWrites.updateStatusNative — acceptance gate on CONFIRMED (#98
       const p = await ctx.db.query("projects").withIndex("by_cuid", (q) => q.eq("id", "p1")).first();
       expect(p?.status).toBe("CONFIRMED");
       const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
-      expect(log?.metadata).toEqual({ justification: "Client confirmed verbally on site; PO to follow." });
+      expect(log?.metadata).toEqual({
+        lockTierFrom: "OPEN",
+        lockTierTo: "FINANCE_LOCKED",
+        justification: "Client confirmed verbally on site; PO to follow.",
+      });
     });
   });
 
@@ -329,6 +333,8 @@ describe("projectWrites.updateStatusNative — hard-lock revert (#792)", () => {
       expect(p?.status).toBe("QUOTING");
       const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
       expect(log?.metadata).toEqual({
+        lockTierFrom: "HARD_LOCKED",
+        lockTierTo: "OPEN",
         justification: "Client asked us to redo the whole quote from scratch.",
         justificationSource: "manual",
       });
@@ -345,6 +351,8 @@ describe("projectWrites.updateStatusNative — hard-lock revert (#792)", () => {
       expect(p?.status).toBe("QUOTING");
       const log = await ctx.db.query("activityLogs").withIndex("by_cuid", (q) => q.eq("id", "log1")).first();
       expect(log?.metadata).toEqual({
+        lockTierFrom: "HARD_LOCKED",
+        lockTierTo: "OPEN",
         justification: "Client requested a correction after the invoice was voided.",
         justificationSource: "unlock_session",
       });

--- a/convex/projectWrites.ts
+++ b/convex/projectWrites.ts
@@ -24,6 +24,8 @@ import {
   isRevertOutOfHardLock,
   lifecycleAuditMetadata,
   LOCKED_PROJECT_FIELDS,
+  lockTierForStatus,
+  LOCK_TIER_RANK,
   requireHardLockOverrideAllowed,
   requireJustification,
 } from "./lib/projectLocks";
@@ -232,6 +234,21 @@ export const updateStatusNative = mutation({
       await autoCommitOpenSession(ctx, orgId, id, project.projectNumber, actor, now);
     }
 
+    // Locking itself has no dedicated status-change verb (unlocking does — see
+    // the explicit UNLOCK_OPENED/COMMITTED/DISCARDED actions in
+    // projectUnlockSessionsWrites.ts) — a status move can cross a lock-tier
+    // boundary in either direction, so stamp that onto THIS row rather than
+    // inventing a second action a caller would have to also watch for.
+    const fromTier = lockTierForStatus(from);
+    const toTier = lockTierForStatus(status);
+    const tierDelta = LOCK_TIER_RANK[toTier] - LOCK_TIER_RANK[fromTier];
+    const lockTierSuffix =
+      tierDelta > 0
+        ? ` — project locked (${toTier})`
+        : tierDelta < 0
+          ? ` — project unlocked (${toTier})`
+          : "";
+
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId: orgId,
@@ -241,18 +258,21 @@ export const updateStatusNative = mutation({
       entityName: project.projectNumber,
       userId: actor.userId,
       userName: actor.userName,
-      summary: `Changed project ${project.projectNumber} status from ${from} to ${status}`,
+      summary: `Changed project ${project.projectNumber} status from ${from} to ${status}${lockTierSuffix}`,
       details: { changes: [{ field: "status", from, to: status }] },
-      metadata: revertJustification
-        ? {
-            justification: revertJustification,
-            // Distinguishes "typed a fresh reason" from "an already-open FULL
-            // unlock session covered it" in the audit trail (#792 unification).
-            justificationSource: justification?.trim() ? "manual" : "unlock_session",
-          }
-        : justification?.trim()
-          ? { justification: justification.trim() } // CONFIRMED-without-quote gate path, unchanged
-          : undefined,
+      metadata: {
+        ...(tierDelta !== 0 ? { lockTierFrom: fromTier, lockTierTo: toTier } : {}),
+        ...(revertJustification
+          ? {
+              justification: revertJustification,
+              // Distinguishes "typed a fresh reason" from "an already-open FULL
+              // unlock session covered it" in the audit trail (#792 unification).
+              justificationSource: justification?.trim() ? "manual" : "unlock_session",
+            }
+          : justification?.trim()
+            ? { justification: justification.trim() } // CONFIRMED-without-quote gate path, unchanged
+            : {}),
+      },
       projectId: id,
       createdAt: now,
     });

--- a/convex/quotesWrites.ts
+++ b/convex/quotesWrites.ts
@@ -347,7 +347,7 @@ export const sendNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_SENT",
       entityType: "quote",
       entityId: quoteId,
       entityName: label,
@@ -442,7 +442,7 @@ export const recallNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_RECALLED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -536,7 +536,7 @@ export const newVersionNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "CREATE",
+      action: "QUOTE_CREATED",
       entityType: "quote",
       entityId: id,
       entityName: label,
@@ -648,7 +648,7 @@ export const deleteDraftNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "DELETE",
+      action: "QUOTE_DELETED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -717,7 +717,7 @@ export const deleteRecalledNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "DELETE",
+      action: "QUOTE_DELETED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -866,7 +866,7 @@ export const repriceFromRevisionNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "CREATE",
+      action: "QUOTE_CREATED",
       entityType: "quote",
       entityId: id,
       entityName: label,
@@ -930,7 +930,7 @@ export const markAcceptedNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_ACCEPTED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -987,7 +987,7 @@ export const markDeclinedNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_DECLINED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -1054,7 +1054,7 @@ export const unacceptNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_UNACCEPTED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -1112,7 +1112,7 @@ export const setQuoteProtectedNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: protect ? "QUOTE_PROTECTED" : "QUOTE_UNPROTECTED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,
@@ -1209,7 +1209,7 @@ export const correctQuoteNative = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: "QUOTE_CORRECTED",
       entityType: "quote",
       entityId: quote.id,
       entityName: label,

--- a/convex/xeroPush.ts
+++ b/convex/xeroPush.ts
@@ -260,7 +260,7 @@ export const logXeroPushActivity = mutation({
     await writeActivityLog(ctx, {
       id: auditId,
       organizationId,
-      action: "UPDATE",
+      action: success ? "INVOICE_XERO_SYNCED" : "INVOICE_XERO_SYNC_FAILED",
       entityType: "invoice",
       entityId: invoiceId,
       entityName: invoiceLabel,
@@ -271,6 +271,7 @@ export const logXeroPushActivity = mutation({
           ? `Updated ${invoiceLabel} in Xero`
           : `Pushed ${invoiceLabel} to Xero as a draft invoice`
         : `Xero push failed for ${invoiceLabel}${detail ? `: ${detail}` : ""}`,
+      metadata: !success && detail ? { detail } : undefined,
       createdAt: now,
     });
   },

--- a/src/app/(app)/activity/page.tsx
+++ b/src/app/(app)/activity/page.tsx
@@ -34,6 +34,8 @@ const entityTypeLabels: Record<string, string> = {
   member: "Member",
   invitation: "Invitation",
   settings: "Settings",
+  quote: "Quote",
+  invoice: "Invoice",
 };
 
 const actionLabels: Record<string, string> = {
@@ -48,10 +50,48 @@ const actionLabels: Record<string, string> = {
   EXPORT: "Export",
   IMPORT: "Import",
   INVITE: "Invite",
+  // Finance — quotes (convex/quotesWrites.ts / src/server/finance-documents.ts)
+  QUOTE_CREATED: "Quote Created",
+  QUOTE_SENT: "Quote Sent",
+  QUOTE_RECALLED: "Quote Recalled",
+  QUOTE_DELETED: "Quote Deleted",
+  QUOTE_ACCEPTED: "Quote Accepted",
+  QUOTE_DECLINED: "Quote Declined",
+  QUOTE_UNACCEPTED: "Quote Unaccepted",
+  QUOTE_PROTECTED: "Quote Protected",
+  QUOTE_UNPROTECTED: "Quote Unprotected",
+  QUOTE_CORRECTED: "Quote Corrected",
+  QUOTE_DOCUMENT_STORED: "Quote PDF Stored",
+  // Finance — invoices (convex/invoicesWrites.ts / convex/xeroPush.ts)
+  INVOICE_CREATED: "Invoice Created",
+  INVOICE_ISSUED: "Invoice Issued",
+  INVOICE_VOIDED: "Invoice Voided",
+  INVOICE_DELETED: "Invoice Deleted",
+  INVOICE_CREDIT_CREATED: "Credit Invoice Created",
+  INVOICE_DOCUMENT_STORED: "Invoice PDF Stored",
+  INVOICE_XERO_SYNCED: "Synced to Xero",
+  INVOICE_XERO_SYNC_FAILED: "Xero Sync Failed",
+  // Project lock/unlock (convex/projectUnlockSessionsWrites.ts — locking itself
+  // rides on STATUS_CHANGE, see the lockTierFrom/lockTierTo metadata note below)
+  UNLOCK_OPENED: "Unlock Opened",
+  UNLOCK_COMMITTED: "Unlock Saved & Relocked",
+  UNLOCK_DISCARDED: "Unlock Discarded",
+  UNLOCK_AUTO_COMMITTED: "Unlock Auto-Closed",
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyLog = Record<string, any>;
+
+/** `metadata.justification` (lock-tier gates, unlock sessions) and
+ *  `metadata.reason` (quote recall/decline, invoice void) are two names for the
+ *  same "why" a finance/lifecycle action needed a typed explanation — surfaced
+ *  under one label here rather than adding a second column. */
+function justificationOf(row: AnyLog): string | undefined {
+  const metadata = row.metadata;
+  if (typeof metadata !== "object" || metadata === null) return undefined;
+  const value = (metadata as Record<string, unknown>).justification ?? (metadata as Record<string, unknown>).reason;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
 
 /** Read-side of `writeActivityLog`'s agent stamp (`convex/lib/audit.ts`) — mirrors
  *  `convex/activityLog.ts`'s `isAgentAuthored` (Phase 4, #1000, decision 1), kept
@@ -147,6 +187,23 @@ function useActivityColumns(): ColumnDef<AnyLog>[] {
       cell: (row) => (
         <span className="text-sm max-w-[300px] truncate block">{row.summary}</span>
       ),
+    },
+    {
+      id: "justification",
+      header: "Reason / Justification",
+      sortable: false,
+      responsiveHide: "lg",
+      mobile: "meta",
+      cell: (row) => {
+        const value = justificationOf(row);
+        return value ? (
+          <span className="text-sm text-fg-3 max-w-[240px] truncate block" title={value}>
+            {value}
+          </span>
+        ) : (
+          <span className="text-sm text-fg-3">—</span>
+        );
+      },
     },
   ];
 }

--- a/src/components/activity/activity-timeline.tsx
+++ b/src/components/activity/activity-timeline.tsx
@@ -49,6 +49,12 @@ export function ActivityTimeline({ entityType, entityId, limit = 5 }: ActivityTi
         const action = log.action as string;
         const details = log.details as Record<string, unknown> | null;
         const changes = details?.changes as Array<{ field: string; from: unknown; to: unknown; fromLabel?: string; toLabel?: string }> | undefined;
+        // `metadata.justification` (lock-tier gates, unlock sessions) and
+        // `metadata.reason` (quote recall/decline, invoice void) are the same
+        // "why" a finance/lifecycle action needed a typed explanation.
+        const metadata = log.metadata as Record<string, unknown> | null;
+        const justificationRaw = metadata?.justification ?? metadata?.reason;
+        const justification = typeof justificationRaw === "string" && justificationRaw.trim() ? justificationRaw : undefined;
 
         return (
           <div key={log.id as string} className="flex gap-3 text-sm">
@@ -78,6 +84,11 @@ export function ActivityTimeline({ entityType, entityId, limit = 5 }: ActivityTi
                     </p>
                   ))}
                 </div>
+              )}
+              {justification && (
+                <p className="mt-1 text-xs text-fg-3">
+                  <span className="font-medium">Reason:</span> {justification}
+                </p>
               )}
             </div>
           </div>

--- a/src/server/finance-documents.ts
+++ b/src/server/finance-documents.ts
@@ -98,7 +98,7 @@ export async function generateQuoteArtifact(quoteId: string): Promise<ArtifactRe
 
   await logActivity({
     organizationId,
-    action: "CREATE",
+    action: "QUOTE_DOCUMENT_STORED",
     entityType: "quote",
     entityId: quote.quoteId,
     entityName: quote.label,
@@ -162,7 +162,7 @@ export async function generateInvoiceArtifact(invoiceId: string): Promise<Artifa
 
   await logActivity({
     organizationId,
-    action: "CREATE",
+    action: "INVOICE_DOCUMENT_STORED",
     entityType: "invoice",
     entityId: invoice.invoiceId,
     entityName: invoice.invoiceNumber ?? invoice.invoiceId,


### PR DESCRIPTION
## Summary

Most quote/invoice/Xero/project-lock mutations already wrote an activity-log row, but they were invisible as a *category*: everything logged a generic `CREATE`/`UPDATE`/`DELETE`, `quote`/`invoice` weren't in the UI's entity-type filter, and — the main gap — justification/reason text was captured in `metadata` but never rendered anywhere in the activity log UI.

- **Quotes** (`convex/quotesWrites.ts`): each verb now writes its own action — `QUOTE_CREATED`, `QUOTE_SENT`, `QUOTE_RECALLED`, `QUOTE_DELETED`, `QUOTE_ACCEPTED`, `QUOTE_DECLINED`, `QUOTE_UNACCEPTED`, `QUOTE_PROTECTED`/`UNPROTECTED`, `QUOTE_CORRECTED`, plus `QUOTE_DOCUMENT_STORED` for the PDF-store step.
- **Invoices** (`convex/invoicesWrites.ts`, `convex/xeroPush.ts`): `INVOICE_CREATED`, `INVOICE_ISSUED`, `INVOICE_VOIDED`, `INVOICE_DELETED`, `INVOICE_CREDIT_CREATED`, `INVOICE_DOCUMENT_STORED`, `INVOICE_XERO_SYNCED`/`SYNC_FAILED`. Void's reason now also lands in `metadata.reason` (previously only baked into the summary string), matching how quote recall/decline already work.
- **Project lock/unlock**: unlock sessions already had explicit `UNLOCK_OPENED`/`COMMITTED`/`DISCARDED`/`AUTO_COMMITTED` actions with justification in `metadata`. Added `LOCK_TIER_RANK` to `convex/lib/projectLocks.ts` so `updateStatusNative` can detect when an ordinary status change crosses a lock-tier boundary — the `STATUS_CHANGE` row's summary now gets a `— project locked (TIER)` / `— project unlocked (TIER)` suffix, and `metadata.lockTierFrom`/`lockTierTo` are stamped.
- **Activity log UI**: added `quote`/`invoice` to the entity-type filter, labels for every new (and previously-unlabeled `UNLOCK_*`) action, and a new **Reason / Justification column** reading `metadata.justification ?? metadata.reason` — the two names the codebase uses for the same "why" text. `ActivityTimeline` (per-entity compact view) renders the same text under the summary line.
- **Docs**: updated FEATUREDOCS/24 (activity log), 62 (project lifecycle locks), 66 (finance/Xero) per the repo's docs-in-same-PR rule.

`action` stays a free-form string (no schema enum), consistent with the existing convention.

## Testing

- `pnpm exec vitest run convex/quotesWrites.test.ts convex/invoicesWrites.test.ts convex/projectWrites.test.ts convex/xeroPush.test.ts convex/activityLog.test.ts convex/writeParity.test.ts convex/projectLifecycleLocks.test.ts` — 236/236 passed. Updated 3 pre-existing `metadata` `toEqual` assertions in `projectWrites.test.ts` that now also see the new `lockTierFrom`/`lockTierTo` fields on a tier-crossing status change.
- `pnpm exec tsc --noEmit` — clean on every file touched by this PR (remaining repo-wide errors are pre-existing, from a missing generated Prisma client in this sandbox — unrelated to this change).
- `pnpm exec eslint` on all touched files — 0 errors (only pre-existing complexity/length warnings on functions this PR didn't restructure).
- Could not run `pnpm exec convex dev --once` against the real shared dev deployment in this sandbox (no `CONVEX_DEPLOY_KEY`/`DATABASE_URL` configured here) — Convex functions will deploy normally via CI on merge or a dev's local `convex dev`.

## Checklist

- [x] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3) — N/A, no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_019e1oAhcGJFchBj67R526nP)_