### PR TITLE
Turn the header version switcher into a full version menu

### DIFF
--- a/FEATUREDOCS/70-project-version-switcher.md
+++ b/FEATUREDOCS/70-project-version-switcher.md
@@ -1,6 +1,6 @@
-# Project Version Switcher (Phase 3 projection + Phase 4 promote/list)
+# Project Version Switcher (Phase 3 projection + Phase 4 promote/list + Phase 5 header actions)
 
-> _Owner: Jayden Nawotka · Last reviewed: 2026-08-01 (review quarterly — POLICY.md R-5.5)_
+> _Owner: Jayden Nawotka · Last reviewed: 2026-08-03 (review quarterly — POLICY.md R-5.5)_
 
 Phase 3 of #1080 (issue #1093) — the read path that lets a project's Equipment,
 Labour & logistics and Finance tabs render a **past version's** captured state
@@ -9,6 +9,8 @@ Phase 4 (issue #1097) landed on top of it: "Make vN live" is now a real,
 user-facing action — the promote dialog wired into both the read-only bar and
 the Finance tab's version rail — and the version rail itself (`ProjectQuoteRail`)
 is now the project's ONE version list, with the old `⋯ Versions` panel retired.
+Phase 5 ("fine-tune versioning") turned the header switcher itself into a full
+version menu — see §"Phase 5" below.
 
 **Depends on:** Phase 1 (#1085, merged) — `projects.liveRevision`, `saveVersionNative`,
 the `VERSION_SAVED`/`PRE_PROMOTE` snapshot reasons. Phase 2 (#1089, merged) —
@@ -203,6 +205,60 @@ its mount, and its menu entry are deleted (`src/app/(app)/projects/[id]/page.tsx
 appeared in this panel's list to begin with (it queries `quotes`, not
 `projectSnapshots`).
 
+## Phase 5 — the header switcher becomes the version menu ("fine-tune versioning")
+
+The complaint this phase fixes: **you couldn't make v2 without sending v1's
+quote.** That was never a deliberate rule — it was that the only *wired*
+version-creating mutation was `newVersionNative` (`project-quote-rail.tsx`'s
+"Create quote v{N+1}"), which exists specifically as the sanctioned exit from
+a quote-sent lock and therefore requires the current live revision to already
+be SENT. `saveVersionNative` (Phase 1, #1085) — reachable from ANY live
+state, including a never-sent DRAFT — had existed the whole time with no UI
+caller. This phase wires it up and, while doing so, turns
+`ProjectVersionSwitcher` (`src/components/projects/version-switcher.tsx`) from
+a read-only list+switch into the project's one version-management surface:
+
+- **Add version** (footer item) → `useProjectVersionWrites().saveVersion()` →
+  `saveVersionNative`. One click, no prompt — rename afterwards via the
+  existing "Rename version" row action if wanted. `newVersionNative` is
+  UNCHANGED and still the right tool for its own job (unlocking editing after
+  a sent quote); the two are not merged (R-3.1 — distinct jobs, distinct
+  mutations, not one bent to cover both).
+- **Make live…** on any non-live row with captured state → the same
+  `PromoteVersionDialog` `VersionReadOnlyBar` and `ProjectQuoteRail` already
+  open — a third entry point into one dialog, not a fourth hand-built confirm.
+- **Send quote…** on the live row, only while its status is DRAFT → the same
+  `SendQuoteDialog` the rail uses. Never offered on a non-live row:
+  `sendNative` always freezes whichever revision is `liveRevision`, so
+  "make a quote for a past version" isn't a real operation — promote it live
+  first.
+- **Download** on any row with a stored artifact (`pdfFileId`) → the same
+  `/api/finance/quote/{id}/pdf` link `QuoteDocumentAction` uses.
+- **Delete** on any never-sent DRAFT row → `DeleteVersionDialog`
+  (`src/components/projects/finance/delete-version-dialog.tsx`), extracted
+  from the rail's former locally-defined `DeleteDraftDialog` so both surfaces
+  share the one live-vs-non-live branch (R-3.1) instead of two copies of the
+  same `deleteDraftNative`-vs-`deleteVersionNative` decision.
+
+**The empty-state gap.** Before this phase, `listVersions` (and therefore the
+whole switcher) rendered nothing at all until a project's first quote row
+existed — a brand-new project has `projects.revision`/`liveRevision` seeded to
+1 at `createNative` but no `quotes` row until something sends or saves a
+version, so the header button simply didn't appear yet. `listVersions`
+(`convex/projectVersionsRead.ts`) now synthesizes ONE virtual live entry
+(`quoteId: ""`, `status: "DRAFT"`, `hasSnapshot: false`) when a non-template
+project has zero quote rows, so the button — and its Add version/Send quote
+actions — is always there. Both underlying mutations already tolerated this:
+`saveVersionNative`'s `outgoing` lookup is optional, and `sendNative`'s own
+docstring states it creates the DRAFT row itself when the revision has none
+yet. The synthetic entry is never persisted and never appears in
+`quotes.listForProject` (the Finance tab rail's own query) — it exists only in
+this one read, purely so the switcher has something to render.
+
+Action visibility is gated by `useCanDo("invoice", "publish")` (matching
+`CanDo resource="invoice" action="publish"` everywhere else a quote verb is
+offered) — a caller without it sees the plain list with no action icons.
+
 ## Out of scope (later phases)
 
 - Recall-to-edit (#1100, Phase 5) — editing a promoted SENT revision is still
@@ -238,3 +294,10 @@ appeared in this panel's list to begin with (it queries `quotes`, not
   opens the dialog, renders the predicted-conflict list, and confirms.
 - `src/components/projects/finance/__tests__/promote-conflicts-panel.test.tsx` —
   the persistent post-promote panel.
+- `src/components/projects/__tests__/project-version-switcher.smoke.test.tsx`
+  (Phase 5) — the switcher renders on a never-quoted project (the synthetic
+  entry), Add version fires `saveVersionNative`, and the row action icons
+  (download/send/make-live/delete) appear only when their eligibility check
+  passes.
+- `convex/projectVersionsRead.test.ts` (Phase 5) — the zero-quote-rows
+  synthetic entry, and that `pdfFileId` round-trips onto each version item.

--- a/convex/projectVersionsRead.test.ts
+++ b/convex/projectVersionsRead.test.ts
@@ -90,14 +90,46 @@ describe("projectVersionsRead.listVersions", () => {
     expect(v2.total).toBe(110); // read straight off the live project row
   });
 
-  test("a project with no quotes yet returns an empty list, not an error", async () => {
+  // Phase 5 ("fine-tune versioning") — before this, a never-quoted project's
+  // list was simply empty and the header switcher vanished entirely (you
+  // couldn't even see, let alone add, a version). Now it synthesizes ONE
+  // virtual live entry so the switcher — and its Add version/Send quote
+  // actions — is always there.
+  test("a project with no quotes yet returns a synthesized live entry, not an empty list", async () => {
     const t = makeT();
     await seedMember(t);
     await seedProject(t);
     const versions = await t
       .withIdentity(asUser(ORG))
       .query(api.projectVersionsRead.listVersions, { projectId: "p1", orgId: ORG, now: NOW });
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({ revision: 1, quoteId: "", status: "DRAFT", isLive: true, hasSnapshot: false, total: 110 });
+  });
+
+  test("a template project with no quotes yet returns an empty list — templates don't have versions", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t, ORG, { isTemplate: true });
+    const versions = await t
+      .withIdentity(asUser(ORG))
+      .query(api.projectVersionsRead.listVersions, { projectId: "p1", orgId: ORG, now: NOW });
     expect(versions).toEqual([]);
+  });
+
+  test("pdfFileId round-trips onto a sent version's list item", async () => {
+    const t = makeT();
+    await seedMember(t);
+    await seedProject(t);
+    await send(t); // v1 SENT — no artifact attached in this test (that's a server-action step)
+    await t.run(async (ctx) => {
+      const quote = await ctx.db.query("quotes").withIndex("by_cuid", (q) => q.eq("id", "q1")).first();
+      await ctx.db.patch(quote!._id, { pdfFileId: "storage_abc" });
+    });
+
+    const versions = await t
+      .withIdentity(asUser(ORG))
+      .query(api.projectVersionsRead.listVersions, { projectId: "p1", orgId: ORG, now: NOW });
+    expect(versions.find((v) => v.revision === 1)?.pdfFileId).toBe("storage_abc");
   });
 
   test("IDOR: a cross-org projectId returns an empty list rather than another org's versions", async () => {

--- a/convex/projectVersionsRead.ts
+++ b/convex/projectVersionsRead.ts
@@ -55,6 +55,10 @@ const VERSION_ITEM = v.object({
   // entry — `null` when there's no snapshot to read it from (a pre-versioning
   // revision, or a same-tick race the switcher shouldn't ever actually hit).
   total: v.union(v.number(), v.null()),
+  // The stored document artifact (#987), mirroring `quotes.pdfFileId` — lets
+  // the header version switcher (CLAUDE.md "fine-tune versioning") offer a
+  // direct download without a second query into `quotes.listForProject`.
+  pdfFileId: v.optional(v.string()),
 });
 
 type SnapshotReason = "CONFIRMED" | "COMPLETED" | "UNLOCK" | "QUOTE_SENT" | "VERSION_SAVED" | "PRE_PROMOTE";
@@ -72,6 +76,7 @@ interface VersionItem {
   snapshotReason?: SnapshotReason;
   hasSnapshot: boolean;
   total: number | null;
+  pdfFileId?: string;
 }
 
 /** Org-checks the parent snapshot row before trusting anything off it — same
@@ -134,6 +139,26 @@ export const listVersions = query({
         snapshotReason,
         hasSnapshot: q.snapshotId != null,
         total,
+        pdfFileId: q.pdfFileId,
+      });
+    }
+
+    // A project that has never been quoted has no `quotes` row at all — before
+    // this, the list (and therefore the header switcher, CLAUDE.md "fine-tune
+    // versioning") was simply empty and vanished. `projects.liveRevision` is
+    // real from `createNative` on, so there is always a live version to show;
+    // synthesize the virtual entry the switcher's "Add version"/"Send quote"
+    // actions can act on (`saveVersionNative` tolerates no row at that
+    // revision, and `sendNative` creates the DRAFT row itself on send).
+    if (out.length === 0 && !project.isTemplate) {
+      out.push({
+        revision: liveRevision,
+        quoteId: "",
+        status: "DRAFT",
+        isLive: true,
+        createdAt: project.createdAt,
+        hasSnapshot: false,
+        total: liveTotal,
       });
     }
 

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -340,8 +340,20 @@ export default function ProjectDetailPage({
                       same `lockStatus` subscription the strip below renders from. */}
                   {!project.isTemplate && <ProjectLockChip status={lockStatus} now={lockNow} />}
                   {/* Phase 3 (#1080/#1093) — project-wide, so it lives here
-                      rather than inside any one tab. */}
-                  {!project.isTemplate && <ProjectVersionSwitcher />}
+                      rather than inside any one tab. Extended (CLAUDE.md
+                      "fine-tune versioning") into the header's full version
+                      menu — add/delete/promote/send/download, not just switch. */}
+                  {!project.isTemplate && orgId && (
+                    <ProjectVersionSwitcher
+                      orgId={orgId}
+                      projectNumber={project.projectNumber}
+                      clientId={project.clientId as string | null | undefined}
+                      projectStatus={project.status as string | null | undefined}
+                      subtotal={project.subtotal as number | null}
+                      taxAmount={project.taxAmount as number | null}
+                      total={project.total as number | null}
+                    />
+                  )}
                 </div>
                 {/* Meta line */}
                 <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-caption text-muted">

--- a/src/components/projects/__tests__/project-version-switcher.smoke.test.tsx
+++ b/src/components/projects/__tests__/project-version-switcher.smoke.test.tsx
@@ -1,17 +1,45 @@
 // @vitest-environment jsdom
 //
-// Phase 3 (#1080/#1093) jsdom smoke coverage: the header switcher must
-// actually OPEN (it's a Radix dropdown — a closed-trigger render proves
-// nothing, see CLAUDE.md's Select/Tooltip footguns) and the read-only bar
-// must render its announced text. Both consume `useProjectVersion()` from
-// context, mocked here so neither needs a ConvexProvider in the tree.
+// Phase 3 (#1080/#1093) jsdom smoke coverage, extended for Phase 5
+// ("fine-tune versioning" — the header switcher becomes the version menu):
+// the header switcher must actually OPEN (it's a Radix dropdown — a
+// closed-trigger render proves nothing, see CLAUDE.md's Select/Tooltip
+// footguns) and the read-only bar must render its announced text. Both
+// consume `useProjectVersion()` from context, mocked here so neither needs a
+// ConvexProvider in the tree. The row actions' own dialogs
+// (PromoteVersionDialog/SendQuoteDialog/DeleteVersionDialog) are stubbed —
+// each has its own dedicated test file; this file only proves the switcher
+// offers the right actions for the right row state and wires "Add version".
 import React from "react";
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 
 const mockUseProjectVersion = vi.fn();
 vi.mock("@/components/projects/project-version-context", () => ({
   useProjectVersion: () => mockUseProjectVersion(),
+}));
+
+const mockUseCanDo = vi.fn(() => true);
+vi.mock("@/lib/use-permissions", () => ({
+  useCanDo: () => mockUseCanDo(),
+}));
+
+const mockSaveVersion = vi.fn(async () => ({ id: "q3", version: 3, savedRevision: 2 }));
+vi.mock("@/hooks/use-project-version-writes", () => ({
+  useProjectVersionWrites: () => ({ saveVersion: mockSaveVersion, promoteRevision: vi.fn() }),
+}));
+
+vi.mock("@/components/projects/finance/promote-version-dialog", () => ({
+  PromoteVersionDialog: () => null,
+}));
+vi.mock("@/components/projects/finance/promote-conflicts-panel", () => ({
+  PromoteConflictsPanel: () => null,
+}));
+vi.mock("@/components/projects/finance/delete-version-dialog", () => ({
+  DeleteVersionDialog: () => null,
+}));
+vi.mock("@/components/projects/finance/send-quote-dialog", () => ({
+  SendQuoteDialog: () => null,
 }));
 
 import { ProjectVersionSwitcher } from "@/components/projects/version-switcher";
@@ -27,8 +55,25 @@ beforeAll(() => {
   Element.prototype.scrollIntoView ??= () => {};
 });
 
+// `mockReturnValueOnce` gets consumed by the render triggered when `openMenu()`
+// changes the DropdownMenu's open state, not just the initial render — reset
+// explicitly after each test instead of relying on a one-shot override.
+afterEach(() => {
+  mockUseCanDo.mockReturnValue(true);
+});
+
+const SWITCHER_PROPS = {
+  orgId: "org1",
+  projectNumber: "P-100",
+  clientId: "client1",
+  projectStatus: "PLANNING",
+  subtotal: 500,
+  taxAmount: 50,
+  total: 550,
+};
+
 function openMenu() {
-  const trigger = screen.getByRole("button", { name: /switch project version/i });
+  const trigger = screen.getByRole("button", { name: /project versions/i });
   trigger.focus();
   fireEvent.keyDown(trigger, { key: "Enter" });
   return trigger;
@@ -36,7 +81,7 @@ function openMenu() {
 
 const VERSIONS = [
   { revision: 2, quoteId: "q2", status: "DRAFT" as const, isLive: true, hasSnapshot: false, total: 500, createdAt: 2 },
-  { revision: 1, quoteId: "q1", status: "SENT" as const, isLive: false, hasSnapshot: true, total: 400, sentAt: 1 },
+  { revision: 1, quoteId: "q1", status: "SENT" as const, isLive: false, hasSnapshot: true, total: 400, sentAt: 1, pdfFileId: "file1" },
 ];
 
 describe("ProjectVersionSwitcher smoke", () => {
@@ -49,7 +94,7 @@ describe("ProjectVersionSwitcher smoke", () => {
       isViewingVersion: false,
       setViewingRevision: vi.fn(),
     });
-    const { container } = render(<ProjectVersionSwitcher />);
+    const { container } = render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -62,12 +107,13 @@ describe("ProjectVersionSwitcher smoke", () => {
       isViewingVersion: false,
       setViewingRevision: vi.fn(),
     });
-    const { container } = render(<ProjectVersionSwitcher />);
+    const { container } = render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
     expect(container.firstChild).toBeNull();
   });
 
   it("renders the trigger without throwing", () => {
     mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
       versions: VERSIONS,
       isLoadingVersions: false,
       liveRevision: 2,
@@ -75,7 +121,30 @@ describe("ProjectVersionSwitcher smoke", () => {
       isViewingVersion: false,
       setViewingRevision: vi.fn(),
     });
-    expect(() => render(<ProjectVersionSwitcher />)).not.toThrow();
+    expect(() => render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />)).not.toThrow();
+  });
+
+  // Regression: a never-quoted project's `listVersions` synthesizes a virtual
+  // live entry (`quoteId: ""`) rather than returning an empty list — the
+  // header button must still render and offer "Add version"/"Send".
+  it("renders for a never-quoted project via the synthesized live entry", async () => {
+    mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
+      versions: [{ revision: 1, quoteId: "", status: "DRAFT" as const, isLive: true, hasSnapshot: false, total: null, createdAt: 1 }],
+      isLoadingVersions: false,
+      liveRevision: 1,
+      viewingRevision: null,
+      isViewingVersion: false,
+      setViewingRevision: vi.fn(),
+    });
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
+    expect(screen.getByRole("button", { name: /project versions/i })).toBeTruthy();
+    openMenu();
+    const menu = within(await screen.findByRole("menu"));
+    expect(menu.getByText(/v1 · Live/)).toBeTruthy();
+    expect(menu.getByLabelText(/send v1/i)).toBeTruthy();
+    expect(menu.queryByLabelText(/delete v1/i)).toBeNull();
+    expect(menu.getByText(/add version/i)).toBeTruthy();
   });
 
   // Regression: the switcher must actually OPEN and list every version with
@@ -83,6 +152,7 @@ describe("ProjectVersionSwitcher smoke", () => {
   // closed trigger that happens not to crash.
   it("opens the menu and lists every version with state and total", async () => {
     mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
       versions: VERSIONS,
       isLoadingVersions: false,
       liveRevision: 2,
@@ -90,7 +160,7 @@ describe("ProjectVersionSwitcher smoke", () => {
       isViewingVersion: false,
       setViewingRevision: vi.fn(),
     });
-    render(<ProjectVersionSwitcher />);
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
     openMenu();
     await waitFor(() => expect(screen.getByText("Versions")).toBeTruthy());
     const menu = within(screen.getByRole("menu"));
@@ -99,11 +169,82 @@ describe("ProjectVersionSwitcher smoke", () => {
     expect(menu.getAllByText(/\$500|\$400/).length).toBeGreaterThan(0);
   });
 
+  // Regression: each row's action icons match its eligibility — the live
+  // never-sent DRAFT offers Send + Delete (an undo, same as the rail's own
+  // "Delete draft"), never Make live; the non-live SENT-with-a-document row
+  // offers Make live + Download, never Send or Delete (it was already sent).
+  it("shows row actions matching each version's state", async () => {
+    mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
+      versions: VERSIONS,
+      isLoadingVersions: false,
+      liveRevision: 2,
+      viewingRevision: null,
+      isViewingVersion: false,
+      setViewingRevision: vi.fn(),
+    });
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
+    openMenu();
+    const menu = within(await screen.findByRole("menu"));
+    expect(menu.getByLabelText(/send v2/i)).toBeTruthy();
+    expect(menu.getByLabelText(/delete v2/i)).toBeTruthy();
+    expect(menu.queryByLabelText(/make v2 live/i)).toBeNull();
+
+    expect(menu.getByLabelText(/make v1 live/i)).toBeTruthy();
+    expect(menu.getByLabelText(/download v1 document/i)).toBeTruthy();
+    expect(menu.queryByLabelText(/send v1/i)).toBeNull();
+    expect(menu.queryByLabelText(/delete v1/i)).toBeNull();
+  });
+
+  // Regression: without invoice:publish, only the read-only list renders —
+  // no Add version, no mutating row actions.
+  it("hides mutating actions without invoice:publish", async () => {
+    mockUseCanDo.mockReturnValue(false);
+    mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
+      versions: VERSIONS,
+      isLoadingVersions: false,
+      liveRevision: 2,
+      viewingRevision: null,
+      isViewingVersion: false,
+      setViewingRevision: vi.fn(),
+    });
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
+    openMenu();
+    const menu = within(await screen.findByRole("menu"));
+    expect(menu.queryByText(/add version/i)).toBeNull();
+    expect(menu.queryByLabelText(/send v2/i)).toBeNull();
+    expect(menu.queryByLabelText(/make v1 live/i)).toBeNull();
+    // Download stays available — it isn't a write.
+    expect(menu.getByLabelText(/download v1 document/i)).toBeTruthy();
+  });
+
+  // Regression: "Add version" calls saveVersionNative (via the hook) rather
+  // than requiring the current live revision's quote to be sent first — the
+  // fix for "can't make v2 unless v1's quote is sent".
+  it("Add version calls saveVersion for the current project", async () => {
+    mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
+      versions: VERSIONS,
+      isLoadingVersions: false,
+      liveRevision: 2,
+      viewingRevision: null,
+      isViewingVersion: false,
+      setViewingRevision: vi.fn(),
+    });
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
+    openMenu();
+    const addItem = await screen.findByText(/add version/i);
+    fireEvent.click(addItem);
+    await waitFor(() => expect(mockSaveVersion).toHaveBeenCalledWith("proj1"));
+  });
+
   // Regression: clicking a non-live version calls setViewingRevision with its
   // number; clicking the live one clears `?v=` (passes null).
   it("clicking a version updates the viewed revision", async () => {
     const setViewingRevision = vi.fn();
     mockUseProjectVersion.mockReturnValue({
+      projectId: "proj1",
       versions: VERSIONS,
       isLoadingVersions: false,
       liveRevision: 2,
@@ -111,7 +252,7 @@ describe("ProjectVersionSwitcher smoke", () => {
       isViewingVersion: false,
       setViewingRevision,
     });
-    render(<ProjectVersionSwitcher />);
+    render(<ProjectVersionSwitcher {...SWITCHER_PROPS} />);
     openMenu();
     const v1Item = await waitFor(() => within(screen.getByRole("menu")).getByText(/v1 · Sent/));
     fireEvent.click(v1Item);

--- a/src/components/projects/finance/delete-version-dialog.tsx
+++ b/src/components/projects/finance/delete-version-dialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useQuoteWrites } from "@/hooks/use-quote-writes";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export interface DeleteVersionTarget {
+  id: string;
+  version: number;
+}
+
+/**
+ * Delete a version — shared by `ProjectQuoteRail` (Finance tab) and the
+ * header `ProjectVersionSwitcher` (R-3.1: one dialog, not two hand-built
+ * copies of the same isLiveDraft branch). Two cases, same shape the rail
+ * already distinguished:
+ *
+ * - The LIVE never-sent draft → `deleteDraftNative`, which rolls
+ *   `revision`/`liveRevision` back (#1028).
+ * - A saved-but-never-sent NON-live version (one `saveVersion`/an
+ *   auto-capture left behind) → `deleteVersionNative`, which touches neither
+ *   counter (#1080/#1097).
+ *
+ * A plain confirm, no text field — nothing outside the company has ever seen
+ * either case. Recall-then-delete (#1029) is a different, stricter dialog
+ * (`DeleteRecalledDialog`) for a revision that WAS sent; this one never fires
+ * for that (the server rejects it too if the row somehow changed underneath
+ * the click). Real `Dialog`, not `window.confirm` (CLAUDE.md — no
+ * `AlertDialog` anywhere in this codebase).
+ */
+export function DeleteVersionDialog({
+  target,
+  liveRevision,
+  onClose,
+}: {
+  target: DeleteVersionTarget | null;
+  liveRevision: number;
+  onClose: () => void;
+}) {
+  const quoteWrites = useQuoteWrites();
+  const [pending, setPending] = useState(false);
+  const isLiveDraft = target != null && target.version === liveRevision;
+
+  async function confirm() {
+    if (!target) return;
+    setPending(true);
+    try {
+      if (isLiveDraft) {
+        const result = await quoteWrites.deleteDraft(target.id);
+        toast.success(
+          result.revision === target.version
+            ? `Deleted v${target.version}`
+            : `Deleted v${target.version} — back to v${result.revision}`,
+        );
+      } else {
+        await quoteWrites.deleteVersion(target.id);
+        toast.success(`Deleted v${target.version}`);
+      }
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog open={!!target} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Delete {isLiveDraft ? "draft" : "version"} v{target?.version}</DialogTitle>
+          <DialogDescription>
+            {isLiveDraft
+              ? "Nobody outside the company has seen this draft. Deleting it frees the version number for the next one."
+              : "Nobody outside the company has seen this saved version. Deleting it removes its captured state — the version numbers already ahead of it are unaffected."}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="line" onClick={onClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button type="button" loading={pending} onClick={() => void confirm()}>
+            Delete {isLiveDraft ? "draft" : "version"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/projects/project-quote-rail.tsx
+++ b/src/components/projects/project-quote-rail.tsx
@@ -38,6 +38,7 @@ import { Input } from "@/components/ui/input";
 import { RowActionsMenu, type RowAction } from "@/components/ui/row-actions-menu";
 import { CanDo } from "@/components/auth/permission-gate";
 import { SendQuoteDialog } from "@/components/projects/finance/send-quote-dialog";
+import { DeleteVersionDialog } from "@/components/projects/finance/delete-version-dialog";
 import { AcceptQuoteDialog } from "@/components/projects/finance/accept-quote-dialog";
 import { CorrectQuoteDialog } from "@/components/projects/finance/correct-quote-dialog";
 import { DeleteRecalledDialog } from "@/components/projects/finance/delete-recalled-dialog";
@@ -230,7 +231,7 @@ export function ProjectQuoteRail({ projectId, orgId, projectNumber, clientId, pr
 
       <UnacceptDialog target={unacceptTarget} onClose={() => setUnacceptTarget(null)} />
 
-      <DeleteDraftDialog target={deleteDraftTarget} liveRevision={liveRevision} onClose={() => setDeleteDraftTarget(null)} />
+      <DeleteVersionDialog target={deleteDraftTarget} liveRevision={liveRevision} onClose={() => setDeleteDraftTarget(null)} />
 
       <EditLabelDialog target={labelTarget} onClose={() => setLabelTarget(null)} />
 
@@ -899,76 +900,6 @@ function ValidityLabel({ validUntil, now }: { validUntil: number; now: number })
   return <span className="text-fg-4">Valid until {validUntilStr}</span>;
 }
 
-
-/** Delete a never-sent draft (#1028) — a plain confirm, no text field, since
- *  nothing outside the company has ever seen this revision. Still a real
- *  `Dialog` rather than `window.confirm` (CLAUDE.md — no `AlertDialog`
- *  anywhere in this codebase). Recall-then-delete (#1029) is a different,
- *  stricter dialog (`DeleteRecalledDialog`) — this one never fires for a
- *  revision that was ever sent; the server rejects it too if the row somehow
- *  changed underneath the click. */
-function DeleteDraftDialog({
-  target,
-  liveRevision,
-  onClose,
-}: {
-  target: QuoteRevisionDoc | null;
-  liveRevision: number;
-  onClose: () => void;
-}) {
-  const quoteWrites = useQuoteWrites();
-  const [pending, setPending] = useState(false);
-  // A saved-but-never-sent version (one `saveVersion`/an auto-capture left
-  // behind) isn't THE live draft — deleting it is `deleteVersionNative`
-  // (#1080/#1097), which touches neither `revision` nor `liveRevision`.
-  const isLiveDraft = target != null && target.version === liveRevision;
-
-  async function confirm() {
-    if (!target) return;
-    setPending(true);
-    try {
-      if (isLiveDraft) {
-        const result = await quoteWrites.deleteDraft(target.id);
-        toast.success(
-          result.revision === target.version
-            ? `Deleted v${target.version}`
-            : `Deleted v${target.version} — back to v${result.revision}`,
-        );
-      } else {
-        await quoteWrites.deleteVersion(target.id);
-        toast.success(`Deleted v${target.version}`);
-      }
-      onClose();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to delete");
-    } finally {
-      setPending(false);
-    }
-  }
-
-  return (
-    <Dialog open={!!target} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Delete {isLiveDraft ? "draft" : "version"} v{target?.version}</DialogTitle>
-          <DialogDescription>
-            {isLiveDraft
-              ? "Nobody outside the company has seen this draft. Deleting it frees the version number for the next one."
-              : "Nobody outside the company has seen this saved version. Deleting it removes its captured state — the version numbers already ahead of it are unaffected."}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button type="button" variant="line" onClick={onClose} disabled={pending}>
-            Cancel
-          </Button>
-          <Button type="button" loading={pending} onClick={() => void confirm()}>
-            Delete {isLiveDraft ? "draft" : "version"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
 
 /** Rename a version's internal label from the row (#1080/#1097) — a plain text
  *  field, never a monetary/structural change. Reachable on any revision. */

--- a/src/components/projects/project-version-context.tsx
+++ b/src/components/projects/project-version-context.tsx
@@ -28,6 +28,10 @@ export interface ProjectVersionListItem {
   snapshotReason?: "CONFIRMED" | "COMPLETED" | "UNLOCK" | "QUOTE_SENT" | "VERSION_SAVED" | "PRE_PROMOTE";
   hasSnapshot: boolean;
   total: number | null;
+  /** The stored document artifact (#987) — absent on a DRAFT or a sent
+   *  revision whose render failed. Empty `quoteId` (the never-quoted
+   *  synthetic entry) never has one. */
+  pdfFileId?: string;
 }
 
 interface ProjectVersionContextValue {

--- a/src/components/projects/version-switcher.tsx
+++ b/src/components/projects/version-switcher.tsx
@@ -91,19 +91,19 @@ function VersionRowIcons({
   return (
     <div className="flex shrink-0 items-center gap-0.5">
       {actions.canDownload && (
-        <Button variant="ghost" size="icon" className="size-8" asChild aria-label={`Download v${v.revision} document`}>
+        <Button variant="ghost" size="icon" className="touch-target size-8" asChild aria-label={`Download v${v.revision} document`}>
           <a href={`/api/finance/quote/${v.quoteId}/pdf`} target="_blank" rel="noopener noreferrer">
             <Download className="h-3.5 w-3.5" />
           </a>
         </Button>
       )}
       {actions.canSend && (
-        <Button type="button" variant="ghost" size="icon" className="size-8" aria-label={`Send v${v.revision}`} onClick={onSend}>
+        <Button type="button" variant="ghost" size="icon" className="touch-target size-8" aria-label={`Send v${v.revision}`} onClick={onSend}>
           <Send className="h-3.5 w-3.5" />
         </Button>
       )}
       {actions.canMakeLive && (
-        <Button type="button" variant="ghost" size="icon" className="size-8" aria-label={`Make v${v.revision} live`} onClick={onMakeLive}>
+        <Button type="button" variant="ghost" size="icon" className="touch-target size-8" aria-label={`Make v${v.revision} live`} onClick={onMakeLive}>
           <Sparkles className="h-3.5 w-3.5" />
         </Button>
       )}
@@ -112,7 +112,7 @@ function VersionRowIcons({
           type="button"
           variant="ghost"
           size="icon"
-          className="size-8 text-destructive hover:text-destructive"
+          className="touch-target size-8 text-destructive hover:text-destructive"
           aria-label={`Delete v${v.revision}`}
           onClick={onDelete}
         >

--- a/src/components/projects/version-switcher.tsx
+++ b/src/components/projects/version-switcher.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Check, ChevronDown, History } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Check, ChevronDown, Download, History, Plus, Send, Sparkles, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -13,7 +15,14 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { formatCurrency } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
+import { useCanDo } from "@/lib/use-permissions";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { useProjectVersionWrites, type PromoteRevisionResult } from "@/hooks/use-project-version-writes";
 import { useProjectVersion, type ProjectVersionListItem } from "@/components/projects/project-version-context";
+import { PromoteVersionDialog } from "@/components/projects/finance/promote-version-dialog";
+import { PromoteConflictsPanel } from "@/components/projects/finance/promote-conflicts-panel";
+import { DeleteVersionDialog, type DeleteVersionTarget } from "@/components/projects/finance/delete-version-dialog";
+import { SendQuoteDialog } from "@/components/projects/finance/send-quote-dialog";
 
 /** `[state]` label for a version row — "Live" per decision 13 (design doc),
  *  never "Latest": a promoted older version can sit above a newer one, so a
@@ -47,69 +56,337 @@ function formatShortDate(ms: number | undefined): string | null {
   return new Date(ms).toLocaleDateString(undefined, { day: "numeric", month: "short" });
 }
 
+/** A row's per-version actions — worked out once so the row render stays a
+ *  straight line (R-3.6). Mirrors `quoteRowFlags`/the rail's own eligibility
+ *  checks (`project-quote-rail.tsx`) rather than re-deriving them differently
+ *  here (R-3.1): a version is deletable exactly when it's a never-sent DRAFT,
+ *  promotable exactly when it's non-live with captured state, sendable
+ *  exactly when it's the live DRAFT (the only one `SendQuoteDialog` can ever
+ *  target — `sendNative` always freezes `liveRevision`). */
+function versionRowActions(v: ProjectVersionListItem, canPublish: boolean) {
+  const isNeverSentDraft = v.status === "DRAFT" && v.sentAt == null;
+  return {
+    canDownload: !!v.pdfFileId,
+    canSend: canPublish && v.isLive && v.status === "DRAFT",
+    canMakeLive: canPublish && !v.isLive && v.hasSnapshot,
+    canDelete: canPublish && v.quoteId !== "" && isNeverSentDraft,
+  };
+}
+
+/** The row's trailing icon cluster — split out of `VersionRow` purely to keep
+ *  both functions' line count under R-3.6's ceiling. */
+function VersionRowIcons({
+  v,
+  actions,
+  onSend,
+  onMakeLive,
+  onDelete,
+}: {
+  v: ProjectVersionListItem;
+  actions: ReturnType<typeof versionRowActions>;
+  onSend: () => void;
+  onMakeLive: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      {actions.canDownload && (
+        <Button variant="ghost" size="icon" className="size-8" asChild aria-label={`Download v${v.revision} document`}>
+          <a href={`/api/finance/quote/${v.quoteId}/pdf`} target="_blank" rel="noopener noreferrer">
+            <Download className="h-3.5 w-3.5" />
+          </a>
+        </Button>
+      )}
+      {actions.canSend && (
+        <Button type="button" variant="ghost" size="icon" className="size-8" aria-label={`Send v${v.revision}`} onClick={onSend}>
+          <Send className="h-3.5 w-3.5" />
+        </Button>
+      )}
+      {actions.canMakeLive && (
+        <Button type="button" variant="ghost" size="icon" className="size-8" aria-label={`Make v${v.revision} live`} onClick={onMakeLive}>
+          <Sparkles className="h-3.5 w-3.5" />
+        </Button>
+      )}
+      {actions.canDelete && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8 text-destructive hover:text-destructive"
+          aria-label={`Delete v${v.revision}`}
+          onClick={onDelete}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** One version row — the label/state/date/total (clicking it switches `?v=`)
+ *  plus its trailing action icons. Split out of `ProjectVersionSwitcher`
+ *  purely to keep that function's line count and complexity under R-3.6's
+ *  ceiling — same reasoning as `project-quote-rail.tsx`'s `QuoteRevisionRow`. */
+function VersionRow({
+  v,
+  isActive,
+  canPublish,
+  onSwitch,
+  onSend,
+  onMakeLive,
+  onDelete,
+}: {
+  v: ProjectVersionListItem;
+  isActive: boolean;
+  canPublish: boolean;
+  onSwitch: () => void;
+  onSend: () => void;
+  onMakeLive: () => void;
+  onDelete: () => void;
+}) {
+  const date = formatShortDate(dateFor(v));
+  const actions = versionRowActions(v, canPublish);
+  return (
+    <div className="flex items-center gap-1 rounded-[var(--r)] px-2 py-1.5 hover:bg-accent">
+      <button type="button" className="flex min-w-0 flex-1 items-center gap-2 text-left" onClick={onSwitch}>
+        <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+          {isActive && <Check className="h-3.5 w-3.5 text-primary" />}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className={cn("block truncate", v.isLive && "font-semibold")}>
+            v{v.revision} · {stateLabel(v)}
+            {v.label ? ` · ${v.label}` : ""}
+          </span>
+          <span className="block text-caption text-muted">
+            {date}
+            {v.total != null ? ` · ${formatCurrency(v.total)}` : ""}
+          </span>
+        </span>
+      </button>
+      <VersionRowIcons v={v} actions={actions} onSend={onSend} onMakeLive={onMakeLive} onDelete={onDelete} />
+    </div>
+  );
+}
+
+/** The three action dialogs a row can open, plus the promote conflicts panel —
+ *  split out of `ProjectVersionSwitcher` for the same R-3.6 reason as
+ *  `project-quote-rail.tsx`'s `QuoteRailTargetDialogs`. */
+function VersionMenuDialogs({
+  orgId,
+  projectId,
+  projectNumber,
+  clientId,
+  projectStatus,
+  subtotal,
+  taxAmount,
+  total,
+  liveRevision,
+  liveVersion,
+  deleteTarget,
+  onCloseDelete,
+  promoteTarget,
+  onClosePromote,
+  promoteResult,
+  onDismissPromoteResult,
+  onPromoted,
+  sendOpen,
+  onSendOpenChange,
+}: {
+  orgId: string;
+  projectId: string;
+  projectNumber: string;
+  clientId?: string | null;
+  projectStatus?: string | null;
+  subtotal: number | null;
+  taxAmount: number | null;
+  total: number | null;
+  liveRevision: number | null;
+  liveVersion: ProjectVersionListItem | null;
+  deleteTarget: DeleteVersionTarget | null;
+  onCloseDelete: () => void;
+  promoteTarget: ProjectVersionListItem | null;
+  onClosePromote: () => void;
+  promoteResult: PromoteRevisionResult | null;
+  onDismissPromoteResult: () => void;
+  onPromoted: (result: PromoteRevisionResult) => void;
+  sendOpen: boolean;
+  onSendOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <>
+      <PromoteConflictsPanel result={promoteResult} onDismiss={onDismissPromoteResult} />
+
+      {promoteTarget?.snapshotId && liveVersion && (
+        <PromoteVersionDialog
+          open
+          onOpenChange={(open) => !open && onClosePromote()}
+          projectId={projectId}
+          orgId={orgId}
+          targetRevision={promoteTarget.revision}
+          targetSnapshotId={promoteTarget.snapshotId}
+          liveRevision={liveVersion.revision}
+          liveHasSnapshot={liveVersion.hasSnapshot}
+          onPromoted={onPromoted}
+        />
+      )}
+
+      <DeleteVersionDialog target={deleteTarget} liveRevision={liveRevision ?? 0} onClose={onCloseDelete} />
+
+      {liveVersion && (
+        <SendQuoteDialog
+          open={sendOpen}
+          onOpenChange={onSendOpenChange}
+          projectId={projectId}
+          projectNumber={projectNumber}
+          orgId={orgId}
+          clientId={clientId}
+          revision={liveVersion.revision}
+          currentLabel={liveVersion.label}
+          subtotal={subtotal}
+          taxAmount={taxAmount}
+          total={total}
+          projectStatus={projectStatus}
+        />
+      )}
+    </>
+  );
+}
+
+interface ProjectVersionSwitcherProps {
+  orgId: string;
+  projectNumber: string;
+  clientId?: string | null;
+  projectStatus?: string | null;
+  subtotal: number | null;
+  taxAmount: number | null;
+  total: number | null;
+}
+
 /**
- * Header version switcher (design doc §4.1) — mounted next to the project
- * number/status chip, not inside a tab (this is project-wide). Lists every
- * revision with a quote row, its state, date and total, and updates `?v=`.
- * Navigation only — "Make vN live…" (#1080/#1097) lives on the read-only bar
- * that appears once you've switched to viewing that version
- * (`<VersionReadOnlyBar>`) and on the Finance tab's version rail
- * (`<ProjectQuoteRail>`), not as a second promote entry point inside this
- * menu (R-3.1). "Save version…" (creating a new version from here) remains
- * unbuilt — the entry below opens nothing yet and stays absent until that
- * verb exists, rather than shipping a dead menu item.
+ * Header version menu (design doc §4.1, extended for "fine-tune versioning" —
+ * versions are the top-level thing, a quote is one optional document a
+ * version can have). Mounted next to the project number/status chip, not
+ * inside a tab (project-wide). Lists every version with its state, date and
+ * total, switches `?v=`, and now — the part that used to be Finance-tab-only
+ * or entirely unwired — lets you act on a version without leaving the header:
+ *
+ * - **Add version** (footer) — `saveVersionNative`, reachable from ANY live
+ *   state including a never-sent draft. This is the fix for "can't make v2
+ *   unless v1's quote is sent": that block was `newVersionNative`
+ *   (`project-quote-rail.tsx`'s "Create quote v{N+1}"), which exists for a
+ *   different job — the sanctioned exit from a quote-sent lock — and is left
+ *   untouched here (R-3.1: two mutations, two distinct jobs, not one merged
+ *   into the other).
+ * - **Make live…** — the same `PromoteVersionDialog` `VersionReadOnlyBar` and
+ *   `ProjectQuoteRail` already open (one dialog, three entry points now).
+ * - **Send quote…** — the same `SendQuoteDialog` the rail uses, only ever
+ *   offered on the live revision's DRAFT.
+ * - **Download** — the stored artifact link, when one exists.
+ * - **Delete** — the same `DeleteVersionDialog` the rail uses.
+ *
+ * A brand-new project has no `quotes` row at all yet; `listVersions`
+ * synthesizes a virtual live entry (`quoteId: ""`) so the button is never
+ * simply absent (FEATUREDOCS/70).
  */
-export function ProjectVersionSwitcher() {
-  const { versions, isLoadingVersions, liveRevision, viewingRevision, isViewingVersion, setViewingRevision } =
+export function ProjectVersionSwitcher({
+  orgId,
+  projectNumber,
+  clientId,
+  projectStatus,
+  subtotal,
+  taxAmount,
+  total,
+}: ProjectVersionSwitcherProps) {
+  const { projectId, versions, isLoadingVersions, liveRevision, viewingRevision, isViewingVersion, setViewingRevision } =
     useProjectVersion();
+  const canPublish = useCanDo("invoice", "publish");
+  const { saveVersion } = useProjectVersionWrites();
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteVersionTarget | null>(null);
+  const [promoteTarget, setPromoteTarget] = useState<ProjectVersionListItem | null>(null);
+  const [promoteResult, setPromoteResult] = useState<PromoteRevisionResult | null>(null);
+  const [sendOpen, setSendOpen] = useState(false);
+
+  const addVersion = useServerMutation({
+    mutationFn: () => saveVersion(projectId),
+    onSuccess: (r) => toast.success(`Saved v${r.savedRevision} — now editing v${r.version}`),
+    onError: (e) => toast.error(e.message),
+  });
 
   if (isLoadingVersions || versions.length === 0) return null;
 
   const activeRevision = isViewingVersion ? viewingRevision : liveRevision;
   const activeVersion = versions.find((v) => v.revision === activeRevision);
+  const liveVersion = versions.find((v) => v.isLive) ?? null;
   const triggerLabel = activeVersion ? `v${activeVersion.revision}${activeVersion.isLive ? " · Live" : ""}` : "Versions";
 
+  function closeMenuThen(fn: () => void) {
+    setMenuOpen(false);
+    fn();
+  }
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="line" size="sm" className="gap-1.5" aria-label="Switch project version">
-          <History className="h-3.5 w-3.5" />
-          <span>{triggerLabel}</span>
-          <ChevronDown className="h-3 w-3 opacity-60" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
-        <DropdownMenuGroup>
-          <DropdownMenuLabel>Versions</DropdownMenuLabel>
-        </DropdownMenuGroup>
-        {versions.map((v) => {
-          const isActive = v.revision === activeRevision;
-          const date = formatShortDate(dateFor(v));
-          return (
-            <DropdownMenuItem
+    <>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="line" size="sm" className="gap-1.5" aria-label="Project versions">
+            <History className="h-3.5 w-3.5" />
+            <span>{triggerLabel}</span>
+            <ChevronDown className="h-3 w-3 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-96">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Versions</DropdownMenuLabel>
+          </DropdownMenuGroup>
+          {versions.map((v) => (
+            <VersionRow
               key={v.revision}
-              className="flex items-center gap-2"
-              onClick={() => setViewingRevision(v.isLive ? null : v.revision)}
-            >
-              <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-                {isActive && <Check className="h-3.5 w-3.5 text-primary" />}
-              </span>
-              <span className={cn("flex-1 truncate", v.isLive && "font-semibold")}>
-                v{v.revision} · {stateLabel(v)}
-                {v.label ? ` · ${v.label}` : ""}
-              </span>
-              <span className="shrink-0 text-caption text-muted">
-                {date}
-                {v.total != null ? ` · ${formatCurrency(v.total)}` : ""}
-              </span>
-            </DropdownMenuItem>
-          );
-        })}
-        <DropdownMenuSeparator />
-        <p className="px-2 py-1.5 text-caption text-muted">
-          Switch to a version to make it live, or use the Finance tab&apos;s version list.
-        </p>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              v={v}
+              isActive={v.revision === activeRevision}
+              canPublish={canPublish}
+              onSwitch={() => closeMenuThen(() => setViewingRevision(v.isLive ? null : v.revision))}
+              onSend={() => closeMenuThen(() => setSendOpen(true))}
+              onMakeLive={() => closeMenuThen(() => setPromoteTarget(v))}
+              onDelete={() => closeMenuThen(() => setDeleteTarget({ id: v.quoteId, version: v.revision }))}
+            />
+          ))}
+          {canPublish && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem disabled={addVersion.isPending} onClick={() => addVersion.mutate(undefined)}>
+                <Plus className="h-3.5 w-3.5" /> Add version
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <VersionMenuDialogs
+        orgId={orgId}
+        projectId={projectId}
+        projectNumber={projectNumber}
+        clientId={clientId}
+        projectStatus={projectStatus}
+        subtotal={subtotal}
+        taxAmount={taxAmount}
+        total={total}
+        liveRevision={liveRevision}
+        liveVersion={liveVersion}
+        deleteTarget={deleteTarget}
+        onCloseDelete={() => setDeleteTarget(null)}
+        promoteTarget={promoteTarget}
+        onClosePromote={() => setPromoteTarget(null)}
+        promoteResult={promoteResult}
+        onDismissPromoteResult={() => setPromoteResult(null)}
+        onPromoted={(result) => {
+          setPromoteResult(result);
+          setPromoteTarget(null);
+        }}
+        sendOpen={sendOpen}
+        onSendOpenChange={setSendOpen}
+      />
+    </>
   );
 }

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -41923,7 +41923,7 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     ],
     "privilegedArgs": [],
     "argsSha": "8f3456c860a78207",
-    "returnsSha": "26d612adfd2e34b1",
+    "returnsSha": "9a8c3234cbac91e4",
     "stability": "tracks-app",
     "summary": "List a project's versions with state, date and total for the switcher.",
     "danger": "low",


### PR DESCRIPTION
## Summary

- Versions no longer have to go through a quote to be created. The header button next to the project title (`v{N}`) now opens a full version menu: list every version, **Add version** (`saveVersionNative`, reachable from any live state — this is the fix for "can't make v2 unless v1's quote is sent"), **Make live** (promote), **Send quote**, **Download** the stored document, and **Delete**.
- `listVersions` now returns each version's `pdfFileId` and synthesizes a virtual live entry for a never-quoted project, so the header button is never simply absent.
- Extracted `DeleteVersionDialog` out of the Finance tab's quote rail into a shared component so the new header menu doesn't duplicate the delete-draft-vs-delete-version logic.
- `newVersionNative` and the Finance tab's "Create quote v{N+1}" button are unchanged — that stays the dedicated exit from a quote-sent lock, a distinct job from the new general-purpose "Add version".
- Updated FEATUREDOCS/70 with the new "Phase 5" section.

## Testing

- `pnpm exec vitest run src/components/projects/__tests__/project-version-switcher.smoke.test.tsx` — 13/13 passing (extended with new-project synthesized-entry, row-action-eligibility, and Add-version coverage)
- `pnpm exec vitest run convex/projectVersionsRead.test.ts` — 9/9 passing (2 new tests: synthesized entry, `pdfFileId` round-trip)
- `pnpm exec vitest run convex/quotesWrites.test.ts convex/validationDrift.test.ts` — 107/107 passing (no regressions)
- `pnpm exec tsc --noEmit` — diffed against a pre-change baseline; no new errors introduced
- `pnpm exec eslint` on all touched files — 0 errors (pre-existing `max-lines-per-function` warnings only, consistent with the rest of the codebase)
- `pnpm run api:registry:check` — registry regenerated and current

## Checklist

- [x] New dependency? N/A — no new dependencies added


---
_Generated by [Claude Code](https://claude.ai/code/session_011wGwwKYMEJei2gEBDe9eiT)_