### PR TITLE
Fix checkOutItems Server Error + accessory-override deploy bug

### DIFF
--- a/FEATUREDOCS/48-child-assets-accessories.md
+++ b/FEATUREDOCS/48-child-assets-accessories.md
@@ -402,12 +402,24 @@ either kind runs `warehouseWrites.logAccessoryCheckoutOverride` — a new
 activity log (one entry per skipped accessory, e.g. `"Deployed <parent>
 without default accessory <name>: <reason>"`) and that accessory child line's
 own `notes` field (merge-appended, same "join with `; `" convention as custom
-line item notes) — then the actual `checkOutItems` call proceeds unchanged.
-The gate is client-side pre-flight only; it does not touch
-`checkoutAccessoryChildren`/`expandAccessoriesForAsset` in
-`convex/warehouseOps.ts` — an accessory that was never prepped simply has no
-unit to flip, so the existing cascade does nothing for it either way, exactly
-as if the operator had scanned the parent alone.
+line item notes) — then the resent `checkOutItems` call carries an
+`includeAccessoryIds` narrowed to every accessory child of the deploying
+parent(s) **except** the ones just declared missing (computed client-side from
+`accessoryChildrenOf` minus the skipped set, translated to asset/bulk-asset
+identity the same way `findPartiallyVerifiedAccessoryParent` does).
+
+This narrowing is load-bearing for a **bulk** DEFAULT accessory (e.g. a
+battery-kit template accessory) that was already added to the project at
+add-time but never packed: the "no unit to flip" assumption above only holds
+for a *serialised* accessory. A bulk one gets its unit **materialised at
+checkout time** by `expandAccessoriesForAsset` regardless of prep state (it's
+how a never-touched DEFAULT bulk accessory ever gets a unit at all), and
+`checkoutAccessoryChildren` immediately flips whatever unit exists — so
+without the narrowing, the very accessory the operator just said was missing
+got silently checked out anyway in the same call. `includeAccessoryIds` is
+exactly the existing "verified subset" filter both of those functions already
+respect (issue #794's partial-deploy escape hatch), so no new gate was needed
+on the Convex side — the client just wasn't setting it on the override path.
 
 ## Not in v1
 

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -78,15 +78,21 @@ export async function syncLineItemRollup(ctx: Ctx, lineItemId: string): Promise<
   });
 }
 
-/** Find-or-create the serialised unit for a (line, asset) pair. */
+/** Find-or-create the serialised unit for a (line, asset) pair. Uses `.collect()` +
+ *  take-first rather than `.unique()`: a duplicate row on `by_lineItemId_assetId`
+ *  (e.g. from an old double-submit before the client had pending-state guards)
+ *  must not turn every future checkout of that asset into a masked Convex system
+ *  error — degrade to "use the first one" instead of throwing (see CLAUDE.md's
+ *  `.unique()`-on-a-duplicate-row footgun). */
 export async function ensureSerialisedUnit(
   ctx: Ctx,
   args: { organizationId: string; lineItemId: string; assetId: string },
 ): Promise<{ id: string; created: boolean }> {
-  const existing = await ctx.db
+  const existingRows = await ctx.db
     .query("projectLineItemUnits")
     .withIndex("by_lineItemId_assetId", (q) => q.eq("lineItemId", args.lineItemId).eq("assetId", args.assetId))
-    .unique();
+    .collect();
+  const existing = existingRows[0];
   if (existing) return { id: existing.id, created: false };
 
   const siblings = await lineUnits(ctx, args.lineItemId);

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -56,10 +56,14 @@ async function checkOutSerializedItem(
   const asset = await assetByCuid(ctx, p.targetAssetId);
   if (!asset || asset.organizationId !== p.organizationId) throw new ConvexError("Asset not found in this organization");
   if (asset.status === "CHECKED_OUT") {
-    const ownUnit = await ctx.db
+    // `.collect()` + take-first, not `.unique()`: a stray duplicate row on this
+    // (lineItemId, assetId) pair must degrade gracefully, not turn this into a
+    // masked Convex system error (see fulfillment.ts's ensureSerialisedUnit).
+    const ownUnits = await ctx.db
       .query("projectLineItemUnits")
       .withIndex("by_lineItemId_assetId", (q) => q.eq("lineItemId", p.lineItemId).eq("assetId", p.targetAssetId))
-      .unique();
+      .collect();
+    const ownUnit = ownUnits.find((u) => u.status === "CHECKED_OUT") ?? ownUnits[0];
     if (ownUnit && ownUnit.status === "CHECKED_OUT") return "continue";
     throw new ConvexError(`Asset ${asset.assetTag} is already deployed`);
   }

--- a/convex/warehouseWrites.test.ts
+++ b/convex/warehouseWrites.test.ts
@@ -715,6 +715,26 @@ describe("checkOutItems", () => {
     expect(payload.assetIds).toEqual(["a1"]);
   });
 
+  test("pre-existing duplicate (lineItemId, assetId) unit rows → checkout still succeeds (no masked system error)", async () => {
+    // Regression: a stray duplicate on `by_lineItemId_assetId` (e.g. an old
+    // double-submit before client pending-state guards existed) used to make
+    // `ensureSerialisedUnit`'s `.unique()` throw a Convex SYSTEM error — masked
+    // to the client as a generic "Server Error", not a ConvexError.
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", { id: "dup1", organizationId: ORG, lineItemId: "li1", ordinal: 1, assetId: "a1", quantity: 1, status: "CONFIRMED", createdAt: NOW, updatedAt: NOW });
+      await ctx.db.insert("projectLineItemUnits", { id: "dup2", organizationId: ORG, lineItemId: "li1", ordinal: 2, assetId: "a1", quantity: 1, status: "CONFIRMED", createdAt: NOW, updatedAt: NOW });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkOutItems, {
+      orgId: ORG, projectId: "p1",
+      items: [{ lineItemId: "li1", assetId: "a1" }],
+      includeAccessories: true, auditIds: ["log1"], now: NOW, actor: SPOOF,
+    });
+    expect(res.updatedLineIds).toEqual(["li1"]);
+    expect((await assetById(t, "a1"))?.status).toBe("CHECKED_OUT");
+  });
+
   test("no active subscription → no delivery rows (but checkout still succeeds)", async () => {
     const t = makeT();
     await seed(t);

--- a/src/app/(app)/warehouse/[projectId]/page.tsx
+++ b/src/app/(app)/warehouse/[projectId]/page.tsx
@@ -2168,10 +2168,29 @@ function WarehouseProjectPage({
     } catch {
       // Never let the audit trail write block the actual deploy.
     }
+
+    // Narrow each pending parent's accessory cascade to exclude the accessories
+    // just declared missing — the override records WHY they're being left
+    // behind, it must not also silently deploy them anyway (issue #794: this
+    // gate previously logged the reason but still checked out the "missing"
+    // accessory since `includeAccessoryIds` was never set on the resend).
+    const skippedLineIds = new Set(skipped.map((s) => s.accessoryLineItemId));
+    const narrowedItems = pendingCheckOutItems.map((item) => {
+      const li = lineItems.find((l) => l.id === item.lineItemId);
+      if (!li) return item;
+      const allAccessories = accessoryChildrenOf(li);
+      const eligible = allAccessories.filter((c) => !skippedLineIds.has(c.id));
+      if (eligible.length === allAccessories.length) return item; // nothing skipped for this parent
+      const includeAccessoryIds = eligible
+        .map((c) => c.assetId ?? c.bulkAssetId ?? "")
+        .filter((v): v is string => v !== "");
+      return { ...item, includeAccessoryIds };
+    });
+
     setAccessoryGate(null);
     setDefaultOverrideReason("");
     setOptionalSkipReasons({});
-    runCheckOut(pendingCheckOutItems);
+    runCheckOut(narrowedItems);
   };
 
   // De-prep selected returned items: run return checks where the model has them,


### PR DESCRIPTION
## Summary
- `warehouseWrites.checkOutItems` could crash with a generic, masked "Server Error" whenever a duplicate `projectLineItemUnits` row existed for the same `(lineItemId, assetId)` pair — `ensureSerialisedUnit` and `checkOutSerializedItem`'s own-unit lookup both used `.unique()`, which throws a raw Convex system error (not a `ConvexError`) on more than one match. Switched both to `.collect()` + take-first so a stray duplicate degrades gracefully instead of crashing the whole checkout.
- Separately: the warehouse Deploy gate's "missing accessory" override logged the operator's reason (e.g. "Sent Non-rechargables") but then resent the checkout *without* excluding that accessory — so a bulk DEFAULT accessory declared missing got its unit materialised and checked out anyway in the same call, contradicting the just-recorded reason. `confirmAccessoryGate` now narrows `includeAccessoryIds` to exclude exactly what was declared missing.
- Updated FEATUREDOCS/48 to correct the stale "no unit to flip" assumption for bulk accessories.

## Test plan
- [x] `pnpm exec vitest run convex/` — 2295 tests pass (1 unrelated pre-existing failure: missing generated Prisma client in this sandbox, no DB configured)
- [x] New regression test in `convex/warehouseWrites.test.ts` reproduces the exact unmasked error (`unique() query returned more than one result from table projectLineItemUnits`) when the fix is reverted, and passes with it applied
- [x] `pnpm exec tsc --noEmit` — no new errors introduced (pre-existing unrelated errors from a missing generated Prisma client)
- [x] `pnpm exec eslint` on all touched files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014hMEcT1rj3ujZxtYr7cA6Z)_