### PR TITLE
fix(dnd): group/line-item reorder gaps + drop-target highlighting

### DIFF
--- a/FEATUREDOCS/47-cross-type-equipment-unification.md
+++ b/FEATUREDOCS/47-cross-type-equipment-unification.md
@@ -589,6 +589,53 @@ node at all and was unreachable by drag until something already lived there.
   landed in Uncategorized could never be dragged back into a category, only
   moved there via the "Move to category" dialog.
 
+### A group dropped on a LINE ITEM (not a group) — same-category vs. cross-category
+
+The Drop Matrix's "reorder past (edge)" cell only ever fired within the SAME
+category — `resolveCrossKindCategoryReorder` (see "Groups and standalone line
+items share one order" above) requires both the dragged id and the hovered id
+to already share one category's combined order. Two related gaps followed
+from that scope, both fixed together:
+
+- **Same-category, `middle` drop zone.** `resolveCrossKindCategoryReorder`
+  used to short-circuit to a noop whenever `dropZone === "middle"`, regardless
+  of direction — correct for a LINE ITEM hovering the middle of a GROUP (that's
+  "enter this group," resolved elsewhere), but wrong for the reverse: a GROUP
+  has no "enter this line item" interpretation, so "middle" there had nothing
+  else to fall through to and just swallowed the drag. It now collapses to
+  `"before"` specifically when the ACTIVE side is the group/sub-hire-group —
+  hovering ANYWHERE over a line item's row (not just its top/bottom edge) now
+  reorders the group next to it.
+- **Cross-category, any zone.** `resolveGroupDropTarget` had no `li-` branch
+  at all, so a group dragged near a standalone line item in a DIFFERENT
+  category didn't resolve to anything — the only way to move a group into
+  that category was finding its header specifically. `resolveGroupDropOnLineItem`
+  (a new small helper, extracted to keep `resolveGroupDropTarget` under the
+  complexity ratchet) resolves the hovered line item's owning category via
+  `buildLineItemCategoryIndex` (bare lineItemId → categoryId, built fresh from
+  `categoriesRef.current` — a deliberately minimal, single-purpose lookup, NOT
+  a merge of the line-item/group container systems `buildContainerMap` /
+  `buildGroupContainerMap` stay deliberately separate) and lands the group
+  there, append-only — same result as dropping on that category's header, just
+  a more discoverable gesture ("drop near any row in category B").
+
+### Drop-target highlighting
+
+Every draggable row (`DragHandleControls.dropHighlight`, `equipment-rows.tsx`)
+now rings itself when it's the CURRENT hover target of an in-progress drag —
+`ring-ok` (green) when the Drop Matrix allows landing there, `ring-destructive`
+(red) when it doesn't. `use-equipment-dnd.ts`'s `handleDragOver` already
+tracked `invalidOverId`; this adds the unconditional `hoveredOverId` sibling
+(a strict superset) so a valid target can be highlighted too, not just an
+invalid one. `equipment-tab.tsx`'s `dropHighlightFor(sortableId, hoveredOverId,
+invalidOverId)` compares each row's own sortable id against both and resolves
+`"valid"` / `"invalid"` / `undefined`. `dropHighlightClass` lives in
+`equipment-row-types.ts` (not `equipment-rows.tsx`) specifically so
+`equipment-cards.tsx`'s mobile card primitives (`GroupCard`,
+`CategoryCardHeading`) can share it without creating an import edge back into
+the row-rendering component — the same reason that file's types live there in
+the first place (see its header comment).
+
 ## Margin column toggle (8H)
 
 Toolbar button "Show margin" / "Hide margin" toggles a conditional Cost

--- a/src/components/projects/equipment-cards.tsx
+++ b/src/components/projects/equipment-cards.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { ChevronRight, Container, Handshake, Plus } from "lucide-react";
 import { cn, focusRing } from "@/lib/utils";
 import { formatCurrency } from "@/lib/formatters";
-import { type LineItemData } from "./equipment-row-types";
+import { type LineItemData, type DropHighlight, dropHighlightClass } from "./equipment-row-types";
 
 /**
  * Presentational card primitives for the project equipment tab on mobile. Mirrors
@@ -72,6 +72,7 @@ export function GroupCard({
   dragListeners,
   dragStyle,
   isDragging,
+  dropHighlight,
 }: {
   title: string;
   subtext?: React.ReactNode;
@@ -95,6 +96,7 @@ export function GroupCard({
    *  equipment-rows.tsx's `DragHandleControls`. */
   dragStyle?: React.CSSProperties;
   isDragging?: boolean;
+  dropHighlight?: DropHighlight;
 }) {
   return (
     <>
@@ -107,6 +109,7 @@ export function GroupCard({
         className={cn(
           "flex min-h-11 touch-manipulation items-center gap-2 rounded-[var(--r)] bg-card px-3 py-2 ring-1 ring-line-2 active:cursor-grabbing md:cursor-grab",
           isDragging && "opacity-40",
+          dropHighlightClass(dropHighlight),
         )}
       >
         <button
@@ -146,6 +149,7 @@ export function CategoryCardHeading({
   dragListeners,
   dragStyle,
   isDragging,
+  dropHighlight,
 }: {
   name: string;
   action?: React.ReactNode;
@@ -155,6 +159,7 @@ export function CategoryCardHeading({
   dragListeners?: Record<string, unknown>;
   dragStyle?: React.CSSProperties;
   isDragging?: boolean;
+  dropHighlight?: DropHighlight;
 }) {
   return (
     <div
@@ -166,6 +171,7 @@ export function CategoryCardHeading({
       className={cn(
         "flex touch-manipulation items-center justify-between gap-2 rounded-[var(--r)] px-1 pb-0.5 pt-3 active:cursor-grabbing md:cursor-grab",
         isDragging && "opacity-40",
+        dropHighlightClass(dropHighlight),
       )}
     >
       <div className="flex items-center gap-1.5 text-caption font-semibold text-ink-2">

--- a/src/components/projects/equipment-row-types.ts
+++ b/src/components/projects/equipment-row-types.ts
@@ -173,3 +173,22 @@ export interface CategoryData {
   mixedGroups?: MixedGroupSlot[];
   lineItems?: LineItemData[];
 }
+
+/** "Valid"/"invalid" drop-target ring state — see `DragHandleControls`'s
+ *  `dropHighlight` doc comment (equipment-rows.tsx). Lives here (not in
+ *  equipment-rows.tsx itself) so equipment-cards.tsx's mobile card
+ *  primitives can share the exact same styling without creating an import
+ *  edge into the row-rendering component (the same reason this whole file
+ *  exists — see the file header). */
+export type DropHighlight = "valid" | "invalid";
+
+/** Shared ring classes for a `DropHighlight` — same treatment on every
+ *  draggable row kind (desktop `<tr>` and mobile card root alike) so a
+ *  category, group, sub-hire group, or line item all read identically as
+ *  "you're about to drop here" / "that drop isn't allowed". `ring-inset`
+ *  keeps the ring from clipping against neighbouring rows in a table. */
+export function dropHighlightClass(dropHighlight: DropHighlight | undefined): string | undefined {
+  if (dropHighlight === "valid") return "ring-2 ring-inset ring-ok";
+  if (dropHighlight === "invalid") return "ring-2 ring-inset ring-destructive";
+  return undefined;
+}

--- a/src/components/projects/equipment-rows.tsx
+++ b/src/components/projects/equipment-rows.tsx
@@ -53,7 +53,8 @@ import type { MarkerStatus } from "@/components/collaboration/review-marker-badg
 import { CommentThreadPanel } from "@/components/collaboration/comment-thread-panel";
 import { useCollaborationWrites } from "@/hooks/use-collaboration-writes";
 import { toast } from "sonner";
-import type { LineItemData, GroupData, SubHireGroupData, CategoryData } from "./equipment-row-types";
+import type { LineItemData, GroupData, SubHireGroupData, CategoryData, DropHighlight } from "./equipment-row-types";
+import { dropHighlightClass } from "./equipment-row-types";
 
 export type {
   LineItemData,
@@ -61,6 +62,7 @@ export type {
   SubHireGroupData,
   MixedGroupSlot,
   CategoryData,
+  DropHighlight,
 } from "./equipment-row-types";
 
 /**
@@ -132,6 +134,13 @@ export interface DragHandleControls {
   /** No drag entry point at all when true (e.g. sub-hire/kit group children,
    *  which aren't independently reorderable). */
   isDragDisabled?: boolean;
+  /** Set while another row is being dragged and the pointer is currently
+   *  over THIS row — "valid" rings the row to show it's a legitimate drop
+   *  target, "invalid" rings it to show the Drop Matrix rejects landing
+   *  here (equipment-tab.tsx compares `useEquipmentDnd`'s `hoveredOverId`/
+   *  `invalidOverId` against this row's own sortable id). Undefined the rest
+   *  of the time — never set on the row currently being dragged itself. */
+  dropHighlight?: DropHighlight;
 }
 
 // Column count used for category-row + empty-state colSpans. Spans every
@@ -305,6 +314,7 @@ export function GroupRow({
   dragStyle,
   isDragging,
   isDragDisabled,
+  dropHighlight,
   onInlinePriceUpdate,
   moneyLocked,
   lockReason,
@@ -412,6 +422,7 @@ export function GroupRow({
         dragListeners={dragListeners}
         dragStyle={dragStyle}
         isDragging={isDragging}
+        dropHighlight={dropHighlight}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
             {orgId && projectId && (
@@ -451,7 +462,12 @@ export function GroupRow({
 
   return (
     <TableRow
-      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
+      className={cn(
+        "group/row",
+        !isDragDisabled && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40",
+        dropHighlightClass(dropHighlight),
+      )}
       style={dragStyle}
       ref={dragHandleRef}
       data-drag-row="true"
@@ -638,6 +654,7 @@ export function SubHireGroupRow({
   dragStyle,
   isDragging,
   isDragDisabled,
+  dropHighlight,
   onInlinePriceUpdate,
 }: {
   group: SubHireGroupData;
@@ -689,6 +706,7 @@ export function SubHireGroupRow({
         dragListeners={dragListeners}
         dragStyle={dragStyle}
         isDragging={isDragging}
+        dropHighlight={dropHighlight}
         actions={
           <div className="flex shrink-0 items-center gap-0.5">
             <DropdownMenu>
@@ -727,7 +745,12 @@ export function SubHireGroupRow({
 
   return (
     <TableRow
-      className={cn("group/row", !isDragDisabled && "cursor-grab active:cursor-grabbing", isDragging && "opacity-40")}
+      className={cn(
+        "group/row",
+        !isDragDisabled && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40",
+        dropHighlightClass(dropHighlight),
+      )}
       style={dragStyle}
       ref={dragHandleRef}
       data-drag-row="true"
@@ -847,6 +870,7 @@ export function CategoryRow({
   dragStyle,
   isDragging,
   isDragDisabled,
+  dropHighlight,
 }: {
   cat: CategoryData;
   /** Total rendered column count (COL_COUNT + cost). The header cell spans this so it
@@ -925,6 +949,7 @@ export function CategoryRow({
         dragListeners={dragListeners}
         dragStyle={dragStyle}
         isDragging={isDragging}
+        dropHighlight={dropHighlight}
         action={
           <div className="flex shrink-0 items-center gap-1">
             {onAddEquipment && <CardAddButton onClick={onAddEquipment} />}
@@ -941,6 +966,7 @@ export function CategoryRow({
         "group/cat border-b-0 bg-paper-2/50 hover:bg-elev",
         !isDragDisabled && "cursor-grab active:cursor-grabbing",
         isDragging && "opacity-40",
+        dropHighlightClass(dropHighlight),
       )}
       style={dragStyle}
       ref={dragHandleRef}
@@ -1030,6 +1056,7 @@ export function LineItemRow({
   dragStyle,
   isDragging,
   isDragDisabled,
+  dropHighlight,
   onInlineUpdate,
   moneyLocked,
   lockReason,
@@ -1305,6 +1332,7 @@ export function LineItemRow({
             justChanged && "collab-changed",
             !isDragDisabled && "active:cursor-grabbing md:cursor-grab",
             isDragging && "opacity-40",
+            dropHighlightClass(dropHighlight),
           )}
         >
           {selectable && (
@@ -1435,6 +1463,7 @@ export function LineItemRow({
         justChanged && "collab-changed",
         !isDragDisabled && "cursor-grab active:cursor-grabbing",
         isDragging && "opacity-40",
+        dropHighlightClass(dropHighlight),
       )}
       style={dragStyle}
       onClick={onClick}

--- a/src/components/projects/equipment-tab.tsx
+++ b/src/components/projects/equipment-tab.tsx
@@ -93,7 +93,9 @@ import {
   type MixedGroupSlot,
   type OverbookedInfo,
   type GroupInlinePricePatch,
+  type DropHighlight,
 } from "./equipment-rows";
+import { dropHighlightClass } from "./equipment-row-types";
 import { ReassignProvider, type ReassignTarget, type ReassignSerial } from "./reassign-context";
 import { useWarehouseWrites } from "@/hooks/use-warehouse-writes";
 import { useSelection } from "./use-selection";
@@ -330,6 +332,23 @@ function SortableCategoryRow({
   );
 }
 
+/**
+ * Whether THIS row should show a drop-target ring right now — "valid" while
+ * something else is being dragged and the pointer is over this exact
+ * sortable id, "invalid" when that hover ALSO trips the Drop Matrix
+ * (`useEquipmentDnd`'s `invalidOverId` is a strict subset of `hoveredOverId`
+ * for exactly that reason). Undefined otherwise, including for the row
+ * currently being dragged itself (dnd-kit's `over` never equals `active`).
+ */
+function dropHighlightFor(
+  sortableId: string,
+  hoveredOverId: string | null,
+  invalidOverId: string | null,
+): DropHighlight | undefined {
+  if (hoveredOverId !== sortableId) return undefined;
+  return invalidOverId === sortableId ? "invalid" : "valid";
+}
+
 // ─── Uncategorized zone header / drop target ────────────────────────────────
 //
 // Previously this header (and any empty-state hint) only rendered once
@@ -348,24 +367,26 @@ function UncategorizedHeader({
   isMobile,
   colCount,
   isEmpty,
+  dropHighlight,
 }: {
   isMobile: boolean;
   colCount: number;
   isEmpty: boolean;
+  dropHighlight?: DropHighlight;
 }) {
   const { setNodeRef } = useDroppable({ id: "uncat-zone" });
   const hint = "Drag items or groups here to remove them from a category.";
   if (isMobile) {
     return (
       <div ref={setNodeRef}>
-        <CategoryCardHeading name="Uncategorised" />
+        <CategoryCardHeading name="Uncategorised" dropHighlight={dropHighlight} />
         {isEmpty && <p className="px-3 py-2 text-caption text-muted">{hint}</p>}
       </div>
     );
   }
   return (
     <>
-      <TableRow ref={setNodeRef} className="bg-paper-2/40 hover:bg-paper-2/40">
+      <TableRow ref={setNodeRef} className={cn("bg-paper-2/40 hover:bg-paper-2/40", dropHighlightClass(dropHighlight))}>
         <TableCell colSpan={colCount} className="py-2 px-1">
           <div className="flex items-center gap-1.5">
             <div className="w-6" />
@@ -1513,6 +1534,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                       {/* Category label row */}
                       <SortableCategoryRow
                         sortableId={`cat-${cat.id}`}
+                        dropHighlight={dropHighlightFor(`cat-${cat.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                         containerId="categories"
                         dragDisabled={!canDragEquipment}
                         cat={cat}
@@ -1565,6 +1587,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                             <SortableLineItemRow
                               key={item.id}
                               sortableId={`li-${item.id}`}
+                              dropHighlight={dropHighlightFor(`li-${item.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                               containerId={`mixed:${cat.id}`}
                               dragDisabled={!canDragEquipment}
                               item={item}
@@ -1615,6 +1638,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                             <React.Fragment key={`shg-${shGroup.id}`}>
                               <SortableSubHireGroupRow
                                 sortableId={`shg-${shGroup.id}`}
+                                dropHighlight={dropHighlightFor(`shg-${shGroup.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                                 containerId={`mixed:${cat.id}`}
                                 dragDisabled={!canDragEquipment}
                                 group={shGroup}
@@ -1688,6 +1712,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           <React.Fragment key={group.id}>
                             <SortableGroupRow
                               sortableId={`grp-${group.id}`}
+                              dropHighlight={dropHighlightFor(`grp-${group.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                               containerId={`mixed:${cat.id}`}
                               dragDisabled={!canDragEquipment}
                               group={group}
@@ -1756,6 +1781,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                                 <SortableLineItemRow
                                   key={item.id}
                                   sortableId={`li-${item.id}`}
+                                  dropHighlight={dropHighlightFor(`li-${item.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                                   containerId={`items:${group.id}`}
                                   dragDisabled={!canDragEquipment}
                                   item={item}
@@ -1808,7 +1834,12 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                     or group dragged out of a category (see
                     UncategorizedHeader's doc comment). */}
                 {hasCategories && (
-                  <UncategorizedHeader isMobile={isMobile} colCount={colCount} isEmpty={!hasUncategorized} />
+                  <UncategorizedHeader
+                    isMobile={isMobile}
+                    colCount={colCount}
+                    isEmpty={!hasUncategorized}
+                    dropHighlight={dropHighlightFor("uncat-zone", dnd.hoveredOverId, dnd.invalidOverId)}
+                  />
                 )}
                 {(() => {
                   const uncatVisible = (uncategorizedItems as LineItemData[]).filter((i) => !isHiddenFromList(i) && !pendingRemovalIds.has(i.id));
@@ -1821,6 +1852,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                         <SortableLineItemRow
                           key={item.id}
                           sortableId={`li-${item.id}`}
+                          dropHighlight={dropHighlightFor(`li-${item.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                           containerId="uncategorized-standalone"
                           dragDisabled={!canDragEquipment}
                           item={item}
@@ -1890,6 +1922,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                     <React.Fragment key={`pg-${group.id}`}>
                       <SortableGroupRow
                         sortableId={`grp-${group.id}`}
+                        dropHighlight={dropHighlightFor(`grp-${group.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                         containerId="uncategorized-groups"
                         dragDisabled={!canDragEquipment}
                         group={group}
@@ -1955,6 +1988,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                           <SortableLineItemRow
                             key={item.id}
                             sortableId={`li-${item.id}`}
+                            dropHighlight={dropHighlightFor(`li-${item.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                             containerId={`items:${group.id}`}
                             dragDisabled={!canDragEquipment}
                             item={item}
@@ -2004,6 +2038,7 @@ export function EquipmentTab({ projectId, rentalStartDate, rentalEndDate, addMen
                     <React.Fragment key={`shg-${shGroup.id}`}>
                       <SortableSubHireGroupRow
                         sortableId={`shg-${shGroup.id}`}
+                        dropHighlight={dropHighlightFor(`shg-${shGroup.id}`, dnd.hoveredOverId, dnd.invalidOverId)}
                         containerId="uncategorized-groups"
                         dragDisabled={!canDragEquipment}
                         group={shGroup}

--- a/src/hooks/use-equipment-dnd.test.ts
+++ b/src/hooks/use-equipment-dnd.test.ts
@@ -4,6 +4,7 @@ import {
   resolveLineItemDragAction,
   buildGroupContainerMap,
   resolveGroupDragAction,
+  buildLineItemCategoryIndex,
   planGroupReorder,
   resolveCategoryDragAction,
   buildCategoryTopLevelOrder,
@@ -302,6 +303,21 @@ describe("buildGroupContainerMap", () => {
   });
 });
 
+describe("buildLineItemCategoryIndex", () => {
+  test("indexes standalone AND grouped line items by their top-level category", () => {
+    const g1 = group("g1", [li("gi1")]);
+    const catA = category("catA", { standalone: [li("s1")], groups: [g1] });
+    const catB = category("catB", { standalone: [li("s2")] });
+
+    const index = buildLineItemCategoryIndex([catA, catB]);
+
+    expect(index.get("s1")).toBe("catA");
+    expect(index.get("gi1")).toBe("catA");
+    expect(index.get("s2")).toBe("catB");
+    expect(index.has("ghost")).toBe(false);
+  });
+});
+
 describe("resolveGroupDragAction", () => {
   function groupCtxFor(catA: CategoryData, orphanGroups: GroupData[] = [], orphanSh: SubHireGroupData[] = []): GroupContainerContext {
     return buildGroupContainerMap([catA], orphanGroups, orphanSh);
@@ -501,6 +517,46 @@ describe("resolveGroupDragAction", () => {
     expect(action).toEqual({ kind: "noop" });
   });
 
+  test("cross-category move: dropped directly on a LINE ITEM in a different category -> move, append order", () => {
+    // Regression: resolveGroupDropTarget had no li- branch at all, so
+    // dropping a group anywhere near a standalone line item in another
+    // category (rather than precisely on that category's header, or on one
+    // of ITS groups) silently no-opped — the only way in was finding the
+    // category header specifically.
+    const catA = category("catA", {
+      groups: [group("g1", [])],
+      mixedGroups: [{ kind: "project", sortOrder: 0, projectGroupId: "g1" }],
+    });
+    const catB = category("catB", { standalone: [li("b1")], groups: [], mixedGroups: [] });
+    const ctx = buildGroupContainerMap([catA, catB], [], []);
+    const lineItemCategoryIndex = buildLineItemCategoryIndex([catA, catB]);
+    const action = resolveGroupDragAction({
+      activeSortableId: "grp-g1",
+      overSortableId: "li-b1",
+      ctx,
+      lineItemCategoryIndex,
+    });
+    expect(action).toEqual({
+      kind: "move",
+      groupKind: "project",
+      groupId: "g1",
+      fromContainerId: "mixed:catA",
+      toContainerId: "mixed:catB",
+      targetCategoryId: "catB",
+      resultingOrder: undefined,
+    });
+  });
+
+  test("dropped on a line item with no lineItemCategoryIndex supplied -> noop, not a crash", () => {
+    const catA = category("catA", {
+      groups: [group("g1", [])],
+      mixedGroups: [{ kind: "project", sortOrder: 0, projectGroupId: "g1" }],
+    });
+    const ctx = groupCtxFor(catA);
+    const action = resolveGroupDragAction({ activeSortableId: "grp-g1", overSortableId: "li-x", ctx });
+    expect(action).toEqual({ kind: "noop" });
+  });
+
   test("Drop Matrix: a project group onto a sub-hire group is blocked (no nested groups)", () => {
     const catA = category("catA", {
       groups: [group("g1", [])],
@@ -677,8 +733,32 @@ describe("computeDropZone", () => {
 describe("resolveCrossKindCategoryReorder", () => {
   const order = new Map([["catA", ["grp-g1", "li-a", "shg-shg1"]]]);
 
-  test("middle drop zone -> noop (that's still 'enter', handled elsewhere)", () => {
+  test("line item dropped in the middle of a group -> noop (that's still 'enter', handled elsewhere)", () => {
     expect(resolveCrossKindCategoryReorder("li-a", "grp-g1", "middle", order)).toEqual({ kind: "noop" });
+  });
+
+  test("group dropped in the middle of a line item -> reorders it before that line item, not a noop", () => {
+    // Regression: a group has no "enter this line item" interpretation the
+    // way a line item entering a group does, so "middle" used to silently
+    // swallow the drag entirely instead of falling back to an ordinary
+    // reorder. Collapses to "before" — see the doc comment above. Uses its
+    // own fixture (li-a first) since in the shared `order` above grp-g1 is
+    // ALREADY immediately before li-a — "before" would be a no-op there.
+    const orderLiFirst = new Map([["catA", ["li-a", "grp-g1", "shg-shg1"]]]);
+    expect(resolveCrossKindCategoryReorder("grp-g1", "li-a", "middle", orderLiFirst)).toEqual({
+      kind: "reorder",
+      categoryId: "catA",
+      orderedIds: ["grp-g1", "li-a", "shg-shg1"],
+    });
+  });
+
+  test("sub-hire group dropped in the middle of a line item -> also reorders, not a noop", () => {
+    const orderLiFirst = new Map([["catA", ["li-a", "grp-g1", "shg-shg1"]]]);
+    expect(resolveCrossKindCategoryReorder("shg-shg1", "li-a", "middle", orderLiFirst)).toEqual({
+      kind: "reorder",
+      categoryId: "catA",
+      orderedIds: ["shg-shg1", "li-a", "grp-g1"],
+    });
   });
 
   test("line item dropped on a group's top edge -> reorders it before the group", () => {

--- a/src/hooks/use-equipment-dnd.ts
+++ b/src/hooks/use-equipment-dnd.ts
@@ -430,6 +430,27 @@ export function buildGroupContainerMap(
   return { containerOf, itemsByContainer, containerMeta };
 }
 
+/**
+ * Bare line-item id -> the categoryId it top-level belongs to (its own
+ * category if standalone, or its parent group's category if it's a group
+ * child) — used ONLY by `resolveGroupDropTarget`'s `li-` fallback branch
+ * below, to resolve a group dropped onto (or near) a line item in a
+ * DIFFERENT category. Deliberately NOT part of `GroupContainerContext`
+ * itself (see that type's doc comment on why line items and groups stay
+ * separate container systems) — this is a minimal, single-purpose lookup,
+ * not a merge of the two.
+ */
+export function buildLineItemCategoryIndex(categories: readonly CategoryData[]): ReadonlyMap<string, string> {
+  const index = new Map<string, string>();
+  for (const cat of categories) {
+    for (const item of cat.lineItems ?? []) index.set(item.id, cat.id);
+    for (const g of cat.groups ?? []) {
+      for (const item of g.lineItems ?? []) index.set(item.id, cat.id);
+    }
+  }
+  return index;
+}
+
 // ─── The pure "what should this drop do" decision (groups) ──────────────────
 
 export type GroupDragAction =
@@ -461,9 +482,36 @@ export type GroupDragAction =
  * ways a drop can resolve a target here (onto another group, onto a category
  * row, onto an empty container) vs. line items' two.
  */
+/**
+ * The `li-` branch of `resolveGroupDropTarget` — a group dropped on a LINE
+ * ITEM in a DIFFERENT category (the SAME-category case — reordering a group
+ * past a line item already sharing its top-level list — is intercepted
+ * earlier by `resolveCrossKindCategoryReorder`, so this only ever fires
+ * cross-category). Extracted for the same complexity-ratchet reason every
+ * other `plan*`/`resolve*` split in this file was.
+ *
+ * There's no specific-sibling positioning here (that would need the full
+ * interleaved order this container map deliberately doesn't track — see
+ * `buildLineItemCategoryIndex`'s doc comment) — append-only, same as
+ * dropping on that category's header, just a more discoverable gesture
+ * ("drop near any row in category B" instead of having to find its header
+ * specifically).
+ */
+function resolveGroupDropOnLineItem(
+  overBareLineItemId: string,
+  ctx: GroupContainerContext,
+  lineItemCategoryIndex: ReadonlyMap<string, string> | undefined,
+): { toContainerId: GroupContainerId } | null {
+  const categoryId = lineItemCategoryIndex?.get(overBareLineItemId);
+  if (!categoryId) return null;
+  const candidate: GroupContainerId = `mixed:${categoryId}`;
+  return ctx.itemsByContainer.has(candidate) ? { toContainerId: candidate } : null;
+}
+
 function resolveGroupDropTarget(
   overSortableId: string,
   ctx: GroupContainerContext,
+  lineItemCategoryIndex?: ReadonlyMap<string, string>,
 ): { toContainerId: GroupContainerId; overSlotId?: string } | null {
   if (overSortableId.startsWith("grp-") || overSortableId.startsWith("shg-")) {
     const toContainerId = ctx.containerOf.get(overSortableId);
@@ -475,6 +523,9 @@ function resolveGroupDropTarget(
     // reparenting to a new category, landing at the end of its mixed list).
     const candidate: GroupContainerId = `mixed:${overSortableId.slice(4)}`;
     return ctx.itemsByContainer.has(candidate) ? { toContainerId: candidate } : null;
+  }
+  if (overSortableId.startsWith("li-")) {
+    return resolveGroupDropOnLineItem(overSortableId.slice(3), ctx, lineItemCategoryIndex);
   }
   // The Uncategorized zone's header/landing-zone row — see
   // `resolveLineItemDropTarget`'s matching branch.
@@ -554,8 +605,12 @@ export function resolveGroupDragAction(input: {
   activeSortableId: string;
   overSortableId: string | null;
   ctx: GroupContainerContext;
+  /** See `buildLineItemCategoryIndex` — only needed to resolve a group
+   *  dropped on a line item in a different category. Omit in tests that
+   *  don't exercise that branch. */
+  lineItemCategoryIndex?: ReadonlyMap<string, string>;
 }): GroupDragAction {
-  const { activeSortableId, overSortableId, ctx } = input;
+  const { activeSortableId, overSortableId, ctx, lineItemCategoryIndex } = input;
 
   if (!isGroupSortableId(activeSortableId)) return { kind: "noop" };
   if (!overSortableId || activeSortableId === overSortableId) return { kind: "noop" };
@@ -566,7 +621,7 @@ export function resolveGroupDragAction(input: {
   const fromContainerId = ctx.containerOf.get(activeSortableId);
   if (!fromContainerId) return { kind: "noop" };
 
-  const target = resolveGroupDropTarget(overSortableId, ctx);
+  const target = resolveGroupDropTarget(overSortableId, ctx, lineItemCategoryIndex);
   if (!target) return { kind: "noop" };
   const { toContainerId, overSlotId } = target;
 
@@ -726,12 +781,21 @@ function spliceCrossKind(
 
 /**
  * Pure — resolves the "reorder a line item past a group in the same
- * category" gap. Requires: an edge drop zone (not "middle" — that's still
- * "enter", handled by `resolveLineItemDragAction` as before), one side a
- * line item and the other a group/sub-hire-group, and BOTH ids present in
- * the SAME category's combined order (a grouped line-item child never is,
- * by construction — so this can never fire for "leave my group", only ever
- * for two items already siblings at the top of one category).
+ * category" gap. Requires one side a line item and the other a
+ * group/sub-hire-group, and BOTH ids present in the SAME category's combined
+ * order (a grouped line-item child never is, by construction — so this can
+ * never fire for "leave my group", only ever for two items already siblings
+ * at the top of one category).
+ *
+ * A "middle" drop zone is ambiguous only in ONE direction: a LINE ITEM
+ * dropped in the middle of a GROUP/sub-hire-group row means "enter that
+ * group" (handled by `resolveLineItemDragAction` elsewhere, so this function
+ * stays a noop for that pairing). The reverse — a GROUP dropped in the
+ * middle of a LINE ITEM row — has no such "enter" interpretation (a group
+ * can never contain a line item), so there's nothing else to fall through
+ * to; treating it as a noop there just silently swallowed the drag. Collapse
+ * that one direction's "middle" to "before" instead, so hovering ANYWHERE
+ * over the line item's row reorders the group next to it.
  */
 export function resolveCrossKindCategoryReorder(
   activeSortableId: string,
@@ -739,12 +803,15 @@ export function resolveCrossKindCategoryReorder(
   dropZone: "before" | "middle" | "after",
   categoryTopLevelOrder: ReadonlyMap<string, readonly string[]>,
 ): CrossKindReorderAction {
-  if (dropZone === "middle") return { kind: "noop" };
   if (!isCrossKindPair(activeSortableId, overSortableId)) return { kind: "noop" };
+
+  const activeIsGroupish = activeSortableId.startsWith("grp-") || activeSortableId.startsWith("shg-");
+  const effectiveDropZone = dropZone === "middle" && activeIsGroupish ? "before" : dropZone;
+  if (effectiveDropZone === "middle") return { kind: "noop" };
 
   for (const [categoryId, order] of categoryTopLevelOrder) {
     if (!order.includes(activeSortableId) || !order.includes(overSortableId)) continue;
-    const orderedIds = spliceCrossKind(order, activeSortableId, overSortableId, dropZone);
+    const orderedIds = spliceCrossKind(order, activeSortableId, overSortableId, effectiveDropZone);
     return orderedIds ? { kind: "reorder", categoryId, orderedIds } : { kind: "noop" };
   }
   return { kind: "noop" };

--- a/src/hooks/use-equipment-dnd.ts
+++ b/src/hooks/use-equipment-dnd.ts
@@ -941,6 +941,12 @@ export interface UseEquipmentDndResult {
   /** The `over.id` currently being hovered when the Drop Matrix disallows it
    *  — null otherwise. Lets the caller render invalid-drop styling. */
   invalidOverId: string | null;
+  /** The `over.id` currently being hovered, valid or not — null when nothing
+   *  is being dragged or the pointer isn't over any droppable. Lets the
+   *  caller render a "you're about to drop here" highlight on whatever
+   *  category/group/line-item row the pointer is over, distinct from
+   *  `invalidOverId`'s narrower "and it's disallowed" signal. */
+  hoveredOverId: string | null;
   handleDragStart: (event: DragStartEvent) => void;
   handleDragOver: (event: DragOverEvent) => void;
   handleDragEnd: (event: DragEndEvent) => void;
@@ -993,6 +999,11 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [draggedRowClone, setDraggedRowClone] = useState<DraggedRowClone | null>(null);
   const [invalidOverId, setInvalidOverId] = useState<string | null>(null);
+  /** The `over.id` currently being hovered, valid or not — lets the caller
+   *  highlight whatever category/group/line-item row the pointer is over,
+   *  same idea as `invalidOverId` but unconditional (that one is a strict
+   *  subset, only set when the Drop Matrix disallows the hovered target). */
+  const [hoveredOverId, setHoveredOverId] = useState<string | null>(null);
   const [orderOverlay, setOrderOverlay] = useState<ReadonlyMap<string, OptimisticOrderEdit>>(
     () => new Map(),
   );
@@ -1092,6 +1103,7 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
     const overId = event.over ? String(event.over.id) : null;
+    setHoveredOverId(overId);
     if (!overId) {
       setInvalidOverId(null);
       return;
@@ -1113,7 +1125,8 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
         uncategorizedProjectGroupsRef.current ?? [],
         uncategorizedSubHireGroupsRef.current ?? [],
       );
-      const action = resolveGroupDragAction({ activeSortableId, overSortableId, ctx: groupCtx });
+      const lineItemCategoryIndex = buildLineItemCategoryIndex(categoriesRef.current ?? []);
+      const action = resolveGroupDragAction({ activeSortableId, overSortableId, ctx: groupCtx, lineItemCategoryIndex });
 
       if (action.kind === "noop") return;
       if (action.kind === "blocked") {
@@ -1274,6 +1287,7 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
     setActiveDragId(null);
     setDraggedRowClone(null);
     setInvalidOverId(null);
+    setHoveredOverId(null);
   }, []);
 
   // Dispatch for `resolveCrossKindCategoryReorder`'s "reorder" result — a
@@ -1320,6 +1334,7 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
       setActiveDragId(null);
       setDraggedRowClone(null);
       setInvalidOverId(null);
+      setHoveredOverId(null);
 
       const activeSortableId = String(event.active.id);
       const overSortableId = event.over ? String(event.over.id) : null;
@@ -1365,6 +1380,7 @@ export function useEquipmentDnd(args: UseEquipmentDndArgs): UseEquipmentDndResul
     activeDragId,
     draggedRowClone,
     invalidOverId,
+    hoveredOverId,
     handleDragStart,
     handleDragOver,
     handleDragEnd,


### PR DESCRIPTION
## Summary

Follow-up to #1121 — the user reported dragging into the middle of another category didn't work, and asked for visual feedback showing where a drag is about to land. Investigation turned up two more real gaps plus the missing highlighting:

- `resolveCrossKindCategoryReorder` collapsed any `middle` drop zone to a noop regardless of direction. Correct for a line item hovering the middle of a group (that's "enter this group," resolved elsewhere) — wrong for the reverse: a group has no "enter this line item" interpretation, so hovering the middle of a line item's row (not just its top/bottom edge) used to silently swallow the drag entirely. Now collapses to "before" whenever the active side is the group/sub-hire-group.
- `resolveGroupDropTarget` had no `li-` branch at all, so a group dragged near a standalone line item in a **different** category didn't resolve to anything — the only way in was finding that category's header specifically. `resolveGroupDropOnLineItem` (extracted to stay under the complexity ratchet) resolves the destination via a new `buildLineItemCategoryIndex` lookup and lands the group there, append-only.
- Drop-target highlighting: every draggable row now rings itself when it's the current hover target of an in-progress drag — green (`ring-ok`) when the Drop Matrix allows landing there, red (`ring-destructive`) when it doesn't. `use-equipment-dnd.ts` already tracked `invalidOverId` but never consumed it anywhere; this adds the unconditional `hoveredOverId` sibling and wires both into every row kind (desktop + mobile).

### Size rationale (R-2.8 / T-2)

All three found and fixed together in one debugging pass off the same user report — the highlighting fix in particular is what made the middle-zone bug visible/diagnosable in the first place (confirmed live: the hover ring showed the correct target, but the drop was a silent no-op until the resolver fix landed).

## Testing

- `pnpm test` — 444 files / 5622 tests pass (5 new: middle-zone collapse for both directions, `buildLineItemCategoryIndex`, cross-category group-onto-line-item, no-crash-without-index guard).
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint` on touched files — no new warnings/errors.
- `node scripts/complexity-ratchet.mjs` — 684/684 (the new `li-` branch was extracted into `resolveGroupDropOnLineItem` to stay under it).
- `node scripts/collect-ratchet.mjs` / `any-ratchet.sh` / `depcruise-ratchet.mjs` — all hold at baseline, untouched.
- **Manual verification**, live against a real local dev stack (self-hosted Convex + Postgres + `pnpm dev`), driven via the `browse` skill in real headless Chromium with synthetic pointer-event drags: confirmed the hover ring turns green over a valid target mid-drag; confirmed a group dropped in the middle of a line item's row (same category) now reorders instead of no-op-ing; confirmed a group dragged from one category directly onto a line item in a different category now moves there instead of no-op-ing.

## Checklist

- [x] No new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjv9HbJGzmNqARgidutm2t)_