### PR TITLE
fix(dnd): drag preview is now a pixel-accurate clone of the real row

### DIFF
--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -448,6 +448,44 @@ the dragged node itself was measured. `equipment-tab.tsx` wraps its
 any other transformed ancestor) entirely — do not remove that portal, and if
 another `<DragOverlay>` is ever added elsewhere in the app, portal it too.
 
+### The DragOverlay is a live DOM clone of the row, not a hand-built summary
+
+The floating preview shown while dragging is a genuine visual copy of the row
+you grabbed — same checkbox, name, type badge, qty/price/total cells — not a
+simplified "item name + qty + total" chip. Earlier iterations tried the chip
+approach and it read as "the drag lost the rest of the table info," which is
+the wrong tradeoff: the point of a drag preview is to look like the thing
+you're moving.
+
+`use-equipment-dnd.ts`'s `cloneDragRow` does this by deep-cloning the actual
+row/card DOM node (`event.activatorEvent.target.closest("[data-drag-row]")`)
+in `handleDragStart`, BEFORE `setActiveDragId` re-renders the source row into
+its dimmed `isDragging` state — cloning first is what captures the row at
+full opacity instead of already-dimmed. Every draggable row root
+(`GroupRow`/`SubHireGroupRow`/`CategoryRow`/`LineItemRow` in
+`equipment-rows.tsx`, `GroupCard`/`CategoryCardHeading` in
+`equipment-cards.tsx`) carries a `data-drag-row="true"` marker for this to
+find, tag-agnostic (`<tr>` on desktop, `<div>` on mobile cards).
+
+A cloned `<TableRow>` needs its per-`<td>` widths frozen explicitly:
+`equipment-tab.tsx`'s `DragRowOverlayContent` re-wraps the clone in its own
+one-row `<table>` (a bare `<tr>` can't render outside a table/tbody), but a
+standalone one-row table has no sibling rows to inform the browser's table
+layout algorithm — it would size each cell to that cell's own content alone,
+disagreeing with the live table's multi-row-informed column widths.
+`cloneDragRow` measures each source `<td>`'s `getBoundingClientRect().width`
+and sets it inline (`boxSizing: border-box`) on the matching cloned `<td>`
+BEFORE the source is detached from anything, sidestepping the mismatch
+entirely. The clone's own overall width is captured the same way (a detached
+node's `getBoundingClientRect()` is always zero, so the width has to travel
+alongside the node — see `DraggedRowClone`, not be re-measured after cloning).
+
+`onDragCancel` (window resize, Escape, tab visibility change — dnd-kit
+cancels the drag without ever calling `onDragEnd` for any of these) clears
+`activeDragId`/`draggedRowClone` the same as a normal drop; without it the
+DragOverlay would stay stuck open and the source row stuck dimmed until the
+next full remount.
+
 ### Drop Matrix 8C summary
 
 | Source ↓ \ Dest → | ProjectCategory | ProjectGroup | SubHireGroup | Uncat | SubHire (top) |

--- a/src/components/projects/equipment-cards.tsx
+++ b/src/components/projects/equipment-cards.tsx
@@ -100,6 +100,7 @@ export function GroupCard({
     <>
       <div
         ref={dragHandleRef}
+        data-drag-row="true"
         {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
         {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
         style={dragStyle}
@@ -158,6 +159,7 @@ export function CategoryCardHeading({
   return (
     <div
       ref={dragHandleRef}
+      data-drag-row="true"
       {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
       style={dragStyle}

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -454,6 +454,7 @@ export function GroupRow({
       className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
       style={dragStyle}
       ref={dragHandleRef}
+      data-drag-row="true"
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...shortcuts}
@@ -729,6 +730,7 @@ export function SubHireGroupRow({
       className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
       style={dragStyle}
       ref={dragHandleRef}
+      data-drag-row="true"
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...shortcuts}
@@ -942,6 +944,7 @@ export function CategoryRow({
       )}
       style={dragStyle}
       ref={dragHandleRef}
+      data-drag-row="true"
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
     >
@@ -1291,6 +1294,7 @@ export function LineItemRow({
       <div className={cn("space-y-1.5", nestInset)}>
         <div
           ref={dragHandleRef}
+          data-drag-row="true"
           {...(dragAttributes as React.HTMLAttributes<HTMLDivElement> | undefined)}
           {...(dragListeners as React.HTMLAttributes<HTMLDivElement> | undefined)}
           style={dragStyle}
@@ -1435,6 +1439,7 @@ export function LineItemRow({
       style={dragStyle}
       onClick={onClick}
       ref={dragHandleRef}
+      data-drag-row="true"
       {...(dragAttributes as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...(dragListeners as React.HTMLAttributes<HTMLTableRowElement> | undefined)}
       {...shortcuts}

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -18,7 +18,7 @@ import {
   computeLineTotal,
   type OptimisticLineEdit,
 } from "@/hooks/use-native-line-item-writes";
-import { useEquipmentDnd } from "@/hooks/use-equipment-dnd";
+import { useEquipmentDnd, type DraggedRowClone } from "@/hooks/use-equipment-dnd";
 import { useCanDo } from "@/lib/use-permissions";
 import { Plus, FolderPlus, FolderTree, Pencil, Trash2, ChevronDown as ChevronDownIcon } from "lucide-react";
 import {
@@ -130,24 +130,50 @@ function buildDragStyle(
   return { transform: CSS.Transform.toString(transform), transition };
 }
 
-/** DragOverlay preview for a dragged project group — title/qty/total math
- *  mirrors GroupRow's own display (equipment-rows.tsx) so the floating
- *  preview agrees with the real row. Extracted out of the `draggedGroup`
- *  lookup (equipment-tab.tsx render body) so ITS branch count stays low. */
-function previewProjectGroup(g: GroupData | undefined): { title: string; qty: number; total: number | null } | null {
-  if (!g) return null;
-  const priceVal = g.price != null ? Number(g.price) : null;
-  const discountVal = g.discount != null ? Number(g.discount) : 0;
-  const total = priceVal != null ? Math.max(0, priceVal * g.quantity - discountVal) : null;
-  return { title: g.title, qty: g.quantity, total };
-}
+/**
+ * Mounts `use-equipment-dnd.ts`'s `draggedRowClone` — a deep clone of the
+ * ACTUAL row/card DOM node being dragged — inside the DragOverlay, so the
+ * floating preview is a pixel-accurate copy of the real row instead of a
+ * hand-built summary ("it should look exactly the same" — a name-only or
+ * qty/total-only chip was the earlier, explicitly rejected attempt at this).
+ * `appendChild`s the raw node imperatively (a cloned DOM node, not a React
+ * element/JSX, can't be returned from render) into a plain wrapper div; a
+ * `<tr>` clone is re-wrapped in its own `<table>` so it renders as a table
+ * row would (browsers refuse to render a bare `<tr>` outside a table/tbody).
+ * `cloneDragRow` already freezes each `<td>`'s width inline before handing it
+ * here, so this one-row table doesn't get re-sized by the browser's table
+ * layout algorithm (which would otherwise size columns from this row's own
+ * content alone, disagreeing with the live table's multi-row-informed
+ * widths).
+ */
+function DragRowOverlayContent({ clone }: { clone: DraggedRowClone }) {
+  const { node, width } = clone;
+  const containerRef = React.useRef<HTMLElement>(null);
 
-/** Sibling of `previewProjectGroup` for a dragged sub-hire group — total
- *  math mirrors SubHireGroupRow's own display. */
-function previewSubHireGroup(g: SubHireGroupData | undefined): { title: string; qty: number; total: number | null } | null {
-  if (!g) return null;
-  const chargeVal = g.charge != null ? Number(g.charge) : null;
-  return { title: g.title, qty: g.quantity, total: chargeVal != null ? chargeVal * g.quantity : null };
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.replaceChildren(node);
+    return () => {
+      container.replaceChildren();
+    };
+  }, [node]);
+
+  const isRow = node.tagName === "TR";
+  return (
+    <div
+      className="cursor-grabbing overflow-hidden rounded-[var(--r)] shadow-[var(--sh-card)]"
+      style={{ width }}
+    >
+      {isRow ? (
+        <table className="w-full border-collapse bg-card">
+          <tbody ref={containerRef as React.Ref<HTMLTableSectionElement>} />
+        </table>
+      ) : (
+        <div ref={containerRef as React.Ref<HTMLDivElement>} className="bg-card" />
+      )}
+    </div>
+  );
 }
 
 // ─── Sortable line-item row wrapper ──────────────────────────────────────────
@@ -1219,57 +1245,6 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
     if (sh.status === "DRAFT") draftSubHireIds.add(sh.id as string);
   }
 
-  // DragOverlay content (see the DndContext wrap below) — a small floating
-  // label naming whatever line item is currently being dragged. Looked up
-  // from the same reconstructed tree the rows render from; a plain O(n) scan
-  // is fine at this scale (one drag at a time, small trees).
-  const draggedLineItem = (() => {
-    const bareId = dnd.activeDragId?.startsWith("li-") ? dnd.activeDragId.slice(3) : null;
-    if (!bareId) return null;
-    const allLineItems: LineItemData[] = [
-      ...typedCategories.flatMap((cat) => cat.lineItems ?? []),
-      ...typedCategories.flatMap((cat) => cat.groups.flatMap((g) => g.lineItems ?? [])),
-      ...(uncategorizedItems as LineItemData[]),
-      ...orphanProjectGroups.flatMap((g) => g.lineItems ?? []),
-    ];
-    return allLineItems.find((li) => li.id === bareId) ?? null;
-  })();
-
-  // DragOverlay content for a dragged GROUP (project group or sub-hire
-  // group) — title + qty/total, same "read as the real row" fidelity as
-  // draggedLineItem above (a name-only chip was the "loses the rest of the
-  // table info" complaint — the whole point of dragging IS to see what
-  // you're moving). Looked up the same way, from the same reconstructed tree
-  // the rows render from. Totals mirror GroupRow's/SubHireGroupRow's own
-  // display math (equipment-rows.tsx) so the preview agrees with the row —
-  // computed by previewProjectGroup/previewSubHireGroup (module scope, below
-  // the component) so this lookup's own branch count stays low.
-  const draggedGroup = (() => {
-    const id = dnd.activeDragId;
-    if (!id) return null;
-    if (id.startsWith("grp-")) {
-      const allProjectGroups = [...typedCategories.flatMap((cat) => cat.groups), ...orphanProjectGroups];
-      return previewProjectGroup(allProjectGroups.find((group) => group.id === id.slice(4)));
-    }
-    if (id.startsWith("shg-")) {
-      const allSubHireGroups: SubHireGroupData[] = [
-        ...typedCategories.flatMap((cat) => cat.subHireGroupTargets ?? []),
-        ...orphanSubHireGroups,
-      ];
-      return previewSubHireGroup(allSubHireGroups.find((group) => group.id === id.slice(4)));
-    }
-    return null;
-  })();
-
-  // DragOverlay content for a dragged CATEGORY — just its name, same simple
-  // label treatment as the line-item/group overlays above.
-  const draggedCategoryTitle = (() => {
-    const id = dnd.activeDragId;
-    if (!id?.startsWith("cat-")) return null;
-    const bareId = id.slice(4);
-    return typedCategories.find((cat) => cat.id === bareId)?.name ?? null;
-  })();
-
   // Build flat list of all line-item IDs in visual order. Used by
   // shift-click range selection (handleRowClick). Walks each category's
   // mixed group list in canonical (CategorySlot) order. Falls back to
@@ -2123,38 +2098,13 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
             onDragStart={dnd.handleDragStart}
             onDragOver={dnd.handleDragOver}
             onDragEnd={dnd.handleDragEnd}
+            onDragCancel={dnd.handleDragCancel}
           >
             {content}
             {typeof document !== "undefined" &&
               createPortal(
                 <DragOverlay>
-                  {draggedLineItem ? (
-                    <div className="flex h-full w-full cursor-grabbing items-center justify-between gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                      <span className="min-w-0 truncate font-medium">
-                        {draggedLineItem.model?.name ?? draggedLineItem.description ?? "Item"}
-                      </span>
-                      <span className="flex shrink-0 items-center gap-2 text-caption text-muted tabular-nums">
-                        <span>Qty {draggedLineItem.quantity}</span>
-                        {draggedLineItem.lineTotal != null && (
-                          <span className="t-mono text-ink-2">{formatCurrency(Number(draggedLineItem.lineTotal))}</span>
-                        )}
-                      </span>
-                    </div>
-                  ) : draggedGroup ? (
-                    <div className="flex h-full w-full cursor-grabbing items-center justify-between gap-3 rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                      <span className="min-w-0 truncate font-medium">{draggedGroup.title}</span>
-                      <span className="flex shrink-0 items-center gap-2 text-caption text-muted tabular-nums">
-                        <span>Qty {draggedGroup.qty}</span>
-                        {draggedGroup.total != null && (
-                          <span className="t-mono text-ink-2">{formatCurrency(draggedGroup.total)}</span>
-                        )}
-                      </span>
-                    </div>
-                  ) : draggedCategoryTitle ? (
-                    <div className="flex h-full w-full cursor-grabbing items-center rounded-[var(--r)] border border-line bg-card px-3 py-1.5 text-table-cell shadow-[var(--sh-card)]">
-                      {draggedCategoryTitle}
-                    </div>
-                  ) : null}
+                  {dnd.draggedRowClone ? <DragRowOverlayContent clone={dnd.draggedRowClone} /> : null}
                 </DragOverlay>,
                 document.body,
               )}

--- a/src/hooks/use-equipment-dnd.ts
+++ b/src/hooks/use-equipment-dnd.ts
@@ -58,6 +58,7 @@ import {
   type DragStartEvent,
   type DragOverEvent,
   type DragEndEvent,
+  type DragCancelEvent,
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates, arrayMove } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis, restrictToWindowEdges } from "@dnd-kit/modifiers";
@@ -660,18 +661,69 @@ export interface UseEquipmentDndArgs {
  *  layout-agnostic. */
 const dragModifiers = [restrictToVerticalAxis, restrictToWindowEdges];
 
+/** A cloned drag-row DOM node plus its measured width — the clone itself is
+ *  detached (never mounted), so `getBoundingClientRect()` on it always
+ *  returns zeroes; the width has to be captured from the still-mounted
+ *  SOURCE at clone time and carried alongside it. */
+export interface DraggedRowClone {
+  node: HTMLElement;
+  width: number;
+}
+
+/**
+ * Clone the actual row/card DOM node being dragged, so the DragOverlay can
+ * render a pixel-accurate copy of the real thing instead of a hand-built
+ * summary chip (the "it should look exactly the same" ask). Walks up from
+ * the pointerdown target to the nearest `[data-drag-row]` ancestor
+ * (equipment-rows.tsx/equipment-cards.tsx tag every draggable row root with
+ * this) and deep-clones it BEFORE React re-renders the source row into its
+ * dimmed `isDragging` state, so the clone captures the row at full opacity.
+ *
+ * `<TableRow>` clones need their per-cell widths frozen explicitly: a
+ * standalone one-row `<table>` has no sibling rows to inform the browser's
+ * table layout algorithm, so it would size each `<td>` to that cell's own
+ * content instead of matching the live table's column widths. Locking each
+ * cloned cell's width (measured from the source, which is still mounted at
+ * clone time) to a `px` value sidesteps that entirely.
+ */
+function cloneDragRow(target: EventTarget | null): DraggedRowClone | null {
+  if (!(target instanceof Element)) return null;
+  const source = target.closest<HTMLElement>("[data-drag-row]");
+  if (!source) return null;
+  const clone = source.cloneNode(true) as HTMLElement;
+  const width = source.getBoundingClientRect().width;
+  if (source.tagName === "TR") {
+    const sourceCells = Array.from(source.children);
+    const clonedCells = Array.from(clone.children);
+    sourceCells.forEach((cell, i) => {
+      const clonedCell = clonedCells[i];
+      if (!(clonedCell instanceof HTMLElement)) return;
+      clonedCell.style.width = `${cell.getBoundingClientRect().width}px`;
+      clonedCell.style.boxSizing = "border-box";
+    });
+  }
+  return { node: clone, width };
+}
+
 export interface UseEquipmentDndResult {
   sensors: ReturnType<typeof useSensors>;
   /** Pass to `<DndContext modifiers={modifiers}>` — see `dragModifiers`'s
    *  doc comment for why these two, and why they apply uniformly. */
   modifiers: typeof dragModifiers;
   activeDragId: string | null;
+  /** A deep clone of the row/card DOM node being dragged, captured at
+   *  drag-start — render this inside `<DragOverlay>` (wrapped in a
+   *  matching-width `<table>` for `<tr>` clones) so the floating preview is
+   *  a pixel-accurate copy of the real row, not a hand-built summary. Null
+   *  when nothing is being dragged. */
+  draggedRowClone: DraggedRowClone | null;
   /** The `over.id` currently being hovered when the Drop Matrix disallows it
    *  — null otherwise. Lets the caller render invalid-drop styling. */
   invalidOverId: string | null;
   handleDragStart: (event: DragStartEvent) => void;
   handleDragOver: (event: DragOverEvent) => void;
   handleDragEnd: (event: DragEndEvent) => void;
+  handleDragCancel: (event: DragCancelEvent) => void;
   orderOverlay: ReadonlyMap<string, OptimisticOrderEdit>;
   /** Groups' sibling of `orderOverlay` — see `use-native-line-item-writes.ts`'s
    *  `GroupOrderEdit` / `applyGroupOrderOverlay`. */
@@ -718,6 +770,7 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
   const sensors = useSensors(pointerSensor, keyboardSensor);
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [draggedRowClone, setDraggedRowClone] = useState<DraggedRowClone | null>(null);
   const [invalidOverId, setInvalidOverId] = useState<string | null>(null);
   const [orderOverlay, setOrderOverlay] = useState<ReadonlyMap<string, OptimisticOrderEdit>>(
     () => new Map(),
@@ -809,6 +862,10 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    // Clone BEFORE flipping activeDragId — that state flip is what re-renders
+    // the source row into its dimmed `isDragging` state, so the clone must be
+    // taken first to capture the row at full opacity.
+    setDraggedRowClone(cloneDragRow(event.activatorEvent?.target ?? null));
     setActiveDragId(String(event.active.id));
   }, []);
 
@@ -988,9 +1045,20 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
     [categoriesRef, uncategorizedItemsRef, uncategorizedProjectGroupsRef, justifiedReorder, justifiedMove, onSettled],
   );
 
+  // dnd-kit cancels a drag (Escape, window resize, tab visibility change)
+  // without ever calling onDragEnd — without this, activeDragId/
+  // draggedRowClone would stay stuck set, leaving the DragOverlay open and
+  // the source row dimmed indefinitely.
+  const handleDragCancel = useCallback(() => {
+    setActiveDragId(null);
+    setDraggedRowClone(null);
+    setInvalidOverId(null);
+  }, []);
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       setActiveDragId(null);
+      setDraggedRowClone(null);
       setInvalidOverId(null);
 
       const activeSortableId = String(event.active.id);
@@ -1021,10 +1089,12 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
     sensors,
     modifiers: dragModifiers,
     activeDragId,
+    draggedRowClone,
     invalidOverId,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
+    handleDragCancel,
     orderOverlay,
     groupOrderOverlay,
     categoryOrderOverlay,


### PR DESCRIPTION
## Summary

Verified this round's fixes empirically (real Convex + Postgres dev stack, real Chromium via the `browse` skill — not just static code reading) after repeated reports that drag-and-drop still didn't feel right:

- The DragOverlay preview is now a **deep clone of the actual row/card DOM node** being dragged, not a hand-built "name + qty + total" chip. Every draggable row root gets a `data-drag-row` marker; `cloneDragRow` (`use-equipment-dnd.ts`) clones it at drag-start, before the source row re-renders into its dimmed state, so the floating preview shows the exact checkbox/badges/qty/price/total the real row shows.
- A cloned `<tr>` gets its per-cell widths frozen inline (measured from the still-mounted source) since a standalone one-row `<table>` has no sibling rows to size its columns against.
- Added `onDragCancel` handling (window resize / Escape / tab visibility change — dnd-kit cancels these without ever firing `onDragEnd`) so the overlay/dimmed row can't get stuck open.
- Confirms the earlier group-drop-noop fix (this branch) and same-container reorder both persist correctly across a full reload, verified with a real drag gesture (synthetic PointerEvents dispatched through a real Chromium instance, not jsdom) against a project seeded through the actual UI.

## Testing

- `pnpm test` — 438 files / 5508 tests pass.
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint` on touched files — no new errors (pre-existing complexity/line-count warnings only, gated by the ratchet).
- `node scripts/complexity-ratchet.mjs` — 685/685, no regression.
- **Manual verification**, live against a real local dev stack (self-hosted Convex + Postgres + `pnpm dev`), driven via the `browse` skill in a real headless Chromium (not jsdom, which can't trigger dnd-kit's pointer activation pipeline):
  - Registered a user, created an org and a test project, added a category, two custom line items, and a group through the real UI.
  - Dragged a standalone item onto an adjacent item within the same category — reorder applied and **persisted across a full page reload**.
  - Dragged a standalone item onto a group's own row — item moved **into** the group and **persisted across reload**.
  - Inspected the DragOverlay DOM mid-drag: it renders a real `<table><tbody><tr>` with the source row's exact classes/content, positioned exactly at the pointer coordinates (verified by direct rect comparison, not just visually).

## Checklist

- [x] No new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t)_