### PR TITLE
react-pdf migration 3/7: migrate invoice doc type (#1153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not wired into `generate-pdf.ts`/`pdf-render.ts`; no user-facing change
   yet.
 
+- **#1153** — `invoice` doc type ported to react-pdf
+  (`src/lib/react-pdf/invoice-document.tsx`), reusing #1152's shared
+  components: the country-derived "TAX INVOICE"/"INVOICE" heading (I4,
+  #1083), client tax id / payment terms / issued invoice number in the
+  details row, deposit paid / balance due / due date in the totals block,
+  the bold due-date header highlight, and a new payment-details block (bank
+  details) that shares terms & conditions' free-text convention without
+  forcing its own page. Still standalone and not wired into
+  `generate-pdf.ts`/`pdf-render.ts`; no user-facing change yet.
+
 - **#1092** — A brand-new account with no organisation and no pending invite
   now lands on `/welcome`, a fork between "Set up a new company" and "Join my
   team" — instead of dead-ending on the old onboarding bounce. The create

--- a/FEATUREDOCS/13-pdfs.md
+++ b/FEATUREDOCS/13-pdfs.md
@@ -144,6 +144,30 @@ Helvetica-only / em-dash-normalization question the spike flagged as
 `draft-watermark.tsx` keeps the normalization as cheap insurance pending
 that verification.
 
+**Invoice ported (#1153, 2026-08-04).** `src/lib/react-pdf/invoice-document.tsx`
+composes the same shared components as `quote-document.tsx` — still standalone,
+still not wired into `generate-pdf.ts`/`pdf-render.ts`, still hand-composed in
+JSX rather than walking `DOCUMENT_LAYOUTS.invoice` (point (1) above is
+unchanged; it's a later issue). The delta over quote, all mirroring the old
+pipeline's `invoice`-specific branches in `document-composer.ts`:
+
+- `DetailsRow` (`components/details-row.tsx`) gained an optional `config` prop
+  gating `showClientTaxId`/`showPaymentTerms`/`showInvoiceNumber` — quote
+  passes no config, so its rendering is unchanged; invoice turns all three on.
+  The pure line-building functions (`buildClientLines`/`buildProjectLines`)
+  are exported and unit-tested directly (`__tests__/details-row.test.ts`),
+  the same convention `line-items-table.tsx`'s pure decision functions use.
+- The `TAX INVOICE` heading takes the I4 (#1083) country-derived
+  `org_invoice_heading` override — `TotalsBlock`'s Deposit Paid/Balance Due/
+  Due Date rows and `Header`'s bold "Due: <date>" highlight needed **no**
+  changes; #1152 already gated both on the data being present rather than a
+  separate config flag.
+- A new `paymentDetails` block (bank details, invoice-only, same free-text/
+  markdown-lite convention as terms & conditions) renders directly after the
+  totals block. Unlike terms & conditions it does **not** use `break` — it's
+  meant to flow onto whatever room is left after the totals block, not read
+  as its own legal section.
+
 **Quote/invoice table simplification (2026-07-26):** the quote/invoice table
 dropped its separate "Days" column — it duplicated the per-line `duration`
 value next to the rate/total columns without adding information the reader

--- a/src/lib/react-pdf/components/__tests__/details-row.test.ts
+++ b/src/lib/react-pdf/components/__tests__/details-row.test.ts
@@ -1,0 +1,65 @@
+/**
+ * #1153 — regression coverage for details-row.tsx's `config`-gated fields
+ * (`showClientTaxId`/`showPaymentTerms`/`showInvoiceNumber`), the invoice
+ * layout's delta over quote's plain `DetailsRow` usage. Mirrors
+ * line-items-table.test.ts's convention of asserting on the exported pure
+ * functions directly rather than rendering a PDF.
+ */
+import { describe, it, expect } from "vitest";
+import { buildClientLines, buildProjectLines } from "../details-row";
+import { makeSpikeData } from "../../fixture";
+
+describe("buildClientLines", () => {
+  it("omits the client tax id line with no config (quote's usage)", () => {
+    const data = makeSpikeData({ client_tax_id: "98 765 432 100" });
+    const lines = buildClientLines(data, {});
+    expect(lines.some((l) => l.includes("98 765 432 100"))).toBe(false);
+  });
+
+  it("includes the client tax id line, labelled with the org's country-derived business-number label, when showClientTaxId is on", () => {
+    const data = makeSpikeData({ client_tax_id: "98 765 432 100", org_business_number_label: "ABN" });
+    const lines = buildClientLines(data, { showClientTaxId: true });
+    expect(lines).toContain("ABN: 98 765 432 100");
+  });
+
+  it("uses a GB org's business-number label instead of ABN", () => {
+    const data = makeSpikeData({ client_tax_id: "GB987654321", org_business_number_label: "VAT number" });
+    const lines = buildClientLines(data, { showClientTaxId: true });
+    expect(lines).toContain("VAT number: GB987654321");
+    expect(lines.some((l) => l.startsWith("ABN:"))).toBe(false);
+  });
+
+  it("omits the tax id line even with showClientTaxId on when the client has none set", () => {
+    const data = makeSpikeData({ client_tax_id: "" });
+    const lines = buildClientLines(data, { showClientTaxId: true });
+    expect(lines.some((l) => l.includes("ABN") || l.includes("VAT"))).toBe(false);
+  });
+});
+
+describe("buildProjectLines", () => {
+  it("omits payment terms and invoice number with no config (quote's usage)", () => {
+    const data = makeSpikeData({ client_payment_terms: "14 days", invoice_number: "INV-2026-0142" });
+    const lines = buildProjectLines(data, {});
+    expect(lines.some((l) => l.startsWith("Payment Terms:"))).toBe(false);
+    expect(lines.some((l) => l.startsWith("Invoice #:"))).toBe(false);
+  });
+
+  it("includes payment terms and invoice number when both config flags are on and the data is set", () => {
+    const data = makeSpikeData({ client_payment_terms: "14 days", invoice_number: "INV-2026-0142" });
+    const lines = buildProjectLines(data, { showPaymentTerms: true, showInvoiceNumber: true });
+    expect(lines).toContain("Payment Terms: 14 days");
+    expect(lines).toContain("Invoice #: INV-2026-0142");
+  });
+
+  it("omits the invoice number line when the invoice hasn't been issued yet, even with showInvoiceNumber on (WS1 #940)", () => {
+    const data = makeSpikeData({ invoice_number: "" });
+    const lines = buildProjectLines(data, { showInvoiceNumber: true });
+    expect(lines.some((l) => l.startsWith("Invoice #:"))).toBe(false);
+  });
+
+  it("omits the payment terms line when the client has none set, even with showPaymentTerms on", () => {
+    const data = makeSpikeData({ client_payment_terms: "" });
+    const lines = buildProjectLines(data, { showPaymentTerms: true });
+    expect(lines.some((l) => l.startsWith("Payment Terms:"))).toBe(false);
+  });
+});

--- a/src/lib/react-pdf/components/details-row.tsx
+++ b/src/lib/react-pdf/components/details-row.tsx
@@ -2,10 +2,21 @@
  * #1151 spike — client/project two-column details row (quote's
  * `defaultClientDetails`/`defaultProjectDetails` config from
  * document-layouts.ts).
+ *
+ * #1153 extended this with an optional `config` for the fields invoice's
+ * layout turns on (`showClientTaxId`/`showPaymentTerms`/`showInvoiceNumber` —
+ * see document-composer.ts's `detailsRow` case, the source these mirror).
+ * Quote passes no config, so its rendering is unchanged.
  */
 import { Text, View } from "@react-pdf/renderer";
 import type { DocumentData } from "@/lib/pdfme/types";
 import { COLORS, FONT_SIZE } from "../styles";
+
+export interface DetailsRowConfig {
+  showClientTaxId?: boolean;
+  showPaymentTerms?: boolean;
+  showInvoiceNumber?: boolean;
+}
 
 function formatDateRange(label: string, start: string, end: string): string | null {
   if (!start || start === "-") return null;
@@ -13,21 +24,30 @@ function formatDateRange(label: string, start: string, end: string): string | nu
   return `${label}: ${start}${endPart}`;
 }
 
-function buildClientLines(data: DocumentData): string[] {
+export function buildClientLines(data: DocumentData, config: DetailsRowConfig): string[] {
   return [
     data.client_name,
     data.client_contact ? `Attn: ${data.client_contact}` : null,
     data.client_email,
     data.client_billing_address,
+    // Same country-derived label as the org's own number in the header (I4,
+    // #1083) — it names the org's home-jurisdiction registration-number
+    // format, not a per-party thing.
+    config.showClientTaxId && data.client_tax_id ? `${data.org_business_number_label}: ${data.client_tax_id}` : null,
   ].filter((line): line is string => !!line);
 }
 
-function buildProjectLines(data: DocumentData): string[] {
+export function buildProjectLines(data: DocumentData, config: DetailsRowConfig): string[] {
   return [
     data.project_name,
     data.venue_name ? `Venue: ${data.venue_name}` : null,
     formatDateRange("Rental", data.rental_start, data.rental_end),
     formatDateRange("Event", data.event_start, data.event_end),
+    config.showPaymentTerms && data.client_payment_terms ? `Payment Terms: ${data.client_payment_terms}` : null,
+    // WS1 (#940) — only renders once the invoice has actually been ISSUED
+    // (build-document-data.ts resolves this to "" for a DRAFT-only project,
+    // and the guard here matches every other conditional line above).
+    config.showInvoiceNumber && data.invoice_number ? `Invoice #: ${data.invoice_number}` : null,
   ].filter((line): line is string => !!line);
 }
 
@@ -46,11 +66,11 @@ function DetailsColumn({ lines }: { lines: string[] }) {
   );
 }
 
-export function DetailsRow({ data }: { data: DocumentData }) {
+export function DetailsRow({ data, config = {} }: { data: DocumentData; config?: DetailsRowConfig }) {
   return (
     <View style={{ flexDirection: "row", justifyContent: "space-between" }} wrap={false}>
-      <DetailsColumn lines={buildClientLines(data)} />
-      <DetailsColumn lines={buildProjectLines(data)} />
+      <DetailsColumn lines={buildClientLines(data, config)} />
+      <DetailsColumn lines={buildProjectLines(data, config)} />
     </View>
   );
 }

--- a/src/lib/react-pdf/invoice-document.test.ts
+++ b/src/lib/react-pdf/invoice-document.test.ts
@@ -1,0 +1,108 @@
+/**
+ * #1153 — automated smoke coverage for the standalone react-pdf invoice
+ * component tree, mirroring `quote-document.test.ts`'s bar (render, no
+ * throw, page-count sanity — see that file's header comment and
+ * `totals-block.test.tsx` for why this codebase's react-pdf tests stop
+ * there rather than parsing PDF text). Covers the invoice-specific delta
+ * `document-composer.test.ts` exercises against the old pipeline: due date,
+ * payment details, ABN/client tax id, deposit/balance, and the
+ * `org_invoice_heading` country-derived title override (I4, #1083).
+ */
+import { describe, it, expect } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { PDFDocument as PdfLibDocument } from "@pdfme/pdf-lib";
+import { InvoiceDocument } from "./invoice-document";
+import { makeSpikeData, makeLongLineItemList } from "./fixture";
+
+async function pageCount(data: ReturnType<typeof makeSpikeData>, draftPreview = false) {
+  const buffer = await renderToBuffer(InvoiceDocument({ data, draftPreview }));
+  const pdf = await PdfLibDocument.load(buffer);
+  return pdf.getPageCount();
+}
+
+describe("InvoiceDocument (react-pdf)", () => {
+  it("renders a single-page invoice with no line items and no terms & conditions", async () => {
+    const data = makeSpikeData({ line_items: [], total_items: 0, terms_and_conditions: "" });
+    expect(await pageCount(data)).toBe(1);
+  });
+
+  it("paginates a long, varied line-item list across multiple pages with no throw", async () => {
+    const items = makeLongLineItemList(60);
+    const data = makeSpikeData({ line_items: items, total_items: items.length });
+    const pages = await pageCount(data);
+    expect(pages).toBeGreaterThanOrEqual(3);
+    expect(pages).toBeLessThanOrEqual(6);
+  });
+
+  it("adds a page for terms & conditions (forced own-page) without losing content", async () => {
+    const withoutTerms = makeSpikeData({ line_items: [], total_items: 0, terms_and_conditions: "" });
+    const withTerms = makeSpikeData({ line_items: [], total_items: 0 }); // fixture default has terms_and_conditions set
+    const before = await pageCount(withoutTerms);
+    const after = await pageCount(withTerms);
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("does not force a new page for payment details, unlike terms & conditions", async () => {
+    const withoutPaymentDetails = makeSpikeData({ line_items: [], total_items: 0, terms_and_conditions: "", payment_details: "" });
+    const withPaymentDetails = makeSpikeData({
+      line_items: [],
+      total_items: 0,
+      terms_and_conditions: "",
+      payment_details: "Bank: Test Bank\nBSB: 000-000\nAcct: 12345678",
+    });
+    expect(await pageCount(withoutPaymentDetails)).toBe(1);
+    expect(await pageCount(withPaymentDetails)).toBe(1);
+  });
+
+  it("reserves space for the draft-preview watermark and repeats it without dropping the table's tail", async () => {
+    const items = makeLongLineItemList(60);
+    const data = makeSpikeData({ line_items: items, total_items: items.length });
+    const withoutWatermark = await pageCount(data, false);
+    const withWatermark = await pageCount(data, true);
+    expect(withWatermark).toBeGreaterThanOrEqual(withoutWatermark);
+  });
+
+  it("renders every header mode (logo/icon/none) without throwing", async () => {
+    const items = makeLongLineItemList(1);
+    for (const documentLogoMode of ["logo", "icon", "none"] as const) {
+      const data = makeSpikeData({
+        line_items: items,
+        total_items: items.length,
+        org_logo: documentLogoMode === "logo" ? "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" : null,
+        org_icon: documentLogoMode === "icon" ? "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" : null,
+        org_branding: { documentLogoMode, showOrgNameOnDocuments: true, documentColor: "#0d4f4f" },
+      });
+      await expect(pageCount(data)).resolves.toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("groups a Project Group's synthetic row and an accessory-parent row without expanding children (showKitChildren off)", async () => {
+    const items = makeLongLineItemList(1);
+    const data = makeSpikeData({ line_items: items, total_items: items.length });
+    await expect(pageCount(data)).resolves.toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the full invoice-only shape — due date, deposit/balance, payment details, client tax id, payment terms, invoice number — together without throwing", async () => {
+    const data = makeSpikeData({
+      line_items: [],
+      total_items: 0,
+      terms_and_conditions: "",
+      invoice_due_date: "2026-09-17",
+      deposit_paid: 500,
+      balance_due: 18560.8,
+      payment_details: "Bank: Test Bank\nBSB: 000-000\nAcct: 12345678",
+      client_tax_id: "98 765 432 100",
+      client_payment_terms: "14 days",
+      invoice_number: "INV-2026-0142",
+    });
+    await expect(pageCount(data)).resolves.toBe(1);
+  });
+
+  it("renders the AU default 'TAX INVOICE' heading, a GB org_invoice_heading override, and a missing heading fallback without throwing", async () => {
+    const items = makeLongLineItemList(1);
+    for (const org_invoice_heading of ["TAX INVOICE", "INVOICE", ""]) {
+      const data = makeSpikeData({ line_items: items, total_items: items.length, org_invoice_heading });
+      await expect(pageCount(data)).resolves.toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/src/lib/react-pdf/invoice-document.tsx
+++ b/src/lib/react-pdf/invoice-document.tsx
@@ -1,0 +1,135 @@
+/**
+ * #1153 — standalone react-pdf component tree for the `invoice` document
+ * type. Same status as `quote-document.tsx`: NOT wired into
+ * `generate-pdf.ts`/`pdf-render.ts` (that's a later issue in the #1150
+ * sequence — see FEATUREDOCS/13-pdfs.md), and composes its blocks directly
+ * in JSX rather than walking `DOCUMENT_LAYOUTS.invoice` (porting the
+ * declarative layout table itself was explicitly deferred by #1152).
+ *
+ * Shares `clientFacingTable` and every component with `quote-document.tsx`
+ * (issue 1's spike) — the delta, all mirroring `document-composer.ts`'s
+ * `invoice`-specific branches:
+ * - `showClientTaxId`/`showPaymentTerms`/`showInvoiceNumber` in `DetailsRow`
+ * - the `org_invoice_heading` country-derived title override (I4, #1083)
+ * - `TotalsBlock`'s Deposit Paid / Balance Due / Due Date rows (already
+ *   data-gated in the component from #1152 — nothing to wire here)
+ * - the `Header`'s bold "Due: <date>" highlight (also already data-gated)
+ * - the `paymentDetails` block (bank details) directly after the totals
+ *   block, sharing the same free-text/markdown-lite convention as T&Cs but
+ *   never forcing a new page
+ */
+import { Document, Page, View, Text } from "@react-pdf/renderer";
+import type { DocumentData } from "@/lib/pdfme/types";
+import type { ProjectDocumentType } from "@/lib/pdfme/document-layouts";
+import { Header } from "./components/header";
+import { DetailsRow } from "./components/details-row";
+import { LineItemsTable } from "./components/line-items-table";
+import { TotalsBlock } from "./components/totals-block";
+import { DraftWatermark } from "./components/draft-watermark";
+import { Footer } from "./components/footer";
+import { RichText } from "./components/rich-text";
+import { COLORS, FONT_SIZE, PAGE_MARGIN } from "./styles";
+import { MARGIN, FOOTER_HEIGHT } from "@/lib/pdfme/template-constants";
+
+const PAGE_PADDING_BOTTOM = `${MARGIN + FOOTER_HEIGHT + 8}mm`;
+
+const DRAFT_PREVIEW_TITLE = "DRAFT PREVIEW — NOT SENT";
+const DRAFT_PREVIEW_SUBTITLE = "Live pricing, not frozen — this invoice has not been issued and has no invoice number.";
+
+export function InvoiceDocument({ data, draftPreview = false }: { data: DocumentData; draftPreview?: boolean }) {
+  const docType: ProjectDocumentType = "invoice";
+  const itemDiscountTotal = data.line_items.reduce((sum, li) => sum + (li.discount ?? 0), 0);
+  // I4 (#1083) — "TAX INVOICE" for AU/NZ, "INVOICE" elsewhere; falls back to
+  // the generic heading when the org's country doesn't resolve one.
+  const docTitle = data.org_invoice_heading || "TAX INVOICE";
+
+  const tableConfig = {
+    documentType: docType,
+    documentColor: data.org_document_color || "#0d4f4f",
+    showGroupHeaders: true,
+    showKitChildren: false,
+    showCheckboxes: false,
+    showConditionColumns: false,
+    showPricing: true,
+    showBadges: false,
+    showNotes: true,
+    showPerUnitCheckboxes: false,
+    showAssetTags: false,
+    showCategories: false,
+    showRowNumbers: false,
+    filterOptional: false,
+    filterByStatus: null,
+    hidePricingPeriodSuffix: true,
+  } as const;
+
+  return (
+    <Document title={`${data.org_name} — Invoice ${data.invoice_number || data.project_number}`}>
+      <Page
+        size="A4"
+        wrap
+        style={{
+          paddingTop: PAGE_MARGIN,
+          paddingBottom: PAGE_PADDING_BOTTOM,
+          paddingLeft: PAGE_MARGIN,
+          paddingRight: PAGE_MARGIN,
+          fontFamily: "Helvetica",
+        }}
+      >
+        <View fixed style={{ marginBottom: "3mm" }}>
+          <Header data={data} docType={docType} docTitle={docTitle} />
+        </View>
+
+        {draftPreview && (
+          <View fixed style={{ marginBottom: "3mm" }}>
+            <DraftWatermark title={DRAFT_PREVIEW_TITLE} subtitle={DRAFT_PREVIEW_SUBTITLE} />
+          </View>
+        )}
+
+        <View style={{ marginBottom: "4mm" }} wrap={false}>
+          <DetailsRow data={data} config={{ showClientTaxId: true, showPaymentTerms: true, showInvoiceNumber: true }} />
+        </View>
+
+        <View style={{ marginBottom: "4mm" }}>
+          <LineItemsTable items={data.line_items} config={tableConfig} docColor={tableConfig.documentColor} />
+        </View>
+
+        <View style={{ marginBottom: "4mm" }} wrap={false}>
+          <TotalsBlock data={data} itemDiscountTotal={itemDiscountTotal} />
+        </View>
+
+        {data.payment_details && (
+          <View style={{ marginBottom: "4mm" }}>
+            <Text style={{ fontSize: FONT_SIZE.child, fontFamily: "Helvetica-Bold", color: COLORS.text, marginBottom: "1mm" }}>
+              Payment Details
+            </Text>
+            <RichText text={data.payment_details} />
+          </View>
+        )}
+
+        {data.client_notes && (
+          <View style={{ marginBottom: "4mm" }}>
+            <Text style={{ fontSize: FONT_SIZE.child, fontFamily: "Helvetica-Bold", color: COLORS.text, marginBottom: "1mm" }}>
+              Notes
+            </Text>
+            <RichText text={data.client_notes} />
+          </View>
+        )}
+
+        {data.terms_and_conditions && (
+          // `break` forces this block onto its own page — see
+          // quote-document.tsx's comment for why this doesn't insert a
+          // spurious blank page when the block already lands first on a
+          // fresh page.
+          <View break>
+            <Text style={{ fontSize: FONT_SIZE.child, fontFamily: "Helvetica-Bold", color: COLORS.text, marginBottom: "1mm" }}>
+              Terms & Conditions
+            </Text>
+            <RichText text={data.terms_and_conditions} />
+          </View>
+        )}
+
+        <Footer text={data.document_footer_text || `${data.org_name} | ${data.org_email} | ${data.org_phone}`} />
+      </Page>
+    </Document>
+  );
+}

--- a/src/lib/react-pdf/render-spike.tsx
+++ b/src/lib/react-pdf/render-spike.tsx
@@ -16,6 +16,14 @@
  *                                 already lands first on a fresh page, to
  *                                 empirically check react-pdf's `break`
  *                                 doesn't insert a spurious blank page
+ *
+ * #1153 added the invoice-only renders for visual sign-off against the
+ * fields that don't exist on quote: deposit/balance/due-date totals rows,
+ * the due-date header highlight, payment details, client tax id, payment
+ * terms, and invoice number:
+ *   - invoice-long-icon.pdf     — the realistic long fixture with every
+ *                                 invoice-only field populated
+ *   - invoice-header-logo.pdf   — header logo mode, single page
  */
 import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -23,6 +31,7 @@ import { join } from "path";
 import { renderToBuffer } from "@react-pdf/renderer";
 import { PDFDocument as PdfLibDocument } from "@pdfme/pdf-lib";
 import { QuoteDocument } from "./quote-document";
+import { InvoiceDocument } from "./invoice-document";
 import { makeSpikeData, makeLongLineItemList } from "./fixture";
 
 // Tiny 1x1 PNG — real image bytes are irrelevant to this spike (it's testing
@@ -91,6 +100,34 @@ async function main() {
     "quote-tc-freshpage",
     <QuoteDocument data={makeSpikeData({ line_items: freshPageItems, total_items: freshPageItems.length })} />,
     join(outDir, "quote-tc-freshpage.pdf"),
+  );
+
+  const invoiceItems = makeLongLineItemList(60);
+  const invoiceData = makeSpikeData({
+    line_items: invoiceItems,
+    total_items: invoiceItems.length,
+    invoice_number: "INV-2026-0142",
+    invoice_due_date: "2026-09-17",
+    deposit_paid: 500,
+    balance_due: 18560.8,
+    payment_details: "Bank: Test Bank\nBSB: 000-000\nAcct: 12345678\nReference: PRJ-2026-0142",
+  });
+
+  await renderAndReport("invoice-long-icon", <InvoiceDocument data={invoiceData} />, join(outDir, "invoice-long-icon.pdf"));
+
+  await renderAndReport(
+    "invoice-header-logo",
+    <InvoiceDocument
+      data={makeSpikeData({
+        line_items: shortItems,
+        total_items: shortItems.length,
+        org_logo: PLACEHOLDER_PNG,
+        org_branding: { documentLogoMode: "logo", showOrgNameOnDocuments: true, documentColor: "#0d4f4f" },
+        invoice_number: "INV-2026-0143",
+        invoice_due_date: "2026-09-17",
+      })}
+    />,
+    join(outDir, "invoice-header-logo.pdf"),
   );
 
   // eslint-disable-next-line no-console -- manual CLI dev script, see the reason above.


### PR DESCRIPTION
## Summary

Part of #1150. Sub-issue 3 of 7 (#1153). Wires the #1152 shared react-pdf component library into the `invoice` layout, mirroring `quote-document.tsx`'s (#1151) standalone shape.

- New `src/lib/react-pdf/invoice-document.tsx` composing the shared components for `invoice`.
- `DetailsRow` (`src/lib/react-pdf/components/details-row.tsx`) gains an optional `config` prop gating `showClientTaxId` / `showPaymentTerms` / `showInvoiceNumber`, mirroring `document-composer.ts`'s `detailsRow` branches. Quote passes no config, so its rendering is unchanged. The pure line-building functions are exported and unit-tested directly.
- The `TAX INVOICE` / `INVOICE` heading takes the I4 (#1083) country-derived `org_invoice_heading` override.
- A new `paymentDetails` block (bank details, invoice-only) renders directly after the totals block, sharing terms & conditions' free-text/markdown-lite convention but — unlike T&Cs — never forcing its own page.
- `TotalsBlock`'s Deposit Paid / Balance Due / Due Date rows and `Header`'s bold "Due: <date>" highlight needed **no** changes — #1152 already gated both on the data being present rather than a separate config flag.

Still standalone: **not** wired into `generate-pdf.ts`/`pdf-render.ts` (cutover is a later issue in the #1150 sequence, #1156), and still hand-composed in JSX rather than walking `DOCUMENT_LAYOUTS.invoice` (porting that declarative table itself was explicitly deferred by #1152). No user-facing or production-pipeline change.

## Testing

- `pnpm exec vitest run src/lib/react-pdf` — 67 tests pass, including new coverage:
  - `invoice-document.test.ts` — page-count/no-throw smoke tests (pagination, draft-preview watermark, header modes, T&Cs forced page break, payment-details NOT forcing a page break, and the full invoice-only shape — due date, deposit/balance, payment details, client tax id, payment terms, invoice number — together).
  - `components/__tests__/details-row.test.ts` — direct unit tests of the new config-gated line-building logic (tax id label, GB vs AU business-number label, payment terms, invoice-number WS1 #940 not-yet-issued gate).
- `pnpm exec tsc --noEmit` — no new errors introduced (pre-existing baseline errors are unrelated missing-generated-Prisma-client noise, same on `main`).
- `pnpm exec eslint` on all changed files — 0 errors (2 pre-existing-pattern `max-lines-per-function` warnings, same as `quote-document.tsx`/`render-spike.tsx` already carry).
- Docs updated in the same PR: `FEATUREDOCS/13-pdfs.md` and `CHANGELOG.md` (POLICY.md R-5.2/R-5.3).

## Checklist

- [x] New dependency? N/A — no new dependency added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoUtX6i6Nd6vtAvQGB5sso)_