### PR TITLE
fix(warehouse): stop checkOutItems crashing on a duplicate unit row

### DIFF
--- a/FEATUREDOCS/12-warehouse.md
+++ b/FEATUREDOCS/12-warehouse.md
@@ -517,6 +517,23 @@ Two invariants `checkOutItems` enforces (see `warehouse-tenant-tt-safety.int.tes
 - **Org-scoped asset writes.** The asset id used for a serialised checkout can come from the untrusted scan payload (`item.assetId`), so it is re-scoped to the caller's org with `findFirst({ id, organizationId })` before any write; a miss throws "Asset not found in this organization". The status/location mutation is an org-scoped `updateMany` (defense-in-depth), as is the accessory-cascade asset write in `checkoutAccessoryChildren`. Without this a caller could flip another tenant's asset status/location by scanning its id onto their own line.
 - **Accessories are T&T-gated.** The top-level T&T preflight (`assertTestTagAllowsCheckout`) only sees the scanned parent lines + their units. Accessory children are **separate line items** with their own ids/units (materialised at prep time on different line ids, or at scan time *after* the preflight runs), so they never reach the top-level gate. `checkoutAccessoryChildren` therefore runs its own `assertTestTagAllowsCheckout` over the accessory children's asset/bulk ids before flipping them — a failed/overdue accessory throws `TestTagBlockError` and rolls back the whole batch. The gate is scoped to children that are **not already `CHECKED_OUT`** (mirroring the cascade's skip-already-out guards) so an already-shipped sibling accessory whose T&T lapsed doesn't block a later partial deploy of the same multi-quantity parent line. (A not-yet-deployed sibling accessory is still gated, since the line-scoped cascade would flip it — true per-unit scoping is the deferred "snapshot per-unit accessory contributions" follow-up.) See [Child Assets / Accessories](./48-child-assets-accessories.md).
 
+### ⚠️ A stray duplicate `projectLineItemUnits` row must never crash checkout
+`by_lineItemId_assetId` is an ordinary, **non-unique** Convex index (schema.ts has no
+uniqueness constraint on it) — Convex only enforces it *conceptually*, not structurally.
+`ensureSerialisedUnit` (`convex/lib/fulfillment.ts`) and `checkOutSerializedItem`'s
+already-deployed check (`convex/warehouseOps.ts`) both look up a line's unit for a given
+asset by this pair; a production incident (delivery-docket deploy failing with an opaque
+Convex "Server Error") traced back to one of them calling `ctx.db….unique()` on this index,
+which throws Convex's raw, unmasked system error the instant two rows share a
+`(lineItemId, assetId)` pair — the exact `create`-vs-`createIfMissing` footgun this file's
+parent CLAUDE.md documents for `by_cuid`, just on a different index. Both call sites now
+find the unit via `.find()` over the line's already-collected units (same pattern as
+`ensureBulkUnit`/`ensureAccessoryUnit`) so a stray duplicate degrades to "pick one", not a
+crash. Regression coverage: `checkOutItems > a pre-existing duplicate unit row…` and
+`> re-deploying an already-checked-out asset with a duplicate unit row…` in
+`convex/warehouseWrites.test.ts`. **Never reintroduce a bare `.unique()` on
+`by_lineItemId_assetId`** — use `.find()` over `lineUnits(ctx, lineItemId)` instead.
+
 ## Cross-Navigation
 - **Warehouse → Project**: "View Project" button in warehouse header links to `/projects/[id]`
 - **Project → Warehouse**: "Warehouse" button in project header links to `/warehouse/[id]`

--- a/convex/lib/fulfillment.ts
+++ b/convex/lib/fulfillment.ts
@@ -78,18 +78,21 @@ export async function syncLineItemRollup(ctx: Ctx, lineItemId: string): Promise<
   });
 }
 
-/** Find-or-create the serialised unit for a (line, asset) pair. */
+/** Find-or-create the serialised unit for a (line, asset) pair.
+ *  Finds via a JS `.find()` over the line's collected units (like its
+ *  ensureBulkUnit/ensureAccessoryUnit siblings below), not `ctx.db…unique()` —
+ *  `by_lineItemId_assetId` is a non-unique Convex index, and any stray
+ *  duplicate row for the pair would make `.unique()` throw a raw, unmasked
+ *  system error that surfaces to the client as an opaque "Server Error"
+ *  instead of failing gracefully. */
 export async function ensureSerialisedUnit(
   ctx: Ctx,
   args: { organizationId: string; lineItemId: string; assetId: string },
 ): Promise<{ id: string; created: boolean }> {
-  const existing = await ctx.db
-    .query("projectLineItemUnits")
-    .withIndex("by_lineItemId_assetId", (q) => q.eq("lineItemId", args.lineItemId).eq("assetId", args.assetId))
-    .unique();
+  const siblings = await lineUnits(ctx, args.lineItemId);
+  const existing = siblings.find((u) => u.assetId === args.assetId);
   if (existing) return { id: existing.id, created: false };
 
-  const siblings = await lineUnits(ctx, args.lineItemId);
   const id = createId();
   const now = Date.now();
   await ctx.db.insert("projectLineItemUnits", {

--- a/convex/warehouseOps.ts
+++ b/convex/warehouseOps.ts
@@ -56,10 +56,12 @@ async function checkOutSerializedItem(
   const asset = await assetByCuid(ctx, p.targetAssetId);
   if (!asset || asset.organizationId !== p.organizationId) throw new ConvexError("Asset not found in this organization");
   if (asset.status === "CHECKED_OUT") {
-    const ownUnit = await ctx.db
-      .query("projectLineItemUnits")
-      .withIndex("by_lineItemId_assetId", (q) => q.eq("lineItemId", p.lineItemId).eq("assetId", p.targetAssetId))
-      .unique();
+    // `.find()` over the collected units, not `ctx.db…unique()` on
+    // by_lineItemId_assetId — that index is non-unique, so a stray duplicate
+    // row for the pair would make `.unique()` throw a raw, unmasked Convex
+    // system error instead of the intended ConvexError below (see the same
+    // fix in ensureSerialisedUnit, convex/lib/fulfillment.ts).
+    const ownUnit = (await lineUnits(ctx, p.lineItemId)).find((u) => u.assetId === p.targetAssetId);
     if (ownUnit && ownUnit.status === "CHECKED_OUT") return "continue";
     throw new ConvexError(`Asset ${asset.assetTag} is already deployed`);
   }

--- a/convex/warehouseWrites.test.ts
+++ b/convex/warehouseWrites.test.ts
@@ -726,6 +726,61 @@ describe("checkOutItems", () => {
     expect(await deliveriesForOrg(t)).toHaveLength(0);
   });
 
+  // Regression: `by_lineItemId_assetId` is a non-unique Convex index. A stray
+  // duplicate row for the (line, asset) pair used to make the internal
+  // `.unique()` lookups throw a raw, unmasked Convex system error instead of
+  // completing the checkout — surfacing to the client as an opaque "Server
+  // Error" (the checkOutItems production incident this pins down).
+  test("a pre-existing duplicate unit row for the (line, asset) pair doesn't crash checkout", async () => {
+    const t = makeT();
+    await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "dup1", organizationId: ORG, lineItemId: "li1", ordinal: 0, assetId: "a1",
+        quantity: 1, returnedQuantity: 0, status: "CONFIRMED", createdAt: NOW, updatedAt: NOW,
+      });
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "dup2", organizationId: ORG, lineItemId: "li1", ordinal: 1, assetId: "a1",
+        quantity: 1, returnedQuantity: 0, status: "CONFIRMED", createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    const res = await t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkOutItems, {
+      orgId: ORG, projectId: "p1", items: [{ lineItemId: "li1", assetId: "a1" }],
+      includeAccessories: true, auditIds: ["log1"], now: NOW, actor: SPOOF,
+    });
+    expect(res.updatedLineIds).toEqual(["li1"]);
+    expect((await assetById(t, "a1"))?.status).toBe("CHECKED_OUT");
+  });
+
+  // Same regression, but through the `asset already CHECKED_OUT` re-deploy
+  // path (checkOutSerializedItem's ownUnit lookup), not ensureSerialisedUnit.
+  test("re-deploying an already-checked-out asset with a duplicate unit row doesn't crash", async () => {
+    const t = makeT();
+    await member(t, "member");
+    await seedProject(t);
+    await seedModelAsset(t, ORG, "CHECKED_OUT");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("projectLineItems", baseLine("li1", { modelId: "m1", assetId: "a1", status: "CONFIRMED" }));
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "own1", organizationId: ORG, lineItemId: "li1", ordinal: 0, assetId: "a1",
+        quantity: 1, returnedQuantity: 0, status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW,
+      });
+      await ctx.db.insert("projectLineItemUnits", {
+        id: "dup1", organizationId: ORG, lineItemId: "li1", ordinal: 1, assetId: "a1",
+        quantity: 1, returnedQuantity: 0, status: "CHECKED_OUT", createdAt: NOW, updatedAt: NOW,
+      });
+    });
+    // Already deployed on this exact line → checkOutSerializedItem's "continue"
+    // short-circuit (no-op, not an error). The regression under test is that this
+    // resolves at all instead of throwing on the duplicate-row `.unique()` lookup.
+    await expect(
+      t.withIdentity(asUser(ORG)).mutation(api.warehouseWrites.checkOutItems, {
+        orgId: ORG, projectId: "p1", items: [{ lineItemId: "li1", assetId: "a1" }],
+        includeAccessories: true, auditIds: ["log1"], now: NOW, actor: SPOOF,
+      }),
+    ).resolves.toEqual({ updatedLineIds: [] });
+  });
+
   test("blocking comment present → ConvexError, no write", async () => {
     const t = makeT();
     await seed(t);


### PR DESCRIPTION
## Summary

Deploying gear (ahead of sending a delivery docket) was failing with an opaque Convex `Server Error` from `checkOutItems`:

```
[CONVEX M(warehouseWrites:checkOutItems)] [Request ID: 7ced1af06c7bb05e] Server Error Called by client
```

Root cause: `ensureSerialisedUnit` (`convex/lib/fulfillment.ts`) and `checkOutSerializedItem`'s already-deployed check (`convex/warehouseOps.ts`) both looked up a line's unit for an asset via `ctx.db….unique()` on `by_lineItemId_assetId` — an ordinary, **non-unique** Convex index. A stray duplicate `projectLineItemUnits` row for that `(lineItemId, assetId)` pair makes `.unique()` throw Convex's raw, unmasked system error instead of a `ConvexError`, which the Convex production boundary masks to a generic "Server Error" — exactly the `create`-vs-`createIfMissing`/`by_cuid` footgun this repo's CLAUDE.md already documents, just on a different index.

- Reproduced the exact production stack trace locally by seeding a duplicate unit row and running the mutation against the pre-fix code: `Error: unique() query returned more than one result from table projectLineItemUnits`.
- Fixed both call sites to find the unit via `.find()` over the line's already-collected units — the same pattern already used by their `ensureBulkUnit`/`ensureAccessoryUnit` siblings and by `returnsWrites.ts`'s own lookup on the same index — so a stray duplicate degrades to "pick one" instead of crashing.
- Documented the footgun in `FEATUREDOCS/12-warehouse.md` (Checkout Safety Invariants) so `.unique()` doesn't creep back onto this index.

## Testing

- Added two regression tests in `convex/warehouseWrites.test.ts` (fresh-deploy path via `ensureSerialisedUnit`, and re-deploy path via `checkOutSerializedItem`'s ownUnit lookup) that seed a duplicate unit row and assert `checkOutItems` resolves instead of throwing.
- Verified both new tests fail with the pre-fix code (reproducing the exact prod error) and pass with the fix.
- `pnpm exec vitest run convex/warehouseWrites.test.ts convex/bulk-fulfillment-quantity.test.ts convex/agentPhase4SafetyRails.test.ts convex/warehousePageBatch.test.ts convex/forceReturnKitsBatch.test.ts` — all pass.
- `pnpm exec tsc --noEmit` — no new errors in touched files (pre-existing unrelated failures in this sandbox are all missing-generated-Prisma-client, fixed by `pnpm exec prisma generate`, and are unrelated to this change).
- `pnpm exec eslint convex/lib/fulfillment.ts convex/warehouseOps.ts convex/warehouseWrites.test.ts` — 0 errors (pre-existing complexity/max-lines warnings only, none new).
- Could not push to the Convex dev deployment from this sandbox (no `CONVEX_DEPLOY_KEY` in this environment) — the normal deploy pipeline pushes Convex functions to prod on merge to `main`.

## Checklist

- [x] New dependency? N/A — no new dependencies.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BFjhrxRLk1gCdprtHw2toL)_