### PR TITLE
Fix: DEPOSIT/BALANCE/CREDIT invoice PDFs showed the full project total

### DIFF
--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -248,6 +248,62 @@ What this changes in the PDF pipeline itself:
 Superseded, recalled and voided rows keep their artifacts: the client may be
 holding that copy, so deleting ours makes the record worse, not better.
 
+### `invoice` rendering is keyed to a SPECIFIC invoice, not just the project (bug fix)
+
+Every `docType: "invoice"` render used to take only `projectId` — never an
+`invoiceId` — all the way through `generatePdf`/`buildDocumentData`. That
+meant `subtotal`/`tax_amount`/`total` and the line items always came from the
+LIVE PROJECT total/breakdown, which is only correct for a `FULL` invoice: a
+`DEPOSIT`/`BALANCE`/`CREDIT` invoice's PDF (preview AND its permanent stored
+artifact) showed the whole project amount instead of its own, even though the
+correct figures were sitting right there on the `invoices`/`invoiceLines`
+rows the whole time.
+
+Fixed by threading an optional `invoiceId` through the whole chain:
+
+```
+href/generateInvoiceArtifact(invoiceId)
+  ──▶ generatePdf(..., { invoiceId })
+        ──▶ buildDocumentData(..., { invoiceId })
+              ──▶ convex/financeArtifacts.ts invoiceArtifactContext(invoiceId, orgId)
+                    → { kind, subtotal, taxAmount, total, invoiceNumber, lines }
+```
+
+When `invoiceId` is supplied and `docType === "invoice"`:
+
+- `subtotal`/`tax_amount`/`total`/`invoice_number` come from the invoice's
+  own row, never the live project (a `FULL` invoice's own total is a frozen
+  snapshot too, so this is strictly more correct even for that kind — it can
+  predate a later line-item edit).
+- For any kind OTHER than `FULL`, the rendered line items are the invoice's
+  own stored `invoiceLines` (`invoiceLineToDocumentLineItem` in
+  `build-document-data.ts`), not the live equipment/service breakdown — a
+  `DEPOSIT`/`BALANCE` invoice only ever carries one summary line by design
+  (`invoicesWrites.ts createNative`), and `CREDIT` carries one negated line
+  (`createCreditNative`). `FULL` still uses the live structured render
+  (`structureLineItems` + billable services) — its `invoiceLines` are a flat
+  snapshot of the same data at creation time, not a richer category/kit/
+  group tree, so the live render stays strictly more correct for it.
+- `invoiceLineToDocumentLineItem` sets `groupName`/`categoryName` to `null`
+  (unlike the billable-service mapping right above it in the same file,
+  which deliberately sets `"Services"` to force a section header) — the
+  synthetic row renders as a bare line with none.
+
+Every call site was updated: the preview route
+(`/api/documents/[projectId]?type=invoice&preview=1&invoiceId=…`),
+`generateInvoiceArtifact` (the stored-artifact path — so an ISSUED
+`DEPOSIT`/`BALANCE`/`CREDIT` invoice's permanent PDF is correct from the
+moment it's issued going forward), and the two UI preview links that
+already had the specific invoice in scope but weren't passing its id
+(`project-finance-panel.tsx`'s `InvoiceDocumentAction`,
+`issue-invoice-dialog.tsx`). Omitting `invoiceId` keeps the legacy live-render
+behaviour (the fallback for any caller not yet updated).
+
+**Not retroactive.** Already-issued invoices with a stored `pdfFileId` keep
+whatever bytes were rendered before this fix (`attachInvoiceArtifact` refuses
+to overwrite — the client may already hold that copy, same "never regenerate"
+rule as everywhere else in this file). Only new renders are correct.
+
 ## Global Document Settings
 
 Org-level, stored in the existing `orgSettings` Convex blob (`OrgSettings.documents`,

--- a/FEATUREDOCS/66-finance-quotes-invoices-xero.md
+++ b/FEATUREDOCS/66-finance-quotes-invoices-xero.md
@@ -111,6 +111,15 @@ rather than leaking a foreign org's model name.
 `recalcProjectTotals` (summed from this project's `ISSUED` invoices — see
 "Derive, don't hand-type" below), not the invoice-level fields above.
 
+**The PDF a DEPOSIT/BALANCE/CREDIT invoice renders is THIS invoice's own
+snapshot, not the live project.** A pre-existing bug (fixed alongside the
+invoice-menu redesign above) meant the render pipeline had no concept of an
+individual invoice row — every "invoice" PDF, preview or stored artifact,
+showed the whole project's total/breakdown regardless of kind. See
+FEATUREDOCS/13's "`invoice` rendering is keyed to a SPECIFIC invoice" for the
+fix (`invoiceId` threaded through `generatePdf`/`buildDocumentData`,
+`convex/financeArtifacts.ts invoiceArtifactContext`).
+
 ## Quote revisions (#986 — Phase A of #985)
 
 WS1 shipped `quotes.version` as a number bumped inside `publishNative` by

--- a/convex/financeArtifacts.test.ts
+++ b/convex/financeArtifacts.test.ts
@@ -219,6 +219,48 @@ describe("artifact context queries (what the download routes authorise against)"
     ).rejects.toThrow(/not found/i);
   });
 
+  test("an invoice's context carries its OWN money snapshot and lines — never the live project's", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("invoiceLines", {
+        id: "il1", invoiceId: "inv_draft", sourceType: "CUSTOM",
+        description: "Deposit (25% of project total)", quantity: 1, unitPrice: 27.5, lineTotal: 27.5, sortOrder: 0,
+      });
+    });
+
+    const ctx = await svc(t).query(api.financeArtifacts.invoiceArtifactContext, {
+      invoiceId: "inv_draft", orgId: ORG,
+    });
+
+    expect(ctx.kind).toBe("DEPOSIT");
+    expect(ctx.subtotal).toBe(25);
+    expect(ctx.taxAmount).toBe(2.5);
+    expect(ctx.total).toBe(27.5);
+    expect(ctx.lines).toEqual([
+      { id: "il1", description: "Deposit (25% of project total)", quantity: 1, unitPrice: 27.5, lineTotal: 27.5 },
+    ]);
+  });
+
+  test("lines come back sorted by sortOrder, and an invoice with none returns an empty array", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("invoiceLines", {
+        id: "il_b", invoiceId: "inv1", sourceType: "CUSTOM", description: "Second", quantity: 1, unitPrice: 1, lineTotal: 1, sortOrder: 1,
+      });
+      await ctx.db.insert("invoiceLines", {
+        id: "il_a", invoiceId: "inv1", sourceType: "CUSTOM", description: "First", quantity: 1, unitPrice: 1, lineTotal: 1, sortOrder: 0,
+      });
+    });
+
+    const withLines = await svc(t).query(api.financeArtifacts.invoiceArtifactContext, { invoiceId: "inv1", orgId: ORG });
+    expect(withLines.lines.map((l) => l.description)).toEqual(["First", "Second"]);
+
+    const withoutLines = await svc(t).query(api.financeArtifacts.invoiceArtifactContext, { invoiceId: "inv_draft", orgId: ORG });
+    expect(withoutLines.lines).toEqual([]);
+  });
+
   test("a quote whose PROJECT belongs to another org is NOT_FOUND (no cross-tenant join)", async () => {
     const t = makeT();
     await seed(t);

--- a/convex/financeArtifacts.ts
+++ b/convex/financeArtifacts.ts
@@ -120,13 +120,29 @@ export const quoteArtifactContext = query({
 });
 
 /** The invoice equivalent. `issuedAt` is the document date an issued invoice
- *  freezes at — the same "don't recompute from now" rule as a quote's dates. */
+ *  freezes at — the same "don't recompute from now" rule as a quote's dates.
+ *
+ *  Also carries the invoice's own money snapshot (`subtotal`/`taxAmount`/
+ *  `total`) and its `invoiceLines` — the PDF pipeline used to have no
+ *  awareness of a specific invoice row at all (every "invoice" render just
+ *  used the LIVE project total/breakdown), so a DEPOSIT/BALANCE/CREDIT
+ *  invoice's PDF always showed the full project amount instead of its own.
+ *  `build-document-data.ts` reads these to render the actual invoice being
+ *  requested instead of guessing from live project state. */
 export const invoiceArtifactContext = query({
   args: { invoiceId: v.string(), orgId: v.string() },
   handler: async (ctx, { invoiceId, orgId }) => {
     await requireService(ctx);
     const invoice = await requireInvoiceInOrg(ctx, invoiceId, orgId);
     const project = await requireProjectInOrg(ctx, invoice.projectId, orgId);
+    // Bounded by invoiceId (R-9.8) — an invoice's own line count is small and
+    // fixed (one summary line for DEPOSIT/BALANCE/CREDIT, the equipment/
+    // service breakdown for FULL), same bound deleteVoidNative already uses.
+    const lines = await ctx.db
+      .query("invoiceLines")
+      .withIndex("by_invoiceId", (q) => q.eq("invoiceId", invoiceId))
+      .take(500);
+    lines.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
     return {
       invoiceId: invoice.id,
       projectId: invoice.projectId,
@@ -138,6 +154,17 @@ export const invoiceArtifactContext = query({
       issuedAt: invoice.issuedAt ?? null,
       invoiceDate: invoice.invoiceDate ?? null,
       dueDate: invoice.dueDate ?? null,
+      subtotal: invoice.subtotal,
+      taxAmount: invoice.taxAmount,
+      total: invoice.total,
+      notes: invoice.notes ?? null,
+      lines: lines.map((l) => ({
+        id: l.id,
+        description: l.description,
+        quantity: l.quantity,
+        unitPrice: l.unitPrice,
+        lineTotal: l.lineTotal,
+      })),
     };
   },
 });

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -2603,12 +2603,6 @@ function WarehouseProjectPage({
               <DropdownMenuItem onClick={() => window.open(`/api/documents/${projectId}?type=return-sheet`, "_blank")}>
                 Return sheet
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => window.open(`/api/documents/${projectId}?type=quote`, "_blank")}>
-                Quote / proposal
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => window.open(`/api/documents/${projectId}?type=invoice`, "_blank")}>
-                Invoice
-              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
           {/* Desktop: View Project button */}

--- a/src/app/api/documents/[projectId]/route.tsx
+++ b/src/app/api/documents/[projectId]/route.tsx
@@ -41,7 +41,9 @@ export async function GET(
   // Which SPECIFIC invoice this preview is for — without it, `generatePdf`
   // falls back to the live project total/breakdown, which is only correct
   // for a FULL invoice (bug fix: a DEPOSIT/BALANCE/CREDIT invoice needs its
-  // own snapshot, not the whole project's). Ignored for every other type.
+  // own snapshot, not the whole project's). Passed through unconditionally
+  // below — `buildDocumentData` only reads it for `docType: "invoice"`, so
+  // it's a harmless no-op on any other type, not worth its own branch here.
   const invoiceId = url.searchParams.get("invoiceId") || undefined;
 
   let session;
@@ -81,7 +83,7 @@ export async function GET(
     // a draft of anything, so it never carries the banner.
     const pdf = await generatePdf(projectId, organizationId, docType, {
       draftPreview: preview && PREVIEW_ONLY_TYPES.has(docType),
-      invoiceId: docType === "invoice" ? invoiceId : undefined,
+      invoiceId,
     });
     const filename = `${docType}-${projectId}.pdf`;
     return new NextResponse(Buffer.from(pdf), {

--- a/src/app/api/documents/[projectId]/route.tsx
+++ b/src/app/api/documents/[projectId]/route.tsx
@@ -38,6 +38,11 @@ export async function GET(
   const url = new URL(request.url);
   const type = url.searchParams.get("type") || "quote";
   const preview = url.searchParams.get("preview") === "1";
+  // Which SPECIFIC invoice this preview is for — without it, `generatePdf`
+  // falls back to the live project total/breakdown, which is only correct
+  // for a FULL invoice (bug fix: a DEPOSIT/BALANCE/CREDIT invoice needs its
+  // own snapshot, not the whole project's). Ignored for every other type.
+  const invoiceId = url.searchParams.get("invoiceId") || undefined;
 
   let session;
   try {
@@ -76,6 +81,7 @@ export async function GET(
     // a draft of anything, so it never carries the banner.
     const pdf = await generatePdf(projectId, organizationId, docType, {
       draftPreview: preview && PREVIEW_ONLY_TYPES.has(docType),
+      invoiceId: docType === "invoice" ? invoiceId : undefined,
     });
     const filename = `${docType}-${projectId}.pdf`;
     return new NextResponse(Buffer.from(pdf), {

--- a/src/app/api/finance/__tests__/artifact-routes.test.ts
+++ b/src/app/api/finance/__tests__/artifact-routes.test.ts
@@ -211,4 +211,34 @@ describe("GET /api/documents/[projectId] — the rogue path is closed", () => {
 
     expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "delivery-docket", { draftPreview: false });
   });
+
+  // Bug fix: previewing a DEPOSIT/BALANCE/CREDIT invoice used to always show
+  // the live project's full total/breakdown, because this route never told
+  // generatePdf WHICH invoice it was previewing.
+  test("an invoice preview's invoiceId query param is forwarded to generatePdf", async () => {
+    await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=invoice&preview=1&invoiceId=inv_deposit") as never,
+      projectParams,
+    );
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "invoice", { draftPreview: true, invoiceId: "inv_deposit" });
+  });
+
+  test("an invoice preview with no invoiceId falls back to the legacy live render (no id to key off)", async () => {
+    await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=invoice&preview=1") as never,
+      projectParams,
+    );
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "invoice", { draftPreview: true, invoiceId: undefined });
+  });
+
+  test("an invoiceId on a NON-invoice type is ignored — it's meaningless for a quote/warehouse doc", async () => {
+    await getProjectDocument(
+      req("http://localhost/api/documents/p1?type=quote&preview=1&invoiceId=inv1") as never,
+      projectParams,
+    );
+
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", { draftPreview: true });
+  });
 });

--- a/src/app/api/finance/__tests__/artifact-routes.test.ts
+++ b/src/app/api/finance/__tests__/artifact-routes.test.ts
@@ -233,12 +233,12 @@ describe("GET /api/documents/[projectId] — the rogue path is closed", () => {
     expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "invoice", { draftPreview: true, invoiceId: undefined });
   });
 
-  test("an invoiceId on a NON-invoice type is ignored — it's meaningless for a quote/warehouse doc", async () => {
+  test("an invoiceId on a NON-invoice type reaches generatePdf but is meaningless there — buildDocumentData only reads it for docType invoice", async () => {
     await getProjectDocument(
       req("http://localhost/api/documents/p1?type=quote&preview=1&invoiceId=inv1") as never,
       projectParams,
     );
 
-    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", { draftPreview: true });
+    expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "quote", { draftPreview: true, invoiceId: "inv1" });
   });
 });

--- a/src/components/projects/finance/issue-invoice-dialog.tsx
+++ b/src/components/projects/finance/issue-invoice-dialog.tsx
@@ -157,7 +157,7 @@ export function IssueInvoiceDialog({ open, onOpenChange, projectId, invoiceId, i
                 Cancel
               </Button>
               <Button type="button" asChild variant="line">
-                <a href={`/api/documents/${projectId}?type=invoice&preview=1`} target="_blank" rel="noopener noreferrer">
+                <a href={`/api/documents/${projectId}?type=invoice&preview=1&invoiceId=${invoiceId}`} target="_blank" rel="noopener noreferrer">
                   <Eye className="h-3.5 w-3.5" /> Preview
                 </a>
               </Button>

--- a/src/components/projects/project-finance-panel.tsx
+++ b/src/components/projects/project-finance-panel.tsx
@@ -614,11 +614,13 @@ function InvoiceDocumentAction({ invoice: inv, projectId }: { invoice: InvoiceRo
 
   // A draft's only document is the watermarked preview — the one place a
   // client-facing finance PDF is still rendered from live state, and it says
-  // "NOT SENT" on every page.
+  // "NOT SENT" on every page. `invoiceId` matters here: without it the
+  // preview showed the live PROJECT total/breakdown regardless of this
+  // invoice's own kind — a 25% deposit draft rendered as the full invoice.
   if (inv.issuedAt == null) {
     return (
       <Button variant="line" size="sm" asChild>
-        <a href={`/api/documents/${projectId}?type=invoice&preview=1`} target="_blank" rel="noopener noreferrer">
+        <a href={`/api/documents/${projectId}?type=invoice&preview=1&invoiceId=${inv.id}`} target="_blank" rel="noopener noreferrer">
           <Eye className="h-3.5 w-3.5" /> Preview
         </a>
       </Button>

--- a/src/lib/pdfme/build-document-data.ts
+++ b/src/lib/pdfme/build-document-data.ts
@@ -52,6 +52,46 @@ const DEFAULT_DOC_COLOR = "#0d4f4f";
  * subHires + crewAssignments stay Prisma reads here.
  */
 
+/**
+ * A DEPOSIT/BALANCE/CREDIT invoice carries exactly one stored summary line
+ * (never the project's full equipment/service breakdown — see
+ * `invoicesWrites.ts createNative`/`createCreditNative`) — this maps that
+ * stored shape into the same `DocumentLineItem` shape a live line item has,
+ * minus every field that only makes sense for a real equipment/service row.
+ * `groupName`/`categoryName` are left `null` so it renders as a bare row
+ * with no section header (contrast the billable-service mapping below,
+ * which sets `"Services"` specifically TO get one).
+ */
+export function invoiceLineToDocumentLineItem(line: {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+}): DocumentLineItem {
+  return {
+    id: `invline-${line.id}`,
+    description: line.description,
+    quantity: line.quantity,
+    checkedOutQuantity: 0,
+    unitPrice: line.unitPrice,
+    pricingType: "FLAT",
+    duration: 1,
+    discount: null,
+    lineTotal: line.lineTotal,
+    groupName: null,
+    categoryName: null,
+    groupTitle: null,
+    isGroupRow: false,
+    isOptional: false,
+    notes: null,
+    status: "CONFIRMED",
+    model: null,
+    asset: null,
+    bulkAsset: null,
+  };
+}
+
 /** Serialize Decimal fields to numbers (Prisma v6 Decimal type) */
 function serializeDecimals<T>(obj: T): T {
   return JSON.parse(
@@ -107,6 +147,21 @@ export async function buildDocumentData(
      * pipeline's three-consumer audit (CLAUDE.md).
      */
     versionSuffix?: string;
+    /**
+     * The SPECIFIC invoice this render represents (`docType: "invoice"`
+     * only) — bug fix: this pipeline used to have no concept of an
+     * individual invoice row, so EVERY "invoice" render (preview or the
+     * stored artifact) showed the live project's full total/breakdown, even
+     * for a DEPOSIT/BALANCE/CREDIT invoice whose actual amount is a fraction
+     * of that. When set, `invoiceNumber`/`subtotal`/`taxAmount`/`total` come
+     * from the invoice's own row, and for any kind other than FULL the line
+     * items are the invoice's own stored summary line(s)
+     * (`convex/financeArtifacts.ts` `invoiceArtifactContext`) instead of the
+     * live equipment/service breakdown. Omitted ⇒ unchanged legacy
+     * behaviour (live project state) — every non-invoice doc type, and any
+     * caller that hasn't been updated to pass one yet.
+     */
+    invoiceId?: string;
   }
 ): Promise<DocumentData> {
   const expandProjectGroups = options?.expandProjectGroups ?? false;
@@ -376,12 +431,31 @@ export async function buildDocumentData(
     }
   }
 
-  const lineItems: DocumentLineItem[] = structureLineItems(
-    rawLineItems,
-    categories,
-    { expandProjectGroups, packerSort },
-    subHireGroups,
-  );
+  // A specific invoice's own money/lines (bug fix — see this function's
+  // `invoiceId` doc above): fetched once, up front, so both the line items
+  // below and the subtotal/tax/total/invoiceNumber fields further down read
+  // the SAME snapshot rather than two independent (and possibly racing)
+  // Convex round trips.
+  const invoiceContext =
+    docType === "invoice" && options?.invoiceId
+      ? await (
+          await getConvexClient()
+        ).query(api.financeArtifacts.invoiceArtifactContext, {
+          invoiceId: options.invoiceId,
+          orgId: organizationId,
+        })
+      : null;
+  // FULL still renders the live equipment/service breakdown below — its
+  // `invoiceLines` are a flat snapshot of the SAME data at creation time
+  // (`buildFinanceLines`), not a richer category/kit/group tree, so re-using
+  // the live structured render is strictly more correct, not less. Every
+  // other kind (DEPOSIT/BALANCE/CREDIT) carries exactly its own summary
+  // line(s) and nothing else.
+  const usesLiveBreakdown = !invoiceContext || invoiceContext.kind === "FULL";
+
+  const lineItems: DocumentLineItem[] = usesLiveBreakdown
+    ? structureLineItems(rawLineItems, categories, { expandProjectGroups, packerSort }, subHireGroups)
+    : invoiceContext.lines.map(invoiceLineToDocumentLineItem);
 
   // ─── Append billable services as virtual line items ─────────────────────────
   // A service appears on quotes/invoices as its own section once it has an actual
@@ -392,16 +466,20 @@ export async function buildDocumentData(
   // not a second one (R-3.1). projectService is dual-written to Convex — read the
   // org's services, filter to this project and order by sortOrder asc,
   // replicating the dropped Prisma findMany.
-  const billableServices = (await getProjectServicesByOrg(organizationId))
-    .filter(
-      (s) =>
-        s.projectId === projectId &&
-        s.status !== "CANCELLED" &&
-        Number(s.lineTotal) > 0,
-    )
-    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+  //
+  // Skipped when rendering a DEPOSIT/BALANCE/CREDIT invoice's own summary
+  // line(s) — those already ARE the whole invoice; appending the project's
+  // live services here would silently show more than that invoice bills for.
+  if (usesLiveBreakdown) {
+    const billableServices = (await getProjectServicesByOrg(organizationId))
+      .filter(
+        (s) =>
+          s.projectId === projectId &&
+          s.status !== "CANCELLED" &&
+          Number(s.lineTotal) > 0,
+      )
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
 
-  if (billableServices.length > 0) {
     for (const svc of billableServices) {
       lineItems.push({
         id: `svc-${svc.id}`,
@@ -729,8 +807,17 @@ export async function buildDocumentData(
       : new Date(computeValidUntil(documentDate.getTime(), paymentTermsDays, orgTimezone));
 
   // WS1 (#940) — only the invoice doc type renders this; skip the extra
-  // Convex round trip for the other 4 doc types.
-  const invoiceNumber = docType === "invoice" ? await getLatestInvoiceNumberForProject(projectId, organizationId) : null;
+  // Convex round trip for the other 4 doc types. When a specific invoiceId
+  // was given, its OWN number wins (null while still DRAFT — correct: a
+  // preview of an unissued invoice has no number, rather than borrowing
+  // whichever OTHER invoice on the project happens to be most recently
+  // issued). The heuristic fallback is only for callers with no invoiceId.
+  const invoiceNumber =
+    invoiceContext != null
+      ? invoiceContext.invoiceNumber
+      : docType === "invoice"
+        ? await getLatestInvoiceNumberForProject(projectId, organizationId)
+        : null;
 
   return {
     // Org
@@ -783,13 +870,17 @@ export async function buildDocumentData(
     site_contact_phone: serialized.siteContactPhone || "",
     site_contact_email: serialized.siteContactEmail || "",
 
-    // Financial
-    subtotal: Number(serialized.subtotal) || 0,
+    // Financial — a specific invoice's own frozen snapshot wins over the
+    // live project figures (bug fix, see `invoiceId` doc above): a
+    // DEPOSIT/BALANCE/CREDIT invoice's total is a fraction of the project's,
+    // and even a FULL invoice's total is frozen at whenever it was created,
+    // which can predate a later line-item edit.
+    subtotal: invoiceContext ? invoiceContext.subtotal : Number(serialized.subtotal) || 0,
     discount_percent: Number(serialized.discountPercent) || 0,
     discount_amount: Number(serialized.discountAmount) || 0,
     tax_label: (orgSettings.taxLabel as string) || (country?.taxLabel ?? "GST"),
-    tax_amount: Number(serialized.taxAmount) || 0,
-    total: totalNum,
+    tax_amount: invoiceContext ? invoiceContext.taxAmount : Number(serialized.taxAmount) || 0,
+    total: invoiceContext ? invoiceContext.total : totalNum,
     deposit_paid: depositNum,
     balance_due: totalNum - depositNum,
 

--- a/src/lib/pdfme/generate-pdf.ts
+++ b/src/lib/pdfme/generate-pdf.ts
@@ -34,6 +34,14 @@ export interface ProjectPdfOptions {
   draftPreview?: boolean;
   /** #1080/#1097 — see `buildDocumentData`'s `versionSuffix`. */
   versionSuffix?: string;
+  /**
+   * The SPECIFIC invoice this render represents — `docType: "invoice"` only.
+   * Without this, the render falls back to the live project total/breakdown,
+   * which is only ever correct for a FULL invoice; a DEPOSIT/BALANCE/CREDIT
+   * invoice needs its OWN money snapshot and single summary line, not the
+   * whole project's. See `buildDocumentData`'s `invoiceId` option.
+   */
+  invoiceId?: string;
 }
 
 /**
@@ -56,6 +64,7 @@ export async function generatePdf(
     expandProjectGroups: layout.expandProjectGroups,
     stampedDates: options?.stampedDates,
     versionSuffix: options?.versionSuffix,
+    invoiceId: options?.invoiceId,
   });
 
   // Real font metrics for composeDocument's accurate text-wrap measurement

--- a/src/lib/pdfme/invoice-line-to-document-line-item.test.ts
+++ b/src/lib/pdfme/invoice-line-to-document-line-item.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+//
+// invoiceLineToDocumentLineItem (bug fix) — the mapping a DEPOSIT/BALANCE/
+// CREDIT invoice's own stored summary line goes through to become the ONE
+// row a PDF render shows for it, instead of the live project's full
+// equipment/service breakdown. Kept as a pure, isolated function so this
+// mapping is testable without pulling in build-document-data.ts's Prisma/
+// Convex/storage dependencies.
+import { describe, test, expect } from "vitest";
+import { invoiceLineToDocumentLineItem } from "./build-document-data";
+
+describe("invoiceLineToDocumentLineItem", () => {
+  test("maps a stored deposit summary line to the invoice amount, not any live pricing", () => {
+    const result = invoiceLineToDocumentLineItem({
+      id: "il1",
+      description: "Deposit (25% of project total)",
+      quantity: 1,
+      unitPrice: 275,
+      lineTotal: 275,
+    });
+
+    expect(result.description).toBe("Deposit (25% of project total)");
+    expect(result.unitPrice).toBe(275);
+    expect(result.lineTotal).toBe(275);
+    expect(result.quantity).toBe(1);
+  });
+
+  test("carries no groupName/categoryName — renders as a bare row with no section header", () => {
+    const result = invoiceLineToDocumentLineItem({
+      id: "il2",
+      description: "Balance due",
+      quantity: 1,
+      unitPrice: 825,
+      lineTotal: 825,
+    });
+
+    expect(result.groupName).toBeNull();
+    expect(result.categoryName).toBeNull();
+    expect(result.groupTitle).toBeNull();
+  });
+
+  test("is never mistaken for equipment/kit content that other PDF consumers special-case", () => {
+    const result = invoiceLineToDocumentLineItem({
+      id: "il3",
+      description: "Credit for invoice INV-2026-0004",
+      quantity: 1,
+      unitPrice: -110,
+      lineTotal: -110,
+    });
+
+    expect(result.isKitChild).toBeUndefined();
+    expect(result.kitId).toBeUndefined();
+    expect(result.model).toBeNull();
+    expect(result.asset).toBeNull();
+    expect(result.bulkAsset).toBeNull();
+    expect(result.isGroupRow).toBe(false);
+    expect(result.type).toBeUndefined();
+  });
+
+  test("id is namespaced so it can never collide with a real project line item's id", () => {
+    const result = invoiceLineToDocumentLineItem({
+      id: "shared-id",
+      description: "Deposit",
+      quantity: 1,
+      unitPrice: 100,
+      lineTotal: 100,
+    });
+
+    expect(result.id).toBe("invline-shared-id");
+  });
+});

--- a/src/server/finance-documents.test.ts
+++ b/src/server/finance-documents.test.ts
@@ -207,12 +207,13 @@ describe("generateQuoteArtifact — stamped dates (the silent-validity-extension
     );
   });
 
-  test("an issued invoice's document date is its issuedAt", async () => {
+  test("an issued invoice's document date is its issuedAt, and its own invoiceId is threaded through", async () => {
     generatePdf.mockResolvedValue(new Uint8Array([1]));
     await generateInvoiceArtifact("inv1");
 
     expect(generatePdf).toHaveBeenCalledWith("p1", "org_1", "invoice", {
-      stampedDates: { documentDate: SENT_AT },
+      stampedDates: { documentDate: SENT_AT, invoiceDueDate: undefined },
+      invoiceId: "inv1",
     });
   });
 });

--- a/src/server/finance-documents.ts
+++ b/src/server/finance-documents.ts
@@ -141,6 +141,12 @@ export async function generateInvoiceArtifact(invoiceId: string): Promise<Artifa
       documentDate: invoice.invoiceDate ?? invoice.issuedAt,
       invoiceDueDate: invoice.dueDate ?? undefined,
     },
+    // Bug fix: without this, every issued invoice's STORED artifact rendered
+    // the live project's full total/breakdown regardless of kind — a 25%
+    // deposit's permanent PDF showed the whole project amount. This invoice's
+    // own snapshot (subtotal/taxAmount/total + its stored summary line for
+    // anything but FULL) now wins — see `buildDocumentData`'s `invoiceId` doc.
+    invoiceId,
   });
 
   const fileName = invoiceArtifactFileName(invoice.projectNumber, invoice.invoiceNumber);


### PR DESCRIPTION
## Summary

Reported live: a 25% partial (DEPOSIT) invoice's generated PDF showed the project's full total and full itemized breakdown instead of the deposit amount.

**Root cause (pre-existing, not introduced by the invoice-menu PR — just newly hit because partial invoicing is now the primary flow):** the entire `docType: "invoice"` PDF pipeline (`generatePdf` → `buildDocumentData`) only ever took a `projectId`, never the specific `invoiceId` being rendered. So every invoice render — the draft preview *and* the permanent stored artifact generated when an invoice is issued — always used the live project's full total/breakdown, which is only correct for a `FULL` invoice. A `DEPOSIT`/`BALANCE`/`CREDIT` invoice's PDF has been wrong since deposit invoicing was first built (#940/#1055), even though the correct amount and summary line were sitting right there on the `invoices`/`invoiceLines` rows the whole time.

## Fix

Threaded an optional `invoiceId` through the whole chain:

```
href / generateInvoiceArtifact(invoiceId)
  → generatePdf(..., { invoiceId })
      → buildDocumentData(..., { invoiceId })
          → convex/financeArtifacts.ts invoiceArtifactContext(invoiceId, orgId)
              → { kind, subtotal, taxAmount, total, invoiceNumber, lines }
```

- `convex/financeArtifacts.ts` `invoiceArtifactContext` now also returns the invoice's own `subtotal`/`taxAmount`/`total`/`notes` and its `invoiceLines`.
- `buildDocumentData` uses that snapshot for `subtotal`/`tax_amount`/`total`/`invoice_number` whenever `invoiceId` is given. For any kind other than `FULL`, the rendered line items are the invoice's own stored summary line(s) (`invoiceLineToDocumentLineItem`) instead of the live equipment/service breakdown. `FULL` keeps the live structured render (richer than its flat `invoiceLines` snapshot).
- Every call site updated: the preview route (`?type=invoice&preview=1&invoiceId=…`), `generateInvoiceArtifact` (so newly-issued invoices' *stored* PDFs are correct going forward), and the two UI preview links that already had the specific invoice in scope but weren't passing its id (`project-finance-panel.tsx`, `issue-invoice-dialog.tsx`).
- Drive-by: removed the warehouse page's dead "Quote / proposal"/"Invoice" Documents-menu items — they've unconditionally 400'd since the #987 redesign moved finance docs out of that menu.

**Not retroactive.** Already-issued invoices keep whatever PDF bytes were rendered before this fix — `attachInvoiceArtifact` refuses to overwrite an existing artifact (the client may already hold that copy), matching the app's "never regenerate a stored finance document" rule. Only new renders (previews and newly-issued invoices) are correct.

## Size rationale (R-2.8)

Marginally over the 400-LOC SHOULD-target (412). Not split, because this is one call chain, not several independent changes: the Convex query, the two pipeline functions it feeds, and the two UI call sites that were silently dropping the id are all one fix — splitting would either leave an intermediate PR with dead/unused plumbing (a query nothing calls yet) or a PR that fixes the data layer without fixing the actual bug anyone can observe.

## Testing

- `pnpm exec vitest run` — full suite green: 475 files / 5903 tests.
- `pnpm exec tsc --noEmit` — 0 errors.
- `pnpm exec eslint .` — 0 errors (warnings only, all pre-existing).
- `pnpm run api:registry:check` — current (the extended query is service-gated, not agent-reachable).
- `node scripts/knip-ratchet.mjs` — 415 (baseline 415).
- `node scripts/complexity-ratchet.mjs` — 685 (baseline 685).
- New/updated tests: `financeArtifacts.test.ts` (money+lines on the context query), `invoice-line-to-document-line-item.test.ts` (new, isolated unit tests for the line mapping), `artifact-routes.test.ts` (invoiceId forwarding through the preview route), `finance-documents.test.ts` (invoiceId forwarding through `generateInvoiceArtifact`).

## Checklist

- [x] New dependency? N/A — no new dependencies added.