### PR TITLE
B1: org-creation gate (site-admin toggle + signup code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#1092** — A brand-new account with no organisation and no pending invite
+  now lands on `/welcome`, a fork between "Set up a new company" and "Join my
+  team" — instead of dead-ending on the old onboarding bounce. The create
+  option disappears automatically when a site admin has org creation switched
+  off; an invite link still skips the fork entirely and goes straight to
+  accepting it.
+
 - **#1095** — Site admins can now gate who's allowed to create a new
   organisation on this platform: an on/off toggle, and an optional signup
   code (with copy/regenerate) required in addition. The code is never shown

--- a/FEATUREDOCS/04-auth-permissions.md
+++ b/FEATUREDOCS/04-auth-permissions.md
@@ -32,12 +32,14 @@ or the gate check itself. Verification is constant-time
 (`checkOrgCreationRateLimit`, `convex/siteSettings.ts`, 5/hour) — **not** per-IP,
 since neither Better Auth hook exposes the request in this version (1.6.25); see
 `org-creation-gate.ts`'s doc comment for the scope note. `getOrgCreationPolicy`
-(any authenticated user) is the status check the not-yet-built B1 fork screen
-(#1092) will use to decide whether to show a "set up a new company" option and
-whether to prompt for a code — it never returns the code itself. Additional orgs
-can also still be created by a site admin directly (`adminCreateOrganization`,
-`src/server/site-admin.ts`), which is not code-gated (a site admin is already
-trusted).
+(any authenticated user) is the status check `/welcome` (the B1 fork screen,
+#1092) uses to decide whether to show a "set up a new company" card at all,
+and whether `/onboarding` — the "Set up a new company" destination — should
+render a signup-code field. It never returns the code itself; hiding the card
+or the field is cosmetic only, `beforeCreateOrganization` is the real gate
+either way (R-9.3). Additional orgs can also still be created by a site admin
+directly (`adminCreateOrganization`, `src/server/site-admin.ts`), which is not
+code-gated (a site admin is already trusted).
 
 ### Org resolution: the session, re-validated (`src/lib/auth-server.ts`)
 - `requireOrganization()` / `getActiveOrganizationId()` resolve the **active org from
@@ -61,10 +63,20 @@ SSO auto-provisioning (`handleSSOProvisioning`, AUTO_CREATE mode), org-create
 `adminAddMemberToOrg`). The `user.create` database hook's old single-org auto-join
 (every new signup silently joined "the org") was deleted (#1071, A1) — a fresh
 signup with no invite and no org to bootstrap lands with **zero** memberships and is
-routed to `/onboarding`. **Known gap:** with `registrationPolicy: OPEN` and no
-pending invite, that onboarding visit dead-ends once an org already exists (org
-creation is gated off, D7) — the "request to join" flow that resolves this
-(`DOMAIN_REQUEST` join policy, design doc §4.3) hasn't landed yet.
+routed to `/welcome`, the create-vs-join fork (#1092, B1) — same target every other
+0-org entry point uses (login, register, `/no-organization`, and the authenticated
+app-shell gate in `src/app/(app)/layout.tsx`). An invite signup never sees the fork
+at all: `register/page.tsx` routes straight to `/invite/[id]` when an `invite` query
+param is present.
+
+`/welcome`'s "Set up a new company" card is hidden outright when `getOrgCreationPolicy()`
+returns `allowed: false` (site admin has org creation switched off, D7's soak
+posture); its "Join my team" card is always shown, but — since #1067's B2 (invite-code
+entry + verified-domain request-to-join) hasn't landed yet — leads to an inline
+"ask your admin to send you an invite link" panel rather than a real join flow. **Known
+gap:** that's the one still open. A user with an `@bigcorp.com` email and no invite
+still has no self-serve way to request into an org that domain belongs to
+(`DOMAIN_REQUEST` join policy, design doc §4.3) until B2 ships.
 
 ### Which org(s) does this user belong to? (`src/server/public-org.ts`)
 - `getMyOrganizations()` — the calling session's memberships (`{ id, name, slug,
@@ -378,7 +390,7 @@ consumer of this same identity kind — **FEATUREDOCS/68**.
 - **Server actions**: `src/server/invitations.ts` — `getMyPendingInvitations()`, `getInvitationEmail()`, `checkIsSiteAdmin()`, `getInvitationOrganizationId()`.
 - Each invitation targets a specific org (`Invitation.organizationId`) — the invite-accept page resolves which org to activate from the invitation row itself via `getInvitationOrganizationId()`, not a single-org assumption.
 - **Membership always requires the recipient's consent (#1073, A3).** `addMemberByEmail` (`src/server/settings.ts`, the "Invite" control on `/settings/team`) creates an `Invitation` and emails an accept link (`/invite/[id]`) for EVERY case — including an email that already has an account. There is no direct-add path: under multi-tenancy, silently creating a `Member` row for a known email would let any org owner pull a stranger's account into their org with no consent, putting an unwanted org in that person's switcher. `/invite/[id]` itself branches on whether the recipient is already signed in (accept immediately) or needs to sign in/register first — the invite email is the same either way (`invitationEmail`, not a register-specific template).
-- **Known gap, not built yet**: a per-org join policy (`INVITE_ONLY` | `DOMAIN_REQUEST` | `CLOSED`, distinct from the platform-global `registrationPolicy` above) is designed (`docs/designs/onboarding-and-activation.md` §2.4/§4.3) but has no consumer until Phase B's (#1067) create-vs-join signup fork exists — there's currently no self-serve "request to join an org" flow for it to gate, so it wasn't added as an inert setting. Revisit alongside #1067.
+- **Known gap, not built yet**: a per-org join policy (`INVITE_ONLY` | `DOMAIN_REQUEST` | `CLOSED`, distinct from the platform-global `registrationPolicy` above) is designed (`docs/designs/onboarding-and-activation.md` §2.4/§4.3) but has no consumer yet. The create-vs-join fork itself shipped (`/welcome`, #1092, B1) — its "Join my team" card is live — but the fork only points at an "ask your admin for an invite link" placeholder today, since #1067's B2 (invite-code entry + verified-domain request-to-join, the actual consumer of this join policy) hasn't landed. Revisit alongside B2.
 
 ### Account Page Sections
 The `/account` page is organized into: Profile (avatar + name), Security (password, 2FA, passkeys, connected accounts), Active Sessions.

--- a/e2e/harness-a11y.spec.ts
+++ b/e2e/harness-a11y.spec.ts
@@ -16,7 +16,9 @@ test.describe("harness: a11y (authenticated)", () => {
     await page.getByLabel(/email/i).first().fill(email);
     await page.getByLabel(/password/i).first().fill("harness-password-123");
     await page.getByRole("button", { name: /create|register|sign up/i }).first().click();
-    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    // A fresh registration with no org lands on the create-vs-join fork
+    // (/welcome, #1092) rather than an authenticated dashboard directly.
+    await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
     await page.waitForLoadState("networkidle");
 
     const results = await new AxeBuilder({ page })

--- a/e2e/harness-auth.spec.ts
+++ b/e2e/harness-auth.spec.ts
@@ -26,7 +26,8 @@ test.describe("harness: authenticated flow", () => {
       .first()
       .click();
 
-    // First user bootstraps as admin and lands on the dashboard (or onboarding).
-    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    // First user bootstraps as admin and lands on the dashboard, or — with no
+    // org yet — the create-vs-join fork (/welcome, #1092).
+    await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
   });
 });

--- a/e2e/harness-cookie-flags.spec.ts
+++ b/e2e/harness-cookie-flags.spec.ts
@@ -18,7 +18,9 @@ test.describe("harness: session cookie flags", () => {
     await page.getByLabel(/email/i).first().fill(email);
     await page.getByLabel(/password/i).first().fill("harness-password-123");
     await page.getByRole("button", { name: /create|register|sign up/i }).first().click();
-    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    // A fresh registration with no org lands on the create-vs-join fork
+    // (/welcome, #1092) rather than an authenticated dashboard directly.
+    await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
 
     const cookies = await context.cookies();
     const session = cookies.find((c) => /better-auth\.session_token/.test(c.name));

--- a/e2e/harness-create-inventory.spec.ts
+++ b/e2e/harness-create-inventory.spec.ts
@@ -36,10 +36,16 @@ test.describe("harness: create inventory", () => {
         .getByRole("button", { name: /create|register|sign up/i })
         .first()
         .click();
-      await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+      // A fresh registration with no org lands on the create-vs-join fork
+      // (/welcome, #1092) rather than an authenticated dashboard directly.
+      await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
     });
 
     await test.step("complete onboarding (create the org) if needed", async () => {
+      if (new URL(page.url()).pathname === "/welcome") {
+        await page.getByRole("button", { name: "Set up a new company" }).click();
+        await expect(page).toHaveURL(/\/onboarding\b/, { timeout: 20000 });
+      }
       if (new URL(page.url()).pathname === "/onboarding") {
         await page.getByLabel("Organization name").fill(`Inventory Org ${unique}`);
         await page.getByRole("button", { name: "Create organization" }).click();

--- a/e2e/harness-onboarding.spec.ts
+++ b/e2e/harness-onboarding.spec.ts
@@ -39,11 +39,18 @@ test.describe("harness: register / onboarding", () => {
       .getByRole("button", { name: /create|register|sign up/i })
       .first()
       .click();
-    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    // A fresh registration with no org lands on the create-vs-join fork
+    // (/welcome, #1092) rather than an authenticated dashboard directly.
+    await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
 
     // The first user on a fresh harness has no org yet, so the (app) layout
-    // redirects every protected route to /onboarding (src/app/(app)/layout.tsx)
-    // until one is created.
+    // redirects every protected route to /welcome (src/app/(app)/layout.tsx)
+    // until one is created. "Set up a new company" leads to /onboarding, the
+    // actual create-org form.
+    if (new URL(page.url()).pathname === "/welcome") {
+      await page.getByRole("button", { name: "Set up a new company" }).click();
+      await expect(page).toHaveURL(/\/onboarding\b/, { timeout: 20000 });
+    }
     if (new URL(page.url()).pathname === "/onboarding") {
       await page.getByLabel("Organization name").fill(orgName);
       await page.getByRole("button", { name: "Create organization" }).click();

--- a/e2e/harness-revenue-path.spec.ts
+++ b/e2e/harness-revenue-path.spec.ts
@@ -96,14 +96,21 @@ test.describe("harness: primary revenue path", () => {
         .getByRole("button", { name: /create|register|sign up/i })
         .first()
         .click();
-      await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+      // A fresh registration with no org lands on the create-vs-join fork
+      // (/welcome, #1092) rather than an authenticated dashboard directly.
+      await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
     });
 
     await test.step("complete onboarding (create the org) if needed", async () => {
-      // The (app) layout redirects every route to /onboarding until an org
+      // The (app) layout redirects every route to /welcome until an org
       // exists (src/app/(app)/layout.tsx) — a fresh registration on this harness
       // has no org yet, so this step is required before any protected page
-      // (the model/asset/project forms below) will render at all.
+      // (the model/asset/project forms below) will render at all. "Set up a
+      // new company" leads to /onboarding, the actual create-org form.
+      if (new URL(page.url()).pathname === "/welcome") {
+        await page.getByRole("button", { name: "Set up a new company" }).click();
+        await expect(page).toHaveURL(/\/onboarding\b/, { timeout: 20000 });
+      }
       if (new URL(page.url()).pathname === "/onboarding") {
         await page.getByLabel("Organization name").fill(`Revenue Path Org ${unique}`);
         await page.getByRole("button", { name: "Create organization" }).click();

--- a/e2e/harness-sign-out.spec.ts
+++ b/e2e/harness-sign-out.spec.ts
@@ -37,11 +37,18 @@ test.describe("harness: sign out", () => {
       .getByRole("button", { name: /create|register|sign up/i })
       .first()
       .click();
-    await expect(page).toHaveURL(/\/(dashboard|onboarding)\b/, { timeout: 20000 });
+    // A fresh registration with no org lands on the create-vs-join fork
+    // (/welcome, #1092) rather than an authenticated dashboard directly.
+    await expect(page).toHaveURL(/\/(dashboard|welcome)\b/, { timeout: 20000 });
 
     // Run standalone against a fresh harness, this is the first-ever user, so
-    // the (app) layout redirects to /onboarding (no org yet) — which has no
-    // UserNav, so "Account menu" below wouldn't exist without this.
+    // the (app) layout redirects to /welcome (no org yet) — which has no
+    // UserNav, so "Account menu" below wouldn't exist without completing it.
+    // "Set up a new company" leads to /onboarding, the actual create-org form.
+    if (new URL(page.url()).pathname === "/welcome") {
+      await page.getByRole("button", { name: "Set up a new company" }).click();
+      await expect(page).toHaveURL(/\/onboarding\b/, { timeout: 20000 });
+    }
     if (new URL(page.url()).pathname === "/onboarding") {
       await page.getByLabel("Organization name").fill(`Sign Out Org ${unique}`);
       await page.getByRole("button", { name: "Create organization" }).click();

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -20,16 +20,16 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     redirect("/login");
   }
 
-  // If the user belongs to no LIVE org, either they never had one (→
-  // onboarding, #1071 A1) or every one of theirs is archived (→ an
-  // explanatory screen, not the create-org form — #1075 A5). The org switcher
-  // / picker for 2+ memberships is handled client-side via OrgActivator.
+  // If the user belongs to no LIVE org, either they never had one (→ the
+  // create-vs-join fork, #1092 B1) or every one of theirs is archived (→ an
+  // explanatory screen, not the fork — #1075 A5). The org switcher / picker
+  // for 2+ memberships is handled client-side via OrgActivator.
   const myOrgs = await getMyOrganizations();
   if (myOrgs.length === 0) {
     if (await hasOnlyArchivedMemberships()) {
       redirect("/organization-archived");
     }
-    redirect("/onboarding");
+    redirect("/welcome");
   }
 
   return (

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -56,7 +56,7 @@ async function resolveSSOProviderForEmail(
 async function handlePostLogin(router: ReturnType<typeof useRouter>, callbackUrl: string | null) {
   const orgs = await getMyOrganizations();
   if (orgs.length === 0) {
-    router.push("/onboarding");
+    router.push("/welcome");
     return;
   }
   if (orgs.length === 1) {

--- a/src/app/(auth)/no-organization/page.tsx
+++ b/src/app/(auth)/no-organization/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+// A user with zero orgs is never stranded here (#1092, B1) — this becomes
+// the create-vs-join fork, not a dead end.
 export default function NoOrganizationPage() {
-  redirect("/onboarding");
+  redirect("/welcome");
 }

--- a/src/app/(auth)/onboarding/__tests__/page.smoke.test.tsx
+++ b/src/app/(auth)/onboarding/__tests__/page.smoke.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// Smoke test for the org-creation form's B1 wiring (#1092): it's the "Set up
+// a new company" destination from /welcome, so it must (a) bounce away if
+// org creation has since been gated off rather than show a form the server
+// will refuse anyway, and (b) collect + submit the signup code when the gate
+// requires one, via the same `organization.create({ metadata: { orgCreationCode
+// } })` shape src/lib/auth.ts's beforeCreateOrganization expects.
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// See the sibling /welcome smoke test for why these go through vi.hoisted()
+// rather than bare top-level consts: vi.mock factories are hoisted above
+// every import/const in this file.
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  create: vi.fn(async () => ({ data: { id: "org1" }, error: null as { message: string } | null })),
+  setActive: vi.fn(async () => undefined),
+  getOrgCreationPolicy: vi.fn(async () => ({ allowed: true, codeRequired: false })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace, back: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("@/lib/auth-client", () => ({
+  organization: { create: mocks.create, setActive: mocks.setActive },
+}));
+vi.mock("@/server/public-org", () => ({
+  getMyOrganizations: () => Promise.resolve([]),
+  mirrorMyMembership: () => Promise.resolve(undefined),
+  seedOrgDefaultTaxRate: () => Promise.resolve(undefined),
+}));
+vi.mock("@/server/site-admin", () => ({
+  getOrgCreationPolicy: mocks.getOrgCreationPolicy,
+}));
+
+import OnboardingPage from "../page";
+
+beforeEach(() => {
+  mocks.push.mockClear();
+  mocks.replace.mockClear();
+  mocks.create.mockClear();
+  mocks.setActive.mockClear();
+  mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: true, codeRequired: false });
+});
+
+describe("OnboardingPage (smoke)", () => {
+  it("bounces to /welcome when org creation has been gated off", async () => {
+    mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: false, codeRequired: false });
+    render(<OnboardingPage />);
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/welcome"));
+  });
+
+  it("does not render a signup-code field when none is required", async () => {
+    render(<OnboardingPage />);
+    await screen.findByLabelText("Organization name");
+    expect(screen.queryByLabelText("Signup code")).toBeNull();
+  });
+
+  it("renders and submits a signup-code field when the gate requires one", async () => {
+    mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: true, codeRequired: true });
+    const user = userEvent.setup();
+    render(<OnboardingPage />);
+
+    const codeInput = await screen.findByLabelText("Signup code");
+    await user.type(await screen.findByLabelText("Organization name"), "Acme Productions");
+    await user.type(codeInput, "abc123");
+    await user.click(screen.getByRole("button", { name: /create organization/i }));
+
+    await waitFor(() =>
+      expect(mocks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Acme Productions",
+          metadata: { orgCreationCode: "abc123" },
+        }),
+      ),
+    );
+  });
+});

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { organization } from "@/lib/auth-client";
 import { getMyOrganizations, mirrorMyMembership, seedOrgDefaultTaxRate } from "@/server/public-org";
+import { getOrgCreationPolicy } from "@/server/site-admin";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,7 +24,9 @@ export default function OnboardingPage() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
+  const [codeRequired, setCodeRequired] = useState(false);
 
   // Redirect away if the user already belongs to an org. Guard on a cancelled
   // flag: if the user navigates away before this async check resolves, the
@@ -38,6 +41,26 @@ export default function OnboardingPage() {
     };
   }, [router]);
 
+  // This form is the "Set up a new company" branch of /welcome (#1092, B1) —
+  // if a site admin has switched org creation off since the fork screen was
+  // rendered (or someone bookmarked this URL directly), bounce back rather
+  // than show a form the server will refuse anyway (R-9.3: hiding it here is
+  // cosmetic, `beforeCreateOrganization` is the real gate either way).
+  useEffect(() => {
+    let cancelled = false;
+    getOrgCreationPolicy().then((policy) => {
+      if (cancelled) return;
+      if (!policy.allowed) {
+        router.replace("/welcome");
+        return;
+      }
+      setCodeRequired(policy.codeRequired);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
   const handleNameChange = (value: string) => {
     setName(value);
     setSlug(slugify(value));
@@ -45,12 +68,16 @@ export default function OnboardingPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || !slug.trim()) return;
+    if (!name.trim() || !slug.trim() || (codeRequired && !code.trim())) return;
     setLoading(true);
     try {
       const result = await organization.create({
         name: name.trim(),
         slug: slug.trim(),
+        // Verified server-side in beforeCreateOrganization (src/lib/auth.ts) —
+        // stripped from the persisted org row either way (it's a one-time
+        // proof of authorization, not org data).
+        ...(codeRequired ? { metadata: { orgCreationCode: code.trim() } } : {}),
       });
       if (result.error) {
         toast.error(result.error.message || "Failed to create organization");
@@ -116,6 +143,19 @@ export default function OnboardingPage() {
               Used internally. Only lowercase letters, numbers, and hyphens.
             </p>
           </div>
+          {codeRequired && (
+            <div className="space-y-2">
+              <Label htmlFor="org-creation-code">Signup code</Label>
+              <Input
+                id="org-creation-code"
+                type="text"
+                placeholder="Ask your admin for this"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                required
+              />
+            </div>
+          )}
           <Button type="submit" className="w-full" disabled={loading}>
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Create organization

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -73,7 +73,7 @@ function RegisterContent() {
             await organization.setActive({ organizationId: orgs[0].id });
             router.push("/dashboard");
           } else {
-            router.push("/onboarding");
+            router.push("/welcome");
           }
         }
       }

--- a/src/app/(auth)/select-organization/page.tsx
+++ b/src/app/(auth)/select-organization/page.tsx
@@ -31,7 +31,7 @@ function SelectOrganizationContent() {
       if (cancelled) return;
       // 0 or 1 memberships don't belong on this page — bounce to where they do.
       if (result.length === 0) {
-        router.replace("/onboarding");
+        router.replace("/welcome");
         return;
       }
       if (result.length === 1) {

--- a/src/app/(auth)/welcome/__tests__/page.smoke.test.tsx
+++ b/src/app/(auth)/welcome/__tests__/page.smoke.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// Smoke test for the create-vs-join fork screen (#1092, B1). Covers the
+// three behaviours the issue's exit criteria call out: the create-company
+// card disappears when org creation is gated off (hiding it is cosmetic —
+// the server enforces the gate regardless, R-9.3), the join card never
+// navigates anywhere since B2 (#1067) hasn't landed yet, and a user who
+// already has exactly one org is bounced away rather than shown the fork.
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// vi.mock factories are hoisted above every import/const in this file, so
+// anything they close over must itself come from vi.hoisted() — a bare
+// top-level const referenced directly in the object literal a factory
+// returns is read before its own initializer runs (TDZ), not merely before
+// the test body executes.
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  setActive: vi.fn(async () => undefined),
+  signOut: vi.fn(async () => undefined),
+  getMyOrganizations: vi.fn(async () => [] as { id: string; name: string; slug: string; role: string }[]),
+  getOrgCreationPolicy: vi.fn(async () => ({ allowed: true, codeRequired: false })),
+  sessionData: {
+    user: { name: "Sam Roadie", email: "sam@northlight.com.au" },
+  } as { user: { name: string; email: string } } | null,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace, back: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("@/lib/auth-client", () => ({
+  organization: { setActive: mocks.setActive },
+  signOut: mocks.signOut,
+  useSession: () => ({ data: mocks.sessionData }),
+}));
+vi.mock("@/server/public-org", () => ({
+  getMyOrganizations: mocks.getMyOrganizations,
+}));
+vi.mock("@/server/site-admin", () => ({
+  getOrgCreationPolicy: mocks.getOrgCreationPolicy,
+}));
+
+import WelcomePage from "../page";
+
+beforeEach(() => {
+  mocks.push.mockClear();
+  mocks.replace.mockClear();
+  mocks.setActive.mockClear();
+  mocks.signOut.mockClear();
+  mocks.getMyOrganizations.mockResolvedValue([]);
+  mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: true, codeRequired: false });
+  mocks.sessionData = { user: { name: "Sam Roadie", email: "sam@northlight.com.au" } };
+});
+
+describe("WelcomePage (smoke)", () => {
+  it("shows both fork cards when org creation is allowed", async () => {
+    render(<WelcomePage />);
+    expect(await screen.findByText("Set up a new company")).toBeTruthy();
+    expect(screen.getByText("Join my team")).toBeTruthy();
+  });
+
+  it("hides the create-company card when org creation is gated off", async () => {
+    mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: false, codeRequired: false });
+    render(<WelcomePage />);
+    expect(await screen.findByText("Join my team")).toBeTruthy();
+    expect(screen.queryByText("Set up a new company")).toBeNull();
+  });
+
+  it("routes 'Set up a new company' to /onboarding", async () => {
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Set up a new company"));
+    expect(mocks.push).toHaveBeenCalledWith("/onboarding");
+  });
+
+  it("'Join my team' shows an in-flow placeholder instead of navigating", async () => {
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Join my team"));
+    expect(
+      await screen.findByText(/You'll need an invite from whoever runs your organisation/),
+    ).toBeTruthy();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("bounces a user who already has exactly one org to /dashboard", async () => {
+    mocks.getMyOrganizations.mockResolvedValue([{ id: "org1", name: "Acme", slug: "acme", role: "owner" }]);
+    render(<WelcomePage />);
+    await waitFor(() => expect(mocks.setActive).toHaveBeenCalledWith({ organizationId: "org1" }));
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("sends a user with 2+ orgs to /select-organization", async () => {
+    mocks.getMyOrganizations.mockResolvedValue([
+      { id: "org1", name: "Acme", slug: "acme", role: "owner" },
+      { id: "org2", name: "Beta", slug: "beta", role: "member" },
+    ]);
+    render(<WelcomePage />);
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/select-organization"));
+  });
+});

--- a/src/app/(auth)/welcome/page.tsx
+++ b/src/app/(auth)/welcome/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+// use-client: interactive — session/org-creation-policy fetch + branch state (R-8.1.1)
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { organization, signOut, useSession } from "@/lib/auth-client";
+import { getMyOrganizations } from "@/server/public-org";
+import { getOrgCreationPolicy } from "@/server/site-admin";
+import { AuthShell } from "../auth-playful";
+import { cn } from "@/lib/utils";
+import { Loader2, Building2, Users2, ArrowLeft } from "lucide-react";
+
+/**
+ * `/welcome` — B1 (#1092), the create-vs-join fork. Reached by a signed-in
+ * user with zero live org memberships and no pending invite (invite signups
+ * skip this entirely — register/page.tsx routes them straight to
+ * /invite/[id]). `/no-organization` and every 0-org redirect in the app now
+ * land here instead of the old dead-end `/onboarding` bounce.
+ */
+export default function WelcomePage() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [policy, setPolicy] = useState<{ allowed: boolean; codeRequired: boolean } | null>(null);
+  const [view, setView] = useState<"fork" | "join">("fork");
+
+  // A user who actually has a live org (arrived here via a stale bookmark, or
+  // a second tab that just accepted an invite) never sees the fork — bounce
+  // them to where they belong, same 0/1/2+ resolution as login/register.
+  useEffect(() => {
+    let cancelled = false;
+    getMyOrganizations().then(async (orgs) => {
+      if (cancelled) return;
+      if (orgs.length === 1) {
+        await organization.setActive({ organizationId: orgs[0].id });
+        router.replace("/dashboard");
+      } else if (orgs.length > 1) {
+        router.replace("/select-organization");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  useEffect(() => {
+    let cancelled = false;
+    getOrgCreationPolicy().then((p) => {
+      if (!cancelled) setPolicy(p);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleNotYou = async () => {
+    await signOut();
+    router.push("/login");
+  };
+
+  if (view === "join") {
+    return <JoinPlaceholder onBack={() => setView("fork")} />;
+  }
+
+  return (
+    <ForkView
+      session={session}
+      policy={policy}
+      onCreateCompany={() => router.push("/onboarding")}
+      onJoinTeam={() => setView("join")}
+      onNotYou={handleNotYou}
+    />
+  );
+}
+
+function ForkView({
+  session,
+  policy,
+  onCreateCompany,
+  onJoinTeam,
+  onNotYou,
+}: {
+  session: ReturnType<typeof useSession>["data"];
+  policy: { allowed: boolean; codeRequired: boolean } | null;
+  onCreateCompany: () => void;
+  onJoinTeam: () => void;
+  onNotYou: () => void;
+}) {
+  return (
+    <AuthShell accent="welcome" annotation="pick a lane — you can change it later.">
+      <ForkHeader name={session?.user?.name} />
+
+      <div className="space-y-3">
+        {policy === null ? (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-6 w-6 animate-spin text-muted" />
+          </div>
+        ) : (
+          <>
+            {policy.allowed && (
+              <ForkCard
+                primary
+                icon={<Building2 className="h-[18px] w-[18px]" />}
+                title="Set up a new company"
+                desc="You run the gear. We'll walk you through tax, branding and numbering."
+                onClick={onCreateCompany}
+              />
+            )}
+            <ForkCard
+              icon={<Users2 className="h-[18px] w-[18px]" />}
+              title="Join my team"
+              desc="Someone already set it up. Use an invite link, or ask to be let in."
+              onClick={onJoinTeam}
+            />
+          </>
+        )}
+      </div>
+
+      {session?.user?.email ? <SignedInAs email={session.user.email} onNotYou={onNotYou} /> : null}
+    </AuthShell>
+  );
+}
+
+function ForkHeader({ name }: { name: string | undefined }) {
+  return (
+    <div className="mb-6">
+      {name ? <p className="t-annotation text-[15px] text-red">Welcome, {name.split(" ")[0]}</p> : null}
+      <h1 className="t-title text-ink">What brings you here?</h1>
+      <p className="mt-1 text-sm text-muted">You can change this later — nothing is locked in.</p>
+    </div>
+  );
+}
+
+function SignedInAs({ email, onNotYou }: { email: string; onNotYou: () => void }) {
+  return (
+    <p className="mt-6 text-center text-sm text-muted">
+      Signed in as <span className="font-mono text-xs text-ink-2">{email}</span>
+      {" · "}
+      <button type="button" onClick={onNotYou} className="text-link hover:underline">
+        Not you?
+      </button>
+    </p>
+  );
+}
+
+/**
+ * Placeholder destination for "Join my team" until #1067's B2 (invite-code
+ * entry + verified-domain request-to-join) ships. Never strands the user —
+ * just points them at the invite-link path that already works end to end.
+ */
+function JoinPlaceholder({ onBack }: { onBack: () => void }) {
+  return (
+    <AuthShell accent="join" annotation="ask nicely, tape's cheap.">
+      <button
+        type="button"
+        onClick={onBack}
+        className="mb-4 flex items-center gap-1 text-sm text-muted transition-colors hover:text-ink"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Back
+      </button>
+      <div className="mb-4">
+        <h1 className="t-title text-ink">Join my team</h1>
+        <p className="mt-1 text-sm text-muted">
+          You&apos;ll need an invite from whoever runs your organisation.
+        </p>
+      </div>
+      <div className="space-y-3 rounded-[var(--r)] border-2 border-line-2 bg-elev p-4 text-sm text-ink-2">
+        <p>
+          Ask them to send you an invite from{" "}
+          <span className="font-medium text-ink">Settings → Team</span>. Open the link they
+          send you and you&apos;ll land straight in — no need to come back here.
+        </p>
+        <p className="text-muted">
+          Already have an invite link in your email? Open it directly instead of signing in
+          here first.
+        </p>
+      </div>
+    </AuthShell>
+  );
+}
+
+function ForkCard({
+  icon,
+  title,
+  desc,
+  onClick,
+  primary,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  onClick: () => void;
+  primary?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group flex w-full items-start gap-4 rounded-[var(--r)] border-2 bg-card p-4 text-left shadow-[var(--sh-card)] transition-all duration-200 hover:-translate-y-px hover:shadow-[var(--sh-hover)]",
+        primary ? "border-red" : "border-line-2",
+      )}
+    >
+      <span
+        className={cn(
+          "flex size-[38px] flex-none items-center justify-center rounded-[10px] border-2 shadow-[var(--sh-stk)]",
+          primary ? "border-red text-red" : "border-line-2 text-muted",
+        )}
+      >
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-[14.5px] font-bold text-ink">{title}</span>
+        <span className="text-xs leading-relaxed text-muted">{desc}</span>
+      </span>
+      <span
+        aria-hidden
+        className={cn("mt-2 flex-none text-[15px]", primary ? "text-red" : "text-faint")}
+      >
+        →
+      </span>
+    </button>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -156,10 +156,11 @@ export const auth = betterAuth({
       },
       organizationHooks: {
         // Verifies the signup code submitted as `metadata.orgCreationCode` on
-        // the `organization.create()` call (Phase B's B1 fork screen, #1092,
-        // is the eventual caller — not built yet). Strips the code out of
-        // `metadata` before it's persisted on the org row either way: it's a
-        // one-time proof of authorization, not org data.
+        // the `organization.create()` call — src/app/(auth)/onboarding/page.tsx,
+        // reached via the "Set up a new company" card on /welcome (Phase B's
+        // B1 fork screen, #1092). Strips the code out of `metadata` before
+        // it's persisted on the org row either way: it's a one-time proof of
+        // authorization, not org data.
         beforeCreateOrganization: async ({ organization, user }) => {
           if (await isOrgCreationBootstrap()) return;
 
@@ -345,8 +346,8 @@ export const auth = betterAuth({
           // No auto-join (#1071, A1/A3): membership is only ever created by
           // invite-accept, request-approval, or org-create (creatorRole above).
           // A fresh signup with no invite and no org to bootstrap lands with
-          // zero memberships and is routed to /onboarding, same as a 0-org
-          // login (src/app/(auth)/onboarding/page.tsx).
+          // zero memberships and is routed to /welcome, the create-vs-join
+          // fork (#1092, B1), same as a 0-org login.
 
           // Mirror the new user into Convex (best-effort; runs after the role
           // write above so the mirror captures the final role).

--- a/src/lib/org-creation-gate.ts
+++ b/src/lib/org-creation-gate.ts
@@ -68,9 +68,9 @@ function constantTimeEqual(a: string, b: string): boolean {
  * better-auth version (1.6.25), so per-IP limiting isn't available at this
  * call site. Per-user limiting plus the fact that creating an org already
  * requires an authenticated account (registration is itself gated) is the
- * mitigating factor; a future pre-flight HTTP endpoint (once Phase B's B1
- * fork screen exists) would have request access and could add per-IP limiting
- * on top of this if abuse is ever observed.
+ * mitigating factor; a future pre-flight HTTP endpoint would have request
+ * access and could add per-IP limiting on top of this if abuse is ever
+ * observed.
  */
 export async function verifyOrgCreationCode(
   submittedCode: string | null | undefined,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 // "/docs/api" (Phase 8, #1004): the agent API reference, public for the same
 // reason /api/v1/openapi.json and /llms.txt already are — a prospective
 // integrator reads it before they have an account or a key.
-const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/onboarding", "/pending-approval", "/api/integrations/woocommerce/webhook", "/api/integrations/xero/callback", "/docs/api"];
+const publicRoutes = ["/login", "/register", "/api/auth", "/api/platform-name", "/api/registration-policy", "/invite", "/two-factor", "/welcome", "/onboarding", "/pending-approval", "/api/integrations/woocommerce/webhook", "/api/integrations/xero/callback", "/docs/api"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/server/site-admin.ts
+++ b/src/server/site-admin.ts
@@ -99,11 +99,12 @@ async function isOrgCreationBootstrap(): Promise<boolean> {
 }
 
 /**
- * Status check for the (future) create-vs-join fork screen: may the CURRENT
- * user see a "set up a new company" option, and if so, will it demand a
- * signup code? Never returns the code itself. Safe for any authenticated user
- * to call — it's a UI-affordance check, not a secret read; the server refuses
- * the actual creation regardless of what this returns (R-9.3).
+ * Status check for the create-vs-join fork screen (`/welcome`, #1092, B1):
+ * may the CURRENT user see a "set up a new company" option, and if so, will
+ * it demand a signup code? Never returns the code itself. Safe for any
+ * authenticated user to call — it's a UI-affordance check, not a secret read;
+ * the server refuses the actual creation regardless of what this returns
+ * (R-9.3).
  */
 export async function getOrgCreationPolicy(): Promise<{ allowed: boolean; codeRequired: boolean }> {
   await requireSession();


### PR DESCRIPTION
## Summary

Implements **B1 — the fork screen** (#1092), the next open item in the multi-tenant + international tracking issue (#1063 → Phase B, #1067). Continues the work already landed on Phase A (multi-tenancy foundation, #1064, fully shipped) and Phase B's B3 (org-creation gate, #1095, shipped in #1148).

- New `/welcome` route: two cards, "Set up a new company" and "Join my team," replacing the old dead-end `/onboarding` bounce a zero-org user used to hit.
  - "Set up a new company" is **hidden outright** when `getOrgCreationPolicy()` says org creation is gated off — hiding it is cosmetic only, `beforeCreateOrganization` (`src/lib/auth.ts`) enforces the real gate server-side regardless (R-9.3).
  - "Join my team" leads to an in-flow placeholder (not a new route) pointing the user at the invite-link path, since B2 — the actual invite-code-entry / verified-domain request-to-join flow (#1067) — hasn't shipped yet. Never strands the user; doesn't fake B2's functionality either.
  - A user who already has exactly one live org is bounced to `/dashboard`; 2+ orgs go to `/select-organization`.
  - An invite signup still skips the fork entirely (`register/page.tsx` already routed straight to `/invite/[id]`) — untouched.
- Every 0-org entry point (`/no-organization`, `login`, `register`, `select-organization`, the authenticated app-shell layout gate) now points at `/welcome` instead of `/onboarding`.
- `/onboarding` — the fork's "Set up a new company" destination — now:
  - Bounces back to `/welcome` if org creation has since been gated off, rather than showing a form the server will refuse.
  - Renders a signup-code field when the gate requires one, submitting `organization.create({ metadata: { orgCreationCode } })` — closing a gap B3 (#1095) left: the gate's enforcement and admin controls shipped, but no create-org form ever had a code input.
- Updated stale "not-yet-built (#1092)" comments in `auth.ts` / `site-admin.ts` / `org-creation-gate.ts` now that this is built.
- `FEATUREDOCS/04-auth-permissions.md` and `CHANGELOG.md` updated in the same PR (POLICY.md R-5.2/R-5.3).

## Size note (R-2.8 / T-2)

545 changed LOC is over the ≤400 SHOULD-level target. Splitting further isn't practical here: the fork screen is non-functional without the redirect rewiring (every 0-org entry point has to point at it or the old dead-end resurfaces), and the onboarding code-field fix closes a gap the fork's own gate check exposes (a gated instance would otherwise show a "Set up a new company" card that leads to a form the server always rejects). These land together as one working change; the 5 commits separate them logically for review.

## Testing

- `pnpm exec vitest run` — full suite, 485/485 files, 5992/5992 tests passing (includes 9 new tests across two smoke-test files covering the fork's card visibility/gating, the join placeholder, org-count bounce logic, and the onboarding page's code-field gating).
- `pnpm exec tsc --noEmit` — clean.
- `pnpm run lint` — clean on every file touched (pre-existing warnings elsewhere untouched).
- `pnpm build` — compiled and type-checked successfully; page-data collection fails in this sandbox only because no real `.env` (`BETTER_AUTH_SECRET`/`BETTER_AUTH_URL`/`NEXT_PUBLIC_APP_URL`) is configured — a sandbox limitation, not a code issue.

## Checklist

- [x] New dependency? — None added.