### PR TITLE
Fix drag preview: portal past transformed ancestor, dim source row in place

### DIFF
--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -430,6 +430,24 @@ call it to short-circuit a disallowed drop with a toast. It has no
 category-vs-category rule — categories don't nest into anything, so no
 category drop needs blocking.
 
+### ⚠️ `<DragOverlay>` MUST be portaled to `document.body`
+
+dnd-kit's `<DragOverlay>` renders in place (no portal of its own) and relies
+entirely on `position: fixed` to visually escape the layout. `src/app/(app)/
+projects/[id]/page.tsx` wraps the whole page — including the equipment tab —
+in `<FadeIn>` (`src/components/ui/motion.tsx`), a Framer Motion `motion.div`
+whose `animate={{ y: 0 }}` leaves a persistent (non-`none`) `transform` style
+on that ancestor even at rest. ANY non-`none` `transform`/`filter`/
+`perspective`/`will-change: transform` on an ancestor establishes a NEW
+containing block for `position: fixed` descendants — so the overlay was
+positioning itself relative to that page wrapper instead of the viewport,
+making the dragged preview appear to snap to a fixed spot near the top of the
+page, completely disconnected from the cursor, regardless of how correctly
+the dragged node itself was measured. `equipment-tab.tsx` wraps its
+`<DragOverlay>` in `createPortal(..., document.body)` to sidestep this (and
+any other transformed ancestor) entirely — do not remove that portal, and if
+another `<DragOverlay>` is ever added elsewhere in the app, portal it too.
+
 ### Drop Matrix 8C summary
 
 | Source ↓ \ Dest → | ProjectCategory | ProjectGroup | SubHireGroup | Uncat | SubHire (top) |

--- a/src/components/projects/equipment-cards.tsx
+++ b/src/components/projects/equipment-cards.tsx
@@ -70,6 +70,8 @@ export function GroupCard({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
 }: {
   title: string;
   subtext?: React.ReactNode;
@@ -88,6 +90,11 @@ export function GroupCard({
   dragHandleRef?: (el: HTMLElement | null) => void;
   dragAttributes?: Record<string, unknown>;
   dragListeners?: Record<string, unknown>;
+  /** `useSortable()`'s `transform`/`transition` as an inline style, and
+   *  whether this is the ONE card currently being dragged — same contract as
+   *  equipment-rows.tsx's `DragHandleControls`. */
+  dragStyle?: React.CSSProperties;
+  isDragging?: boolean;
 }) {
   return (
     <>
@@ -95,7 +102,11 @@ export function GroupCard({
         ref={dragHandleRef}
         {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
         {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
-        className="flex min-h-11 touch-manipulation items-center gap-2 rounded-[var(--r)] bg-card px-3 py-2 ring-1 ring-line-2 active:cursor-grabbing md:cursor-grab"
+        style={dragStyle}
+        className={cn(
+          "flex min-h-11 touch-manipulation items-center gap-2 rounded-[var(--r)] bg-card px-3 py-2 ring-1 ring-line-2 active:cursor-grabbing md:cursor-grab",
+          isDragging && "opacity-40",
+        )}
       >
         <button
           type="button"
@@ -132,6 +143,8 @@ export function CategoryCardHeading({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
 }: {
   name: string;
   action?: React.ReactNode;
@@ -139,13 +152,19 @@ export function CategoryCardHeading({
   dragHandleRef?: (el: HTMLElement | null) => void;
   dragAttributes?: Record<string, unknown>;
   dragListeners?: Record<string, unknown>;
+  dragStyle?: React.CSSProperties;
+  isDragging?: boolean;
 }) {
   return (
     <div
       ref={dragHandleRef}
       {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
-      className="flex touch-manipulation items-center justify-between gap-2 rounded-[var(--r)] px-1 pb-0.5 pt-3 active:cursor-grabbing md:cursor-grab"
+      style={dragStyle}
+      className={cn(
+        "flex touch-manipulation items-center justify-between gap-2 rounded-[var(--r)] px-1 pb-0.5 pt-3 active:cursor-grabbing md:cursor-grab",
+        isDragging && "opacity-40",
+      )}
     >
       <div className="flex items-center gap-1.5 text-caption font-semibold text-ink-2">
         <Container className="h-3.5 w-3.5" />

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -119,6 +119,16 @@ export interface DragHandleControls {
   dragHandleRef?: (el: HTMLElement | null) => void;
   dragAttributes?: Record<string, unknown>;
   dragListeners?: Record<string, unknown>;
+  /** `useSortable()`'s `transform`/`transition` turned into an inline style
+   *  (equipment-tab.tsx's `buildDragStyle`) — applied to the same ROOT
+   *  element as the ref/attributes/listeners above. This is what makes OTHER
+   *  rows slide out of the way live while something is dragged over them. */
+  dragStyle?: React.CSSProperties;
+  /** True for the ONE row currently being dragged. Dims it in place (rather
+   *  than leaving it fully visible while an unrelated floating preview
+   *  follows the cursor) so it reads as "this line lifted up", not "a new
+   *  one appeared". */
+  isDragging?: boolean;
   /** No drag entry point at all when true (e.g. sub-hire/kit group children,
    *  which aren't independently reorderable). */
   isDragDisabled?: boolean;
@@ -292,6 +302,8 @@ export function GroupRow({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
   isDragDisabled,
   onInlinePriceUpdate,
   moneyLocked,
@@ -398,6 +410,8 @@ export function GroupRow({
         dragHandleRef={dragHandleRef}
         dragAttributes={dragAttributes}
         dragListeners={dragListeners}
+        dragStyle={dragStyle}
+        isDragging={isDragging}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
             {orgId && projectId && (
@@ -437,7 +451,8 @@ export function GroupRow({
 
   return (
     <TableRow
-      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
+      style={dragStyle}
       ref={dragHandleRef}
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
@@ -619,6 +634,8 @@ export function SubHireGroupRow({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
   isDragDisabled,
   onInlinePriceUpdate,
 }: {
@@ -669,6 +686,8 @@ export function SubHireGroupRow({
         dragHandleRef={dragHandleRef}
         dragAttributes={dragAttributes}
         dragListeners={dragListeners}
+        dragStyle={dragStyle}
+        isDragging={isDragging}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
             <DropdownMenu>
@@ -707,7 +726,8 @@ export function SubHireGroupRow({
 
   return (
     <TableRow
-      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
+      style={dragStyle}
       ref={dragHandleRef}
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
@@ -822,6 +842,8 @@ export function CategoryRow({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
   isDragDisabled,
 }: {
   cat: CategoryData;
@@ -899,6 +921,8 @@ export function CategoryRow({
         dragHandleRef={dragHandleRef}
         dragAttributes={dragAttributes}
         dragListeners={dragListeners}
+        dragStyle={dragStyle}
+        isDragging={isDragging}
         action={
           <div className="flex shrink-0 items-center gap-1">
             {onAddEquipment && <CardAddButton onClick={onAddEquipment} />}
@@ -911,7 +935,12 @@ export function CategoryRow({
 
   return (
     <TableRow
-      className={cn("group/cat border-b-0 bg-paper-2/50 hover:bg-elev", !isDragDisabled && "cursor-grab active:cursor-grabbing")}
+      className={cn(
+        "group/cat border-b-0 bg-paper-2/50 hover:bg-elev",
+        !isDragDisabled && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40",
+      )}
+      style={dragStyle}
       ref={dragHandleRef}
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
@@ -995,6 +1024,8 @@ export function LineItemRow({
   dragHandleRef,
   dragAttributes,
   dragListeners,
+  dragStyle,
+  isDragging,
   isDragDisabled,
   onInlineUpdate,
   moneyLocked,
@@ -1262,12 +1293,14 @@ export function LineItemRow({
           ref={dragHandleRef}
           {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
           {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
+          style={dragStyle}
           className={cn(
             "flex min-h-11 touch-manipulation items-start gap-2 rounded-[var(--r)] bg-card transition-colors",
             isContainer ? "px-3 py-2 ring-1 ring-line-2" : "px-3 py-2 ring-1 ring-line",
             isSelected && "ring-2 ring-red",
             justChanged && "collab-changed",
             !isDragDisabled && "active:cursor-grabbing md:cursor-grab",
+            isDragging && "opacity-40",
           )}
         >
           {selectable && (
@@ -1397,7 +1430,9 @@ export function LineItemRow({
         isSelected && "bg-select",
         justChanged && "collab-changed",
         !isDragDisabled && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40",
       )}
+      style={dragStyle}
       onClick={onClick}
       ref={dragHandleRef}
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { createPortal } from "react-dom";
 import { DndContext, DragOverlay, closestCenter } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { readMigratedLocalStorage } from "@/lib/local-storage-migrate";
 import { api } from "../../../convex/_generated/api";
@@ -114,6 +115,21 @@ interface EquipmentTabProps {
   addMenuSlot?: HTMLElement | null;
 }
 
+/** `useSortable()`'s `transform`/`transition` turned into an inline style —
+ *  applied to the row/card ROOT alongside `dragHandleRef`/`dragAttributes`/
+ *  `dragListeners` (see equipment-rows.tsx's `DragHandleControls` doc
+ *  comment). This is what makes OTHER rows slide out of the way live as a
+ *  drag passes over them (dnd-kit's `verticalListSortingStrategy` computes
+ *  the shift automatically from each row's position in its `SortableContext`
+ *  — no manual reorder-preview logic needed here). Without it, the list sat
+ *  frozen until drop then snapped to the new order all at once. */
+function buildDragStyle(
+  transform: ReturnType<typeof useSortable>["transform"],
+  transition: ReturnType<typeof useSortable>["transition"],
+): React.CSSProperties {
+  return { transform: CSS.Transform.toString(transform), transition };
+}
+
 // ─── Sortable line-item row wrapper ──────────────────────────────────────────
 //
 // Groups convert to drag below via SortableGroupRow/SortableSubHireGroupRow,
@@ -137,9 +153,9 @@ function SortableLineItemRow({
   dragDisabled?: boolean;
 } & Omit<
   React.ComponentProps<typeof LineItemRow>,
-  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled"
+  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled" | "dragStyle" | "isDragging"
 >) {
-  const { setNodeRef, attributes, listeners } = useSortable({
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
     id: sortableId,
     data: { containerId },
     disabled: dragDisabled,
@@ -151,6 +167,8 @@ function SortableLineItemRow({
       dragAttributes={attributes as unknown as Record<string, unknown>}
       dragListeners={listeners as unknown as Record<string, unknown>}
       isDragDisabled={dragDisabled}
+      dragStyle={buildDragStyle(transform, transition)}
+      isDragging={isDragging}
     />
   );
 }
@@ -177,9 +195,9 @@ function SortableGroupRow({
   dragDisabled?: boolean;
 } & Omit<
   React.ComponentProps<typeof GroupRow>,
-  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled"
+  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled" | "dragStyle" | "isDragging"
 >) {
-  const { setNodeRef, attributes, listeners } = useSortable({
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
     id: sortableId,
     data: { containerId },
     disabled: dragDisabled,
@@ -191,6 +209,8 @@ function SortableGroupRow({
       dragAttributes={attributes as unknown as Record<string, unknown>}
       dragListeners={listeners as unknown as Record<string, unknown>}
       isDragDisabled={dragDisabled}
+      dragStyle={buildDragStyle(transform, transition)}
+      isDragging={isDragging}
     />
   );
 }
@@ -206,9 +226,9 @@ function SortableSubHireGroupRow({
   dragDisabled?: boolean;
 } & Omit<
   React.ComponentProps<typeof SubHireGroupRow>,
-  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled"
+  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled" | "dragStyle" | "isDragging"
 >) {
-  const { setNodeRef, attributes, listeners } = useSortable({
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
     id: sortableId,
     data: { containerId },
     disabled: dragDisabled,
@@ -220,6 +240,8 @@ function SortableSubHireGroupRow({
       dragAttributes={attributes as unknown as Record<string, unknown>}
       dragListeners={listeners as unknown as Record<string, unknown>}
       isDragDisabled={dragDisabled}
+      dragStyle={buildDragStyle(transform, transition)}
+      isDragging={isDragging}
     />
   );
 }
@@ -242,9 +264,9 @@ function SortableCategoryRow({
   dragDisabled?: boolean;
 } & Omit<
   React.ComponentProps<typeof CategoryRow>,
-  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled"
+  "dragHandleRef" | "dragAttributes" | "dragListeners" | "isDragDisabled" | "dragStyle" | "isDragging"
 >) {
-  const { setNodeRef, attributes, listeners } = useSortable({
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
     id: sortableId,
     data: { containerId },
     disabled: dragDisabled,
@@ -256,6 +278,8 @@ function SortableCategoryRow({
       dragAttributes={attributes as unknown as Record<string, unknown>}
       dragListeners={listeners as unknown as Record<string, unknown>}
       isDragDisabled={dragDisabled}
+      dragStyle={buildDragStyle(transform, transition)}
+      isDragging={isDragging}
     />
   );
 }

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -2052,6 +2052,22 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
         // instead of rendering as a small fixed-size chip inside it, which is
         // what keeps it tracking the exact point the user grabbed rather than
         // snapping to a corner.
+        //
+        // dnd-kit's <DragOverlay> renders IN PLACE (no portal of its own —
+        // confirmed reading @dnd-kit/core's source) and relies entirely on
+        // `position: fixed` to visually escape the layout. `<FadeIn>`
+        // (src/app/(app)/projects/[id]/page.tsx wraps the whole page in it)
+        // is a Framer Motion `motion.div` whose `animate={{ y: 0 }}` leaves a
+        // persistent (non-`none`) `transform` style on that ancestor even at
+        // rest — any non-`none` transform establishes a NEW containing block
+        // for `position: fixed` descendants, so the overlay was positioning
+        // itself relative to that page wrapper instead of the viewport. That
+        // silent coordinate-system mismatch (not the row-vs-handle sizing
+        // fixed above) is what made the dragged preview appear to "jump to
+        // the top" disconnected from the cursor. Portaling straight to
+        // `document.body` sidesteps this (and any other transformed
+        // ancestor) entirely, matching dnd-kit's own documented fix for this
+        // exact class of bug.
         return (
           <DndContext
             sensors={dnd.sensors}
@@ -2062,21 +2078,25 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
             onDragEnd={dnd.handleDragEnd}
           >
             {content}
-            <DragOverlay>
-              {draggedLineItem ? (
-                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                  {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
-                </div>
-              ) : draggedGroupTitle ? (
-                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                  {draggedGroupTitle}
-                </div>
-              ) : draggedCategoryTitle ? (
-                <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                  {draggedCategoryTitle}
-                </div>
-              ) : null}
-            </DragOverlay>
+            {typeof document !== "undefined" &&
+              createPortal(
+                <DragOverlay>
+                  {draggedLineItem ? (
+                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                      {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
+                    </div>
+                  ) : draggedGroupTitle ? (
+                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                      {draggedGroupTitle}
+                    </div>
+                  ) : draggedCategoryTitle ? (
+                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                      {draggedCategoryTitle}
+                    </div>
+                  ) : null}
+                </DragOverlay>,
+                document.body,
+              )}
           </DndContext>
         );
       })()}


### PR DESCRIPTION
## Summary

Follow-up to #1059 — a screenshot showed the drag preview still detached from the cursor, floating near the top of the panel instead of tracking the grab point. Two separate bugs, both fixed here:

1. **Wrong coordinate system.** dnd-kit's `<DragOverlay>` renders in place and relies purely on `position: fixed` to escape the layout — it has no portal of its own. The whole page (including the equipment tab) is wrapped in `<FadeIn>` (`src/app/(app)/projects/[id]/page.tsx`), a Framer Motion `motion.div` whose `animate={{ y: 0 }}` leaves a persistent, non-`none` `transform` style on that ancestor even at rest. Any non-`none` transform on an ancestor establishes a *new* containing block for `position: fixed` descendants, so the overlay was positioning itself relative to that page wrapper instead of the viewport — completely disconnected from the cursor. #1059's row-measurement fix was necessary but not sufficient; this containing-block issue meant the coordinate system itself was wrong. **Fix:** wrap `<DragOverlay>` in `createPortal(..., document.body)`, dnd-kit's own documented pattern for this exact class of bug.

2. **Looked like a duplicate, not the same line moving.** The row being dragged stayed fully visible and unchanged in its slot while a separate floating label followed the cursor — reading as "a second thing appeared" rather than "this line lifted up." **Fix:** each row/card now applies `useSortable()`'s `isDragging` as reduced opacity on its own root, and its `transform`/`transition` as an inline style so *other* rows slide out of the way live while a drag passes over them (dnd-kit's standard sortable behavior, not wired up before — the list previously sat frozen until drop, then snapped to the new order all at once).

## Testing

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm exec eslint .` — 0 errors (only pre-existing function-length/complexity warnings)
- [x] Full unit suite — 5507/5507 pass
- [x] Complexity ratchet — holds at baseline (685/685)
- [ ] Manual browser QA of the drag gesture itself — same jsdom limitation noted in #1059; recommended via a preview/dev deploy before relying on this for real usage.

## Checklist

- [ ] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3)

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t)_