### PR TITLE
I6: week start, address bias; collapse the duplicate startOfWeek (#1086)

### DIFF
--- a/FEATUREDOCS/27-settings-admin.md
+++ b/FEATUREDOCS/27-settings-admin.md
@@ -128,6 +128,37 @@ address lookups across ~19 countries and is a different concern from the
 7-row operational table above; Phase C's wizard country step is what wires
 the two together.
 
+### Week start + address bias (I6, #1086)
+
+`useOrgWeekStartsOn()` (`src/lib/use-org-country.ts`, sibling to
+`useOrgCountry()`) returns `date-fns`'s `weekStartsOn` value (`0` Sunday /
+`1` Monday) from the country table, defaulting to Monday (`1`) when no
+country is set — the same value every hardcoded `weekStartsOn: 1` it
+replaces already assumed. Wired into:
+
+- `crew/planner/page.tsx` — its hand-rolled `startOfWeek()` (a DRY violation,
+  ignoring `date-fns` entirely) is gone; it now calls `date-fns`'s
+  `startOfWeek(date, { weekStartsOn })`.
+- `availability/page.tsx` — `gridStart`/`gridEnd` use the hook instead of a
+  hardcoded `{ weekStartsOn: 1 }`. Also fixes a companion bug the week-start
+  change would otherwise have introduced: the month grid's `WEEKDAYS` header
+  labels were a hardcoded Monday-first array — for a Sunday-starting org the
+  header and the day cells would have visibly misaligned. Both now derive
+  from the same `weekStartsOn` via `weekdayLabels()`.
+
+Address-bias (`AddressInput`'s `countryCode` prop via `useOrgCountry()`) was
+already wired everywhere except `services-panel.tsx`'s delivery/pickup
+address field — the one gap, now closed. See FEATUREDOCS/30 for the full
+Places-autocomplete picture.
+
+**Not done in #1086** — units (weights/dimensions/rigging loads, kg-only
+today): the issue itself flags this as an open scope question ("decide the
+boundary before implementing rather than during" — dimensions and rigging
+loads are a larger surface than weights alone, and mixed units in a
+warehouse are their own hazard) rather than a spec to implement blind.
+Deferred pending that decision. Number grouping needed no work — it came
+free once the locale was threaded (I2, #1081).
+
 ## Platform Branding (`SiteSettings`)
 - `platformName` — Displayed in sidebar, page titles, emails
 - `platformIcon` — Lucide icon name, rendered via `DynamicIcon`

--- a/FEATUREDOCS/30-maps-integration.md
+++ b/FEATUREDOCS/30-maps-integration.md
@@ -40,8 +40,12 @@ Universal address autocomplete (Google Places API) and interactive maps (Google 
 ## Country Bias
 - `OrgSettings.country` (ISO 3166-1 alpha-2, e.g. "AU") set in Settings -> General
 - `useOrgCountry()` hook (`src/lib/use-org-country.ts`) reads from cached org query
-- Passed as `countryCode` to `AddressInput` in all forms
+- Passed as `countryCode` to every `<AddressInput>` call site — client/supplier/location/crew
+  forms, plus `services-panel.tsx`'s delivery/pickup address field (I6, #1086 — the one call
+  site that had been missing it)
 - Google Places `includedRegionCodes` restricts results to that country
+- This is the `useOrgCountry()`-driven half of I6; `useOrgWeekStartsOn()` (same file) is the
+  sibling hook for the week-start half — see FEATUREDOCS/27's I6 section
 
 ## Database Fields
 All coordinate fields are `Float?` (nullable). No coordinates = freeform text, no map.

--- a/src/app/(app)/availability/page.tsx
+++ b/src/app/(app)/availability/page.tsx
@@ -45,8 +45,18 @@ import { projectStatusLabels } from "@/lib/status-labels";
 
 import { RequirePermission } from "@/components/auth/require-permission";
 import { useActiveOrganization } from "@/lib/auth-client";
+import { useOrgWeekStartsOn } from "@/lib/use-org-country";
 
-const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const WEEKDAYS_FROM_MONDAY = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+/** I6 (#1086) — the grid header labels have to agree with `gridStart`'s own
+ *  `weekStartsOn`, or a Sunday-starting org's day cells and header labels
+ *  visibly misalign. */
+function weekdayLabels(weekStartsOn: 0 | 1): string[] {
+  return weekStartsOn === 0
+    ? [WEEKDAYS_FROM_MONDAY[6], ...WEEKDAYS_FROM_MONDAY.slice(0, 6)]
+    : WEEKDAYS_FROM_MONDAY;
+}
 
 /** Normalise a project's rental window to whole-day local bounds. */
 function projectBounds(p: CalendarProject): { start: Date; end: Date } | null {
@@ -179,6 +189,7 @@ function AvailabilityPage() {
   const { isAuthenticated } = useConvexAuth();
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const weekStartsOn = useOrgWeekStartsOn();
   const today = useMemo(() => new Date(), []);
   const [view, setView] = useState<ViewMode>("month");
 
@@ -208,8 +219,8 @@ function AvailabilityPage() {
   }, [initialDateTime]);
 
   // Query range: full calendar grid (might include days from prev/next months)
-  const gridStart = startOfWeek(startOfMonth(currentMonth), { weekStartsOn: 1 });
-  const gridEnd = endOfWeek(endOfMonth(currentMonth), { weekStartsOn: 1 });
+  const gridStart = startOfWeek(startOfMonth(currentMonth), { weekStartsOn });
+  const gridEnd = endOfWeek(endOfMonth(currentMonth), { weekStartsOn });
 
   const { data: projects = [], isLoading } = useServerQuery({
     queryKey: ["calendar", orgId, format(currentMonth, "yyyy-MM")],
@@ -342,7 +353,7 @@ function AvailabilityPage() {
               </div>
 
               {isLoading ? (
-                <CalendarSkeleton />
+                <CalendarSkeleton weekStartsOn={weekStartsOn} />
               ) : view === "month" ? (
                 <MonthGrid
                   weeks={weeks}
@@ -353,6 +364,7 @@ function AvailabilityPage() {
                   selectedDay={selectedDay}
                   onSelectDay={setSelectedDay}
                   onSelectProject={(p) => setSelectedDay(projectBounds(p)?.start ?? today)}
+                  weekStartsOn={weekStartsOn}
                 />
               ) : (
                 <AgendaView
@@ -483,6 +495,7 @@ function MonthGrid({
   selectedDay,
   onSelectDay,
   onSelectProject,
+  weekStartsOn,
 }: {
   weeks: Date[][];
   weekBars: WeekBar[][];
@@ -492,12 +505,13 @@ function MonthGrid({
   selectedDay: Date | null;
   onSelectDay: (d: Date) => void;
   onSelectProject: (p: CalendarProject) => void;
+  weekStartsOn: 0 | 1;
 }) {
   return (
     <div className="overflow-hidden rounded-[var(--r-lg)] border border-line-2 bg-card shadow-[var(--sh-card)]">
       {/* Weekday header */}
       <div className="grid grid-cols-7 border-b border-line">
-        {WEEKDAYS.map((d) => (
+        {weekdayLabels(weekStartsOn).map((d) => (
           <div key={d} className="py-2 text-center t-micro text-muted">
             {d}
           </div>
@@ -825,11 +839,11 @@ function DayProjectCard({
 
 /* ── Loading skeleton ─────────────────────────────────────────────── */
 
-function CalendarSkeleton() {
+function CalendarSkeleton({ weekStartsOn }: { weekStartsOn: 0 | 1 }) {
   return (
     <div className="overflow-hidden rounded-[var(--r-lg)] border border-line-2 bg-card shadow-[var(--sh-card)]">
       <div className="grid grid-cols-7 border-b border-line">
-        {WEEKDAYS.map((d) => (
+        {weekdayLabels(weekStartsOn).map((d) => (
           <div key={d} className="py-2 text-center t-micro text-muted">
             {d}
           </div>

--- a/src/app/(app)/crew/planner/page.tsx
+++ b/src/app/(app)/crew/planner/page.tsx
@@ -15,9 +15,11 @@ import {
   CircleSlash,
 } from "lucide-react";
 
+import { startOfWeek } from "date-fns";
 import { useConvex, useConvexAuth } from "convex/react";
 import { api } from "../../../../../convex/_generated/api";
 import { useActiveOrganization } from "@/lib/auth-client";
+import { useOrgWeekStartsOn } from "@/lib/use-org-country";
 import { useOrgCrewAssignments, fingerprintCrewAssignments, useOrgAvailabilities, fingerprintAvailabilities } from "@/hooks/use-crew-scheduling";
 import { getStatusColor } from "@/lib/status-colors";
 import { RequirePermission } from "@/components/auth/require-permission";
@@ -47,16 +49,6 @@ import {
 } from "@/components/ui/tooltip";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function startOfWeek(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
-  // Monday start
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
 
 function addDays(date: Date, days: number): Date {
   const d = new Date(date);
@@ -105,8 +97,9 @@ export default function CrewPlannerPage() {
   const orgId = activeOrg?.id;
   const pConvex = useConvex();
   const { isAuthenticated: pAuthed } = useConvexAuth();
+  const weekStartsOn = useOrgWeekStartsOn();
 
-  const [weekStart, setWeekStart] = useState(() => startOfWeek(new Date()));
+  const [weekStart, setWeekStart] = useState(() => startOfWeek(new Date(), { weekStartsOn }));
 
   // ── Filter state ──────────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
@@ -149,7 +142,7 @@ export default function CrewPlannerPage() {
 
   const goBack = () => setWeekStart((d) => addDays(d, -7));
   const goForward = () => setWeekStart((d) => addDays(d, 7));
-  const goToday = () => setWeekStart(startOfWeek(new Date()));
+  const goToday = () => setWeekStart(startOfWeek(new Date(), { weekStartsOn }));
 
   // Stable "today" so the summary useMemo doesn't recompute every render.
   const today = useMemo(() => new Date(), []);

--- a/src/components/projects/services-panel.tsx
+++ b/src/components/projects/services-panel.tsx
@@ -60,6 +60,7 @@ import { resolveRate, calculateEstimatedCost, resolveChargeRate } from "../../..
 import { useIsManagerPlus } from "@/lib/use-permissions";
 import { CrewPanel } from "./crew-panel";
 import { useActiveOrganization } from "@/lib/auth-client";
+import { useOrgCountry } from "@/lib/use-org-country";
 import { formatCurrency } from "@/lib/formatters";
 import { cn, focusRing } from "@/lib/utils";
 import { CanDo } from "@/components/auth/permission-gate";
@@ -1483,6 +1484,7 @@ function ServiceDialog({
 }) {
   const { data: activeOrg } = useActiveOrganization();
   const orgId = activeOrg?.id;
+  const orgCountry = useOrgCountry();
   const isEditing = !!editingService;
   const isManagerPlus = useIsManagerPlus();
   const svcWrites = useProjectServiceWrites();
@@ -1948,6 +1950,7 @@ function ServiceDialog({
                       }
                     : undefined
                 }
+                countryCode={orgCountry}
               />
             </div>
           )}

--- a/src/lib/use-org-country.test.tsx
+++ b/src/lib/use-org-country.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const h = vi.hoisted(() => ({
+  activeOrgData: { id: "org_1" } as { id: string } | undefined,
+  orgData: undefined as { settings: Record<string, unknown> } | undefined,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useActiveOrganization: () => ({ data: h.activeOrgData }),
+}));
+
+vi.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({ data: h.orgData }),
+}));
+
+import { useOrgCountry, useOrgWeekStartsOn } from "./use-org-country";
+
+describe("useOrgCountry", () => {
+  it("returns the org's configured country code", () => {
+    h.orgData = { settings: { country: "GB" } };
+    const { result } = renderHook(() => useOrgCountry());
+    expect(result.current).toBe("GB");
+  });
+
+  it("returns undefined when no country is set", () => {
+    h.orgData = { settings: {} };
+    const { result } = renderHook(() => useOrgCountry());
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe("useOrgWeekStartsOn (I6, #1086)", () => {
+  it("defaults to Monday (1) when no country is set", () => {
+    h.orgData = { settings: {} };
+    const { result } = renderHook(() => useOrgWeekStartsOn());
+    expect(result.current).toBe(1);
+  });
+
+  it("US is the only launch market that starts Sunday (0)", () => {
+    h.orgData = { settings: { country: "US" } };
+    const { result } = renderHook(() => useOrgWeekStartsOn());
+    expect(result.current).toBe(0);
+  });
+
+  it("every other launch market starts Monday (1)", () => {
+    for (const country of ["AU", "NZ", "GB", "IE"]) {
+      h.orgData = { settings: { country } };
+      const { result } = renderHook(() => useOrgWeekStartsOn());
+      expect(result.current).toBe(1);
+    }
+  });
+
+  it("an unknown country code falls back to Monday, never guesses Sunday", () => {
+    h.orgData = { settings: { country: "ZZ" } };
+    const { result } = renderHook(() => useOrgWeekStartsOn());
+    expect(result.current).toBe(1);
+  });
+});

--- a/src/lib/use-org-country.ts
+++ b/src/lib/use-org-country.ts
@@ -3,6 +3,7 @@
 import { useActiveOrganization } from "@/lib/auth-client";
 import { useOrganization } from "@/hooks/use-organization";
 import { type OrgSettings } from "@/lib/org-settings-types";
+import { getCountry } from "@/lib/countries";
 
 /** Returns the org's configured country code (e.g. "AU"), or undefined. */
 export function useOrgCountry(): string | undefined {
@@ -13,4 +14,13 @@ export function useOrgCountry(): string | undefined {
 
   const settings = (org as Record<string, unknown>)?.settings as OrgSettings | undefined;
   return settings?.country || undefined;
+}
+
+/** I6 (#1086) — the `date-fns` `weekStartsOn` value (0 = Sunday, 1 = Monday)
+ *  for the active org's country. Defaults to Monday (1) — the same value
+ *  every hardcoded `weekStartsOn: 1` this replaces already assumed — when no
+ *  country is set. Only the US (of the launch markets) starts Sunday. */
+export function useOrgWeekStartsOn(): 0 | 1 {
+  const countryCode = useOrgCountry();
+  return getCountry(countryCode)?.weekStart === "SUN" ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Week start was hardcoded Monday **twice**, per the issue:

- `crew/planner/page.tsx` hand-rolled its own `startOfWeek()`, ignoring `date-fns` entirely — a DRY violation and a second place to get it wrong.
- `availability/page.tsx` hardcoded `date-fns`'s `startOfWeek(date, { weekStartsOn: 1 })`.

Both now use `useOrgWeekStartsOn()` — a new hook (`src/lib/use-org-country.ts`, sibling to the existing `useOrgCountry()`) returning `date-fns`'s `weekStartsOn` value (0/1) from the I1 country table, defaulting to Monday when no country is set (the same value every hardcoded `weekStartsOn: 1` already assumed). `crew/planner/page.tsx`'s hand-rolled function is gone entirely, per the issue's own instruction to "collapse it into `date-fns` first."

**Fixes a companion bug the week-start change would otherwise have introduced**: `availability/page.tsx`'s month-grid header used a hardcoded Monday-first `WEEKDAYS` array. Once the grid itself could start on Sunday, the header labels and day cells would have visibly misaligned for a Sunday-starting org. Both now derive from the same `weekStartsOn` via a new `weekdayLabels()` helper (also threaded through the loading skeleton, for consistency).

**Address bias**: `AddressInput`'s `countryCode` prop (via `useOrgCountry()`, restricting Google Places suggestions to the org's country) turned out to already be wired everywhere the design doc's audit predates — client/supplier/location/crew forms — **except** `services-panel.tsx`'s delivery/pickup address field, which was missing it. That's now fixed; `FEATUREDOCS/30-maps-integration.md`'s "all forms" claim is accurate again.

**Deliberately not touched**: units (weights/dimensions/rigging loads — kg-only today). The issue itself flags this as an open scope question ("decide the boundary before implementing rather than during" — dimensions and rigging loads are a larger surface than weights alone, and mixed units in a warehouse are their own hazard), not a spec to implement blind. Number grouping needed no work — it came free once the locale was threaded (I2, #1081).

Part of #1065 (Phase I — internationalisation), part of the [multi-tenant + international tracking epic](https://github.com/TwoToned/gearflow/issues/1063). Depends on #1079 (I1, merged) — runs in parallel with I3/I4/I5 per Phase I's stated order.

## Testing

- `src/lib/use-org-country.test.tsx` (new) — `useOrgCountry()` reads the org's country; `useOrgWeekStartsOn()` defaults to Monday when unset, US is the only launch market returning Sunday, every other launch market returns Monday, and an unknown country code falls back to Monday rather than guessing Sunday.
- `pnpm exec vitest run` — 5293/5293 runnable tests pass on this base (same pre-existing sandbox-only 50-file Prisma-client gap noted on the last five PRs).
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` on changed files — no new errors (existing warnings unrelated to this diff, verified against `git diff`).
- `pnpm exec knip` / `node scripts/complexity-ratchet.mjs` / `node scripts/depcruise-ratchet.mjs` / `bash scripts/date-format-ratchet.sh` / `bash scripts/any-ratchet.sh` — all hold at their baselines.

## Checklist

- [x] New dependency? N/A — no new dependency


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uo5dncqjQun7bhjaHVBLrM)_