### PR TITLE
Phase 5: recall-to-edit — the lock strip's second exit from QUOTE_SENT

### DIFF
--- a/FEATUREDOCS/62-project-lifecycle-locks.md
+++ b/FEATUREDOCS/62-project-lifecycle-locks.md
@@ -99,6 +99,60 @@ quote it's about to move past). Both pass `bypassQuoteLock: true` to
 deliberate opt-out `LifecycleGuardOptions` exposes, and the only two call
 sites that should ever set it.
 
+**The quote-sent escalation checks the LIVE revision, not the allocator
+(#1080/#1100, Phase 5 fix).** `assertLifecycleGuard` and
+`projectLocksRead.status` resolve `currentRevisionQuoteStatus` against
+`projectLiveRevision(project)`, never `projectRevision(project)`. Before a
+promote (#1080/#1089) could leave the two apart, they were always the same
+number, so reading either worked; once `liveRevision` can sit BEHIND
+`revision` (a promoted v2 live while v3/v4 exist as saved-but-never-sent
+drafts ahead of it), checking the allocator would read v4's still-`DRAFT`
+quote and wrongly resolve `OPEN` even though the live v2 is out with the
+client — the exact scenario recall-to-edit (below) exists to gate correctly.
+`projectLocksRead.status` now returns both `revision` (the allocator, what
+"Create quote v(N+1)" allocates off) and `liveRevision` (the one a
+`QUOTE_SENT` reason is actually describing) — see
+`convex/projectLifecycleLocks.test.ts`'s `#1080/#1100` describe block for the
+regression coverage (a SENT row at the allocator's max must never leak the
+lock onto a still-DRAFT live revision, and vice versa).
+
+### Recall-to-edit — the lock's second exit from QUOTE_SENT (#1080/#1100, Phase 5)
+
+`newVersionNative` ("Create quote v(N+1)") was, until this phase, the ONLY
+exit from a `QUOTE_SENT` lock — which is exactly wrong for a promoted SENT
+revision (#1080/#1089's decision 1: a promoted version keeps its own number,
+so abandoning it to a fresh vN+1 defeats the whole point of promoting it).
+The lock strip (`project-lock-strip.tsx`) now offers a second, PRIMARY exit
+when `reason === "QUOTE_SENT"`: **"Recall vN to edit"**, alongside the
+existing "Create quote v(N+1)" (now secondary).
+
+Clicking it opens `<RecallToEditDialog>`
+(`src/components/projects/finance/recall-to-edit-dialog.tsx`) — a one-click
+confirm, not a bare toast, because un-sending a document a client already
+holds is not something to do as a side effect of a keystroke:
+
+- **Plain SENT/ACCEPTED-but-unprotected revision** — "v2 was sent to the
+  client on 19 Jul. Editing it recalls the quote — the PDF they're holding
+  will no longer match v2. The old document is kept in the audit trail,"
+  with `[ Recall v2 and edit ]` / `[ Create v(N+1) instead ]` / `[ Cancel ]`.
+  Confirming calls the EXISTING `recallNative` unchanged (no new mutation, no
+  second recall path) with a fixed reason string — the dialog itself IS the
+  explicit act every other un-send path already requires, so it doesn't also
+  make the user type one.
+- **Protected (auto-protected on ACCEPTED, #1030)** — the SAME dialog
+  reports the real situation instead of letting a raw `QUOTE_PROTECTED` error
+  surface: "v1 was accepted on 21 Jul and is protected. An owner must
+  unprotect it before it can be edited," offering only
+  `[ Create v(N+1) instead ]` / `[ Cancel ]` — never a recall button the
+  caller can't use. A race (someone else protects it between the strip
+  rendering and the confirm click) is caught and flips the dialog to the same
+  explanation rather than a bare toast.
+
+`LockTier` values, `FINANCIALS_LOCKED`/`PROJECT_LOCKED` codes and their toast
+mappings are unchanged — this is a new client-side exit, not a new server
+gate. Out of scope, deliberately: any change to `recallNative` itself
+(#1032's shipped recall/resend behaviour is depended on, not modified here).
+
 ## The shared guard: `assertLifecycleGuard`
 
 One function every gate site calls, encoding the full precedence table:
@@ -363,10 +417,11 @@ surfaces, one shared source per surface (POLICY.md R-3.1):
    mounted ONCE at `id="lock-strip"` above the tabs (not inside Finance),
    replacing Phase D's Finance-tab-only `QuoteLockStrip`. Renders
    `<UnlockSessionBanner>` while a session is open; otherwise the
-   `resolveLockCopy` line plus the exit that matches `reason` — "Create
-   quote v(N+1)" + "Recall" for `QUOTE_SENT` (reusing `project-quote-rail.tsx`'s
-   exported `<ReasonDialog>` rather than a second recall dialog), or the
-   existing unlock-session flow for `STATUS`.
+   `resolveLockCopy` line plus the exit that matches `reason` — for
+   `QUOTE_SENT`, "Recall vN to edit" (primary, opens
+   `<RecallToEditDialog>` — `src/components/projects/finance/recall-to-edit-dialog.tsx`,
+   #1080/#1100 Phase 5) + "Create quote v(N+1)" (secondary) — or the existing
+   unlock-session flow for `STATUS`.
 4. **`src/components/ui/locked-field.tsx`** — the field-level wrapper. Uses a
    native `<fieldset disabled>` around the child rather than cloning
    `disabled`/`readOnly` onto it: a fieldset cascades to every descendant

--- a/convex/lib/projectLocks.ts
+++ b/convex/lib/projectLocks.ts
@@ -2,7 +2,7 @@ import { ConvexError } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { assertStrLen } from "./fieldGuards";
-import { currentRevisionQuoteStatus, projectRevision, type EffectiveQuoteStatus } from "./quoteState";
+import { currentRevisionQuoteStatus, projectLiveRevision, type EffectiveQuoteStatus } from "./quoteState";
 
 /**
  * Project lifecycle lock-tier module (#957) — the SINGLE source of truth for the
@@ -73,7 +73,9 @@ export function isConfirmedOrLater(status: string | null | undefined): boolean {
  *  the right exit (Phase E). `STATUS` covers both "nothing is locked" and
  *  every status-driven tier (FINANCE_LOCKED/JUSTIFY/HARD_LOCKED via CONFIRMED+);
  *  `QUOTE_SENT` is the one new case — an OPEN-status project (ENQUIRY/QUOTING/
- *  QUOTED) whose current revision has already gone out. */
+ *  QUOTED) whose LIVE revision (`projectLiveRevision`, #1080/#1085 — not
+ *  necessarily the allocator's high-water mark once a promote has moved them
+ *  apart) has already gone out. */
 export type LockTierReason = "STATUS" | "QUOTE_SENT";
 
 export interface ResolveLockTierResult {
@@ -289,25 +291,33 @@ export function requireJustification(justification: string | null | undefined, m
  *    prompt); otherwise requires a bounded justification.
  *
  * #988 (Phase C) folds one more input into the SAME tier: an OPEN-status
- * project (ENQUIRY/QUOTING/QUOTED) whose current revision has already been
+ * project (ENQUIRY/QUOTING/QUOTED) whose LIVE revision has already been
  * sent resolves to FINANCE_LOCKED too (`resolveLockTier`) — every rule above
  * still applies unchanged, just against a tier that can now come from either
  * source. The quote lookup only runs when the status tier is itself OPEN
  * (any higher tier already dominates — monotonic), so this adds no DB read to
  * the CONFIRMED+/ON_SITE+/COMPLETED+ paths that make up most gated writes.
+ * #1080/#1100 — looks up `projectLiveRevision(project)`, not the allocator: a
+ * promote can leave `revision` (the high-water mark) ahead of `liveRevision`,
+ * and it's the LIVE revision's quote that's actually with the client.
  *
  * Throws `ConvexError` with a stable `code` the client can branch on:
  * `PROJECT_LOCKED` | `FINANCIALS_LOCKED` | `JUSTIFICATION_REQUIRED`.
  */
 export async function assertLifecycleGuard(
   ctx: MutationCtx,
-  project: Pick<Doc<"projects">, "id" | "organizationId" | "status" | "revision">,
+  project: Pick<Doc<"projects">, "id" | "organizationId" | "status" | "revision" | "liveRevision">,
   opts: LifecycleGuardOptions,
 ): Promise<LifecycleGuardResult> {
   const statusTier = lockTierForStatus(project.status);
+  // #1080/#1100 — the quote-sent escalation checks the LIVE revision's quote
+  // state, never the allocator's. Post-promote, `revision` (the allocator) can
+  // sit ahead of `liveRevision` (e.g. a saved-but-never-sent v4 while v2 is the
+  // live, SENT revision) — checking the allocator would read that v4 DRAFT and
+  // wrongly resolve OPEN even though the live v2 is out with the client.
   const quoteState =
     statusTier === "OPEN" && !opts.bypassQuoteLock
-      ? await currentRevisionQuoteStatus(ctx, project.organizationId, project.id, projectRevision(project))
+      ? await currentRevisionQuoteStatus(ctx, project.organizationId, project.id, projectLiveRevision(project))
       : null;
   const { tier, reason } = resolveLockTier({ status: project.status, quoteState });
   if (tier === "OPEN") return { tier, reason, openSession: null, defaultToZero: false };

--- a/convex/projectLifecycleLocks.test.ts
+++ b/convex/projectLifecycleLocks.test.ts
@@ -764,3 +764,81 @@ describe("#988 quote-derived lock tier", () => {
     expect(status?.quoteState).toBeNull();
   });
 });
+
+/**
+ * #1080/#1100 (Phase 5) — the QUOTE_SENT escalation must check the LIVE
+ * revision's quote (`projectLiveRevision`), never the allocator's
+ * (`projectRevision`, the high-water mark). Once a promote (#1089) has moved
+ * `liveRevision` behind `revision` — e.g. a saved-but-never-sent v4 sitting
+ * ahead of a promoted, SENT, live v2 — checking the allocator would read v4's
+ * still-DRAFT quote and wrongly resolve OPEN even though v2 is out with the
+ * client. This is the exact scenario recall-to-edit (Phase 5) has to gate
+ * correctly: editing a promoted SENT revision must be refused (FINANCE_LOCKED)
+ * so the recall-to-edit exit is even reachable.
+ */
+describe("#1080/#1100 the quote-sent lock follows liveRevision, not the allocator", () => {
+  type QuoteStatus = "DRAFT" | "SENT" | "ACCEPTED" | "DECLINED" | "SUPERSEDED" | "EXPIRED" | "PUBLISHED";
+  async function quoteAt(t: ReturnType<typeof makeT>, version: number, status: QuoteStatus, extra: Record<string, unknown> = {}) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("quotes", {
+        id: `q${version}`, organizationId: ORG, projectId: "p1", version, status,
+        snapshot: null, ...extra,
+      });
+    });
+  }
+
+  test("a promoted (non-allocator-max) live revision that's SENT still locks money fields", async () => {
+    const t = makeT();
+    await member(t, "member");
+    // revision (allocator) sits at 4 — v3/v4 were saved-but-never-sent
+    // versions — while liveRevision points back at v2, the promoted, SENT
+    // revision actually live on the project (design decision 1).
+    await project(t, "QUOTED", { revision: 4, liveRevision: 2 });
+    await quoteAt(t, 1, "SUPERSEDED");
+    await quoteAt(t, 2, "SENT", { sentAt: NOW });
+    await quoteAt(t, 3, "DRAFT");
+    await quoteAt(t, 4, "DRAFT");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", { id: "li1", organizationId: ORG, projectId: "p1", description: "Speaker", unitPrice: 100, quantity: 1, isKitChild: false });
+    });
+    await expect(
+      t.withIdentity(asUser()).mutation(api.lineItemWrites.patchNative, {
+        id: "li1", orgId: ORG, set: { unitPrice: 200 }, clear: [], entityName: "Speaker", allowOverbook: false, actor: ACTOR, auditId: "log1", now: NOW,
+      }),
+    ).rejects.toThrow(/FINANCIALS_LOCKED|locked/i);
+  });
+
+  test("projectLocksRead.status reports the LIVE revision's quote state and both revision numbers", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await project(t, "QUOTED", { revision: 4, liveRevision: 2 });
+    await quoteAt(t, 2, "SENT", { sentAt: NOW });
+    await quoteAt(t, 4, "DRAFT");
+    const status = await t.withIdentity(asUser()).query(api.projectLocksRead.status, { projectId: "p1", orgId: ORG });
+    expect(status?.tier).toBe("FINANCE_LOCKED");
+    expect(status?.reason).toBe("QUOTE_SENT");
+    expect(status?.revision).toBe(4);
+    expect(status?.liveRevision).toBe(2);
+    expect(status?.quoteState).toBe("SENT");
+  });
+
+  test("a promoted live revision that's still DRAFT (never sent) stays OPEN even with a SENT row at the allocator's max", async () => {
+    const t = makeT();
+    await member(t, "member");
+    // Inverse of the bug: liveRevision (2) is an unsent DRAFT, while the
+    // allocator's max (v4) happens to be SENT. The lock must follow the LIVE
+    // revision and stay OPEN — a SENT row elsewhere never leaks in.
+    await project(t, "QUOTED", { revision: 4, liveRevision: 2 });
+    await quoteAt(t, 2, "DRAFT");
+    await quoteAt(t, 4, "SENT", { sentAt: NOW });
+    await t.withIdentity(asUser()).mutation(api.lineItemWrites.addCustomNative, {
+      id: "li1", organizationId: ORG, projectId: "p1",
+      fields: { description: "Extra cable", quantity: 1, unitPrice: 500 },
+      actor: ACTOR, auditId: "log1", now: NOW,
+    });
+    await t.run(async (ctx) => {
+      const li = await ctx.db.query("projectLineItems").withIndex("by_cuid", (q) => q.eq("id", "li1")).first();
+      expect(Number(li?.unitPrice)).toBe(500); // not $0-defaulted — the project read as OPEN
+    });
+  });
+});

--- a/convex/projectLocksRead.ts
+++ b/convex/projectLocksRead.ts
@@ -4,7 +4,7 @@ import { requireOrgPermission } from "./lib/auth";
 import { getOpenUnlockSession, isHardLockOverrideAllowed, resolveLockTier } from "./lib/projectLocks";
 import { getAuthContext } from "./lib/auth";
 import { collectCurrentEntries } from "./lib/projectSnapshots";
-import { effectiveQuoteStatus, findQuoteAtRevision, projectRevision } from "./lib/quoteState";
+import { effectiveQuoteStatus, findQuoteAtRevision, projectLiveRevision, projectRevision } from "./lib/quoteState";
 
 const ENTRY_RETURNS = v.array(
   v.object({
@@ -52,6 +52,11 @@ export const status = query({
       // so Phase E can render one coherent banner from this single query instead
       // of a second round trip.
       revision: v.number(),
+      // #1080/#1100 — the LIVE revision (`projectLiveRevision`), separate from
+      // `revision` (the allocator) once a promote has moved them apart. The
+      // QUOTE_SENT escalation below is resolved against THIS number, not
+      // `revision` — see `assertLifecycleGuard`'s matching fix.
+      liveRevision: v.number(),
       quoteState: v.union(
         v.null(),
         v.literal("DRAFT"),
@@ -86,7 +91,10 @@ export const status = query({
     if (!project || project.organizationId !== orgId) return null;
 
     const revision = projectRevision(project);
-    const currentQuote = await findQuoteAtRevision(ctx, orgId, projectId, revision);
+    const liveRevision = projectLiveRevision(project);
+    // The QUOTE_SENT escalation is about the LIVE revision's quote — not the
+    // allocator's high-water mark, which a promote can leave ahead of it.
+    const currentQuote = await findQuoteAtRevision(ctx, orgId, projectId, liveRevision);
     const quoteState = currentQuote ? effectiveQuoteStatus(currentQuote, now ?? 0) : null;
     const { tier, reason } = resolveLockTier({ status: project.status, quoteState });
     const session = await getOpenUnlockSession(ctx, orgId, projectId);
@@ -100,6 +108,7 @@ export const status = query({
       tier,
       reason,
       revision,
+      liveRevision,
       quoteState,
       canOverrideHardLock,
       openSession: session

--- a/convex/quotes.ts
+++ b/convex/quotes.ts
@@ -82,6 +82,10 @@ export const revisionStateForProject = query({
             sentAt: live.quote.sentAt ?? live.quote.publishedAt ?? null,
             validUntil: live.quote.validUntil ?? null,
             snapshotId: live.quote.snapshotId ?? null,
+            // #1080/#1100 — the recall-to-edit dialog needs this to decide
+            // between "Recall vN and edit" and the un-protect explanation
+            // without a second round trip.
+            protected: live.quote.protected ?? false,
           }
         : null,
     };

--- a/src/components/projects/finance/__tests__/recall-to-edit-dialog.smoke.test.tsx
+++ b/src/components/projects/finance/__tests__/recall-to-edit-dialog.smoke.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const recall = vi.fn().mockResolvedValue({ id: "q2", version: 2, restoredQuoteId: null });
+
+vi.mock("@/hooks/use-quote-writes", () => ({
+  useQuoteWrites: vi.fn(() => ({ recall })),
+}));
+
+import { RecallToEditDialog } from "@/components/projects/finance/recall-to-edit-dialog";
+
+/**
+ * #1080/#1100 (Phase 5) — the recall-to-edit confirm dialog. Opens for real
+ * (not just the closed-trigger render — CLAUDE.md) and asserts all three
+ * actions are keyboard-reachable in the non-protected case, and that a
+ * protected/ACCEPTED revision never even offers the recall button (it must
+ * never reach `recallNative` — the server-side gate is belt-and-braces, the
+ * UI shouldn't dangle a button that can only error).
+ */
+describe("RecallToEditDialog smoke", () => {
+  const onOpenChange = vi.fn();
+  const onCreateNextVersion = vi.fn();
+
+  beforeEach(() => {
+    recall.mockClear();
+    onOpenChange.mockClear();
+    onCreateNextVersion.mockClear();
+  });
+
+  const liveQuote = { id: "q2", version: 2, sentAt: Date.parse("2026-07-19"), protected: false };
+
+  it("opens and offers all three actions when the live revision is a plain SENT quote", async () => {
+    render(
+      <RecallToEditDialog
+        open
+        onOpenChange={onOpenChange}
+        liveQuote={liveQuote}
+        nextVersion={3}
+        onCreateNextVersion={onCreateNextVersion}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: /Edit v2\?/ })).toBeTruthy());
+    expect(screen.getByText(/PDF they.re holding will no longer match v2/)).toBeTruthy();
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /create v3 instead/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /recall v2 and edit/i })).toBeTruthy();
+  });
+
+  it("confirming recall calls the existing recallNative-backed hook and closes", async () => {
+    const user = userEvent.setup();
+    render(
+      <RecallToEditDialog
+        open
+        onOpenChange={onOpenChange}
+        liveQuote={liveQuote}
+        nextVersion={3}
+        onCreateNextVersion={onCreateNextVersion}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /recall v2 and edit/i }));
+    await waitFor(() => expect(recall).toHaveBeenCalledWith("q2", { reason: expect.any(String) }));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("'Create v(N+1) instead' calls the caller's handler and closes without touching recall", async () => {
+    const user = userEvent.setup();
+    render(
+      <RecallToEditDialog
+        open
+        onOpenChange={onOpenChange}
+        liveQuote={liveQuote}
+        nextVersion={3}
+        onCreateNextVersion={onCreateNextVersion}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /create v3 instead/i }));
+    expect(onCreateNextVersion).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(recall).not.toHaveBeenCalled();
+  });
+
+  it("a protected revision surfaces the un-protect explanation and never offers Recall", async () => {
+    render(
+      <RecallToEditDialog
+        open
+        onOpenChange={onOpenChange}
+        liveQuote={{ ...liveQuote, protected: true }}
+        nextVersion={3}
+        onCreateNextVersion={onCreateNextVersion}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: /v2 is protected/ })).toBeTruthy());
+    expect(screen.getByText(/An owner must unprotect it before it can be edited/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /recall v2 and edit/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /create v3 instead/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+
+    expect(recall).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is no live quote to act on", () => {
+    const { container } = render(
+      <RecallToEditDialog
+        open
+        onOpenChange={onOpenChange}
+        liveQuote={null}
+        nextVersion={3}
+        onCreateNextVersion={onCreateNextVersion}
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+});

--- a/src/components/projects/finance/recall-to-edit-dialog.tsx
+++ b/src/components/projects/finance/recall-to-edit-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { ConvexError } from "convex/values";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useQuoteWrites } from "@/hooks/use-quote-writes";
+import { formatDate } from "@/lib/formatters";
+
+/**
+ * #1080/#1100 (Phase 5) — the lock strip's second exit from a `QUOTE_SENT`
+ * lock: "Recall vN to edit" alongside the existing "Create v(N+1)". Refines
+ * decision 5 (design doc §2.7) — a bare auto-recall on first edit can't be
+ * implemented as stated (a SENT quote already raises the project to
+ * FINANCE_LOCKED before any auto-recall could fire), so the lock learns this
+ * one-click confirm instead of a bare toast.
+ *
+ * Calls the EXISTING `recallNative` unchanged (out of scope: any change to
+ * recall itself) — this is decision 5's behaviour with one confirmation in
+ * front of it, not a second recall path. The reason text is a fixed string
+ * rather than a free-text field: the whole point is "one click", and every
+ * other un-send path already requires an explicit reason — this dialog IS
+ * that explicit act.
+ */
+
+const RECALL_TO_EDIT_REASON = "Recalled to edit from the project's lock strip.";
+
+export interface RecallToEditLiveQuote {
+  id: string;
+  version: number;
+  sentAt?: number | null;
+  protected?: boolean;
+}
+
+interface RecallToEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The live quote a QUOTE_SENT lock is describing. Null renders nothing —
+   *  defensive only, since the strip never opens this without one in hand. */
+  liveQuote: RecallToEditLiveQuote | null;
+  /** The allocator + 1 — what `newVersionNative` actually allocates,
+   *  regardless of which revision is live (#1080/#1085). */
+  nextVersion: number;
+  onCreateNextVersion: () => void;
+  creatingNextVersion?: boolean;
+}
+
+function quoteProtectedError(e: unknown): boolean {
+  return (
+    e instanceof ConvexError &&
+    !!e.data &&
+    typeof e.data === "object" &&
+    (e.data as { code?: unknown }).code === "QUOTE_PROTECTED"
+  );
+}
+
+/** The recall attempt itself, split out purely to keep the component's own
+ *  line count down (R-3.6) — returns an outcome rather than throwing, so the
+ *  component only ever has to route it to a toast/state update. */
+type RecallOutcome = { kind: "success"; toastMessage: string } | { kind: "protectedRace" } | { kind: "error"; message: string };
+
+async function runRecall(
+  recall: (id: string, data: { reason: string }) => Promise<{ restoredQuoteId: string | null }>,
+  liveQuote: RecallToEditLiveQuote,
+): Promise<RecallOutcome> {
+  try {
+    const result = await recall(liveQuote.id, { reason: RECALL_TO_EDIT_REASON });
+    return {
+      kind: "success",
+      toastMessage: result.restoredQuoteId
+        ? `Recalled v${liveQuote.version} — the previous revision is the client's current quote again`
+        : `Recalled v${liveQuote.version} — it's a draft again`,
+    };
+  } catch (e) {
+    if (quoteProtectedError(e)) return { kind: "protectedRace" };
+    return { kind: "error", message: e instanceof Error ? e.message : "Failed to recall" };
+  }
+}
+
+/** Split out purely to keep `RecallToEditDialog`'s own line count down
+ *  (R-3.6) — the protected/unprotected branch each has its own title +
+ *  explanation (design §2.7), never a raw `QUOTE_PROTECTED` error. */
+function recallDialogCopy(version: number, isProtected: boolean, sentPhrase: string): { title: string; description: string } {
+  if (isProtected) {
+    return {
+      title: `v${version} is protected`,
+      description: `v${version} was accepted${sentPhrase} and is protected. An owner must unprotect it before it can be edited.`,
+    };
+  }
+  return {
+    title: `Edit v${version}?`,
+    description: `v${version} was sent to the client${sentPhrase}. Editing it recalls the quote — the PDF they're holding will no longer match v${version}. The old document is kept in the audit trail.`,
+  };
+}
+
+export function RecallToEditDialog({
+  open,
+  onOpenChange,
+  liveQuote,
+  nextVersion,
+  onCreateNextVersion,
+  creatingNextVersion,
+}: RecallToEditDialogProps) {
+  const quoteWrites = useQuoteWrites();
+  const [pending, setPending] = useState(false);
+  // Belt-and-braces: a race (someone else protects the quote between the
+  // strip rendering and this dialog's confirm click) surfaces the SAME
+  // un-protect explanation rather than a raw QUOTE_PROTECTED toast — never
+  // just re-showing the button that just failed.
+  const [raceProtected, setRaceProtected] = useState(false);
+
+  if (!liveQuote) return null;
+  const quote = liveQuote;
+  const isProtected = quote.protected || raceProtected;
+  const sentPhrase = quote.sentAt != null ? ` on ${formatDate(new Date(quote.sentAt))}` : "";
+
+  async function confirmRecall() {
+    setPending(true);
+    const outcome = await runRecall(quoteWrites.recall, quote);
+    setPending(false);
+    if (outcome.kind === "protectedRace") return setRaceProtected(true);
+    if (outcome.kind === "error") return toast.error(outcome.message);
+    toast.success(outcome.toastMessage);
+    onOpenChange(false);
+  }
+
+  function createNextVersion() {
+    onCreateNextVersion();
+    onOpenChange(false);
+  }
+
+  const { title, description } = recallDialogCopy(quote.version, isProtected, sentPhrase);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !pending && onOpenChange(next)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="line" onClick={() => onOpenChange(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button type="button" variant="line" loading={creatingNextVersion} disabled={pending} onClick={createNextVersion}>
+            Create v{nextVersion} instead
+          </Button>
+          {!isProtected && (
+            <Button type="button" loading={pending} onClick={() => void confirmRecall()}>
+              Recall v{quote.version} and edit
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/projects/finance/recall-to-edit-dialog.tsx
+++ b/src/components/projects/finance/recall-to-edit-dialog.tsx
@@ -17,8 +17,8 @@ import { formatDate } from "@/lib/formatters";
  * FINANCE_LOCKED before any auto-recall could fire), so the lock learns this
  * one-click confirm instead of a bare toast.
  *
- * Calls the EXISTING `recallNative` unchanged (out of scope: any change to
- * recall itself) — this is decision 5's behaviour with one confirmation in
+ * Calls the EXISTING `recallNative` unchanged (changing recall itself is
+ * out of scope here) — this is decision 5's behaviour with one confirmation in
  * front of it, not a second recall path. The reason text is a fixed string
  * rather than a free-text field: the whole point is "one click", and every
  * other un-send path already requires an explicit reason — this dialog IS

--- a/src/components/projects/project-lock-strip.tsx
+++ b/src/components/projects/project-lock-strip.tsx
@@ -15,7 +15,7 @@ import { resolveLockCopy, type LockCopyStatus } from "@/lib/lock-copy";
 import { intentStyles, intentBorderClass } from "@/lib/status-colors";
 import { cn } from "@/lib/utils";
 import { UnlockSessionBanner } from "@/components/projects/unlock-session-banner";
-import { ReasonDialog, type ReasonTarget } from "@/components/projects/project-quote-rail";
+import { RecallToEditDialog } from "@/components/projects/finance/recall-to-edit-dialog";
 
 interface ProjectLockStripStatus extends LockCopyStatus {
   loading: boolean;
@@ -42,29 +42,14 @@ interface ProjectLockStripProps {
  *
  * Renders `resolveLockCopy()` (the ONE copy module, `src/lib/lock-copy.ts`)
  * plus the exit that matches `status.reason`:
- *   - `QUOTE_SENT`  → "Create quote v(N+1)" (primary) + "Recall" (secondary)
+ *   - `QUOTE_SENT`  → "Recall vN to edit" (primary, #1080/#1100 Phase 5 — opens
+ *     `<RecallToEditDialog>`, a one-click confirm rather than a bare toast) +
+ *     "Create quote v(N+1)" (secondary, still available)
  *   - `STATUS`      → the existing unlock-session flow
  *   - session open  → `<UnlockSessionBanner>` (Save & relock / Discard, #988's
  *     diff-before-commit)
  */
 export function ProjectLockStrip({ projectId, orgId, status, now, onOpenUnlock }: ProjectLockStripProps) {
-  const [reasonTarget, setReasonTarget] = useState<ReasonTarget | null>(null);
-  const quoteWrites = useQuoteWrites();
-
-  const newVersionMutation = useServerMutation({
-    mutationFn: () => quoteWrites.newVersion(projectId),
-    onSuccess: (r: { version: number }) => toast.success(`Started quote v${r.version} — open the Finance tab to send it`),
-    onError: (e: Error) => toast.error(e.message),
-  });
-
-  // Only needed to resolve the live quote's id for Recall — skip the read
-  // entirely outside the one state that needs it.
-  const needsLiveQuote = status.reason === "QUOTE_SENT" && !status.hasOpenSession;
-  const revisionState = useAuthedQuery(
-    api.quotes.revisionStateForProject,
-    orgId && needsLiveQuote ? { orgId, projectId, now } : "skip",
-  );
-
   if (status.loading) return null;
 
   if (status.hasOpenSession && status.openSession && orgId) {
@@ -95,31 +80,14 @@ export function ProjectLockStrip({ projectId, orgId, status, now, onOpenUnlock }
       </p>
 
       {copy.exitLabel && status.reason === "QUOTE_SENT" && (
-        <div className="flex items-center gap-2">
-          <CanDo resource="invoice" action="publish">
-            <Button
-              variant="line"
-              size="sm"
-              loading={newVersionMutation.isPending}
-              onClick={() => newVersionMutation.mutate(undefined)}
-            >
-              <FileText className="h-3.5 w-3.5" /> {copy.exitLabel}
-            </Button>
-          </CanDo>
-          <CanDo resource="invoice" action="publish">
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={!revisionState?.liveQuote}
-              onClick={() =>
-                revisionState?.liveQuote &&
-                setReasonTarget({ id: revisionState.liveQuote.id, version: revisionState.liveQuote.version, verb: "recall" })
-              }
-            >
-              <Undo2 className="h-3.5 w-3.5" /> Recall
-            </Button>
-          </CanDo>
-        </div>
+        <QuoteSentLockExit
+          projectId={projectId}
+          orgId={orgId}
+          now={now}
+          exitLabel={copy.exitLabel}
+          liveRevision={status.liveRevision ?? status.revision ?? 1}
+          nextVersion={(status.revision ?? 1) + 1}
+        />
       )}
 
       {copy.exitLabel && status.reason !== "QUOTE_SENT" && status.tier === "HARD_LOCKED" && (
@@ -143,8 +111,66 @@ export function ProjectLockStrip({ projectId, orgId, status, now, onOpenUnlock }
           </Button>
         </CanDo>
       )}
-
-      <ReasonDialog target={reasonTarget} onClose={() => setReasonTarget(null)} />
     </div>
+  );
+}
+
+/** The QUOTE_SENT exit cluster — split out purely to keep `ProjectLockStrip`'s
+ *  own complexity/line count down (R-3.6). Owns the "Recall vN to edit" +
+ *  "Create v(N+1)" actions and the `<RecallToEditDialog>` they open — the
+ *  revision-state read and the new-version mutation only ever mount for this
+ *  one reason, so they're scoped here rather than always registered on the
+ *  strip regardless of `status.reason`. */
+function QuoteSentLockExit({
+  projectId,
+  orgId,
+  now,
+  exitLabel,
+  liveRevision,
+  nextVersion,
+}: {
+  projectId: string;
+  orgId: string | undefined;
+  now: number;
+  exitLabel: string;
+  liveRevision: number;
+  nextVersion: number;
+}) {
+  const [recallDialogOpen, setRecallDialogOpen] = useState(false);
+  const quoteWrites = useQuoteWrites();
+  const revisionState = useAuthedQuery(api.quotes.revisionStateForProject, orgId ? { orgId, projectId, now } : "skip");
+
+  const newVersionMutation = useServerMutation({
+    mutationFn: () => quoteWrites.newVersion(projectId),
+    onSuccess: (r: { version: number }) => toast.success(`Started quote v${r.version} — open the Finance tab to send it`),
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        {/* Primary affordance (design §2.7): "Recall vN to edit" alongside
+            the existing "Create v(N+1)" — recalling keeps the version's own
+            number rather than abandoning it to a fresh draft (decision 1). */}
+        <CanDo resource="invoice" action="publish">
+          <Button variant="line" size="sm" disabled={!revisionState?.liveQuote} onClick={() => setRecallDialogOpen(true)}>
+            <Undo2 className="h-3.5 w-3.5" /> Recall v{revisionState?.liveQuote?.version ?? liveRevision} to edit
+          </Button>
+        </CanDo>
+        <CanDo resource="invoice" action="publish">
+          <Button variant="ghost" size="sm" loading={newVersionMutation.isPending} onClick={() => newVersionMutation.mutate(undefined)}>
+            <FileText className="h-3.5 w-3.5" /> {exitLabel}
+          </Button>
+        </CanDo>
+      </div>
+      <RecallToEditDialog
+        open={recallDialogOpen}
+        onOpenChange={setRecallDialogOpen}
+        liveQuote={revisionState?.liveQuote ?? null}
+        nextVersion={nextVersion}
+        onCreateNextVersion={() => newVersionMutation.mutate(undefined)}
+        creatingNextVersion={newVersionMutation.isPending}
+      />
+    </>
   );
 }

--- a/src/components/projects/project-quote-rail.tsx
+++ b/src/components/projects/project-quote-rail.tsx
@@ -1074,10 +1074,10 @@ function UnacceptDialog({ target, onClose }: { target: QuoteRevisionDoc | null; 
 
 /** Recall and decline both take a bounded reason, so both route through ONE
  *  Dialog rather than two near-identical ones. (Radix `Dialog` — there is no
- *  `AlertDialog` in this codebase.) Exported so `<ProjectLockStrip>` (#990)
- *  can offer "Recall" from the top-level lock strip without a second
- *  hand-built recall dialog (POLICY.md R-3.1). */
-export function ReasonDialog({ target, onClose }: { target: ReasonTarget | null; onClose: () => void }) {
+ *  `AlertDialog` in this codebase.) Row-scoped only — the top-level lock
+ *  strip's own recall exit is `<RecallToEditDialog>` (#1080/#1100, Phase 5),
+ *  a one-click confirm rather than this free-text reason form. */
+function ReasonDialog({ target, onClose }: { target: ReasonTarget | null; onClose: () => void }) {
   const [reason, setReason] = useState("");
   const quoteWrites = useQuoteWrites();
   const isRecall = target?.verb === "recall";

--- a/src/hooks/use-project-lock.ts
+++ b/src/hooks/use-project-lock.ts
@@ -27,6 +27,7 @@ function deriveLockStatus(status: ProjectLockStatus) {
     canOverrideHardLock = false,
     reason = "STATUS",
     revision = 1,
+    liveRevision = revision,
     quoteState = null,
   } = status ?? {};
   return {
@@ -37,6 +38,7 @@ function deriveLockStatus(status: ProjectLockStatus) {
     canOverrideHardLock,
     reason,
     revision,
+    liveRevision,
     quoteState,
   };
 }

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -36423,7 +36423,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     ],
     "privilegedArgs": [],
     "argsSha": "8f3456c860a78207",
-    "returnsSha": "9deebb65ff588551",
+    "returnsSha": "ea61ad99a75567c7",
     "stability": "tracks-app",
     "summary": null,
     "danger": null,

--- a/src/lib/lock-copy.ts
+++ b/src/lib/lock-copy.ts
@@ -28,7 +28,14 @@ export interface LockCopyOpenSession {
 export interface LockCopyStatus {
   tier: LockTier;
   reason?: LockReason;
+  /** The allocator — the highest version number ever handed out. Used for the
+   *  "Create quote v(N+1)" exit, since that's what `newVersionNative` actually
+   *  allocates off. */
   revision?: number;
+  /** The version currently projected onto the live tables (#1080/#1085) — the
+   *  one a QUOTE_SENT reason is actually describing. Absent ⇒ `revision`
+   *  (every pre-#1085 project, where the two numbers were the same field). */
+  liveRevision?: number;
   hasOpenSession?: boolean;
   openSession?: LockCopyOpenSession | null;
 }
@@ -127,7 +134,12 @@ function sessionOpenCopy(intent: ColorIntent, session: LockCopyOpenSession, now:
 /** The FINANCE_LOCKED branch — split out for the same reason as `sessionOpenCopy`. */
 function financeLockedCopy(intent: ColorIntent, status: LockCopyStatus, revision: number): LockCopy {
   if (status.reason === "QUOTE_SENT") {
-    const detail = `Quote v${revision} is with the client.`;
+    // The sentence is about the LIVE revision (the one actually with the
+    // client) — "Create v(N+1)" still allocates off the counter (`revision`),
+    // since that's what `newVersionNative` does regardless of which version
+    // is live (#1080/#1100).
+    const liveRevision = status.liveRevision ?? revision;
+    const detail = `Quote v${liveRevision} is with the client.`;
     const exitLabel = `Create quote v${revision + 1}`;
     return {
       intent,


### PR DESCRIPTION
## Summary

Phase 5 of #1080 (project version switching), closing #1100.

Editing a promoted, sent revision was only reachable via "Create quote
v(N+1)" — which abandons the promoted version's own number, exactly what
decision 1 says not to do. This lands the lock's second exit:

- **Fixed a real bug found while implementing this**: `assertLifecycleGuard`
  and `projectLocksRead.status` resolved the `QUOTE_SENT` escalation against
  `projects.revision` (the allocator — the highest version number ever
  handed out), not `projects.liveRevision`. Once a promote (#1089) can leave
  the two apart — e.g. a promoted, `SENT` v2 live while v3/v4 sit ahead as
  saved-but-never-sent drafts — checking the allocator read the wrong
  quote's state and could wrongly resolve `OPEN` even though the live
  revision is out with the client. This is the exact scenario recall-to-edit
  needs gated correctly for its exit to even be reachable, so it's fixed
  here with regression coverage (`convex/projectLifecycleLocks.test.ts`'s
  `#1080/#1100` describe block).
- `projectLocksRead.status` now returns `liveRevision` alongside `revision`;
  `quotes.revisionStateForProject`'s `liveQuote` now carries `protected`.
- **`<RecallToEditDialog>`** (`src/components/projects/finance/recall-to-edit-dialog.tsx`)
  — a one-click confirm, not a bare toast, since un-sending a document a
  client already holds deserves an explicit act:
  - plain sent/unprotected: "Recall vN and edit" / "Create v(N+1) instead" /
    "Cancel" — confirming calls the **existing** `recallNative` unchanged,
    with a fixed reason string (no new mutation, no second recall path).
  - protected (auto-protected on `ACCEPTED`): reports the real situation
    ("an owner must unprotect it") instead of a raw `QUOTE_PROTECTED` error,
    and never offers a recall button the caller can't use. A race with
    another tab protecting the quote mid-dialog is caught and flips to the
    same explanation.
- The lock strip (`project-lock-strip.tsx`) now offers "Recall vN to edit"
  as the primary affordance alongside the existing "Create v(N+1)" whenever
  the live revision is `SENT`/`ACCEPTED`. Split `QuoteSentLockExit` out to
  scope the query/mutation to the one reason that needs them and keep the
  strip's own complexity below its pre-existing baseline (19 → 18).
- FEATUREDOCS/62 updated with the new exit + the liveRevision fix.
- API registry regenerated (`projectLocksRead.status`'s returns-shape hash
  changed with the new `liveRevision` field; openapi/llms.txt/mcp-manifest
  regenerated idempotently, no diff).

Out of scope (per #1100): any change to `recallNative` itself — this reuses
#1032's shipped recall/resend behaviour unchanged.

## Testing

- `pnpm test` — full suite, 5791 tests / 466 files, all passing.
- New regression tests in `convex/projectLifecycleLocks.test.ts` proving the
  quote-sent lock follows `liveRevision`, not the allocator, in both
  directions (a SENT row at the allocator's max must never leak the lock
  onto a still-DRAFT live revision, and vice versa).
- New jsdom smoke test (`recall-to-edit-dialog.smoke.test.tsx`) — opens the
  dialog for real, asserts all three actions are keyboard-reachable in the
  plain case, and that a protected revision never offers Recall (and never
  reaches the mutation).
- `pnpm exec tsc --noEmit` — clean on every touched file.
- `pnpm run lint` — 0 errors; `ProjectLockStrip`'s complexity warning is
  lower than its pre-existing baseline despite the new feature.
- `pnpm run api:registry:check` — passes after regenerating.

## Checklist

- [x] No new dependency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MMEkPe4vqjqbk3VfeQbfNA)_