### PR TITLE
B2: join an existing org — invite code + verified-domain request (#1094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **#1094** — `/welcome`'s "Join my team" card is now a real join flow instead
+  of a placeholder: paste an invite link or code to go straight to it, or —
+  once your email is verified — search for a team already using RVLT Flow at
+  your company's email domain and ask to join. Org admins can now turn on
+  "Allow domain requests" in Settings → Team, review who's asked to join, and
+  approve or reject each one; requesters get an email either way.
+
 - **#1092** — A brand-new account with no organisation and no pending invite
   now lands on `/welcome`, a fork between "Set up a new company" and "Join my
   team" — instead of dead-ending on the old onboarding bounce. The create

--- a/FEATUREDOCS/04-auth-permissions.md
+++ b/FEATUREDOCS/04-auth-permissions.md
@@ -71,12 +71,19 @@ param is present.
 
 `/welcome`'s "Set up a new company" card is hidden outright when `getOrgCreationPolicy()`
 returns `allowed: false` (site admin has org creation switched off, D7's soak
-posture); its "Join my team" card is always shown, but — since #1067's B2 (invite-code
-entry + verified-domain request-to-join) hasn't landed yet — leads to an inline
-"ask your admin to send you an invite link" panel rather than a real join flow. **Known
-gap:** that's the one still open. A user with an `@bigcorp.com` email and no invite
-still has no self-serve way to request into an org that domain belongs to
-(`DOMAIN_REQUEST` join policy, design doc §4.3) until B2 ships.
+posture); its "Join my team" card (#1094, B2) offers two real paths — paste an invite
+code/link (validated via `checkInviteCode()` before navigating to `/invite/[id]`; no
+verification needed, possession of the invite is the proof), or, for a user with a
+**verified** email, search for orgs whose `joinPolicy` (`src/lib/org-join-policy.ts`) is
+`DOMAIN_REQUEST` and that already have a member sharing their email domain
+(`getJoinableOrgs()`/`requestToJoinOrg()`, `src/server/org-join.ts`). A personal-email
+domain (gmail.com and similar, `convex/lib/personalEmailDomains.ts`) never matches —
+otherwise any Gmail user would match every org with a Gmail-using member. Requests land
+in Settings → Team's "Pending Join Requests" section (`approveJoinRequest`/
+`rejectJoinRequest`, same atomic PENDING→APPROVED/REJECTED claim as
+`approveSSOUser`/`rejectSSOUser`), with an immediate email to the org's owners/admins
+(`joinRequestReceivedEmail`) and a `pending_join_requests` bell notification
+(FEATUREDOCS/17) visible to owner/admin viewers only.
 
 ### Which org(s) does this user belong to? (`src/server/public-org.ts`)
 - `getMyOrganizations()` — the calling session's memberships (`{ id, name, slug,
@@ -390,7 +397,7 @@ consumer of this same identity kind — **FEATUREDOCS/68**.
 - **Server actions**: `src/server/invitations.ts` — `getMyPendingInvitations()`, `getInvitationEmail()`, `checkIsSiteAdmin()`, `getInvitationOrganizationId()`.
 - Each invitation targets a specific org (`Invitation.organizationId`) — the invite-accept page resolves which org to activate from the invitation row itself via `getInvitationOrganizationId()`, not a single-org assumption.
 - **Membership always requires the recipient's consent (#1073, A3).** `addMemberByEmail` (`src/server/settings.ts`, the "Invite" control on `/settings/team`) creates an `Invitation` and emails an accept link (`/invite/[id]`) for EVERY case — including an email that already has an account. There is no direct-add path: under multi-tenancy, silently creating a `Member` row for a known email would let any org owner pull a stranger's account into their org with no consent, putting an unwanted org in that person's switcher. `/invite/[id]` itself branches on whether the recipient is already signed in (accept immediately) or needs to sign in/register first — the invite email is the same either way (`invitationEmail`, not a register-specific template).
-- **Known gap, not built yet**: a per-org join policy (`INVITE_ONLY` | `DOMAIN_REQUEST` | `CLOSED`, distinct from the platform-global `registrationPolicy` above) is designed (`docs/designs/onboarding-and-activation.md` §2.4/§4.3) but has no consumer yet. The create-vs-join fork itself shipped (`/welcome`, #1092, B1) — its "Join my team" card is live — but the fork only points at an "ask your admin for an invite link" placeholder today, since #1067's B2 (invite-code entry + verified-domain request-to-join, the actual consumer of this join policy) hasn't landed. Revisit alongside B2.
+- **Per-org join policy (#1073/A3's deferred half, shipped in #1094/B2)**: `OrgSettings.joinPolicy` (`INVITE_ONLY` | `DOMAIN_REQUEST` | `CLOSED`, `src/lib/org-join-policy.ts`), distinct from the platform-global `registrationPolicy` above — set in Settings → Team, default `INVITE_ONLY` (byte-identical to every pre-B2 org). Only `DOMAIN_REQUEST` orgs are discoverable by `/welcome`'s domain search; `CLOSED` is invite-only and not even shown as a match. See the "Membership creation" section above for the full request/approve/reject flow.
 
 ### Account Page Sections
 The `/account` page is organized into: Profile (avatar + name), Security (password, 2FA, passkeys, connected accounts), Active Sessions.

--- a/FEATUREDOCS/17-notifications.md
+++ b/FEATUREDOCS/17-notifications.md
@@ -15,6 +15,7 @@
 | `pending_timesheets` | Crew time entries in SUBMITTED status | `/crew/timesheets` |
 | `flagged_asset` | Project line item in FLAGGED_FAULTY/FLAGGED_TT_OVERDUE | `/warehouse/{projectId}` |
 | `incident_report` | New/open MaintenanceRecord with `incidentType` set (Report Issue or an immediate check-item FAIL) — see FEATUREDOCS/64 | `/warehouse/{projectId}` or `/maintenance/{id}` |
+| `pending_join_requests` | Pending `PendingOrgJoinRequest` rows (B2, #1094) — owner/admin viewers only | `/settings/team` |
 
 ## Implementation
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -211,6 +211,7 @@ import type * as overbookingBoard from "../overbookingBoard.js";
 import type * as parity from "../parity.js";
 import type * as payments from "../payments.js";
 import type * as paymentsWrites from "../paymentsWrites.js";
+import type * as pendingOrgJoinRequests from "../pendingOrgJoinRequests.js";
 import type * as pendingSSOApprovals from "../pendingSSOApprovals.js";
 import type * as projectCategories from "../projectCategories.js";
 import type * as projectCategoriesWrites from "../projectCategoriesWrites.js";
@@ -504,6 +505,7 @@ declare const fullApi: ApiFromModules<{
   parity: typeof parity;
   payments: typeof payments;
   paymentsWrites: typeof paymentsWrites;
+  pendingOrgJoinRequests: typeof pendingOrgJoinRequests;
   pendingSSOApprovals: typeof pendingSSOApprovals;
   projectCategories: typeof projectCategories;
   projectCategoriesWrites: typeof projectCategoriesWrites;

--- a/convex/lib/personalEmailDomains.test.ts
+++ b/convex/lib/personalEmailDomains.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { isPersonalEmailDomain, emailDomain } from "./personalEmailDomains";
+
+describe("emailDomain", () => {
+  it("extracts the domain, lowercased", () => {
+    expect(emailDomain("Sam@Northlight.COM.AU")).toBe("northlight.com.au");
+  });
+
+  it("returns undefined for malformed input", () => {
+    expect(emailDomain("not-an-email")).toBeUndefined();
+    expect(emailDomain("@no-local-part.com")).toBeUndefined();
+    expect(emailDomain("no-domain@")).toBeUndefined();
+    expect(emailDomain("")).toBeUndefined();
+  });
+});
+
+describe("isPersonalEmailDomain", () => {
+  it("flags common free-mail domains", () => {
+    expect(isPersonalEmailDomain("gmail.com")).toBe(true);
+    expect(isPersonalEmailDomain("Gmail.com")).toBe(true);
+    expect(isPersonalEmailDomain("outlook.com")).toBe(true);
+    expect(isPersonalEmailDomain("icloud.com")).toBe(true);
+  });
+
+  it("does not flag a company domain", () => {
+    expect(isPersonalEmailDomain("northlight.com.au")).toBe(false);
+    expect(isPersonalEmailDomain("rvlt.app")).toBe(false);
+  });
+});

--- a/convex/lib/personalEmailDomains.ts
+++ b/convex/lib/personalEmailDomains.ts
@@ -1,0 +1,38 @@
+/**
+ * Free/consumer email domains excluded from B2's (#1094) verified-domain
+ * "ask to join" match. Without this, a request from `you@gmail.com` would
+ * match every org that happens to have any Gmail-using member — an
+ * undifferentiated result set that leaks "does this org have a Gmail user"
+ * for a domain that says nothing about which company someone works for.
+ * Domain-request matching only makes sense for a company's own mail domain.
+ *
+ * Not exhaustive — a short, deliberately conservative list (R-3.1: one place
+ * to extend). Checked both client-side (so the search never surfaces a
+ * personal-domain match) and inside the `request` mutation itself (defence in
+ * depth — R-9.3, the server re-derives this regardless of what the UI did).
+ */
+const PERSONAL_EMAIL_DOMAINS = new Set([
+  "gmail.com",
+  "yahoo.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "icloud.com",
+  "me.com",
+  "aol.com",
+  "protonmail.com",
+  "proton.me",
+  "gmx.com",
+  "mail.com",
+]);
+
+export function isPersonalEmailDomain(domain: string): boolean {
+  return PERSONAL_EMAIL_DOMAINS.has(domain.toLowerCase());
+}
+
+/** `undefined` for anything without an `@`, an empty local part, or no domain. */
+export function emailDomain(email: string): string | undefined {
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at === email.length - 1) return undefined;
+  return email.slice(at + 1).toLowerCase();
+}

--- a/convex/pendingOrgJoinRequests.ts
+++ b/convex/pendingOrgJoinRequests.ts
@@ -1,0 +1,250 @@
+import { v, ConvexError } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requireService } from "./lib/auth";
+import { isPersonalEmailDomain, emailDomain } from "./lib/personalEmailDomains";
+import type { QueryCtx } from "./_generated/server";
+import type { AgentOpsAnnotations } from "./lib/agentOps";
+
+/**
+ * PendingOrgJoinRequest — B2 (#1094), the "join an existing org" half of
+ * Phase B. A user with zero orgs and a verified email whose domain matches an
+ * existing member's can ask to join (gated on the org's `joinPolicy` being
+ * DOMAIN_REQUEST, `src/lib/org-join-policy.ts`). An org admin then
+ * approves (→ creates a Better-Auth member, same as SSO approval) or rejects.
+ *
+ * SERVICE-only (like `pendingSSOApprovals.ts`) — RBAC/validation/audit/member
+ * creation stay in the Next.js server actions (`src/server/org-join.ts`);
+ * these are the trusted-backend data layer. Every authority check that
+ * decides WHETHER a request may be created (policy, membership, domain match)
+ * lives inside the `request` mutation itself, not the caller — R-9.3, and it
+ * closes the TOCTOU window a two-step check-then-create would leave open.
+ */
+
+/** Pending requests for an org (the admin review queue), newest first. */
+export const list = query({
+  args: { orgId: v.string() },
+  handler: async (ctx, { orgId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("pendingOrgJoinRequests")
+      .withIndex("by_organizationId_status", (q) => q.eq("organizationId", orgId).eq("status", "PENDING"))
+      .order("desc")
+      .collect();
+  },
+});
+
+/** Every PENDING request a user has open, across all orgs — drives the
+ *  "request sent" state on `/welcome` so a reload doesn't offer a duplicate
+ *  "ask to join" button. */
+export const listPendingByUser = query({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    await requireService(ctx);
+    return await ctx.db
+      .query("pendingOrgJoinRequests")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("status"), "PENDING"))
+      .collect();
+  },
+});
+
+async function orgMemberDomains(ctx: QueryCtx, organizationId: string): Promise<Set<string>> {
+  const members = await ctx.db
+    .query("members")
+    .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+    .collect();
+  const domains = new Set<string>();
+  for (const m of members) {
+    const user = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", m.userId)).unique();
+    const d = user?.email ? emailDomain(user.email) : undefined;
+    if (d) domains.add(d);
+  }
+  return domains;
+}
+
+/**
+ * Orgs whose `joinPolicy` is DOMAIN_REQUEST and that have at least one
+ * existing member sharing the caller's email domain, excluding orgs the
+ * caller is already a member of. Bounded by (# orgs with the policy enabled)
+ * × (their member count) — expected small since it's opt-in per org, not a
+ * scan of every org's members. Revisit with a dedicated domain index
+ * (`orgJoinableDomains`-style) if that assumption stops holding.
+ */
+export const findJoinableOrgsForDomain = query({
+  args: { domain: v.string(), excludeUserId: v.string() },
+  handler: async (ctx, { domain, excludeUserId }) => {
+    await requireService(ctx);
+    const normalizedDomain = domain.toLowerCase();
+    if (isPersonalEmailDomain(normalizedDomain)) return [];
+
+    const allSettings = await ctx.db.query("orgSettings").collect(); // r9.8-ok: per-org opt-in scan, bounded by total org count — see doc comment above
+    const domainPolicyOrgIds: string[] = [];
+    for (const row of allSettings) {
+      if (!row.settings) continue;
+      try {
+        const parsed = JSON.parse(row.settings) as { joinPolicy?: string };
+        if (parsed.joinPolicy === "DOMAIN_REQUEST") domainPolicyOrgIds.push(row.organizationId);
+      } catch {
+        // Malformed blob — skip, never crash the search over one bad row.
+      }
+    }
+
+    const results: { organizationId: string; organizationName: string; memberCount: number }[] = [];
+    for (const organizationId of domainPolicyOrgIds) {
+      const existingMembership = await ctx.db
+        .query("members")
+        .withIndex("by_org_user", (q) => q.eq("organizationId", organizationId).eq("userId", excludeUserId))
+        .first();
+      if (existingMembership) continue;
+
+      const members = await ctx.db
+        .query("members")
+        .withIndex("by_organizationId", (q) => q.eq("organizationId", organizationId))
+        .collect();
+      let memberCount = 0;
+      for (const m of members) {
+        const user = await ctx.db.query("users").withIndex("by_cuid", (q) => q.eq("id", m.userId)).unique();
+        if (user?.email && emailDomain(user.email) === normalizedDomain) memberCount++;
+      }
+      if (memberCount === 0) continue;
+
+      const org = await ctx.db.query("organizations").withIndex("by_cuid", (q) => q.eq("id", organizationId)).unique();
+      if (!org) continue;
+      results.push({ organizationId, organizationName: org.name, memberCount });
+    }
+    return results;
+  },
+});
+
+/**
+ * Create (or idempotently return) a PENDING join request. Re-derives and
+ * re-checks every authority condition itself rather than trusting the caller
+ * (R-9.3): the org's `joinPolicy` must be DOMAIN_REQUEST, the requester must
+ * not already be a member, and at least one existing member must share the
+ * requester's email domain (the same test `findJoinableOrgsForDomain` used to
+ * surface this org in the first place — re-verified here so a stale client
+ * read or a direct call can't create a request the search would never have
+ * offered).
+ */
+export const request = mutation({
+  args: {
+    id: v.string(),
+    organizationId: v.string(),
+    userId: v.string(),
+    email: v.string(),
+    name: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireService(ctx);
+
+    const domain = emailDomain(args.email);
+    if (!domain || isPersonalEmailDomain(domain)) {
+      throw new ConvexError("This email domain can't be used to request to join an organisation.");
+    }
+
+    const settingsRow = await ctx.db
+      .query("orgSettings")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", args.organizationId))
+      .unique();
+    const joinPolicy = settingsRow?.settings ? (JSON.parse(settingsRow.settings) as { joinPolicy?: string }).joinPolicy : undefined;
+    if (joinPolicy !== "DOMAIN_REQUEST") {
+      throw new ConvexError("This organisation isn't accepting join requests.");
+    }
+
+    const existingMembership = await ctx.db
+      .query("members")
+      .withIndex("by_org_user", (q) => q.eq("organizationId", args.organizationId).eq("userId", args.userId))
+      .first();
+    if (existingMembership) {
+      throw new ConvexError("You're already a member of this organisation.");
+    }
+
+    const memberDomains = await orgMemberDomains(ctx, args.organizationId);
+    if (!memberDomains.has(domain)) {
+      throw new ConvexError("No existing member of this organisation shares your email domain.");
+    }
+
+    const existing = await ctx.db
+      .query("pendingOrgJoinRequests")
+      .withIndex("by_organizationId_userId", (q) => q.eq("organizationId", args.organizationId).eq("userId", args.userId))
+      .unique();
+    if (existing) {
+      if (existing.status === "PENDING") return { id: existing.id, created: false };
+      // A previously REJECTED/APPROVED request doesn't block a fresh ask —
+      // APPROVED shouldn't recur (existingMembership above would have caught
+      // it), but a REJECTED one is a legitimate "circumstances changed" retry.
+      await ctx.db.patch(existing._id, {
+        status: "PENDING",
+        reviewedById: undefined,
+        reviewedAt: undefined,
+        reviewNote: undefined,
+        createdAt: args.createdAt,
+      });
+      return { id: existing.id, created: true };
+    }
+
+    await ctx.db.insert("pendingOrgJoinRequests", {
+      id: args.id,
+      organizationId: args.organizationId,
+      userId: args.userId,
+      email: args.email,
+      name: args.name,
+      status: "PENDING",
+      createdAt: args.createdAt,
+    });
+    return { id: args.id, created: true };
+  },
+});
+
+/**
+ * Approve/reject: org-guarded, only transitions a currently-PENDING row — the
+ * same atomic mutual-exclusion gate as `pendingSSOApprovals.review`. A
+ * concurrent reject or double-approve loses here (throws), so the caller
+ * creates the member AT MOST ONCE and NEVER after a rejection.
+ */
+export const review = mutation({
+  args: {
+    id: v.string(),
+    orgId: v.string(),
+    status: v.union(v.literal("APPROVED"), v.literal("REJECTED")),
+    reviewedById: v.string(),
+    reviewedAt: v.number(),
+    reviewNote: v.optional(v.string()),
+  },
+  handler: async (ctx, { id, orgId, status, reviewedById, reviewedAt, reviewNote }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("pendingOrgJoinRequests").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId || doc.status !== "PENDING") {
+      throw new ConvexError("Pending join request not found");
+    }
+    await ctx.db.patch(doc._id, { status, reviewedById, reviewedAt, ...(reviewNote ? { reviewNote } : {}) });
+    return { userId: doc.userId, email: doc.email };
+  },
+});
+
+/** Roll a just-APPROVED request back to PENDING when the downstream
+ *  member.create failed — mirrors `pendingSSOApprovals.revertToPending`. */
+export const revertToPending = mutation({
+  args: { id: v.string(), orgId: v.string() },
+  handler: async (ctx, { id, orgId }) => {
+    await requireService(ctx);
+    const doc = await ctx.db.query("pendingOrgJoinRequests").withIndex("by_cuid", (q) => q.eq("id", id)).unique();
+    if (!doc || doc.organizationId !== orgId || doc.status !== "APPROVED") return;
+    await ctx.db.patch(doc._id, {
+      status: "PENDING",
+      reviewedById: undefined,
+      reviewedAt: undefined,
+      reviewNote: undefined,
+    });
+  },
+});
+
+const denyReason =
+  "Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet.";
+
+export const agentOps: AgentOpsAnnotations = {
+  list: { agentAccess: "denied", reason: denyReason },
+  listPendingByUser: { agentAccess: "denied", reason: denyReason },
+  findJoinableOrgsForDomain: { agentAccess: "denied", reason: denyReason },
+};

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -191,6 +191,30 @@ export default defineSchema({
     .index("by_organizationId_userId", ["organizationId", "userId"])
     .index("by_organizationId_status", ["organizationId", "status"]),
 
+  // PendingOrgJoinRequest — B2 (#1094): a user's self-serve "ask to join"
+  // request against an org whose joinPolicy is DOMAIN_REQUEST. Distinct from
+  // PendingSSOApproval above (SSO auto-provisioning enqueues those on login;
+  // this one is user-initiated from `/welcome`'s domain-match search) — same
+  // PENDING/APPROVED/REJECTED shape, deliberately not sharing the SSO table
+  // since the two are unrelated triggers with different admin-review copy.
+  pendingOrgJoinRequests: defineTable({
+    id: v.string(),
+    organizationId: v.string(),
+    userId: v.string(),
+    email: v.string(),
+    name: v.optional(v.string()),
+    status: v.optional(v.union(v.literal("PENDING"), v.literal("APPROVED"), v.literal("REJECTED"))),
+    reviewedById: v.optional(v.string()),
+    reviewedAt: v.optional(v.number()),
+    reviewNote: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+  })
+    .index("by_cuid", ["id"])
+    .index("by_organizationId", ["organizationId"])
+    .index("by_userId", ["userId"])
+    .index("by_organizationId_userId", ["organizationId", "userId"])
+    .index("by_organizationId_status", ["organizationId", "status"]),
+
   // ApiKey — agent-accessible API/MCP access keys (docs/designs/api-mcp-agent-access.md).
   // `by_tokenHash` is the auth verify path (the token IS the credential, so a global
   // lookup by hash is correct — like by_cuid; the found key carries its own orgId).

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -22,9 +22,9 @@ convention:
 
 | | Total public | Agent-reachable | SERVICE-only | Org-read (fails closed for agents) | Unclassified |
 |---|---|---|---|---|---|
-| Queries | 414 | 290 | 122 | 1 | 1 |
-| Mutations | 761 | 277 | 475 | 0 | 9 |
-| **Total** | **1175** | **567** | **597** | **1** | **10** |
+| Queries | 417 | 290 | 125 | 1 | 1 |
+| Mutations | 764 | 277 | 478 | 0 | 9 |
+| **Total** | **1181** | **567** | **603** | **1** | **10** |
 
 <!-- reachability-floor: 567 -->
 
@@ -87,6 +87,7 @@ add a redacted sibling, or record as permanently denied with a reason.
 | `orgExport` | 6 |
 | `orgSettings` | 8 |
 | `parity` | 1 |
+| `pendingOrgJoinRequests` | 6 |
 | `pendingSSOApprovals` | 5 |
 | `projectNumberSequences` | 7 |
 | `siteSettings` | 9 |
@@ -157,6 +158,9 @@ fails the build otherwise.
 | `orgSettings.getByIcalToken` | Global secret-token lookup (no orgId argument to scope against) — structurally not an org-scoped read. |
 | `orgSettings.getByOrg` | Row/lookup exposes apiKillSwitchAt (the org's own write-kill-switch state) and/or icalToken (a bearer credential for the public iCal feed); no redacted projection exists here (contrast xeroIntegrations.getForOrg). |
 | `parity.countPage` | Internal migration-parity diagnostic tool, not an application read surface. |
+| `pendingOrgJoinRequests.findJoinableOrgsForDomain` | Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet. |
+| `pendingOrgJoinRequests.list` | Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet. |
+| `pendingOrgJoinRequests.listPendingByUser` | Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet. |
 | `pendingSSOApprovals.getByOrgUser` | Site-admin SSO approval queue; platform-operator surface, not an org-scoped agent concern. |
 | `pendingSSOApprovals.list` | Site-admin SSO approval queue; platform-operator surface, not an org-scoped agent concern. |
 | `projectLineItemUnits.getById` | Point-read by global by_cuid with no orgId arg to verify the result against — would let an agent read another org's unit by guessing its cuid. |

--- a/scripts/org-export-tables.ts
+++ b/scripts/org-export-tables.ts
@@ -79,6 +79,7 @@ export const DIRECT_TABLES = [
   "notificationEmailLogs",
   "orgSettings",
   "payments",
+  "pendingOrgJoinRequests",
   "pendingSSOApprovals",
   "projectCategories",
   "projectGroups",
@@ -235,7 +236,9 @@ export const CLASSIFIED_TABLES: string[] = [...EXPORTED_TABLES, ...EXCLUDED_TABL
 // #1004 follow-up (Mira LLM tool-calling): +3 — miraOrgSettings (DIRECT, per-org
 // OpenRouter key + model settings), miraConversations/miraMessages (EXCLUDED/
 // ephemeral, live chat transcript).
-export const EXPECTED_TABLE_COUNT = 116;
+// #1094 (B2): +1 — pendingOrgJoinRequests (DIRECT, org-scoped join requests,
+// same shape as pendingSSOApprovals above).
+export const EXPECTED_TABLE_COUNT = 117;
 
 /**
  * Assert the classification is internally consistent (no dupes, expected total).

--- a/src/app/(app)/settings/team/page.tsx
+++ b/src/app/(app)/settings/team/page.tsx
@@ -4,12 +4,15 @@
 import { Separator } from "@/components/ui/separator";
 import { InviteMember } from "@/components/settings/invite-member";
 import { MemberList } from "@/components/settings/member-list";
+import { JoinPolicySettings } from "@/components/settings/join-policy-settings";
+import { JoinRequestApprovals } from "@/components/settings/join-request-approvals";
 import { FormSection, SettingsCard } from "@/components/layout/page-layouts";
 import { useCanDo } from "@/lib/use-permissions";
 import { FadeIn } from "@/components/ui/motion";
 
 export default function TeamSettingsPage() {
   const canInvite = useCanDo("orgMembers", "invite");
+  const canManageJoinPolicy = useCanDo("orgSettings", "update");
 
   return (
     <FadeIn>
@@ -30,6 +33,32 @@ export default function TeamSettingsPage() {
           </div>
         </FormSection>
       </SettingsCard>
+
+      {canManageJoinPolicy && (
+        <SettingsCard>
+          <FormSection
+            title="Join Policy"
+            description="Control whether people can ask to join this organisation without an invite."
+          >
+            <div className="sm:col-span-2">
+              <JoinPolicySettings />
+            </div>
+          </FormSection>
+        </SettingsCard>
+      )}
+
+      {canInvite && (
+        <SettingsCard>
+          <FormSection
+            title="Pending Join Requests"
+            description="Review people who asked to join by matching your organisation's email domain."
+          >
+            <div className="sm:col-span-2">
+              <JoinRequestApprovals />
+            </div>
+          </FormSection>
+        </SettingsCard>
+      )}
     </div>
     </FadeIn>
   );

--- a/src/app/(auth)/welcome/__tests__/page.smoke.test.tsx
+++ b/src/app/(auth)/welcome/__tests__/page.smoke.test.tsx
@@ -1,15 +1,16 @@
 // @vitest-environment jsdom
 //
-// Smoke test for the create-vs-join fork screen (#1092, B1). Covers the
-// three behaviours the issue's exit criteria call out: the create-company
-// card disappears when org creation is gated off (hiding it is cosmetic —
-// the server enforces the gate regardless, R-9.3), the join card never
-// navigates anywhere since B2 (#1067) hasn't landed yet, and a user who
-// already has exactly one org is bounced away rather than shown the fork.
+// Smoke test for the create-vs-join fork screen (#1092, B1) and the join
+// flow it forks into (#1094, B2). Covers the three behaviours the B1 issue's
+// exit criteria call out (create-company card disappears when org creation
+// is gated off — cosmetic only, the server enforces the gate regardless,
+// R-9.3; a user with exactly one org is bounced away rather than shown the
+// fork), plus B2's invite-code entry and verified-domain request UI.
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { JoinableOrg } from "@/server/org-join";
 
 // vi.mock factories are hoisted above every import/const in this file, so
 // anything they close over must itself come from vi.hoisted() — a bare
@@ -23,6 +24,9 @@ const mocks = vi.hoisted(() => ({
   signOut: vi.fn(async () => undefined),
   getMyOrganizations: vi.fn(async () => [] as { id: string; name: string; slug: string; role: string }[]),
   getOrgCreationPolicy: vi.fn(async () => ({ allowed: true, codeRequired: false })),
+  checkInviteCode: vi.fn(async () => null as { id: string } | null),
+  getJoinableOrgs: vi.fn(async () => ({ requiresVerification: false, orgs: [] as JoinableOrg[] })),
+  requestToJoinOrg: vi.fn(async () => ({ id: "req_1", created: true })),
   sessionData: {
     user: { name: "Sam Roadie", email: "sam@northlight.com.au" },
   } as { user: { name: string; email: string } } | null,
@@ -42,6 +46,12 @@ vi.mock("@/server/public-org", () => ({
 vi.mock("@/server/site-admin", () => ({
   getOrgCreationPolicy: mocks.getOrgCreationPolicy,
 }));
+vi.mock("@/server/org-join", () => ({
+  checkInviteCode: mocks.checkInviteCode,
+  getJoinableOrgs: mocks.getJoinableOrgs,
+  requestToJoinOrg: mocks.requestToJoinOrg,
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 import WelcomePage from "../page";
 
@@ -52,6 +62,9 @@ beforeEach(() => {
   mocks.signOut.mockClear();
   mocks.getMyOrganizations.mockResolvedValue([]);
   mocks.getOrgCreationPolicy.mockResolvedValue({ allowed: true, codeRequired: false });
+  mocks.checkInviteCode.mockResolvedValue(null);
+  mocks.getJoinableOrgs.mockResolvedValue({ requiresVerification: false, orgs: [] });
+  mocks.requestToJoinOrg.mockResolvedValue({ id: "req_1", created: true });
   mocks.sessionData = { user: { name: "Sam Roadie", email: "sam@northlight.com.au" } };
 });
 
@@ -76,14 +89,56 @@ describe("WelcomePage (smoke)", () => {
     expect(mocks.push).toHaveBeenCalledWith("/onboarding");
   });
 
-  it("'Join my team' shows an in-flow placeholder instead of navigating", async () => {
+  it("'Join my team' shows the invite-code + domain-request UI, not a placeholder", async () => {
     const user = userEvent.setup();
     render(<WelcomePage />);
     await user.click(await screen.findByText("Join my team"));
-    expect(
-      await screen.findByText(/You'll need an invite from whoever runs your organisation/),
-    ).toBeTruthy();
+    expect(await screen.findByText("Have an invite?")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Paste your invite link or code")).toBeTruthy();
     expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("invite-code entry navigates to /invite/[id] when the code resolves", async () => {
+    mocks.checkInviteCode.mockResolvedValue({ id: "inv_123" });
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Join my team"));
+    await user.type(screen.getByPlaceholderText("Paste your invite link or code"), "inv_123");
+    await user.click(screen.getByText("Continue"));
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/invite/inv_123"));
+  });
+
+  it("invite-code entry shows an inline error for an unknown code", async () => {
+    mocks.checkInviteCode.mockResolvedValue(null);
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Join my team"));
+    await user.type(screen.getByPlaceholderText("Paste your invite link or code"), "bogus");
+    await user.click(screen.getByText("Continue"));
+    expect(await screen.findByText(/couldn't find that invite/i)).toBeTruthy();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("prompts email verification before showing domain-matched orgs", async () => {
+    mocks.getJoinableOrgs.mockResolvedValue({ requiresVerification: true, orgs: [] });
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Join my team"));
+    expect(await screen.findByText(/Verify your email to search for a team/)).toBeTruthy();
+  });
+
+  it("offers 'Ask to join' for a domain-matched org and calls requestToJoinOrg", async () => {
+    mocks.getJoinableOrgs.mockResolvedValue({
+      requiresVerification: false,
+      orgs: [{ organizationId: "org_x", organizationName: "Northlight AV", memberCount: 3, alreadyRequested: false }],
+    });
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+    await user.click(await screen.findByText("Join my team"));
+    expect(await screen.findByText("Northlight AV")).toBeTruthy();
+    await user.click(screen.getByText("Ask to join"));
+    await waitFor(() => expect(mocks.requestToJoinOrg).toHaveBeenCalledWith("org_x"));
+    expect(await screen.findByText("Request sent")).toBeTruthy();
   });
 
   it("bounces a user who already has exactly one org to /dashboard", async () => {

--- a/src/app/(auth)/welcome/page.tsx
+++ b/src/app/(auth)/welcome/page.tsx
@@ -6,9 +6,11 @@ import { useRouter } from "next/navigation";
 import { organization, signOut, useSession } from "@/lib/auth-client";
 import { getMyOrganizations } from "@/server/public-org";
 import { getOrgCreationPolicy } from "@/server/site-admin";
+import { checkInviteCode, getJoinableOrgs, requestToJoinOrg, type JoinableOrg } from "@/server/org-join";
 import { AuthShell } from "../auth-playful";
 import { cn } from "@/lib/utils";
-import { Loader2, Building2, Users2, ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+import { Loader2, Building2, Users2, ArrowLeft, KeyRound, Globe2, MailWarning } from "lucide-react";
 
 /**
  * `/welcome` — B1 (#1092), the create-vs-join fork. Reached by a signed-in
@@ -58,7 +60,7 @@ export default function WelcomePage() {
   };
 
   if (view === "join") {
-    return <JoinPlaceholder onBack={() => setView("fork")} />;
+    return <JoinView onBack={() => setView("fork")} />;
   }
 
   return (
@@ -143,11 +145,12 @@ function SignedInAs({ email, onNotYou }: { email: string; onNotYou: () => void }
 }
 
 /**
- * Placeholder destination for "Join my team" until #1067's B2 (invite-code
- * entry + verified-domain request-to-join) ships. Never strands the user —
- * just points them at the invite-link path that already works end to end.
+ * "Join my team" destination (#1067's B2, #1094) — two ways in. Possession of
+ * an invite code is proof enough on its own (no verification needed); the
+ * verified-domain "ask to join" branch requires `emailVerified` (anyone could
+ * otherwise claim `@bigcorp.com` and request into a stranger's org).
  */
-function JoinPlaceholder({ onBack }: { onBack: () => void }) {
+function JoinView({ onBack }: { onBack: () => void }) {
   return (
     <AuthShell accent="join" annotation="ask nicely, tape's cheap.">
       <button
@@ -160,22 +163,166 @@ function JoinPlaceholder({ onBack }: { onBack: () => void }) {
       </button>
       <div className="mb-4">
         <h1 className="t-title text-ink">Join my team</h1>
-        <p className="mt-1 text-sm text-muted">
-          You&apos;ll need an invite from whoever runs your organisation.
-        </p>
+        <p className="mt-1 text-sm text-muted">Use an invite code, or ask to be let in.</p>
       </div>
-      <div className="space-y-3 rounded-[var(--r)] border-2 border-line-2 bg-elev p-4 text-sm text-ink-2">
-        <p>
-          Ask them to send you an invite from{" "}
-          <span className="font-medium text-ink">Settings → Team</span>. Open the link they
-          send you and you&apos;ll land straight in — no need to come back here.
-        </p>
-        <p className="text-muted">
-          Already have an invite link in your email? Open it directly instead of signing in
-          here first.
-        </p>
+      <div className="space-y-4">
+        <InviteCodeEntry />
+        <DomainJoinRequest />
       </div>
     </AuthShell>
+  );
+}
+
+function InviteCodeEntry() {
+  const router = useRouter();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!value.trim()) return;
+    setChecking(true);
+    setError(null);
+    try {
+      const found = await checkInviteCode(value);
+      if (!found) {
+        setError("We couldn't find that invite. Check the code or link and try again.");
+        return;
+      }
+      router.push(`/invite/${found.id}`);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <div className="rounded-[var(--r)] border-2 border-line-2 bg-card p-4">
+      <p className="mb-2 flex items-center gap-1.5 text-[13px] font-bold text-ink">
+        <KeyRound className="h-3.5 w-3.5" />
+        Have an invite?
+      </p>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          placeholder="Paste your invite link or code"
+          className="min-w-0 flex-1 rounded-[8px] border-2 border-line-2 bg-elev px-3 py-1.5 text-sm text-ink outline-none focus:border-red"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={checking || !value.trim()}
+          className="flex-none rounded-[8px] border-2 border-line-2 bg-elev px-3 py-1.5 text-sm font-bold text-ink transition-colors hover:border-red hover:text-red disabled:opacity-50"
+        >
+          {checking ? <Loader2 className="h-4 w-4 animate-spin" /> : "Continue"}
+        </button>
+      </div>
+      {error ? <p className="mt-2 text-xs text-red">{error}</p> : null}
+    </div>
+  );
+}
+
+function DomainJoinRequest() {
+  const [state, setState] = useState<{ requiresVerification: boolean; orgs: JoinableOrg[] } | null>(null);
+  const [requestedIds, setRequestedIds] = useState<Set<string>>(new Set());
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getJoinableOrgs().then((r) => {
+      if (!cancelled) setState(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleRequest = async (orgId: string) => {
+    setPendingId(orgId);
+    try {
+      await requestToJoinOrg(orgId);
+      setRequestedIds((prev) => new Set(prev).add(orgId));
+      toast.success("Request sent — you'll hear back once an admin reviews it.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't send that request.");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  if (state === null) {
+    return (
+      <div className="flex justify-center py-3">
+        <Loader2 className="h-5 w-5 animate-spin text-muted" />
+      </div>
+    );
+  }
+
+  if (state.requiresVerification) {
+    return (
+      <div className="flex items-start gap-2 rounded-[var(--r)] border-2 border-line-2 bg-elev p-4 text-sm text-ink-2">
+        <MailWarning className="mt-0.5 h-4 w-4 flex-none text-muted" />
+        <p>Verify your email to search for a team at your company&apos;s domain.</p>
+      </div>
+    );
+  }
+
+  if (state.orgs.length === 0) {
+    return (
+      <div className="rounded-[var(--r)] border-2 border-line-2 bg-elev p-4 text-sm text-ink-2">
+        <p>We didn&apos;t find a team at your email domain. Ask your admin for an invite instead.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[var(--r)] border-2 border-line-2 bg-card p-4">
+      <p className="mb-2 flex items-center gap-1.5 text-[13px] font-bold text-ink">
+        <Globe2 className="h-3.5 w-3.5" />
+        People at your company already use this
+      </p>
+      <div className="space-y-2">
+        {state.orgs.map((org) => {
+          const requested = requestedIds.has(org.organizationId) || org.alreadyRequested;
+          return (
+            <div
+              key={org.organizationId}
+              className="flex items-center justify-between gap-3 rounded-[8px] border-2 border-line-2 bg-elev px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-ink">{org.organizationName}</p>
+                <p className="text-xs text-muted">
+                  {org.memberCount} {org.memberCount === 1 ? "person" : "people"} already here
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRequest(org.organizationId)}
+                disabled={requested || pendingId === org.organizationId}
+                className="flex-none rounded-[8px] border-2 border-line-2 bg-card px-3 py-1.5 text-xs font-bold text-ink transition-colors hover:border-red hover:text-red disabled:opacity-50"
+              >
+                {pendingId === org.organizationId ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : requested ? (
+                  "Request sent"
+                ) : (
+                  "Ask to join"
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/src/components/settings/join-policy-settings.tsx
+++ b/src/components/settings/join-policy-settings.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useServerQuery } from "@/hooks/use-server-query";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { getJoinPolicy, setJoinPolicy } from "@/server/org-join";
+import { ORG_JOIN_POLICIES, type OrgJoinPolicy } from "@/lib/org-join-policy";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { toast } from "sonner";
+
+const POLICY_LABELS: Record<OrgJoinPolicy, { label: string; desc: string }> = {
+  INVITE_ONLY: { label: "Invite only", desc: "Only an admin-sent invite can add someone to this org." },
+  DOMAIN_REQUEST: {
+    label: "Allow domain requests",
+    desc: "People whose verified email matches an existing member's domain can ask to join.",
+  },
+  CLOSED: { label: "Closed", desc: "No self-serve path at all — not even discoverable by domain." },
+};
+
+/** B2 (#1094) / #1073's deferred per-org join policy control. Gates whether
+ *  `/welcome`'s verified-domain "ask to join" search surfaces this org. */
+export function JoinPolicySettings() {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+
+  const { data: policy, isLoading, refetch } = useServerQuery({
+    queryKey: ["org-join-policy", orgId],
+    queryFn: () => getJoinPolicy(),
+  });
+
+  const mutation = useServerMutation({
+    mutationFn: (next: OrgJoinPolicy) => setJoinPolicy(next),
+    onSuccess: () => {
+      refetch();
+      toast.success("Join policy updated");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const current = policy ?? "INVITE_ONLY";
+
+  if (isLoading) {
+    return <div className="h-9 w-48 animate-pulse rounded-md bg-bg-inset" />;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Select value={current} onValueChange={(v) => mutation.mutate(v as OrgJoinPolicy)}>
+        <SelectTrigger className="w-full sm:w-[260px]">
+          <SelectValue>{POLICY_LABELS[current].label}</SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {ORG_JOIN_POLICIES.map((p) => (
+            <SelectItem key={p} value={p}>
+              {POLICY_LABELS[p].label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="t-micro text-muted">{POLICY_LABELS[current].desc}</p>
+    </div>
+  );
+}

--- a/src/components/settings/join-request-approvals.tsx
+++ b/src/components/settings/join-request-approvals.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useServerQuery } from "@/hooks/use-server-query";
+import { useServerMutation } from "@/hooks/use-server-mutation";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Check, X, Clock } from "lucide-react";
+import { getPendingJoinRequests, approveJoinRequest, rejectJoinRequest } from "@/server/org-join";
+import { useActiveOrganization } from "@/lib/auth-client";
+import { toast } from "sonner";
+
+const BUILT_IN_ROLES = [
+  { value: "admin", label: "Admin" },
+  { value: "manager", label: "Manager" },
+  { value: "member", label: "Member" },
+  { value: "warehouse", label: "Warehouse" },
+  { value: "viewer", label: "Viewer" },
+];
+
+/** B2 (#1094) — verified-domain "ask to join" requests, reviewed here rather
+ *  than a second queue: the design doc calls for these landing beside
+ *  approvals in Settings → Team, not a copy of the SSO queue's location. */
+export function JoinRequestApprovals() {
+  const { data: activeOrg } = useActiveOrganization();
+  const orgId = activeOrg?.id;
+  const [roleOverrides, setRoleOverrides] = useState<Record<string, string>>({});
+
+  const { data: requests, isLoading, refetch } = useServerQuery({
+    queryKey: ["org-join-requests", orgId],
+    queryFn: () => getPendingJoinRequests(),
+  });
+
+  const approveMut = useServerMutation({
+    mutationFn: ({ id, role }: { id: string; role?: string }) => approveJoinRequest(id, role),
+    onSuccess: () => {
+      refetch();
+      toast.success("Request approved");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const rejectMut = useServerMutation({
+    mutationFn: (id: string) => rejectJoinRequest(id),
+    onSuccess: () => {
+      refetch();
+      toast.success("Request rejected");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return <div className="h-20 animate-pulse rounded-md bg-bg-inset" />;
+  }
+
+  if (!requests || requests.length === 0) {
+    return (
+      <div className="py-6 text-center text-sm text-fg-3">
+        <Clock className="mx-auto mb-2 h-8 w-8 opacity-50" />
+        No pending join requests.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      {requests.map((request: any) => (
+        <div key={request.id} className="flex items-center justify-between rounded-md border p-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium">{request.name || request.email}</p>
+              {request.name && <span className="text-xs text-fg-3">{request.email}</span>}
+            </div>
+            <p className="text-xs text-fg-3">{new Date(request.createdAt).toLocaleDateString()}</p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Select
+              value={roleOverrides[request.id] || "member"}
+              onValueChange={(v) => setRoleOverrides({ ...roleOverrides, [request.id]: v })}
+            >
+              <SelectTrigger className="h-8 w-36 text-xs">
+                <SelectValue>
+                  {BUILT_IN_ROLES.find((r) => r.value === (roleOverrides[request.id] || "member"))?.label}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {BUILT_IN_ROLES.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              size="sm"
+              variant="line"
+              className="border-green-600/20 text-green-600 hover:bg-green-600/10"
+              onClick={() => approveMut.mutate({ id: request.id, role: roleOverrides[request.id] })}
+              disabled={approveMut.isPending}
+            >
+              <Check className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant="line"
+              className="border-red-600/20 text-red-600 hover:bg-red-600/10"
+              onClick={() => rejectMut.mutate(request.id)}
+              disabled={rejectMut.isPending}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/api/registry.generated.ts
+++ b/src/lib/api/registry.generated.ts
@@ -32965,6 +32965,228 @@ export const API_REGISTRY: readonly RegistryOperation[] = [
     "deniedReason": null
   },
   {
+    "operation": "pendingOrgJoinRequests.findJoinableOrgsForDomain",
+    "module": "pendingOrgJoinRequests",
+    "fn": "findJoinableOrgsForDomain",
+    "kind": "query",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "domain",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "excludeUserId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "35829a05c2ae9581",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": "denied",
+    "deniedReason": "Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet."
+  },
+  {
+    "operation": "pendingOrgJoinRequests.list",
+    "module": "pendingOrgJoinRequests",
+    "fn": "list",
+    "kind": "query",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "549a746c6908f6ab",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": "denied",
+    "deniedReason": "Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet."
+  },
+  {
+    "operation": "pendingOrgJoinRequests.listPendingByUser",
+    "module": "pendingOrgJoinRequests",
+    "fn": "listPendingByUser",
+    "kind": "query",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "userId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "3b83ee450a3cde21",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": "denied",
+    "deniedReason": "Trusted-backend join-request queue/search; no org-scoped agent concern is defined for it yet."
+  },
+  {
+    "operation": "pendingOrgJoinRequests.request",
+    "module": "pendingOrgJoinRequests",
+    "fn": "request",
+    "kind": "mutation",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "createdAt",
+        "optional": true,
+        "type": "number"
+      },
+      {
+        "name": "email",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "id",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "optional": true,
+        "type": "string"
+      },
+      {
+        "name": "organizationId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "userId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "872fef7b7003490a",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": null,
+    "deniedReason": null
+  },
+  {
+    "operation": "pendingOrgJoinRequests.revertToPending",
+    "module": "pendingOrgJoinRequests",
+    "fn": "revertToPending",
+    "kind": "mutation",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "id",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "a4467f3b7f553dc9",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": null,
+    "deniedReason": null
+  },
+  {
+    "operation": "pendingOrgJoinRequests.review",
+    "module": "pendingOrgJoinRequests",
+    "fn": "review",
+    "kind": "mutation",
+    "guard": "service",
+    "resource": null,
+    "action": null,
+    "scopePairs": [],
+    "agentReachable": false,
+    "args": [
+      {
+        "name": "id",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "orgId",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "reviewedAt",
+        "optional": false,
+        "type": "number"
+      },
+      {
+        "name": "reviewedById",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "reviewNote",
+        "optional": true,
+        "type": "string"
+      },
+      {
+        "name": "status",
+        "optional": false,
+        "type": "union"
+      }
+    ],
+    "privilegedArgs": [],
+    "argsSha": "10cbf57951d691a7",
+    "returnsSha": "74234e98afe7498f",
+    "stability": "tracks-app",
+    "summary": null,
+    "danger": null,
+    "mcpTier": null,
+    "agentAccess": null,
+    "deniedReason": null
+  },
+  {
     "operation": "pendingSSOApprovals.createForProvisioning",
     "module": "pendingSSOApprovals",
     "fn": "createForProvisioning",
@@ -61043,10 +61265,10 @@ export const API_REGISTRY_BY_OPERATION: ReadonlyMap<string, RegistryOperation> =
 
 /** Counts published so the coverage table and any consumer agree by construction. */
 export const REGISTRY_COUNTS = {
-  total: 1175,
+  total: 1181,
   agentReachable: 567,
-  queries: 414,
-  mutations: 761,
+  queries: 417,
+  mutations: 764,
   agentReachableQueries: 290,
   agentReachableMutations: 277,
 } as const;

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -187,6 +187,42 @@ export function ssoAccessRejectedEmail({
   };
 }
 
+/**
+ * B2 (#1094) — an org admin/owner is notified immediately when someone asks
+ * to join via verified-domain match, the same "send right away, don't wait
+ * for the notification cron" posture as `invitationEmail` (Better Auth's own
+ * invite email is immediate too). Approval/rejection of the request reuses
+ * `ssoAccessApprovedEmail`/`ssoAccessRejectedEmail` as-is — the "your request
+ * to join X was approved/not approved" copy is identical regardless of
+ * whether the request came from SSO auto-provisioning or a domain match, so a
+ * second near-duplicate template would just be two copies of one fact (R-3.1).
+ */
+export function joinRequestReceivedEmail({
+  orgName,
+  requesterName,
+  requesterEmail,
+  reviewUrl,
+  platformName = "RVLT Flow",
+}: {
+  orgName: string;
+  requesterName?: string;
+  requesterEmail: string;
+  reviewUrl: string;
+  platformName?: string;
+}): EmailContent {
+  const who = requesterName
+    ? `${escapeHtml(requesterName)} (${escapeHtml(requesterEmail)})`
+    : escapeHtml(requesterEmail);
+  return {
+    subject: `${who} wants to join ${orgName}`,
+    html: emailShell(
+      `<h2>Join Request</h2>` +
+        `<p>${who} has asked to join <strong>${escapeHtml(orgName)}</strong> on ${platformName}, matched by your organisation's email domain.</p>` +
+        emailButton({ href: reviewUrl, label: "Review Request" }),
+    ),
+  };
+}
+
 const DIGEST_BODY_FONT_SIZE = "14px";
 
 function testTagDigestRow(item: TestTagDigestAsset): string {

--- a/src/lib/org-join-policy.test.ts
+++ b/src/lib/org-join-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isOrgJoinPolicy, toOrgJoinPolicy, DEFAULT_ORG_JOIN_POLICY, ORG_JOIN_POLICIES } from "./org-join-policy";
+
+describe("org-join-policy", () => {
+  it("recognises every valid policy", () => {
+    for (const p of ORG_JOIN_POLICIES) {
+      expect(isOrgJoinPolicy(p)).toBe(true);
+    }
+  });
+
+  it("rejects garbage", () => {
+    expect(isOrgJoinPolicy("OPEN")).toBe(false);
+    expect(isOrgJoinPolicy(undefined)).toBe(false);
+    expect(isOrgJoinPolicy(null)).toBe(false);
+    expect(isOrgJoinPolicy(42)).toBe(false);
+  });
+
+  it("defaults an absent/invalid value to INVITE_ONLY — every pre-B2 org", () => {
+    expect(toOrgJoinPolicy(undefined)).toBe(DEFAULT_ORG_JOIN_POLICY);
+    expect(toOrgJoinPolicy("garbage")).toBe(DEFAULT_ORG_JOIN_POLICY);
+    expect(DEFAULT_ORG_JOIN_POLICY).toBe("INVITE_ONLY");
+  });
+
+  it("passes through a valid value unchanged", () => {
+    expect(toOrgJoinPolicy("DOMAIN_REQUEST")).toBe("DOMAIN_REQUEST");
+    expect(toOrgJoinPolicy("CLOSED")).toBe("CLOSED");
+  });
+});

--- a/src/lib/org-join-policy.ts
+++ b/src/lib/org-join-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-org join policy (#1073/A3's deferred half, wired up by B2 #1094) — the
+ * single source of truth (R-3.1) for the literal union and its default, so
+ * the settings UI, the `/welcome` domain-search server action and the Convex
+ * `pendingOrgJoinRequests.request` mutation can't disagree on what a missing
+ * value means.
+ *
+ * Distinct from the platform-global `SiteSettings.registrationPolicy` (which
+ * gates *account* creation) — this gates *org membership* self-serve requests
+ * for an org that already exists.
+ *
+ * - `INVITE_ONLY` — the default (byte-identical to pre-B2 behaviour): no
+ *   self-serve path, an admin must send an invite.
+ * - `DOMAIN_REQUEST` — additionally offers "ask to join" to a user whose
+ *   verified email domain matches an existing member's.
+ * - `CLOSED` — not even discoverable via domain match; invite is the only way
+ *   in, and the org is not shown to anyone searching by domain.
+ */
+
+export const ORG_JOIN_POLICIES = ["INVITE_ONLY", "DOMAIN_REQUEST", "CLOSED"] as const;
+
+export type OrgJoinPolicy = (typeof ORG_JOIN_POLICIES)[number];
+
+export const DEFAULT_ORG_JOIN_POLICY: OrgJoinPolicy = "INVITE_ONLY";
+
+/** Narrowing guard for the settings blob's `v.any()`-adjacent JSON boundary. */
+export function isOrgJoinPolicy(value: unknown): value is OrgJoinPolicy {
+  return (ORG_JOIN_POLICIES as readonly unknown[]).includes(value);
+}
+
+/** A stored/untrusted value coerced to a valid policy, defaulting to
+ *  `INVITE_ONLY` for anything absent or unrecognised — every pre-B2 org. */
+export function toOrgJoinPolicy(value: unknown): OrgJoinPolicy {
+  return isOrgJoinPolicy(value) ? value : DEFAULT_ORG_JOIN_POLICY;
+}

--- a/src/lib/org-settings-types.ts
+++ b/src/lib/org-settings-types.ts
@@ -1,5 +1,6 @@
 import type { OrgSSOSettings } from "@/lib/sso-types";
 import type { IncrementReset } from "@/lib/project-number";
+import type { OrgJoinPolicy } from "@/lib/org-join-policy";
 
 /**
  * Pure type definitions for org settings — split out of `server/settings.ts`
@@ -101,4 +102,8 @@ export interface OrgSettings {
   icalEnabled?: boolean;
   prepKitCategoryId?: string;
   sso?: OrgSSOSettings;
+  /** B2 (#1094) — governs whether a non-member can self-serve request to join
+   *  via verified-domain match. Absent = `INVITE_ONLY` (see
+   *  `src/lib/org-join-policy.ts` for the full policy + default). */
+  joinPolicy?: OrgJoinPolicy;
 }

--- a/src/server/notifications.ts
+++ b/src/server/notifications.ts
@@ -19,7 +19,7 @@ import {
 
 export interface AppNotification {
   id: string;
-  type: "overdue_maintenance" | "overdue_return" | "upcoming_project" | "pending_invitation" | "pending_offers" | "pending_timesheets" | "flagged_asset" | "incident_report";
+  type: "overdue_maintenance" | "overdue_return" | "upcoming_project" | "pending_invitation" | "pending_offers" | "pending_timesheets" | "flagged_asset" | "incident_report" | "pending_join_requests";
   title: string;
   description: string;
   href: string;
@@ -290,6 +290,29 @@ export async function getNotifications(): Promise<AppNotification[]> {
         href: m.projectId ? `/warehouse/${m.projectId}` : `/maintenance/${m.id}`,
         severity: m.incidentSeverity === "MAJOR" ? "error" : "warning",
         timestamp: m.createdAt.toISOString(),
+      });
+    }
+  }
+
+  // 11. Pending org join requests (B2, #1094) — admin/owner visible only,
+  // since a member can see the count but can't act on it in Settings → Team.
+  const viewerMember = await prisma.member.findFirst({
+    where: { organizationId, userId },
+    select: { role: true },
+  });
+  if (viewerMember && (viewerMember.role === "owner" || viewerMember.role === "admin")) {
+    const pendingJoinRequests = await (await getConvexClient()).query(api.pendingOrgJoinRequests.list, {
+      orgId: organizationId,
+    });
+    if (pendingJoinRequests.length > 0) {
+      notifications.push({
+        id: "org-pending-join-requests",
+        type: "pending_join_requests",
+        title: `${pendingJoinRequests.length} pending join request${pendingJoinRequests.length !== 1 ? "s" : ""}`,
+        description: `${pendingJoinRequests.length} ${pendingJoinRequests.length !== 1 ? "people are" : "person is"} asking to join your organisation`,
+        href: "/settings/team",
+        severity: "info",
+        timestamp: now.toISOString(),
       });
     }
   }

--- a/src/server/org-join.test.ts
+++ b/src/server/org-join.test.ts
@@ -1,0 +1,232 @@
+/**
+ * src/server/org-join.ts — B2 (#1094): invite-code validation, the per-org
+ * join policy, verified-domain discovery/request, and approve/reject. Every
+ * mutating path re-checks emailVerified/policy server-side (R-9.3), so these
+ * tests focus on the gates rather than re-testing Convex's own logic (that
+ * lives in convex/pendingOrgJoinRequests.ts, exercised separately).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/env", () => ({ env: { NEXT_PUBLIC_APP_URL: "https://flow.example" } }));
+
+const getOrgContext = vi.fn();
+const requirePermission = vi.fn();
+vi.mock("@/lib/org-context", () => ({
+  getOrgContext: (...a: unknown[]) => getOrgContext(...a),
+  requirePermission: (...a: unknown[]) => requirePermission(...a),
+}));
+
+const requireSession = vi.fn();
+vi.mock("@/lib/auth-server", () => ({
+  requireSession: (...a: unknown[]) => requireSession(...a),
+}));
+
+const invitationFindUnique = vi.fn();
+const organizationFindUnique = vi.fn();
+const memberFindMany = vi.fn();
+const memberFindFirst = vi.fn();
+const memberCreate = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    invitation: { findUnique: (...a: unknown[]) => invitationFindUnique(...a) },
+    organization: { findUnique: (...a: unknown[]) => organizationFindUnique(...a) },
+    member: {
+      findMany: (...a: unknown[]) => memberFindMany(...a),
+      findFirst: (...a: unknown[]) => memberFindFirst(...a),
+      create: (...a: unknown[]) => memberCreate(...a),
+    },
+  },
+}));
+
+const convexMock = vi.hoisted(() => ({ query: vi.fn(), mutation: vi.fn() }));
+vi.mock("@/lib/convex-client", () => ({ getConvexClient: vi.fn(async () => convexMock) }));
+
+const readOrgSettingsBlob = vi.fn();
+const saveOrgSettings = vi.fn();
+vi.mock("@/lib/org-settings-read", () => ({
+  readOrgSettingsBlob: (...a: unknown[]) => readOrgSettingsBlob(...a),
+  saveOrgSettings: (...a: unknown[]) => saveOrgSettings(...a),
+}));
+
+const sendEmail: (...args: unknown[]) => Promise<void> = vi.fn(async () => undefined);
+vi.mock("@/lib/email", () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+vi.mock("@/lib/platform", () => ({ getPlatformName: vi.fn(async () => "RVLT Flow") }));
+vi.mock("@/lib/activity-log", () => ({ logActivity: vi.fn(async () => {}) }));
+vi.mock("@/lib/member-mirror", () => ({ upsertMemberMirrorByOrgUser: vi.fn(async () => {}) }));
+
+import {
+  checkInviteCode,
+  getJoinPolicy,
+  setJoinPolicy,
+  getJoinableOrgs,
+  requestToJoinOrg,
+  getPendingJoinRequests,
+  approveJoinRequest,
+  rejectJoinRequest,
+} from "./org-join";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getOrgContext.mockResolvedValue({ organizationId: "org_A", userId: "user_owner", userName: "Owner" });
+  requirePermission.mockResolvedValue({ organizationId: "org_A", userId: "user_owner", userName: "Owner" });
+  readOrgSettingsBlob.mockResolvedValue({});
+  organizationFindUnique.mockResolvedValue({ name: "Acme" });
+});
+
+describe("checkInviteCode", () => {
+  it("resolves a bare pending invite id", async () => {
+    invitationFindUnique.mockResolvedValue({ status: "pending", expiresAt: new Date(Date.now() + 1000) });
+    const result = await checkInviteCode("inv_123");
+    expect(result).toEqual({ id: "inv_123" });
+  });
+
+  it("extracts the id from a pasted invite URL", async () => {
+    invitationFindUnique.mockResolvedValue({ status: "pending", expiresAt: new Date(Date.now() + 1000) });
+    const result = await checkInviteCode("https://flow.rvlt.app/invite/inv_abc?foo=bar");
+    expect(result).toEqual({ id: "inv_abc" });
+    expect(invitationFindUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "inv_abc" } }));
+  });
+
+  it("returns null for an unknown, expired, or non-pending invite", async () => {
+    invitationFindUnique.mockResolvedValue(null);
+    expect(await checkInviteCode("bogus")).toBeNull();
+
+    invitationFindUnique.mockResolvedValue({ status: "pending", expiresAt: new Date(Date.now() - 1000) });
+    expect(await checkInviteCode("expired")).toBeNull();
+
+    invitationFindUnique.mockResolvedValue({ status: "cancelled", expiresAt: new Date(Date.now() + 1000) });
+    expect(await checkInviteCode("cancelled")).toBeNull();
+  });
+
+  it("returns null for blank input without touching the database", async () => {
+    expect(await checkInviteCode("   ")).toBeNull();
+    expect(invitationFindUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("join policy", () => {
+  it("defaults to INVITE_ONLY when unset", async () => {
+    readOrgSettingsBlob.mockResolvedValue({});
+    expect(await getJoinPolicy()).toBe("INVITE_ONLY");
+  });
+
+  it("returns the stored policy", async () => {
+    readOrgSettingsBlob.mockResolvedValue({ joinPolicy: "DOMAIN_REQUEST" });
+    expect(await getJoinPolicy()).toBe("DOMAIN_REQUEST");
+  });
+
+  it("rejects an invalid policy value", async () => {
+    // @ts-expect-error deliberate garbage input
+    await expect(setJoinPolicy("OPEN")).rejects.toThrow(/invalid/i);
+    expect(saveOrgSettings).not.toHaveBeenCalled();
+  });
+
+  it("persists a valid policy change", async () => {
+    readOrgSettingsBlob.mockResolvedValue({});
+    await setJoinPolicy("DOMAIN_REQUEST");
+    expect(saveOrgSettings).toHaveBeenCalledWith("org_A", { joinPolicy: "DOMAIN_REQUEST" });
+  });
+});
+
+describe("getJoinableOrgs", () => {
+  it("requires email verification before searching", async () => {
+    requireSession.mockResolvedValue({ user: { id: "u1", email: "sam@northlight.com.au", emailVerified: false } });
+    const result = await getJoinableOrgs();
+    expect(result).toEqual({ requiresVerification: true, orgs: [] });
+    expect(convexMock.query).not.toHaveBeenCalled();
+  });
+
+  it("searches by domain once verified, marking already-requested orgs", async () => {
+    requireSession.mockResolvedValue({ user: { id: "u1", email: "sam@northlight.com.au", emailVerified: true } });
+    convexMock.query
+      .mockResolvedValueOnce([{ organizationId: "org_x", organizationName: "Northlight AV", memberCount: 3 }])
+      .mockResolvedValueOnce([{ organizationId: "org_x" }]);
+
+    const result = await getJoinableOrgs();
+    expect(result.requiresVerification).toBe(false);
+    expect(result.orgs).toEqual([
+      { organizationId: "org_x", organizationName: "Northlight AV", memberCount: 3, alreadyRequested: true },
+    ]);
+  });
+});
+
+describe("requestToJoinOrg", () => {
+  it("rejects an unverified email before calling Convex", async () => {
+    requireSession.mockResolvedValue({ user: { id: "u1", email: "sam@northlight.com.au", emailVerified: false } });
+    await expect(requestToJoinOrg("org_x")).rejects.toThrow(/verify your email/i);
+    expect(convexMock.mutation).not.toHaveBeenCalled();
+  });
+
+  it("creates the request and emails owners/admins", async () => {
+    requireSession.mockResolvedValue({
+      user: { id: "u1", email: "sam@northlight.com.au", name: "Sam", emailVerified: true },
+    });
+    convexMock.mutation.mockResolvedValue({ id: "req_1", created: true });
+    memberFindMany.mockResolvedValue([
+      { user: { email: "owner@northlight.com.au" } },
+      { user: { email: "admin@northlight.com.au" } },
+    ]);
+
+    const result = await requestToJoinOrg("org_x");
+    expect(result).toEqual({ id: "req_1", created: true });
+    expect(convexMock.mutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: "org_x", userId: "u1", email: "sam@northlight.com.au" }),
+    );
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("doesn't re-email admins for an idempotent duplicate request", async () => {
+    requireSession.mockResolvedValue({ user: { id: "u1", email: "sam@northlight.com.au", emailVerified: true } });
+    convexMock.mutation.mockResolvedValue({ id: "req_1", created: false });
+
+    await requestToJoinOrg("org_x");
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("approveJoinRequest / rejectJoinRequest", () => {
+  it("approves, creates the member, and emails the requester", async () => {
+    convexMock.mutation.mockResolvedValue({ userId: "u_target", email: "target@northlight.com.au" });
+    memberFindFirst.mockResolvedValue(null);
+
+    const result = await approveJoinRequest("req_1", "member");
+    expect(result).toEqual({ success: true });
+    expect(memberCreate).toHaveBeenCalledWith({
+      data: { organizationId: "org_A", userId: "u_target", role: "member" },
+    });
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to member role for an unassignable role", async () => {
+    convexMock.mutation.mockResolvedValue({ userId: "u_target", email: "target@northlight.com.au" });
+    memberFindFirst.mockResolvedValue(null);
+
+    await approveJoinRequest("req_1", "owner");
+    expect(memberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ role: "member" }) }),
+    );
+  });
+
+  it("rejects and emails the requester without creating a member", async () => {
+    convexMock.mutation.mockResolvedValue({ userId: "u_target", email: "target@northlight.com.au" });
+
+    const result = await rejectJoinRequest("req_1", "not a fit");
+    expect(result).toEqual({ success: true });
+    expect(memberCreate).not.toHaveBeenCalled();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a clear error when the request no longer exists", async () => {
+    convexMock.mutation.mockRejectedValue(new Error("Pending join request not found"));
+    await expect(approveJoinRequest("req_gone")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("getPendingJoinRequests", () => {
+  it("coerces createdAt to a Date", async () => {
+    convexMock.query.mockResolvedValue([{ id: "req_1", email: "a@b.com", createdAt: 1700000000000 }]);
+    const result = await getPendingJoinRequests();
+    expect(result[0].createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/server/org-join.ts
+++ b/src/server/org-join.ts
@@ -1,0 +1,292 @@
+"use server";
+
+import { createId } from "@paralleldrive/cuid2";
+import { prisma } from "@/lib/prisma";
+import { getConvexClient } from "@/lib/convex-client";
+import { api } from "../../convex/_generated/api";
+import { getOrgContext, requirePermission } from "@/lib/org-context";
+import { requireSession } from "@/lib/auth-server";
+import { serialize } from "@/lib/serialize";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+import {
+  joinRequestReceivedEmail,
+  ssoAccessApprovedEmail,
+  ssoAccessRejectedEmail,
+} from "@/lib/email-templates";
+import { getPlatformName } from "@/lib/platform";
+import { logActivity } from "@/lib/activity-log";
+import { upsertMemberMirrorByOrgUser } from "@/lib/member-mirror";
+import { readOrgSettingsBlob, saveOrgSettings } from "@/lib/org-settings-read";
+import { env } from "@/env";
+import {
+  isOrgJoinPolicy,
+  toOrgJoinPolicy,
+  type OrgJoinPolicy,
+} from "@/lib/org-join-policy";
+
+/**
+ * B2 (#1094) — "join an existing org", the second branch of `/welcome`'s
+ * create-vs-join fork (B1, #1092). Two self-serve paths:
+ *
+ *  - Invite code: reuses the existing `Invitation` → `/invite/[id]` →
+ *    `acceptInvitation` flow unchanged; `checkInviteCode` below just
+ *    validates a pasted code/link before navigating there.
+ *  - Verified-domain request: the functions below. Gated on the requesting
+ *    user's `emailVerified` (never on the client alone — every mutating
+ *    action re-checks server-side, R-9.3) and on the target org's
+ *    `joinPolicy` being DOMAIN_REQUEST (#1073's deferred half).
+ */
+
+// ─── Invite code ─────────────────────────────────────────────────────────────
+
+/** Extract a bare invitation id from a pasted invite link or raw id, and
+ *  confirm it's still a live pending invite — so `/welcome`'s code field can
+ *  show an inline error instead of a blind navigation to a dead invite. */
+export async function checkInviteCode(rawInput: string): Promise<{ id: string } | null> {
+  const trimmed = rawInput.trim();
+  if (!trimmed) return null;
+  const marker = "/invite/";
+  const afterMarker = trimmed.includes(marker) ? trimmed.slice(trimmed.lastIndexOf(marker) + marker.length) : trimmed;
+  const id = afterMarker.split(/[/?#]/)[0]?.trim();
+  if (!id) return null;
+
+  const invitation = await prisma.invitation.findUnique({
+    where: { id },
+    select: { status: true, expiresAt: true },
+  });
+  if (!invitation || invitation.status !== "pending" || invitation.expiresAt < new Date()) {
+    return null;
+  }
+  return { id };
+}
+
+// ─── Join policy (Settings → Team) ──────────────────────────────────────────
+
+export async function getJoinPolicy(): Promise<OrgJoinPolicy> {
+  const { organizationId } = await getOrgContext();
+  const settings = await readOrgSettingsBlob(organizationId);
+  return toOrgJoinPolicy(settings.joinPolicy);
+}
+
+export async function setJoinPolicy(policy: OrgJoinPolicy) {
+  const { organizationId, userId, userName } = await requirePermission("orgSettings", "update");
+  if (!isOrgJoinPolicy(policy)) throw new Error("Invalid join policy");
+
+  const settings = await readOrgSettingsBlob(organizationId);
+  settings.joinPolicy = policy;
+  await saveOrgSettings(organizationId, settings);
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "UPDATE",
+    entityType: "org_join_policy",
+    entityId: organizationId,
+    entityName: "Join Policy",
+    summary: `Set join policy to ${policy}`,
+  });
+
+  return { success: true };
+}
+
+// ─── Verified-domain request — discovery + create (public-to-a-session) ────
+
+export interface JoinableOrg {
+  organizationId: string;
+  organizationName: string;
+  memberCount: number;
+  alreadyRequested: boolean;
+}
+
+/**
+ * Orgs a signed-in, zero-org user can ask to join by domain match. Requires a
+ * session but deliberately NOT an org context — this runs for a user who by
+ * definition doesn't have one yet (`/welcome`).
+ */
+export async function getJoinableOrgs(): Promise<{ requiresVerification: boolean; orgs: JoinableOrg[] }> {
+  const session = await requireSession();
+  if (!session.user.emailVerified) {
+    return { requiresVerification: true, orgs: [] };
+  }
+
+  const email = session.user.email?.toLowerCase();
+  const domain = email?.split("@")[1];
+  if (!domain) return { requiresVerification: false, orgs: [] };
+
+  const convex = await getConvexClient();
+  const [matches, pending] = await Promise.all([
+    convex.query(api.pendingOrgJoinRequests.findJoinableOrgsForDomain, {
+      domain,
+      excludeUserId: session.user.id,
+    }),
+    convex.query(api.pendingOrgJoinRequests.listPendingByUser, { userId: session.user.id }),
+  ]);
+  const pendingOrgIds = new Set(pending.map((p) => p.organizationId));
+
+  return {
+    requiresVerification: false,
+    orgs: matches.map((m) => ({ ...m, alreadyRequested: pendingOrgIds.has(m.organizationId) })),
+  };
+}
+
+/** Ask to join `organizationId`. Every authority check (policy, membership,
+ *  domain match) is re-derived and re-verified inside the Convex `request`
+ *  mutation itself, not here — this action only supplies the identity. */
+export async function requestToJoinOrg(organizationId: string) {
+  const session = await requireSession();
+  if (!session.user.emailVerified) {
+    throw new Error("Please verify your email before requesting to join an organisation.");
+  }
+  if (!session.user.email) throw new Error("Your account has no email address.");
+
+  const convex = await getConvexClient();
+  const result = await convex.mutation(api.pendingOrgJoinRequests.request, {
+    id: createId(),
+    organizationId,
+    userId: session.user.id,
+    email: session.user.email,
+    name: session.user.name || undefined,
+    createdAt: Date.now(),
+  });
+
+  if (result.created) {
+    const org = await prisma.organization.findUnique({ where: { id: organizationId }, select: { name: true } });
+    const admins = await prisma.member.findMany({
+      where: { organizationId, role: { in: ["owner", "admin"] } },
+      include: { user: { select: { email: true } } },
+    });
+    const pName = await getPlatformName();
+    const reviewUrl = `${env.NEXT_PUBLIC_APP_URL}/settings/team`;
+    await Promise.all(
+      admins
+        .filter((m: { user: { email: string } }) => m.user.email)
+        .map((m: { user: { email: string } }) =>
+          sendEmail({
+            to: m.user.email,
+            ...joinRequestReceivedEmail({
+              orgName: org?.name || "your organisation",
+              requesterName: session.user.name,
+              requesterEmail: session.user.email,
+              reviewUrl,
+              platformName: pName,
+            }),
+          }).catch((e) => logger.error("async task failed", { error: e })),
+        ),
+    );
+  }
+
+  return serialize(result);
+}
+
+// ─── Approve / reject (Settings → Team) ─────────────────────────────────────
+
+export async function getPendingJoinRequests() {
+  const { organizationId } = await getOrgContext();
+  const rows = await (await getConvexClient()).query(api.pendingOrgJoinRequests.list, { orgId: organizationId });
+  const requests = rows.map((r) => ({ ...r, createdAt: r.createdAt != null ? new Date(r.createdAt) : new Date(0) }));
+  return serialize(requests);
+}
+
+const JOIN_APPROVAL_ROLES = ["admin", "manager", "member", "warehouse", "viewer"];
+
+export async function approveJoinRequest(requestId: string, role?: string) {
+  const { organizationId, userId, userName } = await requirePermission("orgMembers", "create");
+  const convex = await getConvexClient();
+
+  let claimed: { userId: string; email: string };
+  try {
+    claimed = await convex.mutation(api.pendingOrgJoinRequests.review, {
+      id: requestId,
+      orgId: organizationId,
+      status: "APPROVED",
+      reviewedById: userId,
+      reviewedAt: Date.now(),
+    });
+  } catch {
+    throw new Error("Pending join request not found");
+  }
+
+  const assignRole = role && JOIN_APPROVAL_ROLES.includes(role) ? role : "member";
+
+  try {
+    const existingMember = await prisma.member.findFirst({
+      where: { organizationId, userId: claimed.userId },
+      select: { id: true },
+    });
+    if (!existingMember) {
+      await prisma.member.create({ data: { organizationId, userId: claimed.userId, role: assignRole } });
+    }
+  } catch (e) {
+    await convex
+      .mutation(api.pendingOrgJoinRequests.revertToPending, { id: requestId, orgId: organizationId })
+      .catch(() => {});
+    throw e;
+  }
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "CREATE",
+    entityType: "member",
+    entityId: claimed.userId,
+    entityName: claimed.email,
+    summary: `Approved join request from ${claimed.email} with role ${assignRole}`,
+  });
+
+  await upsertMemberMirrorByOrgUser(organizationId, claimed.userId);
+
+  const pName = await getPlatformName();
+  const org = await prisma.organization.findUnique({ where: { id: organizationId }, select: { name: true } });
+  sendEmail({
+    to: claimed.email,
+    ...ssoAccessApprovedEmail({
+      orgName: org?.name || "the organization",
+      role: assignRole,
+      dashboardUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard`,
+      platformName: pName,
+    }),
+  }).catch((e) => logger.error("async task failed", { error: e }));
+
+  return { success: true };
+}
+
+export async function rejectJoinRequest(requestId: string, note?: string) {
+  const { organizationId, userId, userName } = await requirePermission("orgMembers", "create");
+
+  let request: { userId: string; email: string };
+  try {
+    request = await (await getConvexClient()).mutation(api.pendingOrgJoinRequests.review, {
+      id: requestId,
+      orgId: organizationId,
+      status: "REJECTED",
+      reviewedById: userId,
+      reviewedAt: Date.now(),
+      reviewNote: note,
+    });
+  } catch {
+    throw new Error("Pending join request not found");
+  }
+
+  await logActivity({
+    organizationId,
+    userId,
+    userName,
+    action: "DELETE",
+    entityType: "pending_org_join_request",
+    entityId: requestId,
+    entityName: request.email,
+    summary: `Rejected join request from ${request.email}${note ? `: ${note}` : ""}`,
+  });
+
+  const pName = await getPlatformName();
+  const org = await prisma.organization.findUnique({ where: { id: organizationId }, select: { name: true } });
+  sendEmail({
+    to: request.email,
+    ...ssoAccessRejectedEmail({ orgName: org?.name || "the organization", note, platformName: pName }),
+  }).catch((e) => logger.error("async task failed", { error: e }));
+
+  return { success: true };
+}


### PR DESCRIPTION
## Summary

Implements **B2 — join an existing org** (#1094), part of Phase B (#1067) of the multi-tenant + international tracking epic (#1063). Replaces `/welcome`'s "Join my team" placeholder (shipped in #1164/B1) with the real flow described in the design doc (`onboarding-and-activation.md` §5.2):

- **Invite code entry** — paste an invite link or bare code; `checkInviteCode()` validates it's a live pending invite before navigating to the existing `/invite/[id]` → `acceptInvitation` flow. No verification needed (possession of the invite is the proof).
- **Verified-domain "ask to join"** — gated on `emailVerified`. `getJoinableOrgs()`/`requestToJoinOrg()` (`src/server/org-join.ts`) search for orgs whose `joinPolicy` (new `src/lib/org-join-policy.ts`, default `INVITE_ONLY` — byte-identical for every pre-existing org) is `DOMAIN_REQUEST` and share the requester's email domain. Every authority check (policy, existing membership, domain match) is re-derived server-side inside the new Convex `pendingOrgJoinRequests` module — never trusted from the client. Personal-mail domains (gmail.com etc., `convex/lib/personalEmailDomains.ts`) are excluded from matching.
- **Settings → Team** — a join-policy control plus a "Pending Join Requests" approval queue, structurally cloned from the existing SSO approvals' atomic PENDING→APPROVED/REJECTED claim pattern. Requesters get an immediate email either way; org owners/admins get an immediate email on a new request plus a `pending_join_requests` bell notification.
- This also gives **#1073**'s previously-deferred per-org join policy its first real consumer.

## Testing

- `src/server/org-join.test.ts`, `src/lib/org-join-policy.test.ts`, `convex/lib/personalEmailDomains.test.ts` — new, cover the policy defaults, invite-code validation, the email-verification/domain-match gates, and approve/reject.
- Updated `src/app/(auth)/welcome/__tests__/page.smoke.test.tsx` for the new join UI (invite-code entry, domain-request cards).
- `pnpm exec vitest run` — full suite, 5444/5444 tests passing (52 files fail to *collect* in this sandbox only, due to a missing generated Prisma client with no `.env` configured here — pre-existing, unrelated to this diff).
- `pnpm exec tsc --noEmit` — clean.
- `pnpm run lint` — clean on every touched file (pre-existing warnings elsewhere untouched).
- `complexity-ratchet` / `any-ratchet` / `knip-ratchet` / `api:registry:check` — all pass.
- `pnpm run api:registry && pnpm run api:docs && pnpm run api:mcp` — regenerated and committed.

## Checklist

- [x] New dependency? — None added.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZMWHhSQHN2EuFcrv8m1cp)_