### PR TITLE
Fix equipment drag-and-drop: whole-row grab, mobile sensor conflict, overlay tracking

### DIFF
--- a/FEATUREDOCS/10-projects.md
+++ b/FEATUREDOCS/10-projects.md
@@ -609,9 +609,11 @@ HERO CARD (rounded-[--r-lg] border-2 bg-card, full width):
   category's mixed project+sub-hire group list; each group's/category's/
   Uncategorized's line items), not one flat context — `handleDragEnd`
   dispatches on the dragged sortable id's `cat-`/`grp-`/`shg-`/`li-` prefix
-  to one of three pure resolver functions. Long-press (mobile `TouchSensor`)
-  and keyboard (`KeyboardSensor`) both work; drag handles are gated on
-  `project:manage_line_items` and hidden at `HARD_LOCKED`. See
+  to one of three pure resolver functions. No dedicated handle — press and
+  hold anywhere on the row (one `PointerSensor` with a `{delay: 200,
+  tolerance: 8}` activation constraint covers mouse, touch/long-press, AND
+  pen alike); `KeyboardSensor` covers keyboard reordering. Dragging is gated
+  on `project:manage_line_items` and disabled at `HARD_LOCKED`. See
   [47-cross-type-equipment-unification.md](./47-cross-type-equipment-unification.md#reordering-drag-and-drop)
   for the full architecture.
 - Inline "Add Group" button in toolbar with template picker

--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -112,10 +112,15 @@ Reordering is real **drag-and-drop** again (`@dnd-kit`, re-added after the
 `chore/remove-pdf-builder-and-dnd` removal) — see
 [Reordering](#reordering-drag-and-drop) below. Each row takes
 `dragHandleRef`/`dragAttributes`/`dragListeners`/`isDragDisabled`
-(`DragHandleControls`, `equipment-rows.tsx`); the shared `DragHandle` helper
-renders a `GripVertical` grab handle and renders nothing when
-`isDragDisabled`. The `cat-`/`grp-`/`shg-`/`li-` id prefixes referenced below
-are real `useSortable()` ids, not just historical scope labels.
+(`DragHandleControls`, `equipment-rows.tsx`), spread onto the row's/card's
+ROOT element — there is no dedicated grab handle. Pressing and holding
+anywhere on the row starts the drag; a delay-based sensor activation
+constraint (not a drag-handle button) is what lets a normal click/tap on the
+row's own buttons/checkboxes/inputs still work. `useSortable({disabled: true})`
+already makes `listeners` a no-op, so a row with `isDragDisabled` simply never
+activates a drag — no separate handle-hiding logic needed. The
+`cat-`/`grp-`/`shg-`/`li-` id prefixes referenced below are real
+`useSortable()` ids, not just historical scope labels.
 
 - **`CategoryRow`** — ProjectCategory header. Kebab:
   Add Equipment / Add Kit / Add Custom Item / Rename / Delete. The three
@@ -375,7 +380,21 @@ tracking, a per-row-kind optimistic `sortOrder`/placement overlay applied to
 the `equipmentTab.bundle` bundle BEFORE reconstruction (so a drop updates
 instantly, cleared once the real write settles), and the justified-mutation
 wrappers (`useJustifiedMutation` — #990's justify-tier prompt) that fire the
-real reorder/move mutations. A single `DndContext` in
+real reorder/move mutations.
+
+Sensors are ONE `PointerSensor` (not `PointerSensor`+`TouchSensor` — Pointer
+Events fire for both mouse and touch, so the two used to race for the same
+gesture, with `PointerSensor`'s old distance-based constraint winning almost
+instantly on touch and hijacking the long-press) with a single
+`{delay: 200, tolerance: 8}` activation constraint covering mouse/touch/pen
+uniformly, plus `KeyboardSensor` for accessibility. There is no dedicated drag
+handle — every row's `useSortable()` ref/listeners are spread onto the
+row's/card's own root element, so pressing and holding ANYWHERE on the row
+starts the drag; the delay is what lets a quick tap on a nested
+button/checkbox/input still work normally instead of a separate handle button
+being the only pointer-capture target.
+
+A single `DndContext` in
 [`src/components/projects/equipment-tab.tsx`](../src/components/projects/equipment-tab.tsx)
 wraps the whole tree; `handleDragEnd` dispatches on the active sortable id's
 prefix to one of three pure, unit-tested decision functions:

--- a/src/components/projects/__tests__/equipment-row-drag-interaction.test.tsx
+++ b/src/components/projects/__tests__/equipment-row-drag-interaction.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+/**
+ * Regression coverage for the whole-row drag fix (no dedicated handle — the
+ * row's/card's own root now carries dnd-kit's `useSortable()` ref/attributes/
+ * listeners; see equipment-rows.tsx's `DragHandleControls` doc comment).
+ *
+ * This does NOT (and cannot, in jsdom) verify that holding the row actually
+ * starts a drag — dnd-kit's `PointerSensor` activation pipeline isn't
+ * reliably triggerable via synthetic `PointerEvent`s outside a real browser
+ * (confirmed by hand: even a minimal bare-bones `useSortable` div wired up
+ * exactly like dnd-kit's own docs never reaches its delay-based `setTimeout`
+ * under `fireEvent.pointerDown` + fake timers here) — that gesture is
+ * `/qa`/manual-browser territory, same as every other pointer/touch timing
+ * question in this feature (see FEATUREDOCS/47's "Manual/browser QA
+ * required" note).
+ *
+ * What IS verifiable, and is the actual regression this guards: mounting a
+ * REAL `DndContext`/`useSortable` around `LineItemRow` and spreading its ref/
+ * attributes/listeners onto the row root (not a separate handle) must not
+ * break the row's own nested interactive controls — the checkbox, the
+ * caller's row-level `onClick` (desktop multi-select), and the kebab menu
+ * still need to fire/open normally.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { SortableContext, useSortable } from "@dnd-kit/sortable";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/hooks/use-authed-query", () => ({ useAuthedQuery: () => undefined }));
+vi.mock("@/hooks/use-collaboration-writes", () => ({
+  useCollaborationWrites: () => ({ setReviewMarker: vi.fn(async () => {}) }),
+}));
+vi.mock("@/server/warehouse", () => ({ getScanLog: vi.fn(async () => ({ logs: [] })) }));
+
+import { LineItemRow, type LineItemData } from "../equipment-rows";
+
+const baseItem: LineItemData = {
+  id: "li1",
+  modelId: "m1",
+  description: null,
+  quantity: 2,
+  unitPrice: 100,
+  lineTotal: 200,
+  model: { name: "Shure QLXD Receiver" },
+};
+
+// Same sensor shape as use-equipment-dnd.ts's production setup (a
+// delay/tolerance PointerSensor, not a distance-based one) — see that file's
+// sensor-setup comment for why (PointerSensor+TouchSensor used to race and
+// break touch entirely).
+function Harness({
+  onSelectChange,
+  onClick,
+}: {
+  onSelectChange: (checked: boolean, shiftKey: boolean) => void;
+  onClick?: (e: React.MouseEvent) => void;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+  );
+  const { setNodeRef, attributes, listeners } = useSortable({ id: "li-li1" });
+  return (
+    <DndContext sensors={sensors}>
+      <SortableContext items={["li-li1"]}>
+        <table>
+          <tbody>
+            <LineItemRow
+              item={baseItem}
+              indent=""
+              selectable
+              isSelected={false}
+              onSelectChange={onSelectChange}
+              onEdit={vi.fn()}
+              onMoveToCategory={vi.fn()}
+              onMoveToGroup={vi.fn()}
+              onRemove={vi.fn()}
+              onClick={onClick}
+              dragHandleRef={setNodeRef}
+              dragAttributes={attributes as unknown as Record<string, unknown>}
+              dragListeners={listeners as unknown as Record<string, unknown>}
+            />
+          </tbody>
+        </table>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+describe("whole-row drag wiring doesn't break nested row controls", () => {
+  it("the row root carries dnd-kit's sortable attributes (no separate handle)", () => {
+    const { container } = render(<Harness onSelectChange={vi.fn()} />);
+    const row = container.querySelector("tr")!;
+    expect(row.getAttribute("aria-roledescription")).toBe("sortable");
+    expect(row.getAttribute("tabindex")).toBe("0");
+    // The dedicated GripVertical handle button is gone — dragging is a
+    // property of the row itself now, not a separate small button.
+    expect(screen.queryByLabelText("Reorder")).toBeNull();
+  });
+
+  it("a click on the checkbox still toggles selection", () => {
+    const onSelectChange = vi.fn();
+    render(<Harness onSelectChange={onSelectChange} />);
+    const checkbox = screen.getByLabelText("Select item");
+    fireEvent.click(checkbox);
+    expect(onSelectChange).toHaveBeenCalledWith(true, expect.any(Boolean));
+  });
+
+  it("a click on the row's own onClick (desktop multi-select) still fires, even though the row root also carries dnd-kit's listeners", () => {
+    const onClick = vi.fn();
+    const { container } = render(<Harness onSelectChange={vi.fn()} onClick={onClick} />);
+    const row = container.querySelector("tr")!;
+    fireEvent.click(row);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("the kebab menu button still opens (not swallowed by the row's drag listeners)", () => {
+    // Selected by `aria-haspopup` (the DropdownMenuTrigger) rather than an
+    // accessible-name query — same ambiguity risk noted above applies to
+    // getByRole name matching once the row itself carries role="button".
+    // Radix's DropdownMenu opens on keyboard/pointer events, not a bare
+    // click — same as equipment-mobile-cards.smoke.test.tsx's kebab test.
+    const { container } = render(<Harness onSelectChange={vi.fn()} />);
+    const kebab = container.querySelector('button[aria-haspopup="menu"]')!;
+    fireEvent.keyDown(kebab, { key: "Enter" });
+    expect(kebab.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/src/components/projects/equipment-cards.tsx
+++ b/src/components/projects/equipment-cards.tsx
@@ -67,6 +67,9 @@ export function GroupCard({
   onToggle,
   children,
   actions,
+  dragHandleRef,
+  dragAttributes,
+  dragListeners,
 }: {
   title: string;
   subtext?: React.ReactNode;
@@ -77,10 +80,23 @@ export function GroupCard({
   onToggle?: () => void;
   children?: React.ReactNode;
   actions?: React.ReactNode;
+  /** Real @dnd-kit drag entry point for the whole card — pressing/holding
+   *  anywhere on the card body (not a dedicated handle) starts the drag; see
+   *  equipment-rows.tsx's `DragHandleControls` doc comment. Spread onto this
+   *  root div rather than the inner toggle button so dragging isn't scoped
+   *  to just the title/chevron area. */
+  dragHandleRef?: (el: HTMLElement | null) => void;
+  dragAttributes?: Record<string, unknown>;
+  dragListeners?: Record<string, unknown>;
 }) {
   return (
     <>
-      <div className="flex min-h-11 items-center gap-2 rounded-[var(--r)] bg-card px-3 py-2 ring-1 ring-line-2">
+      <div
+        ref={dragHandleRef}
+        {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
+        {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
+        className="flex min-h-11 touch-manipulation items-center gap-2 rounded-[var(--r)] bg-card px-3 py-2 ring-1 ring-line-2 active:cursor-grabbing md:cursor-grab"
+      >
         <button
           type="button"
           aria-expanded={isExpanded}
@@ -113,12 +129,24 @@ export function GroupCard({
 export function CategoryCardHeading({
   name,
   action,
+  dragHandleRef,
+  dragAttributes,
+  dragListeners,
 }: {
   name: string;
   action?: React.ReactNode;
+  /** Same whole-surface drag entry point as `GroupCard` — see its doc comment. */
+  dragHandleRef?: (el: HTMLElement | null) => void;
+  dragAttributes?: Record<string, unknown>;
+  dragListeners?: Record<string, unknown>;
 }) {
   return (
-    <div className="flex items-center justify-between gap-2 px-1 pb-0.5 pt-3">
+    <div
+      ref={dragHandleRef}
+      {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
+      {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
+      className="flex touch-manipulation items-center justify-between gap-2 rounded-[var(--r)] px-1 pb-0.5 pt-3 active:cursor-grabbing md:cursor-grab"
+    >
       <div className="flex items-center gap-1.5 text-caption font-semibold text-ink-2">
         <Container className="h-3.5 w-3.5" />
         {name}

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -14,7 +14,6 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { api } from "../../../convex/_generated/api";
 import {
   ChevronRight,
-  GripVertical,
   Plus,
   Package,
   MoreHorizontal,
@@ -97,53 +96,32 @@ export function getDisallowedDropReason(
   return null;
 }
 
-// ─── Drag handle (every row kind) ────────────────────────────────────────────
+// ─── Drag entry point (every row kind) ───────────────────────────────────────
 //
-// The real @dnd-kit drag entry point, shared by LineItemRow, GroupRow,
-// SubHireGroupRow, and CategoryRow (the last to convert — categories used to
-// keep their ▲/▼ MoveButtons). Kept generic (`Record<string, unknown>` for
+// The real @dnd-kit wiring, shared by LineItemRow, GroupRow, SubHireGroupRow,
+// and CategoryRow. There is no dedicated drag handle — pressing and holding
+// ANYWHERE on the row/card starts the drag (a small delay-based activation
+// constraint on the sensor, see use-equipment-dnd.ts, distinguishes a quick
+// tap/click from a deliberate hold, so nested buttons/checkboxes/inputs keep
+// working normally). `dragHandleRef`/`dragAttributes`/`dragListeners` are
+// `useSortable()`'s `setNodeRef`/`attributes`/`listeners`, spread onto the
+// row's/card's ROOT element (the `<TableRow>` on desktop, the card container
+// on mobile) so dnd-kit measures and tracks the actual visible surface being
+// dragged — not a separate, differently-sized node — which is also what keeps
+// the drag preview tracking the exact point the user grabbed instead of
+// snapping to some other anchor. Kept generic (`Record<string, unknown>` for
 // attributes/listeners) so this file stays free of a hard `@dnd-kit` import —
 // the caller (equipment-tab.tsx, which DOES import dnd-kit) passes its
 // `useSortable()` return values straight through.
 
 export interface DragHandleControls {
-  /** `useSortable()`'s `setNodeRef`, attached to this handle button (not the
-   *  whole row) — the button is what dnd-kit measures/tracks for this item. */
+  /** `useSortable()`'s `setNodeRef` — attach to the row/card ROOT element. */
   dragHandleRef?: (el: HTMLElement | null) => void;
   dragAttributes?: Record<string, unknown>;
   dragListeners?: Record<string, unknown>;
   /** No drag entry point at all when true (e.g. sub-hire/kit group children,
    *  which aren't independently reorderable). */
   isDragDisabled?: boolean;
-}
-
-function DragHandle({
-  dragHandleRef,
-  dragAttributes,
-  dragListeners,
-  isDragDisabled,
-  className,
-}: DragHandleControls & { className?: string }) {
-  if (isDragDisabled) return null;
-  return (
-    // Same hover/focus-reveal treatment as the old MoveButtons — hidden by
-    // default on desktop, shown on row hover/keyboard focus, always visible on
-    // touch (no hover) via the `md:` gate.
-    <button
-      type="button"
-      aria-label="Reorder"
-      ref={dragHandleRef}
-      {...(dragAttributes as React.HTMLAttributes<HTMLButtonElement> | undefined)}
-      {...(dragListeners as React.HTMLAttributes<HTMLButtonElement> | undefined)}
-      className={cn(
-        "cursor-grab touch-none rounded-sm text-muted transition-opacity hover:text-ink active:cursor-grabbing md:opacity-0 md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100",
-        focusRing,
-        className,
-      )}
-    >
-      <GripVertical className="h-3.5 w-3.5" />
-    </button>
-  );
 }
 
 // Column count used for category-row + empty-state colSpans. Spans every
@@ -417,19 +395,11 @@ export function GroupRow({
         total={groupTotal}
         isExpanded={isExpanded}
         onToggle={onToggle}
+        dragHandleRef={dragHandleRef}
+        dragAttributes={dragAttributes}
+        dragListeners={dragListeners}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
-            {/* Mobile drag handle — mirrors LineItemRow's mobile treatment:
-                this row previously had ZERO reorder affordance on touch
-                (MoveButtons hid itself there too), long-press-to-drag
-                (TouchSensor) is the first reorder entry point here. */}
-            <DragHandle
-              dragHandleRef={dragHandleRef}
-              dragAttributes={dragAttributes}
-              dragListeners={dragListeners}
-              isDragDisabled={isDragDisabled}
-              className="inline-flex min-h-11 min-w-8 items-center justify-center"
-            />
             {orgId && projectId && (
               <CommentThreadPanel
                 orgId={orgId}
@@ -466,17 +436,14 @@ export function GroupRow({
   }
 
   return (
-    <TableRow className="group/row" {...shortcuts}>
-      <TableCell className="px-0">
-        <div className={`flex justify-end ${indented ? "ml-3" : "px-1"}`}>
-          <DragHandle
-            dragHandleRef={dragHandleRef}
-            dragAttributes={dragAttributes}
-            dragListeners={dragListeners}
-            isDragDisabled={isDragDisabled}
-          />
-        </div>
-      </TableCell>
+    <TableRow
+      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      ref={dragHandleRef}
+      {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...shortcuts}
+    >
+      <TableCell className="px-0" />
       <TableCell>
         <div className={`flex items-center gap-1.5 ${indented ? "ml-2" : ""}`}>
           <button
@@ -699,18 +666,11 @@ export function SubHireGroupRow({
         total={charge != null ? charge * group.quantity : null}
         isExpanded={isExpanded}
         onToggle={onToggle}
+        dragHandleRef={dragHandleRef}
+        dragAttributes={dragAttributes}
+        dragListeners={dragListeners}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
-            {/* Mobile drag handle — same treatment as GroupRow's mobile
-                card (see that component's comment); this row previously had
-                no reorder affordance on touch either. */}
-            <DragHandle
-              dragHandleRef={dragHandleRef}
-              dragAttributes={dragAttributes}
-              dragListeners={dragListeners}
-              isDragDisabled={isDragDisabled}
-              className="inline-flex min-h-11 min-w-8 items-center justify-center"
-            />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="size-8">
@@ -746,17 +706,14 @@ export function SubHireGroupRow({
   }
 
   return (
-    <TableRow className="group/row" {...shortcuts}>
-      <TableCell className="px-0">
-        <div className={`flex justify-end ${indented ? "ml-3" : "px-1"}`}>
-          <DragHandle
-            dragHandleRef={dragHandleRef}
-            dragAttributes={dragAttributes}
-            dragListeners={dragListeners}
-            isDragDisabled={isDragDisabled}
-          />
-        </div>
-      </TableCell>
+    <TableRow
+      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      ref={dragHandleRef}
+      {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...shortcuts}
+    >
+      <TableCell className="px-0" />
       <TableCell>
         <div className={`flex items-start gap-1.5 ${indented ? "ml-2" : ""}`}>
           <button
@@ -939,18 +896,11 @@ export function CategoryRow({
     return (
       <CategoryCardHeading
         name={cat.name}
+        dragHandleRef={dragHandleRef}
+        dragAttributes={dragAttributes}
+        dragListeners={dragListeners}
         action={
           <div className="flex shrink-0 items-center gap-1">
-            {/* Mobile drag handle — same treatment as GroupRow/SubHireGroupRow's
-                mobile cards (see those components' comments); this heading
-                previously had zero reorder affordance on touch either. */}
-            <DragHandle
-              dragHandleRef={dragHandleRef}
-              dragAttributes={dragAttributes}
-              dragListeners={dragListeners}
-              isDragDisabled={isDragDisabled}
-              className="inline-flex min-h-11 min-w-8 items-center justify-center"
-            />
             {onAddEquipment && <CardAddButton onClick={onAddEquipment} />}
             {categoryMenu}
           </div>
@@ -960,16 +910,14 @@ export function CategoryRow({
   }
 
   return (
-    <TableRow className="group/cat border-b-0 bg-paper-2/50 hover:bg-elev">
+    <TableRow
+      className={cn("group/cat border-b-0 bg-paper-2/50 hover:bg-elev", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      ref={dragHandleRef}
+      {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+    >
       <TableCell colSpan={columnCount} className="py-2 px-1">
         <div className="flex items-center gap-1.5">
-          <DragHandle
-            dragHandleRef={dragHandleRef}
-            dragAttributes={dragAttributes}
-            dragListeners={dragListeners}
-            isDragDisabled={isDragDisabled}
-            className="px-1 md:group-hover/cat:opacity-100 md:group-focus-within/cat:opacity-100"
-          />
           <h3 className="t-overline text-muted">{cat.name}</h3>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -1165,9 +1113,6 @@ export function LineItemRow({
     }
   };
 
-  // Map content indent to grip indent (margin-based to avoid affecting column width)
-  const gripIndent = indent === "ml-12" ? "ml-8" : indent === "ml-3" ? "ml-1" : "";
-
   // Deeper indent for child rows
   const childIndent = indent === "ml-12" ? "ml-16" : indent === "ml-3" ? "ml-8" : "ml-6";
 
@@ -1314,11 +1259,15 @@ export function LineItemRow({
     return (
       <div className={cn("space-y-1.5", nestInset)}>
         <div
+          ref={dragHandleRef}
+          {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
+          {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
           className={cn(
-            "flex min-h-11 items-start gap-2 rounded-[var(--r)] bg-card transition-colors",
+            "flex min-h-11 touch-manipulation items-start gap-2 rounded-[var(--r)] bg-card transition-colors",
             isContainer ? "px-3 py-2 ring-1 ring-line-2" : "px-3 py-2 ring-1 ring-line",
             isSelected && "ring-2 ring-red",
             justChanged && "collab-changed",
+            !isDragDisabled && "active:cursor-grabbing md:cursor-grab",
           )}
         >
           {selectable && (
@@ -1326,6 +1275,7 @@ export function LineItemRow({
               onMouseDown={(e) => {
                 shiftKeyRef.current = e.shiftKey;
               }}
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
               className="inline-flex min-h-11 min-w-8 shrink-0 items-center justify-center"
             >
@@ -1354,17 +1304,6 @@ export function LineItemRow({
             <div className="min-w-0 flex-1">{bodyInner}</div>
           )}
           <div className="flex shrink-0 items-center gap-0.5">
-            {/* Mobile drag handle — this row type previously had ZERO reorder
-                affordance on touch (MoveButtons hid itself entirely there's no
-                up/down concept worth tapping on a phone); long-press-to-drag
-                (TouchSensor) is the first reorder entry point here. */}
-            <DragHandle
-              dragHandleRef={dragHandleRef}
-              dragAttributes={dragAttributes}
-              dragListeners={dragListeners}
-              isDragDisabled={isDragDisabled}
-              className="inline-flex min-h-11 min-w-8 items-center justify-center"
-            />
             {hasChildren && (
               <button
                 type="button"
@@ -1457,20 +1396,15 @@ export function LineItemRow({
         "group/row",
         isSelected && "bg-select",
         justChanged && "collab-changed",
+        !isDragDisabled && "cursor-grab active:cursor-grabbing",
       )}
       onClick={onClick}
+      ref={dragHandleRef}
+      {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
+      {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...shortcuts}
     >
-      <TableCell className="px-0">
-        <div className={`flex justify-end ${gripIndent || "px-1"}`}>
-          <DragHandle
-            dragHandleRef={dragHandleRef}
-            dragAttributes={dragAttributes}
-            dragListeners={dragListeners}
-            isDragDisabled={isDragDisabled}
-          />
-        </div>
-      </TableCell>
+      <TableCell className="px-0" />
       <TableCell>
         <div className={`flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0 ${indent}`}>
           {selectable && (
@@ -1482,6 +1416,7 @@ export function LineItemRow({
               onMouseDown={(e) => {
                 shiftKeyRef.current = e.shiftKey;
               }}
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
               className={cn(
                 "shrink-0 transition-opacity",

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -121,10 +121,11 @@ interface EquipmentTabProps {
 // header). One `useSortable()` call per row, kept in a small wrapper (rather
 // than inline in the .map() callbacks below) so the hook isn't called from a
 // plain callback, which would trip react-hooks/rules-of-hooks. `dragHandleRef`
-// is `useSortable`'s `setNodeRef` (NOT `setActivatorNodeRef`) attached to the
-// handle button itself, so that small button is the only DOM node dnd-kit
-// measures/tracks for this row —
-// see equipment-rows.tsx's `DragHandleControls` doc comment.
+// is `useSortable`'s `setNodeRef`, attached to the row's/card's ROOT element —
+// there is no dedicated handle; pressing and holding anywhere on the row
+// starts the drag (a delay-based activation constraint distinguishes a quick
+// click from a hold — see use-equipment-dnd.ts's sensor setup) — see
+// equipment-rows.tsx's `DragHandleControls` doc comment.
 function SortableLineItemRow({
   sortableId,
   containerId,
@@ -161,9 +162,10 @@ function SortableLineItemRow({
 // (Uncategorized-zone) groups — they're still registered as sortable items
 // (so the Uncategorized zone resolves as a valid drop container/target for a
 // group leaving a category — see use-equipment-dnd.ts's
-// `buildGroupContainerMap`) but can't originate a drag themselves, matching
-// their existing no-reorder-affordance behaviour (`DragHandle` renders
-// nothing when `isDragDisabled`).
+// `buildGroupContainerMap`) but can't originate a drag themselves: dnd-kit's
+// own `useSortable({disabled: true})` already makes `listeners` a no-op (see
+// equipment-rows.tsx's `DragHandleControls` doc comment), so the row simply
+// never activates a drag — no separate handle-hiding logic needed.
 function SortableGroupRow({
   sortableId,
   containerId,
@@ -2042,12 +2044,14 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         );
         // Drag-and-drop for LINE ITEMS, GROUPS, and CATEGORIES (see
         // use-equipment-dnd.ts). A single DndContext wraps both the desktop
-        // table and mobile card shells; DragOverlay renders a small floating
-        // label for whatever's being dragged (dragHandleRef only registers
-        // the tiny handle button with dnd-kit — not the whole row — as a
-        // drop-target/measured node, so this overlay is the user's main
-        // "something is being dragged" feedback; see equipment-rows.tsx's
-        // DragHandleControls doc comment).
+        // table and mobile card shells. `dragHandleRef` now registers the
+        // WHOLE row/card as dnd-kit's measured/dragged node (equipment-rows.tsx's
+        // `DragHandleControls` doc comment), so dnd-kit's own <DragOverlay>
+        // wrapper is sized and positioned to exactly match the row the user
+        // grabbed — this floating label fills that wrapper (`h-full w-full`)
+        // instead of rendering as a small fixed-size chip inside it, which is
+        // what keeps it tracking the exact point the user grabbed rather than
+        // snapping to a corner.
         return (
           <DndContext
             sensors={dnd.sensors}
@@ -2060,15 +2064,15 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
             {content}
             <DragOverlay>
               {draggedLineItem ? (
-                <div className="rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
                   {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
                 </div>
               ) : draggedGroupTitle ? (
-                <div className="rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
                   {draggedGroupTitle}
                 </div>
               ) : draggedCategoryTitle ? (
-                <div className="rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
                   {draggedCategoryTitle}
                 </div>
               ) : null}

--- a/src/hooks/use-equipment-dnd.ts
+++ b/src/hooks/use-equipment-dnd.ts
@@ -52,7 +52,6 @@ import * as React from "react";
 import { useCallback, useState } from "react";
 import {
   PointerSensor,
-  TouchSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
@@ -687,10 +686,20 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
     onSettled,
   } = args;
 
-  const pointerSensor = useSensor(PointerSensor, { activationConstraint: { distance: 4 } });
-  const touchSensor = useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } });
+  // ONE PointerSensor, not PointerSensor+TouchSensor: Pointer Events fire for
+  // mouse, touch, AND pen alike, so a touch interaction used to trigger BOTH
+  // sensors at once — PointerSensor's old 4px `distance` constraint won the
+  // race almost immediately (any touch jitter clears 4px well before
+  // TouchSensor's 250ms delay elapsed), hijacking the long-press gesture and
+  // fighting the browser's native scroll, which is what made drag "just not
+  // work" on phones. A single delay-based constraint applied to PointerSensor
+  // covers mouse/touch/pen uniformly (dnd-kit's own recommended pattern for
+  // combined pointer-type support) and IS the "press and hold, then drag"
+  // feel — no separate handle needed, and no dedicated touch-only sensor to
+  // race against.
+  const pointerSensor = useSensor(PointerSensor, { activationConstraint: { delay: 200, tolerance: 8 } });
   const keyboardSensor = useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates });
-  const sensors = useSensors(pointerSensor, touchSensor, keyboardSensor);
+  const sensors = useSensors(pointerSensor, keyboardSensor);
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [invalidOverId, setInvalidOverId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Real-world feedback on the just-shipped drag-and-drop (#1058) surfaced three bugs the sandboxed CI-only verification in that PR couldn't catch:

1. **Drag didn't work on mobile at all.** `PointerSensor` and `TouchSensor` were both registered. Pointer Events fire for touch as well as mouse, so the two sensors raced the same gesture — `PointerSensor`'s 4px distance constraint won almost instantly (any touch jitter clears it well before `TouchSensor`'s 250ms delay), hijacking the long-press and fighting the browser's native scroll. Fixed: **one** `PointerSensor` with a `{delay: 200, tolerance: 8}` activation constraint, covering mouse/touch/pen uniformly — dnd-kit's own recommended pattern for combined pointer-type support, and no dedicated `TouchSensor` left to race against.
2. **Had to hit a tiny drag handle precisely.** `useSortable()`'s ref/attributes/listeners were attached only to the small `GripVertical` button, not the row. Fixed: every row's/card's own root element now carries the drag wiring, so pressing and holding **anywhere** on the row starts the drag. The dedicated handle button is gone. Nested buttons/checkboxes/links still work normally — the delay-based activation constraint (not a separate handle) is what lets a quick tap pass through untouched.
3. **Dragged item jumped to the top / didn't track the grab point.** dnd-kit measures whichever node the ref is attached to; since that was the tiny handle, the floating drag preview was anchored to that small corner instead of the actual row. Fixed by (2) plus making the preview fill its (now correctly row-sized) overlay wrapper, so it tracks the exact point the user grabbed for the whole drag.

## Size rationale (POLICY.md R-2.8 / T-2)

437 LOC, just over the 400 target. These three bug fixes are mechanically the same change (whole-row drag wiring) applied consistently across the 4 row/card components plus the sensor config and the overlay content that depends on it — splitting by row kind or by symptom would land each fix in a broken intermediate state (e.g. a handle removed from one row but not another), and the new interaction test necessarily covers the combined behavior. Not practical to split further.

## Testing

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm exec eslint .` — 0 errors (only pre-existing function-length/complexity warnings)
- [x] Full unit suite — 5507/5507 pass, including a new interaction test (`equipment-row-drag-interaction.test.tsx`) that mounts a real `DndContext`/`useSortable` around `LineItemRow` and verifies the row root carries dnd-kit's sortable attributes with no separate handle, and that the checkbox, the caller's row-level `onClick` (desktop multi-select), and the kebab menu all still fire/open normally now that the whole row is the drag surface
- [x] `pnpm build` — succeeds
- [ ] Manual browser/touch QA of the actual drag gestures — jsdom can't reliably trigger dnd-kit's `PointerSensor` activation via synthetic `PointerEvent`s (confirmed by hand against a minimal bare-bones `useSortable` div outside this app's own code), so the delay/hold-to-drag timing itself remains `/qa`/manual-browser territory, same as the rest of this feature's pointer and touch behaviour. Recommended before merge via a preview/dev deploy.

## Checklist

- [ ] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3)

No new dependencies — this only changes how the existing `@dnd-kit` dependency (added in #1058) is wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t