### PR TITLE
Fix drag-drop reorder no-op onto group rows + richer drag preview

### DIFF
--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -130,6 +130,26 @@ function buildDragStyle(
   return { transform: CSS.Transform.toString(transform), transition };
 }
 
+/** DragOverlay preview for a dragged project group — title/qty/total math
+ *  mirrors GroupRow's own display (equipment-rows.tsx) so the floating
+ *  preview agrees with the real row. Extracted out of the `draggedGroup`
+ *  lookup (equipment-tab.tsx render body) so ITS branch count stays low. */
+function previewProjectGroup(g: GroupData | undefined): { title: string; qty: number; total: number | null } | null {
+  if (!g) return null;
+  const priceVal = g.price != null ? Number(g.price) : null;
+  const discountVal = g.discount != null ? Number(g.discount) : 0;
+  const total = priceVal != null ? Math.max(0, priceVal * g.quantity - discountVal) : null;
+  return { title: g.title, qty: g.quantity, total };
+}
+
+/** Sibling of `previewProjectGroup` for a dragged sub-hire group — total
+ *  math mirrors SubHireGroupRow's own display. */
+function previewSubHireGroup(g: SubHireGroupData | undefined): { title: string; qty: number; total: number | null } | null {
+  if (!g) return null;
+  const chargeVal = g.charge != null ? Number(g.charge) : null;
+  return { title: g.title, qty: g.quantity, total: chargeVal != null ? chargeVal * g.quantity : null };
+}
+
 // ─── Sortable line-item row wrapper ──────────────────────────────────────────
 //
 // Groups convert to drag below via SortableGroupRow/SortableSubHireGroupRow,
@@ -1216,24 +1236,27 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
   })();
 
   // DragOverlay content for a dragged GROUP (project group or sub-hire
-  // group) — just its title, the simplest label consistent with the
-  // line-item overlay above. Looked up the same way, from the same
-  // reconstructed tree the rows render from.
-  const draggedGroupTitle = (() => {
+  // group) — title + qty/total, same "read as the real row" fidelity as
+  // draggedLineItem above (a name-only chip was the "loses the rest of the
+  // table info" complaint — the whole point of dragging IS to see what
+  // you're moving). Looked up the same way, from the same reconstructed tree
+  // the rows render from. Totals mirror GroupRow's/SubHireGroupRow's own
+  // display math (equipment-rows.tsx) so the preview agrees with the row —
+  // computed by previewProjectGroup/previewSubHireGroup (module scope, below
+  // the component) so this lookup's own branch count stays low.
+  const draggedGroup = (() => {
     const id = dnd.activeDragId;
     if (!id) return null;
     if (id.startsWith("grp-")) {
-      const bareId = id.slice(4);
       const allProjectGroups = [...typedCategories.flatMap((cat) => cat.groups), ...orphanProjectGroups];
-      return allProjectGroups.find((g) => g.id === bareId)?.title ?? null;
+      return previewProjectGroup(allProjectGroups.find((group) => group.id === id.slice(4)));
     }
     if (id.startsWith("shg-")) {
-      const bareId = id.slice(4);
       const allSubHireGroups: SubHireGroupData[] = [
         ...typedCategories.flatMap((cat) => cat.subHireGroupTargets ?? []),
         ...orphanSubHireGroups,
       ];
-      return allSubHireGroups.find((g) => g.id === bareId)?.title ?? null;
+      return previewSubHireGroup(allSubHireGroups.find((group) => group.id === id.slice(4)));
     }
     return null;
   })();
@@ -2106,12 +2129,26 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
               createPortal(
                 <DragOverlay>
                   {draggedLineItem ? (
-                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                      {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
+                    <div className="flex h-full w-full cursor-grabbing items-center justify-between gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                      <span className="min-w-0 truncate font-medium">
+                        {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
+                      </span>
+                      <span className="flex shrink-0 items-center gap-2 text-caption text-muted tabular-nums">
+                        <span>Qty {draggedLineItem.quantity}</span>
+                        {draggedLineItem.lineTotal != null && (
+                          <span className="t-mono text-ink-2">{formatCurrency(Number(draggedLineItem.lineTotal))}</span>
+                        )}
+                      </span>
                     </div>
-                  ) : draggedGroupTitle ? (
-                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                      {draggedGroupTitle}
+                  ) : draggedGroup ? (
+                    <div className="flex h-full w-full cursor-grabbing items-center justify-between gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
+                      <span className="min-w-0 truncate font-medium">{draggedGroup.title}</span>
+                      <span className="flex shrink-0 items-center gap-2 text-caption text-muted tabular-nums">
+                        <span>Qty {draggedGroup.qty}</span>
+                        {draggedGroup.total != null && (
+                          <span className="t-mono text-ink-2">{formatCurrency(draggedGroup.total)}</span>
+                        )}
+                      </span>
                     </div>
                   ) : draggedCategoryTitle ? (
                     <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">

--- a/src/hooks/use-equipment-dnd.test.ts
+++ b/src/hooks/use-equipment-dnd.test.ts
@@ -174,6 +174,30 @@ describe("resolveLineItemDragAction", () => {
     });
   });
 
+  test("different container, dropped directly ON the group's own row -> move into that group, append order", () => {
+    // Regression: dropping on the GROUP ROW itself (grp-g1), not one of its
+    // child line items or the empty-container landing zone, used to resolve
+    // to nothing (`resolveLineItemDropTarget` had no grp-/shg- branch) —
+    // silently no-opping the drop back to its original position even though
+    // the Drop Matrix allows a line item entering a project group.
+    const g1 = group("g1", [li("x")]);
+    const catA = category("catA", { standalone: [li("a")], groups: [g1] });
+    const action = resolveLineItemDragAction({
+      activeSortableId: "li-a",
+      overSortableId: "grp-g1",
+      ctx: ctxFor(catA),
+    });
+    expect(action).toEqual({
+      kind: "move",
+      lineItemId: "a",
+      fromContainerId: "standalone:catA",
+      toContainerId: "items:g1",
+      targetCategoryId: "catA",
+      targetGroupId: "g1",
+      resultingOrder: undefined,
+    });
+  });
+
   test("Drop Matrix: a line item onto a sub-hire group is blocked", () => {
     const catA = category("catA", { standalone: [li("a")] });
     const action = resolveLineItemDragAction({

--- a/src/hooks/use-equipment-dnd.ts
+++ b/src/hooks/use-equipment-dnd.ts
@@ -192,6 +192,22 @@ function resolveLineItemDropTarget(
     const toContainerId = ctx.containerOf.get(overBareId);
     return toContainerId ? { toContainerId, overBareId } : null;
   }
+  // Dropping directly ON a group/sub-hire-group row (rather than on one of
+  // its child line items) targets THAT group's own `items:{groupId}`
+  // container, append-only — there's no specific sibling to land before.
+  // Drop Matrix 8C says li- onto grp- is a valid "enter group" move; without
+  // this branch the drop resolved to nothing (`target` stayed null below),
+  // which silently no-opped the drop back to its original position instead
+  // of moving the item into the group. `getDisallowedDropReason` (checked
+  // earlier in `resolveLineItemDragAction`) already rejects li- onto shg-
+  // before this runs, and `buildContainerMap` never registers an
+  // `items:{shgId}` container in the first place (sub-hire groups can't hold
+  // plain line items) — so the `has()` check below is a defensive no-op for
+  // shg-, not the thing actually blocking it.
+  if (overSortableId.startsWith("grp-") || overSortableId.startsWith("shg-")) {
+    const candidate: ContainerId = `items:${overSortableId.slice(4)}`;
+    return ctx.itemsByContainer.has(candidate) ? { toContainerId: candidate } : null;
+  }
   // Hovering an (empty) container's own landing zone directly.
   if (ctx.itemsByContainer.has(overSortableId as ContainerId)) {
     return { toContainerId: overSortableId as ContainerId };


### PR DESCRIPTION
## Summary

Follow-up to #1059/#1060 — user feedback after those landed: dragging worked visually but (1) a drop near a group row silently snapped back instead of moving anything, and (2) the floating preview showed only the item name, losing qty/price.

1. **Reorder actually not persisting.** `resolveLineItemDropTarget` (`src/hooks/use-equipment-dnd.ts`) only handled dropping on another line item or on an empty container's own landing zone — there was no branch for dropping directly ON a group/sub-hire-group row. The Drop Matrix explicitly allows a line item entering a project group ("✓ enter group"), but with no target resolution the drop fell through to a silent noop: nothing moved, no error shown, the item just snapped back to where it started. This is almost certainly what "when I drop it just goes straight back to where it was" was describing — the exact case in the reported screenshot (a standalone item sitting right below a group). Fixed by adding the missing `grp-`/`shg-` branch, mirroring `resolveGroupDropTarget`'s existing `cat-` branch for the analogous "landed on a parent-typed row" case. Added a regression test.

2. **Drag preview enriched.** The floating preview during a drag showed only the item/group name — losing everything else the row displayed. Both the line-item and group/sub-hire-group `DragOverlay` content now show Qty + total, computed the same way `GroupRow`/`SubHireGroupRow` display them (extracted to module-scope `previewProjectGroup`/`previewSubHireGroup` helpers so the added branching doesn't land on the render-body lookup's own complexity score).

## Testing

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm exec eslint .` — 0 errors (only pre-existing function-length/complexity warnings)
- [x] Full unit suite — 5508/5508 pass, including a new regression test for the missing grp-/shg- drop-target branch
- [x] Complexity ratchet — holds at baseline (685/685)
- [ ] Manual browser QA of the actual drag/drop gesture — same jsdom limitation noted in prior PRs; recommended via a preview/dev deploy.

## Checklist

- [ ] New dependency? Confirm platform/stdlib insufficiency and link the justification (POLICY.md R-6.3)

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t)_