### PR TITLE
A2: Org switcher + Convex token re-mint (#1072)

### DIFF
--- a/FEATUREDOCS/04-auth-permissions.md
+++ b/FEATUREDOCS/04-auth-permissions.md
@@ -58,7 +58,7 @@ creation is gated off, D7) — the "request to join" flow that resolves this
   docstring — without it the bootstrap owner has a Postgres membership and no
   Convex one, and every Convex-authorized action fails).
 
-### The org switcher and picker
+### The org switcher and picker (#1072, A2 — D14)
 - `src/app/(auth)/select-organization/page.tsx` — the "never guess" picker: shown to
   a 2+-membership user post-login/post-SSO/via `OrgActivator`, lets them choose,
   then calls `organization.setActive()` and navigates to a tenant-neutral
@@ -67,9 +67,56 @@ creation is gated off, D7) — the "request to join" flow that resolves this
   missing active org on the client (mainly the SSO-redirect gap): 1 membership →
   activate it; 2+ → route to the picker; 0 → nothing to activate (the `(app)`
   layout's own guard handles 0 memberships).
-- A full org-switcher **dropdown** (D14, re-minting the Convex token on switch) is
-  `#1072`/A2 — not built yet; today switching means signing into a different
-  session or using the picker above.
+- **The switcher dropdown** (`UserNav`, `src/components/layout/user-nav.tsx`) adds an
+  "Organisations" group to the existing sidebar-footer menu — one item per
+  `getMyOrganizations()` membership (never a client-filtered list of all orgs), a
+  check against the active org, role as secondary text. Shown only with ≥2
+  memberships; the active org's name fills the trigger's second line regardless
+  (replacing what used to be a duplicate of the email shown two rows below).
+  Picking an org calls `organization.setActive()` then `router.push("/dashboard")` —
+  same tenant-neutral-root rule as the picker.
+
+#### The sharp edge: re-minting the Convex token on switch
+
+`organization.setActive()` updates the Better Auth session, but the Convex JWT bakes
+`orgId` in as a claim (`definePayload`, `src/lib/auth.ts`) — and Convex's
+`ConvexProviderWithAuth` only refetches that token on its own schedule (mount +
+pre-expiry), never merely because a render happened. Left alone, every live
+subscription would keep serving the **previous** org's data until the token
+happened to expire — a cross-tenant read produced by the switcher itself.
+
+Fixed centrally in `src/components/providers/convex-provider.tsx`, not in the
+switcher: `useBetterAuthForConvex`'s `fetchAccessToken` callback includes the
+active org id in its dependency array. Convex's own `ConvexAuthStateFirstEffect`
+calls `client.setAuth(fetchAccessToken, ...)` inside a `useEffect` keyed on that
+callback's identity — and `client.setAuth` (`AuthenticationManager.setConfig`,
+verified against the installed `convex` package source, not assumed from docs)
+unconditionally pauses the socket, force-fetches a fresh token, and
+re-authenticates. So switching org changes `orgId` → `fetchAccessToken` gets a new
+identity → the effect reruns → the client force-reauthenticates and every
+subscription re-evaluates under the new claim. No caller (switcher, picker,
+`OrgActivator`) has to orchestrate this itself — there's exactly one place a
+Convex identity is minted, and the reactivity lives there.
+
+`useServerQuery` reads (server-action-backed, not Convex subscriptions) invalidate
+correctly only when their `queryKey` includes `orgId` — `UserNav`'s own
+`my-crew-id`/`my-organizations` keys follow this. **Known gap**: no exhaustive
+sweep of every `useServerQuery` call site for a missing `orgId` key has been done
+yet — deferred to A6 (`#1076`), the registry-driven cross-tenant audit, rather than
+hand-checked here.
+
+**Known gap, E2E coverage**: the design called for an explicit E2E (a user in two
+orgs switches, asserts the second org's dashboard shows none of the first org's
+entities), but writing one hits the same root cause already blocking
+`harness-onboarding`/`harness-revenue-path`/`harness-sign-out` (`#1118`): the
+shared-DB harness can't create a second org once one exists in a run, and this
+scenario additionally needs invitation-acceptance across two accounts, which has
+no test-harness affordance for reading a sent invite without email delivery.
+Covered instead by a jsdom smoke test that actually opens the menu
+(`src/components/layout/__tests__/user-nav.test.tsx`) — proves the group's
+membership-count gating, the per-item render, and that a click fires
+`setActive()` + `push("/dashboard")`, but not live cross-tenant data isolation.
+Tracked under the same `#1118` as the other quarantined harness gaps.
 
 ### Org archiving (#1075, A5 — D12) — archived, never deleted, reversible
 - `Organization.archivedAt DateTime?` (Postgres — `apiKillSwitchAt`'s sibling column).

--- a/src/components/layout/__tests__/user-nav.test.tsx
+++ b/src/components/layout/__tests__/user-nav.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+/**
+ * The org switcher (design doc §4.3.1, A2) — added to the always-mounted
+ * sidebar-footer menu. Covers the two things a closed-trigger render can't
+ * prove (CLAUDE.md, "Test menus by actually OPENING them"): the Organisations
+ * group only shows with >=2 memberships, and picking one calls
+ * organization.setActive() then navigates to a tenant-neutral root (never
+ * stays on the current page — see convex-provider.tsx for why: it's the
+ * re-authentication trigger, not just navigation UX).
+ */
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const setActive = vi.fn(async (..._args: unknown[]) => ({}));
+const signOutMock = vi.fn(async (..._args: unknown[]) => ({}));
+let sessionData: { user: { id: string; name: string; email: string } } | null = {
+  user: { id: "user_1", name: "Ada Lovelace", email: "ada@example.com" },
+};
+let activeOrgData: { id: string; name: string } | undefined = {
+  id: "org_1",
+  name: "Org One",
+};
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: sessionData }),
+  useActiveOrganization: () => ({ data: activeOrgData }),
+  organization: { setActive: (...a: unknown[]) => setActive(...a) },
+  signOut: (...a: unknown[]) => signOutMock(...a),
+}));
+
+let myOrgsResult: { id: string; name: string; slug: string; role: string }[] = [];
+vi.mock("@/server/public-org", () => ({
+  getMyOrganizations: () => Promise.resolve(myOrgsResult),
+}));
+
+vi.mock("@/hooks/use-profile", () => ({
+  useProfile: () => ({ data: undefined }),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({ query: vi.fn(async () => null) }),
+  useConvexAuth: () => ({ isAuthenticated: false }),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  useSidebar: () => ({ state: "expanded", isMobile: false }),
+}));
+
+import { UserNav } from "@/components/layout/user-nav";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+beforeEach(() => {
+  push.mockClear();
+  setActive.mockClear();
+  signOutMock.mockClear();
+  sessionData = { user: { id: "user_1", name: "Ada Lovelace", email: "ada@example.com" } };
+  activeOrgData = { id: "org_1", name: "Org One" };
+  myOrgsResult = [];
+});
+
+function openMenu() {
+  const trigger = screen.getByRole("button", { name: "Account menu" });
+  trigger.focus();
+  fireEvent.keyDown(trigger, { key: "Enter" });
+  return trigger;
+}
+
+describe("UserNav", () => {
+  it("shows the active org name on the trigger's second line, not the email", () => {
+    render(<UserNav />);
+    expect(screen.getByText("Org One")).toBeTruthy();
+    expect(screen.queryByText("ada@example.com")).toBeNull();
+  });
+
+  it("hides the Organisations group entirely with a single membership", async () => {
+    myOrgsResult = [{ id: "org_1", name: "Org One", slug: "org-one", role: "OWNER" }];
+    render(<UserNav />);
+    openMenu();
+    // The menu still opens (proves it isn't crashing), just without a switcher.
+    await waitFor(() => expect(screen.getByRole("menu")).toBeTruthy());
+    expect(screen.queryByText("Organisations")).toBeNull();
+  });
+
+  it("shows one item per membership, checked against the active org, once there are >=2", async () => {
+    myOrgsResult = [
+      { id: "org_1", name: "Org One", slug: "org-one", role: "OWNER" },
+      { id: "org_2", name: "Org Two", slug: "org-two", role: "MEMBER" },
+    ];
+    render(<UserNav />);
+    openMenu();
+    const menu = within(await waitFor(() => screen.getByRole("menu")));
+    expect(menu.getByText("Organisations")).toBeTruthy();
+    expect(menu.getByText("Org One")).toBeTruthy();
+    expect(menu.getByText("Org Two")).toBeTruthy();
+    expect(menu.getByText("MEMBER")).toBeTruthy();
+  });
+
+  it("switching org calls setActive then navigates to /dashboard — never stays put", async () => {
+    myOrgsResult = [
+      { id: "org_1", name: "Org One", slug: "org-one", role: "OWNER" },
+      { id: "org_2", name: "Org Two", slug: "org-two", role: "MEMBER" },
+    ];
+    render(<UserNav />);
+    openMenu();
+    const target = await waitFor(() => screen.getByText("Org Two"));
+    fireEvent.click(target);
+
+    await waitFor(() => expect(setActive).toHaveBeenCalledWith({ organizationId: "org_2" }));
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("clicking the already-active org is a no-op — no redundant setActive/navigate", async () => {
+    myOrgsResult = [
+      { id: "org_1", name: "Org One", slug: "org-one", role: "OWNER" },
+      { id: "org_2", name: "Org Two", slug: "org-two", role: "MEMBER" },
+    ];
+    render(<UserNav />);
+    openMenu();
+    const menu = within(await waitFor(() => screen.getByRole("menu")));
+    const current = menu.getByText("Org One");
+    fireEvent.click(current);
+
+    expect(setActive).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/user-nav.tsx
+++ b/src/components/layout/user-nav.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { LogOut, User, ChevronsUpDown, Shield, HardHat } from "lucide-react";
+import { LogOut, User, ChevronsUpDown, Shield, HardHat, Check, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { isSiteAdminRole } from "@/lib/admin-role";
-import { useSession, signOut, useActiveOrganization } from "@/lib/auth-client";
+import { useSession, signOut, useActiveOrganization, organization } from "@/lib/auth-client";
 import { useServerQuery } from "@/hooks/use-server-query";
 import { useProfile } from "@/hooks/use-profile";
+import { getMyOrganizations } from "@/server/public-org";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useConvex, useConvexAuth } from "convex/react";
 import { api } from "../../../convex/_generated/api";
@@ -51,6 +53,33 @@ export function UserNav() {
     enabled: !!orgId && isAuthenticated,
   });
 
+  // Org switcher (design doc §4.3.1, A2) — membership-derived, never a client-
+  // filtered list of all orgs. Shown only when there are ≥2 memberships; the
+  // active org's name still fills the trigger's second line for everyone,
+  // since that's context, not the switcher UI itself.
+  const { data: myOrgs } = useServerQuery({
+    queryKey: ["my-organizations", user?.id],
+    queryFn: () => getMyOrganizations(),
+    enabled: !!user?.id,
+  });
+  const [switchingId, setSwitchingId] = useState<string | null>(null);
+
+  async function switchOrganization(targetOrgId: string) {
+    if (targetOrgId === orgId || switchingId) return;
+    setSwitchingId(targetOrgId);
+    try {
+      await organization.setActive({ organizationId: targetOrgId });
+      // Always land on a tenant-neutral root — never carry an id belonging to
+      // the previous org into the newly-activated one (design doc §4.3.1). The
+      // Convex client re-authenticates for free (src/components/providers/
+      // convex-provider.tsx reacts to the orgId change), so nothing else here
+      // needs to force a token refresh or drop a cache.
+      router.push("/dashboard");
+    } finally {
+      setSwitchingId(null);
+    }
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -72,7 +101,9 @@ export function UserNav() {
             <>
               <span className="grid flex-1 text-left leading-tight">
                 <span className="truncate text-[13px] font-medium text-ink">{user?.name || "User"}</span>
-                <span className="truncate text-[11px] text-muted">{user?.email}</span>
+                <span className="truncate text-[11px] text-muted">
+                  {activeOrg?.name ?? user?.email}
+                </span>
               </span>
               <ChevronsUpDown className="ml-auto size-4 shrink-0 text-muted" />
             </>
@@ -85,6 +116,39 @@ export function UserNav() {
         side={collapsed ? "right" : "top"}
         sideOffset={collapsed ? 8 : 4}
       >
+        {myOrgs && myOrgs.length >= 2 && (
+          <>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="font-normal text-[11px] text-muted">
+                Organisations
+              </DropdownMenuLabel>
+              {myOrgs.map((org) => (
+                <DropdownMenuItem
+                  key={org.id}
+                  disabled={switchingId !== null}
+                  onClick={() => switchOrganization(org.id)}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    {switchingId === org.id ? (
+                      <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                    ) : (
+                      <Check
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          org.id === orgId ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                    )}
+                    <span className="truncate">{org.name}</span>
+                  </span>
+                  <span className="shrink-0 text-[11px] text-muted">{org.role}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuGroup>
           <DropdownMenuLabel className="font-normal">
             <div className="flex flex-col space-y-1">

--- a/src/components/providers/convex-provider.tsx
+++ b/src/components/providers/convex-provider.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { ConvexReactClient, ConvexProviderWithAuth } from "convex/react";
 import { logger } from "@/lib/logger";
 import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
-import { authClient } from "@/lib/auth-client";
+import { authClient, useActiveOrganization } from "@/lib/auth-client";
 import { fetchConvexAccessToken } from "@/lib/convex-token-fetch";
 
 /**
@@ -41,9 +41,29 @@ const CACHE_MAX_IDLE_ENTRIES = 250;
  * ES256 JWT (or null when logged out / on error); Convex calls it on mount and
  * refreshes it before expiry (forceRefreshToken just re-fetches — the endpoint
  * always mints a fresh token from the live session).
+ *
+ * The org switcher's sharp edge (design doc §4.3.1, A2): `organization.setActive()`
+ * updates the Better Auth session, but the JWT bakes `orgId` in as a claim
+ * (`definePayload`, src/lib/auth.ts) and Convex only refetches that token on its
+ * own schedule (mount + pre-expiry) — NOT on every render. Left alone, every live
+ * subscription would keep serving the PREVIOUS org's data until the token happened
+ * to expire: a cross-tenant read produced by the switcher itself.
+ *
+ * `ConvexProviderWithAuth` calls `client.setAuth(fetchAccessToken, ...)` inside a
+ * `useEffect` keyed on `fetchAccessToken`'s identity (convex/react's
+ * ConvexAuthState.js) — and `client.setAuth` unconditionally pauses the socket,
+ * force-fetches a fresh token, and re-authenticates (authentication_manager.js
+ * `setConfig`), which is exactly the reauth-and-resubscribe-everything sequence
+ * needed. So including `orgId` in this callback's deps is enough to trigger it:
+ * switching org changes `orgId` → `fetchAccessToken` gets a new identity → the
+ * provider's effect reruns → the client force-reauthenticates. No caller (the
+ * switcher, the select-organization page, OrgActivator) needs to orchestrate this
+ * itself — it's centralized here, the one place a Convex identity is minted.
  */
 function useBetterAuthForConvex() {
   const { data: session, isPending } = authClient.useSession();
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
 
   const fetchAccessToken = useCallback(
     // forceRefreshToken is ignored — /api/auth/token always mints a fresh token
@@ -51,8 +71,12 @@ function useBetterAuthForConvex() {
     // resilient: a TRANSIENT /api/auth/token failure is retried rather than
     // collapsed to null (null de-auths Convex and makes every live subscription
     // throw "Unauthorized" — the "random client crash"). See convex-token-fetch.ts.
+    // `orgId` is read only to force a new callback identity on org switch — it's
+    // not used in the body itself, fetchConvexAccessToken always reads the live
+    // session server-side.
     async (): Promise<string | null> => fetchConvexAccessToken(),
-    [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- orgId intentionally unused in body, see comment above
+    [orgId],
   );
 
   return useMemo(


### PR DESCRIPTION
## Summary

Phase A, section A2 (#1072) of #1064. Adds the org switcher dropdown to the sidebar-footer user menu, and fixes the "sharp edge" the design doc calls out: making sure the Convex client actually re-authenticates when the active org changes.

- **Switcher UI** (`UserNav`, `src/components/layout/user-nav.tsx`): an "Organisations" group at the top of the existing Radix `DropdownMenu`, one item per `getMyOrganizations()` membership (never a client-filtered all-orgs list), a check against the active org, role as secondary text. Shown only at ≥2 memberships. The trigger's second line now shows the active org's name instead of the email (which was already duplicated in the menu header two rows below).
- **The sharp edge**: `organization.setActive()` updates the Better Auth session, but the Convex JWT bakes `orgId` in as a claim, and `ConvexProviderWithAuth` only refetches that token on its own schedule (mount + pre-expiry) — never merely because a render happened. Left alone, every live Convex subscription would keep serving the *previous* org's data until the token happened to expire: a cross-tenant read produced by the switcher itself.
  - Fixed centrally in `src/components/providers/convex-provider.tsx`, not per-caller: `useBetterAuthForConvex`'s `fetchAccessToken` callback now includes the active org id in its dependency array. I verified against the **installed `convex` package source** (not assumed from docs) that `client.setAuth` (`AuthenticationManager.setConfig`) unconditionally pauses the socket, force-fetches a fresh token, and re-authenticates every time it's called, and that `ConvexProviderWithAuth`'s effect re-invokes `client.setAuth` whenever `fetchAccessToken`'s identity changes. So switching org → `orgId` changes → `fetchAccessToken` gets a new identity → the effect reruns → the client force-reauthenticates and every subscription re-evaluates under the new claim. No caller (switcher, `select-organization` picker, `OrgActivator`) needs to orchestrate this itself.
- Picking an org calls `organization.setActive()` then `router.push("/dashboard")` — same tenant-neutral-root rule as the existing picker, for the same reason: staying on `/projects/<id>` would carry an id belonging to the old org into the new one.

### Known gaps (documented, not silent)

1. **No exhaustive `useServerQuery` orgId-key sweep.** The design doc flags "any key missing `orgId` is a bug the switcher will expose — worth a sweep." I did a scoped pass but not an exhaustive one (~110 call sites) — deferred to **A6 (#1076)**, the registry-driven cross-tenant audit, which is explicitly the phase's exhaustive/ratcheted gate rather than something to hand-verify here.
2. **No E2E for the switcher.** The design called for one (a user in two orgs switches, asserts the second org's dashboard shows none of the first org's entities), but it hits the same root cause already blocking `harness-onboarding`/`harness-revenue-path`/`harness-sign-out` (**#1118**, already quarantined): the shared-DB harness can't create a second org once one exists in a run. This scenario additionally needs cross-account invite acceptance, with no harness affordance for reading a sent invite without email delivery. Rather than write a speculative test with two independent unresolved blockers, I covered what's actually testable now: a jsdom smoke test that **opens** the menu (`user-nav.test.tsx`) and proves the membership-count gating, per-item render, and that a click fires `setActive()` + `push("/dashboard")`. Tracked under the same #1118.

## Testing

- `pnpm test` — 5716/5716 passing (new `user-nav.test.tsx`: 5 tests covering trigger label, single-membership hides the group, multi-membership renders + checks the active org, switch calls setActive+navigates, clicking the already-active org is a no-op)
- `tsc --noEmit` — clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- All CI-blocking ratchets green, no regressions
- `pnpm build` — production build succeeds

## Checklist

- [x] New dependency? N/A — no new dependencies added (verified via `check-dependency-justification.mjs`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KskmC2d2LWoxCzmavijhhv)_