### PR TITLE
Fix crew tab double-counting service-linked crew cost

### DIFF
--- a/FEATUREDOCS/31-crew-management.md
+++ b/FEATUREDOCS/31-crew-management.md
@@ -206,7 +206,12 @@ service's line item and the project's `serviceCostTotal`. This is enforced from
   (`convex/lib/recalc.ts`) only sums assignments with **no** `serviceId` — a
   service-linked assignment's cost is already inside `serviceCostTotal` via the
   service's own `costTotal`. Standalone assignments (rare now — see below) still
-  roll up through `labourCostTotal` as before.
+  roll up through `labourCostTotal` as before. The SAME exclusion applies to
+  `crewAssignments.projectLabourCost` (the "Crew" tile in `ProjectSummaryStrip`
+  and the "Est. labour" figure in `CrewPanel`'s summary bar) and its pure
+  counterpart `aggregateProjectLabourCost` — both were fixed to exclude
+  service-linked assignments after they were found double-displaying a
+  service's crew cost as a second, separate "Crew" total.
 - A **crew-less** service keeps whatever `costTotal` was last set manually (e.g. a
   vehicle/transport-only service with no crew) — `recalcServiceCostFromCrew()` only
   takes over once the service has 1+ crew.

--- a/convex/crewAssignments.ts
+++ b/convex/crewAssignments.ts
@@ -131,8 +131,14 @@ export const projectLabourCost = query({
   args: { projectId: v.string(), orgId: v.string() },
   handler: async (ctx, { projectId, orgId }) => {
     await requireOrgReadFor(ctx, orgId, "crew"); // Phase 2 read bootstrap (#998)
+    // A service-linked assignment's cost is already rolled into its service's
+    // `costTotal` (convex/lib/serviceCost.ts recalcServiceCostFromCrew), which
+    // feeds `serviceCostTotal` — summing it again here would double it against
+    // that. Mirrors recalcProjectTotals's `labourCostTotal` exclusion exactly
+    // (convex/lib/recalc.ts, issue #796) so this display total and the real P&L
+    // total never disagree.
     const assignments = (await ctx.db.query("crewAssignments").withIndex("by_projectId", (q) => q.eq("projectId", projectId)).collect())
-      .filter((a) => a.organizationId === orgId && !EXCLUDED_STATUSES.has(a.status ?? ""));
+      .filter((a) => a.organizationId === orgId && !EXCLUDED_STATUSES.has(a.status ?? "") && a.serviceId == null);
     return { totalLabourCost: assignments.reduce((sum, a) => sum + (a.estimatedCost ?? 0), 0), assignmentCount: assignments.length };
   },
 });

--- a/convex/crewAssignmentsWrites.test.ts
+++ b/convex/crewAssignmentsWrites.test.ts
@@ -187,14 +187,17 @@ describe("crewAssignments reads", () => {
       await ctx.db.insert("crewAssignments", { id: "a3", organizationId: ORG, projectId: "p1", crewMemberId: "c1", status: "CANCELLED", estimatedCost: 999 });
       await ctx.db.insert("crewShifts", { id: "sh1", assignmentId: "a1", date: NOW });
       await ctx.db.insert("crewAssignments", { id: "aX", organizationId: OTHER, projectId: "p1", crewMemberId: "c1", status: "CONFIRMED", estimatedCost: 777 });
+      // Service-linked — its cost already lives in the service's own costTotal, so
+      // projectLabourCost must not sum it again (issue #796 / the crew-tab double-count bug).
+      await ctx.db.insert("crewAssignments", { id: "a4", organizationId: ORG, projectId: "p1", crewMemberId: "c1", serviceId: "s1", status: "CONFIRMED", estimatedCost: 5000 });
     });
     const crew = await t.withIdentity(asUser).query(api.crewAssignments.projectCrew, { projectId: "p1", orgId: ORG });
-    expect(crew.map((a) => a.id)).toEqual(["a2", "a1", "a3"]); // PM first (a2), then non-PM
+    expect(crew.map((a) => a.id)).toEqual(["a2", "a1", "a3", "a4"]); // PM first (a2), then non-PM
     expect(crew.find((a) => a.id === "a1")?.crewMember.lastName).toBe("Ryan");
     expect(crew.find((a) => a.id === "a1")?.crewRole?.name).toBe("Rigger");
     expect(crew.find((a) => a.id === "a1")?.shifts).toHaveLength(1);
     const labour = await t.withIdentity(asUser).query(api.crewAssignments.projectLabourCost, { projectId: "p1", orgId: ORG });
-    expect(labour.totalLabourCost).toBe(1500); // a1+a2, excludes CANCELLED a3 + foreign aX
+    expect(labour.totalLabourCost).toBe(1500); // a1+a2, excludes CANCELLED a3, foreign aX, and service-linked a4
     expect(labour.assignmentCount).toBe(2);
   });
 

--- a/src/lib/crew-scheduling-read.test.ts
+++ b/src/lib/crew-scheduling-read.test.ts
@@ -287,6 +287,14 @@ describe("project crew", () => {
     expect(aggregateProjectLabourCost(list)).toEqual({ totalLabourCost: 150, assignmentCount: 3 });
   });
 
+  it("aggregateProjectLabourCost: excludes service-linked assignments (already counted in serviceCostTotal)", () => {
+    const list = [
+      mAssign({ status: "CONFIRMED", estimatedCost: 100, serviceId: null }),
+      mAssign({ status: "CONFIRMED", estimatedCost: 500, serviceId: "svc1" }),
+    ];
+    expect(aggregateProjectLabourCost(list)).toEqual({ totalLabourCost: 100, assignmentCount: 1 });
+  });
+
   it("shiftsForAssignmentSortedAsc filters by assignment and sorts date asc", () => {
     const shifts = [
       mapShift({ id: "s1", assignmentId: "a1", date: ms("2026-06-09T00:00:00Z") } as ConvexCrewShift),

--- a/src/lib/crew-scheduling-read.ts
+++ b/src/lib/crew-scheduling-read.ts
@@ -468,12 +468,16 @@ export function sortProjectCrew<
   });
 }
 
-/** getProjectLabourCost aggregate: sum estimatedCost + count, over status not in CANCELLED|DECLINED. */
+/** getProjectLabourCost aggregate: sum estimatedCost + count, over status not in
+ *  CANCELLED|DECLINED, excluding service-linked assignments — their cost already
+ *  rolled into the owning service's `costTotal` (convex/lib/serviceCost.ts), so
+ *  counting it again here would double it. Mirrors recalcProjectTotals's
+ *  `labourCostTotal` exclusion (convex/lib/recalc.ts, issue #796). */
 export function aggregateProjectLabourCost(assignments: MappedCrewAssignment[]): {
   totalLabourCost: number;
   assignmentCount: number;
 } {
-  const eligible = assignments.filter((a) => !EXCLUDED_ASSIGNMENT_STATUSES.has(a.status));
+  const eligible = assignments.filter((a) => !EXCLUDED_ASSIGNMENT_STATUSES.has(a.status) && a.serviceId == null);
   return {
     totalLabourCost: eligible.reduce((sum, a) => sum + (a.estimatedCost ?? 0), 0),
     assignmentCount: eligible.length,


### PR DESCRIPTION
## Summary

- `crewAssignments.projectLabourCost` (the "Crew" tile in the project summary strip, and `CrewPanel`'s "Est. labour" figure) summed every crew assignment's `estimatedCost`, including assignments linked to a service.
- A service-linked assignment's cost is already rolled into its service's `costTotal` (issue #796's rate cascade — `convex/lib/serviceCost.ts`), which feeds `serviceCostTotal` (shown right next to it as "Services · cost"). Since the app now requires all crew to be added via a service, this meant the Crew tab was showing the same dollars a second time.
- The real P&L total (`recalcProjectTotals`'s `labourCostTotal` in `convex/lib/recalc.ts`) already excluded service-linked assignments correctly — this fix brings the two display-only totals (`projectLabourCost` and its pure counterpart `aggregateProjectLabourCost`) in line with that same exclusion so they can't disagree.
- Documented the fix in FEATUREDOCS/31 next to the existing double-counting note.

## Testing

- `pnpm exec vitest run src/lib/crew-scheduling-read.test.ts convex/crewAssignmentsWrites.test.ts` — 2 files, 48 tests passed, including new coverage asserting service-linked assignments are excluded from both totals.
- `tsc --noEmit` — no new errors in the changed files.

## Checklist

- [x] No new dependency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTgTmJ9iR9TnwbA5DEGDuY)_