### PR TITLE
Match version-viewing Equipment tab layout to the live tab structurally

### DIFF
--- a/FEATUREDOCS/70-project-version-switcher.md
+++ b/FEATUREDOCS/70-project-version-switcher.md
@@ -362,6 +362,27 @@ consistency, with zero editing affordances. Visually matches the live table's
 columns, grouping and totals; is not literally the same React component
 instances.
 
+**Structural revision, same day:** the first cut above rendered each category
+as its own bordered card with its own `<table>`, and groups/sub-hire groups
+always expanded — functionally complete (sub-hires, custom items and
+`categorySlots` ordering all showed) but visibly a different layout from the
+live tab side-by-side, which is exactly what was reported back. The live
+Equipment tab (`equipment-tab.tsx`) renders every category inside ONE
+continuous `<table>` — category names are in-table header rows
+(`CategoryRow`'s `bg-paper-2/50`/`t-overline text-muted` styling), not card
+headings — and groups/sub-hire groups are collapsed by default
+(`expandedGroups`, an empty `Set` on mount), expanding only on click.
+`version-projected-equipment.tsx` was rewritten to match structurally, not
+just visually: one `<table>` with the same `colgroup`/column widths wrapping
+every category plus "Uncategorized", `CategoryHeaderRow` as an in-table row
+using the identical classes, and a local `useExpanded()` hook (a plain
+`useState<Set<string>>`, empty by default) gating group/sub-hire-group child
+rows behind a chevron toggle — the read-only equivalent of the live tab's own
+collapse state. Toggling it only touches local view state, never data, so
+it's safe even though nothing else in this view is editable. The chevron
+toggle is the one interactive element this view has; every other affordance
+(edit, delete, drag, add) is still absent.
+
 ## Out of scope (later phases)
 
 - Recall-to-edit (#1100, Phase 5) — editing a promoted SENT revision is still
@@ -416,7 +437,10 @@ instances.
   (Phase 6) — an integration-style test (not a plugin-layer unit test, per
   CLAUDE.md's PDF-pipeline testing rule applied here too) that runs a real
   bundle fixture through the ACTUAL `reconstructProjectCategories` and
-  renders it: asserts the sub-hire group and custom item both appear, in
-  `categorySlots` order (project group → sub-hire group → standalone item —
-  proving real interleaving, not "groups first"), zero buttons/mutation
-  controls render, and the old "not captured" caveat banner is gone.
+  renders it: asserts the category header, group and sub-hire group titles
+  appear in `categorySlots` order (project group → sub-hire group →
+  standalone item — proving real interleaving, not "groups first"), that
+  group/sub-hire-group child rows are absent until their chevron toggle is
+  clicked (the one interactive element this view has, matching the live
+  tab's own collapsed-by-default state), and that the old "not captured"
+  caveat banner is gone.

--- a/src/components/projects/__tests__/version-projected-views.smoke.test.tsx
+++ b/src/components/projects/__tests__/version-projected-views.smoke.test.tsx
@@ -6,7 +6,7 @@
 // ConvexProvider is needed.
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 const mockUseProjectVersion = vi.fn();
 vi.mock("@/components/projects/project-version-context", () => ({
@@ -81,7 +81,7 @@ describe("VersionProjectedEquipment smoke", () => {
     expect(screen.getByText(/No equipment captured for v1/)).toBeTruthy();
   });
 
-  it("renders the category, group, sub-hire group and custom item — interleaved in categorySlots order, no caveat banner", () => {
+  it("renders the category, group, sub-hire group and custom item — interleaved in categorySlots order, no caveat banner, groups collapsed by default", () => {
     mockUseProjectVersion.mockReturnValue({
       isLoadingProjection: false,
       isLoadingEquipmentBundle: false,
@@ -92,17 +92,17 @@ describe("VersionProjectedEquipment smoke", () => {
 
     expect(screen.getByText("Lighting")).toBeTruthy();
     expect(screen.getByText("MA3 kit")).toBeTruthy();
-    expect(screen.getByText("MA3")).toBeTruthy();
     // Sub-hire group renders with its supplier + order number.
     expect(screen.getByText("Truss package")).toBeTruthy();
     expect(screen.getByText(/ACME Rigging/)).toBeTruthy();
     expect(screen.getByText(/SH-001/)).toBeTruthy();
-    expect(screen.getByText("6m truss")).toBeTruthy();
-    // The custom standalone item, tagged.
+    // The custom standalone item is not gated behind a group — always visible.
     expect(screen.getByText("Gaffer tape")).toBeTruthy();
     expect(screen.getByText("Custom")).toBeTruthy();
-    // No mutation affordances — a read-only render has no edit/delete controls.
-    expect(screen.queryByRole("button")).toBeNull();
+    // Matches the live tab's own default: groups/sub-hire groups collapsed on
+    // first render, so their child rows aren't in the DOM yet.
+    expect(screen.queryByText("MA3")).toBeNull();
+    expect(screen.queryByText("6m truss")).toBeNull();
     // The old "not captured" caveat is gone — sub-hires ARE captured now.
     expect(screen.queryByText(/Sub-hires and custom item ordering/)).toBeNull();
 
@@ -116,6 +116,14 @@ describe("VersionProjectedEquipment smoke", () => {
     expect(groupIdx).toBeGreaterThanOrEqual(0);
     expect(groupIdx).toBeLessThan(subHireIdx);
     expect(subHireIdx).toBeLessThan(customIdx);
+
+    // Expanding the group/sub-hire group toggles (chevron buttons) reveals
+    // their child rows — the read-only equivalent of the live tab's
+    // expandedGroups toggle, minus any edit/delete/drag affordances.
+    fireEvent.click(screen.getByRole("button", { name: /MA3 kit/ }));
+    expect(screen.getByText("MA3")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Truss package/ }));
+    expect(screen.getByText("6m truss")).toBeTruthy();
   });
 });
 

--- a/src/components/projects/version-projected-equipment.tsx
+++ b/src/components/projects/version-projected-equipment.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Boxes, Handshake } from "lucide-react";
+import { useState } from "react";
+import { Boxes, ChevronRight, Handshake } from "lucide-react";
 import { formatCurrency } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useProjectVersion } from "@/components/projects/project-version-context";
 import {
   reconstructProjectCategories,
@@ -26,17 +27,27 @@ import type { CategoryData, GroupData, LineItemData, SubHireGroupData, MixedGrou
  * by `categorySlots`) is byte-for-byte the same algorithm, not a second
  * hand-written shape (R-3.1).
  *
+ * Structurally mirrors `equipment-tab.tsx`'s desktop table ONE continuous
+ * `<table>` for every category + Uncategorized (not a card per category —
+ * that was this component's first pass, and it's why v1/v2 looked visibly
+ * different: category names as in-table header rows, same `colgroup`/column
+ * widths, groups/sub-hire groups collapsible and COLLAPSED BY DEFAULT
+ * (`expandedGroups` empty on mount), same as the live tab's own default.
+ * Collapse state is local, view-only React state — toggling it never touches
+ * data, so it's fine even though nothing else here is editable.
+ *
  * This is NOT `equipment-tab.tsx`'s row components (`GroupRow`/`LineItemRow`/
- * `SubHireGroupRow`) — those require several mutation callbacks (onEdit/
- * onDelete/onToggle/onAddEquipment/...) that aren't optional, and unconditionally
- * subscribe to LIVE collaboration comment counts keyed by the current item id,
- * which would be actively wrong here (a comment count sourced from "now" on a
- * row from three versions ago). This renders the SAME data
- * (`CategoryData`/`GroupData`/`SubHireGroupData`/`LineItemData`) and the same
- * `mixedGroups` order through genuinely static markup instead — visually
- * matching the live table's columns/grouping/totals, with zero editing
- * affordances (no buttons, no drag, no inline edit) since nothing here is
- * live to edit.
+ * `SubHireGroupRow`/`CategoryRow`) — those require several mutation callbacks
+ * (onEdit/onDelete/onToggle/onAddEquipment/...) that aren't optional, and
+ * `LineItemRow` unconditionally subscribes to LIVE collaboration comment
+ * counts keyed by the current item id, which would be actively wrong here (a
+ * comment count sourced from "now" on a row from three versions ago). This
+ * renders the SAME data (`CategoryData`/`GroupData`/`SubHireGroupData`/
+ * `LineItemData`) and the same `mixedGroups` order through markup styled to
+ * match those components' classes, with zero editing affordances (no
+ * buttons, no drag, no inline edit, no per-row badges beyond "Custom" — kit/
+ * subhire/sale/prep badges need asset/unit data this view doesn't have, see
+ * the bundle query's own scope note).
  *
  * `units` (per-serial fulfillment) and live availability/warehouse status are
  * still not shown, on purpose — see the file's own bundle query for why.
@@ -53,12 +64,27 @@ function groupTotal(g: GroupData): number {
   return Math.max(0, price * g.quantity - num(g.discount));
 }
 
-function LineRow({ item, indent }: { item: LineItemData; indent?: boolean }) {
+/** Toggle set for group/sub-hire-group collapse state — empty by default
+ *  (everything collapsed on first render), mirroring `equipment-tab.tsx`'s
+ *  own `expandedGroups` Set. */
+function useExpanded() {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  return { isExpanded: (id: string) => expanded.has(id), toggle };
+}
+
+function LineRow({ item, indent }: { item: LineItemData; indent?: string }) {
   const total = item.lineTotal != null ? num(item.lineTotal) : num(item.unitPrice) * item.quantity;
   return (
     <>
       <TableRow>
-        <TableCell className={cn(indent && "pl-8")}>
+        <TableCell className={indent}>
           <span className="truncate">{item.description || "Untitled item"}</span>
           {item.isCustomItem && (
             <Badge status="neutral" className="ml-2 align-middle">
@@ -66,105 +92,121 @@ function LineRow({ item, indent }: { item: LineItemData; indent?: boolean }) {
             </Badge>
           )}
         </TableCell>
-        <TableCell className="text-center tabular-nums">{item.quantity}</TableCell>
-        <TableCell className="text-right tabular-nums">{formatCurrency(num(item.unitPrice))}</TableCell>
-        <TableCell className="text-right tabular-nums">{formatCurrency(total)}</TableCell>
+        <TableCell className="text-center t-data">{item.quantity}</TableCell>
+        <TableCell className="text-right whitespace-nowrap t-data">{formatCurrency(num(item.unitPrice))}</TableCell>
+        <TableCell className="text-right font-medium whitespace-nowrap t-data">{formatCurrency(total)}</TableCell>
       </TableRow>
-      {item.childLineItems?.map((child) => <LineRow key={child.id} item={child} indent />)}
+      {item.childLineItems?.map((child) => <LineRow key={child.id} item={child} indent="pl-8" />)}
     </>
   );
 }
 
-function GroupRows({ group }: { group: GroupData }) {
+function GroupRows({ group, isExpanded, onToggle }: { group: GroupData; isExpanded: boolean; onToggle: () => void }) {
+  const items = group.lineItems ?? [];
   return (
     <>
-      <TableRow className="bg-card-2">
-        <TableCell className="font-semibold">{group.title || "Untitled group"}</TableCell>
-        <TableCell className="text-center tabular-nums">{group.quantity}</TableCell>
-        <TableCell className="text-right">—</TableCell>
-        <TableCell className="text-right font-semibold tabular-nums">{formatCurrency(groupTotal(group))}</TableCell>
-      </TableRow>
-      {(group.lineItems ?? []).map((li) => (
-        <LineRow key={li.id} item={li} indent />
-      ))}
-    </>
-  );
-}
-
-function SubHireGroupRows({ group }: { group: SubHireGroupData }) {
-  return (
-    <>
-      <TableRow className="bg-card-2">
-        <TableCell className="font-semibold">
-          <span className="inline-flex items-center gap-1.5">
-            <Handshake className="h-3.5 w-3.5 shrink-0 text-muted" aria-hidden />
-            {group.title || "Untitled sub-hire group"}
-            <Badge status="neutral">Sub-hire</Badge>
-          </span>
-          <span className="mt-0.5 block text-caption text-muted">
-            {group.subHire.supplier?.name ?? "Unknown supplier"} · {group.subHire.orderNumber}
-          </span>
+      <TableRow>
+        <TableCell>
+          <button type="button" onClick={onToggle} className="flex items-center gap-1.5 text-left">
+            <ChevronRight className={cn("h-4 w-4 shrink-0 text-muted transition-transform", isExpanded && "rotate-90")} />
+            <span className="font-semibold">{group.title || "Untitled group"}</span>
+          </button>
         </TableCell>
-        <TableCell className="text-center tabular-nums">{group.quantity}</TableCell>
-        <TableCell className="text-right">—</TableCell>
-        <TableCell className="text-right font-semibold tabular-nums">{formatCurrency(num(group.charge))}</TableCell>
+        <TableCell className="text-center t-data">{group.quantity}</TableCell>
+        <TableCell className="text-right whitespace-nowrap t-data text-faint">—</TableCell>
+        <TableCell className="text-right font-medium whitespace-nowrap t-data">{formatCurrency(groupTotal(group))}</TableCell>
       </TableRow>
-      {(group.items ?? []).map((it) => (
-        <TableRow key={it.id}>
-          <TableCell className="pl-8">{it.description || "Untitled item"}</TableCell>
-          <TableCell className="text-center tabular-nums">{it.quantity}</TableCell>
-          <TableCell className="text-right tabular-nums">{formatCurrency(num(it.unitCharge))}</TableCell>
-          <TableCell className="text-right tabular-nums">{formatCurrency(num(it.unitCharge) * it.quantity)}</TableCell>
-        </TableRow>
-      ))}
+      {isExpanded && items.map((li) => <LineRow key={li.id} item={li} indent="pl-8" />)}
     </>
+  );
+}
+
+function SubHireGroupRows({ group, isExpanded, onToggle }: { group: SubHireGroupData; isExpanded: boolean; onToggle: () => void }) {
+  const items = group.items ?? [];
+  return (
+    <>
+      <TableRow>
+        <TableCell>
+          <button type="button" onClick={onToggle} className="flex items-center gap-1.5 text-left">
+            <ChevronRight className={cn("h-4 w-4 shrink-0 text-muted transition-transform", isExpanded && "rotate-90")} />
+            <Handshake className="h-3.5 w-3.5 shrink-0 text-muted" aria-hidden />
+            <span className="font-semibold">{group.title || "Untitled sub-hire group"}</span>
+          </button>
+          <p className="mt-0.5 pl-[22px] text-caption text-muted">
+            {group.subHire.supplier?.name ?? "Unknown supplier"} · {group.subHire.orderNumber}
+          </p>
+        </TableCell>
+        <TableCell className="text-center t-data">{group.quantity}</TableCell>
+        <TableCell className="text-right whitespace-nowrap t-data text-faint">—</TableCell>
+        <TableCell className="text-right font-medium whitespace-nowrap t-data">{formatCurrency(num(group.charge))}</TableCell>
+      </TableRow>
+      {isExpanded &&
+        items.map((it) => (
+          <TableRow key={it.id}>
+            <TableCell className="pl-8">{it.description || "Untitled item"}</TableCell>
+            <TableCell className="text-center t-data">{it.quantity}</TableCell>
+            <TableCell className="text-right whitespace-nowrap t-data">{formatCurrency(num(it.unitCharge))}</TableCell>
+            <TableCell className="text-right font-medium whitespace-nowrap t-data">{formatCurrency(num(it.unitCharge) * it.quantity)}</TableCell>
+          </TableRow>
+        ))}
+    </>
+  );
+}
+
+/** Category name as an in-table header row — matches `CategoryRow`'s desktop
+ *  classes (`bg-paper-2/50`, `t-overline text-muted`) rather than a card
+ *  heading, since the live tab renders every category inside ONE table, not
+ *  one table per category. */
+function CategoryHeaderRow({ name }: { name: string }) {
+  return (
+    <TableRow className="border-b-0 bg-paper-2/50 hover:bg-paper-2/50">
+      <TableCell colSpan={4} className="py-2 t-overline text-muted">
+        {name || "Untitled category"}
+      </TableCell>
+    </TableRow>
   );
 }
 
 /** Walks a category's `mixedGroups` (the `categorySlots`-driven combined
  *  order) and renders each slot by kind — the same order the live tab's own
  *  walk produces, just without the Sortable/dnd-kit wrapping. */
-function CategoryBlock({ category }: { category: CategoryData }) {
+function CategoryRows({
+  category,
+  isExpanded,
+  toggle,
+}: {
+  category: CategoryData;
+  isExpanded: (id: string) => boolean;
+  toggle: (id: string) => void;
+}) {
   const slots: MixedGroupSlot[] = category.mixedGroups ?? [];
   const groupById = new Map((category.groups ?? []).map((g) => [g.id, g]));
   const subHireGroupById = new Map((category.subHireGroupTargets ?? []).map((g) => [g.id, g]));
   const lineItemById = new Map((category.lineItems ?? []).map((li) => [li.id, li]));
-  const isEmpty = slots.length === 0;
 
   return (
-    <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-4">
-      <h3 className="text-card-title font-bold text-ink">{category.name || "Untitled category"}</h3>
-      {isEmpty ? (
-        <p className="mt-2 text-caption text-muted">No equipment in this category.</p>
-      ) : (
-        <div className="mt-2 overflow-hidden rounded-[var(--r)] border border-line">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Item</TableHead>
-                <TableHead className="text-center">Qty</TableHead>
-                <TableHead className="text-right">Unit price</TableHead>
-                <TableHead className="text-right">Total</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {slots.map((slot) => {
-                if (slot.kind === "project") {
-                  const g = groupById.get(slot.projectGroupId);
-                  return g ? <GroupRows key={`g-${g.id}`} group={g} /> : null;
-                }
-                if (slot.kind === "subHire") {
-                  const sg = subHireGroupById.get(slot.subHireGroupId);
-                  return sg ? <SubHireGroupRows key={`sh-${sg.id}`} group={sg} /> : null;
-                }
-                const li = lineItemById.get(slot.lineItemId);
-                return li ? <LineRow key={`li-${li.id}`} item={li} /> : null;
-              })}
-            </TableBody>
-          </Table>
-        </div>
+    <>
+      <CategoryHeaderRow name={category.name} />
+      {slots.length === 0 && (
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={4} className="py-3 text-center text-caption text-muted">
+            No equipment in this category.
+          </TableCell>
+        </TableRow>
       )}
-    </div>
+      {slots.map((slot) => {
+        if (slot.kind === "project") {
+          const g = groupById.get(slot.projectGroupId);
+          return g ? <GroupRows key={`g-${g.id}`} group={g} isExpanded={isExpanded(g.id)} onToggle={() => toggle(g.id)} /> : null;
+        }
+        if (slot.kind === "subHire") {
+          const sg = subHireGroupById.get(slot.subHireGroupId);
+          return sg ? <SubHireGroupRows key={`sh-${sg.id}`} group={sg} isExpanded={isExpanded(sg.id)} onToggle={() => toggle(sg.id)} /> : null;
+        }
+        const li = lineItemById.get(slot.lineItemId);
+        return li ? <LineRow key={`li-${li.id}`} item={li} /> : null;
+      })}
+    </>
   );
 }
 
@@ -173,60 +215,67 @@ function CategoryBlock({ category }: { category: CategoryData }) {
  *  are NOT `categorySlots`-interleaved (that table is scoped by
  *  `projectCategoryId`, which none of these have) — same sequential
  *  groups-then-items convention the live tab uses for this bucket. */
-function UncategorizedBlock({
+function UncategorizedRows({
   groups,
   subHireGroups,
   lineItems,
+  isExpanded,
+  toggle,
 }: {
   groups: GroupData[];
   subHireGroups: SubHireGroupData[];
   lineItems: LineItemData[];
+  isExpanded: (id: string) => boolean;
+  toggle: (id: string) => void;
 }) {
   if (groups.length === 0 && subHireGroups.length === 0 && lineItems.length === 0) return null;
   return (
-    <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-4">
-      <h3 className="text-card-title font-bold text-ink">Uncategorized</h3>
-      <div className="mt-2 overflow-hidden rounded-[var(--r)] border border-line">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Item</TableHead>
-              <TableHead className="text-center">Qty</TableHead>
-              <TableHead className="text-right">Unit price</TableHead>
-              <TableHead className="text-right">Total</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {groups.map((g) => (
-              <GroupRows key={`g-${g.id}`} group={g} />
-            ))}
-            {subHireGroups.map((sg) => (
-              <SubHireGroupRows key={`sh-${sg.id}`} group={sg} />
-            ))}
-            {lineItems.map((li) => (
-              <LineRow key={`li-${li.id}`} item={li} />
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+    <>
+      <CategoryHeaderRow name="Uncategorized" />
+      {groups.map((g) => (
+        <GroupRows key={`g-${g.id}`} group={g} isExpanded={isExpanded(g.id)} onToggle={() => toggle(g.id)} />
+      ))}
+      {subHireGroups.map((sg) => (
+        <SubHireGroupRows key={`sh-${sg.id}`} group={sg} isExpanded={isExpanded(sg.id)} onToggle={() => toggle(sg.id)} />
+      ))}
+      {lineItems.map((li) => (
+        <LineRow key={`li-${li.id}`} item={li} />
+      ))}
+    </>
+  );
+}
+
+function LoadingState({ viewingRevision }: { viewingRevision: number | null }) {
+  return (
+    <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-6 text-center text-muted">
+      Loading v{viewingRevision}…
+    </div>
+  );
+}
+
+function NoBundleState({ viewingRevision }: { viewingRevision: number | null }) {
+  return (
+    <div className="flex items-start gap-2 rounded-[var(--r)] border border-line bg-card px-3 py-2 text-caption text-muted">
+      <Boxes className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span>No equipment captured for v{viewingRevision}.</span>
+    </div>
+  );
+}
+
+function EmptyState({ viewingRevision }: { viewingRevision: number | null }) {
+  return (
+    <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-6 text-center text-muted">
+      No equipment captured for v{viewingRevision}.
     </div>
   );
 }
 
 export function VersionProjectedEquipment() {
   const { isLoadingProjection, viewingRevision, equipmentBundle, isLoadingEquipmentBundle } = useProjectVersion();
+  const { isExpanded, toggle } = useExpanded();
 
-  if (isLoadingProjection || isLoadingEquipmentBundle) {
-    return <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-6 text-center text-muted">Loading v{viewingRevision}…</div>;
-  }
-  if (!equipmentBundle) {
-    return (
-      <div className="flex items-start gap-2 rounded-[var(--r)] border border-line bg-card px-3 py-2 text-caption text-muted">
-        <Boxes className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span>No equipment captured for v{viewingRevision}.</span>
-      </div>
-    );
-  }
+  if (isLoadingProjection || isLoadingEquipmentBundle) return <LoadingState viewingRevision={viewingRevision} />;
+  if (!equipmentBundle) return <NoBundleState viewingRevision={viewingRevision} />;
 
   const bundle = equipmentBundle as unknown as EquipmentTabBundleData;
   const categories = reconstructProjectCategories(bundle);
@@ -239,24 +288,38 @@ export function VersionProjectedEquipment() {
     uncategorizedSubHireGroups.length === 0 &&
     uncategorizedProjectGroups.length === 0;
 
-  if (isEmpty) {
-    return (
-      <div className="rounded-[var(--r-lg)] border-2 border-line bg-card p-6 text-center text-muted">
-        No equipment captured for v{viewingRevision}.
-      </div>
-    );
-  }
+  if (isEmpty) return <EmptyState viewingRevision={viewingRevision} />;
 
   return (
-    <div className="space-y-4">
-      {categories.map((c) => (
-        <CategoryBlock key={c.id} category={c} />
-      ))}
-      <UncategorizedBlock
-        groups={uncategorizedProjectGroups}
-        subHireGroups={uncategorizedSubHireGroups}
-        lineItems={uncategorizedLineItems}
-      />
+    <div className="overflow-x-auto rounded-[var(--r)] border border-line">
+      <table className="w-full caption-bottom text-[13.5px] table-fixed">
+        <colgroup>
+          <col />
+          <col className="w-16" />
+          <col className="w-28" />
+          <col className="w-28" />
+        </colgroup>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Item</TableHead>
+            <TableHead className="text-center">Qty</TableHead>
+            <TableHead className="text-right whitespace-nowrap">Unit price</TableHead>
+            <TableHead className="text-right whitespace-nowrap">Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {categories.map((c) => (
+            <CategoryRows key={c.id} category={c} isExpanded={isExpanded} toggle={toggle} />
+          ))}
+          <UncategorizedRows
+            groups={uncategorizedProjectGroups}
+            subHireGroups={uncategorizedSubHireGroups}
+            lineItems={uncategorizedLineItems}
+            isExpanded={isExpanded}
+            toggle={toggle}
+          />
+        </TableBody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Follow-up to #1146 (Phase 6 equipment-parity data layer). Feedback on the live version was that v1 (live) and v2 (viewing a saved version) didn't look the same, even though the underlying data (sub-hires, custom items, `categorySlots` ordering) was already identical.
- Rebuilds `version-projected-equipment.tsx` from a bordered card-per-category layout (always-expanded groups) into **one continuous `<table>`** with in-table category header rows, matching `equipment-tab.tsx`'s exact wrapper/`colgroup`/header structure.
- Groups and sub-hire groups are now collapsible via a chevron toggle, **collapsed by default** — the read-only equivalent of the live tab's own `expandedGroups` state, instead of always rendering every child row.
- No change to the data/ordering pipeline — still `reconstructProjectCategories`/`reconstructUncategorized*` (`@/lib/equipment-tab-reconstruct.ts`) feeding the render, so `categorySlots` interleaving stays byte-for-byte identical to the live bundle.
- Updated `FEATUREDOCS/70-project-version-switcher.md`'s Phase 6 section to document the structural revision.

## Testing

- `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- `pnpm exec eslint` (touched files + full repo) — 0 errors, no new warnings
- `pnpm exec vitest run` — full suite, 478 files / 5943 tests passing
- Updated `src/components/projects/__tests__/version-projected-views.smoke.test.tsx` for the new default-collapsed behavior (chevron-toggle buttons now legitimately exist; asserts child rows are absent until clicked, then appear after)
- Local hygiene ratchets all pass at baseline: `collect-ratchet`, `knip-ratchet`, `complexity-ratchet`, `xtenant-bycuid-ratchet`, `check-client-routes`
- `api:registry:check`, `api:docs:check`, `api:mcp:check`, `mira:feature-map:check` — all current

## Checklist

- [x] No new dependency introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_011wGwwKYMEJei2gEBDe9eiT)_