### PR TITLE
I1: the country table — one definition, many consumers (#1079)

### DIFF
--- a/FEATUREDOCS/27-settings-admin.md
+++ b/FEATUREDOCS/27-settings-admin.md
@@ -34,6 +34,31 @@ type). `abn` is edited on the General settings page (`/settings`, next to
 address/email/phone); the `documents` fields are edited on the "Documents"
 card at `/settings/branding` (`document-settings.tsx`).
 
+### The country table (I1, #1079)
+
+`src/lib/countries.ts` is the single source of truth (POLICY.md R-3.1) for
+every country-derived property — currency, date order/separator, decimal
+separator, week start, paper size, unit system, tax label, default tax rate,
+and the business-number label — for the launch markets (M1: AU/NZ/UK/US/IE)
+plus NL/DE, which ship in the table but are excluded from
+`listEnabledCountries()` until decimal-comma input parsing (#1087, M7) lands.
+Adding a country is a data row there, not code. The US row's
+`defaultTaxRate` is genuinely `null` (no national rate) — never invent one
+(see #1088). Consumers: `formatters.ts` (I2, locale-aware formatting), the
+document composer (I4/I5, doc labels + paper size), and calendar/unit
+settings (I6) — none wired yet; this issue only lands the table.
+
+`OrgSettings.country` (the field above) is **immutable after creation
+(M6)** — `src/server/settings.ts`'s `updateOrganization` enforces it
+server-side via `withImmutableCountry()`, which forces the persisted value
+back onto any patch once one is set, the same "strip on the server" posture
+as `PROJECT_UPDATE_IMMUTABLE` (`convex/projectWrites.ts:420`). This is
+independent of the pre-existing, broader `COUNTRIES` picker on the General
+settings page (`settings/page.tsx`) — that one biases Places-autocomplete
+address lookups across ~19 countries and is a different concern from the
+7-row operational table above; Phase C's wizard country step is what wires
+the two together.
+
 ## Platform Branding (`SiteSettings`)
 - `platformName` — Displayed in sidebar, page titles, emails
 - `platformIcon` — Lucide icon name, rendered via `DynamicIcon`

--- a/src/lib/countries.test.ts
+++ b/src/lib/countries.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { COUNTRIES, getCountry, listEnabledCountries, isCountryEnabled } from "./countries";
+
+describe("countries — the single source of truth (I1, #1079)", () => {
+  it("US has no default tax rate — genuinely null, not 0 (#1088)", () => {
+    expect(getCountry("US")?.defaultTaxRate).toBeNull();
+  });
+
+  it("every other launch market has a positive default tax rate", () => {
+    for (const c of COUNTRIES) {
+      if (c.code === "US") continue;
+      expect(c.defaultTaxRate).not.toBeNull();
+      expect(c.defaultTaxRate).toBeGreaterThan(0);
+    }
+  });
+
+  it("decimal separator is keyed off locale, not currency — IE and NL both use EUR but disagree", () => {
+    const ie = getCountry("IE")!;
+    const nl = getCountry("NL")!;
+    expect(ie.currency).toBe(nl.currency);
+    expect(ie.decimalSeparator).not.toBe(nl.decimalSeparator);
+    expect(ie.decimalSeparator).toBe(".");
+    expect(nl.decimalSeparator).toBe(",");
+  });
+
+  it("the US is the only market with month-first dates, Sunday weeks, Letter paper and imperial units", () => {
+    const nonUS = COUNTRIES.filter((c) => c.code !== "US");
+    expect(nonUS.every((c) => c.dateOrder === "DMY")).toBe(true);
+    expect(nonUS.every((c) => c.weekStart === "MON")).toBe(true);
+    expect(nonUS.every((c) => c.paperSize === "A4")).toBe(true);
+    expect(nonUS.every((c) => c.units === "METRIC")).toBe(true);
+
+    const us = getCountry("US")!;
+    expect(us.dateOrder).toBe("MDY");
+    expect(us.weekStart).toBe("SUN");
+    expect(us.paperSize).toBe("LETTER");
+    expect(us.units).toBe("IMPERIAL");
+  });
+
+  it("Germany is the only market with a dotted date separator", () => {
+    const nonDE = COUNTRIES.filter((c) => c.code !== "DE");
+    expect(nonDE.every((c) => c.dateSeparator === "/")).toBe(true);
+    expect(getCountry("DE")?.dateSeparator).toBe(".");
+  });
+
+  it("NL and DE ship in the table but are excluded from the enabled list (M7)", () => {
+    expect(getCountry("NL")?.enabled).toBe(false);
+    expect(getCountry("DE")?.enabled).toBe(false);
+    expect(isCountryEnabled("NL")).toBe(false);
+    expect(isCountryEnabled("DE")).toBe(false);
+
+    const enabledCodes = listEnabledCountries().map((c) => c.code);
+    expect(enabledCodes).toEqual(["AU", "NZ", "GB", "US", "IE"]);
+  });
+
+  it("every AU/NZ/UK/US/IE launch market is enabled", () => {
+    for (const code of ["AU", "NZ", "GB", "US", "IE"] as const) {
+      expect(isCountryEnabled(code)).toBe(true);
+    }
+  });
+
+  it("getCountry returns undefined for an unknown or unset code, never a guessed default", () => {
+    expect(getCountry("XX")).toBeUndefined();
+    expect(getCountry(null)).toBeUndefined();
+    expect(getCountry(undefined)).toBeUndefined();
+  });
+
+  it("every row has a unique code", () => {
+    const codes = COUNTRIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -1,0 +1,187 @@
+/**
+ * The country table (I1, #1079) — single source of truth (POLICY.md R-3.1) for
+ * every country-derived property: currency, date format, decimal separator,
+ * week start, paper size, unit system, tax label/default rate, and the
+ * business-number label. Feeds the setup wizard's country step (Phase C),
+ * `formatters.ts` (I2), the document composer (I4/I5), and calendar/unit
+ * settings (I6).
+ *
+ * Adding a country is a data row, not code — that's the test of whether this
+ * module is doing its job. Don't redeclare any of this shape elsewhere
+ * (a second country→label map is a defect even in sync, per CLAUDE.md).
+ *
+ * See docs/designs/multi-tenant-and-international.md §1a for the country
+ * table this mirrors, and decisions M1/M6/M7.
+ */
+
+/**
+ * These aren't exported individually — nothing outside this file needs to
+ * name them yet, and an exported-but-unimported type is dead code (R-4.2,
+ * the knip ratchet). A consumer that needs one can pull it off
+ * `CountryDefinition["dateOrder"]` etc., or a real consumer can export it
+ * from here when it lands.
+ */
+/** Launch markets (M1) + the two EU markets documented but disabled (M7). */
+type CountryCode = "AU" | "NZ" | "GB" | "US" | "IE" | "NL" | "DE";
+
+type DateOrder = "DMY" | "MDY";
+type DateSeparator = "/" | ".";
+type DecimalSeparator = "." | ",";
+type WeekStart = "MON" | "SUN";
+type PaperSize = "A4" | "LETTER";
+type UnitSystem = "METRIC" | "IMPERIAL";
+
+export interface CountryDefinition {
+  code: CountryCode;
+  name: string;
+  /** ISO 4217 currency code. */
+  currency: string;
+  dateOrder: DateOrder;
+  dateSeparator: DateSeparator;
+  /** Keyed off locale, not currency — IE and NL both use EUR, only NL writes
+   *  `1.234,56`. Don't derive this from `currency`. */
+  decimalSeparator: DecimalSeparator;
+  weekStart: WeekStart;
+  paperSize: PaperSize;
+  units: UnitSystem;
+  taxLabel: string;
+  /** Genuinely absent (not 0) for the US — there is no national sales-tax
+   *  rate. The wizard/settings UI must show this as unset, never invent a
+   *  default (see #1088, the recalc.ts fallback this exact shape guards
+   *  against repeating). */
+  defaultTaxRate: number | null;
+  businessNumberLabel: string;
+  /** M7 — ships in this table but excluded from any country-selecting UI
+   *  (wizard, settings) until decimal-comma input parsing (#1087) lands.
+   *  Misreading a typed price by 100x is the worst failure available in a
+   *  quoting tool, so NL/DE stay documented-but-off rather than half-done. */
+  enabled: boolean;
+}
+
+export const COUNTRIES: readonly CountryDefinition[] = [
+  {
+    code: "AU",
+    name: "Australia",
+    currency: "AUD",
+    dateOrder: "DMY",
+    dateSeparator: "/",
+    decimalSeparator: ".",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "GST",
+    defaultTaxRate: 10,
+    businessNumberLabel: "ABN",
+    enabled: true,
+  },
+  {
+    code: "NZ",
+    name: "New Zealand",
+    currency: "NZD",
+    dateOrder: "DMY",
+    dateSeparator: "/",
+    decimalSeparator: ".",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "GST",
+    defaultTaxRate: 15,
+    businessNumberLabel: "NZBN",
+    enabled: true,
+  },
+  {
+    code: "GB",
+    name: "United Kingdom",
+    currency: "GBP",
+    dateOrder: "DMY",
+    dateSeparator: "/",
+    decimalSeparator: ".",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "VAT",
+    defaultTaxRate: 20,
+    businessNumberLabel: "VAT number",
+    enabled: true,
+  },
+  {
+    code: "US",
+    name: "United States",
+    currency: "USD",
+    dateOrder: "MDY",
+    dateSeparator: "/",
+    decimalSeparator: ".",
+    weekStart: "SUN",
+    paperSize: "LETTER",
+    units: "IMPERIAL",
+    taxLabel: "Sales tax",
+    defaultTaxRate: null,
+    businessNumberLabel: "EIN",
+    enabled: true,
+  },
+  {
+    code: "IE",
+    name: "Ireland",
+    currency: "EUR",
+    dateOrder: "DMY",
+    dateSeparator: "/",
+    decimalSeparator: ".",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "VAT",
+    defaultTaxRate: 23,
+    businessNumberLabel: "VAT number",
+    enabled: true,
+  },
+  {
+    code: "NL",
+    name: "Netherlands",
+    currency: "EUR",
+    dateOrder: "DMY",
+    dateSeparator: "/",
+    decimalSeparator: ",",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "BTW",
+    defaultTaxRate: 21,
+    businessNumberLabel: "BTW-nummer",
+    enabled: false,
+  },
+  {
+    code: "DE",
+    name: "Germany",
+    currency: "EUR",
+    dateOrder: "DMY",
+    dateSeparator: ".",
+    decimalSeparator: ",",
+    weekStart: "MON",
+    paperSize: "A4",
+    units: "METRIC",
+    taxLabel: "MwSt",
+    defaultTaxRate: 19,
+    businessNumberLabel: "USt-IdNr",
+    enabled: false,
+  },
+] as const;
+
+const COUNTRIES_BY_CODE: ReadonlyMap<CountryCode, CountryDefinition> = new Map(
+  COUNTRIES.map((c) => [c.code, c]),
+);
+
+/** Look up a country by code. Returns `undefined` for an unknown/unset code —
+ *  callers must decide their own fallback, this never guesses one. */
+export function getCountry(code: string | null | undefined): CountryDefinition | undefined {
+  return code ? COUNTRIES_BY_CODE.get(code as CountryCode) : undefined;
+}
+
+/** Countries selectable in a country-picking UI (wizard, settings) — excludes
+ *  the M7-disabled rows (NL/DE) without deleting their data from the table. */
+export function listEnabledCountries(): readonly CountryDefinition[] {
+  return COUNTRIES.filter((c) => c.enabled);
+}
+
+export function isCountryEnabled(code: string | null | undefined): boolean {
+  return getCountry(code)?.enabled ?? false;
+}

--- a/src/server/settings-country-immutable.test.ts
+++ b/src/server/settings-country-immutable.test.ts
@@ -1,0 +1,75 @@
+/**
+ * src/server/settings.ts's updateOrganization — M6 (#1079, I1): a set org
+ * country is immutable after creation. Enforced server-side by forcing the
+ * persisted value back onto the patch, the same "strip on the server"
+ * posture as PROJECT_UPDATE_IMMUTABLE (convex/projectWrites.ts) — a client
+ * that sends a different `settings.country` must be silently overridden,
+ * not merely blocked by a disabled input.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const requirePermission = vi.fn();
+vi.mock("@/lib/org-context", () => ({
+  requirePermission: (...a: unknown[]) => requirePermission(...a),
+}));
+
+const organizationUpdate = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    organization: { update: (...a: unknown[]) => organizationUpdate(...a) },
+  },
+}));
+
+const readOrgSettingsBlob = vi.fn();
+const saveOrgSettings = vi.fn();
+vi.mock("@/lib/org-settings-read", () => ({
+  readOrgSettingsBlob: (...a: unknown[]) => readOrgSettingsBlob(...a),
+  saveOrgSettings: (...a: unknown[]) => saveOrgSettings(...a),
+}));
+
+vi.mock("@/lib/activity-log", () => ({ logActivity: vi.fn(async () => {}) }));
+
+import { updateOrganization } from "./settings";
+
+const ACTOR = { organizationId: "org_A", userId: "user_owner", userName: "Owner" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requirePermission.mockResolvedValue(ACTOR);
+  organizationUpdate.mockResolvedValue({ id: "org_A", name: "Acme" });
+  saveOrgSettings.mockResolvedValue(undefined);
+});
+
+describe("updateOrganization — country immutable after creation (M6)", () => {
+  it("accepts the country on the first save (previously unset)", async () => {
+    readOrgSettingsBlob.mockResolvedValue({});
+
+    await updateOrganization({ name: "Acme", settings: { country: "AU" } });
+
+    expect(saveOrgSettings).toHaveBeenCalledWith("org_A", { country: "AU" }, undefined);
+  });
+
+  it("silently forces a changed country back to the existing value once set", async () => {
+    readOrgSettingsBlob.mockResolvedValue({ country: "AU" });
+
+    await updateOrganization({ name: "Acme", settings: { country: "US", phone: "555" } });
+
+    expect(saveOrgSettings).toHaveBeenCalledWith(
+      "org_A",
+      { country: "AU", phone: "555" },
+      undefined,
+    );
+  });
+
+  it("leaves other settings fields untouched when the country is already set and unchanged", async () => {
+    readOrgSettingsBlob.mockResolvedValue({ country: "GB" });
+
+    await updateOrganization({ name: "Acme", settings: { country: "GB", website: "acme.test" } });
+
+    expect(saveOrgSettings).toHaveBeenCalledWith(
+      "org_A",
+      { country: "GB", website: "acme.test" },
+      undefined,
+    );
+  });
+});

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -43,6 +43,16 @@ export async function getOrganization() {
   return serialize({ ...org, defaultTaxRate, settings });
 }
 
+/** M6 — Organization.country is immutable after creation. Enforced by
+ *  forcing the persisted value back onto the patch server-side (the
+ *  PROJECT_UPDATE_IMMUTABLE pattern, convex/projectWrites.ts:420) — never a
+ *  disabled input alone, since `settings` is a client-supplied blob R-9.3
+ *  has to re-check regardless of what the UI sent. Only a still-unset
+ *  country (first save) may be written. */
+function withImmutableCountry(existing: OrgSettings, incoming: OrgSettings): OrgSettings {
+  return existing.country ? { ...incoming, country: existing.country } : incoming;
+}
+
 export async function updateOrganization(data: {
   name: string;
   settings: OrgSettings;
@@ -76,13 +86,16 @@ export async function updateOrganization(data: {
     }
   }
 
+  const existingSettings = await readOrgSettingsBlob(organizationId);
+  const settings = withImmutableCountry(existingSettings, data.settings);
+
   // Identity (name) stays on the Better Auth org row; business settings + tax
   // rate go to Convex (source of truth).
   const updated = await prisma.organization.update({
     where: { id: organizationId },
     data: { name: data.name },
   });
-  await saveOrgSettings(organizationId, data.settings, data.defaultTaxRate);
+  await saveOrgSettings(organizationId, settings, data.defaultTaxRate);
 
   await logActivity({
     organizationId,
@@ -95,7 +108,7 @@ export async function updateOrganization(data: {
     summary: `Updated organization settings`,
   });
 
-  return serialize({ ...updated, settings: data.settings, defaultTaxRate: data.defaultTaxRate });
+  return serialize({ ...updated, settings, defaultTaxRate: data.defaultTaxRate });
 }
 
 /** Get org-level T&T settings (for fallback defaults). */


### PR DESCRIPTION
## Summary

- Adds `src/lib/countries.ts` as the single source of truth (POLICY.md R-3.1) for every country-derived property: currency, date order/separator, decimal separator, week start, paper size, unit system, tax label, default tax rate, and business-number label — covering the M1 launch markets (AU/NZ/UK/US/IE) plus NL/DE, which ship in the table but are excluded from `listEnabledCountries()` until decimal-comma input parsing (#1087, M7) lands.
- The US row's `defaultTaxRate` is genuinely `null` — there is no national sales-tax rate, and the module never invents one (the exact shape of the bug fixed in #1088).
- Enforces **M6**: `Organization.country` is immutable after creation. `src/server/settings.ts`'s `updateOrganization` now forces the persisted country back onto any patch once one is set (`withImmutableCountry()`) — the same server-side "strip the key" posture as `PROJECT_UPDATE_IMMUTABLE` (`convex/projectWrites.ts:420`), not a disabled input alone (R-9.3: `settings` is a client-supplied blob).
- Updated `FEATUREDOCS/27-settings-admin.md` to document the table and the immutability guard, and to note this is independent of the existing broader `COUNTRIES` address-bias picker on the General settings page (a different concern — Places-autocomplete country bias across ~19 countries, not the 7-row operational table).

Part of #1065 (Phase I — internationalisation), part of the [multi-tenant + international tracking epic](https://github.com/TwoToned/gearflow/issues/1063). Per Phase I's own stated order ("I1 first, then I2, then everything else in parallel"), this is the next item after #1088 (T1) landed. **Nothing is wired to a consumer yet** — `formatters.ts` (I2/#1081), the document composer (I4/#1083, I5/#1084), and calendar/unit settings (I6/#1086) are separate sub-issues that will import this table; this PR lands only the table itself and the M6 guard called out explicitly in #1079's body.

## Testing

- `src/lib/countries.test.ts` — the table's structural invariants (US has no default rate, IE/NL share a currency but disagree on decimal separator, only the US differs on date order/week/paper/units, only DE uses a dotted date separator, NL/DE excluded from the enabled list, unique codes).
- `src/server/settings-country-immutable.test.ts` — `updateOrganization` accepts the country on first save, then silently forces a later change back to the persisted value while leaving other fields untouched.
- `pnpm exec vitest run` — 5214/5214 runnable tests pass (the 50 failing test *files* are a pre-existing sandbox-only issue: no `DATABASE_URL`/generated Prisma client in this environment, unrelated to this change).
- `pnpm exec knip` — dead-code count unchanged at the committed baseline (415); the new module's narrow union types are kept un-exported (internal to `CountryDefinition`) specifically to avoid tripping the ratchet before a real consumer lands.
- `pnpm exec eslint` on changed files — no new errors; `updateOrganization`'s pre-existing complexity warning (11/10) is unchanged (the immutability check is factored into its own `withImmutableCountry()` helper rather than inlined).

## Checklist

- [x] New dependency? N/A — no new dependency


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uo5dncqjQun7bhjaHVBLrM)_