### PR TITLE
Overview readiness: hide N/A checks, drop the duplicate staleness row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#1061** — The Finance tab is now the ledger rather than the front door: all
   quote revisions, invoices, payments, the financial summary and operational
   P&L still live there, and it remains the only place to recall, correct,
-  reprice, issue, void, credit or push to Xero. The reservation-conflict and
-  stale-pricing banners that used to sit above the tabs are now rows in the
-  Overview tab's Readiness checklist, carrying the same actions.
+  reprice, issue, void, credit or push to Xero. The reservation-conflict
+  banner that used to sit above the tabs is now a row in the Overview tab's
+  Readiness checklist, carrying the same action. (The stale-pricing banner
+  stayed put on the Finance tab — see below.)
+
+- The Overview Readiness checklist now only shows the **Services** and
+  **Crew** rows for projects that actually have services scheduled or crew
+  assigned — a job with neither no longer carries a permanent "No services
+  scheduled" / "No crew assigned yet" line. The "Pricing is current for these
+  dates" row is gone entirely: it duplicated the Finance tab's
+  `StalePricingBanner`, which remains the one place that surfaces stale
+  auto-pricing.
 
 ### Fixed
 

--- a/FEATUREDOCS/69-project-overview.md
+++ b/FEATUREDOCS/69-project-overview.md
@@ -59,22 +59,40 @@ check navigates you to the tab that fixes it.
 
 ## Readiness
 
-Six checks, always rendered — including the passing ones. This is a departure
-from the banners it replaces (`ProjectConflictsBanner`, `StalePricingBanner`),
-and the reason is worth keeping: a hide-when-clean banner gives zero noise but
-also zero reassurance, and a component that appears and disappears makes the
-page jump. When every check passes the panel collapses to a single line with a
-"Show checks" toggle, so the rows only cost anything when they have something
-to say.
+Five *possible* checks. All are always rendered when they apply — including
+the passing ones — but `services` and `crew` are dropped from the list
+entirely when they're not relevant to this project (2026-08), rather than
+rendered as a permanent "No services scheduled" / "No crew assigned yet" pass
+row:
 
-| Check | Source | Severity |
-|---|---|---|
-| Gear short for this window | `projectReadiness.forProject` | `blocking` (hard) / `warning` (pencilled) |
-| Assets double-booked | `reservationConflicts.projectConflicts` | `blocking` |
-| Services not confirmed / short of crew | `projectReadiness.forProject` | `warning` |
-| Crew unconfirmed | `projectReadiness.forProject` | `warning` |
-| Lines unpriced | `projectReadiness.forProject` | `warning` |
-| Pricing stale for these dates | `lineItemWrites.projectPricingStaleness` | `warning` |
+- `services` renders only when `activeServiceCount > 0` — a job with no
+  services scheduled has nothing there to check.
+- `crew` renders only when `activeCount > 0` — a job with nobody assigned has
+  nothing to chase.
+
+For everything that DOES apply, showing the passing rows (not just the
+failing ones) is still deliberate: this is a departure from the hide-when-clean
+banner it replaces (`ProjectConflictsBanner`), and the reason is worth
+keeping — a hide-when-clean banner gives zero noise but also zero reassurance,
+and a component that appears and disappears makes the page jump. When every
+applicable check passes the panel collapses to a single line with a
+"Show checks" toggle, so the rows only cost anything when they have something
+to say. The distinction is "does this dimension apply to the job" (hide) vs.
+"does this dimension currently have a problem" (always show, pass or fail).
+
+There is no "Pricing stale for these dates" check on this panel. It used to
+duplicate `lineItemWrites.projectPricingStaleness`, which is already surfaced
+on the Finance tab by `StalePricingBanner` — a second copy of the same fact in
+two places was a straight R-3.1 violation, not a distinct signal, so it was
+cut (2026-08) rather than kept "for reassurance."
+
+| Check | Source | Severity | Hidden when |
+|---|---|---|---|
+| Gear short for this window | `projectReadiness.forProject` | `blocking` (hard) / `warning` (pencilled) | never |
+| Assets double-booked | `reservationConflicts.projectConflicts` | `blocking` | never |
+| Services not confirmed / short of crew | `projectReadiness.forProject` | `warning` | no active services |
+| Crew unconfirmed | `projectReadiness.forProject` | `warning` | no crew assigned |
+| Lines unpriced | `projectReadiness.forProject` | `warning` | never |
 
 **Services and crew are separate checks** (#1063). "The bump-in isn't locked in"
 and "Dave hasn't replied to the offer" are different problems with different
@@ -92,8 +110,11 @@ awaiting a yes).
   (committed) vs "would be short if you confirm" (pencilled). An unconfirmed
   project's own demand is pencilled *by definition*, so collapsing these would
   cry wolf on every enquiry.
-- **"No crew assigned yet" ≠ "All crew confirmed."** Both pass, but the first
-  must not imply a roster exists.
+- **A row that doesn't apply doesn't render, at all** — not even as a quiet
+  pass. Unlike the removed hide-when-clean banners, this isn't ambiguous with
+  "not checked yet": the row genuinely never existed for a project with no
+  crew/services, vs. `unknown`, which means a check ran and couldn't answer.
+  Don't conflate "hidden because N/A" with "unknown."
 - **`DECLINED`/`CANCELLED` are settled-no, not unconfirmed.** A decline shrinks
   the active count (the service is a head short) rather than inflating the
   chase-up count — there's nobody left to chase on that row.
@@ -102,12 +123,14 @@ awaiting a yes).
   already underway; `CANCELLED` drops out of both the flagged list and the
   denominator. An absent status reads as `PLANNED` (the pre-status default).
 - **Order is fixed, not severity-sorted**, so rows don't reshuffle under the
-  cursor as problems resolve. Only the marks change.
+  cursor as problems resolve. Only the marks change. A row rejoining the list
+  (crew gets assigned mid-session) inserts back at its fixed position, not at
+  the end.
 
 Each failing row carries the action that fixes it: gear → `/overbookings`
 (where a shortage is actually resolved), conflicts → expands **inline** to the
 swap-to-a-free-asset picker, services and crew → the Labour tab, unpriced →
-Equipment, stale → an inline "Recalculate".
+Equipment.
 
 ## Finance cards
 
@@ -139,7 +162,7 @@ convex/lib/projectReadiness.ts   — pure aggregation (no ctx.db), unit-tested
 convex/projectReadiness.ts       — the `forProject` query (bounded reads, R-9.8)
 src/lib/project-readiness-checks.ts  — severity/wording/ordering (plain module)
 src/lib/project-invoicing-state.ts   — invoicing position + next step
-src/hooks/use-project-readiness.ts   — fans three sources into one check list
+src/hooks/use-project-readiness.ts   — fans two sources into one check list
 src/components/projects/project-readiness-panel.tsx
 src/lib/project-context.ts           — schedule rows + directions, shared by BOTH renderings
 src/components/projects/project-context-rail.tsx     — the sidebar (every tab but Overview)
@@ -149,12 +172,16 @@ src/components/projects/overview/{quote-card,invoicing-card,card-parts,context-c
 
 ### One rule, one home (R-3.1)
 
-The readiness query deliberately does **not** re-implement two checks that
-already had exactly one home each — the panel subscribes to their existing
-queries alongside it:
+The readiness query deliberately does **not** re-implement a check that
+already had exactly one home — the panel subscribes to its existing query
+alongside `projectReadiness.forProject`:
 
 - double-booked assets → `reservationConflicts.projectConflicts`
-- stale auto-pricing → `lineItemWrites.projectPricingStaleness`
+
+Stale auto-pricing (`lineItemWrites.projectPricingStaleness`) is the inverse
+case: it already had exactly one home (`StalePricingBanner`, Finance tab), so
+the readiness panel does NOT also subscribe to it — that would have been the
+duplication this rule exists to prevent, not an application of it.
 
 Three duplications were collapsed while building this, rather than added to:
 

--- a/src/components/projects/__tests__/project-readiness-panel.smoke.test.tsx
+++ b/src/components/projects/__tests__/project-readiness-panel.smoke.test.tsx
@@ -23,10 +23,6 @@ vi.mock("@/hooks/use-project-conflicts", () => ({
   useProjectConflicts: () => mockConflicts(),
   refreshProjectConflicts: vi.fn(),
 }));
-vi.mock("@/hooks/use-billing-summary", () => ({
-  useRecalcAutoPricedLines: () => ({ recalc: vi.fn() }),
-  useProjectPricingStaleness: () => 0,
-}));
 // The permission gate is exercised elsewhere; here it must not swallow the
 // actions the panel is being asserted on.
 vi.mock("@/components/auth/permission-gate", () => ({
@@ -49,7 +45,6 @@ const CLEAN: Parameters<typeof buildReadinessChecks>[0] = {
   crew: { unconfirmedCount: 0, activeCount: 0, servicesMissingCrew: [], crewShortfall: 0, unconfirmedServices: [], activeServiceCount: 0 },
   pricing: { unpriced: [], unpricedCount: 0 },
   conflicts: [],
-  staleLineCount: 0,
 };
 
 function renderPanel(onNavigateTab = vi.fn()) {
@@ -64,10 +59,12 @@ describe("ProjectReadinessPanel smoke", () => {
     mockConflicts.mockReturnValue({ data: [], isLoading: false });
   });
 
-  it("collapses to a single line when every check passes", () => {
+  it("collapses to a single line when every applicable check passes", () => {
     mockReadiness.mockReturnValue(stateFrom(CLEAN));
     renderPanel();
-    expect(screen.getByText(/Ready — all 6 checks pass/)).toBeTruthy();
+    // CLEAN has no crew and no services, so those two rows don't even count
+    // toward the total — only gear, conflicts and pricing apply.
+    expect(screen.getByText(/Ready — all 3 checks pass/)).toBeTruthy();
     // The individual rows stay hidden until asked for.
     expect(screen.queryByText("Enough gear for this window")).toBeNull();
   });
@@ -78,7 +75,15 @@ describe("ProjectReadinessPanel smoke", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show checks" }));
     expect(screen.getByText("Enough gear for this window")).toBeTruthy();
     expect(screen.getByText("No assets double-booked")).toBeTruthy();
-    expect(screen.getByText("Pricing is current for these dates")).toBeTruthy();
+    expect(screen.getByText("Every line is priced")).toBeTruthy();
+  });
+
+  it("drops the crew and services rows entirely when the project has neither", () => {
+    mockReadiness.mockReturnValue(stateFrom(CLEAN));
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Show checks" }));
+    expect(screen.queryByText(/crew/i)).toBeNull();
+    expect(screen.queryByText(/service/i)).toBeNull();
   });
 
   it("shows blocking and warning counts, and renders every row, when things are wrong", () => {

--- a/src/components/projects/project-readiness-panel.tsx
+++ b/src/components/projects/project-readiness-panel.tsx
@@ -1,21 +1,18 @@
 "use client";
-// use-client: interactive — expand/collapse state + a recalculate mutation (R-8.1.1)
+// use-client: interactive — expand/collapse state (R-8.1.1)
 
 import { useState } from "react";
 import Link from "next/link";
-import { Check, AlertTriangle, CircleAlert, CircleHelp, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { Check, AlertTriangle, CircleAlert, CircleHelp, ChevronDown, ChevronRight } from "lucide-react";
 
 import { useProjectReadiness } from "@/hooks/use-project-readiness";
 import { useProjectConflicts } from "@/hooks/use-project-conflicts";
-import { useRecalcAutoPricedLines } from "@/hooks/use-billing-summary";
 import { ConflictRow } from "@/components/projects/conflict-row";
 import type { ReadinessCheck, ReadinessSeverity } from "@/lib/project-readiness-checks";
 import type { ReservationConflict } from "@/lib/reservation-conflicts-types";
 import { Button } from "@/components/ui/button";
 import { Panel } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { showError } from "@/lib/show-error";
 import { cn, focusRing } from "@/lib/utils";
 
 /** Which project tab a check's action sends you to, when it sends you anywhere. */
@@ -101,36 +98,6 @@ function CheckRow({
   );
 }
 
-/** Inline "Recalculate" for the stale-rates check — the write side of #943. */
-function RecalculateAction({ projectId, orgId }: { projectId: string; orgId: string | undefined }) {
-  const [pending, setPending] = useState(false);
-  const { recalc } = useRecalcAutoPricedLines(orgId);
-  return (
-    <Button
-      variant="line"
-      size="sm"
-      className="h-7 shrink-0"
-      disabled={pending}
-      onClick={async () => {
-        setPending(true);
-        try {
-          const { linesUpdated } = await recalc(projectId);
-          toast.success("Pricing recalculated", {
-            description: `Updated ${linesUpdated} line item${linesUpdated === 1 ? "" : "s"} for the current rental dates.`,
-          });
-        } catch (e) {
-          showError(e);
-        } finally {
-          setPending(false);
-        }
-      }}
-    >
-      {pending && <Loader2 className="mr-1 size-3 animate-spin" />}
-      Recalculate
-    </Button>
-  );
-}
-
 /**
  * The action a failing check offers. Conflicts deliberately have none — they
  * resolve inline via the row's expander, where the swap picker lives.
@@ -138,16 +105,13 @@ function RecalculateAction({ projectId, orgId }: { projectId: string; orgId: str
 function CheckAction({
   check,
   projectId,
-  orgId,
   onNavigateTab,
 }: {
   check: ReadinessCheck;
   projectId: string;
-  orgId: string | undefined;
   onNavigateTab: (tab: ProjectTab) => void;
 }) {
   if (!check.actionLabel) return null;
-  if (check.id === "staleness") return <RecalculateAction projectId={projectId} orgId={orgId} />;
 
   // A gear shortage is resolved on the org board (sub-hire, swap, or move the
   // dates) — a project-local view can't show what else is competing for the
@@ -173,14 +137,26 @@ function CheckAction({
   );
 }
 
-/** Every check ran and passed — one line, not five green ticks. */
-function AllClearPanel({ total, onShowAll }: { total: number; onShowAll: () => void }) {
+const CHECK_LABEL: Record<ReadinessCheck["id"], string> = {
+  gear: "gear",
+  conflicts: "conflicts",
+  services: "services",
+  crew: "crew",
+  pricing: "pricing",
+};
+
+/**
+ * Every applicable check ran and passed — one line, not five green ticks.
+ * Named from the actual `checks` list (not a hardcoded string) because
+ * `services`/`crew` may not be present at all for this project.
+ */
+function AllClearPanel({ checks, onShowAll }: { checks: ReadinessCheck[]; onShowAll: () => void }) {
   return (
     <Panel padding="default" className="flex items-center gap-2.5 p-3.5">
       <CheckMark severity="pass" />
       <p className="min-w-0 flex-1 text-ui-text">
-        <span className="font-semibold text-ink">Ready — all {total} checks pass</span>
-        <span className="text-muted"> · gear, conflicts, services, crew, pricing</span>
+        <span className="font-semibold text-ink">Ready — all {checks.length} checks pass</span>
+        <span className="text-muted"> · {checks.map((c) => CHECK_LABEL[c.id]).join(", ")}</span>
       </p>
       <Button variant="line" size="sm" className="h-7 shrink-0" onClick={onShowAll}>
         Show checks
@@ -193,12 +169,18 @@ function AllClearPanel({ total, onShowAll }: { total: number; onShowAll: () => v
  * The project's readiness checklist — the lead section of the Overview tab
  * (#1061).
  *
- * ALWAYS renders every check, passing ones included. This is a deliberate
- * departure from the hide-when-clean banners it replaces (`ProjectConflictsBanner`,
- * `StalePricingBanner`): those gave zero noise but also zero reassurance, and a
- * banner that appears and disappears makes the page jump. A checklist that says
- * "checked, all good" is worth the five rows — and when everything passes it
- * collapses to one line anyway.
+ * Renders every check that APPLIES to this project, passing ones included —
+ * a deliberate departure from the hide-when-clean banner it replaces
+ * (`ProjectConflictsBanner`): that gave zero noise but also zero reassurance,
+ * and a banner that appears and disappears makes the page jump. A checklist
+ * that says "checked, all good" is worth the row — and when everything
+ * passes it collapses to one line anyway.
+ *
+ * "Applies" is narrower than "ran": `crew`/`services` drop out entirely
+ * (not even as a pass) when the project has no crew assigned or no services
+ * scheduled — see `project-readiness-checks.ts`. Unlike a hide-when-clean
+ * banner, this isn't ambiguous with "not checked yet", because the row never
+ * existed for a project with nothing to check there.
  *
  * Severity, wording and ordering come from `project-readiness-checks.ts` (a
  * plain, unit-tested module); this component only renders them and attaches the
@@ -220,7 +202,7 @@ export function ProjectReadinessPanel({ projectId, orgId, onNavigateTab }: Proje
   }
 
   if (summary.allClear && !showAll) {
-    return <AllClearPanel total={summary.total} onShowAll={() => setShowAll(true)} />;
+    return <AllClearPanel checks={checks} onShowAll={() => setShowAll(true)} />;
   }
 
   const conflictList = (conflicts ?? []) as ReservationConflict[];
@@ -243,7 +225,7 @@ export function ProjectReadinessPanel({ projectId, orgId, onNavigateTab }: Proje
           <CheckRow
             key={check.id}
             check={check}
-            action={<CheckAction check={check} projectId={projectId} orgId={orgId} onNavigateTab={onNavigateTab} />}
+            action={<CheckAction check={check} projectId={projectId} onNavigateTab={onNavigateTab} />}
             expandable={isConflicts}
             expanded={isConflicts && expandedId === check.id}
             onToggle={() => setExpandedId((cur) => (cur === check.id ? null : check.id))}

--- a/src/hooks/use-project-readiness.ts
+++ b/src/hooks/use-project-readiness.ts
@@ -3,7 +3,6 @@
 import { useMemo } from "react";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { useProjectConflicts } from "@/hooks/use-project-conflicts";
-import { useProjectPricingStaleness } from "@/hooks/use-billing-summary";
 import { api } from "../../convex/_generated/api";
 import { formatDate } from "@/lib/formatters";
 import {
@@ -16,9 +15,9 @@ import {
 /**
  * The Overview tab's Readiness panel, in one hook (#1061).
  *
- * Fans three sources into the single ordered check list
+ * Fans two sources into the single ordered check list
  * `project-readiness-checks.ts` derives. They stay separate on purpose — each
- * rule has exactly one home (R-3.1), and two of them predate this panel:
+ * rule has exactly one home (R-3.1), and both predate this panel:
  *
  *   - `projectReadiness.forProject`            — gear, crew, unpriced (reactive,
  *     same bounded read shape the org board already subscribes to)
@@ -26,11 +25,14 @@ import {
  *     by design: conflict detection scans the org's whole booking graph, so a
  *     reactive subscription would re-run on every org write (see the R-8.3.3
  *     entry in docs/exceptions.md). It refreshes when a swap resolves one.
- *   - `lineItemWrites.projectPricingStaleness` — stale auto-pricing
+ *
+ * Stale auto-pricing is deliberately NOT fanned in here — it's the Finance
+ * tab's `StalePricingBanner` (`useProjectPricingStaleness`), and surfacing it
+ * a second time on Overview just repeated the same fact.
  *
  * `isLoading` is true only until the readiness query itself resolves. The
- * conflicts one-shot is allowed to lag: a checklist that withholds four known
- * answers waiting on the fifth is worse than one that fills in.
+ * conflicts one-shot is allowed to lag: a checklist that withholds three
+ * known answers waiting on the fourth is worse than one that fills in.
  */
 export function useProjectReadiness(
   projectId: string | undefined,
@@ -45,7 +47,6 @@ export function useProjectReadiness(
     projectId && orgId ? { projectId, orgId } : "skip",
   );
   const { data: conflicts } = useProjectConflicts(projectId);
-  const staleLineCount = useProjectPricingStaleness(projectId, orgId);
 
   return useMemo(() => {
     if (!readiness) {
@@ -60,8 +61,7 @@ export function useProjectReadiness(
       crew: readiness.crew,
       pricing: readiness.pricing,
       conflicts: conflicts ?? [],
-      staleLineCount,
     });
     return { checks, summary: summariseReadiness(checks), isLoading: false };
-  }, [readiness, conflicts, staleLineCount]);
+  }, [readiness, conflicts]);
 }

--- a/src/lib/__tests__/project-readiness-checks.test.ts
+++ b/src/lib/__tests__/project-readiness-checks.test.ts
@@ -15,7 +15,6 @@ function input(over: Partial<BuildChecksInput> = {}): BuildChecksInput {
     crew: { unconfirmedCount: 0, activeCount: 0, servicesMissingCrew: [], crewShortfall: 0, unconfirmedServices: [], activeServiceCount: 0 },
     pricing: { unpriced: [], unpricedCount: 0 },
     conflicts: [],
-    staleLineCount: 0,
     ...over,
   };
 }
@@ -91,10 +90,9 @@ describe("crew check", () => {
     expect(c.title).toBe("3 of 11 crew unconfirmed");
   });
 
-  test("an empty roster passes without claiming everyone confirmed", () => {
-    const c = byId(buildReadinessChecks(input()), "crew");
-    expect(c.severity).toBe("pass");
-    expect(c.title).toBe("No crew assigned yet");
+  test("an empty roster drops the row entirely — nothing to chase, nothing to show", () => {
+    const checks = buildReadinessChecks(input());
+    expect(checks.some((c) => c.id === "crew")).toBe(false);
   });
 
   test("a full confirmed roster says so", () => {
@@ -169,10 +167,9 @@ describe("services check", () => {
     expect(c.detail).toContain("short 1 person");
   });
 
-  test("no services at all passes without implying any exist", () => {
-    const c = byId(buildReadinessChecks(input()), "services");
-    expect(c.severity).toBe("pass");
-    expect(c.title).toBe("No services scheduled");
+  test("no services at all drops the row entirely — nothing scheduled, nothing to show", () => {
+    const checks = buildReadinessChecks(input());
+    expect(checks.some((c) => c.id === "services")).toBe(false);
   });
 
   test("confirmed and staffed says so", () => {
@@ -196,28 +193,26 @@ describe("services check", () => {
   });
 
   test("a CANCELLED service is settled-no — never flagged, never counted", () => {
-    // The lib drops CANCELLED before this point, so the check only ever sees
-    // live services; this pins the contract the lib relies on.
-    const c = byId(
-      buildReadinessChecks(
-        input({
-          crew: {
-            unconfirmedCount: 0,
-            activeCount: 0,
-            servicesMissingCrew: [],
-            crewShortfall: 0,
-            unconfirmedServices: [],
-            activeServiceCount: 0,
-          },
-        }),
-      ),
-      "services",
+    // The lib drops CANCELLED before this point, so `activeServiceCount` is
+    // 0 and the row doesn't render at all — this pins the contract the lib
+    // relies on.
+    const checks = buildReadinessChecks(
+      input({
+        crew: {
+          unconfirmedCount: 0,
+          activeCount: 0,
+          servicesMissingCrew: [],
+          crewShortfall: 0,
+          unconfirmedServices: [],
+          activeServiceCount: 0,
+        },
+      }),
     );
-    expect(c.severity).toBe("pass");
+    expect(checks.some((c) => c.id === "services")).toBe(false);
   });
 });
 
-describe("pricing and staleness checks", () => {
+describe("pricing check", () => {
   test("unpriced lines warn and are named", () => {
     const c = byId(
       buildReadinessChecks(input({ pricing: { unpriced: [{ label: "Truss bracket" }], unpricedCount: 1 } })),
@@ -227,31 +222,41 @@ describe("pricing and staleness checks", () => {
     expect(c.detail).toContain("Truss bracket");
   });
 
-  test("stale rates are a separate check with their own action", () => {
-    const c = byId(buildReadinessChecks(input({ staleLineCount: 4 })), "staleness");
-    expect(c.severity).toBe("warning");
-    expect(c.actionLabel).toBe("Recalculate");
-    expect(c.detail).toContain("4 line items need recalculating");
-  });
-
-  test("both pass on a clean project", () => {
+  test("passes on a clean project", () => {
     const checks = buildReadinessChecks(input());
     expect(byId(checks, "pricing").severity).toBe("pass");
-    expect(byId(checks, "staleness").severity).toBe("pass");
   });
 });
 
 describe("ordering and summary", () => {
   test("order is stable regardless of severity so rows don't reshuffle", () => {
+    // Default crew/services are both empty, so those two rows drop out —
+    // only gear, conflicts and pricing survive on a clean, crewless project.
     const clean = buildReadinessChecks(input()).map((c) => c.id);
     const messy = buildReadinessChecks(
       input({ conflicts: [{ assetTag: "A", modelName: "M", conflictingProject: { projectNumber: "P-1" } }] }),
     ).map((c) => c.id);
-    expect(clean).toEqual(["gear", "conflicts", "services", "crew", "pricing", "staleness"]);
+    expect(clean).toEqual(["gear", "conflicts", "pricing"]);
     expect(messy).toEqual(clean);
   });
 
-  test("all-clear only when every check actually ran and passed", () => {
+  test("services and crew rejoin the (still fixed) order once they're relevant", () => {
+    const checks = buildReadinessChecks(
+      input({
+        crew: {
+          unconfirmedCount: 0,
+          activeCount: 4,
+          servicesMissingCrew: [],
+          crewShortfall: 0,
+          unconfirmedServices: [],
+          activeServiceCount: 2,
+        },
+      }),
+    ).map((c) => c.id);
+    expect(checks).toEqual(["gear", "conflicts", "services", "crew", "pricing"]);
+  });
+
+  test("all-clear only when every applicable check actually ran and passed", () => {
     expect(summariseReadiness(buildReadinessChecks(input())).allClear).toBe(true);
   });
 
@@ -267,7 +272,7 @@ describe("ordering and summary", () => {
         input({
           gear: { hard: [{ modelName: "A", qty: 1 }], pencilled: [] },
           conflicts: [{ assetTag: "A", modelName: "M", conflictingProject: { projectNumber: "P-1" } }],
-          staleLineCount: 2,
+          pricing: { unpriced: [{ label: "Truss bracket" }], unpricedCount: 1 },
         }),
       ),
     );

--- a/src/lib/project-readiness-checks.ts
+++ b/src/lib/project-readiness-checks.ts
@@ -7,11 +7,14 @@
  * severity of a check decides whether the panel shouts or whispers, which is
  * exactly the kind of rule that rots silently if it only exists inside JSX.
  *
- * Three sources feed in, deliberately kept separate (R-3.1 — each rule has
+ * Two sources feed in, deliberately kept separate (R-3.1 — each rule has
  * exactly one home):
  *   - `projectReadiness.forProject`         → gear, crew, unpriced
  *   - `reservationConflicts.projectConflicts` → double-booked assets
- *   - `lineItemWrites.projectPricingStaleness` → stale auto-pricing
+ *
+ * Stale auto-pricing (`lineItemWrites.projectPricingStaleness`) is NOT one of
+ * these checks — it's already surfaced by `StalePricingBanner` on the Finance
+ * tab, and duplicating it here just repeated the same fact in two places.
  */
 
 /**
@@ -23,7 +26,7 @@
  */
 export type ReadinessSeverity = "blocking" | "warning" | "pass" | "unknown";
 
-export type ReadinessCheckId = "gear" | "conflicts" | "crew" | "services" | "pricing" | "staleness";
+export type ReadinessCheckId = "gear" | "conflicts" | "crew" | "services" | "pricing";
 
 export interface ReadinessCheck {
   id: ReadinessCheckId;
@@ -69,7 +72,6 @@ export interface BuildChecksInput {
   crew: ReadinessCrewInput;
   pricing: ReadinessPricingInput;
   conflicts: ReadinessConflictInput[];
-  staleLineCount: number;
 }
 
 const plural = (n: number, one: string, many = one + "s") => (n === 1 ? one : many);
@@ -142,18 +144,15 @@ function conflictsCheck(conflicts: ReadinessConflictInput[]): ReadinessCheck {
  * "Dave hasn't replied" and "the bump-in isn't locked in" are different
  * problems with different fixes, and cramming both into one row made it
  * unreadable at three dimensions.
+ *
+ * Returns `null` — the row doesn't render at all — when nobody's assigned
+ * yet: there's nothing to chase, so "No crew assigned yet" was noise a job
+ * with no crew requirement would carry forever.
  */
-function crewCheck(crew: ReadinessCrewInput): ReadinessCheck {
+function crewCheck(crew: ReadinessCrewInput): ReadinessCheck | null {
+  if (crew.activeCount === 0) return null;
   if (crew.unconfirmedCount === 0) {
-    // "Nobody assigned" is not the same as "everyone confirmed" — a project
-    // with no crew reads as a pass only because nothing is outstanding, and
-    // the wording should not imply a roster exists.
-    return {
-      id: "crew",
-      severity: "pass",
-      title: crew.activeCount === 0 ? "No crew assigned yet" : "All crew confirmed",
-      detail: crew.activeCount === 0 ? "Nothing outstanding — add services on Labour & logistics." : undefined,
-    };
+    return { id: "crew", severity: "pass", title: "All crew confirmed" };
   }
   return {
     id: "crew",
@@ -164,8 +163,15 @@ function crewCheck(crew: ReadinessCrewInput): ReadinessCheck {
   };
 }
 
-/** The WORK: services nobody has confirmed, and services short of people. */
-function servicesCheck(crew: ReadinessCrewInput): ReadinessCheck {
+/**
+ * The WORK: services nobody has confirmed, and services short of people.
+ *
+ * Returns `null` when the project has no services scheduled at all — same
+ * reasoning as `crewCheck`: a job that doesn't need services shouldn't carry
+ * a permanent "No services scheduled" row.
+ */
+function servicesCheck(crew: ReadinessCrewInput): ReadinessCheck | null {
+  if (crew.activeServiceCount === 0) return null;
   const unconfirmed = crew.unconfirmedServices;
   const understaffed = crew.servicesMissingCrew;
   const parts: string[] = [];
@@ -179,12 +185,7 @@ function servicesCheck(crew: ReadinessCrewInput): ReadinessCheck {
   }
 
   if (parts.length === 0) {
-    return {
-      id: "services",
-      severity: "pass",
-      title: crew.activeServiceCount === 0 ? "No services scheduled" : "All services confirmed and staffed",
-      detail: crew.activeServiceCount === 0 ? "Add services on Labour & logistics." : undefined,
-    };
+    return { id: "services", severity: "pass", title: "All services confirmed and staffed" };
   }
 
   const title =
@@ -207,24 +208,16 @@ function pricingCheck(pricing: ReadinessPricingInput): ReadinessCheck {
   };
 }
 
-function stalenessCheck(staleLineCount: number): ReadinessCheck {
-  if (staleLineCount === 0) {
-    return { id: "staleness", severity: "pass", title: "Pricing is current for these dates" };
-  }
-  return {
-    id: "staleness",
-    severity: "warning",
-    title: "Rates derived from old dates",
-    detail: `${staleLineCount} ${plural(staleLineCount, "line item")} ${plural(staleLineCount, "needs", "need")} recalculating for the current rental window`,
-    actionLabel: "Recalculate",
-  };
-}
-
 /**
  * Fixed order, worst-first within it: gear and conflicts can stop a job going
  * out, services and crew are the people side, pricing costs money but not the
  * load-out. The order is stable regardless of severity so the panel doesn't
  * reshuffle under the user as problems resolve — only the marks change.
+ *
+ * `services` and `crew` can each come back `null` (nothing scheduled /
+ * nobody assigned) — those rows are dropped rather than rendered as a
+ * permanent pass, so a job that doesn't need crew or services doesn't carry
+ * checks for facts that were never true.
  */
 export function buildReadinessChecks(input: BuildChecksInput): ReadinessCheck[] {
   return [
@@ -233,8 +226,7 @@ export function buildReadinessChecks(input: BuildChecksInput): ReadinessCheck[] 
     servicesCheck(input.crew),
     crewCheck(input.crew),
     pricingCheck(input.pricing),
-    stalenessCheck(input.staleLineCount),
-  ];
+  ].filter((c): c is ReadinessCheck => c !== null);
 }
 
 export interface ReadinessSummary {


### PR DESCRIPTION
## Summary

- **Crew and Services readiness rows now hide entirely when they don't apply.** A job with nobody assigned no longer shows a permanent "No crew assigned yet" pass row, and a job with no services scheduled no longer shows "No services scheduled." Both checks simply drop out of the list (and out of the "N checks pass" total) when `activeCount`/`activeServiceCount` is zero, and reappear at their normal fixed position once relevant.
- **Removed the "Pricing is current for these dates" (staleness) check** from the Overview Readiness panel. It duplicated `lineItemWrites.projectPricingStaleness`, which the Finance tab's `StalePricingBanner` already surfaces — two copies of the same fact in two places, not a distinct signal. The Finance tab remains the one place that warns about stale auto-pricing.
- Updated `FEATUREDOCS/69-project-overview.md` and `CHANGELOG.md` to match.

## Testing

- `pnpm exec vitest run src/lib/__tests__/project-readiness-checks.test.ts src/components/projects/__tests__/project-readiness-panel.smoke.test.tsx` — 30/30 passing (updated to cover N/A-hiding behavior)
- `pnpm exec eslint` on all touched files — clean
- `pnpm exec tsc --noEmit` — no new errors (pre-existing repo-wide errors are unrelated: missing generated Prisma client in this environment)

## Checklist

- [x] No new dependency added.


---
_Generated by [Claude Code](https://claude.ai/code/session_012L1YfEZMf8fQU8WfdrgTTh)_