### PR TITLE
Show friendly messages for project-service ConvexErrors (fixes ugly FINANCIALS_LOCKED toast)

### DIFF
--- a/src/hooks/use-project-service-writes.ts
+++ b/src/hooks/use-project-service-writes.ts
@@ -7,6 +7,7 @@ import {
   projectServiceSchema,
   type ProjectServiceFormValues,
 } from "@/lib/validations/project-service";
+import { mapNativeWriteError } from "@/lib/native-writes";
 import { api } from "../../convex/_generated/api";
 
 type ServiceStatus = "PLANNED" | "CONFIRMED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
@@ -92,59 +93,95 @@ export function useProjectServiceWrites() {
   return {
     create: async (projectId: string, data: ProjectServiceFormValues): Promise<{ id: string }> => {
       const { input, crew } = buildInput(data);
-      return createM({
-        id: createId(),
-        orgId: requireOrg(),
-        projectId,
-        ...input,
-        crew,
-        now: Date.now(),
-        actor: actor(),
-        auditId: createId(),
-      });
+      try {
+        return await createM({
+          id: createId(),
+          orgId: requireOrg(),
+          projectId,
+          ...input,
+          crew,
+          now: Date.now(),
+          actor: actor(),
+          auditId: createId(),
+        });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     update: async (serviceId: string, data: ProjectServiceFormValues): Promise<{ id: string }> => {
       const { input, crew } = buildInput(data);
-      return updateM({
-        id: serviceId,
-        orgId: requireOrg(),
-        ...input,
-        crew, // always present (even []) → reconcile crew, mirroring the server's crewMemberIds != null
-        now: Date.now(),
-        actor: actor(),
-        auditId: createId(),
-      });
+      try {
+        return await updateM({
+          id: serviceId,
+          orgId: requireOrg(),
+          ...input,
+          crew, // always present (even []) → reconcile crew, mirroring the server's crewMemberIds != null
+          now: Date.now(),
+          actor: actor(),
+          auditId: createId(),
+        });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     /** `justification` (#990) — forwarded to `deleteServiceNative`, required once
      *  the project is ON_SITE+ with no open unlock session. */
     remove: async (serviceId: string, justification?: string): Promise<{ id: string }> => {
-      return deleteM({ id: serviceId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId(), justification });
+      try {
+        return await deleteM({ id: serviceId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId(), justification });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     setStatus: async (serviceId: string, status: ServiceStatus): Promise<{ id: string }> => {
-      return statusM({ id: serviceId, orgId: requireOrg(), status, now: Date.now(), actor: actor(), auditId: createId() });
+      try {
+        return await statusM({ id: serviceId, orgId: requireOrg(), status, now: Date.now(), actor: actor(), auditId: createId() });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     bulkDelete: async (ids: string[], justification?: string): Promise<{ deleted: number; skipped: number }> => {
-      return bulkDeleteM({ ids, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId(), justification });
+      try {
+        return await bulkDeleteM({ ids, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId(), justification });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     bulkSetStatus: async (ids: string[], status: ServiceStatus): Promise<{ updated: number; skipped: number }> => {
-      return bulkStatusM({ ids, orgId: requireOrg(), status, now: Date.now(), actor: actor(), auditId: createId() });
+      try {
+        return await bulkStatusM({ ids, orgId: requireOrg(), status, now: Date.now(), actor: actor(), auditId: createId() });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     generate: async (projectId: string): Promise<{ created: number }> => {
-      return generateM({ projectId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      try {
+        return await generateM({ projectId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     clone: async (targetProjectId: string, sourceProjectId: string): Promise<{ cloned: number }> => {
-      return cloneM({ targetProjectId, sourceProjectId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      try {
+        return await cloneM({ targetProjectId, sourceProjectId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
 
     convertLineItem: async (lineItemId: string): Promise<{ id: string }> => {
-      return convertM({ serviceId: createId(), lineItemId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      try {
+        return await convertM({ serviceId: createId(), lineItemId, orgId: requireOrg(), now: Date.now(), actor: actor(), auditId: createId() });
+      } catch (e) {
+        throw mapNativeWriteError(e);
+      }
     },
   };
 }

--- a/src/lib/native-writes.test.ts
+++ b/src/lib/native-writes.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "vitest";
+import { ConvexError } from "convex/values";
+import { mapNativeWriteError } from "./native-writes";
+import { UserFacingError } from "./errors/user-facing-error";
+
+describe("mapNativeWriteError", () => {
+  test("maps a lifecycle-lock ConvexError to its friendly UserFacingError", () => {
+    // Regression: use-project-service-writes.ts used to let this ConvexError
+    // propagate raw, so the panel's `toast.error(e.message)` showed the ugly
+    // `Uncaught ConvexError: {"code":"FINANCIALS_LOCKED",...}` JSON instead of
+    // the mapped message below.
+    const raw = new ConvexError({
+      code: "FINANCIALS_LOCKED",
+      message: "This project's financials are locked. Open an unlock session (Financials tab) to edit money fields.",
+    });
+    const mapped = mapNativeWriteError(raw);
+    expect(mapped).toBeInstanceOf(UserFacingError);
+    expect((mapped as UserFacingError).code).toBe("FINANCIALS_LOCKED");
+    expect((mapped as UserFacingError).title).toBe("Financials are locked");
+    expect((mapped as UserFacingError).message).toBe(
+      "This project's financials are locked. Open an unlock session (Financials tab) to edit money fields.",
+    );
+  });
+
+  test("unrecognised ConvexError code passes through unchanged", () => {
+    const raw = new ConvexError({ code: "SOME_UNMAPPED_CODE", message: "x" });
+    expect(mapNativeWriteError(raw)).toBe(raw);
+  });
+
+  test("non-ConvexError values pass through unchanged", () => {
+    const raw = new Error("boom");
+    expect(mapNativeWriteError(raw)).toBe(raw);
+  });
+});


### PR DESCRIPTION
## Summary
- `useProjectServiceWrites` (create/update/delete/setStatus/bulkDelete/bulkSetStatus/generate/clone/convertLineItem) let raw `ConvexError`s propagate straight to the services panel's `toast.error(e.message)`. For a structured-payload error like the lifecycle-lock gate's `FINANCIALS_LOCKED` (thrown from `assertLifecycleGuard`, `convex/lib/projectLocks.ts`), that showed the user the raw `Uncaught ConvexError: {"code":"FINANCIALS_LOCKED","message":"..."}` JSON blob instead of the friendly, already-defined message ("This project's financials are locked. Open an unlock session...").
- Every other native-write hook (`use-native-project-writes.ts`, `use-line-item-writes.ts`) already wraps its mutation calls with `mapNativeWriteError` for exactly this reason — `ASSET_WRITE_ERROR_MAP` in `src/lib/native-writes.ts` already has the `FINANCIALS_LOCKED`/`PROJECT_LOCKED`/`JUSTIFICATION_REQUIRED` mappings ready to go. This hook was the one gap.
- Added `src/lib/native-writes.test.ts` (didn't exist before) with a regression test for the mapping.

This surfaced while investigating a user report of "heaps of Convex issues" while editing a locked project — the underlying lock behavior is correct/intentional, it was only the error message that was broken.

## Test plan
- [x] New test: `pnpm exec vitest run src/lib/native-writes.test.ts` — 3 pass
- [x] `pnpm exec vitest run src/hooks/` — 63 pass (1 unrelated pre-existing failure: missing generated Prisma client in this sandbox)
- [x] `pnpm exec tsc --noEmit` — no new errors
- [x] `pnpm exec eslint` on touched files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014hMEcT1rj3ujZxtYr7cA6Z)_