### PR TITLE
I2: locale + currency through formatters.ts (#1081)

### DIFF
--- a/FEATUREDOCS/27-settings-admin.md
+++ b/FEATUREDOCS/27-settings-admin.md
@@ -44,9 +44,40 @@ plus NL/DE, which ship in the table but are excluded from
 `listEnabledCountries()` until decimal-comma input parsing (#1087, M7) lands.
 Adding a country is a data row there, not code. The US row's
 `defaultTaxRate` is genuinely `null` (no national rate) — never invent one
-(see #1088). Consumers: `formatters.ts` (I2, locale-aware formatting), the
-document composer (I4/I5, doc labels + paper size), and calendar/unit
-settings (I6) — none wired yet; this issue only lands the table.
+(see #1088). Each row also carries a `locale` (BCP-47, e.g. `"en-GB"`) — the
+country's OWN locale, driving `Intl`-backed formatting for free. Consumers:
+`formatters.ts` (I2, wired below), the document composer (I4/I5, doc labels
++ paper size) and calendar/unit settings (I6) — still unwired.
+
+### Locale-aware formatting (I2, #1081)
+
+`formatCurrency`/`formatDate` (`src/lib/formatters.ts`) take an **optional**
+`FormatConfig` (`{ locale, currency }`) — omit it and you get the exact
+pre-#1081 AU rendering, so every one of the 241 pre-existing call sites keeps
+working unchanged until it migrates. `formatConfigFromOrgSettings()` derives
+one from `OrgSettings.country` (via the I1 table above) with
+`OrgSettings.currency` as an explicit override of just the currency (the
+locale, i.e. date order, still comes from the country). Two consumers:
+
+- **Client** — `FormatProvider` (`src/components/providers/format-provider.tsx`)
+  is mounted in the app layout next to `BrandingProvider` (same `useOrganization`
+  store, no extra fetch) and exposes `useFormatters()` → locale-bound
+  `formatCurrency`/`formatDate`. A component must explicitly call the hook to
+  render in the org's own country/currency — mounting the provider alone
+  changes nothing for the plain imported functions.
+- **Server/PDF** — call `formatConfigFromOrgSettings(orgSettings)` directly
+  wherever `orgSettings` is already in hand (e.g. `build-document-data.ts`)
+  and pass the result as `formatCurrency`'s/`formatDate`'s second arg.
+
+**Not done in #1081**: migrating the 241 call sites (only
+`src/lib/billing-derivation.ts`'s inline `$${n.toFixed(2)}` — the one
+offender the issue named explicitly — was routed through `formatCurrency`),
+or threading a `FormatConfig` through the PDF pipeline (`gearflow-table.ts`,
+`document-composer.ts`, the 11 other pdfme files that call these two
+functions) — that pipeline still renders every org's documents in AU
+formatting regardless of the org's real country, and needs its own pass with
+the per-doc-type integration tests CLAUDE.md's PDF rule requires for a
+pagination-adjacent change.
 
 `OrgSettings.country` (the field above) is **immutable after creation
 (M6)** — `src/server/settings.ts`'s `updateOrganization` enforces it

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { TopBar } from "@/components/layout/top-bar";
 import { DynamicFavicon } from "@/components/layout/dynamic-favicon";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { BrandingProvider } from "@/components/providers/branding-provider";
+import { FormatProvider } from "@/components/providers/format-provider";
 import MiraContextProvider from "@/components/providers/mira-context-provider";
 import { MiraLauncher } from "@/components/mira/mira-launcher";
 import { getSession } from "@/lib/auth-server";
@@ -38,21 +39,23 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         style={{ "--sidebar-width": "248px", "--sidebar-width-icon": "92px", "--sidebar-width-mobile": "248px" } as React.CSSProperties}
       >
         <BrandingProvider>
-          <MiraContextProvider>
-            <MiraLauncher />
-            <OrgActivator />
-            <PostHogIdentify />
-            <DynamicFavicon />
-            <AppSidebar />
-            <SidebarInset className="min-h-0 min-w-0 overflow-x-clip">
-              <TopBar />
-              {/* Vertical scroll only. Horizontal is CLIPPED so wide content
-                  (tables, etc.) can never shift the whole page left under the
-                  fixed sidebar / sticky top bar. Wide tables scroll inside their
-                  own overflow container (see ui/table.tsx). */}
-              <main className="min-w-0 flex-1 overflow-y-auto overflow-x-clip p-4 md:p-6 animate-page-enter">{children}</main>
-            </SidebarInset>
-          </MiraContextProvider>
+          <FormatProvider>
+            <MiraContextProvider>
+              <MiraLauncher />
+              <OrgActivator />
+              <PostHogIdentify />
+              <DynamicFavicon />
+              <AppSidebar />
+              <SidebarInset className="min-h-0 min-w-0 overflow-x-clip">
+                <TopBar />
+                {/* Vertical scroll only. Horizontal is CLIPPED so wide content
+                    (tables, etc.) can never shift the whole page left under the
+                    fixed sidebar / sticky top bar. Wide tables scroll inside their
+                    own overflow container (see ui/table.tsx). */}
+                <main className="min-w-0 flex-1 overflow-y-auto overflow-x-clip p-4 md:p-6 animate-page-enter">{children}</main>
+              </SidebarInset>
+            </MiraContextProvider>
+          </FormatProvider>
         </BrandingProvider>
       </SidebarProvider>
       <MobileNav />

--- a/src/components/providers/__tests__/format-provider.test.tsx
+++ b/src/components/providers/__tests__/format-provider.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * I2 (#1081) — the client half of the locale-aware formatting lever.
+ * `FormatProvider` derives a `FormatConfig` from the active org's settings
+ * (already loaded by the always-mounted layout, same store `BrandingProvider`
+ * reads) and `useFormatters()` exposes locale-bound `formatCurrency`/
+ * `formatDate`. Outside the provider, `useFormatters()` must still work —
+ * it falls back to the AU default context value, never throws.
+ */
+
+const activeOrgData: { id: string } | undefined = { id: "org_1" };
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: activeOrgData }),
+}));
+
+let orgData: { settings: Record<string, unknown> } | undefined;
+vi.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({ data: orgData }),
+}));
+
+import { FormatProvider, useFormatters } from "../format-provider";
+
+function Probe() {
+  const { formatCurrency, formatDate, config } = useFormatters();
+  return (
+    <div>
+      <span data-testid="currency">{formatCurrency(1234.5)}</span>
+      <span data-testid="date">{formatDate("2024-07-15")}</span>
+      <span data-testid="locale">{config.locale}</span>
+    </div>
+  );
+}
+
+describe("FormatProvider / useFormatters", () => {
+  it("renders AU defaults for an org with no country configured", () => {
+    orgData = { settings: {} };
+    render(
+      <FormatProvider>
+        <Probe />
+      </FormatProvider>,
+    );
+    expect(screen.getByTestId("currency").textContent).toBe("$1,234.50");
+    expect(screen.getByTestId("locale").textContent).toBe("en-AU");
+  });
+
+  it("renders in the org's own country/currency once settings.country is set", () => {
+    orgData = { settings: { country: "US" } };
+    render(
+      <FormatProvider>
+        <Probe />
+      </FormatProvider>,
+    );
+    expect(screen.getByTestId("currency").textContent).toBe("$1,234.50");
+    expect(screen.getByTestId("locale").textContent).toBe("en-US");
+    // en-US month-first: "Jul 15, 2024" — "Jul" precedes "15".
+    const date = screen.getByTestId("date").textContent ?? "";
+    expect(date.indexOf("Jul")).toBeLessThan(date.indexOf("15"));
+  });
+
+  it("renders GBP with the £ symbol for a GB org", () => {
+    orgData = { settings: { country: "GB" } };
+    render(
+      <FormatProvider>
+        <Probe />
+      </FormatProvider>,
+    );
+    expect(screen.getByTestId("currency").textContent).toBe("£1,234.50");
+  });
+
+  it("useFormatters() outside any provider falls back to the AU default, never throws", () => {
+    render(<Probe />);
+    expect(screen.getByTestId("currency").textContent).toBe("$1,234.50");
+    expect(screen.getByTestId("locale").textContent).toBe("en-AU");
+  });
+});

--- a/src/components/providers/format-provider.tsx
+++ b/src/components/providers/format-provider.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { useOrganization } from "@/hooks/use-organization";
+import {
+  formatCurrency as baseFormatCurrency,
+  formatDate as baseFormatDate,
+  formatConfigFromOrgSettings,
+  DEFAULT_FORMAT_CONFIG,
+  type FormatConfig,
+} from "@/lib/formatters";
+import type { OrgSettings } from "@/lib/org-settings-types";
+
+/**
+ * I2 (#1081) — the client half of the locale-aware formatting lever. Org
+ * settings are already loaded in the app layout (`BrandingProvider` reads
+ * the same `useOrganization` store), so this just derives a `FormatConfig`
+ * from them and exposes it as context.
+ *
+ * `formatters.ts`'s bare `formatCurrency`/`formatDate` stay the un-themed
+ * fallback for every call site that hasn't migrated to `useFormatters()`
+ * yet — mounting this provider changes nothing for them. Only a component
+ * that explicitly calls `useFormatters()` renders in the org's own
+ * country/currency.
+ */
+const FormatContext = createContext<FormatConfig>(DEFAULT_FORMAT_CONFIG);
+
+export function FormatProvider({ children }: { children: ReactNode }) {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const { data: org } = useOrganization(orgId);
+
+  const settings = (org as Record<string, unknown> | undefined)?.settings as OrgSettings | undefined;
+  const config = useMemo(() => formatConfigFromOrgSettings(settings), [settings]);
+
+  return <FormatContext.Provider value={config}>{children}</FormatContext.Provider>;
+}
+
+export interface Formatters {
+  formatCurrency: (value: number | null | undefined) => string;
+  formatDate: (date: string | Date | null | undefined) => string;
+  /** The resolved config, for a call site that needs the raw locale/currency
+   *  (e.g. an `<input>` step hint) rather than a formatted string. */
+  config: FormatConfig;
+}
+
+/** Locale-aware `formatCurrency`/`formatDate` bound to the active org's
+ *  country/currency. Outside any `FormatProvider` (or before org settings
+ *  load) this returns the `DEFAULT_FORMAT_CONFIG`-bound (AU) formatters —
+ *  never throws, never blocks render on the org fetch. */
+export function useFormatters(): Formatters {
+  const config = useContext(FormatContext);
+  return useMemo(
+    () => ({
+      formatCurrency: (value: number | null | undefined) => baseFormatCurrency(value, config),
+      formatDate: (date: string | Date | null | undefined) => baseFormatDate(date, config),
+      config,
+    }),
+    [config],
+  );
+}

--- a/src/lib/billing-derivation.ts
+++ b/src/lib/billing-derivation.ts
@@ -26,6 +26,7 @@
  * identical output across the full derivation matrix.
  */
 import { z } from "zod";
+import { formatCurrency, DEFAULT_FORMAT_CONFIG, type FormatConfig } from "./formatters";
 
 const MS_PER_DAY = 86_400_000;
 
@@ -137,15 +138,19 @@ export function computeBlendedCharge(params: {
 }
 
 /** Human-readable breakdown for UI/PDF, e.g. "2 wk @ $150.00 + 3 d @ $30.00" or
- *  "charged as 1 wk (capped)". */
-export function formatPriceBreakdown(b: PriceBreakdown): string {
+ *  "charged as 1 wk (capped)". Routes through `formatCurrency` (I2, #1081)
+ *  rather than a hand-rolled `$${n.toFixed(2)}` — an inline formatter here
+ *  was exactly the kind of bypass #1081 called out to fix. `config` is
+ *  optional so every existing call site keeps the current AU rendering
+ *  until it's threaded a real one. */
+export function formatPriceBreakdown(b: PriceBreakdown, config: FormatConfig = DEFAULT_FORMAT_CONFIG): string {
   if (b.capped) return `charged as ${b.weeks} wk (capped)`;
   if (b.weeklyRate == null) {
-    return b.dailyRate != null ? `${b.days} d @ $${b.dailyRate.toFixed(2)}` : "";
+    return b.dailyRate != null ? `${b.days} d @ ${formatCurrency(b.dailyRate, config)}` : "";
   }
   const parts: string[] = [];
-  if (b.weeks > 0) parts.push(`${b.weeks} wk @ $${b.weeklyRate.toFixed(2)}`);
-  if (b.days > 0 && b.dailyRate != null) parts.push(`${b.days} d @ $${b.dailyRate.toFixed(2)}`);
+  if (b.weeks > 0) parts.push(`${b.weeks} wk @ ${formatCurrency(b.weeklyRate, config)}`);
+  if (b.days > 0 && b.dailyRate != null) parts.push(`${b.days} d @ ${formatCurrency(b.dailyRate, config)}`);
   return parts.length > 0 ? parts.join(" + ") : "0 d";
 }
 

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -36,6 +36,14 @@ export interface CountryDefinition {
   name: string;
   /** ISO 4217 currency code. */
   currency: string;
+  /** BCP-47 locale tag — the country's OWN locale, i.e. how an org based
+   *  there formats its own documents (not the viewer's browser locale).
+   *  Drives `Intl`-backed formatting in `formatters.ts` (I2): passing a
+   *  country's own locale + currency to `Intl.NumberFormat`/`toLocaleDateString`
+   *  reproduces dateOrder/decimalSeparator for free — they're kept as
+   *  explicit fields too because non-Intl consumers (PDF layout math) need
+   *  them without invoking `Intl`. */
+  locale: string;
   dateOrder: DateOrder;
   dateSeparator: DateSeparator;
   /** Keyed off locale, not currency — IE and NL both use EUR, only NL writes
@@ -63,6 +71,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "AU",
     name: "Australia",
     currency: "AUD",
+    locale: "en-AU",
     dateOrder: "DMY",
     dateSeparator: "/",
     decimalSeparator: ".",
@@ -78,6 +87,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "NZ",
     name: "New Zealand",
     currency: "NZD",
+    locale: "en-NZ",
     dateOrder: "DMY",
     dateSeparator: "/",
     decimalSeparator: ".",
@@ -93,6 +103,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "GB",
     name: "United Kingdom",
     currency: "GBP",
+    locale: "en-GB",
     dateOrder: "DMY",
     dateSeparator: "/",
     decimalSeparator: ".",
@@ -108,6 +119,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "US",
     name: "United States",
     currency: "USD",
+    locale: "en-US",
     dateOrder: "MDY",
     dateSeparator: "/",
     decimalSeparator: ".",
@@ -123,6 +135,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "IE",
     name: "Ireland",
     currency: "EUR",
+    locale: "en-IE",
     dateOrder: "DMY",
     dateSeparator: "/",
     decimalSeparator: ".",
@@ -138,6 +151,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "NL",
     name: "Netherlands",
     currency: "EUR",
+    locale: "nl-NL",
     dateOrder: "DMY",
     dateSeparator: "/",
     decimalSeparator: ",",
@@ -153,6 +167,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     code: "DE",
     name: "Germany",
     currency: "EUR",
+    locale: "de-DE",
     dateOrder: "DMY",
     dateSeparator: ".",
     decimalSeparator: ",",

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { formatCurrency, formatDate, formatLabel, roundCurrency } from "./formatters";
+import {
+  formatCurrency,
+  formatDate,
+  formatLabel,
+  roundCurrency,
+  formatConfigFromOrgSettings,
+  DEFAULT_FORMAT_CONFIG,
+} from "./formatters";
 
 describe("formatCurrency", () => {
   it("formats positive whole number", () => {
@@ -40,6 +47,36 @@ describe("formatCurrency", () => {
   });
 });
 
+describe("formatCurrency — locale-aware (I2, #1081)", () => {
+  it("defaults to the exact pre-#1081 AU behaviour when no config is passed", () => {
+    expect(formatCurrency(1500)).toBe(formatCurrency(1500, DEFAULT_FORMAT_CONFIG));
+  });
+
+  it("renders GBP with the £ symbol", () => {
+    expect(formatCurrency(1234.5, { locale: "en-GB", currency: "GBP" })).toBe("£1,234.50");
+  });
+
+  it("renders USD with the $ symbol", () => {
+    expect(formatCurrency(1234.5, { locale: "en-US", currency: "USD" })).toBe("$1,234.50");
+  });
+
+  it("renders EUR with the € symbol, grouped per the locale (Ireland vs Germany)", () => {
+    expect(formatCurrency(1234.5, { locale: "en-IE", currency: "EUR" })).toBe("€1,234.50");
+    // German locale: decimal comma, thousands dot — the exact "1.234,56" case
+    // that motivated keeping decimalSeparator locale-keyed, not currency-keyed.
+    expect(formatCurrency(1234.5, { locale: "de-DE", currency: "EUR" })).toBe("€1.234,50");
+  });
+
+  it("falls back to the ISO code for an unrecognised currency rather than guessing a symbol", () => {
+    expect(formatCurrency(10, { locale: "en-US", currency: "JPY" })).toBe("JPY 10.00");
+  });
+
+  it("still returns the em dash for null/undefined regardless of config", () => {
+    expect(formatCurrency(null, { locale: "en-US", currency: "USD" })).toBe("—");
+    expect(formatCurrency(undefined, { locale: "en-US", currency: "USD" })).toBe("—");
+  });
+});
+
 describe("formatDate", () => {
   it("formats Date object", () => {
     const d = new Date("2024-07-15T00:00:00Z");
@@ -67,6 +104,53 @@ describe("formatDate", () => {
 
   it("returns em dash for empty string", () => {
     expect(formatDate("")).toBe("\u2014");
+  });
+});
+
+describe("formatDate \u2014 locale-aware (I2, #1081)", () => {
+  it("defaults to the exact pre-#1081 AU behaviour when no config is passed", () => {
+    const d = new Date("2024-07-15T00:00:00Z");
+    expect(formatDate(d)).toBe(formatDate(d, DEFAULT_FORMAT_CONFIG));
+  });
+
+  it("US locale renders month-first \u2014 the whole point of threading locale through", () => {
+    const d = new Date("2024-07-15T00:00:00Z");
+    const result = formatDate(d, { locale: "en-US", currency: "USD" });
+    // en-US with {day, month: "short", year}: "Jul 15, 2024" \u2014 month before day.
+    expect(result.indexOf("Jul")).toBeLessThan(result.indexOf("15"));
+  });
+
+  it("still returns the em dash for null/undefined/empty regardless of config", () => {
+    const config = { locale: "en-US", currency: "USD" };
+    expect(formatDate(null, config)).toBe("\u2014");
+    expect(formatDate(undefined, config)).toBe("\u2014");
+    expect(formatDate("", config)).toBe("\u2014");
+  });
+});
+
+describe("formatConfigFromOrgSettings", () => {
+  it("falls back to DEFAULT_FORMAT_CONFIG for an org with no country set", () => {
+    expect(formatConfigFromOrgSettings({})).toEqual(DEFAULT_FORMAT_CONFIG);
+    expect(formatConfigFromOrgSettings(null)).toEqual(DEFAULT_FORMAT_CONFIG);
+    expect(formatConfigFromOrgSettings(undefined)).toEqual(DEFAULT_FORMAT_CONFIG);
+  });
+
+  it("derives locale + currency from the country table", () => {
+    expect(formatConfigFromOrgSettings({ country: "GB" })).toEqual({ locale: "en-GB", currency: "GBP" });
+    expect(formatConfigFromOrgSettings({ country: "US" })).toEqual({ locale: "en-US", currency: "USD" });
+  });
+
+  it("an explicit settings.currency overrides the country default currency, keeping its locale", () => {
+    // An IE org that's been manually set to bill in USD, say \u2014 locale stays
+    // Ireland's (date order etc.), only the currency symbol changes.
+    expect(formatConfigFromOrgSettings({ country: "IE", currency: "USD" })).toEqual({
+      locale: "en-IE",
+      currency: "USD",
+    });
+  });
+
+  it("falls back to DEFAULT_FORMAT_CONFIG for an unknown country code", () => {
+    expect(formatConfigFromOrgSettings({ country: "ZZ" })).toEqual(DEFAULT_FORMAT_CONFIG);
   });
 });
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,16 +1,77 @@
 /**
  * Shared formatting utilities. Use these instead of defining inline formatters.
+ *
+ * `formatCurrency`/`formatDate` take an OPTIONAL `FormatConfig` (I2, #1081) \u2014
+ * omit it and you get the exact pre-#1081 AU behaviour (the "un-themed
+ * fallback" every one of the 241 pre-existing call sites keeps getting for
+ * free, byte-for-byte, until it's migrated). Pass one \u2014 via `useFormatters()`
+ * client-side (`format-provider.tsx`) or `formatConfigFromOrgSettings()`
+ * server/PDF-side \u2014 to render in the org's own country/currency instead.
+ * Never add a second currency-formatting helper anywhere else (R-3.1) \u2014
+ * extend this module's config surface instead.
  */
+import { getCountry } from "./countries";
+import type { OrgSettings } from "./org-settings-types";
 
-export function formatCurrency(value: number | null | undefined): string {
-  if (value == null) return "\u2014";
-  return `$${Number(value).toLocaleString("en-AU", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+export interface FormatConfig {
+  /** BCP-47 locale tag \u2014 drives date order, decimal separator and number
+   *  grouping via `Intl`. */
+  locale: string;
+  /** ISO 4217 currency code \u2014 drives the printed symbol. */
+  currency: string;
 }
 
-export function formatDate(date: string | Date | null | undefined): string {
+/** The pre-#1081 hardcoded behaviour, kept as the explicit default so an
+ *  org with no country configured yet (or a caller that hasn't threaded a
+ *  config through) renders exactly as it always has. */
+export const DEFAULT_FORMAT_CONFIG: FormatConfig = { locale: "en-AU", currency: "AUD" };
+
+/** Currency symbols for the launch markets + the two M7-deferred EU rows
+ *  (`countries.ts`). An unrecognised code (a currency the country table
+ *  doesn't cover yet) falls back to the ISO code itself rather than
+ *  guessing a symbol. */
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  AUD: "$",
+  NZD: "$",
+  GBP: "\u00a3",
+  USD: "$",
+  EUR: "\u20ac",
+};
+
+function currencySymbol(currency: string): string {
+  return CURRENCY_SYMBOLS[currency] ?? `${currency} `;
+}
+
+/** Derive a `FormatConfig` from an org's settings \u2014 `settings.country` (via
+ *  the I1 country table) supplies the default locale/currency;
+ *  `settings.currency` (an existing, previously-unread field) overrides just
+ *  the currency when an operator has explicitly set one. No country on the
+ *  org yet (not onboarded through the wizard) \u2192 `DEFAULT_FORMAT_CONFIG`, the
+ *  same AU behaviour every screen already renders today. */
+export function formatConfigFromOrgSettings(settings: OrgSettings | null | undefined): FormatConfig {
+  const country = getCountry(settings?.country);
+  return {
+    locale: country?.locale ?? DEFAULT_FORMAT_CONFIG.locale,
+    currency: settings?.currency || country?.currency || DEFAULT_FORMAT_CONFIG.currency,
+  };
+}
+
+export function formatCurrency(
+  value: number | null | undefined,
+  config: FormatConfig = DEFAULT_FORMAT_CONFIG,
+): string {
+  if (value == null) return "\u2014";
+  const symbol = currencySymbol(config.currency);
+  return `${symbol}${Number(value).toLocaleString(config.locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function formatDate(
+  date: string | Date | null | undefined,
+  config: FormatConfig = DEFAULT_FORMAT_CONFIG,
+): string {
   if (!date) return "\u2014";
   const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleDateString("en-AU", {
+  return d.toLocaleDateString(config.locale, {
     day: "numeric",
     month: "short",
     year: "numeric",


### PR DESCRIPTION
## Summary

- `formatCurrency`/`formatDate` (`src/lib/formatters.ts`) now take an **optional** `FormatConfig` (`{ locale, currency }`). Omit it and every one of the 241 pre-existing call sites keeps rendering exactly as before, byte-for-byte (en-AU, `$`, day-month-year) — the "un-themed fallback" the issue calls for. Pass one and it renders in an org's own country/currency via `Intl` (locale drives date order, decimal separator and number grouping for free — the exact IE-vs-NL "decimal comma is a locale property, not a currency one" case from the design doc).
- `formatConfigFromOrgSettings()` derives a config from `OrgSettings.country` (the I1 country table, #1079, extended here with a `locale` BCP-47 field per row) with `OrgSettings.currency` as an explicit override of just the currency — that field existed on `OrgSettings` and was never read by the formatter before this (exactly the bug the issue opens with: an org set to GBP rendered `$1,234.56`, AU-grouped).
- **Client**: `FormatProvider` (`src/components/providers/format-provider.tsx`) mounted in the app layout next to `BrandingProvider` (same `useOrganization` store — no extra fetch), exposing `useFormatters()` → locale-bound `formatCurrency`/`formatDate`.
- **Server/PDF**: call `formatConfigFromOrgSettings(orgSettings)` directly wherever `orgSettings` is already in hand (per the issue: `build-document-data.ts:730` already reads `orgSettings.taxLabel`, same object).
- Routed `billing-derivation.ts`'s `formatPriceBreakdown` through `formatCurrency` instead of a hand-rolled `` `$${n.toFixed(2)}` `` — the one inline-formatter bypass the issue named explicitly ("watch for existing inline formatters that bypass this module").
- No second currency-formatting helper anywhere (R-3.1) — one function, one optional config param, extended in place.

**Deliberately not done here** (documented in `FEATUREDOCS/27-settings-admin.md`): migrating the 241 call sites themselves, or threading a `FormatConfig` through the PDF pipeline (`gearflow-table.ts`, `document-composer.ts`, and ~11 other pdfme files that call these two functions). That pipeline still renders every org's documents in AU formatting regardless of the org's real country. Per CLAUDE.md's PDF cross-cutting-audit rule, a pagination-adjacent change like that needs its own pass with per-doc-type integration tests (`document-composer.test.ts`'s standing harness) — bundling it into this PR would make review of the actual lever (the formatter module + provider infra) much harder to verify.

Part of #1065 (Phase I — internationalisation), part of the [multi-tenant + international tracking epic](https://github.com/TwoToned/gearflow/issues/1063). Depends on #1079 (I1, merged in #1133) — next in Phase I's stated order ("I1 first, then I2, then everything else in parallel").

## Testing

- `src/lib/formatters.test.ts` — new `FormatConfig` behaviour: default-config output is byte-identical to the old hardcoded implementation, GBP/USD/EUR symbol rendering, the IE-vs-DE decimal-comma case, an unrecognised-currency fallback to the ISO code, `formatConfigFromOrgSettings` deriving from `country`/`currency`/unset/unknown-code. All pre-existing `formatCurrency`/`formatDate`/`formatLabel`/`roundCurrency` tests pass unchanged.
- `src/components/providers/__tests__/format-provider.test.tsx` — `FormatProvider`/`useFormatters()` render AU defaults for an unconfigured org, switch to US (month-first dates) and GB (£) once `settings.country` is set, and `useFormatters()` outside any provider falls back to the AU default context value rather than throwing.
- `src/lib/billing-derivation.test.ts` — unchanged assertions pass (values under 1,000, so the switch from `toFixed` to `formatCurrency`'s locale-aware grouping is a no-op for these fixtures; the added thousands-separator for larger amounts is the intended fix, not tested here since no existing fixture exercises it).
- `pnpm exec vitest run` — 5231/5231 runnable tests pass (the 50 failing test *files* are the same pre-existing sandbox-only issue noted on the last two PRs: no `DATABASE_URL`/generated Prisma client in this environment).
- `pnpm exec knip` — dead-code count unchanged at the committed baseline (415).
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` on changed files — no new errors.

## Checklist

- [x] New dependency? N/A — no new dependency


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uo5dncqjQun7bhjaHVBLrM)_