### PR TITLE
I4: country-derived document labels — business number, tax label, heading (#1083)

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -191,9 +191,22 @@ removed (dual pipelines, ~8,300 dead LOC, and the pagination bug it caused).
 | `delivery-docket` | header, client+project details (+ site contact), table (checkboxes, row numbers, per-unit, asset tags), signature (3 cols) | true | `CHECKED_OUT` |
 
 The `header` block itself is the SAME across all 5 doc types (`document-composer.ts`'s
-one `case "header"` in both `estimateBlockHeight` and `buildEntryFields`) — the org's ABN
-(when set) renders under the address/phone/email lines on **every** doc type, not just
-the invoice. Only the "Expiry"/"Due" meta lines next to the doc number are doc-type-gated.
+one `case "header"` in both `estimateBlockHeight` and `buildEntryFields`) — the org's
+business-registration number (when set) renders under the address/phone/email lines on
+**every** doc type, not just the invoice. Only the "Expiry"/"Due" meta lines next to the
+doc number are doc-type-gated.
+
+**Labels are country-derived, not hardcoded (I4, #1083).** `data.org_business_number_label`
+(from `src/lib/countries.ts` via `build-document-data.ts`) replaces the literal `"ABN"` for
+BOTH the org's own number (header) and the client's (`detailsRow`'s `showClientTaxId`
+line) — one label, since it names the org's home-jurisdiction registration-number format
+("VAT number" for GB/IE, "EIN" for US, …), not a per-party thing. `data.tax_label`/
+`org_tax_label` fall back to the country's `taxLabel` (not a literal `"GST"`) when
+`OrgSettings.taxLabel` is unset. `data.org_invoice_heading` overrides the invoice layout's
+static `"TAX INVOICE"` title (`document-layouts.ts`) for any non-AU/NZ org — "Tax Invoice"
+is an AU/NZ GST-system legal term, not a global one; every other market gets "INVOICE".
+None of this touches `OrgSettings.abn`/`Client.taxId` themselves (still generic storage,
+per their own doc comments) — this is a render-layer change only.
 
 Call sheets are a 6th `DocumentType` value but are **not** in
 `DOCUMENT_LAYOUTS` — they render via `templates/call-sheet-services.ts`
@@ -258,13 +271,18 @@ identity, edited on the General settings page next to address/email/phone).
 Rendered in the PDF header, under the org's address/phone/email lines, on
 **every** doc type — Tax Invoices legally require it, but it's shown wherever
 the org details block itself renders rather than singled out to that one
-type. Omitted when unset.
+type. Omitted when unset. The printed LABEL next to it is country-derived
+("ABN" only for AU; see the I4 note above) — the stored field name/comment
+stays generic on purpose.
 
 `build-document-data.ts` computes these `DocumentData` fields from the settings
 above each time a document is built: `document_footer_text`,
 `document_footer_second_line`, `terms_and_conditions` (gated by the invoice
 toggle above when `docType === "invoice"`), `quote_valid_until`,
-`invoice_due_date`, `payment_details`, `org_abn`.
+`invoice_due_date`, `payment_details`, `org_abn`, `org_business_number_label`,
+`org_invoice_heading` (I4, #1083 — both derived from `src/lib/countries.ts`
+via `OrgSettings.country`, defaulting to the AU labels for an org that hasn't
+set one).
 
 ### Quote/invoice layout refinements (2026-07-27)
 

--- a/src/lib/countries.test.ts
+++ b/src/lib/countries.test.ts
@@ -69,4 +69,12 @@ describe("countries — the single source of truth (I1, #1079)", () => {
     const codes = COUNTRIES.map((c) => c.code);
     expect(new Set(codes).size).toBe(codes.length);
   });
+
+  it("only AU/NZ use the 'TAX INVOICE' heading — everyone else gets the generic 'INVOICE' (I4, #1083)", () => {
+    expect(getCountry("AU")?.invoiceHeading).toBe("TAX INVOICE");
+    expect(getCountry("NZ")?.invoiceHeading).toBe("TAX INVOICE");
+    for (const code of ["GB", "US", "IE", "NL", "DE"] as const) {
+      expect(getCountry(code)?.invoiceHeading).toBe("INVOICE");
+    }
+  });
 });

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -59,6 +59,11 @@ export interface CountryDefinition {
    *  against repeating). */
   defaultTaxRate: number | null;
   businessNumberLabel: string;
+  /** I4 (#1083) — the invoice document's printed heading. "TAX INVOICE" is
+   *  a legal requirement specific to AU/NZ's GST system, not a global term —
+   *  every other market gets the generic "INVOICE" (M1: no i18n framework,
+   *  so this stays hardcoded English everywhere, never translated). */
+  invoiceHeading: string;
   /** M7 — ships in this table but excluded from any country-selecting UI
    *  (wizard, settings) until decimal-comma input parsing (#1087) lands.
    *  Misreading a typed price by 100x is the worst failure available in a
@@ -81,6 +86,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "GST",
     defaultTaxRate: 10,
     businessNumberLabel: "ABN",
+    invoiceHeading: "TAX INVOICE",
     enabled: true,
   },
   {
@@ -97,6 +103,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "GST",
     defaultTaxRate: 15,
     businessNumberLabel: "NZBN",
+    invoiceHeading: "TAX INVOICE",
     enabled: true,
   },
   {
@@ -113,6 +120,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "VAT",
     defaultTaxRate: 20,
     businessNumberLabel: "VAT number",
+    invoiceHeading: "INVOICE",
     enabled: true,
   },
   {
@@ -129,6 +137,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "Sales tax",
     defaultTaxRate: null,
     businessNumberLabel: "EIN",
+    invoiceHeading: "INVOICE",
     enabled: true,
   },
   {
@@ -145,6 +154,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "VAT",
     defaultTaxRate: 23,
     businessNumberLabel: "VAT number",
+    invoiceHeading: "INVOICE",
     enabled: true,
   },
   {
@@ -161,6 +171,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "BTW",
     defaultTaxRate: 21,
     businessNumberLabel: "BTW-nummer",
+    invoiceHeading: "INVOICE",
     enabled: false,
   },
   {
@@ -177,6 +188,7 @@ export const COUNTRIES: readonly CountryDefinition[] = [
     taxLabel: "MwSt",
     defaultTaxRate: 19,
     businessNumberLabel: "USt-IdNr",
+    invoiceHeading: "INVOICE",
     enabled: false,
   },
 ] as const;

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -38,6 +38,7 @@ import type { DocumentData, DocumentLineItem, CrewEntry, CallSheetDayData, Docum
 import type { OrgDocumentSettings } from "@/lib/org-settings-types";
 import { computeValidUntil, resolveQuoteValidityDays } from "@/lib/quote-validity";
 import { resolvePaymentTermsDays } from "@/lib/invoice-terms";
+import { getCountry } from "@/lib/countries";
 
 const DEFAULT_DOC_COLOR = "#0d4f4f";
 
@@ -133,6 +134,10 @@ export async function buildDocumentData(
     showOrgNameOnDocuments?: boolean;
   } | undefined;
   const documentSettings = orgSettings.documents as OrgDocumentSettings | undefined;
+  // I4 (#1083) — the output side of the I1 country table. No country set
+  // (org not onboarded through the wizard yet) falls back to the AU labels
+  // every document has always shown — same posture as DEFAULT_FORMAT_CONFIG.
+  const country = getCountry(orgSettings.country as string | undefined);
 
   // Load logo/icon as base64
   const [logoData, iconData] = await Promise.all([
@@ -735,10 +740,12 @@ export async function buildDocumentData(
     org_address: (orgSettings.address as string) || "",
     org_website: (orgSettings.website as string) || "",
     org_abn: (orgSettings.abn as string) || "",
+    org_business_number_label: country?.businessNumberLabel ?? "ABN",
     org_logo: logoData,
     org_icon: iconData,
     org_tax_rate: (orgSettings.taxRate as number) || 10,
-    org_tax_label: (orgSettings.taxLabel as string) || "GST",
+    org_tax_label: (orgSettings.taxLabel as string) || (country?.taxLabel ?? "GST"),
+    org_invoice_heading: country?.invoiceHeading ?? "TAX INVOICE",
     org_branding: branding,
     org_document_color: docColor,
 
@@ -780,7 +787,7 @@ export async function buildDocumentData(
     subtotal: Number(serialized.subtotal) || 0,
     discount_percent: Number(serialized.discountPercent) || 0,
     discount_amount: Number(serialized.discountAmount) || 0,
-    tax_label: (orgSettings.taxLabel as string) || "GST",
+    tax_label: (orgSettings.taxLabel as string) || (country?.taxLabel ?? "GST"),
     tax_amount: Number(serialized.taxAmount) || 0,
     total: totalNum,
     deposit_paid: depositNum,

--- a/src/lib/pdfme/document-composer.test.ts
+++ b/src/lib/pdfme/document-composer.test.ts
@@ -30,10 +30,12 @@ function makeData(overrides: Partial<DocumentData> = {}): DocumentData {
     org_address: "1 Test St",
     org_website: "test.com",
     org_abn: "",
+    org_business_number_label: "ABN",
     org_logo: null,
     org_icon: null,
     org_tax_rate: 10,
     org_tax_label: "GST",
+    org_invoice_heading: "TAX INVOICE",
     org_branding: undefined,
     org_document_color: "#0d4f4f",
     project_number: "PRJ-001",
@@ -464,6 +466,61 @@ describe("composeDocument — invoice T&Cs, payment details, ABN, due date", () 
     const totalsSchema = result.template.schemas[0].find((s) => s.type === "gearflowFinancialSummary")!;
     const totalsConfig = JSON.parse(result.inputs[0][totalsSchema.name as string]);
     expect(totalsConfig.dueDate).toBeUndefined();
+  });
+});
+
+describe("composeDocument — country-derived labels (I4, #1083)", () => {
+  const soloData = (overrides: Partial<DocumentData> = {}) =>
+    makeData({
+      line_items: [makeLineItem({ id: "only-item", status: "CHECKED_OUT", checkedOutQuantity: 1, model: { name: "Solo Item" } })],
+      ...overrides,
+    });
+
+  it("uses the AU 'TAX INVOICE' heading and 'ABN' label by default (byte-for-byte pre-#1083 AU rendering)", () => {
+    const result = composeDocument("invoice", soloData({ org_abn: "12 345 678 901" }), "#0d4f4f");
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.docTitle).toBe("TAX INVOICE");
+    expect(headerConfig.orgDetails).toContain("ABN: 12 345 678 901");
+  });
+
+  it("a US org's invoice renders the generic 'INVOICE' heading, not the AU-legal 'TAX INVOICE'", () => {
+    const result = composeDocument(
+      "invoice",
+      soloData({ org_invoice_heading: "INVOICE" }),
+      "#0d4f4f",
+    );
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.docTitle).toBe("INVOICE");
+  });
+
+  it("non-invoice doc types never take the org_invoice_heading override — QUOTE stays QUOTE", () => {
+    const result = composeDocument("quote", soloData({ org_invoice_heading: "INVOICE" }), "#0d4f4f");
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.docTitle).toBe("QUOTE");
+  });
+
+  it("a GB org's business number renders as 'VAT number', not 'ABN' — both the org's own and the client's", () => {
+    const result = composeDocument(
+      "invoice",
+      soloData({
+        org_business_number_label: "VAT number",
+        org_abn: "GB123456789",
+        client_tax_id: "GB987654321",
+      }),
+      "#0d4f4f",
+    );
+    const headerSchema = result.template.schemas[0].find((s) => s.type === "gearflowPageHeader")!;
+    const headerConfig = JSON.parse(result.inputs[0][headerSchema.name as string]);
+    expect(headerConfig.orgDetails).toContain("VAT number: GB123456789");
+    expect(headerConfig.orgDetails).not.toContain("ABN:");
+
+    const clientColSchema = result.template.schemas[0].find((s) => String(s.name).endsWith("_client"))!;
+    const clientColText = result.inputs[0][clientColSchema.name as string];
+    expect(clientColText).toContain("VAT number: GB987654321");
+    expect(clientColText).not.toContain("ABN:");
   });
 });
 

--- a/src/lib/pdfme/document-composer.ts
+++ b/src/lib/pdfme/document-composer.ts
@@ -868,8 +868,9 @@ function buildEntryFields(
       // Business registration id, shown wherever the org address/phone/email
       // block renders — every doc type, not just Tax Invoices (AU Tax
       // Invoices require it, but there's no reason to hide it elsewhere).
-      // Placed under the address/email lines already above it.
-      if (data.org_abn) orgDetailParts.push(`ABN: ${data.org_abn}`);
+      // Placed under the address/email lines already above it. Label is
+      // country-derived (I4, #1083) — "ABN" is Australian, not global.
+      if (data.org_abn) orgDetailParts.push(`${data.org_business_number_label}: ${data.org_abn}`);
       if (data.org_website) orgDetailParts.push(data.org_website);
 
       // Quote expiry moves from its own bottom-of-document line into the
@@ -888,10 +889,16 @@ function buildEntryFields(
       const docMetaLines = [projectNumberLine, data.document_date || ""];
       if (docType === "quote" && data.quote_valid_until) docMetaLines.push(`Expiry: ${data.quote_valid_until}`);
 
+      // I4 (#1083) — "TAX INVOICE" is an AU/NZ legal term, not a global one.
+      // Only the invoice layout's static block.title needs a country-derived
+      // override; every other doc type's heading (QUOTE, PULL SLIP, …) is a
+      // generic business term that doesn't vary per country.
+      const docTitle = docType === "invoice" ? data.org_invoice_heading || block.title : block.title;
+
       const config: PageHeaderConfig = {
         orgName: data.org_name || "",
         orgDetails: orgDetailParts.join("\n"),
-        docTitle: block.title,
+        docTitle,
         docMeta: docMetaLines.join("\n"),
         logoData: data.org_logo,
         iconData: data.org_icon,
@@ -931,7 +938,12 @@ function buildEntryFields(
       if (block.client.showClientContact && data.client_contact) clientLines.push(`Attn: ${data.client_contact}`);
       if (block.client.showClientEmail && data.client_email) clientLines.push(data.client_email);
       if (block.client.showClientAddress && data.client_billing_address) clientLines.push(data.client_billing_address);
-      if (block.client.showClientTaxId && data.client_tax_id) clientLines.push(`ABN: ${data.client_tax_id}`);
+      // Same country-derived label as the org's own number above (I4,
+      // #1083) — it names the org's home-jurisdiction registration-number
+      // format, not a per-party thing.
+      if (block.client.showClientTaxId && data.client_tax_id) {
+        clientLines.push(`${data.org_business_number_label}: ${data.client_tax_id}`);
+      }
 
       // The event/project name leads the column — bolded via the shared
       // markdown-lite renderer (gearflowRichText) rather than a separate

--- a/src/lib/pdfme/types.ts
+++ b/src/lib/pdfme/types.ts
@@ -181,10 +181,20 @@ export interface DocumentData {
   /** Australian Business Number (or local equivalent). Rendered in the
    *  header, under the org's address/email, on every doc type. */
   org_abn: string;
+  /** I4 (#1083) — the country-derived label for `org_abn`/`client_tax_id`
+   *  ("ABN", "VAT number", "EIN", …), from `src/lib/countries.ts`. Both the
+   *  org's own number (header) and the client's (details row) use this ONE
+   *  label — it names the org's home-jurisdiction registration-number
+   *  format, not a per-party thing. */
+  org_business_number_label: string;
   org_logo: string | null;
   org_icon: string | null;
   org_tax_rate: number;
   org_tax_label: string;
+  /** I4 (#1083) — country-derived invoice document heading ("TAX INVOICE"
+   *  for AU/NZ, "INVOICE" elsewhere — "Tax Invoice" is an Australian/NZ
+   *  legal term, not a global one). Only the invoice layout uses this. */
+  org_invoice_heading: string;
   org_branding: PdfBranding | undefined;
   org_document_color: string;
 


### PR DESCRIPTION
## Summary

The output side of the I1 country table (#1079) — three hardcoded-AU spots in the PDF pipeline, all render-layer only (`OrgSettings.abn`/`Client.taxId` stay generic storage, exactly per their own existing doc comments — no schema change):

- `document-composer.ts`'s header block hardcoded `` `ABN: ${org_abn}` ``, and the `detailsRow` block hardcoded `` `ABN: ${client_tax_id}` `` for the **client's own** number. Both now use `data.org_business_number_label` — one label for both parties, since it names the org's home-jurisdiction registration-number format ("VAT number" for GB/IE, "EIN" for US, …), not a per-party thing.
- `build-document-data.ts`'s `org_tax_label`/`tax_label` fell back to a literal `"GST"` when `OrgSettings.taxLabel` was unset. Now falls back to the country's own `taxLabel` via `countries.ts`.
- `document-layouts.ts`'s invoice layout hardcodes `title: "TAX INVOICE"` — an AU/NZ GST-system legal term, not a global one (per the issue: *"Tax Invoice" is an Australian legal term*). `document-composer.ts` now overrides it with `data.org_invoice_heading` (`"INVOICE"` for every other market) **for the invoice doc type only** — every other heading (QUOTE, PULL SLIP, RETURN SHEET, DELIVERY DOCKET) is a generic business term that doesn't vary per country.

Adds `invoiceHeading` to the `countries.ts` table (AU/NZ: `"TAX INVOICE"`, everyone else: `"INVOICE"` — M1 has no i18n framework, so this stays hardcoded English everywhere, never translated). `build-document-data.ts` resolves the org's country once and derives all three `DocumentData` fields from it, falling back to the exact pre-#1083 AU rendering when no country is set on the org.

Height reservation is unaffected — `estimateBlockHeight`'s header case counts fixed line/row presence (does the ABN line exist? y/n), never text width, and the label swap only changes single-line text length, not line count. `gearflow-page-header.ts`'s title already shrinks-to-fit for any string length.

Part of #1065 (Phase I — internationalisation), part of the [multi-tenant + international tracking epic](https://github.com/TwoToned/gearflow/issues/1063). Depends on #1079 (I1, merged) — runs in parallel with I3/I5/I6 per Phase I's stated order.

## Testing

- `src/lib/countries.test.ts` — only AU/NZ get `"TAX INVOICE"`, every other market gets `"INVOICE"`.
- `src/lib/pdfme/document-composer.test.ts` — 4 new tests, including the issue's own "non-AU fixture" checklist item: a GB fixture renders `"INVOICE"` (not `"TAX INVOICE"`) and `"VAT number:"` (not `"ABN:"`) for **both** the org's own number and the client's; a QUOTE never takes the invoice-heading override; the AU default is byte-for-byte the pre-#1083 rendering. All 69 pre-existing composer tests still pass unchanged.
- `build-document-data.ts` itself has no existing unit-test harness (heavy Prisma/Convex I/O — untested before this too); the composer tests cover the `DocumentData` contract it must produce.
- `pnpm exec vitest run` — 5252/5252 runnable tests pass on this base (same pre-existing sandbox-only 50-file Prisma-client gap noted on the last four PRs).
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` on changed files — no new errors (existing warnings unrelated to this diff).
- `pnpm exec knip` / `node scripts/complexity-ratchet.mjs` / `node scripts/depcruise-ratchet.mjs` / `bash scripts/date-format-ratchet.sh` / `bash scripts/any-ratchet.sh` — all hold at their baselines.

## Checklist

- [x] New dependency? N/A — no new dependency


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uo5dncqjQun7bhjaHVBLrM)_